### PR TITLE
Add worker HMAC auth sketch and tests

### DIFF
--- a/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
+++ b/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
@@ -1,0 +1,156 @@
+import Crypto
+import Foundation
+import Vapor
+
+/// Authenticates internal worker requests using HMAC signatures.
+///
+/// Not wired into routes yet. Intended usage later:
+///   let workerAuth = WorkerHMACAuthMiddleware(configuration: .fromEnvironment(app.environment))
+///   let worker = app.grouped("internal", "worker").grouped(workerAuth)
+///   worker.post("heartbeat") { ... }
+struct WorkerHMACAuthMiddleware: AsyncMiddleware {
+    struct Configuration {
+        let sharedSecret: String
+        let maxClockSkewSeconds: Int64
+        let nonceTTLSeconds: Int64
+        let requiredWorkerID: String?
+
+        static func fromEnvironment(_ env: Environment) -> Self {
+            // Expected env vars:
+            // - WORKER_SHARED_SECRET (required)
+            // - WORKER_MAX_CLOCK_SKEW_SECONDS (optional, default 60)
+            // - WORKER_NONCE_TTL_SECONDS (optional, default 300)
+            // - WORKER_REQUIRED_ID (optional)
+            _ = env // placeholder in case you want env-specific defaults later.
+            return Self(
+                sharedSecret: Environment.get("WORKER_SHARED_SECRET") ?? "",
+                maxClockSkewSeconds: Int64(Environment.get("WORKER_MAX_CLOCK_SKEW_SECONDS") ?? "60") ?? 60,
+                nonceTTLSeconds: Int64(Environment.get("WORKER_NONCE_TTL_SECONDS") ?? "300") ?? 300,
+                requiredWorkerID: Environment.get("WORKER_REQUIRED_ID")
+            )
+        }
+    }
+
+    private let configuration: Configuration
+    private let nonceStore: WorkerNonceStore
+
+    init(configuration: Configuration, nonceStore: WorkerNonceStore = .init()) {
+        self.configuration = configuration
+        self.nonceStore = nonceStore
+    }
+
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        guard !configuration.sharedSecret.isEmpty else {
+            request.logger.warning("Worker HMAC auth is enabled but WORKER_SHARED_SECRET is empty.")
+            throw Abort(.unauthorized, reason: "Worker auth is not configured.")
+        }
+
+        let timestampHeader = try request.requireHeader("X-Worker-Timestamp")
+        let nonce = try request.requireHeader("X-Worker-Nonce")
+        let signature = try request.requireHeader("X-Worker-Signature")
+        let workerID = request.headers.first(name: "X-Worker-Id")
+
+        if let required = configuration.requiredWorkerID, workerID != required {
+            throw Abort(.unauthorized, reason: "Invalid worker identity.")
+        }
+
+        guard let timestamp = Int64(timestampHeader) else {
+            throw Abort(.unauthorized, reason: "Invalid worker timestamp.")
+        }
+
+        let now = Int64(Date().timeIntervalSince1970)
+        let drift = abs(now - timestamp)
+        guard drift <= configuration.maxClockSkewSeconds else {
+            throw Abort(.unauthorized, reason: "Worker request timestamp is outside the accepted window.")
+        }
+
+        let nonceKey = (workerID ?? "_anonymous") + ":" + nonce
+        let wasInserted = await nonceStore.insertIfNew(nonceKey, now: now, ttlSeconds: configuration.nonceTTLSeconds)
+        guard wasInserted else {
+            throw Abort(.unauthorized, reason: "Replay detected.")
+        }
+
+        let bodyHash = sha256Hex(bodyBytes(request))
+        let signedPayload = [
+            request.method.rawValue.uppercased(),
+            request.url.path,
+            bodyHash,
+            timestampHeader,
+            nonce
+        ].joined(separator: "\n")
+
+        let expectedSignature = hmacSHA256Hex(message: signedPayload, secret: configuration.sharedSecret)
+        guard constantTimeEquals(expectedSignature.lowercased(), signature.lowercased()) else {
+            throw Abort(.unauthorized, reason: "Invalid worker signature.")
+        }
+
+        return try await next.respond(to: request)
+    }
+}
+
+actor WorkerNonceStore {
+    private var seen: [String: Int64] = [:]
+
+    func insertIfNew(_ nonce: String, now: Int64, ttlSeconds: Int64) -> Bool {
+        purgeExpired(now: now)
+        if seen[nonce] != nil {
+            return false
+        }
+        seen[nonce] = now + ttlSeconds
+        return true
+    }
+
+    private func purgeExpired(now: Int64) {
+        seen = seen.filter { $0.value > now }
+    }
+}
+
+private extension Request {
+    func requireHeader(_ name: String) throws -> String {
+        guard let value = headers.first(name: name), !value.isEmpty else {
+            throw Abort(.unauthorized, reason: "Missing worker auth header: \(name)")
+        }
+        return value
+    }
+}
+
+private func bodyBytes(_ request: Request) -> [UInt8] {
+    guard var data = request.body.data else {
+        return []
+    }
+    return data.readBytes(length: data.readableBytes) ?? []
+}
+
+private func sha256Hex(_ bytes: [UInt8]) -> String {
+    let digest = SHA256.hash(data: Data(bytes))
+    return digest.hexString
+}
+
+private func hmacSHA256Hex(message: String, secret: String) -> String {
+    let key = SymmetricKey(data: Data(secret.utf8))
+    let mac = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: key)
+    return Data(mac).hexEncodedString()
+}
+
+private func constantTimeEquals(_ lhs: String, _ rhs: String) -> Bool {
+    let left = Array(lhs.utf8)
+    let right = Array(rhs.utf8)
+    guard left.count == right.count else { return false }
+    var result: UInt8 = 0
+    for i in left.indices {
+        result |= left[i] ^ right[i]
+    }
+    return result == 0
+}
+
+private extension Digest {
+    var hexString: String {
+        Data(self).hexEncodedString()
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Sources/Worker/WorkerRequestSigner.swift
+++ b/Sources/Worker/WorkerRequestSigner.swift
@@ -1,0 +1,72 @@
+import Crypto
+import Foundation
+import Vapor
+
+/// Builds HMAC-signed headers for worker -> server internal requests.
+///
+/// This is intentionally not wired into request sending yet.
+struct WorkerRequestSigner {
+    let sharedSecret: String
+    let workerID: String?
+
+    init(sharedSecret: String, workerID: String? = nil) {
+        self.sharedSecret = sharedSecret
+        self.workerID = workerID
+    }
+
+    /// Generates headers matching `WorkerHMACAuthMiddleware` expectations.
+    /// Signed payload format:
+    ///   METHOD\nPATH\nBODY_SHA256\nTIMESTAMP\nNONCE
+    func signedHeaders(
+        method: HTTPMethod,
+        path: String,
+        body: ByteBuffer? = nil,
+        timestamp: Int64 = Int64(Date().timeIntervalSince1970),
+        nonce: String = UUID().uuidString
+    ) -> HTTPHeaders {
+        let bodyBytes = bytes(from: body)
+        let bodyHash = sha256Hex(bodyBytes)
+
+        let timestampString = String(timestamp)
+        let payload = [
+            method.rawValue.uppercased(),
+            path,
+            bodyHash,
+            timestampString,
+            nonce
+        ].joined(separator: "\n")
+
+        let signature = hmacSHA256Hex(message: payload, secret: sharedSecret)
+
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: "X-Worker-Timestamp", value: timestampString)
+        headers.replaceOrAdd(name: "X-Worker-Nonce", value: nonce)
+        headers.replaceOrAdd(name: "X-Worker-Signature", value: signature)
+        if let workerID, !workerID.isEmpty {
+            headers.replaceOrAdd(name: "X-Worker-Id", value: workerID)
+        }
+        return headers
+    }
+
+    private func bytes(from body: ByteBuffer?) -> [UInt8] {
+        guard var copy = body else { return [] }
+        return copy.readBytes(length: copy.readableBytes) ?? []
+    }
+
+    private func sha256Hex(_ bytes: [UInt8]) -> String {
+        let digest = SHA256.hash(data: Data(bytes))
+        return Data(digest).hexEncodedString()
+    }
+
+    private func hmacSHA256Hex(message: String, secret: String) -> String {
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: key)
+        return Data(mac).hexEncodedString()
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
+++ b/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+import XCTVapor
+import Crypto
+@testable import chickadee_server
+
+final class WorkerHMACAuthMiddlewareTests: XCTestCase {
+    private let sharedSecret = "test-shared-secret"
+    private let workerID = "worker-a"
+
+    private func makeApp() throws -> Application {
+        let app = Application(.testing)
+        let middleware = WorkerHMACAuthMiddleware(
+            configuration: .init(
+                sharedSecret: sharedSecret,
+                maxClockSkewSeconds: 60,
+                nonceTTLSeconds: 300,
+                requiredWorkerID: workerID
+            )
+        )
+        app.grouped(middleware).post("internal", "worker", "ping") { _ in
+            HTTPStatus.ok
+        }
+        return app
+    }
+
+    private func signedHeaders(
+        method: HTTPMethod,
+        path: String,
+        body: ByteBuffer,
+        timestamp: Int64,
+        nonce: String
+    ) -> HTTPHeaders {
+        var bodyCopy = body
+        let bodyBytes = bodyCopy.readBytes(length: bodyCopy.readableBytes) ?? []
+        let bodyHash = SHA256.hash(data: Data(bodyBytes)).hexString
+        let payload = [
+            method.rawValue.uppercased(),
+            path,
+            bodyHash,
+            String(timestamp),
+            nonce
+        ].joined(separator: "\n")
+        let signature = hmacSHA256Hex(message: payload, secret: sharedSecret)
+
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: "X-Worker-Id", value: workerID)
+        headers.replaceOrAdd(name: "X-Worker-Timestamp", value: String(timestamp))
+        headers.replaceOrAdd(name: "X-Worker-Nonce", value: nonce)
+        headers.replaceOrAdd(name: "X-Worker-Signature", value: signature)
+        headers.contentType = .json
+        return headers
+    }
+
+    func testAcceptsValidSignature() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        let path = "/internal/worker/ping"
+        let now = Int64(Date().timeIntervalSince1970)
+        let body = ByteBuffer(string: #"{"ok":true}"#)
+        let headers = signedHeaders(
+            method: .POST,
+            path: path,
+            body: body,
+            timestamp: now,
+            nonce: UUID().uuidString
+        )
+
+        try app.test(.POST, path, beforeRequest: { req in
+            req.headers = headers
+            req.body = body
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
+
+    func testRejectsMissingHeaders() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.POST, "/internal/worker/ping", beforeRequest: { req in
+            req.headers.contentType = .json
+            req.body = ByteBuffer(string: #"{"ok":true}"#)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        })
+    }
+
+    func testRejectsStaleTimestamp() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        let path = "/internal/worker/ping"
+        let old = Int64(Date().timeIntervalSince1970) - 10_000
+        let body = ByteBuffer(string: #"{"ok":true}"#)
+        let headers = signedHeaders(
+            method: .POST,
+            path: path,
+            body: body,
+            timestamp: old,
+            nonce: UUID().uuidString
+        )
+
+        try app.test(.POST, path, beforeRequest: { req in
+            req.headers = headers
+            req.body = body
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        })
+    }
+
+    func testRejectsReplayNonce() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        let path = "/internal/worker/ping"
+        let now = Int64(Date().timeIntervalSince1970)
+        let nonce = UUID().uuidString
+        let body = ByteBuffer(string: #"{"ok":true}"#)
+        let headers = signedHeaders(
+            method: .POST,
+            path: path,
+            body: body,
+            timestamp: now,
+            nonce: nonce
+        )
+
+        try app.test(.POST, path, beforeRequest: { req in
+            req.headers = headers
+            req.body = body
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+
+        try app.test(.POST, path, beforeRequest: { req in
+            req.headers = headers
+            req.body = body
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        })
+    }
+
+    func testRejectsBadSignature() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        let path = "/internal/worker/ping"
+        let now = Int64(Date().timeIntervalSince1970)
+        let body = ByteBuffer(string: #"{"ok":true}"#)
+        var headers = signedHeaders(
+            method: .POST,
+            path: path,
+            body: body,
+            timestamp: now,
+            nonce: UUID().uuidString
+        )
+        headers.replaceOrAdd(name: "X-Worker-Signature", value: "deadbeef")
+
+        try app.test(.POST, path, beforeRequest: { req in
+            req.headers = headers
+            req.body = body
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        })
+    }
+
+    private func hmacSHA256Hex(message: String, secret: String) -> String {
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: key)
+        return Data(mac).hexEncodedString()
+    }
+}
+
+private extension Digest {
+    var hexString: String {
+        Data(self).hexEncodedString()
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Tests/WorkerTests/WorkerRequestSignerTests.swift
+++ b/Tests/WorkerTests/WorkerRequestSignerTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import Vapor
+import Crypto
+@testable import chickadee_runner
+
+final class WorkerRequestSignerTests: XCTestCase {
+    func testSignerProducesExpectedHeadersAndSignature() {
+        let signer = WorkerRequestSigner(sharedSecret: "secret-123", workerID: "worker-1")
+        let path = "/internal/worker/ping"
+        let body = ByteBuffer(string: #"{"submission":"sub_1"}"#)
+        let timestamp: Int64 = 1_700_000_000
+        let nonce = "nonce-abc"
+
+        let headers = signer.signedHeaders(
+            method: .POST,
+            path: path,
+            body: body,
+            timestamp: timestamp,
+            nonce: nonce
+        )
+
+        XCTAssertEqual(headers.first(name: "X-Worker-Id"), "worker-1")
+        XCTAssertEqual(headers.first(name: "X-Worker-Timestamp"), String(timestamp))
+        XCTAssertEqual(headers.first(name: "X-Worker-Nonce"), nonce)
+
+        var bodyCopy = body
+        let bodyBytes = bodyCopy.readBytes(length: bodyCopy.readableBytes) ?? []
+        let bodyHash = SHA256.hash(data: Data(bodyBytes)).hexString
+        let payload = [
+            "POST",
+            path,
+            bodyHash,
+            String(timestamp),
+            nonce
+        ].joined(separator: "\n")
+        let expected = hmacSHA256Hex(message: payload, secret: "secret-123")
+
+        XCTAssertEqual(headers.first(name: "X-Worker-Signature"), expected)
+    }
+
+    func testSignerOmitsWorkerIDWhenNil() {
+        let signer = WorkerRequestSigner(sharedSecret: "secret-123", workerID: nil)
+        let headers = signer.signedHeaders(
+            method: .GET,
+            path: "/internal/worker/ping",
+            body: nil,
+            timestamp: 1_700_000_000,
+            nonce: "nonce-xyz"
+        )
+
+        XCTAssertNil(headers.first(name: "X-Worker-Id"))
+        XCTAssertNotNil(headers.first(name: "X-Worker-Signature"))
+        XCTAssertNotNil(headers.first(name: "X-Worker-Timestamp"))
+        XCTAssertNotNil(headers.first(name: "X-Worker-Nonce"))
+    }
+
+    private func hmacSHA256Hex(message: String, secret: String) -> String {
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let mac = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: key)
+        return Data(mac).hexEncodedString()
+    }
+}
+
+private extension Digest {
+    var hexString: String {
+        Data(self).hexEncodedString()
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}


### PR DESCRIPTION
## Summary
- add standalone WorkerHMACAuthMiddleware sketch (not integrated into routes)
- add standalone WorkerRequestSigner sketch for worker-side signed headers
- add focused API and Worker tests for signature validation, replay protection, and signer output

## Notes
- no route integration in this PR
- tests added:
  - WorkerHMACAuthMiddlewareTests
  - WorkerRequestSignerTests