### PR TITLE
Stabilize runner-based grading and suite validation flow

### DIFF
--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -43,8 +43,23 @@ Create Assignment
 
     <label class="form-label">
         <span style="white-space:nowrap">Test Suite Files (include one or more scripts like <code>.sh</code> or <code>.py</code>; use <code>01_</code>, <code>02_</code> prefixes to control order)</span>
-        <input class="form-input" type="file" name="suiteFiles" multiple required>
+        <input class="form-input" id="suite-files-input" type="file" name="suiteFiles" multiple required>
     </label>
+    <input type="hidden" id="suite-config-field" name="suiteConfig" value="">
+
+    <div id="suite-config-panel" style="display:none">
+        <table class="results-table">
+            <thead>
+                <tr>
+                    <th>File</th>
+                    <th>Test?</th>
+                    <th>Tier</th>
+                    <th class="time">Order</th>
+                </tr>
+            </thead>
+            <tbody id="suite-config-body"></tbody>
+        </table>
+    </div>
 
     <p class="card-meta">
         The uploaded solution is validated immediately by a runner. The assignment stays closed until validation passes.
@@ -56,5 +71,124 @@ Create Assignment
         <a class="btn" href="/assignments">Cancel</a>
     </div>
 </form>
+<script>
+(function () {
+    'use strict';
+
+    var filesInput = document.getElementById('suite-files-input');
+    var configField = document.getElementById('suite-config-field');
+    var panel = document.getElementById('suite-config-panel');
+    var body = document.getElementById('suite-config-body');
+    if (!filesInput || !configField || !panel || !body) return;
+
+    function isLikelyScript(name) {
+        var lower = (name || '').toLowerCase();
+        return lower.endsWith('.sh')
+            || lower.endsWith('.bash')
+            || lower.endsWith('.zsh')
+            || lower.endsWith('.py')
+            || lower.endsWith('.rb')
+            || lower.endsWith('.pl')
+            || lower.endsWith('.js')
+            || lower.endsWith('.php');
+    }
+
+    function inferredOrder(name, fallback) {
+        var match = (name || '').match(/^([0-9]+)[_-]/);
+        if (!match) return fallback;
+        var n = Number(match[1]);
+        return Number.isFinite(n) && n > 0 ? n : fallback;
+    }
+
+    function renderRows() {
+        var files = Array.from(filesInput.files || []);
+        if (files.length === 0) {
+            panel.style.display = 'none';
+            body.innerHTML = '';
+            configField.value = '';
+            return;
+        }
+
+        panel.style.display = '';
+        body.innerHTML = files.map(function (file, index) {
+            var likelyScript = isLikelyScript(file.name);
+            var checked = likelyScript ? 'checked' : '';
+            var supportSelected = likelyScript ? '' : 'selected';
+            var publicSelected = likelyScript ? 'selected' : '';
+            var order = inferredOrder(file.name, index + 1);
+            return '<tr data-index="' + index + '">'
+                + '<td><code>' + escapeHtml(file.name) + '</code></td>'
+                + '<td><input type="checkbox" class="suite-test-toggle" ' + checked + '></td>'
+                + '<td>'
+                + '  <select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">'
+                + '    <option value="support" ' + supportSelected + '>support</option>'
+                + '    <option value="public" ' + publicSelected + '>public</option>'
+                + '    <option value="secret">secret</option>'
+                + '    <option value="release">release</option>'
+                + '  </select>'
+                + '</td>'
+                + '<td class="time"><input class="form-input suite-order" type="number" min="1" step="1" value="' + order + '" style="width:6rem;padding:.25rem .5rem;font-size:.8rem"></td>'
+                + '</tr>';
+        }).join('');
+        syncConfig();
+    }
+
+    function syncConfig() {
+        var rows = Array.from(body.querySelectorAll('tr[data-index]'));
+        var config = rows.map(function (row) {
+            var index = Number(row.getAttribute('data-index'));
+            var tier = row.querySelector('.suite-tier')?.value || 'public';
+            var toggleEl = row.querySelector('.suite-test-toggle');
+            var toggleChecked = !!toggleEl?.checked;
+            var isTest = toggleChecked && tier !== 'support';
+            var orderRaw = row.querySelector('.suite-order')?.value || '';
+            var order = Number(orderRaw);
+
+            var tierEl = row.querySelector('.suite-tier');
+            var orderEl = row.querySelector('.suite-order');
+            if (toggleEl) {
+                toggleEl.checked = isTest;
+            }
+            if (tierEl) tierEl.disabled = false;
+            if (orderEl) orderEl.disabled = !isTest;
+
+            return {
+                index: index,
+                isTest: isTest,
+                tier: tier,
+                order: Number.isFinite(order) && order > 0 ? Math.floor(order) : null
+            };
+        });
+        configField.value = JSON.stringify(config);
+    }
+
+    function escapeHtml(value) {
+        return String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
+    }
+
+    filesInput.addEventListener('change', renderRows);
+    body.addEventListener('change', syncConfig);
+    body.addEventListener('input', syncConfig);
+
+    var form = filesInput.closest('form');
+    if (form) {
+        form.addEventListener('submit', function (event) {
+            syncConfig();
+            var config = [];
+            try { config = JSON.parse(configField.value || '[]'); } catch (_) { config = []; }
+            var hasTest = config.some(function (row) { return !!row.isTest; });
+            if (!hasTest) {
+                event.preventDefault();
+                window.alert('Select at least one file as a test.');
+            }
+        });
+    }
+})();
+</script>
 #endexport
 #endextend

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -108,6 +108,7 @@ struct BrowserResultRoutes: RouteCollection {
             userID:        caller.id
         )
         try await workerSub.save(on: req.db)
