### PR TITLE
Rename executable targets to chickadee-server and chickadee-runner

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
 
         // MARK: - API Server executable
         .executableTarget(
-            name: "APIServer",
+            name: "chickadee-server",
             dependencies: [
                 .target(name: "Core"),
                 .product(name: "Vapor", package: "vapor"),
@@ -34,7 +34,7 @@ let package = Package(
 
         // MARK: - Worker executable
         .executableTarget(
-            name: "Worker",
+            name: "chickadee-runner",
             dependencies: [
                 .target(name: "Core"),
                 .product(name: "Vapor", package: "vapor"),
@@ -54,7 +54,7 @@ let package = Package(
         .testTarget(
             name: "APITests",
             dependencies: [
-                .target(name: "APIServer"),
+                .target(name: "chickadee-server"),
                 .product(name: "XCTVapor", package: "vapor"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
             ],
@@ -63,7 +63,7 @@ let package = Package(
         .testTarget(
             name: "WorkerTests",
             dependencies: [
-                .target(name: "Worker"),
+                .target(name: "chickadee-runner"),
             ],
             path: "Tests/WorkerTests"
         ),

--- a/README.md
+++ b/README.md
@@ -92,22 +92,30 @@ swift test
 Run the API server:
 
 ```bash
-swift run APIServer
+swift run chickadee-server
 ```
 
-Run the Worker, pointing it at a running API server:
+Run the worker, pointing it at a running API server:
 
 ```bash
-swift run Worker \
+swift run chickadee-runner \
   --api-base-url http://localhost:8080 \
   --worker-id    worker-1 \
   --max-jobs     4
 
 # With sandboxing enabled (recommended for production):
-swift run Worker \
+swift run chickadee-runner \
   --api-base-url http://localhost:8080 \
   --worker-id    worker-1 \
   --sandbox
+```
+
+`swift run` is a development convenience that builds and runs in one step. For production, build a release binary once and invoke it directly — no Swift toolchain is needed at runtime:
+
+```bash
+swift build -c release
+.build/release/chickadee-server
+.build/release/chickadee-runner --api-base-url http://api:8080 --worker-id w1 --sandbox
 ```
 
 ---

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -9,7 +9,7 @@ import Core
 @main
 struct WorkerCommand: AsyncParsableCommand {
     static var configuration = CommandConfiguration(
-        commandName: "Worker",
+        commandName: "chickadee-runner",
         abstract: "Chickadee build worker — polls the API server and processes submissions"
     )
 

--- a/Tests/APITests/ResultRoutesTests.swift
+++ b/Tests/APITests/ResultRoutesTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import XCTVapor
-@testable import APIServer
+@testable import chickadee_server
 @testable import Core
 import Foundation
 

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import XCTVapor
-@testable import APIServer
+@testable import chickadee_server
 @testable import Core
 import FluentSQLiteDriver
 import Foundation

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import Worker
+@testable import chickadee_runner
 import Foundation
 
 final class WorkerTests: XCTestCase {


### PR DESCRIPTION
Binary names now identify the project rather than using generic names. Source directories (Sources/APIServer/, Sources/Worker/) are unchanged — target name and path are independent in SPM.

- Package.swift: APIServer → chickadee-server, Worker → chickadee-runner; test target dependencies updated to match
- Sources/Worker/RunnerDaemon.swift: commandName → "chickadee-runner" (shown in --help usage line)
- Tests/: @testable import APIServer → chickadee_server, @testable import Worker → chickadee_runner (Swift maps hyphens to underscores in module names)
- README.md: update swift run examples to use new names; add note that swift run is a dev convenience — production runs the compiled binaries directly (.build/release/chickadee-server, .build/release/chickadee-runner)

https://claude.ai/code/session_01QDQcFeMmYgfCJ2riHeYqDj