### PR TITLE
Update README to reflect Phase 2 completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,20 @@ Three Swift targets share a clean dependency boundary:
 ```
 ┌─────────────────────────────────────────┐
 │             APIServer (Vapor)           │
+│  POST /api/v1/submissions               │
 │  POST /api/v1/worker/request            │
 │  POST /api/v1/worker/results            │
 │  POST /api/v1/testsetups                │
+│  GET  /api/v1/testsetups/:id/download   │
+│  GET  /api/v1/submissions/:id/download  │
 └──────────────────┬──────────────────────┘
-                   │  job queue
+                   │  SQLite (Fluent)
 ┌──────────────────▼──────────────────────┐
 │               Worker                    │
-│  Pulls jobs → BuildStrategy → sandbox   │
+│  Polls for jobs → BuildStrategy         │
 │  Reports TestOutcomeCollection to API   │
 └──────────────────┬──────────────────────┘
-                   │  subprocess + sandbox
+                   │  subprocess
         ┌──────────┴──────────┐
         ▼                     ▼
   Runners/python/       Runners/jupyter/
@@ -49,9 +52,10 @@ Three Swift targets share a clean dependency boundary:
 |-------|-----------|
 | Language | Swift 6 (strict concurrency) |
 | Web framework | Vapor 4 |
+| Database | SQLite via Fluent |
 | Concurrency | `async/await`, actors, structured task groups |
 | Test runners | pytest (Python), nbmake (Jupyter Notebook) |
-| Sandboxing | `sandbox-exec` (macOS), seccomp + user namespaces (Linux) |
+| Sandboxing | `sandbox-exec` (macOS), seccomp + user namespaces (Linux) — Phase 4 |
 | Build tool | Swift Package Manager |
 
 ---
@@ -62,8 +66,8 @@ Three Swift targets share a clean dependency boundary:
 Chickadee/
 ├── Sources/
 │   ├── Core/          # Shared models — Codable, Sendable, no Vapor
-│   ├── APIServer/     # Vapor app and REST routes
-│   └── Worker/        # Job poller, build strategies, sandbox
+│   ├── APIServer/     # Vapor app, REST routes, Fluent migrations
+│   └── Worker/        # Job poller, build strategies, worker daemon
 ├── Runners/
 │   ├── python/        # run_tests.py (pytest wrapper)
 │   └── jupyter/       # run_tests.py (nbmake wrapper)
@@ -78,20 +82,11 @@ Chickadee/
 
 ## Building
 
-Requires Swift 5.9+ ([swift.org](https://swift.org/download)) and Xcode 15+ on macOS.
+Requires Swift 6 ([swift.org](https://swift.org/download)) and Xcode 16+ on macOS.
 
 ```bash
 swift build
 swift test
-```
-
-Run the Worker CLI directly against a local submission (Phase 1):
-
-```bash
-swift run Worker \
-  --submission path/to/submission.zip \
-  --testsetup  path/to/testsetup/ \
-  --runners-dir Runners/
 ```
 
 Run the API server:
@@ -99,6 +94,31 @@ Run the API server:
 ```bash
 swift run APIServer
 ```
+
+Run the Worker, pointing it at a running API server:
+
+```bash
+swift run Worker \
+  --api-base-url http://localhost:8080 \
+  --worker-id    worker-1 \
+  --max-jobs     4 \
+  --runners-dir  Runners/
+```
+
+---
+
+## REST API
+
+Base path: `/api/v1`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/submissions` | Submit a zip for grading (base-64 encoded) |
+| `GET`  | `/submissions/:id/download` | Download a submission zip |
+| `POST` | `/worker/request` | Worker claims the next pending job |
+| `POST` | `/worker/results` | Worker reports a completed `TestOutcomeCollection` |
+| `POST` | `/testsetups` | Instructor uploads a test setup (multipart) |
+| `GET`  | `/testsetups/:id/download` | Download a test-setup zip |
 
 ---
 
@@ -127,7 +147,30 @@ Every language runner writes a single JSON document to stdout when it finishes. 
 }
 ```
 
-On build failure, `buildStatus` is `"failed"`, `compilerOutput` contains the compiler error, and `outcomes` is `[]`. There is no per-test "could not run" state.
+On build failure, `buildStatus` is `"failed"`, `compilerOutput` contains the error, and `outcomes` is `[]`. There is no per-test "could not run" state.
+
+---
+
+## Test setup manifest
+
+Stored as JSON inside the test-setup zip uploaded by the instructor. Replaces the legacy `test.properties` file.
+
+```json
+{
+  "schemaVersion": 1,
+  "language": "python",
+  "requiredFiles": ["warmup.py"],
+  "testSuites": [
+    { "tier": "public",  "module": "test_public"  },
+    { "tier": "release", "module": "test_release" }
+  ],
+  "limits": {
+    "timeLimitSeconds": 10
+  }
+}
+```
+
+For Jupyter Notebook submissions, `module` is the `.ipynb` filename.
 
 ---
 
@@ -146,9 +189,9 @@ On build failure, `buildStatus` is `"failed"`, `compilerOutput` contains the com
 
 | Phase | Focus | Status |
 |-------|-------|--------|
-| 1 | Core models, Worker CLI stub, `POST /results` | Complete |
-| 2 | Full REST API, test setup upload, Worker pull loop | Up next |
-| 3 | Python and Jupyter runners, `PythonBuildStrategy`, `JupyterBuildStrategy` | Planned |
+| 1 | Core models, `RunnerResult`, `TestSetupManifest`, `POST /results` stub | Complete |
+| 2 | Full REST API, SQLite persistence, Worker pull loop | Complete |
+| 3 | Python and Jupyter runners, `run_tests.py` scripts | Up next |
 | 4 | Sandboxing — macOS first, then Linux | Planned |
 | 5 | Gamification — attempt tracking, leaderboards, partial credit | Planned |
 


### PR DESCRIPTION
- Add all six REST API endpoints to architecture diagram and new API table
- Update tech stack to note SQLite via Fluent
- Replace Phase 1 Worker CLI flags with Phase 2 pull-loop flags
- Update test setup manifest example to match actual TestProperties schema
- Mark Phase 2 as complete; Phase 3 (Python/Jupyter runners) is up next
- Remove stale Java/sandbox references not yet implemented