### PR TITLE
Add MVP Leaf web UI for instructor and student workflows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", from: "4.89.0"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.9.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.6.0"),
+        .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ],
     targets: [
@@ -28,6 +29,7 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "Fluent", package: "fluent"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "Leaf", package: "leaf"),
             ],
             path: "Sources/APIServer"
         ),

--- a/Public/app.js
+++ b/Public/app.js
@@ -1,0 +1,52 @@
+// Drag-drop zone on the submission form
+const dropZone   = document.getElementById('drop-zone');
+const fileInput  = document.getElementById('file-input');
+const fileNameEl = document.getElementById('drop-filename');
+
+if (dropZone && fileInput) {
+    dropZone.addEventListener('click', () => fileInput.click());
+
+    dropZone.addEventListener('dragover', e => {
+        e.preventDefault();
+        dropZone.classList.add('drag-over');
+    });
+
+    dropZone.addEventListener('dragleave', () => {
+        dropZone.classList.remove('drag-over');
+    });
+
+    dropZone.addEventListener('drop', e => {
+        e.preventDefault();
+        dropZone.classList.remove('drag-over');
+        const file = e.dataTransfer.files[0];
+        if (file) {
+            const dt = new DataTransfer();
+            dt.items.add(file);
+            fileInput.files = dt.files;
+            fileNameEl.textContent = file.name;
+        }
+    });
+
+    fileInput.addEventListener('change', () => {
+        fileNameEl.textContent = fileInput.files[0]?.name ?? '';
+    });
+}
+
+// Results page: poll until the submission is no longer pending
+const root = document.getElementById('submission-root');
+if (root && root.dataset.pending === 'true') {
+    const submissionID = root.dataset.submissionId;
+    const poll = setInterval(async () => {
+        try {
+            const res = await fetch(`/api/v1/submissions/${submissionID}`);
+            if (!res.ok) return;
+            const data = await res.json();
+            if (data.status !== 'pending' && data.status !== 'assigned') {
+                clearInterval(poll);
+                window.location.reload();
+            }
+        } catch (_) {
+            // network blip — try again next tick
+        }
+    }, 2000);
+}

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1,0 +1,310 @@
+:root {
+    --blue:    #2563EB;
+    --green:   #16A34A;
+    --red:     #DC2626;
+    --purple:  #9333EA;
+    --amber:   #D97706;
+    --gray-50: #F9FAFB;
+    --gray-100: #F3F4F6;
+    --gray-200: #E5E7EB;
+    --gray-400: #9CA3AF;
+    --gray-600: #4B5563;
+    --gray-900: #111827;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: system-ui, -apple-system, sans-serif;
+    background: var(--gray-50);
+    color: var(--gray-900);
+    line-height: 1.5;
+}
+
+a { color: var(--blue); }
+
+/* ── Nav ─────────────────────────────────────────────── */
+
+.nav {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: .75rem 1.5rem;
+    background: white;
+    border-bottom: 1px solid var(--gray-200);
+}
+
+.nav-brand {
+    font-weight: 700;
+    font-size: 1.05rem;
+    text-decoration: none;
+    color: var(--gray-900);
+}
+
+.nav-link {
+    font-size: .875rem;
+    text-decoration: none;
+    color: var(--blue);
+}
+
+/* ── Main container ──────────────────────────────────── */
+
+.main {
+    max-width: 900px;
+    margin: 2rem auto;
+    padding: 0 1.5rem;
+}
+
+h1 { font-size: 1.4rem; margin-bottom: 1.25rem; }
+h2 { font-size: 1rem;   margin-bottom: .4rem; }
+
+/* ── Cards (test setup list) ─────────────────────────── */
+
+.card-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: .75rem;
+}
+
+.card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: .5rem;
+    padding: 1rem 1.25rem;
+    gap: 1rem;
+}
+
+.card-body  { flex: 1; }
+.card-title { font-size: .95rem; font-weight: 600; font-family: monospace; }
+.card-meta  { font-size: .8rem; color: var(--gray-600); margin-top: .2rem; }
+
+/* ── Buttons ─────────────────────────────────────────── */
+
+.btn {
+    display: inline-block;
+    padding: .45rem .9rem;
+    border-radius: .375rem;
+    font-size: .875rem;
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+    border: 1px solid var(--gray-200);
+    background: white;
+    color: var(--gray-900);
+    white-space: nowrap;
+}
+
+.btn-primary {
+    background: var(--blue);
+    border-color: var(--blue);
+    color: white;
+}
+
+.btn + .btn { margin-left: .5rem; }
+
+/* ── Forms ───────────────────────────────────────────── */
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    max-width: 620px;
+}
+
+.form-label {
+    display: flex;
+    flex-direction: column;
+    gap: .375rem;
+    font-size: .875rem;
+    font-weight: 500;
+}
+
+.form-input {
+    padding: .5rem .75rem;
+    border: 1px solid var(--gray-200);
+    border-radius: .375rem;
+    font-size: .875rem;
+    font-family: inherit;
+    background: white;
+}
+
+textarea.form-input {
+    resize: vertical;
+    font-family: monospace;
+    font-size: .8rem;
+}
+
+/* ── Drop zone ───────────────────────────────────────── */
+
+.drop-zone {
+    border: 2px dashed var(--gray-200);
+    border-radius: .5rem;
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color .15s, background .15s;
+    color: var(--gray-600);
+    font-size: .9rem;
+}
+
+.drop-zone.drag-over {
+    border-color: var(--blue);
+    background: #EFF6FF;
+}
+
+.drop-zone input[type=file] { display: none; }
+
+.drop-filename {
+    font-size: .85rem;
+    color: var(--gray-600);
+    min-height: 1.3rem;
+    margin-top: .35rem;
+}
+
+/* ── Pending spinner ─────────────────────────────────── */
+
+.pending-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 4rem 0;
+    color: var(--gray-600);
+}
+
+.spinner {
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 3px solid var(--gray-200);
+    border-top-color: var(--blue);
+    border-radius: 50%;
+    animation: spin .8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Build failure ───────────────────────────────────── */
+
+.error-box {
+    background: #FEF2F2;
+    border: 1px solid #FECACA;
+    border-radius: .5rem;
+    padding: 1.25rem 1.5rem;
+}
+
+.error-box h2 { color: var(--red); }
+
+.compiler-output {
+    margin-top: .75rem;
+    font-size: .78rem;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    background: white;
+    padding: .75rem;
+    border-radius: .25rem;
+    border: 1px solid #FECACA;
+}
+
+/* ── Results ─────────────────────────────────────────── */
+
+.submission-header { margin-bottom: 1.25rem; }
+
+.submission-meta {
+    font-size: .875rem;
+    color: var(--gray-600);
+    margin-top: .3rem;
+}
+
+.score {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.exec-time {
+    font-size: .875rem;
+    font-weight: 400;
+    color: var(--gray-600);
+}
+
+.results-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: .875rem;
+    background: white;
+    border: 1px solid var(--gray-200);
+    border-radius: .5rem;
+    overflow: hidden;
+}
+
+.results-table th {
+    text-align: left;
+    padding: .6rem .875rem;
+    border-bottom: 2px solid var(--gray-200);
+    color: var(--gray-600);
+    font-weight: 600;
+    font-size: .8rem;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+}
+
+.results-table td {
+    padding: .55rem .875rem;
+    border-bottom: 1px solid var(--gray-100);
+    vertical-align: top;
+}
+
+.results-table tr:last-child td { border-bottom: none; }
+
+.results-table .time {
+    text-align: right;
+    color: var(--gray-600);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+/* Status colour strips */
+.status-pass    td:first-child { border-left: 3px solid var(--green); }
+.status-fail    td:first-child { border-left: 3px solid var(--red); }
+.status-error   td:first-child { border-left: 3px solid var(--purple); }
+.status-timeout td:first-child { border-left: 3px solid var(--amber); }
+
+/* Tier badge */
+.tier {
+    display: inline-block;
+    font-size: .72rem;
+    padding: .1rem .4rem;
+    border-radius: 9999px;
+    background: var(--gray-100);
+    color: var(--gray-600);
+    font-weight: 500;
+}
+
+/* Long result expand */
+details > summary {
+    cursor: pointer;
+    color: var(--gray-600);
+    font-size: .8rem;
+    margin-top: .3rem;
+}
+
+details pre {
+    margin-top: .4rem;
+    font-size: .76rem;
+    white-space: pre-wrap;
+    background: var(--gray-50);
+    padding: .6rem .75rem;
+    border-radius: .25rem;
+    border: 1px solid var(--gray-200);
+    overflow-x: auto;
+}
+
+/* ── Misc ────────────────────────────────────────────── */
+
+.empty { color: var(--gray-600); font-size: .95rem; }
+
+code { font-family: ui-monospace, monospace; font-size: .9em; }

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>#import("title") — Chickadee</title>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<nav class="nav">
+    <a class="nav-brand" href="/">Chickadee</a>
+    <a class="nav-link" href="/testsetups/new">Upload Setup</a>
+</nav>
+<main class="main">
+    #import("content")
+</main>
+<script src="/app.js"></script>
+</body>
+</html>

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -1,0 +1,23 @@
+#extend("base"):
+#export("title"):
+Assignments
+#endexport
+#export("content"):
+<h1>Assignments</h1>
+#if(setups.isEmpty):
+<p class="empty">No test setups uploaded yet. <a href="/testsetups/new">Upload one</a>.</p>
+#else:
+<ul class="card-list">
+#for(setup in setups):
+<li class="card">
+    <div class="card-body">
+        <h2 class="card-title">#(setup.id)</h2>
+        <p class="card-meta">#(setup.suiteCount) test suite(s) · #(setup.createdAt)</p>
+    </div>
+    <a class="btn btn-primary" href="/testsetups/#(setup.id)/submit">Submit</a>
+</li>
+#endfor
+</ul>
+#endif
+#endexport
+#endextend

--- a/Resources/Views/setup-new.leaf
+++ b/Resources/Views/setup-new.leaf
@@ -1,0 +1,23 @@
+#extend("base"):
+#export("title"):
+Upload Test Setup
+#endexport
+#export("content"):
+<h1>Upload Test Setup</h1>
+<form class="form" method="post" action="/testsetups/new" enctype="multipart/form-data">
+    <label class="form-label">
+        Manifest JSON
+        <textarea class="form-input" name="manifest" rows="12" required
+            placeholder='{"schemaVersion":1,"requiredFiles":["warmup.py"],"testSuites":[{"tier":"public","script":"test_public.sh"}],"timeLimitSeconds":10,"makefile":null}'></textarea>
+    </label>
+    <label class="form-label">
+        Test Setup Zip
+        <input class="form-input" type="file" name="files" accept=".zip" required>
+    </label>
+    <div>
+        <button class="btn btn-primary" type="submit">Upload</button>
+        <a class="btn" href="/">Cancel</a>
+    </div>
+</form>
+#endexport
+#endextend

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -1,0 +1,66 @@
+#extend("base"):
+#export("title"):
+Submission #(submissionID)
+#endexport
+#export("content"):
+<div id="submission-root" data-submission-id="#(submissionID)" data-pending="#(isPending)">
+
+<div class="submission-header">
+    <h1>Submission <code>#(submissionID)</code></h1>
+    <p class="submission-meta">
+        Attempt #(attemptNumber) ·
+        <a href="/testsetups/#(testSetupID)/submit">← Submit again</a>
+    </p>
+</div>
+
+#if(isPending):
+<div class="pending-box">
+    <div class="spinner"></div>
+    <p>Waiting for a worker to pick up your submission…</p>
+</div>
+
+#elseif(buildFailed):
+<div class="error-box">
+    <h2>Build failed</h2>
+    #if(compilerOutput):
+    <pre class="compiler-output">#(compilerOutput)</pre>
+    #endif
+</div>
+
+#else:
+<p class="score">#(passCount) / #(totalTests) passed
+    <span class="exec-time">(#(executionTimeMs) ms total)</span>
+</p>
+<table class="results-table">
+    <thead>
+        <tr>
+            <th>Test</th>
+            <th>Tier</th>
+            <th>Result</th>
+            <th>ms</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(outcome in outcomes):
+        <tr class="status-#(outcome.status)">
+            <td><code>#(outcome.testName)</code></td>
+            <td><span class="tier">#(outcome.tier)</span></td>
+            <td>
+                #(outcome.shortResult)
+                #if(outcome.longResult):
+                <details>
+                    <summary>details</summary>
+                    <pre>#(outcome.longResult)</pre>
+                </details>
+                #endif
+            </td>
+            <td class="time">#(outcome.executionTimeMs)</td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+#endif
+
+</div>
+#endexport
+#endextend

--- a/Resources/Views/submit.leaf
+++ b/Resources/Views/submit.leaf
@@ -1,0 +1,20 @@
+#extend("base"):
+#export("title"):
+Submit Code
+#endexport
+#export("content"):
+<h1>Submit to <code>#(testSetupID)</code></h1>
+<form class="form" id="submit-form" method="post"
+    action="/testsetups/#(testSetupID)/submit" enctype="multipart/form-data">
+    <div class="drop-zone" id="drop-zone">
+        <p>Drag your submission zip here, or click to choose a file</p>
+        <input type="file" name="files" id="file-input" accept=".zip" required>
+    </div>
+    <p class="drop-filename" id="drop-filename"></p>
+    <div>
+        <button class="btn btn-primary" type="submit">Submit</button>
+        <a class="btn" href="/">Cancel</a>
+    </div>
+</form>
+#endexport
+#endextend

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -3,6 +3,7 @@
 import Vapor
 import Fluent
 import FluentSQLiteDriver
+import Leaf
 import Foundation
 
 @main
@@ -35,6 +36,11 @@ func configure(_ app: Application) throws {
     app.storage[ResultsDirectoryKey.self]     = resultsDir
     app.storage[TestSetupsDirectoryKey.self]  = setupsDir
     app.storage[SubmissionsDirectoryKey.self] = submissionsDir
+
+    // MARK: - Views + static files
+
+    app.views.use(.leaf)
+    app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
     // MARK: - Database
 

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -1,0 +1,252 @@
+// APIServer/Routes/Web/WebRoutes.swift
+//
+// Browser-facing routes for the Chickadee MVP web UI.
+// No authentication — all submissions are anonymous.
+//
+//   GET  /                          → index.leaf      (list test setups)
+//   GET  /testsetups/new            → setup-new.leaf  (instructor upload form)
+//   POST /testsetups/new            → save test setup, redirect to /
+//   GET  /testsetups/:id/submit     → submit.leaf     (student submission form)
+//   POST /testsetups/:id/submit     → save submission, redirect to /submissions/:id
+//   GET  /submissions/:id           → submission.leaf (live results)
+
+import Vapor
+import Fluent
+import Leaf
+import Core
+import Foundation
+
+struct WebRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get(use: index)
+        routes.get("testsetups", "new", use: newSetupForm)
+        routes.post("testsetups", "new", use: createSetup)
+        routes.get("testsetups", ":testSetupID", "submit", use: submitForm)
+        routes.post("testsetups", ":testSetupID", "submit", use: createSubmission)
+        routes.get("submissions", ":submissionID", use: submissionPage)
+    }
+
+    // MARK: - GET /
+
+    @Sendable
+    func index(req: Request) async throws -> View {
+        let setups = try await APITestSetup.query(on: req.db)
+            .sort(\.$createdAt, .descending)
+            .all()
+
+        let decoder = JSONDecoder()
+        let fmt = DateFormatter()
+        fmt.dateStyle = .medium
+        fmt.timeStyle = .short
+
+        let rows = setups.map { setup -> TestSetupRow in
+            let data  = Data(setup.manifest.utf8)
+            let props = try? decoder.decode(TestProperties.self, from: data)
+            return TestSetupRow(
+                id:        setup.id ?? "",
+                suiteCount: props?.testSuites.count ?? 0,
+                createdAt: setup.createdAt.map { fmt.string(from: $0) } ?? "—"
+            )
+        }
+
+        return try await req.view.render("index", IndexContext(setups: rows))
+    }
+
+    // MARK: - GET /testsetups/new
+
+    @Sendable
+    func newSetupForm(req: Request) async throws -> View {
+        try await req.view.render("setup-new", EmptyContext())
+    }
+
+    // MARK: - POST /testsetups/new
+
+    @Sendable
+    func createSetup(req: Request) async throws -> Response {
+        let upload = try req.content.decode(TestSetupUpload.self)
+
+        let manifestData = Data(upload.manifest.utf8)
+        let decoder      = JSONDecoder()
+        let manifest: TestProperties
+        do {
+            manifest = try decoder.decode(TestProperties.self, from: manifestData)
+        } catch {
+            throw Abort(.badRequest, reason: "Invalid manifest JSON: \(error)")
+        }
+        guard manifest.schemaVersion == 1 else {
+            throw Abort(.badRequest, reason: "Unsupported schemaVersion; expected 1")
+        }
+        guard !manifest.testSuites.isEmpty else {
+            throw Abort(.badRequest, reason: "Manifest must list at least one test suite")
+        }
+
+        let setupsDir = req.application.testSetupsDirectory
+        let setupID   = "setup_\(UUID().uuidString.lowercased().prefix(8))"
+        let zipPath   = setupsDir + "\(setupID).zip"
+        try upload.files.write(to: URL(fileURLWithPath: zipPath))
+
+        let encoder = JSONEncoder()
+        let stored  = String(data: try encoder.encode(manifest), encoding: .utf8) ?? upload.manifest
+        let setup   = APITestSetup(id: setupID, manifest: stored, zipPath: zipPath)
+        try await setup.save(on: req.db)
+
+        return req.redirect(to: "/")
+    }
+
+    // MARK: - GET /testsetups/:id/submit
+
+    @Sendable
+    func submitForm(req: Request) async throws -> View {
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let _ = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+        return try await req.view.render("submit", SubmitContext(testSetupID: setupID))
+    }
+
+    // MARK: - POST /testsetups/:id/submit
+
+    @Sendable
+    func createSubmission(req: Request) async throws -> Response {
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let _ = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        let body    = try req.content.decode(SubmitFormBody.self)
+        let subsDir = req.application.submissionsDirectory
+        let subID   = "sub_\(UUID().uuidString.lowercased().prefix(8))"
+        let zipPath = subsDir + "\(subID).zip"
+        try body.files.write(to: URL(fileURLWithPath: zipPath))
+
+        let priorCount = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .count()
+
+        let submission = APISubmission(
+            id:            subID,
+            testSetupID:   setupID,
+            zipPath:       zipPath,
+            attemptNumber: priorCount + 1
+        )
+        try await submission.save(on: req.db)
+
+        return req.redirect(to: "/submissions/\(subID)")
+    }
+
+    // MARK: - GET /submissions/:id
+
+    @Sendable
+    func submissionPage(req: Request) async throws -> View {
+        guard
+            let subID = req.parameters.get("submissionID"),
+            let submission = try await APISubmission.find(subID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        let isPending = submission.status == "pending" || submission.status == "assigned"
+        var buildFailed     = false
+        var compilerOutput: String? = nil
+        var outcomes:       [OutcomeRow] = []
+        var passCount       = 0
+        var totalTests      = 0
+        var executionTimeMs = 0
+
+        if !isPending {
+            if let result = try await APIResult.query(on: req.db)
+                .filter(\.$submissionID == subID)
+                .sort(\.$receivedAt, .descending)
+                .first()
+            {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                if let data       = result.collectionJSON.data(using: .utf8),
+                   let collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+                {
+                    buildFailed     = collection.buildStatus == .failed
+                    compilerOutput  = collection.compilerOutput
+                    passCount       = collection.passCount
+                    totalTests      = collection.totalTests
+                    executionTimeMs = collection.executionTimeMs
+                    outcomes = collection.outcomes.map { o in
+                        OutcomeRow(
+                            testName:        o.testName,
+                            tier:            o.tier.rawValue,
+                            status:          o.status.rawValue,
+                            shortResult:     o.shortResult,
+                            longResult:      o.longResult,
+                            executionTimeMs: o.executionTimeMs
+                        )
+                    }
+                }
+            }
+        }
+
+        let ctx = SubmissionContext(
+            submissionID:    subID,
+            testSetupID:     submission.testSetupID,
+            status:          submission.status,
+            attemptNumber:   submission.attemptNumber ?? 1,
+            isPending:       isPending,
+            buildFailed:     buildFailed,
+            compilerOutput:  compilerOutput,
+            outcomes:        outcomes,
+            passCount:       passCount,
+            totalTests:      totalTests,
+            executionTimeMs: executionTimeMs
+        )
+        return try await req.view.render("submission", ctx)
+    }
+}
+
+// MARK: - Context types
+
+private struct EmptyContext: Encodable {}
+
+private struct TestSetupRow: Encodable {
+    let id: String
+    let suiteCount: Int
+    let createdAt: String
+}
+
+private struct IndexContext: Encodable {
+    let setups: [TestSetupRow]
+}
+
+private struct SubmitContext: Encodable {
+    let testSetupID: String
+}
+
+private struct OutcomeRow: Encodable {
+    let testName: String
+    let tier: String
+    let status: String
+    let shortResult: String
+    let longResult: String?
+    let executionTimeMs: Int
+}
+
+private struct SubmissionContext: Encodable {
+    let submissionID: String
+    let testSetupID: String
+    let status: String
+    let attemptNumber: Int
+    let isPending: Bool
+    let buildFailed: Bool
+    let compilerOutput: String?
+    let outcomes: [OutcomeRow]
+    let passCount: Int
+    let totalTests: Int
+    let executionTimeMs: Int
+}
+
+// MARK: - Multipart body for code submission
+
+private struct SubmitFormBody: Content {
+    var files: Data
+}

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -3,6 +3,7 @@
 import Vapor
 
 func routes(_ app: Application) throws {
+    try app.register(collection: WebRoutes())
     try app.register(collection: ResultRoutes())
     try app.register(collection: SubmissionRoutes())
     try app.register(collection: SubmissionDownloadRoute())


### PR DESCRIPTION
- Add vapor/leaf dependency; configure Leaf + FileMiddleware in APIServerApp
- WebRoutes.swift: 6 handlers (test setup upload, student submission, live results)
- Leaf templates: base layout, index, setup-new, submit, submission pages
- Public/styles.css: flat stylesheet with card, button, drop zone, spinner, results table
- Public/app.js: drag-drop file zone + 2s polling with auto-reload on completion

https://claude.ai/code/session_01QDQcFeMmYgfCJ2riHeYqDj