### PR TITLE
Phase 4: add SandboxedScriptRunner and update README

### DIFF
--- a/Sources/Worker/SandboxedScriptRunner.swift
+++ b/Sources/Worker/SandboxedScriptRunner.swift
@@ -1,0 +1,128 @@
+// Worker/SandboxedScriptRunner.swift
+//
+// Phase 4: sandboxed subprocess execution.
+//
+// On Linux  — uses `unshare --user --net --map-root-user` to run the script
+//             inside a private user namespace (no real privileges) and a
+//             private network namespace (no outbound connectivity).
+//
+// On macOS  — uses `sandbox-exec -p <profile>` to enforce a TCC-level policy:
+//             deny all network, allow file-reads from the system prefix, allow
+//             file-writes only inside the working directory.
+//
+// Callers interact through the ScriptRunner protocol; no change is needed at
+// call sites compared to UnsandboxedScriptRunner.
+
+import Foundation
+
+struct SandboxedScriptRunner: ScriptRunner {
+
+    func run(script: URL, workDir: URL, timeLimitSeconds: Int) async -> ScriptOutput {
+        let start = Date()
+
+        let proc = Process()
+        configureSandboxedProcess(proc, script: script, workDir: workDir)
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        proc.standardOutput = stdoutPipe
+        proc.standardError  = stderrPipe
+
+        do {
+            try proc.run()
+        } catch {
+            let elapsed = Int(Date().timeIntervalSince(start) * 1000)
+            return ScriptOutput(
+                exitCode: 2,
+                stdout: "",
+                stderr: "Failed to launch sandboxed script: \(error.localizedDescription)",
+                executionTimeMs: elapsed,
+                timedOut: false
+            )
+        }
+
+        var timedOut = false
+        let timeoutItem = DispatchWorkItem {
+            if proc.isRunning {
+                timedOut = true
+                proc.terminate()
+                Thread.sleep(forTimeInterval: 0.5)
+                if proc.isRunning {
+                    kill(proc.processIdentifier, SIGKILL)
+                }
+            }
+        }
+        DispatchQueue.global().asyncAfter(
+            deadline: .now() + .seconds(timeLimitSeconds),
+            execute: timeoutItem
+        )
+
+        proc.waitUntilExit()
+        timeoutItem.cancel()
+
+        let elapsed = Int(Date().timeIntervalSince(start) * 1000)
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+        return ScriptOutput(
+            exitCode: timedOut ? -1 : proc.terminationStatus,
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? "",
+            executionTimeMs: elapsed,
+            timedOut: timedOut
+        )
+    }
+}
+
+// MARK: - Platform-specific sandbox setup
+
+private func configureSandboxedProcess(_ proc: Process, script: URL, workDir: URL) {
+#if os(macOS)
+    let profile = macOSSandboxProfile(workDir: workDir)
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")
+    proc.arguments = ["-p", profile, "/bin/sh", script.path]
+    proc.currentDirectoryURL = workDir
+#elseif os(Linux)
+    // unshare --user  : new user namespace — current UID maps to root inside
+    // unshare --net   : new network namespace — only loopback, no external routes
+    // --map-root-user : write uid_map/gid_map automatically (requires no extra
+    //                   privileges on kernels with unprivileged_userns_clone=1)
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/unshare")
+    proc.arguments = ["--user", "--net", "--map-root-user", "/bin/sh", script.path]
+    proc.currentDirectoryURL = workDir
+#else
+    // Fallback: unsandboxed (unknown platform). Matches UnsandboxedScriptRunner
+    // behaviour so the worker remains functional on unexpected targets.
+    proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+    proc.arguments = [script.path]
+    proc.currentDirectoryURL = workDir
+#endif
+}
+
+// MARK: - macOS sandbox profile
+
+#if os(macOS)
+private func macOSSandboxProfile(workDir: URL) -> String {
+    // Policy intent:
+    //   • Read the entire filesystem (system libs, JDK/Python runtimes, etc.)
+    //   • Write only inside the working directory and /dev/null
+    //   • Deny all network access (remote ip, tcp, udp)
+    //   • Allow process execution and forking (needed to run sub-commands)
+    let wd = workDir.path
+    return """
+    (version 1)
+    (deny default)
+    (allow file-read* (subpath "/"))
+    (allow file-write*
+        (subpath "\(wd)")
+        (literal "/dev/null")
+        (literal "/dev/stdout")
+        (literal "/dev/stderr"))
+    (allow process-exec process-fork)
+    (allow signal)
+    (allow sysctl-read)
+    (allow mach-lookup)
+    (deny network* (remote ip))
+    """
+}
+#endif

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -103,6 +103,84 @@ final class WorkerTests: XCTestCase {
         )
     }
 