+        await ensureLocalRunnerForSubmissionIfNeeded(req: req)
 
         req.logger.info("Browser result stored for \(subID); worker job queued as \(workerSubID)")
 

--- a/Sources/APIServer/Routes/LocalRunnerAutoStart.swift
+++ b/Sources/APIServer/Routes/LocalRunnerAutoStart.swift
@@ -1,0 +1,12 @@
+import Vapor
+
+@Sendable
+func ensureLocalRunnerForSubmissionIfNeeded(req: Request) async {
+    let enabled = await req.application.localRunnerAutoStartStore.isEnabled()
+    guard enabled else { return }
+
+    let hasRecentRunner = await req.application.workerActivityStore.hasRecentActivity(within: 20)
+    guard !hasRecentRunner else { return }
+
+    await req.application.localRunnerManager.ensureRunning(app: req.application, logger: req.logger)
+}

--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -49,6 +49,7 @@ struct SubmissionRoutes: RouteCollection {
             attemptNumber: priorCount + 1
         )
         try await submission.save(on: req.db)
+        await ensureLocalRunnerForSubmissionIfNeeded(req: req)
 
         return SubmissionCreatedResponse(submissionID: subID)
     }
@@ -94,6 +95,7 @@ struct SubmissionRoutes: RouteCollection {
             filename:      body.filename
         )
         try await submission.save(on: req.db)
+        await ensureLocalRunnerForSubmissionIfNeeded(req: req)
 
         return SubmissionCreatedResponse(submissionID: subID)
     }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -133,47 +133,68 @@ struct AssignmentRoutes: RouteCollection {
 
     @Sendable
     func saveNewAssignment(req: Request) async throws -> Response {
-        struct SaveBody: Content {
+        struct SaveBodyMany: Content {
             var assignmentName: String?
             var dueAt: String?
             var assignmentNotebookFile: File?
             var solutionNotebookFile: File?
             var suiteFiles: [File]?
+            var suiteConfig: String?
+        }
+        struct SaveBodySingle: Content {
+            var assignmentName: String?
+            var dueAt: String?
+            var assignmentNotebookFile: File?
+            var solutionNotebookFile: File?
+            var suiteFiles: File?
+            var suiteConfig: String?
         }
 
-        let body = try req.content.decode(SaveBody.self)
-        let title = (body.assignmentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let due = parseDueDate(body.dueAt)
+        let bodyMany = try? req.content.decode(SaveBodyMany.self)
+        let bodySingle = bodyMany == nil ? (try? req.content.decode(SaveBodySingle.self)) : nil
+        guard bodyMany != nil || bodySingle != nil else {
+            throw Abort(.badRequest, reason: "Invalid assignment upload payload")
+        }
+
+        let assignmentName = bodyMany?.assignmentName ?? bodySingle?.assignmentName
+        let dueAtRaw = bodyMany?.dueAt ?? bodySingle?.dueAt
+        let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
+        let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
+        let suiteFilesRaw = bodyMany?.suiteFiles ?? (bodySingle?.suiteFiles.map { [$0] } ?? [])
+        let suiteConfigRaw = bodyMany?.suiteConfig ?? bodySingle?.suiteConfig
+
+        let title = (assignmentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let due = parseDueDate(dueAtRaw)
 
         guard !title.isEmpty else {
-            let q = "assignmentName=&dueAt=\(urlEncode(body.dueAt ?? ""))&error=Assignment%20name%20is%20required"
+            let q = "assignmentName=&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20name%20is%20required"
             return req.redirect(to: "/assignments/new?\(q)")
         }
 
-        guard let assignmentNotebookFile = body.assignmentNotebookFile,
+        guard let assignmentNotebookFile,
               assignmentNotebookFile.data.readableBytes > 0 else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(body.dueAt ?? ""))&error=Assignment%20notebook%20(.ipynb)%20is%20required"
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20notebook%20(.ipynb)%20is%20required"
             return req.redirect(to: "/assignments/new?\(q)")
         }
-        guard let solutionNotebookFile = body.solutionNotebookFile,
+        guard let solutionNotebookFile,
               solutionNotebookFile.data.readableBytes > 0 else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(body.dueAt ?? ""))&error=Solution%20notebook%20(.ipynb)%20is%20required"
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20(.ipynb)%20is%20required"
             return req.redirect(to: "/assignments/new?\(q)")
         }
-        let suiteFiles = (body.suiteFiles ?? []).filter { $0.data.readableBytes > 0 }
+        let suiteFiles = suiteFilesRaw.filter { $0.data.readableBytes > 0 }
         guard !suiteFiles.isEmpty else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(body.dueAt ?? ""))&error=At%20least%20one%20test%20suite%20file%20is%20required"
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=At%20least%20one%20test%20suite%20file%20is%20required"
             return req.redirect(to: "/assignments/new?\(q)")
         }
 
         let assignmentNotebookRaw = Data(assignmentNotebookFile.data.readableBytesView)
         let solutionNotebookRaw = Data(solutionNotebookFile.data.readableBytesView)
         guard (try? JSONSerialization.jsonObject(with: assignmentNotebookRaw)) != nil else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(body.dueAt ?? ""))&error=Assignment%20notebook%20is%20not%20valid%20JSON%20(.ipynb)"
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20notebook%20is%20not%20valid%20JSON%20(.ipynb)"
             return req.redirect(to: "/assignments/new?\(q)")
         }
         guard (try? JSONSerialization.jsonObject(with: solutionNotebookRaw)) != nil else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(body.dueAt ?? ""))&error=Solution%20notebook%20is%20not%20valid%20JSON%20(.ipynb)"
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20is%20not%20valid%20JSON%20(.ipynb)"
             return req.redirect(to: "/assignments/new?\(q)")
         }
 
