### PR TITLE
Phase 5: browser-based notebook grading with Pyodide

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1,146 +1,256 @@
-// notebook.js — Glue between the Chickadee parent page and the JupyterLite iframe.
+// Public/notebook.js
 //
-// Flow:
-//   1. Fetch the instructor's assignment.ipynb from the Chickadee server.
-//   2. Seed it into JupyterLite's IndexedDB storage (only on first visit; don't
-//      overwrite the student's existing work).
-//   3. Navigate the iframe to open the notebook.
-//   4. On Submit: read the current notebook from IndexedDB and POST it to
-//      POST /api/v1/submissions/file.
+// Chickadee in-browser grading engine.
+//
+// Loads the assignment notebook, lets the student edit it in JupyterLite,
+// then on "Submit" runs the notebook via Pyodide, collects per-test outcomes,
+// and POSTs a TestOutcomeCollection to POST /api/v1/submissions/browser-result.
 
-(async function () {
-    const frame   = document.getElementById('jl-frame');
+(function () {
+    'use strict';
+
+    const frame    = document.getElementById('jl-frame');
     const statusEl = document.getElementById('nb-status');
-    const setupID = frame.dataset.setupId;
+    const submitBtn = document.getElementById('nb-submit');
+    const setupID  = frame ? frame.dataset.setupId : null;
 
-    // JupyterLite storage constants (must match the built JupyterLite app).
-    const JL_DB_NAME    = 'JupyterLite Storage - ./';
-    const JL_STORE_NAME = 'files';
-    const NOTEBOOK_KEY  = 'assignment.ipynb';
+    if (!frame || !setupID) return;
 
-    // ── IndexedDB helpers ────────────────────────────────────────────────────
+    // -------------------------------------------------------------------------
+    // 1. Load JupyterLite in the iframe
+    // -------------------------------------------------------------------------
 
-    function openDB() {
-        return new Promise((resolve, reject) => {
-            const req = indexedDB.open(JL_DB_NAME);
-            req.onupgradeneeded = e => {
-                // Create the store if JupyterLite hasn't initialised it yet.
-                if (!e.target.result.objectStoreNames.contains(JL_STORE_NAME)) {
-                    e.target.result.createObjectStore(JL_STORE_NAME);
-                }
-            };
-            req.onsuccess = e => resolve(e.target.result);
-            req.onerror   = e => reject(e.target.error);
-        });
-    }
+    // Point the iframe at the embedded JupyterLite distribution.
+    // We pass the assignment notebook URL as a query parameter so JupyterLite
+    // can pre-populate it.
+    const notebookURL = `/api/v1/testsetups/${setupID}/assignment`;
+    frame.src = `/jupyterlite/index.html?path=assignment.ipynb&fromURL=${encodeURIComponent(notebookURL)}`;
 
-    function dbGet(db, key) {
-        return new Promise((resolve, reject) => {
-            const tx  = db.transaction(JL_STORE_NAME, 'readonly');
-            const req = tx.objectStore(JL_STORE_NAME).get(key);
-            req.onsuccess = e => resolve(e.target.result);
-            req.onerror   = e => reject(e.target.error);
-        });
-    }
+    // -------------------------------------------------------------------------
+    // 2. Submit button — run via Pyodide and POST results
+    // -------------------------------------------------------------------------
 
-    function dbPut(db, key, value) {
-        return new Promise((resolve, reject) => {
-            const tx  = db.transaction(JL_STORE_NAME, 'readwrite');
-            const req = tx.objectStore(JL_STORE_NAME).put(value, key);
-            req.onsuccess = () => resolve();
-            req.onerror   = e => reject(e.target.error);
-        });
-    }
+    submitBtn.addEventListener('click', async () => {
+        submitBtn.disabled = true;
+        setStatus('loading', 'Loading grading engine…');
 
-    // ── Seed the notebook on first visit ─────────────────────────────────────
-
-    async function seedNotebook() {
-        const db = await openDB();
-
-        // Don't overwrite existing student work.
-        const existing = await dbGet(db, NOTEBOOK_KEY);
-        if (existing) {
-            db.close();
-            return;
-        }
-
-        // Fetch the instructor's skeleton from our server.
-        let nb;
         try {
-            const res = await fetch(`/api/v1/testsetups/${setupID}/assignment`);
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            nb = await res.json();
+            // Fetch the notebook JSON directly (same file JupyterLite loaded).
+            const nbRes = await fetch(notebookURL);
+            if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
+            const notebook = await nbRes.json();
+
+            setStatus('loading', 'Running tests…');
+            const outcomes = await runNotebook(notebook);
+
+            setStatus('loading', 'Submitting…');
+            const collection = buildCollection(outcomes, setupID);
+            const response   = await postBrowserResult(collection, notebook, setupID);
+
+            // Redirect to the submission results page (shows browser preview
+            // immediately, polls for the official worker result).
+            window.location.href = `/submissions/${response.workerSubmissionID}`;
         } catch (err) {
-            console.warn('[Chickadee] Could not load assignment notebook:', err);
-            db.close();
-            return;
+            setStatus('error', `Error: ${err.message}`);
+            submitBtn.disabled = false;
         }
-
-        // Write the notebook model in the format JupyterLite's BrowserStorageDrive expects.
-        const now = new Date().toISOString();
-        const model = {
-            name:          NOTEBOOK_KEY,
-            path:          NOTEBOOK_KEY,
-            type:          'notebook',
-            format:        'json',
-            content:       nb,
-            mimetype:      'application/x-ipynb+json',
-            writable:      true,
-            created:       now,
-            last_modified: now,
-            size:          null,
-        };
-
-        await dbPut(db, NOTEBOOK_KEY, model);
-        db.close();
-    }
-
-    // ── Submit handler ────────────────────────────────────────────────────────
-
-    document.getElementById('nb-submit').addEventListener('click', async () => {
-        statusEl.textContent = 'Reading notebook…';
-
-        let model;
-        try {
-            const db = await openDB();
-            model    = await dbGet(db, NOTEBOOK_KEY);
-            db.close();
-        } catch (err) {
-            statusEl.textContent = 'Error reading notebook from storage.';
-            console.error('[Chickadee] IndexedDB read failed:', err);
-            return;
-        }
-
-        if (!model) {
-            statusEl.textContent = 'No notebook found — have you opened the assignment?';
-            return;
-        }
-
-        statusEl.textContent = 'Submitting…';
-
-        const nbJSON = JSON.stringify(model.content);
-        const blob   = new Blob([nbJSON], { type: 'application/json' });
-        const form   = new FormData();
-        form.append('testSetupID', setupID);
-        form.append('filename',    NOTEBOOK_KEY);
-        form.append('file',        blob, NOTEBOOK_KEY);
-
-        let json;
-        try {
-            const resp = await fetch('/api/v1/submissions/file', { method: 'POST', body: form });
-            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-            json = await resp.json();
-        } catch (err) {
-            statusEl.textContent = 'Submission failed — please try again.';
-            console.error('[Chickadee] Submission error:', err);
-            return;
-        }
-
-        window.location.href = `/submissions/${json.submissionID}`;
     });
 
-    // ── Boot sequence ─────────────────────────────────────────────────────────
+    // -------------------------------------------------------------------------
+    // 3. Pyodide execution engine
+    // -------------------------------------------------------------------------
 
-    await seedNotebook();
-    frame.src = `/jupyterlite/lab/index.html?path=${encodeURIComponent(NOTEBOOK_KEY)}`;
-}());
+    let pyodide = null;
+
+    async function loadPyodideOnce() {
+        if (pyodide) return pyodide;
+        // Pyodide is loaded from CDN the first time Submit is clicked.
+        if (!window.loadPyodide) {
+            await loadScript('https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js');
+        }
+        pyodide = await window.loadPyodide();
+        return pyodide;
+    }
+
+    // Run all cells in order; collect outcomes for TEST cells.
+    async function runNotebook(notebook) {
+        const py = await loadPyodideOnce();
+
+        // Reset the interpreter for a clean run.
+        await py.runPythonAsync('import sys; sys.modules.clear()');
+
+        const outcomes = [];
+
+        for (const cell of notebook.cells) {
+            if (cell.cell_type !== 'code') continue;
+
+            const source = Array.isArray(cell.source)
+                ? cell.source.join('')
+                : cell.source;
+
+            if (!source.trim()) continue;
+
+            const testMeta = parseTestComment(source);
+            const startMs  = Date.now();
+
+            if (testMeta) {
+                // This is a test cell — run it and record pass/fail.
+                const outcome = await runTestCell(py, source, testMeta, startMs);
+                outcomes.push(outcome);
+            } else {
+                // Regular cell — run it silently; exceptions propagate and abort.
+                try {
+                    await py.runPythonAsync(source);
+                } catch (err) {
+                    // A non-test cell threw — record a generic error and stop.
+                    outcomes.push({
+                        testName:          'setup_error',
+                        testClass:         null,
+                        tier:              'public',
+                        status:            'error',
+                        shortResult:       `Setup cell failed: ${err.message}`,
+                        longResult:        err.message,
+                        executionTimeMs:   Date.now() - startMs,
+                        memoryUsageBytes:  null,
+                        attemptNumber:     1,
+                        isFirstPassSuccess: false,
+                    });
+                    break;
+                }
+            }
+        }
+
+        return outcomes;
+    }
+
+    // Run a single test cell; return a TestOutcome-shaped object.
+    async function runTestCell(py, source, meta, startMs) {
+        let status      = 'pass';
+        let shortResult = 'passed';
+        let longResult  = null;
+
+        try {
+            await py.runPythonAsync(source);
+        } catch (err) {
+            const msg = err.message || String(err);
+            if (msg.includes('AssertionError') || msg.includes('assert')) {
+                status      = 'fail';
+                shortResult = 'failed';
+            } else {
+                status      = 'error';
+                shortResult = 'error';
+            }
+            longResult = msg;
+        }
+
+        return {
+            testName:          meta.name,
+            testClass:         null,
+            tier:              meta.tier,
+            status,
+            shortResult,
+            longResult,
+            executionTimeMs:   Date.now() - startMs,
+            memoryUsageBytes:  null,
+            attemptNumber:     1,
+            isFirstPassSuccess: status === 'pass',
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. # TEST: comment parser
+    //
+    // Format: # TEST: <name> [key=value ...]
+    // Supported keys: tier (default "public"), weight (reserved), requires (reserved)
+    // -------------------------------------------------------------------------
+
+    function parseTestComment(source) {
+        const firstLine = source.trimStart().split('\n')[0];
+        const match     = firstLine.match(/^#\s*TEST:\s*(\S+)(.*)/);
+        if (!match) return null;
+
+        const name   = match[1];
+        const kvStr  = match[2].trim();
+        const kvPairs = {};
+        for (const part of kvStr.split(/\s+/)) {
+            const [k, v] = part.split('=');
+            if (k && v !== undefined) kvPairs[k] = v;
+        }
+
+        return {
+            name,
+            tier:     kvPairs.tier     || 'public',
+            weight:   kvPairs.weight   ? parseFloat(kvPairs.weight) : null,
+            requires: kvPairs.requires ? kvPairs.requires.split(',') : [],
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. Build TestOutcomeCollection
+    // -------------------------------------------------------------------------
+
+    function buildCollection(outcomes, testSetupID) {
+        const pass    = outcomes.filter(o => o.status === 'pass').length;
+        const fail    = outcomes.filter(o => o.status === 'fail').length;
+        const error   = outcomes.filter(o => o.status === 'error').length;
+        const timeout = outcomes.filter(o => o.status === 'timeout').length;
+        const totalMs = outcomes.reduce((s, o) => s + o.executionTimeMs, 0);
+
+        return {
+            submissionID:    '',          // filled in by server
+            testSetupID,
+            attemptNumber:   1,           // server will recompute
+            buildStatus:     'passed',
+            compilerOutput:  null,
+            outcomes,
+            totalTests:      outcomes.length,
+            passCount:       pass,
+            failCount:       fail,
+            errorCount:      error,
+            timeoutCount:    timeout,
+            executionTimeMs: totalMs,
+            runnerVersion:   'browser-pyodide/1.0',
+            timestamp:       new Date().toISOString(),
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. POST to /api/v1/submissions/browser-result
+    // -------------------------------------------------------------------------
+
+    async function postBrowserResult(collection, notebook, testSetupID) {
+        const formData = new FormData();
+        formData.append('collection',  JSON.stringify(collection));
+        formData.append('notebook',    new Blob([JSON.stringify(notebook)], { type: 'application/json' }), 'notebook.ipynb');
+        formData.append('testSetupID', testSetupID);
+
+        const res = await fetch('/api/v1/submissions/browser-result', {
+            method: 'POST',
+            body:   formData,
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(`Server error ${res.status}: ${text}`);
+        }
+        return res.json();
+    }
+
+    // -------------------------------------------------------------------------
+    // 7. Helpers
+    // -------------------------------------------------------------------------
+
+    function setStatus(type, msg) {
+        statusEl.textContent  = msg;
+        statusEl.className    = `nb-status nb-status-${type}`;
+    }
+
+    function loadScript(src) {
+        return new Promise((resolve, reject) => {
+            const s  = document.createElement('script');
+            s.src    = src;
+            s.onload  = resolve;
+            s.onerror = () => reject(new Error(`Failed to load ${src}`));
+            document.head.appendChild(s);
+        });
+    }
+})();

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -3,7 +3,10 @@
 Submission #(submissionID)
 #endexport
 #export("content"):
-<div id="submission-root" data-submission-id="#(submissionID)" data-pending="#(isPending)">
+<div id="submission-root"
+     data-submission-id="#(submissionID)"
+     data-pending="#(isPending)"
+     data-browser-complete="#(isBrowserComplete)">
 
 <div class="submission-header">
     <h1>Submission <code>#(submissionID)</code></h1>
@@ -19,7 +22,17 @@ Submission #(submissionID)
     <p>Waiting for a worker to pick up your submission…</p>
 </div>
 
-#elseif(buildFailed):
+#else:
+
+#if(isBrowserComplete):
+<div class="info-box">
+    <strong>Preview result</strong> — your code ran in the browser.
+    The official grade is being computed by the server and will appear here automatically.
+    <div class="spinner spinner-inline"></div>
+</div>
+#endif
+
+#if(buildFailed):
 <div class="error-box">
     <h2>Build failed</h2>
     #if(compilerOutput):
@@ -30,6 +43,11 @@ Submission #(submissionID)
 #else:
 <p class="score">#(passCount) / #(totalTests) passed
     <span class="exec-time">(#(executionTimeMs) ms total)</span>
+    #if(isBrowserComplete):
+    <span class="result-source">(browser preview)</span>
+    #else:
+    <span class="result-source">(official)</span>
+    #endif
 </p>
 <table class="results-table">
     <thead>
@@ -59,6 +77,8 @@ Submission #(submissionID)
     #endfor
     </tbody>
 </table>
+#endif
+
 #endif
 
 </div>

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -57,6 +57,7 @@ func configure(_ app: Application) throws {
     app.migrations.add(CreateResults())
     app.migrations.add(AddAttemptNumberToSubmissions())
     app.migrations.add(AddFilenameToSubmissions())
+    app.migrations.add(AddSourceToResults())
 
     try app.autoMigrate().wait()
 

--- a/Sources/APIServer/Migrations/AddSourceToResults.swift
+++ b/Sources/APIServer/Migrations/AddSourceToResults.swift
@@ -1,0 +1,23 @@
+// APIServer/Migrations/AddSourceToResults.swift
+//
+// Adds a `source` column to the results table to distinguish browser-side
+// preliminary results from authoritative worker results.
+//
+//   source = "worker"  — result reported by a worker (official grade)
+//   source = "browser" — result reported by the student's browser (preview)
+
+import Fluent
+
+struct AddSourceToResults: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("results")
+            .field("source", .string)   // nullable on existing rows; treated as "worker"
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("results")
+            .deleteField("source")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIResult.swift
+++ b/Sources/APIServer/Models/APIResult.swift
@@ -15,14 +15,20 @@ final class APIResult: Model, Content, @unchecked Sendable {
     @Field(key: "collection_json")
     var collectionJSON: String  // serialised TestOutcomeCollection
 
+    /// "worker" (official, authoritative) or "browser" (student preview).
+    /// Nil on rows created before this migration — treated as "worker".
+    @OptionalField(key: "source")
+    var source: String?
+
     @Timestamp(key: "received_at", on: .create)
     var receivedAt: Date?
 
     init() {}
 
-    init(id: String, submissionID: String, collectionJSON: String) {
+    init(id: String, submissionID: String, collectionJSON: String, source: String = "worker") {
         self.id             = id
         self.submissionID   = submissionID
         self.collectionJSON = collectionJSON
+        self.source         = source
     }
 }

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -1,0 +1,124 @@
+// APIServer/Routes/BrowserResultRoutes.swift
+//
+// Phase 5: accepts grading results from the student's browser (Pyodide run)
+// and enqueues the notebook for an authoritative worker re-run.
+//
+//   POST /api/v1/submissions/browser-result
+//
+// Multipart body:
+//   collection  — JSON text of a TestOutcomeCollection
+//   notebook    — raw bytes of the student's .ipynb file
+//   testSetupID — ID of the test setup this submission targets
+
+import Vapor
+import Fluent
+import Core
+import Foundation
+
+struct BrowserResultRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.grouped("api", "v1", "submissions")
+            .post("browser-result", use: submitBrowserResult)
+    }
+
+    // MARK: - POST /api/v1/submissions/browser-result
+
+    @Sendable
+    func submitBrowserResult(req: Request) async throws -> BrowserResultResponse {
+        let body = try req.content.decode(BrowserResultBody.self)
+
+        // Validate the referenced test setup exists.
+        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
+            throw Abort(.badRequest, reason: "Unknown testSetupID: \(body.testSetupID)")
+        }
+
+        // Decode the TestOutcomeCollection the browser sent.
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let collection: TestOutcomeCollection
+        do {
+            guard let data = body.collection.data(using: .utf8) else {
+                throw Abort(.badRequest, reason: "collection is not valid UTF-8")
+            }
+            collection = try decoder.decode(TestOutcomeCollection.self, from: data)
+        } catch let e as DecodingError {
+            throw Abort(.unprocessableEntity, reason: "Invalid TestOutcomeCollection: \(e)")
+        }
+
+        // Persist the notebook to disk as the submission artifact.
+        let subsDir = req.application.submissionsDirectory
+        let subID   = "sub_\(UUID().uuidString.lowercased().prefix(8))"
+        let nbPath  = subsDir + "\(subID).ipynb"
+        try body.notebook.write(to: URL(fileURLWithPath: nbPath))
+
+        // Count prior submissions to derive the attempt number.
+        let priorCount = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == setup.id!)
+            .count()
+        let attemptNumber = priorCount + 1
+
+        // Create a submission record in "browser-complete" status.
+        // A second "pending" submission is NOT created here — the same record
+        // transitions to "pending" so the existing worker pull loop picks it up.
+        let submission = APISubmission(
+            id:            subID,
+            testSetupID:   setup.id!,
+            zipPath:       nbPath,
+            attemptNumber: attemptNumber,
+            status:        "browser-complete",
+            filename:      "\(subID).ipynb"
+        )
+        try await submission.save(on: req.db)
+
+        // Persist the browser result, tagged source="browser".
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let collectionJSON = try String(data: encoder.encode(collection), encoding: .utf8) ?? "{}"
+
+        let browserResult = APIResult(
+            id:             "res_\(UUID().uuidString.lowercased().prefix(8))",
+            submissionID:   subID,
+            collectionJSON: collectionJSON,
+            source:         "browser"
+        )
+        try await browserResult.save(on: req.db)
+
+        // Enqueue for the authoritative worker re-run by creating a second
+        // submission record pointing at the same notebook file.
+        let workerSubID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
+        let workerSub = APISubmission(
+            id:            workerSubID,
+            testSetupID:   setup.id!,
+            zipPath:       nbPath,
+            attemptNumber: attemptNumber,
+            status:        "pending",
+            filename:      "\(subID).ipynb"
+        )
+        try await workerSub.save(on: req.db)
+
+        req.logger.info("Browser result stored for \(subID); worker job queued as \(workerSubID)")
+
+        return BrowserResultResponse(
+            submissionID:       subID,
+            workerSubmissionID: workerSubID
+        )
+    }
+}
+
+// MARK: - Request / Response types
+
+struct BrowserResultBody: Content {
+    /// JSON-encoded TestOutcomeCollection from Pyodide.
+    var collection: String
+    /// Raw bytes of the student's .ipynb file.
+    var notebook: Data
+    /// The test setup this submission belongs to.
+    var testSetupID: String
+}
+
+struct BrowserResultResponse: Content {
+    /// ID of the record holding the browser preview result.
+    let submissionID: String
+    /// ID of the pending worker job (for polling the official result).
+    let workerSubmissionID: String
+}

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -9,4 +9,5 @@ func routes(_ app: Application) throws {
     try app.register(collection: SubmissionDownloadRoute())
     try app.register(collection: TestSetupRoutes())
     try app.register(collection: SubmissionQueryRoutes())
+    try app.register(collection: BrowserResultRoutes())
 }

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -3,6 +3,20 @@
 // Replaces legacy test.properties. Stored as JSON inside the test setup
 // zip uploaded by the instructor.
 
+/// Where and how a submission is graded.
+///
+/// - `browser`: The student's browser runs the notebook via Pyodide and POSTs
+///   a preliminary `TestOutcomeCollection`. The server also enqueues the
+///   submission for a worker re-run that produces the official grade.
+/// - `worker`: The submission is queued for a worker immediately on upload
+///   (existing behaviour for shell-script test suites).
+///
+/// Default when the field is absent from JSON: `.browser`.
+public enum GradingMode: String, Codable, Sendable, Equatable {
+    case browser
+    case worker
+}
+
 /// Entry for a single test in the manifest.
 /// `script` is the filename of the shell script at the root of the test setup zip.
 public struct TestSuiteEntry: Codable, Equatable, Sendable {
@@ -18,8 +32,19 @@ public struct MakefileConfig: Codable, Equatable, Sendable {
 /// Top-level manifest describing how to build and test a submission.
 public struct TestProperties: Codable, Equatable, Sendable {
     public let schemaVersion: Int
+    public let gradingMode: GradingMode
     public let requiredFiles: [String]
     public let testSuites: [TestSuiteEntry]
     public let timeLimitSeconds: Int
     public let makefile: MakefileConfig?
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion    = try c.decode(Int.self,                       forKey: .schemaVersion)
+        gradingMode      = try c.decodeIfPresent(GradingMode.self,      forKey: .gradingMode)      ?? .browser
+        requiredFiles    = try c.decodeIfPresent([String].self,         forKey: .requiredFiles)    ?? []
+        testSuites       = try c.decodeIfPresent([TestSuiteEntry].self, forKey: .testSuites)       ?? []
+        timeLimitSeconds = try c.decodeIfPresent(Int.self,              forKey: .timeLimitSeconds) ?? 10
+        makefile         = try c.decodeIfPresent(MakefileConfig.self,   forKey: .makefile)
+    }
 }

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -38,6 +38,8 @@ final class SubmissionQueryRoutesTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(AddAttemptNumberToSubmissions())
+        app.migrations.add(AddFilenameToSubmissions())
+        app.migrations.add(AddSourceToResults())
         try await app.autoMigrate().get()
 
         try routes(app)
@@ -108,7 +110,7 @@ final class SubmissionQueryRoutesTests: XCTestCase {
     private func makeOutcome(
         name: String,
         tier: TestTier = .pub,
-        status: TestOutcomeStatus = .pass
+        status: TestStatus = .pass
     ) -> TestOutcome {
         TestOutcome(
             testName: name,

--- a/Tests/CoreTests/CoreModelTests.swift
+++ b/Tests/CoreTests/CoreModelTests.swift
@@ -15,12 +15,12 @@ final class CoreModelTests: XCTestCase {
         return d
     }()
 
-    // MARK: - TestOutcomeStatus
+    // MARK: - TestStatus
 
-    func testTestOutcomeStatusRoundTrip() throws {
-        for status in [TestOutcomeStatus.pass, .fail, .error, .timeout] {
+    func testTestStatusRoundTrip() throws {
+        for status in [TestStatus.pass, .fail, .error, .timeout] {
             let data = try encoder.encode(status)
-            let decoded = try decoder.decode(TestOutcomeStatus.self, from: data)
+            let decoded = try decoder.decode(TestStatus.self, from: data)
             XCTAssertEqual(status, decoded)
         }
     }
@@ -42,12 +42,47 @@ final class CoreModelTests: XCTestCase {
         XCTAssertEqual(TestTier.student.rawValue, "student")
     }
 
+    // MARK: - GradingMode
+
+    func testGradingModeDefaultsBrowserWhenAbsent() throws {
+        let json = """
+        { "schemaVersion": 1 }
+        """.data(using: .utf8)!
+        let manifest = try decoder.decode(TestProperties.self, from: json)
+        XCTAssertEqual(manifest.gradingMode, .browser)
+    }
+
+    func testGradingModeExplicitBrowser() throws {
+        let json = """
+        { "schemaVersion": 1, "gradingMode": "browser" }
+        """.data(using: .utf8)!
+        let manifest = try decoder.decode(TestProperties.self, from: json)
+        XCTAssertEqual(manifest.gradingMode, .browser)
+    }
+
+    func testGradingModeExplicitWorker() throws {
+        let json = """
+        { "schemaVersion": 1, "gradingMode": "worker" }
+        """.data(using: .utf8)!
+        let manifest = try decoder.decode(TestProperties.self, from: json)
+        XCTAssertEqual(manifest.gradingMode, .worker)
+    }
+
+    func testGradingModeRoundTrip() throws {
+        for mode in [GradingMode.browser, .worker] {
+            let data = try encoder.encode(mode)
+            let decoded = try decoder.decode(GradingMode.self, from: data)
+            XCTAssertEqual(mode, decoded)
+        }
+    }
+
     // MARK: - TestProperties (no Makefile)
 
     func testTestPropertiesRoundTrip() throws {
         let json = """
         {
           "schemaVersion": 1,
+          "gradingMode": "worker",
           "requiredFiles": ["warmup.py"],
           "testSuites": [
             { "tier": "public",  "script": "test_bit_count.sh"  },
@@ -59,6 +94,7 @@ final class CoreModelTests: XCTestCase {
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
         XCTAssertEqual(manifest.schemaVersion, 1)
+        XCTAssertEqual(manifest.gradingMode, .worker)
         XCTAssertEqual(manifest.requiredFiles, ["warmup.py"])
         XCTAssertEqual(manifest.testSuites.count, 2)
         XCTAssertEqual(manifest.testSuites[0].script, "test_bit_count.sh")
@@ -77,6 +113,7 @@ final class CoreModelTests: XCTestCase {
         let json = """
         {
           "schemaVersion": 1,
+          "gradingMode": "worker",
           "requiredFiles": ["warmup.py"],
           "testSuites": [
             { "tier": "public", "script": "test_bit_count.sh" }
@@ -99,6 +136,7 @@ final class CoreModelTests: XCTestCase {
         let json = """
         {
           "schemaVersion": 1,
+          "gradingMode": "worker",
           "requiredFiles": ["warmup.py"],
           "testSuites": [
             { "tier": "public", "script": "test_bit_count.sh" }


### PR DESCRIPTION
Adds GradingMode to TestProperties (default: browser), a Pyodide-powered in-browser grading engine using # TEST: magic comments, and a dual-result display on the submission page (browser preview + official worker result).

Key changes:
- Core: GradingMode enum (browser/worker), gradingMode field on TestProperties
- API: POST /api/v1/submissions/browser-result endpoint stores browser result and enqueues a worker re-run for the official grade
- API: results.source migration ("browser" | "worker") to distinguish the two
- API: upload validation — browser mode requires .ipynb in zip, worker mode requires at least one test suite
- API: submission page prefers worker result, falls back to browser preview
- JS: Pyodide grading engine in notebook.js — executes cells, parses # TEST: name [tier=public weight=1.0] comments, POSTs TestOutcomeCollection
- UI: submission.leaf shows "Preview result / official grade pending" banner and polls until the worker result arrives
- Worker: fix sandbox-exec profile to use POSIX realpath(3) so write rules match /private/var/… paths on macOS (fixes testSandboxedRunnerWorkDir)
- Tests: GradingMode round-trip tests; fix TestOutcomeStatus → TestStatus; add missing migrations to ResultRoutesTests; fix tmpResultsDir trailing slash