### PR TITLE
Split README into project-level overview and per-component docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,12 @@ Three Swift targets share a clean dependency boundary:
 
 ```
 ┌─────────────────────────────────────────┐
-│             APIServer (Vapor)           │
-│  POST /api/v1/submissions               │
-│  GET  /api/v1/submissions               │
-│  GET  /api/v1/submissions/:id           │
-│  GET  /api/v1/submissions/:id/results   │
-│  POST /api/v1/worker/request            │
-│  POST /api/v1/worker/results            │
-│  POST /api/v1/testsetups                │
-│  GET  /api/v1/testsetups/:id/download   │
+│             chickadee-server            │
+│  REST API (Vapor) + Leaf web UI         │
 └──────────────────┬──────────────────────┘
                    │  SQLite (Fluent)
 ┌──────────────────▼──────────────────────┐
-│               Worker                    │
+│             chickadee-runner            │
 │  Polls for jobs → ScriptRunner          │
 │  Reports TestOutcomeCollection to API   │
 └──────────────────┬──────────────────────┘
@@ -43,9 +36,9 @@ Three Swift targets share a clean dependency boundary:
   (instructor-written shell scripts)
 ```
 
-**Core** — shared models with no Vapor dependency. Both APIServer and Worker depend on this.
+**Core** — shared models with no Vapor dependency. Both targets depend on this.
 
-**Shell scripts, not language runners.** Each test suite is a `.sh` file at the root of the instructor's test-setup zip. The worker runs them with `/bin/sh` and maps the exit code to a result. Any helper library (Python, Java, etc.) is bundled inside the zip by the instructor.
+**Shell scripts, not language runners.** Each test suite is a `.sh` file at the root of the instructor's test-setup zip. The runner executes them with `/bin/sh` and maps the exit code to a result. Any helper library (Python, Java, etc.) is bundled inside the zip by the instructor.
 
 ---
 
@@ -69,7 +62,7 @@ Three Swift targets share a clean dependency boundary:
 Chickadee/
 ├── Sources/
 │   ├── Core/          # Shared models — Codable, Sendable, no Vapor
-│   ├── APIServer/     # Vapor app, REST routes, Fluent migrations
+│   ├── APIServer/     # Vapor app, REST routes, Fluent migrations, Leaf UI
 │   └── Worker/        # Job poller, script runner, worker daemon
 ├── Tests/
 │   ├── CoreTests/     # Round-trip JSON encode/decode for all models
@@ -120,96 +113,13 @@ swift build -c release
 
 ---
 
-## REST API
+## Component docs
 