@@ -184,17 +205,21 @@ struct AssignmentRoutes: RouteCollection {
         let notebookPath = setupsDir + "\(setupID).ipynb"
         let zipPath = setupsDir + "\(setupID).zip"
         try assignmentNotebook.write(to: URL(fileURLWithPath: notebookPath))
-        let suiteScripts = try createRunnerSetupZip(
+        let setupPackage = try createRunnerSetupZip(
             assignmentNotebookData: assignmentNotebook,
             suiteFiles: suiteFiles,
+            suiteConfigJSON: suiteConfigRaw,
             zipPath: zipPath
         )
-        guard !suiteScripts.isEmpty else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(body.dueAt ?? ""))&error=No%20supported%20test%20scripts%20found%20in%20test%20suite"
+        guard !setupPackage.testSuites.isEmpty else {
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Select%20at%20least%20one%20test%20file%20in%20the%20suite%20list"
             return req.redirect(to: "/assignments/new?\(q)")
         }
 
-        let manifest = try makeWorkerManifestJSON(scripts: suiteScripts)
+        let manifest = try makeWorkerManifestJSON(
+            testSuites: setupPackage.testSuites,
+            includeMakefile: setupPackage.hasMakefile
+        )
         let setup = APITestSetup(
             id: setupID,
             manifest: manifest,
@@ -232,8 +257,8 @@ struct AssignmentRoutes: RouteCollection {
         case .failed(let summary):
             assignment.validationStatus = "failed"
             try await assignment.save(on: req.db)
-            let q = "notice=\(urlEncode("Assignment saved, but runner validation failed (\(summary)). Fix your solution/test suite and create a new assignment."))"
-            return req.redirect(to: "/assignments/new?\(q)")
+            req.logger.warning("Assignment validation failed for setup \(setupID): \(summary) (submission \(validationSubmissionID))")
+            return req.redirect(to: "/submissions/\(validationSubmissionID)")
         case .timedOut:
             assignment.validationStatus = "pending"
             try await assignment.save(on: req.db)
@@ -413,6 +438,32 @@ struct AssignmentRoutes: RouteCollection {
         else {
             throw Abort(.notFound)
         }
+        let setupID = assignment.testSetupID
+
+        // Delete related submissions and their result rows for this setup.
+        let submissions = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .all()
+        let submissionIDs = submissions.compactMap(\.id)
+        if !submissionIDs.isEmpty {
+            try await APIResult.query(on: req.db)
+                .filter(\.$submissionID ~~ submissionIDs)
+                .delete()
+            try await APISubmission.query(on: req.db)
+                .filter(\.$id ~~ submissionIDs)
+                .delete()
+        }
+
+        // Delete setup artifacts and setup row so it disappears from the assignments list.
+        if let setup = try await APITestSetup.find(setupID, on: req.db) {
+            try? FileManager.default.removeItem(atPath: setup.zipPath)
+            if let notebookPath = setup.notebookPath, !notebookPath.isEmpty {
+                try? FileManager.default.removeItem(atPath: notebookPath)
+            }
+            removeMaterializedNotebookFiles(req: req, setupID: setupID)
+            try await setup.delete(on: req.db)
+        }
+
         try await assignment.delete(on: req.db)
         return req.redirect(to: "/assignments")
     }
@@ -569,14 +620,16 @@ private func defaultNotebookData(title: String) -> Data {
 private func createRunnerSetupZip(
     assignmentNotebookData: Data,
     suiteFiles: [File],
+    suiteConfigJSON: String?,
     zipPath: String
-) throws -> [String] {
+) throws -> RunnerSetupPackage {
     let fm = FileManager.default
     let tempDir = fm.temporaryDirectory.appendingPathComponent("chickadee_runner_setup_\(UUID().uuidString)")
     try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
     defer { try? fm.removeItem(at: tempDir) }
 
     var seenNames: Set<String> = []
+    var storedNameByIndex: [Int: String] = [:]
     for (index, file) in suiteFiles.enumerated() {
         let data = Data(file.data.readableBytesView)
         guard !data.isEmpty else { continue }
@@ -598,16 +651,20 @@ private func createRunnerSetupZip(
         }
         seenNames.insert(finalName)
         try data.write(to: tempDir.appendingPathComponent(finalName))
+        storedNameByIndex[index] = finalName
     }
 
     let notebookURL = tempDir.appendingPathComponent("assignment.ipynb")
     try assignmentNotebookData.write(to: notebookURL)
 
-    let discoveredScripts = discoverTestScripts(in: tempDir)
-    guard !discoveredScripts.isEmpty else {
-        throw Abort(.badRequest, reason: "Test suite must include at least one supported test script")
+    let testSuites = try buildSuiteEntries(
+        suiteFiles: suiteFiles,
+        storedNameByIndex: storedNameByIndex,
+        suiteConfigJSON: suiteConfigJSON
+    )
+    guard !testSuites.isEmpty else {
+        throw Abort(.badRequest, reason: "Select at least one test file in the suite file list")
     }
-    let scripts = try orderSuiteScripts(discoveredScripts)
 
     let zip = Process()
     zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
@@ -618,7 +675,11 @@ private func createRunnerSetupZip(
     guard zip.terminationStatus == 0 else {
         throw Abort(.internalServerError, reason: "Failed to package setup zip")
     }
-    return scripts
+    let hasMakefile = storedNameByIndex.values.contains {
+        let n = $0.lowercased()
+        return n == "makefile" || n == "gnumakefile"
+    }
+    return RunnerSetupPackage(testSuites: testSuites, hasMakefile: hasMakefile)
 }
 
 private func sanitizeSuiteFilename(_ raw: String) -> String {
@@ -629,90 +690,116 @@ private func sanitizeSuiteFilename(_ raw: String) -> String {
     return name
 }
 
-private func discoverTestScripts(in directory: URL) -> [String] {
-    guard let enumerator = FileManager.default.enumerator(
-        at: directory,
-        includingPropertiesForKeys: [.isRegularFileKey],
-        options: [.skipsHiddenFiles]
-    ) else { return [] }
-
-    var scripts: [String] = []
-    for case let fileURL as URL in enumerator {
-        guard isSupportedTestScript(fileURL) else { continue }
-        let relative = fileURL.path.replacingOccurrences(of: directory.path + "/", with: "")
-        scripts.append(relative)
-    }
-    return scripts.sorted()
+private struct SuiteConfigRow: Decodable {
+    let index: Int
+    let isTest: Bool
+    let tier: String?
+    let order: Int?
 }
 
-private func isSupportedTestScript(_ fileURL: URL) -> Bool {
-    let ext = fileURL.pathExtension.lowercased()
-    let supportedExtensions: Set<String> = ["sh", "bash", "zsh", "py", "rb", "pl", "js", "php"]
-    if supportedExtensions.contains(ext) { return true }
-
-    let filename = fileURL.lastPathComponent.lowercased()
-    if filename == "assignment.ipynb" { return false }
-    if FileManager.default.isExecutableFile(atPath: fileURL.path) { return true }
-
-    guard let data = try? Data(contentsOf: fileURL),
-          let text = String(data: data.prefix(256), encoding: .utf8) else {
-        return false
-    }
-    return text.hasPrefix("#!")
+private struct ConfiguredSuiteEntry {
+    let script: String
+    let tier: String
+    let order: Int
 }
 
-private func orderSuiteScripts(_ scripts: [String]) throws -> [String] {
-    struct Entry {
-        let path: String
-        let order: Int?
-    }
+private struct RunnerSetupPackage {
+    let testSuites: [ConfiguredSuiteEntry]
+    let hasMakefile: Bool
+}
 
-    let entries = scripts.map { script -> Entry in
-        let filename = (script as NSString).lastPathComponent
-        let ns = filename as NSString
-        let range = NSRange(location: 0, length: ns.length)
-        let regex = try? NSRegularExpression(pattern: #"^([0-9]+)[_-].+$"#)
-        guard let match = regex?.firstMatch(in: filename, options: [], range: range),
-              match.numberOfRanges >= 2,
-              let orderRange = Range(match.range(at: 1), in: filename),
-              let order = Int(filename[orderRange]) else {
-            return Entry(path: script, order: nil)
+private func buildSuiteEntries(
+    suiteFiles: [File],
+    storedNameByIndex: [Int: String],
+    suiteConfigJSON: String?
+) throws -> [ConfiguredSuiteEntry] {
+    let parsedRows: [SuiteConfigRow] = {
+        guard let raw = suiteConfigJSON?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty,
+              let data = raw.data(using: .utf8),
+              let rows = try? JSONDecoder().decode([SuiteConfigRow].self, from: data) else {
+            return []
         }
-        return Entry(path: script, order: order)
-    }
+        return rows
+    }()
 
-    let hasOrdered = entries.contains { $0.order != nil }
-    let hasUnordered = entries.contains { $0.order == nil }
-    if hasOrdered && hasUnordered {
-        throw Abort(
-            .badRequest,
-            reason: "When using numbered test scripts, every script must start with an order prefix like 01_ or 02-."
-        )
-    }
-
-    if hasOrdered {
-        return entries
+    if !parsedRows.isEmpty {
+        var rowsByIndex: [Int: SuiteConfigRow] = [:]
+        for row in parsedRows {
+            rowsByIndex[row.index] = row
+        }
+        var selected: [ConfiguredSuiteEntry] = []
+        for index in suiteFiles.indices {
+            guard let row = rowsByIndex[index], row.isTest else { continue }
+            guard let script = storedNameByIndex[index], !script.isEmpty else { continue }
+            let tier = normalizeTier(row.tier)
+            selected.append(ConfiguredSuiteEntry(
+                script: script,
+                tier: tier,
+                order: row.order ?? (index + 1)
+            ))
+        }
+        return selected
             .sorted { lhs, rhs in
-                if lhs.order != rhs.order {
-                    return (lhs.order ?? 0) < (rhs.order ?? 0)
-                }
-                return lhs.path < rhs.path
+                if lhs.order != rhs.order { return lhs.order < rhs.order }
+                return lhs.script < rhs.script
             }
-            .map(\.path)
     }
 
-    return scripts.sorted()
+    // Backward-compatible fallback when no suite config JSON is submitted.
+    let supportedExtensions: Set<String> = ["sh", "bash", "zsh", "py", "rb", "pl", "js", "php"]
+    var defaults: [ConfiguredSuiteEntry] = []
+    for index in suiteFiles.indices {
+        guard let script = storedNameByIndex[index], !script.isEmpty else { continue }
+        let ext = URL(fileURLWithPath: script).pathExtension.lowercased()
+        guard supportedExtensions.contains(ext) else { continue }
+        defaults.append(ConfiguredSuiteEntry(
+            script: script,
+            tier: "public",
+            order: inferredOrder(from: script) ?? (index + 1)
+        ))
+    }
+    return defaults
+        .sorted { lhs, rhs in
+            if lhs.order != rhs.order { return lhs.order < rhs.order }
+            return lhs.script < rhs.script
+        }
 }
 
-private func makeWorkerManifestJSON(scripts: [String]) throws -> String {
-    let testSuites = scripts.map { ["tier": "public", "script": $0] }
+private func inferredOrder(from filename: String) -> Int? {
+    let base = (filename as NSString).lastPathComponent
+    let ns = base as NSString
+    let range = NSRange(location: 0, length: ns.length)
+    let regex = try? NSRegularExpression(pattern: #"^([0-9]+)[_-].+$"#)
+    guard let match = regex?.firstMatch(in: base, options: [], range: range),
+          match.numberOfRanges >= 2,
+          let orderRange = Range(match.range(at: 1), in: base) else {
+        return nil
+    }
+    return Int(base[orderRange])
+}
+
+private func normalizeTier(_ raw: String?) -> String {
+    switch (raw ?? "public").lowercased() {
+    case "secret": return "secret"
+    case "release": return "release"
+    case "student": return "student"
+    default: return "public"
+    }
+}
+
+private func makeWorkerManifestJSON(
+    testSuites: [ConfiguredSuiteEntry],
+    includeMakefile: Bool
+) throws -> String {
+    let testSuiteJSON = testSuites.map { ["tier": $0.tier, "script": $0.script] }
     let manifest: [String: Any] = [
         "schemaVersion": 1,
         "gradingMode": "worker",
         "requiredFiles": [],
-        "testSuites": testSuites,
+        "testSuites": testSuiteJSON,
         "timeLimitSeconds": 10,
-        "makefile": NSNull()
+        "makefile": includeMakefile ? ["target": NSNull()] : NSNull()
     ]
     let data = try JSONSerialization.data(withJSONObject: manifest)
     return String(data: data, encoding: .utf8) ?? "{}"
@@ -798,6 +885,21 @@ private func ensureValidationRunnerAvailability(req: Request) async {
 
     await req.application.localRunnerManager.ensureRunning(app: req.application, logger: req.logger)
     try? await Task.sleep(nanoseconds: 1_000_000_000)
+}
+
+private func removeMaterializedNotebookFiles(req: Request, setupID: String) {
+    let roots = [
+        req.application.directory.publicDirectory + "files/",
+        req.application.directory.publicDirectory + "jupyterlite/files/",
+        req.application.directory.publicDirectory + "jupyterlite/lab/files/",
+        req.application.directory.publicDirectory + "jupyterlite/notebooks/files/"
+    ]
+    for root in roots {
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: root) else { continue }
+        for name in entries where name.hasPrefix(setupID) && name.hasSuffix(".ipynb") {
+            try? FileManager.default.removeItem(atPath: root + name)
+        }
+    }
 }
 
 private struct EditContext: Encodable {

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -171,10 +171,14 @@ struct WebRoutes: RouteCollection {
 
         // Detect whether the upload is a zip by checking PK magic bytes.
         let isZip     = body.files.prefix(4) == Data([0x50, 0x4B, 0x03, 0x04])
-        let ext       = body.uploadFilename.flatMap { URL(fileURLWithPath: $0).pathExtension } ?? "zip"
+        let ext: String = {
+            if isZip { return "zip" }
+            return inferredRawSubmissionExtension(data: body.files, uploadFilename: body.uploadFilename)
+        }()
         let storedExt = isZip ? "zip" : ext
         let filePath  = subsDir + "\(subID).\(storedExt)"
         try body.files.write(to: URL(fileURLWithPath: filePath))
+        let fallbackFilename = isZip ? nil : (body.uploadFilename ?? "submission.\(storedExt)")
 
         // Attempt number is scoped to this student for this test setup.
         let priorCount = try await APISubmission.query(on: req.db)
@@ -187,10 +191,11 @@ struct WebRoutes: RouteCollection {
             testSetupID:   setupID,
             zipPath:       filePath,
             attemptNumber: priorCount + 1,
-            filename:      isZip ? nil : body.uploadFilename,
+            filename:      fallbackFilename,
             userID:        user.id
         )
         try await submission.save(on: req.db)
+        await ensureLocalRunnerForSubmissionIfNeeded(req: req)
 
         return req.redirect(to: "/submissions/\(subID)")
     }
@@ -428,4 +433,21 @@ private struct SubmitFormBody: Content {
     var files: Data
     /// Original filename from the browser's multipart upload (nil for older clients).
     var uploadFilename: String?
+}
+
+private func inferredRawSubmissionExtension(data: Data, uploadFilename: String?) -> String {
+    if let uploadFilename {
+        let ext = URL(fileURLWithPath: uploadFilename).pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !ext.isEmpty {
+            return ext.lowercased()
+        }
+    }
+
+    // Heuristic: notebook uploads are JSON with "nbformat" key.
+    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+       json["nbformat"] != nil {
+        return "ipynb"
+    }
+
+    return "txt"
 }

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -106,6 +106,7 @@ actor WorkerDaemon {
                     try await process(job)
                 } catch {
                     fputs("[\(workerID)] Error processing job \(job.submissionID): \(error)\n", stderr)
+                    try? await reportProcessingFailure(job: job, error: error)
                 }
             } else {
                 let delay = backoff.next()
@@ -148,6 +149,12 @@ actor WorkerDaemon {
         if let makefile = manifest.makefile {
             try runMake(in: testSetupDir, target: makefile.target)
         }
+
+        // Run repository-managed notebook prep build step before tests.
+        try runRepositoryPrepMakefile(in: testSetupDir)
+
+        // Install shared Python test runtime helpers for every run.
+        try writePythonRuntimeHelpers(in: testSetupDir)
 
         // Run each test script and collect outcomes.
         var outcomes: [TestOutcome] = []
@@ -213,7 +220,20 @@ actor WorkerDaemon {
             shortResult = status.defaultShortResult
         }
 
-        let longResult = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stderrText = output.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stdoutText = output.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let longResult: String? = {
+            guard status != .pass else { return stderrText.isEmpty ? nil : stderrText }
+            var sections: [String] = []
+            if !stdoutText.isEmpty {
+                sections.append("stdout:\n\(stdoutText)")
+            }
+            if !stderrText.isEmpty {
+                sections.append("stderr:\n\(stderrText)")
+            }
+            if sections.isEmpty { return nil }
+            return sections.joined(separator: "\n\n")
+        }()
         let baseName = (entry.script as NSString).deletingPathExtension
 
         return TestOutcome(
@@ -222,7 +242,7 @@ actor WorkerDaemon {
             tier:               entry.tier,
             status:             status,
             shortResult:        shortResult,
-            longResult:         longResult.isEmpty ? nil : longResult,
+            longResult:         longResult,
             executionTimeMs:    output.executionTimeMs,
             memoryUsageBytes:   nil,
             attemptNumber:      attemptNumber,
@@ -297,6 +317,61 @@ actor WorkerDaemon {
             throw WorkerDaemonError.makeFailed(target)
         }
     }
+
+    private func runRepositoryPrepMakefile(in directory: URL) throws {
+        let repoRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        let sourceMakefile = repoRoot.appendingPathComponent("Tools/runner-support/Makefile")
+        guard FileManager.default.fileExists(atPath: sourceMakefile.path) else {
+            return
+        }
+
+        let localMakefile = directory.appendingPathComponent("ChickadeePrep.mk")
+        if FileManager.default.fileExists(atPath: localMakefile.path) {
+            try FileManager.default.removeItem(at: localMakefile)
+        }
+        try FileManager.default.copyItem(at: sourceMakefile, to: localMakefile)
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/make")
+        proc.arguments = ["-f", localMakefile.lastPathComponent]
+        proc.currentDirectoryURL = directory
+        try proc.run()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else {
+            throw WorkerDaemonError.prepMakeFailed
+        }
+    }
+
+    private func reportProcessingFailure(job: Job, error: Error) async throws {
+        let message = String(describing: error)
+        let collection = TestOutcomeCollection(
+            submissionID:    job.submissionID,
+            testSetupID:     job.testSetupID,
+            attemptNumber:   job.attemptNumber,
+            buildStatus:     .failed,
+            compilerOutput:  message,
+            outcomes:        [],
+            totalTests:      0,
+            passCount:       0,
+            failCount:       0,
+            errorCount:      1,
+            timeoutCount:    0,
+            executionTimeMs: 0,
+            runnerVersion:   "shell-runner/1.0",
+            timestamp:       Date()
+        )
+        try await reporter.report(collection)
+    }
+
+    private func writePythonRuntimeHelpers(in directory: URL) throws {
+        let runtimeURL = directory.appendingPathComponent("test_runtime.py")
+        try testRuntimePy.write(to: runtimeURL, atomically: true, encoding: .utf8)
+
+        // Python auto-imports sitecustomize (if present on sys.path), which
+        // lets helpers be available without explicit imports in each test file.
+        let sitecustomizeURL = directory.appendingPathComponent("sitecustomize.py")
+        try sitecustomizePy.write(to: sitecustomizeURL, atomically: true, encoding: .utf8)
+    }
 }
 
 // MARK: - Script result JSON (optional last-line protocol)
@@ -306,6 +381,134 @@ private struct ScriptResultJSON: Decodable {
     let score: Double?
     let shortResult: String?
 }
+
+private let testRuntimePy = """
+import inspect
+import json
+import traceback
+import importlib.util
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def _caller_file(depth: int = 3) -> Path:
+    frame = inspect.stack()[depth]
+    return Path(frame.filename)
+
+
+def _first_comment_label() -> str:
+    path = _caller_file()
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if not s:
+                continue
+            if s.startswith("#!") or s.startswith("# -*-"):
+                continue
+            if s.startswith("#"):
+                label = s.lstrip("#").strip()
+                return label if label else path.stem
+            break
+    except Exception:
+        pass
+    return path.stem
+
+
+def _emit(payload: Dict[str, object]) -> None:
+    print(json.dumps(payload, ensure_ascii=False))
+
+
+def passed(message: Optional[str] = None):
+    label = _first_comment_label()
+    _emit({
+        "shortResult": message or f"{label}: passed",
+        "status": "pass",
+        "test": label,
+    })
+    raise SystemExit(0)
+
+
+def failed(message: str = "failed"):
+    label = _first_comment_label()
+    _emit({
+        "shortResult": f"{label}: failed",
+        "status": "fail",
+        "test": label,
+        "error": message,
+    })
+    raise SystemExit(1)
+
+
+def errored(message: str = "error", err: Optional[Exception] = None):
+    label = _first_comment_label()
+    payload = {
+        "shortResult": f"{label}: error",
+        "status": "error",
+        "test": label,
+        "error": message,
+    }
+    if err is not None:
+        payload["exception"] = repr(err)
+        payload["traceback"] = traceback.format_exc()
+    _emit(payload)
+    raise SystemExit(2)
+
+
+def _candidate_student_files() -> List[Path]:
+    cwd = Path(".")
+    files = []
+    for p in sorted(cwd.glob("*.py")):
+        name = p.name
+        if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py"}:
+            continue
+        if name.startswith("publictest_") or name.startswith("secrettest_"):
+            continue
+        files.append(p)
+    return files
+
+
+def load_student_module():
+    for path in _candidate_student_files():
+        try:
+            spec = importlib.util.spec_from_file_location(f"student_{path.stem}", path)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+        except Exception:
+            continue
+    return None
+
+
+def require_function(name: str):
+    module = load_student_module()
+    if module is None:
+        errored("Could not load a student Python module from submission.")
+    fn = getattr(module, name, None)
+    if fn is None or not callable(fn):
+        errored(f"Required function '{name}' was not found or is not callable.")
+    return fn
+"""
+
+private let sitecustomizePy = """
+import builtins
+import test_runtime as _tr
+
+builtins.passed = _tr.passed
+builtins.failed = _tr.failed
+builtins.errored = _tr.errored
+builtins.require_function = _tr.require_function
+
+_student_module = _tr.load_student_module()
+builtins.student_module = _student_module
+if _student_module is not None:
+    for _name, _value in vars(_student_module).items():
+        if _name.startswith("_"):
+            continue
+        if callable(_value) and not hasattr(builtins, _name):
+            setattr(builtins, _name, _value)
+"""
 
 // MARK: - Helpers
 
@@ -351,12 +554,14 @@ enum WorkerDaemonError: Error, LocalizedError {
     case downloadFailed(URL)
     case unzipFailed(URL)
     case makeFailed(String?)
+    case prepMakeFailed
 
     var errorDescription: String? {
         switch self {
         case .downloadFailed(let url):  return "Failed to download \(url)"
         case .unzipFailed(let url):     return "Failed to unzip \(url.lastPathComponent)"
         case .makeFailed(let target):   return "make \(target ?? "") failed"
+        case .prepMakeFailed:           return "Repository prep Makefile failed"
         }
     }
 }

--- a/Sources/Worker/ScriptInvocation.swift
+++ b/Sources/Worker/ScriptInvocation.swift
@@ -5,6 +5,37 @@ struct ScriptInvocation {
     let arguments: [String]
 }
 
+private let pythonBootstrap = """
+import builtins
+import runpy
+import sys
+
+import test_runtime as _tr
+
+builtins.passed = _tr.passed
+builtins.failed = _tr.failed
+builtins.errored = _tr.errored
+builtins.require_function = _tr.require_function
+
+_student_module = _tr.load_student_module()
+builtins.student_module = _student_module
+if _student_module is not None:
+    for _name, _value in vars(_student_module).items():
+        if _name.startswith("_"):
+            continue
+        if callable(_value) and not hasattr(builtins, _name):
+            setattr(builtins, _name, _value)
+
+runpy.run_path(sys.argv[1], run_name="__main__")
+"""
+
+private func pythonInvocation(for script: URL) -> ScriptInvocation {
+    ScriptInvocation(
+        executableURL: URL(fileURLWithPath: "/usr/bin/env"),
+        arguments: ["python3", "-c", pythonBootstrap, script.path]
+    )
+}
+
 func scriptInvocation(for script: URL) -> ScriptInvocation {
     let ext = script.pathExtension.lowercased()
     switch ext {
@@ -15,7 +46,7 @@ func scriptInvocation(for script: URL) -> ScriptInvocation {
     case "zsh":
         return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["zsh", script.path])
     case "py":
-        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["python3", script.path])
+        return pythonInvocation(for: script)
     case "rb":
         return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["ruby", script.path])
     case "pl":
@@ -25,10 +56,69 @@ func scriptInvocation(for script: URL) -> ScriptInvocation {
     case "php":
         return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["php", script.path])
     default:
+        if let shebang = shebangLine(for: script) {
+            if shebang.contains("python") {
+                return pythonInvocation(for: script)
+            }
+            if shebang.contains("node") || shebang.contains("javascript") {
+                return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["node", script.path])
+            }
+            if shebang.contains("ruby") {
+                return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["ruby", script.path])
+            }
+            if shebang.contains("perl") {
+                return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["perl", script.path])
+            }
+            if shebang.contains("bash") {
+                return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["bash", script.path])
+            }
+            if shebang.contains("zsh") {
+                return ScriptInvocation(executableURL: URL(fileURLWithPath: "/usr/bin/env"), arguments: ["zsh", script.path])
+            }
+            if shebang.contains("sh") {
+                return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
+            }
+        }
+
+        if looksLikePythonScript(script) {
+            return pythonInvocation(for: script)
+        }
+
         if FileManager.default.isExecutableFile(atPath: script.path) {
             return ScriptInvocation(executableURL: script, arguments: [])
         }
         // Fallback for extension-less shell scripts.
         return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
+    }
+}
+
+private func shebangLine(for script: URL) -> String? {
+    guard let data = try? Data(contentsOf: script),
+          let text = String(data: data.prefix(512), encoding: .utf8) else {
+        return nil
+    }
+    let firstLine = text.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init)
+    guard let firstLine, firstLine.hasPrefix("#!") else { return nil }
+    return firstLine.lowercased()
+}
+
+private func looksLikePythonScript(_ script: URL) -> Bool {
+    guard let data = try? Data(contentsOf: script),
+          let text = String(data: data.prefix(2048), encoding: .utf8) else {
+        return false
+    }
+    let lines = text
+        .split(separator: "\n")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        .prefix(5)
+
+    guard !lines.isEmpty else { return false }
+    return lines.contains { line in
+        line.hasPrefix("import ")
+            || line.hasPrefix("from ")
+            || line.hasPrefix("def ")
+            || line.hasPrefix("class ")
+            || line.hasPrefix("if __name__ == ")
     }
 }

--- a/Tools/runner-support/Makefile
+++ b/Tools/runner-support/Makefile
@@ -1,0 +1,34 @@
+IPYNB := $(wildcard *.ipynb)
+PY    := $(IPYNB:.ipynb=.py)
+
+.PHONY: all clean
+
+all: nb_to_py.py $(PY)
+	@test ! -f compile_fail
+
+nb_to_py.py:
+	@printf '%s\n' \
+"import sys, json" \
+"" \
+"p = sys.argv[1]" \
+"with open(p, 'r', encoding='utf-8') as f:" \
+"    nb = json.load(f)" \
+"" \
+"out = p[:-6] + '.py'" \
+"with open(out, 'w', encoding='utf-8') as w:" \
+"    w.write(f'# Generated from {p}\\n\\n')" \
+"    for cell in nb.get('cells', []):" \
+"        if cell.get('cell_type') == 'code':" \
+"            src = cell.get('source', '')" \
+"            if isinstance(src, list):" \
+"                src = ''.join(src)" \
+"            src = src.rstrip()" \
+"            if src:" \
+"                w.write(src + '\\n\\n')" \
+> $@
+
+%.py: %.ipynb nb_to_py.py
+	@python3 nb_to_py.py "$<" || touch compile_fail
+
+clean:
+	@rm -f $(PY) nb_to_py.py compile_fail

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -1,0 +1,106 @@
+import inspect
+import importlib.util
+import json
+import traceback
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def _caller_file(depth: int = 3) -> Path:
+    frame = inspect.stack()[depth]
+    return Path(frame.filename)
+
+
+def _first_comment_label() -> str:
+    path = _caller_file()
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if not s:
+                continue
+            if s.startswith("#!") or s.startswith("# -*-"):
+                continue
+            if s.startswith("#"):
+                label = s.lstrip("#").strip()
+                return label if label else path.stem
+            break
+    except Exception:
+        pass
+    return path.stem
+
+
+def _emit(payload: Dict[str, object]) -> None:
+    print(json.dumps(payload, ensure_ascii=False))
+
+
+def passed(message: Optional[str] = None):
+    label = _first_comment_label()
+    _emit({
+        "shortResult": message or f"{label}: passed",
+        "status": "pass",
+        "test": label,
+    })
+    raise SystemExit(0)
+
+
+def failed(message: str = "failed"):
+    label = _first_comment_label()
+    _emit({
+        "shortResult": f"{label}: failed",
+        "status": "fail",
+        "test": label,
+        "error": message,
+    })
+    raise SystemExit(1)
+
+
+def errored(message: str = "error", err: Optional[Exception] = None):
+    label = _first_comment_label()
+    payload = {
+        "shortResult": f"{label}: error",
+        "status": "error",
+        "test": label,
+        "error": message,
+    }
+    if err is not None:
+        payload["exception"] = repr(err)
+        payload["traceback"] = traceback.format_exc()
+    _emit(payload)
+    raise SystemExit(2)
+
+
+def _candidate_student_files() -> List[Path]:
+    cwd = Path(".")
+    files = []
+    for p in sorted(cwd.glob("*.py")):
+        name = p.name
+        if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py"}:
+            continue
+        if name.startswith("publictest_") or name.startswith("secrettest_"):
+            continue
+        files.append(p)
+    return files
+
+
+def load_student_module():
+    for path in _candidate_student_files():
+        try:
+            spec = importlib.util.spec_from_file_location(f"student_{path.stem}", path)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+        except Exception:
+            continue
+    return None
+
+
+def require_function(name: str):
+    module = load_student_module()
+    if module is None:
+        errored("Could not load a student Python module from submission.")
+    fn = getattr(module, name, None)
+    if fn is None or not callable(fn):
+        errored(f"Required function '{name}' was not found or is not callable.")
+    return fn


### PR DESCRIPTION
## Summary
- stabilize runner autostart for submission grading paths
- improve submission file extension/type inference for notebook uploads
- add runner-side python test runtime helpers and bootstrap invocation
- support repo prep Makefile execution before tests
- improve assignment suite upload handling and manifest generation for selected tests/support files

## Validation
- swift build
- verified recent submission flow completes with passing result