### PR TITLE
Runner-only assignment creation + validation autostart

### DIFF
--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -21,6 +21,15 @@ Admin
             </div>
         </label>
     </form>
+    <form method="post" action="/admin/runner-autostart" style="margin-top:.75rem;max-width:700px">
+        <label class="form-label" style="display:inline-flex;flex-direction:row;align-items:center;gap:.5rem;white-space:nowrap">
+            <input type="checkbox"
+                   name="localRunnerAutoStart"
+                   onchange="this.form.submit()"
+                   #if(localRunnerAutoStartEnabled):checked#endif>
+            <span>Auto-start one local runner when none are connected</span>
+        </label>
+    </form>
 
     <div style="margin-top:1rem">
         <p id="workers-empty" class="empty" #if(!workers.isEmpty):style="display:none"#endif>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -4,31 +4,55 @@ Create Assignment
 #endexport
 #export("content"):
 <h1>Create new Assignment</h1>
-<p class="card-meta" style="margin-bottom:1.25rem">
-    Step 1 of 2 · Choose how this assignment will be graded.
-</p>
 
-<form class="form" method="get" action="/assignments/new/details">
+#if(error):
+<div class="error-box" style="margin-bottom:1rem">
+    <h2>Could not create assignment</h2>
+    <p class="card-meta" style="margin-top:.5rem">#(error)</p>
+</div>
+#endif
+
+#if(notice):
+<div style="margin-bottom:1rem;padding:1rem;border:1px solid var(--green);border-radius:.5rem;background:#F0FDF4">
+    <p style="margin:0;color:var(--green);font-weight:600">#(notice)</p>
+</div>
+#endif
+
+<form class="form" method="post" action="/assignments/new/save" enctype="multipart/form-data">
     <label class="form-label">
         Assignment Name
-        <input class="form-input" type="text" name="assignmentName" required placeholder="e.g. Lab 2 - Linked Lists">
+        <input class="form-input" type="text" name="assignmentName" required
+               value="#(assignmentName)"
+               placeholder="e.g. Lab 2 - Linked Lists">
     </label>
 
     <label class="form-label">
         Due Date (optional)
-        <input class="form-input" type="datetime-local" name="dueAt">
+        <input class="form-input" type="datetime-local" name="dueAt" value="#(dueAt)">
     </label>
 
     <label class="form-label">
-        Grading Mode
-        <select class="form-input" name="gradingMode" required>
-            <option value="browser">Tested in browser</option>
-            <option value="server">Tested on server</option>
-        </select>
+        <span style="white-space:nowrap">Assignment Notebook (<code>assignment.ipynb</code>)</span>
+        <input class="form-input" type="file" name="assignmentNotebookFile" accept=".ipynb" required>
     </label>
 
+    <label class="form-label">
+        <span style="white-space:nowrap">Solution Notebook (<code>solution.ipynb</code>)</span>
+        <input class="form-input" type="file" name="solutionNotebookFile" accept=".ipynb" required>
+    </label>
+
+    <label class="form-label">
+        <span style="white-space:nowrap">Test Suite Files (include one or more <code>.sh</code> scripts; use <code>01_</code>, <code>02_</code> prefixes to control order)</span>
+        <input class="form-input" type="file" name="suiteFiles" multiple required>
+    </label>
+
+    <p class="card-meta">
+        The uploaded solution is validated immediately by a runner. The assignment stays closed until validation passes.
+        Once it passes, open it from the Instructor dashboard.
+    </p>
+
     <div style="display:flex;gap:.6rem;flex-wrap:wrap">
-        <button class="btn btn-primary" type="submit">Continue</button>
+        <button class="btn btn-primary" type="submit">Create &amp; Validate</button>
         <a class="btn" href="/assignments">Cancel</a>
     </div>
 </form>

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -16,6 +16,7 @@ Assignments
         <tr>
             <th>Name</th>
             <th>Status</th>
+            <th>Validation</th>
             <th class="due-col">Due</th>
             <th>Actions</th>
         </tr>
@@ -31,7 +32,7 @@ Assignments
                 #endif
             </td>
             <td>
-                #if(row.assignmentID):
+                #if(row.assignmentID && row.validationStatus == "passed"):
                 <form method="post" action="/assignments/#(row.assignmentID)/status">
                     <select class="form-input" name="status" onchange="this.form.submit()"
                             style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
@@ -39,12 +40,35 @@ Assignments
                         <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
                     </select>
                 </form>
+                #elseif(row.assignmentID):
+                <span class="tier tier-closed">closed</span>
                 #else:
                 <span class="tier
                     #if(row.status == "open"):tier-open
                     #elseif(row.status == "closed"):tier-closed
                     #elseif(row.status == "unpublished"):tier-unpublished
-                    #endif">#(row.status)</span>
+                #endif">#(row.status)</span>
+                #endif
+            </td>
+            <td>
+                #if(row.validationStatus == "passed"):
+                <span class="tier tier-open">passed</span>
+                #elseif(row.validationStatus == "failed"):
+                <span class="tier tier-closed">failed</span>
+                #if(row.validationSubmissionID):
+                <div style="margin-top:.25rem">
+                    <a href="/submissions/#(row.validationSubmissionID)">view</a>
+                </div>
+                #endif
+                #elseif(row.validationStatus == "pending"):
+                <span class="tier">pending</span>
+                #if(row.validationSubmissionID):
+                <div style="margin-top:.25rem">
+                    <a href="/submissions/#(row.validationSubmissionID)">track</a>
+                </div>
+                #endif
+                #else:
+                <span class="tier">—</span>
                 #endif
             </td>
             <td class="due-col">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>

--- a/Sources/APIServer/Migrations/AddValidationToAssignments.swift
+++ b/Sources/APIServer/Migrations/AddValidationToAssignments.swift
@@ -1,0 +1,17 @@
+import Fluent
+
+struct AddValidationToAssignments: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignments")
+            .field("validation_status", .string)
+            .field("validation_submission_id", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("assignments")
+            .deleteField("validation_submission_id")
+            .deleteField("validation_status")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -34,17 +34,30 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
     @Field(key: "is_open")
     var isOpen: Bool
 
+    /// Runner validation state for instructor-created assignments.
+    /// Values: "pending" | "passed" | "failed"
+    @OptionalField(key: "validation_status")
+    var validationStatus: String?
+
+    /// Submission ID for the runner validation run, if any.
+    @OptionalField(key: "validation_submission_id")
+    var validationSubmissionID: String?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
     init() {}
 
     init(id: UUID? = nil, testSetupID: String, title: String,
-         dueAt: Date? = nil, isOpen: Bool = true) {
+         dueAt: Date? = nil, isOpen: Bool = true,
+         validationStatus: String? = nil,
+         validationSubmissionID: String? = nil) {
         self.id          = id
         self.testSetupID = testSetupID
         self.title       = title
         self.dueAt       = dueAt
         self.isOpen      = isOpen
+        self.validationStatus = validationStatus
+        self.validationSubmissionID = validationSubmissionID
     }
 }


### PR DESCRIPTION
## Summary
- switch Create Assignment to runner-only workflow
- require assignment notebook, solution notebook, and suite file uploads (no zip option)
- auto-generate worker manifest from discovered .sh scripts with numeric-order support
- add assignment validation status/submission tracking and block opening until validation passes
- add admin toggle to auto-start a local sandboxed runner when none are connected
- persist local runner autostart setting and keep runner secret behavior stable

## Validation
- swift build