### PR TITLE
Runner auth + admin dashboard polish + README refresh

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -35,8 +35,8 @@ if (dropZone && fileInput) {
 // Results page: poll until the submission reaches its final state.
 //
 // Statuses that require polling:
-//   pending / assigned       — worker hasn't started yet
-//   browser-complete         — browser run done, waiting for official worker result
+//   pending / assigned       — runner hasn't started yet
+//   browser-complete         — browser run done, waiting for official runner result
 const root = document.getElementById('submission-root');
 if (root) {
     const isPending         = root.dataset.pending === 'true';

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -67,33 +67,35 @@
     // 2. Submit button — run via Pyodide, POST results, render inline
     // -------------------------------------------------------------------------
 
-    submitBtn.addEventListener('click', async () => {
-        submitBtn.disabled = true;
-        clearResults();
-        setStatus('loading', 'Loading grading engine…');
+    if (submitBtn) {
+        submitBtn.addEventListener('click', async () => {
+            submitBtn.disabled = true;
+            clearResults();
+            setStatus('loading', 'Loading grading engine…');
 
-        try {
-            // Fetch the notebook JSON directly (same file JupyterLite loaded).
-            const nbRes = await fetch(notebookURL);
-            if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
-            const notebook = await nbRes.json();
+            try {
+                // Fetch the notebook JSON directly (same file JupyterLite loaded).
+                const nbRes = await fetch(notebookURL);
+                if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
+                const notebook = await nbRes.json();
 
-            setStatus('loading', 'Running tests…');
-            const outcomes = await runNotebook(notebook);
+                setStatus('loading', 'Running tests…');
+                const outcomes = await runNotebook(notebook);
 
-            setStatus('loading', 'Submitting…');
-            const collection = buildCollection(outcomes, setupID);
-            const response   = await postBrowserResult(collection, notebook, setupID);
+                setStatus('loading', 'Submitting…');
+                const collection = buildCollection(outcomes, setupID);
+                const response   = await postBrowserResult(collection, notebook, setupID);
 
-            // Render results inline — no page navigation.
-            renderResults(outcomes, response);
-            setStatus('', '');
-        } catch (err) {
-            setStatus('error', `Error: ${err.message}`);
-        } finally {
-            submitBtn.disabled = false;
-        }
-    });
+                // Render results inline — no page navigation.
+                renderResults(outcomes, response);
+                setStatus('', '');
+            } catch (err) {
+                setStatus('error', `Error: ${err.message}`);
+            } finally {
+                submitBtn.disabled = false;
+            }
+        });
+    }
 
     // -------------------------------------------------------------------------
     // 3. Upload & submit — read file → merge → Pyodide → POST → render
@@ -104,7 +106,7 @@
             const file = uploadFile.files && uploadFile.files[0];
             if (!file) return;
 
-            submitBtn.disabled = true;
+            if (submitBtn) submitBtn.disabled = true;
             clearResults();
             setStatus('loading', 'Loading grading engine…');
 
@@ -137,7 +139,7 @@
             } catch (err) {
                 setStatus('error', `Error: ${err.message}`);
             } finally {
-                submitBtn.disabled = false;
+                if (submitBtn) submitBtn.disabled = false;
                 // Reset so the same file can be re-selected.
                 uploadFile.value = '';
             }

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -45,8 +45,8 @@ a { color: var(--blue); }
 }
 
 .nav-brand-logo {
-    width: 2rem;
-    height: 2rem;
+    width: 2.4rem;
+    height: 2.4rem;
     object-fit: contain;
     display: block;
 }
@@ -359,6 +359,14 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     display: flex;
     align-items: center;
     gap: .75rem;
