### PR TITLE
Generalize test scripts + lock down submission access

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -37,7 +37,8 @@
     // Fall back to a default lab path only if the attribute is missing.
     const notebookURL = `/api/v1/testsetups/${setupID}/assignment`;
     const editorURL = frame.dataset.editorUrl ||
-        `/jupyterlite/lab/index.html?workspace=${encodeURIComponent(setupID)}&reset&path=assignment.ipynb`;
+        frame.getAttribute('src') ||
+        `/jupyterlite/lab/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
     frame.src = editorURL;
 
     // Quick reachability check helps explain blank/failed editor loads.
@@ -86,9 +87,9 @@
                 const collection = buildCollection(outcomes, setupID);
                 const response   = await postBrowserResult(collection, notebook, setupID);
 
-                // Render results inline — no page navigation.
-                renderResults(outcomes, response);
-                setStatus('', '');
+                setStatus('loading', 'Submission queued. Opening grade details…');
+                window.location.assign(`/submissions/${response.workerSubmissionID}`);
+                return;
             } catch (err) {
                 setStatus('error', `Error: ${err.message}`);
             } finally {
@@ -134,8 +135,9 @@
                 // the server will re-inject hidden test cells server-side.
                 const response = await postBrowserResult(collection, uploadedNotebook, setupID);
 
-                renderResults(outcomes, response);
-                setStatus('', '');
+                setStatus('loading', 'Submission queued. Opening grade details…');
+                window.location.assign(`/submissions/${response.workerSubmissionID}`);
+                return;
             } catch (err) {
                 setStatus('error', `Error: ${err.message}`);
             } finally {

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -253,6 +253,15 @@ textarea.form-input {
     margin-bottom: 1rem;
 }
 
+.grade-pill {
+    display: inline-block;
+    padding: .1rem .45rem;
+    border-radius: 9999px;
+    background: #DBEAFE;
+    color: #1D4ED8;
+    font-size: .95rem;
+}
+
 .exec-time {
     font-size: .875rem;
     font-weight: 400;

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -42,7 +42,7 @@ Create Assignment
     </label>
 
     <label class="form-label">
-        <span style="white-space:nowrap">Test Suite Files (include one or more <code>.sh</code> scripts; use <code>01_</code>, <code>02_</code> prefixes to control order)</span>
+        <span style="white-space:nowrap">Test Suite Files (include one or more scripts like <code>.sh</code> or <code>.py</code>; use <code>01_</code>, <code>02_</code> prefixes to control order)</span>
         <input class="form-input" type="file" name="suiteFiles" multiple required>
     </label>
 

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -22,8 +22,8 @@ Notebook
     id="jl-frame"
     class="jl-frame"
     data-setup-id="#(testSetupID)"
-    data-editor-url="/jupyterlite/lab/index.html?workspace=#(testSetupID)&reset&path=#(jupyterLiteNotebookPath)"
-    src="/jupyterlite/lab/index.html?workspace=#(testSetupID)&reset&path=#(jupyterLiteNotebookPath)"
+    data-editor-url="#(jupyterLiteEditorURL)"
+    src="#(jupyterLiteEditorURL)"
     allow="cross-origin-isolated"
     loading="eager">
 </iframe>

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -41,7 +41,7 @@ Submission #(submissionID)
 </div>
 
 #else:
-<p class="score">#(passCount) / #(totalTests) passed
+<p class="score">Grade: <span class="grade-pill">#(gradePercent)%</span> · #(passCount) / #(totalTests) scripts passed
     <span class="exec-time">(#(executionTimeMs) ms total)</span>
     #if(isBrowserComplete):
     <span class="result-source">(browser preview)</span>
@@ -49,12 +49,13 @@ Submission #(submissionID)
     <span class="result-source">(official)</span>
     #endif
 </p>
+<h2>Per-script marks</h2>
 <table class="results-table">
     <thead>
         <tr>
-            <th>Test</th>
+            <th>Script</th>
             <th>Tier</th>
-            <th>Result</th>
+            <th>Mark</th>
             <th>ms</th>
         </tr>
     </thead>
@@ -67,7 +68,7 @@ Submission #(submissionID)
                 #(outcome.shortResult)
                 #if(outcome.longResult):
                 <details>
-                    <summary>details</summary>
+                    <summary>View script output</summary>
                     <pre>#(outcome.longResult)</pre>
                 </details>
                 #endif

--- a/Sources/APIServer/Migrations/AddValidationToAssignments.swift
+++ b/Sources/APIServer/Migrations/AddValidationToAssignments.swift
@@ -1,17 +1,51 @@
 import Fluent
+import SQLKit
 
 struct AddValidationToAssignments: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("assignments")
-            .field("validation_status", .string)
-            .field("validation_submission_id", .string)
-            .update()
+        let existing = try await existingColumns(on: database)
+
+        if !existing.contains("validation_status") {
+            try await database.schema("assignments")
+                .field("validation_status", .string)
+                .update()
+        }
+
+        if !existing.contains("validation_submission_id") {
+            try await database.schema("assignments")
+                .field("validation_submission_id", .string)
+                .update()
+        }
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("assignments")
-            .deleteField("validation_submission_id")
-            .deleteField("validation_status")
-            .update()
+        let existing = try await existingColumns(on: database)
+
+        if existing.contains("validation_submission_id") {
+            try await database.schema("assignments")
+                .deleteField("validation_submission_id")
+                .update()
+        }
+        if existing.contains("validation_status") {
+            try await database.schema("assignments")
+                .deleteField("validation_status")
+                .update()
+        }
+    }
+
+    private func existingColumns(on database: Database) async throws -> Set<String> {
+        guard let sql = database as? SQLDatabase else {
+            return []
+        }
+
+        let rows = try await sql.raw("PRAGMA table_info(assignments)").all()
+        var names: Set<String> = []
+        names.reserveCapacity(rows.count)
+        for row in rows {
+            if let name = try? row.decode(column: "name", as: String.self) {
+                names.insert(name)
+            }
+        }
+        return names
     }
 }

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -18,10 +18,10 @@ public enum GradingMode: String, Codable, Sendable, Equatable {
 }
 
 /// Entry for a single test in the manifest.
-/// `script` is the filename of the shell script at the root of the test setup zip.
+/// `script` is the filename/path of a runnable test script in the test setup zip.
 public struct TestSuiteEntry: Codable, Equatable, Sendable {
     public let tier: TestTier
-    public let script: String      // e.g. "test_bit_count.sh"
+    public let script: String      // e.g. "01_public.py"
 }
 
 /// Optional Makefile step to run before tests.

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -214,9 +214,10 @@ actor WorkerDaemon {
         }
 
         let longResult = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let baseName = (entry.script as NSString).deletingPathExtension
 
         return TestOutcome(
-            testName:           String(entry.script.dropLast(entry.script.hasSuffix(".sh") ? 3 : 0)),
+            testName:           baseName.isEmpty ? entry.script : baseName,
             testClass:          nil,
             tier:               entry.tier,
             status:             status,

--- a/Sources/Worker/ScriptInvocation.swift
+++ b/Sources/Worker/ScriptInvocation.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct ScriptInvocation {
+    let executableURL: URL
+    let arguments: [String]
+}
+
+func scriptInvocation(for script: URL) -> ScriptInvocation {
+    let ext = script.pathExtension.lowercased()
+    switch ext {
+    case "sh":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
+    case "bash":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["bash", script.path])
+    case "zsh":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["zsh", script.path])
+    case "py":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["python3", script.path])
+    case "rb":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["ruby", script.path])
+    case "pl":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["perl", script.path])
+    case "js":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["node", script.path])
+    case "php":
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["php", script.path])
+    default:
+        if FileManager.default.isExecutableFile(atPath: script.path) {
+            return ScriptInvocation(executableURL: script, arguments: [])
+        }
+        // Fallback for extension-less shell scripts.
+        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
+    }
+}

--- a/Sources/Worker/ScriptRunner.swift
+++ b/Sources/Worker/ScriptRunner.swift
@@ -19,8 +19,9 @@ struct UnsandboxedScriptRunner: ScriptRunner {
         let start = Date()
 
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
-        proc.arguments     = [script.path]
+        let invocation = scriptInvocation(for: script)
+        proc.executableURL = invocation.executableURL
+        proc.arguments     = invocation.arguments
         proc.currentDirectoryURL = workDir
 
         let stdoutPipe = Pipe()


### PR DESCRIPTION
## Summary
- allow runner test suites to use non-shell scripts (e.g. .py) in assignment creation flow
- add script invocation mapping in worker runner (python3/node/ruby/etc.) with fallback execution
- keep deterministic script ordering with numeric prefixes across all script types
- improve notebook load compatibility and student submission-grade UX updates
- fix migration robustness for AddValidationToAssignments on SQLite
- enforce per-user isolation on submission query/download APIs and set user ownership for browser-submitted jobs

## Validation
- swift build