### PR TITLE
Stabilize JupyterLite kernel runtime config loading

### DIFF
--- a/Public/jupyterlite/config-utils.js
+++ b/Public/jupyterlite/config-utils.js
@@ -140,13 +140,14 @@ function mergeOneConfig(memo, config) {
 }
 
 function dedupFederatedExtensions(config) {
-  const originalList = Object.keys(config || {})['federated_extensions'] || [];
+  const originalList = (config || {}).federated_extensions || [];
   const named = {};
   for (const ext of originalList) {
     named[ext.name] = ext;
   }
   let allExtensions = [...Object.values(named)];
   allExtensions.sort((a, b) => a.name.localeCompare(b.name));
+  config.federated_extensions = allExtensions;
   return config;
 }
 

--- a/Public/jupyterlite/edit/jupyter-lite.json
+++ b/Public/jupyterlite/edit/jupyter-lite.json
@@ -6,22 +6,6 @@
     "faviconUrl": "./favicon.ico",
     "fullStaticUrl": "../build",
     "settingsUrl": "../build/schemas",
-    "themesUrl": "./build/themes",
-    "defaultKernelName": "python",
-    "fullLabextensionsUrl": "../extensions",
-    "federated_extensions": [
-      {
-        "extension": "./extension",
-        "load": "static/remoteEntry.a117bd216cefa0b341fe.js",
-        "name": "@jupyterlite/pyodide-kernel-extension"
-      }
-    ],
-    "litePluginSettings": {
-      "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pipliteUrls": [
-          "../extensions/@jupyterlite/pyodide-kernel-extension/static/pypi/all.json?sha256=783d01f64a330ecbbd82318ba2fde8842bc8eece502b821b8c0f57cacdde5cdc"
-        ]
-      }
-    }
+    "themesUrl": "./build/themes"
   }
 }

--- a/Public/jupyterlite/jupyter-lite.json
+++ b/Public/jupyterlite/jupyter-lite.json
@@ -2,13 +2,9 @@
   "jupyter-config-data": {
     "appName": "JupyterLite",
     "appUrl": "./lab",
-    "appVersion": "0.7.1",
+    "appVersion": "0.7.1-chickadee.2",
     "baseUrl": "./",
     "defaultKernelName": "python",
-    "enableMemoryStorage": true,
-    "contentsStorageDrivers": ["memoryStorageDriver"],
-    "settingsStorageDrivers": ["memoryStorageDriver"],
-    "workspacesStorageDrivers": ["memoryStorageDriver"],
     "faviconUrl": "./lab/favicon.ico",
     "federated_extensions": [
       {

--- a/Public/jupyterlite/lab/jupyter-lite.json
+++ b/Public/jupyterlite/lab/jupyter-lite.json
@@ -5,22 +5,6 @@
     "settingsUrl": "../build/schemas",
     "showLoadingIndicator": true,
     "themesUrl": "./build/themes",
-    "mode": "multiple-document",
-    "defaultKernelName": "python",
-    "fullLabextensionsUrl": "../extensions",
-    "federated_extensions": [
-      {
-        "extension": "./extension",
-        "load": "static/remoteEntry.a117bd216cefa0b341fe.js",
-        "name": "@jupyterlite/pyodide-kernel-extension"
-      }
-    ],
-    "litePluginSettings": {
-      "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pipliteUrls": [
-          "../extensions/@jupyterlite/pyodide-kernel-extension/static/pypi/all.json?sha256=783d01f64a330ecbbd82318ba2fde8842bc8eece502b821b8c0f57cacdde5cdc"
-        ]
-      }
-    }
+    "mode": "multiple-document"
   }
 }

--- a/Public/jupyterlite/notebooks/jupyter-lite.json
+++ b/Public/jupyterlite/notebooks/jupyter-lite.json
@@ -6,22 +6,6 @@
     "faviconUrl": "./favicon.ico",
     "fullStaticUrl": "../build",
     "settingsUrl": "../build/schemas",
-    "themesUrl": "./build/themes",
-    "defaultKernelName": "python",
-    "fullLabextensionsUrl": "../extensions",
-    "federated_extensions": [
-      {
-        "extension": "./extension",
-        "load": "static/remoteEntry.a117bd216cefa0b341fe.js",
-        "name": "@jupyterlite/pyodide-kernel-extension"
-      }
-    ],
-    "litePluginSettings": {
-      "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pipliteUrls": [
-          "../extensions/@jupyterlite/pyodide-kernel-extension/static/pypi/all.json?sha256=783d01f64a330ecbbd82318ba2fde8842bc8eece502b821b8c0f57cacdde5cdc"
-        ]
-      }
-    }
+    "themesUrl": "./build/themes"
   }
 }


### PR DESCRIPTION
## Summary
- align JupyterLite app-specific `jupyter-lite.json` files with generated defaults, keeping pyodide extension registration in root config only
- remove extra storage-driver overrides from root config that were not part of generated runtime config
- fix `dedupFederatedExtensions` in `config-utils.js` so duplicate federated extension entries are actually deduplicated
- bump `appVersion` to `0.7.1-chickadee.2` to force browser-side service worker/runtime refresh

## Why
The previous config layering could yield duplicate federated extension entries at runtime and stale browser runtime state, which can lead to pyodide kernel plugin not being initialized reliably.

## Testing
- `swift test --filter TestSetupEditTests --filter AssignmentRoutesTests --filter JupyterLiteContentsRoutesTests`