-Base path: `/api/v1`
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/submissions` | Submit a zip for grading (base-64 encoded body) |
-| `GET`  | `/submissions` | List submissions; optional `?testSetupID=` filter |
-| `GET`  | `/submissions/:id` | Submission status (`pending`/`assigned`/`complete`/`failed`) |
-| `GET`  | `/submissions/:id/results` | Full `TestOutcomeCollection`; optional `?tiers=public,student` filter |
-| `POST` | `/worker/request` | Worker claims the next pending job |
-| `POST` | `/worker/results` | Worker reports a completed `TestOutcomeCollection` |
-| `POST` | `/testsetups` | Instructor uploads a test-setup zip (multipart) |
-| `GET`  | `/testsetups/:id/download` | Download a test-setup zip |
-
----
-
-## Test script contract
-
-Each test suite is a shell script run as `/bin/sh <script>` from the test-setup directory as the working directory.
-
-| Exit code | Meaning |
-|-----------|---------|
-| `0` | pass |
-| `1` | fail |
-| `2` | error |
-| Killed after timeout | timeout |
-
-**stdout:** Everything is ignored except the last non-empty line, which is attempted as JSON:
-
-```json
-{ "shortResult": "3/4 cases passed" }
-```
-
-If the last line is not valid JSON it is used as plain-text `shortResult`. If stdout is empty, `shortResult` is synthesised from the exit code.
-
-**stderr:** Captured verbatim as `longResult` (nil if empty).
-
-Build failure (e.g. a `make` step that exits non-zero) is recorded at the collection level — `buildStatus: "failed"`, `outcomes: []`. There is no per-test "could not run" state.
-
----
-
-## Test setup manifest
-
-Stored as `test.properties.json` inside the instructor-uploaded test-setup zip.
-
-```json
-{
-  "schemaVersion": 1,
-  "requiredFiles": ["warmup.py"],
-  "testSuites": [
-    { "tier": "public",  "script": "test_public.sh"  },
-    { "tier": "release", "script": "test_release.sh" },
-    { "tier": "student", "script": "test_student.sh" }
-  ],
-  "timeLimitSeconds": 10,
-  "makefile": null
-}
-```
-
-When `makefile` is non-null, a `make` step runs before the test scripts. Set `"target": null` for bare `make` or `"target": "test"` for `make test`.
-
----
-
-## Test tiers
-
-| Tier | Shown to student |
-|------|-----------------|
-| `public` | Immediately after submission |
-| `release` | Hidden until deadline; unlocked on demand |
-| `secret` | Never shown |
-| `student` | Student-written tests, always visible |
-
-The `GET /submissions/:id/results` endpoint accepts a `?tiers=` query parameter to filter which tiers are returned. Aggregate counts (`passCount`, `failCount`, etc.) are recomputed to match the filtered set.
-
----
-
-## Sandboxing
-
-`ScriptRunner` is the sandbox boundary. Two implementations exist:
-
-- **`UnsandboxedScriptRunner`** — direct subprocess, no restrictions. Default when `--sandbox` is omitted. Suitable for development.
-- **`SandboxedScriptRunner`** — wraps execution in an OS-level sandbox. Use `--sandbox` in production.
-
-| Platform | Mechanism | What it restricts |
-|----------|-----------|------------------|
-| macOS | `sandbox-exec -p <profile>` | Network denied; writes confined to the working directory |
-| Linux | `unshare --user --net --map-root-user` | Private network namespace (no external routes); UID mapped to unprivileged user inside the namespace |
-
-Both implementations honour the same timeout, stdout/stderr capture, and exit-code mapping as the unsandboxed runner. No call sites change when switching between them.
+| Component | README |
+|-----------|--------|
+| Core (shared models) | [Sources/Core/README.md](Sources/Core/README.md) |
+| chickadee-server (API + web UI) | [Sources/APIServer/README.md](Sources/APIServer/README.md) |
+| chickadee-runner (worker) | [Sources/Worker/README.md](Sources/Worker/README.md) |
 
 ---
 

--- a/Sources/APIServer/README.md
+++ b/Sources/APIServer/README.md
@@ -1,0 +1,76 @@
+# chickadee-server
+
+Vapor 4 app. Exposes a REST API for workers and instructors, and a Leaf-rendered web UI for browser access.
+
+---
+
+## REST API
+
+Base path: `/api/v1`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/submissions` | Submit a zip for grading |
+| `GET`  | `/submissions` | List submissions; optional `?testSetupID=` filter |
+| `GET`  | `/submissions/:id` | Submission status (`pending`/`assigned`/`complete`/`failed`) |
+| `GET`  | `/submissions/:id/results` | Full `TestOutcomeCollection`; optional `?tiers=` filter |
+| `POST` | `/worker/request` | Worker claims the next pending job |
+| `POST` | `/worker/results` | Worker reports a completed `TestOutcomeCollection` |
+| `POST` | `/testsetups` | Instructor uploads a test-setup zip (multipart) |
+| `GET`  | `/testsetups/:id/download` | Download a test-setup zip |
+
+### Query parameters
+
+**`GET /submissions`** — `?testSetupID=<id>` filters to submissions for a single test setup.
+
+**`GET /submissions/:id/results`** — `?tiers=public,student` filters which tiers are included in the response. Aggregate counts (`passCount`, `failCount`, etc.) are recomputed to match the filtered set.
+
+---
+
+## Web UI
+
+Browser-facing routes rendered with Leaf templates. No authentication — all submissions are anonymous for MVP.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/` | Home page — lists all test setups |
+| `GET`  | `/testsetups/new` | Instructor upload form |
+| `POST` | `/testsetups/new` | Handle upload; redirect to `/` |
+| `GET`  | `/testsetups/:id/submit` | Student submission form |
+| `POST` | `/testsetups/:id/submit` | Save submission; redirect to `/submissions/:id` |
+| `GET`  | `/submissions/:id` | Live results page (polls API until complete) |
+
+Templates live in `Resources/Views/`. Static assets (CSS, JS) are served from `Public/`.
+
+---
+
+## Test setup manifest
+
+Stored as `test.properties.json` at the root of the instructor-uploaded zip.
+
+```json
+{
+  "schemaVersion": 1,
+  "requiredFiles": ["warmup.py"],
+  "testSuites": [
+    { "tier": "public",  "script": "test_public.sh"  },
+    { "tier": "release", "script": "test_release.sh" },
+    { "tier": "student", "script": "test_student.sh" }
+  ],
+  "timeLimitSeconds": 10,
+  "makefile": null
+}
+```
+
+When `makefile` is non-null, a `make` step runs before the test scripts. Set `"target": null` for bare `make` or `"target": "test"` for `make test`.
+
+---
+
+## Test tiers
+
+| Tier | Shown to student |
+|------|-----------------|
+| `public` | Immediately after submission |
+| `release` | Hidden until deadline; unlocked on demand |
+| `secret` | Never shown |
+| `student` | Student-written tests, always visible |

--- a/Sources/Core/README.md
+++ b/Sources/Core/README.md
@@ -1,0 +1,110 @@
+# Core
+
+Shared models and types. No Vapor dependency. Both `chickadee-server` and `chickadee-runner` depend on this target.
+
+**Rule:** all types must be `Codable`, `Sendable`, and import no Vapor symbols.
+
+---
+
+## Types
+
+### `TestStatus`
+
+The exhaustive set of states a single test case can be in. "Could not run" is not a valid state — build failures are represented at the collection level.
+
+| Case | Meaning |
+|------|---------|
+| `pass` | Test ran and all assertions passed |
+| `fail` | Test ran and an assertion failed |
+| `error` | Test ran but threw an unexpected exception or crash |
+| `timeout` | Test exceeded the time limit |
+
+### `TestTier`
+
+Controls visibility of test results to students.
+
+| Case | Raw value | Shown to student |
+|------|-----------|-----------------|
+| `pub` | `"public"` | Immediately after submission |
+| `release` | `"release"` | Hidden until deadline; unlocked on demand |
+| `secret` | `"secret"` | Never shown |
+| `student` | `"student"` | Student-written tests, always visible |
+
+The case is named `pub` (not `public`) because `public` is a Swift keyword. The JSON encoding uses `"public"`.
+
+### `TestOutcome`
+
+The complete record for a single test case execution.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `testName` | `String` | e.g. `"testBitCount"` |
+| `testClass` | `String?` | Always `nil` for shell-script runners |
+| `tier` | `TestTier` | |
+| `status` | `TestStatus` | |
+| `shortResult` | `String` | One-line human-readable summary |
+| `longResult` | `String?` | Full output, stack trace, diff, etc. |
+| `executionTimeMs` | `Int` | |
+| `memoryUsageBytes` | `Int?` | Gamification — `nil` until measured |
+| `attemptNumber` | `Int` | Which attempt this was (1-based) |
+| `isFirstPassSuccess` | `Bool` | `true` if passed on the very first attempt |
+
+### `BuildStatus`
+
+Collection-level build result.
+
+| Case | Meaning |
+|------|---------|
+| `passed` | Build succeeded; `outcomes` is populated |
+| `failed` | Build failed; `outcomes` is empty |
+| `skipped` | No build step (e.g. download-only dev mode) |
+
+### `TestOutcomeCollection`
+
+The complete result for one submission run, reported by the worker and stored by the server.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `submissionID` | `String` | |
+| `testSetupID` | `String` | |
+| `attemptNumber` | `Int` | |
+| `buildStatus` | `BuildStatus` | |
+| `compilerOutput` | `String?` | `nil` if build passed |
+| `outcomes` | `[TestOutcome]` | Empty if build failed |
+| `totalTests` | `Int` | Derived aggregate |
+| `passCount` | `Int` | |
+| `failCount` | `Int` | |
+| `errorCount` | `Int` | |
+| `timeoutCount` | `Int` | |
+| `executionTimeMs` | `Int` | Wall time for the full run |
+| `runnerVersion` | `String` | e.g. `"shell-runner/1.0"` |
+| `timestamp` | `Date` | |
+
+### `TestProperties`
+
+Decoded from `test.properties.json` inside the instructor-uploaded test-setup zip.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `schemaVersion` | `Int` | Currently `1` |
+| `requiredFiles` | `[String]` | Filenames that must exist in the submission |
+| `testSuites` | `[TestSuiteEntry]` | Ordered list of scripts to run |
+| `timeLimitSeconds` | `Int` | Per-script timeout |
+| `makefile` | `MakefileConfig?` | `nil` if no build step |
+
+**`TestSuiteEntry`** — `{ tier, script }` where `script` is a filename at the root of the test-setup zip.
+
+**`MakefileConfig`** — `{ target? }`. `nil` target means bare `make`; a non-nil target means `make <target>`.
+
+### `Job`
+
+Returned by `POST /api/v1/worker/request`. Carries everything a worker needs to run a submission without additional round-trips.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `submissionID` | `String` | |
+| `testSetupID` | `String` | |
+| `attemptNumber` | `Int` | |
+| `submissionURL` | `URL` | Worker GETs this to download the submission zip |
+| `testSetupURL` | `URL` | Worker GETs this to download the test-setup zip |
+| `manifest` | `TestProperties` | Parsed manifest — avoids a second round-trip |

--- a/Sources/Worker/README.md
+++ b/Sources/Worker/README.md
@@ -1,0 +1,65 @@
+# chickadee-runner
+
+Worker daemon. Polls the API server for pending jobs, runs instructor-defined shell-script test suites in subprocesses, and reports structured results back.
+
+---
+
+## CLI flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--api-base-url` | `String` | Base URL of the API server (e.g. `http://localhost:8080`) |
+| `--worker-id` | `String` | Unique identifier for this worker instance |
+| `--max-jobs` | `Int` | Maximum number of concurrent jobs |
+| `--sandbox` | `Bool` (flag) | Run test scripts inside a network-isolated, privilege-dropped sandbox |
+
+Example:
+
+```bash
+chickadee-runner \
+  --api-base-url http://localhost:8080 \
+  --worker-id    worker-1 \
+  --max-jobs     4 \
+  --sandbox
+```
+
+---
+
+## Test script contract
+
+Each test suite is a shell script run as `/bin/sh <script>` from the test-setup directory as the working directory.
+
+| Exit code | Outcome |
+|-----------|---------|
+| `0` | `pass` |
+| `1` | `fail` |
+| `2` | `error` |
+| Killed after timeout | `timeout` |
+
+**stdout:** Everything is ignored except the last non-empty line, which is attempted as JSON:
+
+```json
+{ "shortResult": "3/4 cases passed" }
+```
+
+If the last line is not valid JSON it is used as plain-text `shortResult`. If stdout is empty, `shortResult` is synthesised from the exit code (`"passed"` / `"failed"` / `"error"`).
+
+**stderr:** Captured verbatim as `longResult` (`nil` if empty).
+
+**Build failure:** If a `make` step exits non-zero, the run is recorded as `buildStatus: "failed"` with `outcomes: []`. There is no per-test "could not run" state.
+
+---
+
+## Sandboxing
+
+`ScriptRunner` is the sandbox boundary. Two implementations exist:
+
+- **`UnsandboxedScriptRunner`** — direct subprocess, no restrictions. Default when `--sandbox` is omitted. Suitable for development.
+- **`SandboxedScriptRunner`** — wraps execution in an OS-level sandbox. Enable with `--sandbox` in production.
+
+| Platform | Mechanism | Restrictions |
+|----------|-----------|-------------|
+| macOS | `sandbox-exec -p <profile>` | Network denied; file writes confined to the working directory |
+| Linux | `unshare --user --net --map-root-user` | Private network namespace (no external routes); UID mapped to unprivileged user inside the namespace |
+
+Both implementations honour the same timeout, stdout/stderr capture, and exit-code mapping as the unsandboxed runner. No call sites change when switching between them.


### PR DESCRIPTION
README.md is now a concise project overview (architecture, tech stack, build commands, phase status). Component-specific details move to:

- Sources/Core/README.md      — all shared model types with field tables
- Sources/APIServer/README.md — REST API, web UI routes, manifest format, tiers
- Sources/Worker/README.md    — CLI flags, test script contract, sandboxing

https://claude.ai/code/session_01QDQcFeMmYgfCJ2riHeYqDj