+    width: 100%;
+}
+
+.notebook-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
 }
 
 .nb-status {

--- a/README.md
+++ b/README.md
@@ -42,37 +42,6 @@ Three Swift targets share a clean dependency boundary:
 
 ---
 
-## Tech stack
-
-| Layer | Technology |
-|-------|-----------|
-| Language | Swift 6 (strict concurrency) |
-| Web framework | Vapor 4 |
-| Database | SQLite via Fluent |
-| Concurrency | `async/await`, actors, structured task groups |
-| Test runners | Instructor-authored shell scripts |
-| Sandboxing | `sandbox-exec` (macOS), `unshare --user --net` (Linux) |
-| Build tool | Swift Package Manager |
-
----
-
-## Project structure
-
-```
-Chickadee/
-├── Sources/
-│   ├── Core/          # Shared models — Codable, Sendable, no Vapor
-│   ├── APIServer/     # Vapor app, REST routes, Fluent migrations, Leaf UI
-│   └── Worker/        # Job poller, script runner, worker daemon
-├── Tests/
-│   ├── CoreTests/     # Round-trip JSON encode/decode for all models
-│   ├── APITests/      # XCTVapor integration tests
-│   └── WorkerTests/   # ScriptRunner and worker unit tests
-└── Assets/            # Project icons
-```
-
----
-
 ## Building
 
 Requires Swift 6 ([swift.org](https://swift.org/download)) and Xcode 16+ on macOS.
@@ -85,21 +54,23 @@ swift test
 Run the API server:
 
 ```bash
-swift run chickadee-server
+swift run chickadee-server serve --port 8080 --worker-secret your-secret
 ```
 
-Run the worker, pointing it at a running API server:
+Run the runner, pointing it at a running API server:
 
 ```bash
 swift run chickadee-runner \
   --api-base-url http://localhost:8080 \
   --worker-id    worker-1 \
+  --worker-secret your-secret \
   --max-jobs     4
 
 # With sandboxing enabled (recommended for production):
 swift run chickadee-runner \
   --api-base-url http://localhost:8080 \
   --worker-id    worker-1 \
+  --worker-secret your-secret \
   --sandbox
 ```
 
@@ -107,8 +78,8 @@ swift run chickadee-runner \
 
 ```bash
 swift build -c release
-.build/release/chickadee-server
-.build/release/chickadee-runner --api-base-url http://api:8080 --worker-id w1 --sandbox
+.build/release/chickadee-server serve --port 8080 --worker-secret your-secret
+.build/release/chickadee-runner --api-base-url http://api:8080 --worker-id runner-1 --worker-secret your-secret --sandbox
 ```
 
 ## JupyterLite rebuilds
@@ -126,30 +97,6 @@ scripts/build-jupyterlite.sh
 ```
 
 The build script keeps runtime notebook storage directories (`Public/jupyterlite/files`, `Public/jupyterlite/lab/files`, `Public/jupyterlite/notebooks/files`) while refreshing generated assets.
-
----
-
-## Component docs
-
-| Component | README |
-|-----------|--------|
-| Core (shared models) | [Sources/Core/README.md](Sources/Core/README.md) |
-| chickadee-server (API + web UI) | [Sources/APIServer/README.md](Sources/APIServer/README.md) |
-| chickadee-runner (worker) | [Sources/Worker/README.md](Sources/Worker/README.md) |
-
----
-
-## Phase status
-
-| Phase | Focus | Status |
-|-------|-------|--------|
-| 1 | Core models, `ScriptRunner`, `POST /results` stub | Complete |
-| 2 | Full REST API, SQLite persistence, worker pull loop, shell-script runner | Complete |
-| 3 | Submission result retrieval — `GET /submissions`, `GET /submissions/:id`, `GET /submissions/:id/results` with tier filtering | Complete |
-| 4 | Sandboxing — `SandboxedScriptRunner` with `sandbox-exec` (macOS) and `unshare` (Linux), `--sandbox` worker flag | Complete |
-| 5 | Gamification — attempt tracking, leaderboards, partial credit | Up next |
-
----
 
 ## License
 

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -5,6 +5,52 @@ Admin
 #export("content"):
 <h1>Admin dashboard</h1>
 
+<section class="admin-section">
+    <h2>Runners</h2>
+    <form method="post" action="/admin/runner-secret" style="max-width:700px">
+        <label class="form-label">
+            Runner shared secret
+            <div style="display:flex;gap:.5rem;align-items:center">
+                <input class="form-input"
+                       type="text"
+                       name="secret"
+                       value="#(workerSecret)"
+                       autocomplete="off"
+                       style="flex:1">
+                <button class="btn" type="submit">Save</button>
+            </div>
+        </label>
+    </form>
+
+    <div style="margin-top:1rem">
+        <p id="workers-empty" class="empty" #if(!workers.isEmpty):style="display:none"#endif>
+            No runners have checked in yet.
+        </p>
+        <table id="workers-table" class="results-table" #if(workers.isEmpty):style="display:none"#endif>
+            <thead>
+                <tr>
+                    <th>Runner</th>
+                    <th>Status</th>
+                    <th class="time">Assigned Jobs</th>
+                    <th class="time">Jobs Processed</th>
+                    <th class="time">Last Active</th>
+                </tr>
+            </thead>
+            <tbody id="workers-body">
+            #for(worker in workers):
+                <tr>
+                    <td><code>#(worker.workerID)</code></td>
+                    <td>#(worker.status)</td>
+                    <td class="time">#(worker.assignedJobs)</td>
+                    <td class="time">#(worker.jobsProcessed)</td>
+                    <td class="time js-relative-time" data-iso="#(worker.lastActive)">#(worker.lastActive)</td>
+                </tr>
+            #endfor
+            </tbody>
+        </table>
+    </div>
+</section>
+
 <!-- ── Users ──────────────────────────────────────────── -->
 <section class="admin-section">
     <h2>Users</h2>
@@ -13,7 +59,7 @@ Admin
             <tr>
                 <th>Username</th>
                 <th>Role</th>
-                <th>Joined</th>
+                <th class="time">Joined</th>
                 <th></th>
             </tr>
         </thead>
@@ -22,7 +68,7 @@ Admin
             <tr>
                 <td><code>#(user.username)</code></td>
                 <td><span class="tier">#(user.role)</span></td>
-                <td class="time">#(user.createdAt)</td>
+                <td class="time js-relative-time" data-iso="#(user.createdAt)">#(user.createdAt)</td>
                 <td>
                     <form method="post" action="/admin/users/#(user.id)/role"
                           style="display:flex;gap:.4rem;align-items:center">
@@ -40,46 +86,108 @@ Admin
         </tbody>
     </table>
 </section>
+<script>
+(function () {
+    'use strict';
 
-<section class="admin-section">
-    <h2>Workers</h2>
-    <form method="post" action="/admin/worker-secret" style="max-width:700px">
-        <label class="form-label">
-            Worker shared secret (visible)
-            <div style="display:flex;gap:.5rem;align-items:center">
-                <input class="form-input"
-                       type="text"
-                       name="secret"
-                       value="#(workerSecret)"
-                       autocomplete="off"
-                       style="flex:1">
-                <button class="btn" type="submit">Save</button>
-            </div>
-        </label>
-    </form>
+    var workersBody = document.getElementById('workers-body');
+    var workersTable = document.getElementById('workers-table');
+    var workersEmpty = document.getElementById('workers-empty');
+    if (!workersBody || !workersTable || !workersEmpty) return;
 
-    <div style="margin-top:1rem">
-        #if(workers.isEmpty):
-            <p class="empty">No workers have checked in yet.</p>
-        #else:
-            <table class="results-table">
-                <thead>
-                    <tr>
-                        <th>Worker</th>
-                        <th>Last Active</th>
-                    </tr>
-                </thead>
-                <tbody>
-                #for(worker in workers):
-                    <tr>
-                        <td><code>#(worker.workerID)</code></td>
-                        <td class="time">#(worker.lastActive)</td>
-                    </tr>
-                #endfor
-                </tbody>
-            </table>
-        #endif
-    </div>
-</section>
+    function escapeHtml(value) {
+        return String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
+    }
+
+    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+    function formatRelative(isoString) {
+        var date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) return isoString;
+
+        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
+        var abs = Math.abs(seconds);
+
+        if (abs < 60) return relativeFormatter.format(seconds, 'second');
+        var minutes = Math.round(seconds / 60);
+        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
+        var hours = Math.round(minutes / 60);
+        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
+        var days = Math.round(hours / 24);
+        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
+        var weeks = Math.round(days / 7);
+        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
+        var months = Math.round(days / 30);
+        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
+        var years = Math.round(days / 365);
+        return relativeFormatter.format(years, 'year');
+    }
+
+    function applyRelativeTimes(root) {
+        var scope = root || document;
+        var nodes = scope.querySelectorAll('.js-relative-time[data-iso]');
+        nodes.forEach(function (el) {
+            var iso = el.getAttribute('data-iso');
+            if (!iso) return;
+            var date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+            el.textContent = formatRelative(iso);
+            el.title = date.toLocaleString();
+        });
+    }
+
+    function renderWorkers(workers) {
+        if (!Array.isArray(workers) || workers.length === 0) {
+            workersBody.innerHTML = '';
+            workersTable.style.display = 'none';
+            workersEmpty.style.display = '';
+            return;
+        }
+
+        workersBody.innerHTML = workers.map(function (worker) {
+            var id = escapeHtml(worker.workerID || '');
+            var status = escapeHtml(worker.status || '');
+            var assignedJobs = escapeHtml(worker.assignedJobs == null ? '' : worker.assignedJobs);
+            var jobsProcessed = escapeHtml(worker.jobsProcessed == null ? '' : worker.jobsProcessed);
+            var lastActive = escapeHtml(worker.lastActive || '');
+            return '<tr>'
+                + '<td><code>' + id + '</code></td>'
+                + '<td>' + status + '</td>'
+                + '<td class="time">' + assignedJobs + '</td>'
+                + '<td class="time">' + jobsProcessed + '</td>'
+                + '<td class="time js-relative-time" data-iso="' + lastActive + '">' + lastActive + '</td>'
+                + '</tr>';
+        }).join('');
+        applyRelativeTimes(workersBody);
+        workersTable.style.display = '';
+        workersEmpty.style.display = 'none';
+    }
+
+    async function refreshWorkers() {
+        try {
+            var res = await fetch('/admin/runners', {
+                headers: { 'Accept': 'application/json' },
+                cache: 'no-store'
+            });
+            if (!res.ok) return;
+            var workers = await res.json();
+            renderWorkers(workers);
+        } catch (_) {
+            // Keep current UI state on transient polling errors.
+        }
+    }
+
+    applyRelativeTimes(document);
+    setInterval(function () {
+        applyRelativeTimes(document);
+        refreshWorkers();
+    }, 5000);
+})();
+</script>
 #endexport
 #endextend

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -1,6 +1,6 @@
 #extend("base"):
 #export("title"):
-Notebook — #(assignmentTitle)
+Notebook
 #endexport
 #export("content"):
 <style>
@@ -8,23 +8,14 @@ Notebook — #(assignmentTitle)
 .main { max-width: 100%; padding: 0 1rem; }
 </style>
 <div class="notebook-header">
-    <h1>#(assignmentTitle)</h1>
     <div class="notebook-toolbar">
-        <button class="btn btn-primary" id="nb-submit">Submit</button>
-        <a class="btn"
-           href="/api/v1/testsetups/#(testSetupID)/assignment/download"
-           download>Download</a>
-        <label class="btn btn-primary" id="nb-upload-label"
-               title="Upload a locally-edited .ipynb and run tests immediately">
-            Upload and Submit
-            <input type="file" id="nb-upload-file" accept=".ipynb" style="display:none">
-        </label>
-        <a class="btn"
-           id="nb-open-editor"
-           href="/jupyterlite/lab/index.html?workspace=#(testSetupID)&reset&path=#(jupyterLiteNotebookPath)"
-           target="_blank"
-           rel="noopener">Open Editor in New Tab</a>
         <span class="nb-status" id="nb-status"></span>
+        <div class="notebook-actions">
+            <button class="btn btn-primary" id="nb-submit">Submit</button>
+            <a class="btn"
+               href="/api/v1/testsetups/#(testSetupID)/assignment/download"
+               download>Download</a>
+        </div>
     </div>
 </div>
 <iframe
@@ -37,7 +28,7 @@ Notebook — #(assignmentTitle)
     loading="eager">
 </iframe>
 <p id="nb-frame-error" class="empty" style="display:none;margin-top:.6rem">
-    The embedded editor did not load. Use <strong>Open Editor in New Tab</strong>.
+    The embedded editor did not load.
 </p>
 <div id="nb-results" class="nb-results" hidden></div>
 <script src="/notebook.js"></script>

--- a/Resources/Views/setup-new.leaf
+++ b/Resources/Views/setup-new.leaf
@@ -17,7 +17,7 @@ Upload Test Setup
         <label style="display:flex;align-items:center;gap:.5rem;cursor:pointer">
             <input type="radio" name="gradingMode" value="worker"
                    onchange="toggleMode(this.value)">
-            <span><strong>Worker</strong> — server-side shell scripts · upload <code>.zip</code></span>
+            <span><strong>Runner</strong> — server-side shell scripts · upload <code>.zip</code></span>
         </label>
     </fieldset>
 
@@ -40,7 +40,7 @@ Upload Test Setup
         </p>
     </div>
 
-    <!-- ── Worker mode: zip ─────────────────────────────────── -->
+    <!-- ── Runner mode: zip ─────────────────────────────────── -->
     <div id="upload-worker" style="display:none">
         <label class="form-label">
             Test Setup Zip (<code>.zip</code>)

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -19,7 +19,7 @@ Submission #(submissionID)
 #if(isPending):
 <div class="pending-box">
     <div class="spinner"></div>
-    <p>Waiting for a worker to pick up your submission…</p>
+    <p>Waiting for a runner to pick up your submission…</p>
 </div>
 
 #else:

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -10,12 +10,13 @@ import Foundation
 struct APIServerApp {
     static func main() async throws {
         var env = try Environment.detect()
+        let cliWorkerSecret = extractWorkerSecretArgument(from: &env)
         try LoggingSystem.bootstrap(from: &env)
 
         let app = try await Application.make(env)
         
         do {
-            try configure(app)
+            try configure(app, cliWorkerSecret: cliWorkerSecret)
             try await app.execute()
         } catch {
             try await app.asyncShutdown()
@@ -26,8 +27,9 @@ struct APIServerApp {
     }
 }
 
-func configure(_ app: Application) throws {
+func configure(_ app: Application, cliWorkerSecret: String?) throws {
     let workDir = DirectoryConfiguration.detect().workingDirectory
+    let workerSecretFile = workDir + ".worker-secret"
 
     // MARK: - Directories
 
@@ -42,7 +44,12 @@ func configure(_ app: Application) throws {
     app.storage[ResultsDirectoryKey.self]     = resultsDir
     app.storage[TestSetupsDirectoryKey.self]  = setupsDir
     app.storage[SubmissionsDirectoryKey.self] = submissionsDir
-    app.storage[WorkerSecretStoreKey.self]    = WorkerSecretStore(initialOverride: randomWorkerPassphrase())
+    app.storage[WorkerSecretFilePathKey.self] = workerSecretFile
+    let startupWorkerSecret = resolveStartupWorkerSecret(
+        cliWorkerSecret: cliWorkerSecret,
+        workerSecretFilePath: workerSecretFile
+    )
+    app.storage[WorkerSecretStoreKey.self]    = WorkerSecretStore(initialOverride: startupWorkerSecret)
     app.storage[WorkerActivityStoreKey.self]  = WorkerActivityStore()
 
     // MARK: - Sessions (in-memory; swap to .fluent for multi-process deployments)
@@ -93,6 +100,9 @@ struct SubmissionsDirectoryKey: StorageKey {
 struct WorkerSecretStoreKey: StorageKey {
     typealias Value = WorkerSecretStore
 }
+struct WorkerSecretFilePathKey: StorageKey {
+    typealias Value = String
+}
 struct WorkerActivityStoreKey: StorageKey {
     typealias Value = WorkerActivityStore
 }
@@ -137,16 +147,6 @@ actor WorkerActivityStore {
     }
 }
 
-private func randomWorkerPassphrase() -> String {
-    let words = [
-        "oak", "river", "falcon", "amber", "lumen", "cedar", "thunder", "pebble",
-        "meadow", "quartz", "north", "willow", "harbor", "maple", "breeze",
-        "summit", "pixel", "cipher", "comet", "forest", "frost", "sparrow",
-        "orbit", "cobalt", "dawn", "ember", "ridge", "tunnel", "canyon", "signal"
-    ]
-    return (0..<3).compactMap { _ in words.randomElement() }.joined(separator: "-")
-}
-
 extension Application {
     var resultsDirectory: String {
         get { storage[ResultsDirectoryKey.self] ?? "results/" }
@@ -188,4 +188,86 @@ extension Application {
             storage[WorkerActivityStoreKey.self] = newValue
         }
     }
+
+    var workerSecretFilePath: String {
+        get { storage[WorkerSecretFilePathKey.self] ?? (DirectoryConfiguration.detect().workingDirectory + ".worker-secret") }
+        set { storage[WorkerSecretFilePathKey.self] = newValue }
+    }
+}
+
+private func extractWorkerSecretArgument(from env: inout Environment) -> String? {
+    let args = env.arguments
+    guard !args.isEmpty else { return nil }
+
+    var found: String?
+    var cleaned: [String] = []
+    cleaned.reserveCapacity(args.count)
+    cleaned.append(args[0]) // executable path
+
+    var i = 1
+    while i < args.count {
+        let arg = args[i]
+        if arg == "--worker-secret" {
+            if i + 1 < args.count {
+                let value = args[i + 1].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !value.isEmpty { found = value }
+                i += 2
+                continue
+            }
+            i += 1
+            continue
+        }
+        if arg.hasPrefix("--worker-secret=") {
+            let raw = String(arg.dropFirst("--worker-secret=".count))
+            let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty { found = value }
+            i += 1
+            continue
+        }
+        cleaned.append(arg)
+        i += 1
+    }
+
+    env.arguments = cleaned
+    return found
+}
+
+private func resolveStartupWorkerSecret(cliWorkerSecret: String?, workerSecretFilePath: String) -> String {
+    if let cli = cliWorkerSecret?.trimmingCharacters(in: .whitespacesAndNewlines), !cli.isEmpty {
+        writeWorkerSecretToDisk(secret: cli, workerSecretFilePath: workerSecretFilePath)
+        return cli
+    }
+    if let previous = readWorkerSecretFromDisk(workerSecretFilePath: workerSecretFilePath), !previous.isEmpty {
+        return previous
+    }
+    let generated = randomWorkerPassphrase()
+    writeWorkerSecretToDisk(secret: generated, workerSecretFilePath: workerSecretFilePath)
+    return generated
+}
+
+func readWorkerSecretFromDisk(workerSecretFilePath: String) -> String? {
+    guard let data = try? Data(contentsOf: URL(fileURLWithPath: workerSecretFilePath)),
+          let text = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+          !text.isEmpty else {
+        return nil
+    }
+    return text
+}
+
+func writeWorkerSecretToDisk(secret: String, workerSecretFilePath: String) {
+    let value = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !value.isEmpty else { return }
+    let url = URL(fileURLWithPath: workerSecretFilePath)
+    try? value.write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func randomWorkerPassphrase() -> String {
+    let words = [
+        "oak", "river", "falcon", "amber", "lumen", "cedar", "thunder", "pebble",
+        "meadow", "quartz", "north", "willow", "harbor", "maple", "breeze",
+        "summit", "pixel", "cipher", "comet", "forest", "frost", "sparrow",
+        "orbit", "cobalt", "dawn", "ember", "ridge", "tunnel", "canyon", "signal"
+    ]
+    return (0..<3).compactMap { _ in words.randomElement() }.joined(separator: "-")
 }

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -17,6 +17,8 @@ struct ResultRoutes: RouteCollection {
     // POST /api/v1/worker/results
     @Sendable
     func reportResults(req: Request) async throws -> ReportResponse {
+        try await requireWorkerSecret(req)
+
         if let workerID = req.headers.first(name: "X-Worker-Id"), !workerID.isEmpty {
             await req.application.workerActivityStore.markActive(workerID: workerID)
         }

--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -9,70 +9,11 @@ struct SubmissionRoutes: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let api = routes.grouped("api", "v1")
 
-        // POST /api/v1/worker/request
-        api.grouped("worker").post("request", use: requestJob)
-
         // POST /api/v1/submissions
         api.post("submissions", use: createSubmission)
 
         // POST /api/v1/submissions/file  — multipart, accepts raw .ipynb / .py
         api.post("submissions", "file", use: createSubmissionFile)
-    }
-
-    // MARK: - POST /api/v1/worker/request
-
-    @Sendable
-    func requestJob(req: Request) async throws -> Response {
-        let body = try req.content.decode(WorkerRequestBody.self)
-        await req.application.workerActivityStore.markActive(workerID: body.workerID)
-
-        // Find the oldest pending submission.
-        guard
-            let submission = try await APISubmission.query(on: req.db)
-                .filter(\.$status == "pending")
-                .sort(\.$submittedAt, .ascending)
-                .first()
-        else {
-            return Response(status: .noContent)
-        }
-
-        // Claim it atomically.
-        submission.status     = "assigned"
-        submission.workerID   = body.workerID
-        submission.assignedAt = Date()
-        try await submission.save(on: req.db)
-
-        guard let setup = try await APITestSetup.find(submission.testSetupID, on: req.db) else {
-            throw Abort(.internalServerError, reason: "TestSetup \(submission.testSetupID) not found")
-        }
-
-        let manifestData = Data(setup.manifest.utf8)
-        let decoder      = JSONDecoder()
-        let manifest     = try decoder.decode(TestProperties.self, from: manifestData)
-
-        let baseURL = req.application.http.server.configuration.hostname
-        let port    = req.application.http.server.configuration.port
-        let base    = "http://\(baseURL):\(port)"
-
-        let job = Job(
-            submissionID:       submission.id!,
-            testSetupID:        setup.id!,
-            attemptNumber:      submission.attemptNumber ?? 1,
-            submissionURL:      URL(string: "\(base)/api/v1/submissions/\(submission.id!)/download")!,
-            testSetupURL:       URL(string: "\(base)/api/v1/testsetups/\(setup.id!)/download")!,
-            manifest:           manifest,
-            submissionFilename: submission.filename
-        )
-
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode(job)
-
-        return Response(
-            status: .ok,
-            headers: ["Content-Type": "application/json"],
-            body: .init(data: data)
-        )
     }
 
     // MARK: - POST /api/v1/submissions
@@ -178,11 +119,6 @@ struct SubmissionDownloadRoute: RouteCollection {
 }
 
 // MARK: - Request / Response types
-
-struct WorkerRequestBody: Content {
-    let workerID: String
-    let hostname: String?
-}
 
 struct CreateSubmissionBody: Content {
     let testSetupID: String

--- a/Sources/APIServer/Routes/WorkerArtifactRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerArtifactRoutes.swift
@@ -1,0 +1,35 @@
+import Vapor
+import Fluent
+
+/// Worker-only artifact download routes authenticated by X-Worker-Secret.
+struct WorkerArtifactRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let worker = routes.grouped("api", "v1", "worker")
+        worker.get("submissions", ":submissionID", "download", use: downloadSubmission)
+        worker.get("testsetups", ":testSetupID", "download", use: downloadTestSetup)
+    }
+
+    @Sendable
+    func downloadSubmission(req: Request) async throws -> Response {
+        try await requireWorkerSecret(req)
+
+        guard let subID = req.parameters.get("submissionID"),
+              let submission = try await APISubmission.find(subID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+        return try await req.fileio.asyncStreamFile(at: submission.zipPath)
+    }
+
+    @Sendable
+    func downloadTestSetup(req: Request) async throws -> Response {
+        try await requireWorkerSecret(req)
+
+        guard let setupID = req.parameters.get("testSetupID"),
+              let setup = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+        return try await req.fileio.asyncStreamFile(at: setup.zipPath)
+    }
+}

--- a/Sources/APIServer/Routes/WorkerAuth.swift
+++ b/Sources/APIServer/Routes/WorkerAuth.swift
@@ -1,0 +1,18 @@
+import Vapor
+
+/// Validates `X-Worker-Secret` against the server's effective worker secret.
+/// This allows non-browser worker processes to authenticate without a session cookie.
+@Sendable
+func requireWorkerSecret(_ req: Request) async throws {
+    let provided = req.headers.first(name: "X-Worker-Secret")?
+        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let expected = (await req.application.workerSecretStore.effectiveSecret() ?? "")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !expected.isEmpty else {
+        throw Abort(.unauthorized, reason: "Worker auth is not configured.")
+    }
+    guard provided == expected else {
+        throw Abort(.unauthorized, reason: "Invalid worker secret.")
+    }
+}

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -1,0 +1,72 @@
+import Vapor
+import Fluent
+import Core
+import Foundation
+
+struct WorkerJobRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.grouped("api", "v1", "worker")
+            .post("request", use: requestJob)
+    }
+
+    // MARK: - POST /api/v1/worker/request
+
+    @Sendable
+    func requestJob(req: Request) async throws -> Response {
+        try await requireWorkerSecret(req)
+
+        let body = try req.content.decode(WorkerRequestBody.self)
+        await req.application.workerActivityStore.markActive(workerID: body.workerID)
+
+        guard
+            let submission = try await APISubmission.query(on: req.db)
+                .filter(\.$status == "pending")
+                .sort(\.$submittedAt, .ascending)
+                .first()
+        else {
+            return Response(status: .noContent)
+        }
+
+        submission.status     = "assigned"
+        submission.workerID   = body.workerID
+        submission.assignedAt = Date()
+        try await submission.save(on: req.db)
+
+        guard let setup = try await APITestSetup.find(submission.testSetupID, on: req.db) else {
+            throw Abort(.internalServerError, reason: "TestSetup \(submission.testSetupID) not found")
+        }
+
+        let manifestData = Data(setup.manifest.utf8)
+        let decoder      = JSONDecoder()
+        let manifest     = try decoder.decode(TestProperties.self, from: manifestData)
+
+        let baseURL = req.application.http.server.configuration.hostname
+        let port    = req.application.http.server.configuration.port
+        let base    = "http://\(baseURL):\(port)"
+
+        let job = Job(
+            submissionID:       submission.id!,
+            testSetupID:        setup.id!,
+            attemptNumber:      submission.attemptNumber ?? 1,
+            submissionURL:      URL(string: "\(base)/api/v1/worker/submissions/\(submission.id!)/download")!,
+            testSetupURL:       URL(string: "\(base)/api/v1/worker/testsetups/\(setup.id!)/download")!,
+            manifest:           manifest,
+            submissionFilename: submission.filename
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(job)
+
+        return Response(
+            status: .ok,
+            headers: ["Content-Type": "application/json"],
+            body: .init(data: data)
+        )
+    }
+}
+
+struct WorkerRequestBody: Content {
+    let workerID: String
+    let hostname: String?
+}

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -9,6 +9,8 @@ func routes(_ app: Application) throws {
 
     try app.register(collection: AuthRoutes())
     try app.register(collection: JupyterLiteContentsRoutes())
+    try app.register(collection: WorkerJobRoutes())
+    try app.register(collection: WorkerArtifactRoutes())
     // Worker result reporting is called by the worker daemon, not the browser.
     // It uses its own workerID for identification (Phase 7 will add worker tokens).
     try app.register(collection: ResultRoutes())

--- a/Sources/Worker/JobPoller.swift
+++ b/Sources/Worker/JobPoller.swift
@@ -9,6 +9,7 @@ import Core
 struct JobPoller: Sendable {
     let apiBaseURL: URL
     let workerID: String
+    let workerSecret: String
 
     private static let session: URLSession = {
         let cfg = URLSessionConfiguration.default
@@ -23,6 +24,10 @@ struct JobPoller: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !workerSecret.isEmpty {
+            request.setValue(workerSecret, forHTTPHeaderField: "X-Worker-Secret")
+            request.setValue(workerID, forHTTPHeaderField: "X-Worker-Id")
+        }
 
         let body = WorkerRequestPayload(
             workerID: workerID,

--- a/Sources/Worker/README.md
+++ b/Sources/Worker/README.md
@@ -1,6 +1,6 @@
 # chickadee-runner
 
-Worker daemon. Polls the API server for pending jobs, runs instructor-defined shell-script test suites in subprocesses, and reports structured results back.
+Runner daemon. Polls the API server for pending jobs, runs instructor-defined shell-script test suites in subprocesses, and reports structured results back.
 
 ---
 
@@ -9,7 +9,7 @@ Worker daemon. Polls the API server for pending jobs, runs instructor-defined sh
 | Flag | Type | Description |
 |------|------|-------------|
 | `--api-base-url` | `String` | Base URL of the API server (e.g. `http://localhost:8080`) |
-| `--worker-id` | `String` | Unique identifier for this worker instance |
+| `--worker-id` | `String` | Unique identifier for this runner instance |
 | `--max-jobs` | `Int` | Maximum number of concurrent jobs |
 | `--sandbox` | `Bool` (flag) | Run test scripts inside a network-isolated, privilege-dropped sandbox |
 

--- a/Sources/Worker/Reporter.swift
+++ b/Sources/Worker/Reporter.swift
@@ -7,6 +7,8 @@ import Core
 
 struct Reporter: Sendable {
     let apiBaseURL: URL
+    let workerID: String
+    let workerSecret: String
 
     private static let session: URLSession = {
         let cfg = URLSessionConfiguration.default
@@ -20,6 +22,10 @@ struct Reporter: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !workerSecret.isEmpty {
+            request.setValue(workerSecret, forHTTPHeaderField: "X-Worker-Secret")
+            request.setValue(workerID, forHTTPHeaderField: "X-Worker-Id")
+        }
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601


### PR DESCRIPTION
## Summary\n- add secret-authenticated runner routes for job polling and artifact downloads\n- secure result reporting with runner secret auth\n- add server startup secret resolution (CLI/env/persisted/generated) and persist admin updates\n- update runner CLI wiring to send auth headers and use runner wording in user-facing text\n- improve Admin page with live Runner status/assigned/processed columns and human-readable time\n- simplify notebook/admin UI labels and alignment fixes\n- refresh README CLI examples and remove requested sections\n\n## Validation\n- swift build