+    // MARK: - SandboxedScriptRunner: basic execution
+
+    func testSandboxedRunnerExitZero() async throws {
+        let script = try writeScript("#!/bin/sh\nexit 0")
+        let runner = SandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertEqual(output.exitCode, 0)
+        XCTAssertFalse(output.timedOut)
+    }
+
+    func testSandboxedRunnerExitOne() async throws {
+        let script = try writeScript("#!/bin/sh\nexit 1")
+        let runner = SandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertEqual(output.exitCode, 1)
+        XCTAssertFalse(output.timedOut)
+    }
+
+    func testSandboxedRunnerCapturesStdout() async throws {
+        let script = try writeScript("#!/bin/sh\necho 'sandbox out'\nexit 0")
+        let runner = SandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertTrue(output.stdout.contains("sandbox out"))
+    }
+
+    func testSandboxedRunnerCapturesStderr() async throws {
+        let script = try writeScript("#!/bin/sh\necho 'sandbox err' >&2\nexit 0")
+        let runner = SandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        XCTAssertTrue(output.stderr.contains("sandbox err"))
+    }
+
+    func testSandboxedRunnerTimesOut() async throws {
+        let script = try writeScript("#!/bin/sh\nsleep 60\nexit 0")
+        let runner = SandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 1)
+        XCTAssertTrue(output.timedOut, "Sandboxed script sleeping 60s should time out with 1s limit")
+        XCTAssertEqual(output.exitCode, -1)
+    }
+
+    func testSandboxedRunnerWorkDir() async throws {
+        let script = try writeScript("#!/bin/sh\ntouch sandboxmarker.txt\nexit 0")
+        let runner = SandboxedScriptRunner()
+        _ = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let markerPath = tmpDir.appendingPathComponent("sandboxmarker.txt").path
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: markerPath),
+            "Sandboxed script should be able to write files in the working directory"
+        )
+    }
+
+    // MARK: - SandboxedScriptRunner: network isolation
+
+    func testSandboxedRunnerBlocksNetworkAccess() async throws {
+        // Write a script that tries to reach an external host.
+        // In a sandboxed network namespace this should fail (exit non-zero from python).
+        // The script exits 0 only if the connection SUCCEEDS — so we assert exit != 0.
+        let script = try writeScript("""
+        #!/bin/sh
+        python3 -c "
+        import socket, sys
+        s = socket.socket()
+        s.settimeout(2)
+        try:
+            s.connect(('8.8.8.8', 53))
+            sys.exit(0)
+        except OSError:
+            sys.exit(1)
+        "
+        """)
+        let runner = SandboxedScriptRunner()
+        let output = await runner.run(script: script, workDir: tmpDir, timeLimitSeconds: 10)
+        XCTAssertNotEqual(
+            output.exitCode, 0,
+            "Sandboxed runner should block outbound network access (exit 0 means connection succeeded)"
+        )
+    }
+
     // MARK: - ExponentialBackoff
 
     func testBackoffResetsToInitial() {


### PR DESCRIPTION
Implements the sandbox boundary described in CLAUDE.md. The existing ScriptRunner protocol is unchanged; no call sites required modification.

SandboxedScriptRunner (Sources/Worker/SandboxedScriptRunner.swift):
- On Linux: wraps execution with `unshare --user --net --map-root-user`, placing the subprocess in a private user namespace (UID mapped to unprivileged user) and a private network namespace (no external routes).
- On macOS: wraps execution with `sandbox-exec -p <profile>`, denying all network access and confining writes to the working directory.
- Same timeout enforcement, stdout/stderr capture, and exit-code mapping as UnsandboxedScriptRunner.

RunnerDaemon (Sources/Worker/RunnerDaemon.swift):
- Adds `--sandbox` boolean flag; instantiates SandboxedScriptRunner when set, UnsandboxedScriptRunner otherwise. Default remains unsandboxed for backward compatibility in development.

WorkerTests (Tests/WorkerTests/WorkerTests.swift):
- Adds six SandboxedScriptRunner tests covering exit codes, stdout/stderr capture, timeout enforcement, working-directory writes, and outbound network blocking.

README.md:
- Pulled latest from main (fast-forward).
- Rewrote to match the actual shell-script-based architecture (not the Python/Jupyter runner protocol described in the previous version).
- Added REST API table with Phase 3 endpoints, test script contract, manifest format, sandboxing section, and updated phase status table.

https://claude.ai/code/session_01QDQcFeMmYgfCJ2riHeYqDj