### PR TITLE
Add inline test feedback on notebook page for intro-course students

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -349,3 +349,21 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     color: var(--gray-600);
     margin-top: .75rem;
 }
+
+/* ── Inline notebook results panel ───────────────────── */
+.nb-results {
+    margin-top: 1.25rem;
+    padding-bottom: 2rem;
+}
+
+.nb-results .score {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: .75rem;
+}
+
+.nb-results-link {
+    display: inline-block;
+    margin-top: .875rem;
+    font-size: .875rem;
+}

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -20,6 +20,7 @@ Notebook — #(testSetupID)
     data-setup-id="#(testSetupID)"
     allow="cross-origin-isolated">
 </iframe>
+<div id="nb-results" class="nb-results" hidden></div>
 <script src="/notebook.js"></script>
 #endexport
 #endextend


### PR DESCRIPTION
Results now render directly below the JupyterLite iframe after Submit, so students never need to navigate away to see what failed. Key changes:

- notebook.js: captureTraceback() asks Python's traceback/sys modules for a full formatted exception (file, line, message) instead of bare err.message
- AssertionError shortResult now surfaces the assertion message inline (e.g. "failed: expected 5, got 3") rather than just "failed"
- renderResults() builds a score line + results table reusing existing .results-table / .status-* CSS classes; includes "View official submission →" link to the permanent worker-graded record
- clearResults() wipes the panel on each re-submit for a clean re-run
- Submit button re-enabled after each run (via finally block)
- notebook.leaf: added <div id="nb-results"> below iframe
- styles.css: added .nb-results, .nb-results .score, .nb-results-link