### PR TITLE
Implement Phase 3: submission result retrieval API and worker tests

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -43,6 +43,7 @@ func configure(_ app: Application) throws {
     app.migrations.add(CreateTestSetups())
     app.migrations.add(CreateSubmissions())
     app.migrations.add(CreateResults())
+    app.migrations.add(AddAttemptNumberToSubmissions())
 
     try app.autoMigrate().wait()
 

--- a/Sources/APIServer/Migrations/AddAttemptNumberToSubmissions.swift
+++ b/Sources/APIServer/Migrations/AddAttemptNumberToSubmissions.swift
@@ -1,0 +1,17 @@
+// APIServer/Migrations/AddAttemptNumberToSubmissions.swift
+
+import Fluent
+
+struct AddAttemptNumberToSubmissions: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("submissions")
+            .field("attempt_number", .int)  // nullable — existing rows default to nil, treated as 1
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("submissions")
+            .deleteField("attempt_number")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APISubmission.swift
+++ b/Sources/APIServer/Models/APISubmission.swift
@@ -27,17 +27,22 @@ final class APISubmission: Model, Content, @unchecked Sendable {
     @OptionalField(key: "assigned_at")
     var assignedAt: Date?
 
+    @OptionalField(key: "attempt_number")
+    var attemptNumber: Int?
+
     init() {}
 
     init(
         id: String,
         testSetupID: String,
         zipPath: String,
+        attemptNumber: Int,
         status: String = "pending"
     ) {
-        self.id          = id
-        self.testSetupID = testSetupID
-        self.zipPath     = zipPath
-        self.status      = status
+        self.id            = id
+        self.testSetupID   = testSetupID
+        self.zipPath       = zipPath
+        self.attemptNumber = attemptNumber
+        self.status        = status
     }
 }

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -1,0 +1,166 @@
+// APIServer/Routes/SubmissionQueryRoutes.swift
+//
+// Phase 3: student-facing read endpoints.
+//
+//   GET /api/v1/submissions                   — list submissions
+//   GET /api/v1/submissions/:id               — submission status
+//   GET /api/v1/submissions/:id/results       — grading results (with optional tier filter)
+
+import Vapor
+import Fluent
+import Core
+import Foundation
+
+struct SubmissionQueryRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let subs = routes.grouped("api", "v1", "submissions")
+        subs.get(use: listSubmissions)
+        subs.get(":submissionID", use: getSubmission)
+        subs.get(":submissionID", "results", use: getResults)
+    }
+
+    // MARK: - GET /api/v1/submissions
+
+    @Sendable
+    func listSubmissions(req: Request) async throws -> SubmissionListResponse {
+        var query = APISubmission.query(on: req.db)
+            .sort(\.$submittedAt, .descending)
+
+        if let testSetupID = req.query[String.self, at: "testSetupID"] {
+            query = query.filter(\.$testSetupID == testSetupID)
+        }
+
+        let submissions = try await query.all()
+        return SubmissionListResponse(
+            submissions: submissions.map(SubmissionSummary.init)
+        )
+    }
+
+    // MARK: - GET /api/v1/submissions/:id
+
+    @Sendable
+    func getSubmission(req: Request) async throws -> SubmissionStatusResponse {
+        guard
+            let subID = req.parameters.get("submissionID"),
+            let submission = try await APISubmission.find(subID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+        return SubmissionStatusResponse(submission: submission)
+    }
+
+    // MARK: - GET /api/v1/submissions/:id/results
+
+    @Sendable
+    func getResults(req: Request) async throws -> Response {
+        guard
+            let subID = req.parameters.get("submissionID"),
+            let _ = try await APISubmission.find(subID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        guard let result = try await APIResult.query(on: req.db)
+            .filter(\.$submissionID == subID)
+            .sort(\.$receivedAt, .descending)
+            .first()
+        else {
+            throw Abort(.notFound, reason: "No results available yet for submission \(subID)")
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard
+            let data = result.collectionJSON.data(using: .utf8),
+            var collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+        else {
+            throw Abort(.internalServerError, reason: "Stored result is corrupt")
+        }
+
+        // Optional tier filter: ?tiers=public,student
+        if let tiersParam = req.query[String.self, at: "tiers"] {
+            let requested = Set(tiersParam.split(separator: ",").map(String.init))
+            collection = collection.filtering(tiers: requested)
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .sortedKeys
+        let responseData = try encoder.encode(collection)
+
+        return Response(
+            status: .ok,
+            headers: ["Content-Type": "application/json"],
+            body: .init(data: responseData)
+        )
+    }
+}
+
+// MARK: - Tier filtering
+
+private extension TestOutcomeCollection {
+    /// Returns a copy with outcomes filtered to the given tier raw values,
+    /// with all aggregate counts recomputed.
+    func filtering(tiers: Set<String>) -> TestOutcomeCollection {
+        // Map raw string to TestTier and filter.
+        let filtered = outcomes.filter { outcome in
+            tiers.contains(outcome.tier.rawValue)
+        }
+        return TestOutcomeCollection(
+            submissionID:    submissionID,
+            testSetupID:     testSetupID,
+            attemptNumber:   attemptNumber,
+            buildStatus:     buildStatus,
+            compilerOutput:  compilerOutput,
+            outcomes:        filtered,
+            totalTests:      filtered.count,
+            passCount:       filtered.filter { $0.status == .pass    }.count,
+            failCount:       filtered.filter { $0.status == .fail    }.count,
+            errorCount:      filtered.filter { $0.status == .error   }.count,
+            timeoutCount:    filtered.filter { $0.status == .timeout }.count,
+            executionTimeMs: executionTimeMs,
+            runnerVersion:   runnerVersion,
+            timestamp:       timestamp
+        )
+    }
+}
+
+// MARK: - Response types
+
+struct SubmissionListResponse: Content {
+    let submissions: [SubmissionSummary]
+}
+
+struct SubmissionSummary: Content {
+    let submissionID: String
+    let testSetupID: String
+    let status: String
+    let attemptNumber: Int
+    let submittedAt: Date?
+
+    init(_ submission: APISubmission) {
+        self.submissionID  = submission.id ?? ""
+        self.testSetupID   = submission.testSetupID
+        self.status        = submission.status
+        self.attemptNumber = submission.attemptNumber ?? 1
+        self.submittedAt   = submission.submittedAt
+    }
+}
+
+struct SubmissionStatusResponse: Content {
+    let submissionID: String
+    let testSetupID: String
+    let status: String
+    let attemptNumber: Int
+    let submittedAt: Date?
+    let assignedAt: Date?
+
+    init(submission: APISubmission) {
+        self.submissionID  = submission.id ?? ""
+        self.testSetupID   = submission.testSetupID
+        self.status        = submission.status
+        self.attemptNumber = submission.attemptNumber ?? 1
+        self.submittedAt   = submission.submittedAt
+        self.assignedAt    = submission.assignedAt
+    }
+}

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -7,4 +7,5 @@ func routes(_ app: Application) throws {
     try app.register(collection: SubmissionRoutes())
     try app.register(collection: SubmissionDownloadRoute())
     try app.register(collection: TestSetupRoutes())
+    try app.register(collection: SubmissionQueryRoutes())
 }

--- a/Sources/Core/Job.swift
+++ b/Sources/Core/Job.swift
@@ -10,6 +10,8 @@ import Foundation
 public struct Job: Codable, Sendable {
     public let submissionID: String
     public let testSetupID: String
+    /// How many times this student has submitted against this test setup (1-based).
+    public let attemptNumber: Int
     /// URL the worker should GET to download the submission zip.
     public let submissionURL: URL
     /// URL the worker should GET to download the test-setup zip.
@@ -20,12 +22,14 @@ public struct Job: Codable, Sendable {
     public init(
         submissionID: String,
         testSetupID: String,
+        attemptNumber: Int,
         submissionURL: URL,
         testSetupURL: URL,
         manifest: TestProperties
     ) {
         self.submissionID  = submissionID
         self.testSetupID   = testSetupID
+        self.attemptNumber = attemptNumber
         self.submissionURL = submissionURL
         self.testSetupURL  = testSetupURL
         self.manifest      = manifest

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -141,8 +141,8 @@ actor WorkerDaemon {
                 timeLimitSeconds: manifest.timeLimitSeconds
             )
 
-            let isFirstAttempt = true  // attempt tracking comes in Phase 5
-            let outcome = interpretOutput(output, entry: entry, attemptNumber: 1, isFirstAttempt: isFirstAttempt)
+            let isFirstAttempt = job.attemptNumber == 1
+            let outcome = interpretOutput(output, entry: entry, attemptNumber: job.attemptNumber, isFirstAttempt: isFirstAttempt)
             outcomes.append(outcome)
         }
 
@@ -220,7 +220,7 @@ actor WorkerDaemon {
         return TestOutcomeCollection(
             submissionID:    job.submissionID,
             testSetupID:     job.testSetupID,
-            attemptNumber:   1,
+            attemptNumber:   job.attemptNumber,
             buildStatus:     buildStatus,
             compilerOutput:  nil,
             outcomes:        outcomes,

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -1,6 +1,129 @@
 import XCTest
 @testable import Worker
+import Foundation
 
-// Worker integration tests will be added in Phase 2.
-// Kept here so the WorkerTests target compiles cleanly.
-final class WorkerTests: XCTestCase {}
+final class WorkerTests: XCTestCase {
+
+    // MARK: - Setup
+
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-worker-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    private func writeScript(_ body: String, name: String = "test.sh") throws -> URL {
+        let url = tmpDir.appendingPathComponent(name)
+        try body.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    // MARK: - UnsandboxedScriptRunner: exit code mapping
+
+    func testScriptExitZeroReportsExitCodeZero() async throws {
+        let script = try writeScript("#!/bin/sh\nexit 0")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertEqual(output.exitCode, 0)
+        XCTAssertFalse(output.timedOut)
+    }
+
+    func testScriptExitOneReportsExitCodeOne() async throws {
+        let script = try writeScript("#!/bin/sh\nexit 1")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertEqual(output.exitCode, 1)
+        XCTAssertFalse(output.timedOut)
+    }
+
+    func testScriptExitTwoReportsExitCodeTwo() async throws {
+        let script = try writeScript("#!/bin/sh\nexit 2")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertEqual(output.exitCode, 2)
+        XCTAssertFalse(output.timedOut)
+    }
+
+    // MARK: - UnsandboxedScriptRunner: output capture
+
+    func testStdoutIsCaptured() async throws {
+        let script = try writeScript("#!/bin/sh\necho 'hello world'\nexit 0")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertTrue(output.stdout.contains("hello world"))
+    }
+
+    func testStderrIsCaptured() async throws {
+        let script = try writeScript("#!/bin/sh\necho 'oops' >&2\nexit 0")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertTrue(output.stderr.contains("oops"))
+    }
+
+    func testStdoutAndStderrAreSeparate() async throws {
+        let script = try writeScript("#!/bin/sh\necho 'out'\necho 'err' >&2\nexit 0")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertTrue(output.stdout.contains("out"))
+        XCTAssertFalse(output.stdout.contains("err"))
+        XCTAssertTrue(output.stderr.contains("err"))
+        XCTAssertFalse(output.stderr.contains("out"))
+    }
+
+    // MARK: - UnsandboxedScriptRunner: timeout
+
+    func testScriptTimesOut() async throws {
+        let script = try writeScript("#!/bin/sh\nsleep 60\nexit 0")
+        let runner = UnsandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 1)
+        XCTAssertTrue(output.timedOut, "Script sleeping 60s should time out with a 1s limit")
+        XCTAssertEqual(output.exitCode, -1)
+    }
+
+    // MARK: - UnsandboxedScriptRunner: working directory
+
+    func testWorkDirIsSetCorrectly() async throws {
+        let script = try writeScript("#!/bin/sh\ntouch marker.txt\nexit 0")
+        let runner = UnsandboxedScriptRunner()
+        _ = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let markerPath = tmpDir.appendingPathComponent("marker.txt").path
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: markerPath),
+            "Script should create marker.txt in the supplied working directory"
+        )
+    }
+
+    // MARK: - ExponentialBackoff
+
+    func testBackoffResetsToInitial() {
+        var backoff = ExponentialBackoff(initial: .seconds(1), max: .seconds(64))
+        for _ in 0..<5 { _ = backoff.next() }
+        backoff.reset()
+        // After reset the next jittered value must be <= 2s (double of the 1s initial).
+        let afterReset = backoff.next()
+        XCTAssertLessThanOrEqual(
+            afterReset.components.seconds, 2,
+            "After reset, next delay should be at most 2s"
+        )
+    }
+
+    func testBackoffRespectsMaximum() {
+        var backoff = ExponentialBackoff(initial: .seconds(1), max: .seconds(4))
+        for _ in 0..<20 { _ = backoff.next() }
+        let capped = backoff.next()
+        XCTAssertLessThanOrEqual(
+            capped.components.seconds, 4,
+            "Backoff should never exceed max"
+        )
+    }
+}


### PR DESCRIPTION
- Add GET /api/v1/submissions — list with optional ?testSetupID filter
- Add GET /api/v1/submissions/:id — submission status and metadata
- Add GET /api/v1/submissions/:id/results — TestOutcomeCollection with
  optional ?tiers=public,student tier filter; recomputes aggregates
- Track attempt number: count prior submissions per test setup on
  creation; store in new attempt_number column (migration added);
  propagate through Job → worker → TestOutcomeCollection
- Worker now uses job.attemptNumber instead of hardcoded 1; sets
  isFirstPassSuccess correctly for attempt > 1
- Add WorkerTests: UnsandboxedScriptRunner (exit codes, stdout/stderr
  capture, timeout enforcement, working directory) and ExponentialBackoff
  (reset and maximum cap)

https://claude.ai/code/session_01QDQcFeMmYgfCJ2riHeYqDj