### PR TITLE
Improve submission UX and switch notebook submit to runner-only

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1,19 +1,15 @@
 // Public/notebook.js
 //
-// Chickadee in-browser grading engine.
+// Chickadee notebook submission page.
 //
 // Loads the assignment notebook, lets the student edit it in JupyterLite,
-// then on "Submit" runs the notebook via Pyodide, collects per-test outcomes,
-// and POSTs a TestOutcomeCollection to POST /api/v1/submissions/browser-result.
+// then on "Submit" sends the notebook directly to the server for runner-based
+// grading. No browser-side grading is performed here.
 //
-// "Upload & submit" (Phase 9): student picks a locally-edited .ipynb file;
-// the upload flow mirrors the Submit flow exactly — Pyodide runs against the
-// uploaded solution (merged with visible test cells from the server), results
-// are shown inline, and the submission is queued for an authoritative worker run.
+// "Upload & submit": if a file picker is present, uploaded notebook files are
+// submitted directly to the runner as well (no browser-side grading).
 //
-// Results are rendered inline on the same page so students can iterate
-// without navigating away. A "View official submission" link is shown
-// after each run for the permanent record.
+// After submission, the page redirects to the canonical submission detail view.
 
 (function () {
     'use strict';
@@ -35,7 +31,7 @@
     // Point the iframe at the embedded JupyterLite distribution.
     // The server provides a concrete JupyterLite file path via data-editor-url.
     // Fall back to a default lab path only if the attribute is missing.
-    const notebookURL = `/api/v1/testsetups/${setupID}/assignment`;
+    const notebookURL = frame.dataset.notebookUrl || `/api/v1/testsetups/${setupID}/assignment`;
     const editorURL = frame.dataset.editorUrl ||
         frame.getAttribute('src') ||
         `/jupyterlite/lab/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
@@ -65,30 +61,24 @@
     }, 5000);
 
     // -------------------------------------------------------------------------
-    // 2. Submit button — run via Pyodide, POST results, render inline
+    // 2. Submit button — queue runner grading
     // -------------------------------------------------------------------------
 
     if (submitBtn) {
         submitBtn.addEventListener('click', async () => {
             submitBtn.disabled = true;
             clearResults();
-            setStatus('loading', 'Loading grading engine…');
+            setStatus('loading', 'Preparing submission…');
 
             try {
-                // Fetch the notebook JSON directly (same file JupyterLite loaded).
-                const nbRes = await fetch(notebookURL);
-                if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
-                const notebook = await nbRes.json();
-
-                setStatus('loading', 'Running tests…');
-                const outcomes = await runNotebook(notebook);
+                setStatus('loading', 'Capturing notebook…');
+                const notebook = await loadNotebookForSubmit();
 
                 setStatus('loading', 'Submitting…');
-                const collection = buildCollection(outcomes, setupID);
-                const response   = await postBrowserResult(collection, notebook, setupID);
+                const response = await postRunnerSubmission(notebook, setupID);
 
                 setStatus('loading', 'Submission queued. Opening grade details…');
-                window.location.assign(`/submissions/${response.workerSubmissionID}`);
+                window.location.assign(`/submissions/${response.submissionID}`);
                 return;
             } catch (err) {
                 setStatus('error', `Error: ${err.message}`);
@@ -98,8 +88,94 @@
         });
     }
 
+    async function loadNotebookForSubmit() {
+        const liveNotebook = await readNotebookFromJupyterFrame();
+        if (liveNotebook) return liveNotebook;
+
+        const nbRes = await fetch(notebookURL);
+        if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
+        return nbRes.json();
+    }
+
+    async function readNotebookFromJupyterFrame() {
+        try {
+            const childWindow = frame.contentWindow;
+            const app = childWindow && childWindow.jupyterapp;
+            if (!app || !app.shell) return null;
+
+            // Best effort: flush edits to the notebook model/context before reading.
+            if (app.commands && typeof app.commands.execute === 'function') {
+                try { await app.commands.execute('docmanager:save'); } catch (_) {}
+            }
+
+            const widget = app.shell.currentWidget;
+            const modelNotebook = notebookFromWidget(widget);
+            if (modelNotebook) return modelNotebook;
+
+            const pathFromWidget = widget && widget.context && widget.context.path;
+            const pathFromURL = extractPathFromEditorURL(editorURL);
+            const notebookPath = pathFromWidget || pathFromURL;
+
+            const contents = app.serviceManager && app.serviceManager.contents;
+            if (!contents || typeof contents.get !== 'function' || !notebookPath) {
+                return null;
+            }
+
+            const contentModel = await contents.get(notebookPath, { content: true });
+            const contentNotebook = contentModel && contentModel.content;
+            if (looksLikeNotebook(contentNotebook)) {
+                return toPlainNotebook(contentNotebook);
+            }
+        } catch (_) {
+            // Fall back to server-provided notebook URL below.
+        }
+        return null;
+    }
+
+    function notebookFromWidget(widget) {
+        if (!widget) return null;
+
+        const candidates = [
+            widget.content && widget.content.model,
+            widget.context && widget.context.model,
+            widget.model
+        ];
+
+        for (const candidate of candidates) {
+            if (!candidate || typeof candidate.toJSON !== 'function') continue;
+            try {
+                const notebook = candidate.toJSON();
+                if (looksLikeNotebook(notebook)) return toPlainNotebook(notebook);
+            } catch (_) {
+                // Try next candidate.
+            }
+        }
+        return null;
+    }
+
+    function extractPathFromEditorURL(url) {
+        try {
+            const parsed = new URL(url, window.location.origin);
+            return parsed.searchParams.get('path');
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function looksLikeNotebook(value) {
+        return !!value && typeof value === 'object' && Array.isArray(value.cells);
+    }
+
+    function toPlainNotebook(notebook) {
+        try {
+            return JSON.parse(JSON.stringify(notebook));
+        } catch (_) {
+            return notebook;
+        }
+    }
+
     // -------------------------------------------------------------------------
-    // 3. Upload & submit — read file → merge → Pyodide → POST → render
+    // 3. Upload & submit — read file → queue runner grading
     // -------------------------------------------------------------------------
 
     if (uploadFile) {
@@ -109,34 +185,22 @@
 
             if (submitBtn) submitBtn.disabled = true;
             clearResults();
-            setStatus('loading', 'Loading grading engine…');
+            setStatus('loading', 'Preparing submission…');
 
             try {
                 // Read the student's uploaded notebook.
                 const uploadedText     = await readFileAsText(file);
                 const uploadedNotebook = JSON.parse(uploadedText);
 
-                // Fetch the assignment notebook to get the visible test cells.
-                setStatus('loading', 'Fetching test definitions…');
-                const nbRes = await fetch(notebookURL);
-                if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
-                const assignmentNotebook = await nbRes.json();
-
-                // Build a merged notebook for Pyodide:
-                // solution cells from the upload + test cells from the assignment.
-                const mergedForPyodide = mergeNotebooksForRun(uploadedNotebook, assignmentNotebook);
-
-                setStatus('loading', 'Running tests…');
-                const outcomes = await runNotebook(mergedForPyodide);
-
                 setStatus('loading', 'Submitting…');
-                const collection = buildCollection(outcomes, setupID);
-                // POST the uploaded (unmerged) notebook as the submission artifact;
-                // the server will re-inject hidden test cells server-side.
-                const response = await postBrowserResult(collection, uploadedNotebook, setupID);
+                const response = await postRunnerSubmission(
+                    uploadedNotebook,
+                    setupID,
+                    file.name || 'submission.ipynb'
+                );
 
                 setStatus('loading', 'Submission queued. Opening grade details…');
-                window.location.assign(`/submissions/${response.workerSubmissionID}`);
+                window.location.assign(`/submissions/${response.submissionID}`);
                 return;
             } catch (err) {
                 setStatus('error', `Error: ${err.message}`);
@@ -366,16 +430,16 @@ else:
     }
 
     // -------------------------------------------------------------------------
-    // 8. POST to /api/v1/submissions/browser-result
+    // 8. POST to /api/v1/submissions/runner-submit
     // -------------------------------------------------------------------------
 
-    async function postBrowserResult(collection, notebook, testSetupID) {
+    async function postRunnerSubmission(notebook, testSetupID, filename = 'submission.ipynb') {
         const formData = new FormData();
-        formData.append('collection',  JSON.stringify(collection));
         formData.append('notebook',    new Blob([JSON.stringify(notebook)], { type: 'application/json' }), 'notebook.ipynb');
         formData.append('testSetupID', testSetupID);
+        formData.append('filename', filename);
 
-        const res = await fetch('/api/v1/submissions/browser-result', {
+        const res = await fetch('/api/v1/submissions/runner-submit', {
             method: 'POST',
             body:   formData,
         });

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -345,6 +345,18 @@ details pre {
     overflow-x: auto;
 }
 
+.script-output-inline {
+    margin-top: .45rem;
+    margin-bottom: 0;
+    font-size: .78rem;
+    line-height: 1.35;
+    white-space: pre-wrap;
+    background: #F8FAFC;
+    padding: .55rem .7rem;
+    border-radius: .25rem;
+    border: 1px solid var(--gray-200);
+}
+
 /* ── Misc ────────────────────────────────────────────── */
 
 .empty { color: var(--gray-600); font-size: .95rem; }

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -13,6 +13,8 @@ Assignments
             <th>Name</th>
             <th>Status</th>
             <th class="due-col">Due</th>
+            <th>Grade</th>
+            <th>History</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -39,13 +41,32 @@ Assignments
             </td>
             <td class="due-col">#if(setup.dueAt):#(setup.dueAt)#else:—#endif</td>
             <td>
+                #if(setup.bestGradeText):
+                    <strong>#(setup.bestGradeText)</strong>
+                #else:
+                    <span class="empty">—</span>
+                #endif
+            </td>
+            <td>
+                #if(setup.submissionCount > 0):
+                    <div style="display:flex;flex-direction:column;gap:.2rem">
+                        #if(setup.hasLatestSubmission):
+                            <a href="/submissions/#(setup.latestSubmissionID)" style="font-size:.82rem">#(setup.latestSubmittedAtText)</a>
+                        #endif
+                        #if(setup.additionalSubmissionCount > 0):
+                            <a href="/testsetups/#(setup.id)/history" style="font-size:.78rem;color:var(--gray-600)">+#(setup.additionalSubmissionCount) more</a>
+                        #endif
+                    </div>
+                #else:
+                    <span class="empty">No submissions yet</span>
+                #endif
+            </td>
+            <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
                     #if(setup.isOpen):
                     <a class="btn btn-primary" href="/testsetups/#(setup.id)/submit"
                        style="font-size:.8rem;padding:.25rem .6rem">Submit</a>
                     #endif
-                    <a class="btn" href="/api/v1/testsetups/#(setup.id)/assignment/download" download
-                       style="font-size:.8rem;padding:.25rem .6rem">Download</a>
                 </div>
             </td>
         </tr>

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -22,6 +22,7 @@ Notebook
     id="jl-frame"
     class="jl-frame"
     data-setup-id="#(testSetupID)"
+    data-notebook-url="#(notebookURL)"
     data-editor-url="#(jupyterLiteEditorURL)"
     src="#(jupyterLiteEditorURL)"
     allow="cross-origin-isolated"

--- a/Resources/Views/submission-history.leaf
+++ b/Resources/Views/submission-history.leaf
@@ -1,0 +1,35 @@
+#extend("base"):
+#export("title"):
+Submission History
+#endexport
+#export("content"):
+<h1>#(assignmentTitle)</h1>
+<p style="margin-top:-.35rem"><a href="/">← Back to assignments</a></p>
+#if(rows.isEmpty):
+<p class="empty">No submissions yet for this assignment.</p>
+#else:
+<table class="results-table">
+    <thead>
+        <tr>
+            <th>Attempt</th>
+            <th>Submitted</th>
+            <th>Status</th>
+            <th>Grade</th>
+            <th>Details</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(row in rows):
+        <tr>
+            <td>#(row.attemptNumber)</td>
+            <td>#(row.submittedAt)</td>
+            <td>#(row.status)</td>
+            <td>#(row.gradeText)</td>
+            <td><a href="/submissions/#(row.submissionID)">View</a></td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+#endif
+#endexport
+#endextend

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -66,9 +66,12 @@ Submission #(submissionID)
             <td><span class="tier">#(outcome.tier)</span></td>
             <td>
                 #(outcome.shortResult)
+                #if(outcome.readableOutput):
+                <pre class="script-output-inline">#(outcome.readableOutput)</pre>
+                #endif
                 #if(outcome.longResult):
                 <details>
-                    <summary>View script output</summary>
+                    <summary>Raw output</summary>
                     <pre>#(outcome.longResult)</pre>
                 </details>
                 #endif

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -65,6 +65,8 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
 
     app.sessions.use(.memory)
     app.middleware.use(app.sessions.middleware)
+    app.middleware.use(UserSessionAuthenticator())
+    app.middleware.use(UserFileNamespaceMiddleware())
     // Allow notebook uploads from the assignment-creation flow.
     app.routes.defaultMaxBodySize = "10mb"
 

--- a/Sources/APIServer/Middleware/UserFileNamespaceMiddleware.swift
+++ b/Sources/APIServer/Middleware/UserFileNamespaceMiddleware.swift
@@ -1,0 +1,43 @@
+import Vapor
+
+/// Guards static user-scoped notebook files under `/.../files/users/<uuid>/...`.
+/// Students may only access their own namespace; instructors/admins may access any.
+struct UserFileNamespaceMiddleware: AsyncMiddleware {
+    private static let guardedPrefixes = [
+        "/files/users/",
+        "/jupyterlite/files/users/",
+        "/jupyterlite/lab/files/users/",
+        "/jupyterlite/notebooks/files/users/"
+    ]
+
+    func respond(to req: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        guard let requestedUser = Self.requestedUserNamespace(from: req.url.path) else {
+            return try await next.respond(to: req)
+        }
+
+        guard let caller = req.auth.get(APIUser.self) else {
+            throw Abort(.unauthorized)
+        }
+        if caller.isInstructor {
+            return try await next.respond(to: req)
+        }
+        guard let callerID = caller.id?.uuidString.lowercased(), callerID == requestedUser else {
+            throw Abort(.forbidden)
+        }
+
+        return try await next.respond(to: req)
+    }
+
+    private static func requestedUserNamespace(from path: String) -> String? {
+        for prefix in guardedPrefixes where path.hasPrefix(prefix) {
+            let remainder = String(path.dropFirst(prefix.count))
+            guard !remainder.isEmpty else { return nil }
+            let namespace = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true).first
+            let value = namespace.map(String.init)?.lowercased()
+            if let value, !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -21,8 +21,9 @@ import Foundation
 
 struct BrowserResultRoutes: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        routes.grouped("api", "v1", "submissions")
-            .post("browser-result", use: submitBrowserResult)
+        let submissions = routes.grouped("api", "v1", "submissions")
+        submissions.post("browser-result", use: submitBrowserResult)
+        submissions.post("runner-submit", use: submitRunnerSubmission)
     }
 
     // MARK: - POST /api/v1/submissions/browser-result
@@ -117,6 +118,47 @@ struct BrowserResultRoutes: RouteCollection {
             workerSubmissionID: workerSubID
         )
     }
+
+    // MARK: - POST /api/v1/submissions/runner-submit
+
+    @Sendable
+    func submitRunnerSubmission(req: Request) async throws -> RunnerSubmissionResponse {
+        let caller = try req.auth.require(APIUser.self)
+        let body = try req.content.decode(RunnerSubmitBody.self)
+
+        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
+            throw Abort(.badRequest, reason: "Unknown testSetupID: \(body.testSetupID)")
+        }
+
+        let subsDir = req.application.submissionsDirectory
+        let subID   = "sub_\(UUID().uuidString.lowercased().prefix(8))"
+        let nbPath  = subsDir + "\(subID).ipynb"
+
+        // Always merge with canonical instructor notebook so hidden tests are present.
+        let instructorData = (try? notebookData(for: setup)) ?? body.notebook
+        let notebookToSave = mergeNotebook(student: body.notebook, instructor: instructorData)
+        try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
+
+        let priorCount = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == setup.id!)
+            .filter(\.$userID == caller.id)
+            .count()
+
+        let submittedFilename = normalizedNotebookFilename(body.filename)
+        let submission = APISubmission(
+            id:            subID,
+            testSetupID:   setup.id!,
+            zipPath:       nbPath,
+            attemptNumber: priorCount + 1,
+            status:        "pending",
+            filename:      submittedFilename,
+            userID:        caller.id
+        )
+        try await submission.save(on: req.db)
+        await ensureLocalRunnerForSubmissionIfNeeded(req: req)
+
+        return RunnerSubmissionResponse(submissionID: subID)
+    }
 }
 
 // MARK: - Request / Response types
@@ -130,9 +172,32 @@ struct BrowserResultBody: Content {
     var testSetupID: String
 }
 
+struct RunnerSubmitBody: Content {
+    var notebook: Data
+    var testSetupID: String
+    var filename: String?
+}
+
 struct BrowserResultResponse: Content {
     /// ID of the record holding the browser preview result.
     let submissionID: String
     /// ID of the pending worker job (for polling the official result).
     let workerSubmissionID: String
+}
+
+struct RunnerSubmissionResponse: Content {
+    let submissionID: String
+}
+
+private func normalizedNotebookFilename(_ filename: String?) -> String {
+    guard var value = filename?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+        return "submission.ipynb"
+    }
+    value = URL(fileURLWithPath: value).lastPathComponent
+    value = value.replacingOccurrences(of: "/", with: "-")
+    value = value.replacingOccurrences(of: "\\", with: "-")
+    if !value.lowercased().hasSuffix(".ipynb") {
+        value += ".ipynb"
+    }
+    return value
 }

--- a/Sources/APIServer/Routes/JupyterLiteContentsRoutes.swift
+++ b/Sources/APIServer/Routes/JupyterLiteContentsRoutes.swift
@@ -1,6 +1,6 @@
 // APIServer/Routes/JupyterLiteContentsRoutes.swift
 //
-// Public (unauthenticated) compatibility routes for JupyterLite's contents API.
+// Authenticated compatibility routes for JupyterLite's contents API.
 // JupyterLite resolves API base paths differently across app entrypoints
 // (`/jupyterlite/lab`, `/jupyterlite/notebooks`, or root), so we expose aliases
 // for all expected URL shapes.
@@ -40,15 +40,24 @@ struct JupyterLiteContentsRoutes: RouteCollection {
     }
 
     private func contentsResponse(req: Request, relativePath: String) throws -> Response {
+        let caller = try req.auth.require(APIUser.self)
         let fm = FileManager.default
         let baseDir = req.application.directory.publicDirectory + "jupyterlite/files/"
         try fm.createDirectory(atPath: baseDir, withIntermediateDirectories: true)
         let baseURL = URL(fileURLWithPath: baseDir, isDirectory: true).standardizedFileURL
 
-        let cleanRel = relativePath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let cleanRel = try scopedRelativePath(for: caller, requested: relativePath)
         let targetURL = baseURL.appendingPathComponent(cleanRel).standardizedFileURL
         guard targetURL.path.hasPrefix(baseURL.path) else {
             throw Abort(.forbidden)
+        }
+        if let userRoot = try userRootPath(for: caller) {
+            let userRootURL = baseURL.appendingPathComponent(userRoot, isDirectory: true).standardizedFileURL
+            let withinUserRoot = targetURL.path == userRootURL.path
+                || targetURL.path.hasPrefix(userRootURL.path + "/")
+            guard withinUserRoot else {
+                throw Abort(.forbidden)
+            }
         }
 
         // JupyterLite 0.7 fetches directory manifests from
@@ -194,5 +203,37 @@ struct JupyterLiteContentsRoutes: RouteCollection {
 
     private func isoDate(_ date: Date) -> String {
         ISO8601DateFormatter().string(from: date)
+    }
+
+    private func userRootPath(for caller: APIUser) throws -> String? {
+        if caller.isInstructor {
+            return nil
+        }
+        guard let userID = caller.id else {
+            throw Abort(.unauthorized)
+        }
+        return "users/\(userID.uuidString.lowercased())"
+    }
+
+    private func scopedRelativePath(for caller: APIUser, requested: String) throws -> String {
+        let clean = requested.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if caller.isInstructor {
+            return clean
+        }
+
+        guard let userRoot = try userRootPath(for: caller) else {
+            return clean
+        }
+
+        if clean.isEmpty {
+            return userRoot
+        }
+        if clean == "all.json" {
+            return "\(userRoot)/all.json"
+        }
+        if clean == userRoot || clean.hasPrefix(userRoot + "/") {
+            return clean
+        }
+        throw Abort(.forbidden)
     }
 }

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -27,7 +27,9 @@ struct WebRoutes: RouteCollection {
         routes.post("testsetups", "new", use: createSetup)
         routes.get("testsetups", ":testSetupID", "submit", use: submitForm)
         routes.post("testsetups", ":testSetupID", "submit", use: createSubmission)
+        routes.get("testsetups", ":testSetupID", "history", use: submissionHistoryPage)
         routes.get("testsetups", ":testSetupID", "notebook", use: notebookPage)
+        routes.get("testsetups", ":testSetupID", "notebook", "source", use: notebookSource)
         routes.get("submissions", ":submissionID", use: submissionPage)
     }
 
@@ -69,11 +71,81 @@ struct WebRoutes: RouteCollection {
                 .all()
         }
 
+        var latestSubmissionBySetupID: [String: LatestSubmissionItem] = [:]
+        var submissionCountBySetupID: [String: Int] = [:]
+        var bestGradePercentBySetupID: [String: Int] = [:]
+        if let userID = user.id {
+            let setupIDs = setups.compactMap(\.id)
+            if !setupIDs.isEmpty {
+                let submissions = try await APISubmission.query(on: req.db)
+                    .filter(\.$userID == userID)
+                    .filter(\.$testSetupID ~~ setupIDs)
+                    .sort(\.$submittedAt, .descending)
+                    .all()
+
+                var grouped: [String: [APISubmission]] = [:]
+                for submission in submissions {
+                    grouped[submission.testSetupID, default: []].append(submission)
+                }
+
+                for (setupID, items) in grouped {
+                    submissionCountBySetupID[setupID] = items.count
+                    if let latest = items.first {
+                        let when = latest.submittedAt.map { fmt.string(from: $0) } ?? "—"
+                        latestSubmissionBySetupID[setupID] = LatestSubmissionItem(
+                            submissionID: latest.id ?? "",
+                            submittedAtText: when
+                        )
+                    }
+                }
+
+                let submissionIDs = submissions.compactMap(\.id)
+                if !submissionIDs.isEmpty {
+                    let resultRows = try await APIResult.query(on: req.db)
+                        .filter(\.$submissionID ~~ submissionIDs)
+                        .sort(\.$receivedAt, .descending)
+                        .all()
+
+                    // Keep one preferred result per submission:
+                    // worker result first; browser result only if no worker exists.
+                    var preferredResultBySubmissionID: [String: APIResult] = [:]
+                    for row in resultRows {
+                        let key = row.submissionID
+                        if let existing = preferredResultBySubmissionID[key] {
+                            let existingSource = existing.source ?? "worker"
+                            let currentSource = row.source ?? "worker"
+                            if existingSource == "worker" { continue }
+                            if currentSource == "worker" {
+                                preferredResultBySubmissionID[key] = row
+                            }
+                        } else {
+                            preferredResultBySubmissionID[key] = row
+                        }
+                    }
+
+                    for submission in submissions {
+                        guard let subID = submission.id,
+                              let result = preferredResultBySubmissionID[subID],
+                              let gradePercent = gradePercentFromCollectionJSON(result.collectionJSON) else {
+                            continue
+                        }
+                        let setupID = submission.testSetupID
+                        let existing = bestGradePercentBySetupID[setupID] ?? 0
+                        if gradePercent > existing {
+                            bestGradePercentBySetupID[setupID] = gradePercent
+                        }
+                    }
+                }
+            }
+        }
+
         let rows = setups.map { setup -> TestSetupRow in
             let setupID    = setup.id ?? ""
             let data       = Data(setup.manifest.utf8)
             let props      = try? decoder.decode(TestProperties.self, from: data)
             let assignment = assignmentBySetup[setupID]
+            let latestSubmission = latestSubmissionBySetupID[setupID]
+            let submissionCount = submissionCountBySetupID[setupID] ?? 0
             let status: String
             if let assignment {
                 status = assignment.isOpen ? "open" : "closed"
@@ -87,7 +159,13 @@ struct WebRoutes: RouteCollection {
                 createdAt:  setup.createdAt.map { fmt.string(from: $0) } ?? "—",
                 dueAt:      assignment?.dueAt.map { fmt.string(from: $0) },
                 status:     status,
-                isOpen:     assignment?.isOpen ?? false
+                isOpen:     assignment?.isOpen ?? false,
+                submissionCount: submissionCount,
+                hasLatestSubmission: latestSubmission != nil,
+                latestSubmissionID: latestSubmission?.submissionID ?? "",
+                latestSubmittedAtText: latestSubmission?.submittedAtText ?? "—",
+                additionalSubmissionCount: max(submissionCount - 1, 0),
+                bestGradeText: bestGradePercentBySetupID[setupID].map { "\($0)%" }
             )
         }
 
@@ -200,6 +278,83 @@ struct WebRoutes: RouteCollection {
         return req.redirect(to: "/submissions/\(subID)")
     }
 
+    // MARK: - GET /testsetups/:id/history
+
+    @Sendable
+    func submissionHistoryPage(req: Request) async throws -> View {
+        let user = try req.auth.require(APIUser.self)
+        guard let userID = user.id else { throw Abort(.unauthorized) }
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let _ = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        let fmt = DateFormatter()
+        fmt.dateStyle = .medium
+        fmt.timeStyle = .short
+
+        let assignment = try await APIAssignment.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .first()
+        let title = assignment?.title ?? setupID
+
+        let submissions = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .filter(\.$userID == userID)
+            .sort(\.$submittedAt, .descending)
+            .all()
+
+        let submissionIDs = submissions.compactMap(\.id)
+        var preferredResultBySubmissionID: [String: APIResult] = [:]
+        if !submissionIDs.isEmpty {
+            let results = try await APIResult.query(on: req.db)
+                .filter(\.$submissionID ~~ submissionIDs)
+                .sort(\.$receivedAt, .descending)
+                .all()
+            for row in results {
+                let key = row.submissionID
+                if let existing = preferredResultBySubmissionID[key] {
+                    let existingSource = existing.source ?? "worker"
+                    let currentSource = row.source ?? "worker"
+                    if existingSource == "worker" { continue }
+                    if currentSource == "worker" {
+                        preferredResultBySubmissionID[key] = row
+                    }
+                } else {
+                    preferredResultBySubmissionID[key] = row
+                }
+            }
+        }
+
+        let rows = submissions.map { submission -> SubmissionHistoryRow in
+            let subID = submission.id ?? ""
+            let gradeText: String
+            if let result = preferredResultBySubmissionID[subID],
+               let pct = gradePercentFromCollectionJSON(result.collectionJSON) {
+                gradeText = "\(pct)%"
+            } else {
+                gradeText = "—"
+            }
+            return SubmissionHistoryRow(
+                submissionID: subID,
+                attemptNumber: submission.attemptNumber ?? 1,
+                status: submission.status,
+                submittedAt: submission.submittedAt.map { fmt.string(from: $0) } ?? "—",
+                gradeText: gradeText
+            )
+        }
+
+        return try await req.view.render("submission-history",
+            SubmissionHistoryContext(
+                testSetupID: setupID,
+                assignmentTitle: title,
+                rows: rows,
+                currentUser: req.currentUserContext
+            ))
+    }
+
     // MARK: - GET /testsetups/:id/notebook
 
     @Sendable
@@ -207,6 +362,8 @@ struct WebRoutes: RouteCollection {
         struct NotebookQuery: Content {
             var title: String?
         }
+        let user = try req.auth.require(APIUser.self)
+        guard let userID = user.id else { throw Abort(.unauthorized) }
         guard
             let setupID = req.parameters.get("testSetupID"),
             let setup = try await APITestSetup.find(setupID, on: req.db)
@@ -224,6 +381,19 @@ struct WebRoutes: RouteCollection {
             if !dbTitle.isEmpty { return dbTitle }
             return "Assignment"
         }()
+        let fallbackNotebookFilename = notebookFilenameForJupyterLite(title: assignmentTitle)
+        let selectedNotebook = try await latestNotebookSubmissionData(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup
+        )
+        let displayFilename = safeNotebookFilename(
+            preferred: selectedNotebook.filename,
+            fallbackTitle: fallbackNotebookFilename
+        )
+        let userSlug = userID.uuidString.lowercased()
+        let jupyterLiteNotebookPath = "users/\(userSlug)/\(displayFilename)"
 
         // Materialize notebook into all likely JupyterLite file roots.
         // Different entrypoints may resolve baseUrl differently and look under
@@ -234,28 +404,51 @@ struct WebRoutes: RouteCollection {
             req.application.directory.publicDirectory + "jupyterlite/lab/files/",
             req.application.directory.publicDirectory + "jupyterlite/notebooks/files/"
         ]
-        let nbData = try notebookData(for: setup)
-        let jlNotebookFilename = notebookFilenameForJupyterLite(title: assignmentTitle)
-        let fallbackNotebookFilename = "assignment.ipynb"
+        let nbData = selectedNotebook.data
         for root in fileRoots {
-            try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
-            try nbData.write(to: URL(fileURLWithPath: root + jlNotebookFilename))
-            if jlNotebookFilename != fallbackNotebookFilename {
-                try nbData.write(to: URL(fileURLWithPath: root + fallbackNotebookFilename))
-            }
+            let userDir = root + "users/\(userSlug)/"
+            try FileManager.default.createDirectory(atPath: userDir, withIntermediateDirectories: true)
+            try nbData.write(to: URL(fileURLWithPath: userDir + displayFilename))
+            try nbData.write(to: URL(fileURLWithPath: userDir + "assignment.ipynb"))
         }
-        let encodedPath = jlNotebookFilename.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let encodedPath = jupyterLiteNotebookPath.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
             ?? "assignment.ipynb"
-        let workspaceID = "\(setupID)-student"
+        let workspaceID = "\(setupID)-\(userSlug)-student"
         let editorURL = "/jupyterlite/lab/index.html?workspace=\(workspaceID)&reset=&path=\(encodedPath)"
 
         return try await req.view.render("notebook",
             NotebookContext(
                 testSetupID: setupID,
                 assignmentTitle: assignmentTitle,
+                notebookURL: "/testsetups/\(setupID)/notebook/source",
                 jupyterLiteEditorURL: editorURL,
                 currentUser: req.currentUserContext
             ))
+    }
+
+    // MARK: - GET /testsetups/:id/notebook/source
+
+    @Sendable
+    func notebookSource(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard let userID = user.id else { throw Abort(.unauthorized) }
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let setup = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        let payload = try await latestNotebookSubmissionData(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup
+        ).data
+
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .contentType, value: "application/json; charset=utf-8")
+        return Response(status: .ok, headers: headers, body: .init(data: payload))
     }
 
     // MARK: - GET /submissions/:id
@@ -323,6 +516,7 @@ struct WebRoutes: RouteCollection {
                         tier:            o.tier.rawValue,
                         status:          o.status.rawValue,
                         shortResult:     o.shortResult,
+                        readableOutput:  readableScriptOutput(from: o.longResult),
                         longResult:      o.longResult,
                         executionTimeMs: o.executionTimeMs
                     )
@@ -365,6 +559,17 @@ private struct TestSetupRow: Encodable {
     let dueAt: String?      // formatted due date, nil if no assignment or no due date
     let status: String      // "unpublished" | "open" | "closed"
     let isOpen: Bool
+    let submissionCount: Int
+    let hasLatestSubmission: Bool
+    let latestSubmissionID: String
+    let latestSubmittedAtText: String
+    let additionalSubmissionCount: Int
+    let bestGradeText: String?
+}
+
+private struct LatestSubmissionItem: Encodable {
+    let submissionID: String
+    let submittedAtText: String
 }
 
 private struct IndexContext: Encodable {
@@ -380,8 +585,24 @@ private struct SubmitContext: Encodable {
 private struct NotebookContext: Encodable {
     let testSetupID: String
     let assignmentTitle: String
+    let notebookURL: String
     let jupyterLiteEditorURL: String
     let currentUser: CurrentUserContext?
+}
+
+private struct SubmissionHistoryContext: Encodable {
+    let testSetupID: String
+    let assignmentTitle: String
+    let rows: [SubmissionHistoryRow]
+    let currentUser: CurrentUserContext?
+}
+
+private struct SubmissionHistoryRow: Encodable {
+    let submissionID: String
+    let attemptNumber: Int
+    let status: String
+    let submittedAt: String
+    let gradeText: String
 }
 
 private struct OutcomeRow: Encodable {
@@ -389,6 +610,7 @@ private struct OutcomeRow: Encodable {
     let tier: String
     let status: String
     let shortResult: String
+    let readableOutput: String?
     let longResult: String?
     let executionTimeMs: Int
 }
@@ -423,6 +645,127 @@ private func notebookFilenameForJupyterLite(title: String) -> String {
     value = value.replacingOccurrences(of: "\r", with: " ")
     if !value.lowercased().hasSuffix(".ipynb") {
         value += ".ipynb"
+    }
+    return value
+}
+
+private func safeNotebookFilename(preferred: String?, fallbackTitle: String) -> String {
+    let fallback = notebookFilenameForJupyterLite(title: fallbackTitle)
+    guard var value = preferred?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+        return fallback
+    }
+    value = URL(fileURLWithPath: value).lastPathComponent
+    value = value.replacingOccurrences(of: "/", with: "-")
+    value = value.replacingOccurrences(of: "\\", with: "-")
+    value = value.replacingOccurrences(of: "\n", with: " ")
+    value = value.replacingOccurrences(of: "\r", with: " ")
+    if !value.lowercased().hasSuffix(".ipynb") {
+        value += ".ipynb"
+    }
+    return value
+}
+
+private func latestNotebookSubmissionData(
+    req: Request,
+    setupID: String,
+    userID: UUID,
+    fallbackSetup: APITestSetup
+) async throws -> (data: Data, filename: String?) {
+    let submissions = try await APISubmission.query(on: req.db)
+        .filter(\.$testSetupID == setupID)
+        .filter(\.$userID == userID)
+        .sort(\.$submittedAt, .descending)
+        .all()
+
+    for submission in submissions {
+        let pathExt = URL(fileURLWithPath: submission.zipPath).pathExtension.lowercased()
+        let nameExt = (submission.filename ?? "").lowercased()
+        guard pathExt == "ipynb" || nameExt.hasSuffix(".ipynb") else {
+            continue
+        }
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: submission.zipPath)),
+              (try? JSONSerialization.jsonObject(with: data)) != nil else {
+            continue
+        }
+        return (data, submission.filename)
+    }
+
+    return (try notebookData(for: fallbackSetup), nil)
+}
+
+private func gradePercentFromCollectionJSON(_ collectionJSON: String) -> Int? {
+    guard let data = collectionJSON.data(using: .utf8),
+          let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let passCount = root["passCount"] as? Int,
+          let totalTests = root["totalTests"] as? Int,
+          totalTests > 0 else {
+        return nil
+    }
+    return Int((Double(passCount) / Double(totalTests) * 100).rounded())
+}
+
+private func readableScriptOutput(from raw: String?) -> String? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    if let payload = firstJSONObject(in: trimmed) {
+        var lines: [String] = []
+        if let shortResult = payload["shortResult"] as? String,
+           !shortResult.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append(shortResult)
+        }
+        if let error = payload["error"] as? String,
+           !error.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("Error: \(error)")
+        }
+        if let test = payload["test"] as? String,
+           !test.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("Script: \(test)")
+        }
+        if let status = payload["status"] as? String,
+           !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("Status: \(status)")
+        }
+        if !lines.isEmpty {
+            return lines.joined(separator: "\n")
+        }
+        if let pretty = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted]),
+           let text = String(data: pretty, encoding: .utf8) {
+            return text
+        }
+    }
+
+    // Fallback: show first few meaningful lines inline.
+    let lines = trimmed
+        .split(separator: "\n", omittingEmptySubsequences: true)
+        .map { String($0).trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+    guard !lines.isEmpty else { return nil }
+    let preview = Array(lines.prefix(3))
+    if lines.count > preview.count {
+        return preview.joined(separator: "\n") + "\n…"
+    }
+    return preview.joined(separator: "\n")
+}
+
+private func firstJSONObject(in text: String) -> [String: Any]? {
+    // Most runner JSON payloads are emitted as a single line near the end.
+    let lines = text
+        .split(separator: "\n", omittingEmptySubsequences: false)
+        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+    for line in lines.reversed() {
+        guard line.first == "{", line.last == "}" else { continue }
+        guard let data = line.data(using: .utf8),
+              let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            continue
+        }
+        return value
+    }
+    guard text.first == "{", text.last == "}",
+          let data = text.data(using: .utf8),
+          let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
     }
     return value
 }

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -8,7 +8,6 @@ func routes(_ app: Application) throws {
     // MARK: - Public routes (no auth required)
 
     try app.register(collection: AuthRoutes())
-    try app.register(collection: JupyterLiteContentsRoutes())
     try app.register(collection: WorkerJobRoutes())
     try app.register(collection: WorkerArtifactRoutes())
     // Worker result reporting is called by the worker daemon, not the browser.
@@ -22,6 +21,7 @@ func routes(_ app: Application) throws {
     try auth.register(collection: SubmissionDownloadRoute())
     try auth.register(collection: SubmissionQueryRoutes())
     try auth.register(collection: BrowserResultRoutes())
+    try auth.register(collection: JupyterLiteContentsRoutes())
     // TestSetupRoutes is in the auth group so students can fetch/download notebooks.
     // Instructor-only handlers (upload, zip-download, save) guard themselves inline.
     try auth.register(collection: TestSetupRoutes())


### PR DESCRIPTION
## Summary
- add compact home-page submission history and a full assignment history page
- add best-grade display and cleaner submission output rendering
- enforce user namespace restrictions for JupyterLite file access
- switch notebook page submit flow to runner-only (disable browser grading path)

## Validation
- swift build