### PR TITLE
Phase 8: instructor notebook editor

### DIFF
--- a/Public/setup-edit.js
+++ b/Public/setup-edit.js
@@ -1,0 +1,394 @@
+// Public/setup-edit.js
+//
+// Instructor notebook editor page (Phase 8).
+//
+// Two independent features:
+//
+// 1. SAVE — The instructor edits the notebook in JupyterLite, downloads it via
+//    JupyterLite's built-in "File → Download" menu, then uploads the .ipynb
+//    here. Clicking the "Save notebook…" label opens a file picker; on change
+//    the file is PUT to /api/v1/testsetups/:id/assignment.
+//
+// 2. RUN TESTS — Re-uses the full Pyodide engine from assignment-validate.js.
+//    The instructor uploads a .py solution file and the saved version of the
+//    notebook is fetched from the server (so they always test the saved state,
+//    not an in-memory draft).
+
+(function () {
+    'use strict';
+
+    const scriptEl     = document.currentScript;
+    const setupID      = scriptEl ? scriptEl.dataset.setupId      : null;
+    const assignmentID = scriptEl ? scriptEl.dataset.assignmentId : null;
+    const notebookURL  = scriptEl ? scriptEl.dataset.notebookUrl  : null;
+
+    // ── DOM refs ─────────────────────────────────────────────────────────────
+    const frame          = document.getElementById('jl-frame');
+    const saveFile       = document.getElementById('save-file');
+    const editStatus     = document.getElementById('edit-status');
+    const runBtn         = document.getElementById('run-btn');
+    const runPanel       = document.getElementById('run-panel');
+    const solutionFile   = document.getElementById('solution-file');
+    const runSolutionBtn = document.getElementById('run-solution-btn');
+    const validateStatus = document.getElementById('validate-status');
+    const resultsEl      = document.getElementById('validate-results');
+
+    if (!setupID || !frame) return;
+
+    // ── 1. Load JupyterLite ──────────────────────────────────────────────────
+    // We load the notebook from the server so the instructor sees the latest
+    // saved version (including any prior edits).
+    frame.src = `/jupyterlite/index.html?path=assignment.ipynb&fromURL=${encodeURIComponent(notebookURL)}`;
+
+    // ── 2. Save notebook ─────────────────────────────────────────────────────
+    // Workflow:
+    //   a. Instructor edits in JupyterLite.
+    //   b. Instructor chooses File → Download in JupyterLite to get the .ipynb.
+    //   c. Instructor clicks "Save notebook…" label → file picker opens.
+    //   d. On file selected: PUT raw JSON to /api/v1/testsetups/:id/assignment.
+
+    if (saveFile) {
+        saveFile.addEventListener('change', async () => {
+            const file = saveFile.files && saveFile.files[0];
+            if (!file) return;
+
+            setStatus(editStatus, 'loading', 'Saving…');
+
+            try {
+                const text = await readFileAsText(file);
+
+                // Basic JSON sanity check before uploading.
+                JSON.parse(text);
+
+                const res = await fetch(`/api/v1/testsetups/${setupID}/assignment`, {
+                    method:  'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body:    text,
+                });
+
+                if (res.ok) {
+                    setStatus(editStatus, 'ok', 'Saved ✓');
+                    setTimeout(() => setStatus(editStatus, '', ''), 4000);
+                } else {
+                    const msg = await res.text().catch(() => res.statusText);
+                    setStatus(editStatus, 'error', `Save failed: ${msg}`);
+                }
+            } catch (err) {
+                setStatus(editStatus, 'error', `Save failed: ${err.message}`);
+            } finally {
+                // Reset the file input so the same file can be selected again.
+                saveFile.value = '';
+            }
+        });
+    }
+
+    // ── 3. Run tests button ──────────────────────────────────────────────────
+    // Shows/hides the inline validation panel.
+
+    if (runBtn && runPanel) {
+        // Enable after page is interactive (always enabled — no prerequisite).
+        runBtn.disabled = false;
+
+        runBtn.addEventListener('click', () => {
+            runPanel.hidden = !runPanel.hidden;
+            if (!runPanel.hidden) {
+                runPanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    }
+
+    // Enable "Run" inside the panel when a solution file is selected.
+    if (solutionFile && runSolutionBtn) {
+        solutionFile.addEventListener('change', () => {
+            runSolutionBtn.disabled = !solutionFile.files || solutionFile.files.length === 0;
+        });
+    }
+
+    if (runSolutionBtn) {
+        runSolutionBtn.addEventListener('click', async () => {
+            if (!solutionFile || !solutionFile.files || solutionFile.files.length === 0) return;
+
+            runSolutionBtn.disabled = true;
+            clearResults();
+            setStatus(validateStatus, 'loading', 'Loading grading engine…');
+
+            try {
+                const solutionSource = await readFileAsText(solutionFile.files[0]);
+
+                // Always fetch the *server-saved* version of the notebook
+                // so that the run reflects the last saved state.
+                setStatus(validateStatus, 'loading', 'Fetching test definitions…');
+                const nbRes = await fetch(notebookURL);
+                if (!nbRes.ok) {
+                    throw new Error(`Could not fetch notebook: ${nbRes.status}. Save your edits first.`);
+                }
+                const notebook = await nbRes.json();
+
+                setStatus(validateStatus, 'loading', 'Running tests…');
+                const outcomes = await runSolutionAgainstNotebook(solutionSource, notebook);
+
+                renderResults(outcomes);
+                setStatus(validateStatus, '', '');
+            } catch (err) {
+                setStatus(validateStatus, 'error', `Error: ${err.message}`);
+            } finally {
+                runSolutionBtn.disabled = false;
+            }
+        });
+    }
+
+    // ── Pyodide execution engine ─────────────────────────────────────────────
+    // (Identical to assignment-validate.js — kept local to avoid a shared
+    //  module dependency for now.)
+
+    let pyodide = null;
+
+    async function loadPyodideOnce() {
+        if (pyodide) return pyodide;
+        if (!window.loadPyodide) {
+            await loadScript('https://cdn.jsdelivr.net/pyodide/v0.27.0/full/pyodide.js');
+        }
+        pyodide = await window.loadPyodide();
+        return pyodide;
+    }
+
+    async function runSolutionAgainstNotebook(solutionSource, notebook) {
+        const py = await loadPyodideOnce();
+
+        // Fresh interpreter for each run.
+        await py.runPythonAsync('import sys; sys.modules.clear()');
+
+        // Step 1: Execute the solution file.
+        try {
+            await py.runPythonAsync(solutionSource);
+        } catch (err) {
+            const longResult = await captureTraceback(py, err);
+            return [{
+                testName:          'solution_load_error',
+                testClass:         null,
+                tier:              'public',
+                status:            'error',
+                shortResult:       `Solution failed to load: ${firstLine(err.message)}`,
+                longResult,
+                executionTimeMs:   0,
+                memoryUsageBytes:  null,
+                attemptNumber:     1,
+                isFirstPassSuccess: false,
+            }];
+        }
+
+        // Step 2: Run setup cells, then test cells.
+        const outcomes = [];
+
+        for (const cell of notebook.cells) {
+            if (cell.cell_type !== 'code') continue;
+
+            const source = Array.isArray(cell.source)
+                ? cell.source.join('')
+                : cell.source;
+
+            if (!source.trim()) continue;
+
+            const testMeta = parseTestComment(source);
+            const startMs  = Date.now();
+
+            if (testMeta) {
+                const outcome = await runTestCell(py, source, testMeta, startMs);
+                outcomes.push(outcome);
+            } else {
+                try {
+                    await py.runPythonAsync(source);
+                } catch (err) {
+                    const longResult = await captureTraceback(py, err);
+                    outcomes.push({
+                        testName:          'setup_error',
+                        testClass:         null,
+                        tier:              'public',
+                        status:            'error',
+                        shortResult:       `Setup cell failed: ${firstLine(err.message)}`,
+                        longResult,
+                        executionTimeMs:   Date.now() - startMs,
+                        memoryUsageBytes:  null,
+                        attemptNumber:     1,
+                        isFirstPassSuccess: false,
+                    });
+                    break;
+                }
+            }
+        }
+
+        return outcomes;
+    }
+
+    async function runTestCell(py, source, meta, startMs) {
+        let status      = 'pass';
+        let shortResult = 'passed';
+        let longResult  = null;
+
+        try {
+            await py.runPythonAsync(source);
+        } catch (err) {
+            const msg = err.message || String(err);
+            longResult = await captureTraceback(py, err);
+
+            if (msg.includes('AssertionError') || msg.includes('assert')) {
+                status = 'fail';
+                const assertMsg = extractAssertionMessage(msg);
+                shortResult = assertMsg
+                    ? `failed: ${assertMsg.substring(0, 80)}`
+                    : 'failed';
+            } else {
+                status      = 'error';
+                shortResult = `error: ${firstLine(msg).substring(0, 80)}`;
+            }
+        }
+
+        return {
+            testName:          meta.name,
+            testClass:         null,
+            tier:              meta.tier,
+            status,
+            shortResult,
+            longResult,
+            executionTimeMs:   Date.now() - startMs,
+            memoryUsageBytes:  null,
+            attemptNumber:     1,
+            isFirstPassSuccess: status === 'pass',
+        };
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function captureTraceback(py, err) {
+        try {
+            const tb = await py.runPythonAsync(`
+import traceback, sys
+_exc = sys.last_value
+if _exc is not None:
+    ''.join(traceback.format_exception(type(_exc), _exc, _exc.__traceback__))
+else:
+    ''
+`);
+            return tb.trim() || (err.message || String(err));
+        } catch (_) {
+            return err.message || String(err);
+        }
+    }
+
+    function extractAssertionMessage(msg) {
+        const line = msg.split('\n').find(l => l.includes('AssertionError'));
+        if (!line) return null;
+        const colon = line.indexOf(':');
+        return colon >= 0 ? line.slice(colon + 1).trim() : null;
+    }
+
+    function firstLine(msg) {
+        return (msg || '').split('\n')[0].trim();
+    }
+
+    function parseTestComment(source) {
+        const line  = source.trimStart().split('\n')[0];
+        const match = line.match(/^#\s*TEST:\s*(\S+)(.*)/);
+        if (!match) return null;
+        const name  = match[1];
+        const kvStr = match[2].trim();
+        const kv    = {};
+        for (const part of kvStr.split(/\s+/)) {
+            const [k, v] = part.split('=');
+            if (k && v !== undefined) kv[k] = v;
+        }
+        return { name, tier: kv.tier || 'public' };
+    }
+
+    function readFileAsText(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload  = e => resolve(e.target.result);
+            reader.onerror = () => reject(new Error('Could not read file'));
+            reader.readAsText(file);
+        });
+    }
+
+    // ── Results rendering ────────────────────────────────────────────────────
+
+    function clearResults() {
+        if (resultsEl) {
+            resultsEl.hidden    = true;
+            resultsEl.innerHTML = '';
+        }
+    }
+
+    function renderResults(outcomes) {
+        if (!resultsEl) return;
+
+        const pass    = outcomes.filter(o => o.status === 'pass').length;
+        const total   = outcomes.length;
+        const totalMs = outcomes.reduce((s, o) => s + o.executionTimeMs, 0);
+        const allPassed = pass === total && total > 0;
+
+        const scoreEl = document.createElement('p');
+        scoreEl.className = 'score';
+        scoreEl.innerHTML =
+            `${pass} / ${total} passed ` +
+            `<span class="exec-time">(${totalMs} ms)</span>` +
+            (allPassed ? ' <span style="color:var(--green)">✓ All tests passed!</span>' : '');
+
+        const table = document.createElement('table');
+        table.className = 'results-table';
+        table.innerHTML = `
+            <thead>
+                <tr>
+                    <th>Test</th>
+                    <th>Tier</th>
+                    <th>Result</th>
+                    <th>ms</th>
+                </tr>
+            </thead>`;
+
+        const tbody = document.createElement('tbody');
+        for (const o of outcomes) {
+            const tr = document.createElement('tr');
+            tr.className = `status-${o.status}`;
+            const longCell = o.longResult
+                ? `<details><summary>details</summary><pre>${escHtml(o.longResult)}</pre></details>`
+                : '';
+            tr.innerHTML = `
+                <td><code>${escHtml(o.testName)}</code></td>
+                <td><span class="tier">${escHtml(o.tier)}</span></td>
+                <td>${escHtml(o.shortResult)}${longCell}</td>
+                <td class="time">${o.executionTimeMs}</td>`;
+            tbody.appendChild(tr);
+        }
+        table.appendChild(tbody);
+
+        resultsEl.innerHTML = '';
+        resultsEl.appendChild(scoreEl);
+        resultsEl.appendChild(table);
+        resultsEl.hidden = false;
+        resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    function escHtml(str) {
+        return String(str ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function setStatus(el, type, msg) {
+        if (!el) return;
+        el.textContent = msg;
+        el.className   = `nb-status${type ? ' nb-status-' + type : ''}`;
+    }
+
+    function loadScript(src) {
+        return new Promise((resolve, reject) => {
+            const s   = document.createElement('script');
+            s.src     = src;
+            s.onload  = resolve;
+            s.onerror = () => reject(new Error(`Failed to load ${src}`));
+            document.head.appendChild(s);
+        });
+    }
+})();

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -67,6 +67,8 @@ Assignments
                         <button class="btn" type="submit"
                                 style="font-size:.8rem;padding:.25rem .6rem">Reopen</button>
                     </form>
+                    <a class="btn" href="/assignments/#(row.assignmentID)/edit"
+                       style="font-size:.8rem;padding:.25rem .6rem">Edit notebook</a>
                     <form method="post" action="/assignments/#(row.assignmentID)/delete"
                           onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                         <button class="btn" type="submit"
@@ -74,10 +76,14 @@ Assignments
                     </form>
                 </div>
                 #elseif(row.status == "open"):
-                <form method="post" action="/assignments/#(row.assignmentID)/close">
-                    <button class="btn" type="submit"
-                            style="font-size:.8rem;padding:.25rem .6rem">Close</button>
-                </form>
+                <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    <form method="post" action="/assignments/#(row.assignmentID)/close">
+                        <button class="btn" type="submit"
+                                style="font-size:.8rem;padding:.25rem .6rem">Close</button>
+                    </form>
+                    <a class="btn" href="/assignments/#(row.assignmentID)/edit"
+                       style="font-size:.8rem;padding:.25rem .6rem">Edit notebook</a>
+                </div>
                 #else:
                 <!-- draft — not yet validated/opened -->
                 <a class="btn btn-primary" href="/assignments/#(row.assignmentID)/validate"

--- a/Resources/Views/setup-edit.leaf
+++ b/Resources/Views/setup-edit.leaf
@@ -1,0 +1,66 @@
+#extend("base"):
+#export("title"):
+Edit — #(title)
+#endexport
+#export("content"):
+<style>
+/* Override the 900px max-width for the editor page only */
+.main { max-width: 100%; padding: 0 1rem; }
+</style>
+
+<div class="notebook-header">
+    <div>
+        <h1 style="margin:0">Edit — #(title)</h1>
+        <p class="card-meta" style="margin:.25rem 0 0"><code>#(setupID)</code></p>
+    </div>
+    <div class="notebook-toolbar" style="gap:.5rem;flex-wrap:wrap;align-items:center">
+        <!-- Save: upload file from JupyterLite's Download → then upload here -->
+        <label class="btn btn-primary" id="save-label" title="Download the notebook from JupyterLite (File → Download), then upload it here to save to the server">
+            Save notebook…
+            <input type="file" id="save-file" accept=".ipynb" style="display:none">
+        </label>
+        <button class="btn" id="run-btn" disabled title="Upload a .py solution file and run tests against the saved notebook">Run tests…</button>
+        <span id="edit-status" class="nb-status"></span>
+        <a class="btn" href="/assignments" style="margin-left:.5rem">← Assignments</a>
+    </div>
+</div>
+
+<!-- JupyterLite iframe (editable) -->
+<iframe
+    id="jl-frame"
+    class="jl-frame"
+    data-setup-id="#(setupID)"
+    data-assignment-id="#(assignmentID)"
+    data-notebook-url="#(notebookURL)"
+    allow="cross-origin-isolated"
+    style="height:68vh;width:100%;border:none;display:block">
+</iframe>
+
+<!-- Run tests panel (hidden until "Run tests…" is clicked) -->
+<div id="run-panel" hidden style="margin-top:1rem;padding:1rem;background:var(--surface);border:1px solid var(--border);border-radius:6px">
+    <h3 style="margin:0 0 .75rem">Validate solution</h3>
+    <p style="margin:0 0 .75rem;font-size:.9rem;color:var(--gray-600)">
+        Upload a reference solution (.py) to run against the <em>currently saved</em> version of the notebook.
+        Save your edits first, then run.
+    </p>
+    <label class="form-label" style="max-width:480px;margin-bottom:.75rem">
+        Solution file (.py)
+        <input class="form-input" id="solution-file" type="file" accept=".py,.ipynb">
+    </label>
+    <div style="display:flex;gap:.75rem;align-items:center;flex-wrap:wrap">
+        <button class="btn btn-primary" id="run-solution-btn" disabled>Run</button>
+        <span id="validate-status" class="nb-status"></span>
+    </div>
+</div>
+
+<!-- Inline results (hidden until run) -->
+<div id="validate-results" hidden style="margin-top:1rem"></div>
+
+<script
+    data-setup-id="#(setupID)"
+    data-assignment-id="#(assignmentID)"
+    data-notebook-url="#(notebookURL)"
+    src="/setup-edit.js">
+</script>
+#endexport
+#endextend

--- a/Resources/Views/setup-new.leaf
+++ b/Resources/Views/setup-new.leaf
@@ -5,19 +5,93 @@ Upload Test Setup
 #export("content"):
 <h1>Upload Test Setup</h1>
 <form class="form" method="post" action="/testsetups/new" enctype="multipart/form-data">
+
+    <!-- ── Grading mode ─────────────────────────────────────── -->
+    <fieldset style="border:1px solid var(--border);border-radius:6px;padding:.75rem 1rem;margin-bottom:1.25rem">
+        <legend style="padding:0 .4rem;font-weight:600;font-size:.9rem">Grading mode</legend>
+        <label style="display:flex;align-items:center;gap:.5rem;margin-bottom:.4rem;cursor:pointer">
+            <input type="radio" name="gradingMode" value="browser" checked
+                   onchange="toggleMode(this.value)">
+            <span><strong>Browser</strong> — students run tests in-browser via Pyodide · upload <code>.ipynb</code></span>
+        </label>
+        <label style="display:flex;align-items:center;gap:.5rem;cursor:pointer">
+            <input type="radio" name="gradingMode" value="worker"
+                   onchange="toggleMode(this.value)">
+            <span><strong>Worker</strong> — server-side shell scripts · upload <code>.zip</code></span>
+        </label>
+    </fieldset>
+
+    <!-- ── Manifest JSON ────────────────────────────────────── -->
     <label class="form-label">
         Manifest JSON
-        <textarea class="form-input" name="manifest" rows="12" required
-            placeholder='{"schemaVersion":1,"requiredFiles":["warmup.py"],"testSuites":[{"tier":"public","script":"test_public.sh"}],"timeLimitSeconds":10,"makefile":null}'></textarea>
+        <textarea class="form-input" name="manifest" id="manifest-field" rows="8" required
+            placeholder='{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}'></textarea>
     </label>
-    <label class="form-label">
-        Test Setup Zip
-        <input class="form-input" type="file" name="files" accept=".zip" required>
-    </label>
-    <div>
+
+    <!-- ── Browser mode: single .ipynb ─────────────────────── -->
+    <div id="upload-browser">
+        <label class="form-label">
+            Notebook (<code>.ipynb</code>)
+            <input class="form-input" type="file" name="files" id="nb-input" accept=".ipynb" required>
+        </label>
+        <p class="card-meta" style="margin-top:.25rem;font-size:.82rem">
+            The notebook must contain at least one code cell with a
+            <code># TEST: name</code> comment.
+        </p>
+    </div>
+
+    <!-- ── Worker mode: zip ─────────────────────────────────── -->
+    <div id="upload-worker" style="display:none">
+        <label class="form-label">
+            Test Setup Zip (<code>.zip</code>)
+            <input class="form-input" type="file" name="files" id="zip-input" accept=".zip">
+        </label>
+        <p class="card-meta" style="margin-top:.25rem;font-size:.82rem">
+            Zip must contain test scripts as <code>.sh</code> files at the root.
+        </p>
+    </div>
+
+    <div style="margin-top:1rem">
         <button class="btn btn-primary" type="submit">Upload</button>
         <a class="btn" href="/">Cancel</a>
     </div>
 </form>
+
+<script>
+(function () {
+    var templates = {
+        browser: '{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}',
+        worker:  '{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_public.sh"}],"timeLimitSeconds":10,"makefile":null}'
+    };
+
+    var manifestField = document.getElementById('manifest-field');
+    var uploadBrowser = document.getElementById('upload-browser');
+    var uploadWorker  = document.getElementById('upload-worker');
+    var nbInput       = document.getElementById('nb-input');
+    var zipInput      = document.getElementById('zip-input');
+
+    window.toggleMode = function (mode) {
+        var isBrowser = mode === 'browser';
+        uploadBrowser.style.display = isBrowser ? '' : 'none';
+        uploadWorker.style.display  = isBrowser ? 'none' : '';
+
+        // Swap required so HTML5 validation fires on the right input.
+        if (nbInput)  nbInput.required  = isBrowser;
+        if (zipInput) zipInput.required = !isBrowser;
+
+        // Pre-populate manifest template when blank or at a known default.
+        if (manifestField && (
+            manifestField.value === '' ||
+            manifestField.value === templates.browser ||
+            manifestField.value === templates.worker
+        )) {
+            manifestField.value = templates[mode];
+        }
+    };
+
+    // Initialise.
+    toggleMode('browser');
+})();
+</script>
 #endexport
 #endextend

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -66,6 +66,7 @@ func configure(_ app: Application) throws {
     app.migrations.add(CreateUsers())
     app.migrations.add(CreateAssignments())
     app.migrations.add(AddUserIDToSubmissions())
+    app.migrations.add(AddNotebookPathToTestSetups())
 
     try app.autoMigrate().wait()
 

--- a/Sources/APIServer/Migrations/AddNotebookPathToTestSetups.swift
+++ b/Sources/APIServer/Migrations/AddNotebookPathToTestSetups.swift
@@ -1,0 +1,21 @@
+// APIServer/Migrations/AddNotebookPathToTestSetups.swift
+//
+// Phase 8: adds a nullable notebook_path column to test_setups.
+// Browser-mode setups store the flat .ipynb file path here so instructors
+// can edit and re-save notebooks without re-uploading the zip.
+
+import Fluent
+
+struct AddNotebookPathToTestSetups: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("test_setups")
+            .field("notebook_path", .string)    // nullable — nil for worker-mode setups
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("test_setups")
+            .deleteField("notebook_path")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APITestSetup.swift
+++ b/Sources/APIServer/Models/APITestSetup.swift
@@ -16,14 +16,22 @@ final class APITestSetup: Model, Content, @unchecked Sendable {
     @Field(key: "zip_path")
     var zipPath: String
 
+    /// Path to the flat `.ipynb` file on disk (browser-mode setups only).
+    /// Nil for worker-mode setups. Set when the setup is first uploaded
+    /// (browser-mode) or after the instructor saves edits via
+    /// `PUT /api/v1/testsetups/:id/assignment`.
+    @OptionalField(key: "notebook_path")
+    var notebookPath: String?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
     init() {}
 
-    init(id: String, manifest: String, zipPath: String) {
-        self.id       = id
-        self.manifest = manifest
-        self.zipPath  = zipPath
+    init(id: String, manifest: String, zipPath: String, notebookPath: String? = nil) {
+        self.id           = id
+        self.manifest     = manifest
+        self.zipPath      = zipPath
+        self.notebookPath = notebookPath
     }
 }

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -48,6 +48,7 @@ final class AssignmentRoutesTests: XCTestCase {
         app.migrations.add(CreateUsers())
         app.migrations.add(CreateAssignments())
         app.migrations.add(AddUserIDToSubmissions())
+        app.migrations.add(AddNotebookPathToTestSetups())
         try await app.autoMigrate().get()
 
         try routes(app)

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -40,6 +40,7 @@ final class AuthRoutesTests: XCTestCase {
         app.migrations.add(CreateUsers())
         app.migrations.add(CreateAssignments())
         app.migrations.add(AddUserIDToSubmissions())
+        app.migrations.add(AddNotebookPathToTestSetups())
         try await app.autoMigrate().get()
 
         try routes(app)

--- a/Tests/APITests/ResultRoutesTests.swift
+++ b/Tests/APITests/ResultRoutesTests.swift
@@ -38,6 +38,7 @@ final class ResultRoutesTests: XCTestCase {
         app.migrations.add(CreateUsers())
         app.migrations.add(CreateAssignments())
         app.migrations.add(AddUserIDToSubmissions())
+        app.migrations.add(AddNotebookPathToTestSetups())
         try await app.autoMigrate().get()
 
         try routes(app)

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -47,6 +47,7 @@ final class SubmissionQueryRoutesTests: XCTestCase {
         app.migrations.add(CreateUsers())
         app.migrations.add(CreateAssignments())
         app.migrations.add(AddUserIDToSubmissions())
+        app.migrations.add(AddNotebookPathToTestSetups())
         try await app.autoMigrate().get()
 
         try routes(app)

--- a/Tests/APITests/TestSetupEditTests.swift
+++ b/Tests/APITests/TestSetupEditTests.swift
@@ -1,0 +1,296 @@
+// Tests/APITests/TestSetupEditTests.swift
+//
+// Integration tests for Phase 8 notebook editor endpoints.
+//
+//   PUT  /api/v1/testsetups/:id/assignment  — save edited notebook
+//   GET  /api/v1/testsetups/:id/assignment  — serves flat file when present
+//   GET  /assignments/:id/edit              — instructor-only editor page
+
+import XCTest
+import XCTVapor
+@testable import chickadee_server
+import FluentSQLiteDriver
+import Foundation
+
+final class TestSetupEditTests: XCTestCase {
+
+    private var app: Application!
+    private var tmpDir: String!
+
+    override func setUp() async throws {
+        app = Application(.testing)
+
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-edit-\(UUID().uuidString)/")
+            .path
+
+        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
+        for dir in dirs {
+            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        }
+        app.resultsDirectory     = dirs[0]
+        app.testSetupsDirectory  = dirs[1]
+        app.submissionsDirectory = dirs[2]
+
+        app.sessions.use(.memory)
+        app.middleware.use(app.sessions.middleware)
+
+        app.databases.use(.sqlite(.memory), as: .sqlite)
+        app.migrations.add(CreateTestSetups())
+        app.migrations.add(CreateSubmissions())
+        app.migrations.add(CreateResults())
+        app.migrations.add(AddAttemptNumberToSubmissions())
+        app.migrations.add(AddFilenameToSubmissions())
+        app.migrations.add(AddSourceToResults())
+        app.migrations.add(CreateUsers())
+        app.migrations.add(CreateAssignments())
+        app.migrations.add(AddUserIDToSubmissions())
+        app.migrations.add(AddNotebookPathToTestSetups())
+        try await app.autoMigrate().get()
+
+        try routes(app)
+    }
+
+    override func tearDown() async throws {
+        app.shutdown()
+        try? FileManager.default.removeItem(atPath: tmpDir)
+    }
+
+    // MARK: - Auth helpers
+
+    private func loginAsInstructor() async throws -> String {
+        let hash = try Bcrypt.hash("testpassword")
+        let user = APIUser(username: "testinstructor_edit", passwordHash: hash, role: "instructor")
+        try await user.save(on: app.db)
+
+        var cookie = ""
+        try await app.test(.POST, "/login", beforeRequest: { req in
+            try req.content.encode(["username": "testinstructor_edit", "password": "testpassword"],
+                                   as: .urlEncodedForm)
+        }, afterResponse: { res in
+            cookie = res.headers.first(name: .setCookie) ?? ""
+        })
+        return cookie
+    }
+
+    private func loginAsStudent() async throws -> String {
+        let hash = try Bcrypt.hash("testpassword")
+        let user = APIUser(username: "teststudent_edit", passwordHash: hash, role: "student")
+        try await user.save(on: app.db)
+
+        var cookie = ""
+        try await app.test(.POST, "/login", beforeRequest: { req in
+            try req.content.encode(["username": "teststudent_edit", "password": "testpassword"],
+                                   as: .urlEncodedForm)
+        }, afterResponse: { res in
+            cookie = res.headers.first(name: .setCookie) ?? ""
+        })
+        return cookie
+    }
+
+    // MARK: - Setup helpers
+
+    /// Creates a test setup record in the DB (no real zip on disk).
+    @discardableResult
+    private func insertSetup(id: String) async throws -> APITestSetup {
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
+        """
+        let setup = APITestSetup(
+            id: id,
+            manifest: manifest,
+            zipPath: tmpDir + "testsetups/\(id).zip"
+        )
+        try await setup.save(on: app.db)
+        return setup
+    }
+
+    @discardableResult
+    private func insertAssignment(testSetupID: String, title: String) async throws -> APIAssignment {
+        let a = APIAssignment(testSetupID: testSetupID, title: title, dueAt: nil, isOpen: true)
+        try await a.save(on: app.db)
+        return a
+    }
+
+    // A minimal valid notebook JSON to use as test data.
+    private let sampleNotebookJSON = """
+    {
+        "nbformat": 4,
+        "nbformat_minor": 5,
+        "metadata": {},
+        "cells": [
+            {
+                "cell_type": "code",
+                "source": ["# TEST: sample tier=public\\nassert 1 == 1"],
+                "metadata": {},
+                "outputs": []
+            }
+        ]
+    }
+    """
+
+    // MARK: - PUT /api/v1/testsetups/:id/assignment
+
+    func testPutAssignmentSavesFileToDisk() async throws {
+        let cookie = try await loginAsInstructor()
+        try await insertSetup(id: "setup_put1")
+
+        try await app.test(.PUT, "/api/v1/testsetups/setup_put1/assignment",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                req.headers.contentType = .json
+                req.body = ByteBuffer(string: sampleNotebookJSON)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .noContent)
+            }
+        )
+
+        // File should be on disk.
+        let expectedPath = tmpDir + "testsetups/setup_put1.ipynb"
+        XCTAssertTrue(FileManager.default.fileExists(atPath: expectedPath),
+                      "Expected flat .ipynb file at \(expectedPath)")
+    }
+
+    func testPutAssignmentUpdatesNotebookPathInDB() async throws {
+        let cookie = try await loginAsInstructor()
+        try await insertSetup(id: "setup_put2")
+
+        try await app.test(.PUT, "/api/v1/testsetups/setup_put2/assignment",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                req.headers.contentType = .json
+                req.body = ByteBuffer(string: sampleNotebookJSON)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .noContent)
+            }
+        )
+
+        let updated = try await APITestSetup.find("setup_put2", on: app.db)
+        XCTAssertNotNil(updated?.notebookPath, "notebookPath should be set after PUT")
+        XCTAssertTrue(updated?.notebookPath?.hasSuffix("setup_put2.ipynb") == true)
+    }
+
+    func testGetAssignmentServesFlatFileWhenPresent() async throws {
+        let cookie = try await loginAsInstructor()
+        try await insertSetup(id: "setup_flat")
+
+        // Write a flat notebook file directly.
+        let flatPath = tmpDir + "testsetups/setup_flat.ipynb"
+        let editedJSON = """
+        {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[{"cell_type":"code","source":["# edited"],"metadata":{},"outputs":[]}]}
+        """
+        try editedJSON.write(toFile: flatPath, atomically: true, encoding: .utf8)
+
+        // Update DB record to point at the flat file.
+        let setup = try await APITestSetup.find("setup_flat", on: app.db)!
+        setup.notebookPath = flatPath
+        try await setup.save(on: app.db)
+
+        // GET should return the flat file's content.
+        try await app.test(.GET, "/api/v1/testsetups/setup_flat/assignment",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .ok)
+                let body = res.body.string
+                XCTAssertTrue(body.contains("# edited"),
+                              "Expected flat file content, got: \(body.prefix(200))")
+            }
+        )
+    }
+
+    func testPutAssignmentRejectsNonJSON() async throws {
+        let cookie = try await loginAsInstructor()
+        try await insertSetup(id: "setup_bad")
+
+        try await app.test(.PUT, "/api/v1/testsetups/setup_bad/assignment",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                req.headers.contentType = .json
+                req.body = ByteBuffer(string: "this is not JSON!!!")
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .unprocessableEntity)
+            }
+        )
+    }
+
+    func testPutAssignmentReturnsNotFoundForUnknownSetup() async throws {
+        let cookie = try await loginAsInstructor()
+
+        try await app.test(.PUT, "/api/v1/testsetups/does_not_exist/assignment",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                req.headers.contentType = .json
+                req.body = ByteBuffer(string: sampleNotebookJSON)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .notFound)
+            }
+        )
+    }
+
+    // MARK: - Role guard on PUT
+
+    func testStudentCannotPutAssignment() async throws {
+        let cookie = try await loginAsStudent()
+        try await insertSetup(id: "setup_student_put")
+
+        // Students are not on the instructor route group — middleware rejects them.
+        try await app.test(.PUT, "/api/v1/testsetups/setup_student_put/assignment",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                req.headers.contentType = .json
+                req.body = ByteBuffer(string: sampleNotebookJSON)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .forbidden)
+            }
+        )
+    }
+
+    // MARK: - GET /assignments/:id/edit
+
+    func testEditPageRequiresInstructor() async throws {
+        let cookie = try await loginAsStudent()
+        try await insertSetup(id: "setup_ep1")
+        let a = try await insertAssignment(testSetupID: "setup_ep1", title: "Lab")
+        let id = try XCTUnwrap(a.id?.uuidString)
+
+        try await app.test(.GET, "/assignments/\(id)/edit",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .forbidden)
+            }
+        )
+    }
+
+    func testEditPageNotFoundForUnknownAssignment() async throws {
+        let cookie = try await loginAsInstructor()
+        let fakeID = UUID().uuidString
+
+        try await app.test(.GET, "/assignments/\(fakeID)/edit",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .notFound)
+            }
+        )
+    }
+
+    func testEditPageInstructorAccessGranted() async throws {
+        let cookie = try await loginAsInstructor()
+        try await insertSetup(id: "setup_ep2")
+        let a = try await insertAssignment(testSetupID: "setup_ep2", title: "My Lab")
+        let id = try XCTUnwrap(a.id?.uuidString)
+
+        try await app.test(.GET, "/assignments/\(id)/edit",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            }, afterResponse: { res in
+                // 500 is expected — Leaf not configured in tests — but middleware passed.
+                XCTAssertNotEqual(res.status, .unauthorized)
+                XCTAssertNotEqual(res.status, .forbidden)
+                XCTAssertNotEqual(res.status, .notFound)
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- **`PUT /api/v1/testsetups/:id/assignment`** — new endpoint saves an edited notebook JSON to disk as `testsetups/<id>.ipynb` and sets `notebookPath` in DB
- **`GET /api/v1/testsetups/:id/assignment`** — updated to serve the flat `.ipynb` when present (falls back to zip extraction)
- **`GET /assignments/:id/edit`** — instructor-only page with JupyterLite iframe for editing notebooks in-browser
- **Save workflow**: instructor edits in JupyterLite → downloads via File→Download → uploads via "Save notebook…" label → PUT to server
- **Validate workflow**: upload `.py` solution → Pyodide runs it against the saved notebook → inline pass/fail results
- **`setup-new.leaf`**: mode-aware upload UI (browser = `.ipynb`, worker = `.zip`) with auto-populated manifest templates
- **`assignments.leaf`**: "Edit notebook" link on open and closed assignments
- New `AddNotebookPathToTestSetups` migration; all 78 tests pass

## Test plan

- [ ] All 78 tests pass (`swift test`)
- [ ] Upload a browser-mode `.ipynb` → flat file appears in `testsetups/`
- [ ] Navigate to `/assignments/:id/edit` → JupyterLite loads the notebook
- [ ] Edit a cell, download from JupyterLite, upload via "Save notebook…" → "Saved ✓" banner
- [ ] Click "Run tests…", upload solution `.py` → results render inline
- [ ] Student hitting `/assignments/:id/edit` → 403
- [ ] Student `PUT /api/v1/testsetups/:id/assignment` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)