### PR TITLE
Improve instructor assignment edit flow and validation fallbacks

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -1,0 +1,227 @@
+#extend("base"):
+#export("title"):
+Edit Assignment
+#endexport
+#export("content"):
+<h1>Edit Assignment</h1>
+
+#if(error):
+<div class="error-box" style="margin-bottom:1rem">
+    <h2>Could not update assignment</h2>
+    <p class="card-meta" style="margin-top:.5rem">#(error)</p>
+</div>
+#endif
+
+#if(notice):
+<div style="margin-bottom:1rem;padding:1rem;border:1px solid var(--green);border-radius:.5rem;background:#F0FDF4">
+    <p style="margin:0;color:var(--green);font-weight:600">#(notice)</p>
+</div>
+#endif
+
+<form class="form" method="post" action="/assignments/#(assignmentID)/edit/save" enctype="multipart/form-data">
+    <label class="form-label">
+        Assignment Name
+        <input class="form-input" type="text" name="assignmentName" required
+               value="#(assignmentName)"
+               placeholder="e.g. Lab 2 - Linked Lists">
+    </label>
+
+    <label class="form-label">
+        Due Date (optional)
+        <input class="form-input" type="datetime-local" name="dueAt" value="#(dueAt)">
+    </label>
+
+    <label class="form-label">
+        <span style="white-space:nowrap">Assignment Notebook (<a href="#(currentAssignmentURL)"><code>#(currentAssignmentFile)</code></a>)</span>
+        <input class="form-input" type="file" name="assignmentNotebookFile" accept=".ipynb">
+    </label>
+
+    <label class="form-label">
+        #if(currentSolutionURL):
+        <span style="white-space:nowrap">Solution Notebook (<a href="#(currentSolutionURL)"><code>#(currentSolutionFile)</code></a>)</span>
+        #else:
+        <span style="white-space:nowrap">Solution Notebook (<code>not set</code>)</span>
+        #endif
+        <input class="form-input" type="file" name="solutionNotebookFile" accept=".ipynb">
+    </label>
+
+    <label class="form-label">
+        <span style="white-space:nowrap">Add Test Suite Files (scripts/support files like <code>.sh</code> or <code>.py</code>)</span>
+        <input class="form-input" id="suite-files-input" type="file" name="suiteFiles" multiple>
+    </label>
+    <input type="hidden" id="suite-config-field" name="suiteConfig" value="">
+
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>File</th>
+                <th>Test?</th>
+                <th>Tier</th>
+                <th class="time">Order</th>
+                <th class="time">Delete</th>
+            </tr>
+        </thead>
+        <tbody id="suite-config-body">
+            #for(row in existingSuiteRows):
+            <tr data-source="existing" data-name="#(row.name)">
+                <td><a href="#(row.url)"><code>#(row.name)</code></a></td>
+                <td><input type="checkbox" class="suite-test-toggle" #if(row.isTest):checked#endif></td>
+                <td>
+                    <select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">
+                        <option value="support" #if(row.tier == "support"):selected#endif>support</option>
+                        <option value="public" #if(row.tier == "public"):selected#endif>public</option>
+                        <option value="secret" #if(row.tier == "secret"):selected#endif>secret</option>
+                        <option value="release" #if(row.tier == "release"):selected#endif>release</option>
+                    </select>
+                </td>
+                <td class="time"><input class="form-input suite-order" type="number" min="1" step="1" value="#(row.order)" style="width:6rem;padding:.25rem .5rem;font-size:.8rem"></td>
+                <td class="time"><button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button></td>
+            </tr>
+            #endfor
+        </tbody>
+    </table>
+
+    <p class="card-meta">
+        Use Delete to remove a file. Add more files above; they will appear in this table. At least one row marked as a test is required.
+    </p>
+
+    <div style="display:flex;gap:.6rem;flex-wrap:wrap">
+        <button class="btn btn-primary" type="submit">Save &amp; Validate</button>
+        <a class="btn" href="/assignments">Cancel</a>
+    </div>
+</form>
+<script>
+(function () {
+    'use strict';
+
+    var filesInput = document.getElementById('suite-files-input');
+    var configField = document.getElementById('suite-config-field');
+    var body = document.getElementById('suite-config-body');
+    if (!filesInput || !configField || !body) return;
+
+    function isLikelyScript(name) {
+        var lower = (name || '').toLowerCase();
+        return lower.endsWith('.sh')
+            || lower.endsWith('.bash')
+            || lower.endsWith('.zsh')
+            || lower.endsWith('.py')
+            || lower.endsWith('.rb')
+            || lower.endsWith('.pl')
+            || lower.endsWith('.js')
+            || lower.endsWith('.php');
+    }
+
+    function inferredOrder(name, fallback) {
+        var match = (name || '').match(/^([0-9]+)[_-]/);
+        if (!match) return fallback;
+        var n = Number(match[1]);
+        return Number.isFinite(n) && n > 0 ? n : fallback;
+    }
+
+    function removeUploadedRows() {
+        body.querySelectorAll('tr[data-source="upload"]').forEach(function (row) { row.remove(); });
+    }
+
+    function renderRows() {
+        var files = Array.from(filesInput.files || []);
+        removeUploadedRows();
+        files.forEach(function (file, index) {
+            var likelyScript = isLikelyScript(file.name);
+            var checked = likelyScript;
+            var supportSelected = likelyScript ? '' : 'selected';
+            var publicSelected = likelyScript ? 'selected' : '';
+            var order = inferredOrder(file.name, index + 1);
+            var tr = document.createElement('tr');
+            tr.setAttribute('data-source', 'upload');
+            tr.setAttribute('data-index', String(index));
+            tr.innerHTML = '<td><code>' + escapeHtml(file.name) + '</code> <span class="card-meta">(new)</span></td>'
+                + '<td><input type="checkbox" class="suite-test-toggle" ' + (checked ? 'checked' : '') + '></td>'
+                + '<td>'
+                + '  <select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">'
+                + '    <option value="support" ' + supportSelected + '>support</option>'
+                + '    <option value="public" ' + publicSelected + '>public</option>'
+                + '    <option value="secret">secret</option>'
+                + '    <option value="release">release</option>'
+                + '  </select>'
+                + '</td>'
+                + '<td class="time"><input class="form-input suite-order" type="number" min="1" step="1" value="' + order + '" style="width:6rem;padding:.25rem .5rem;font-size:.8rem"></td>'
+                + '<td class="time"><button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button></td>';
+            body.appendChild(tr);
+        });
+        syncConfig();
+    }
+
+    function syncConfig() {
+        var rows = Array.from(body.querySelectorAll('tr[data-source]'));
+        var config = rows.map(function (row) {
+            var source = row.getAttribute('data-source') || 'existing';
+            var tier = row.querySelector('.suite-tier')?.value || 'public';
+            var toggleEl = row.querySelector('.suite-test-toggle');
+            var toggleChecked = !!toggleEl?.checked;
+            var isTest = toggleChecked && tier !== 'support';
+            var orderRaw = row.querySelector('.suite-order')?.value || '';
+            var order = Number(orderRaw);
+
+            var tierEl = row.querySelector('.suite-tier');
+            var orderEl = row.querySelector('.suite-order');
+            if (toggleEl) toggleEl.checked = isTest;
+            if (tierEl) tierEl.disabled = false;
+            if (orderEl) orderEl.disabled = !isTest;
+
+            var base = {
+                source: source,
+                isIncluded: true,
+                isTest: isTest,
+                tier: tier,
+                order: Number.isFinite(order) && order > 0 ? Math.floor(order) : null
+            };
+            if (source === 'upload') {
+                base.index = Number(row.getAttribute('data-index'));
+            } else {
+                base.name = row.getAttribute('data-name') || '';
+            }
+            return base;
+        });
+        configField.value = JSON.stringify(config);
+    }
+
+    function escapeHtml(value) {
+        return String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
+    }
+
+    filesInput.addEventListener('change', renderRows);
+    body.addEventListener('change', syncConfig);
+    body.addEventListener('input', syncConfig);
+    body.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!(target instanceof Element)) return;
+        if (!target.classList.contains('suite-delete-btn')) return;
+        var row = target.closest('tr[data-source]');
+        if (!row) return;
+        row.remove();
+        syncConfig();
+    });
+    syncConfig();
+
+    var form = filesInput.closest('form');
+    if (form) {
+        form.addEventListener('submit', function (event) {
+            syncConfig();
+            var config = [];
+            try { config = JSON.parse(configField.value || '[]'); } catch (_) { config = []; }
+            var hasTest = config.some(function (row) { return !!row.isTest; });
+            if (!hasTest) {
+                event.preventDefault();
+                window.alert('Select at least one file as a test.');
+            }
+        });
+    }
+})();
+</script>
+#endexport
+#endextend

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -96,7 +96,7 @@ Assignments
                 </details>
                 #elseif(row.status == "closed"):
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit notebook</a>
+                    <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
                     <form method="post" action="/assignments/#(row.assignmentID)/delete"
                           onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                         <button class="btn action-btn action-danger" type="submit"
@@ -107,7 +107,7 @@ Assignments
                 </div>
                 #elseif(row.status == "open"):
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit notebook</a>
+                    <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
                     <form method="post" action="/assignments/#(row.assignmentID)/delete"
                           onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                         <button class="btn action-btn action-danger" type="submit"

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -9,7 +9,8 @@
 //   POST /assignments/new/save               → save draft assignment, redirect to /assignments
 //   POST /assignments                        → create draft assignment → redirect to validate
 //   GET  /assignments/:assignmentID/validate → assignment-validate.leaf
-//   GET  /assignments/:assignmentID/edit     → setup-edit.leaf (JupyterLite notebook editor) [Phase 8]
+//   GET  /assignments/:assignmentID/edit     → assignment-edit.leaf
+//   POST /assignments/:assignmentID/edit/save → update assignment content + validate
 //   POST /assignments/:assignmentID/status   → set open/closed status → redirect to /assignments
 //   POST /assignments/:assignmentID/open     → set isOpen=true → redirect to /assignments
 //   POST /assignments/:assignmentID/close    → set isOpen=false → redirect to /assignments
@@ -30,7 +31,11 @@ struct AssignmentRoutes: RouteCollection {
         r.post("new", "save", use: saveNewAssignment)
         r.post(use: publish)
         r.get(":assignmentID", "validate", use: validatePage)
-        r.get(":assignmentID", "edit",     use: editPage)         // Phase 8
+        r.get(":assignmentID", "edit",     use: editPage)
+        r.post(":assignmentID", "edit", "save", use: saveEditedAssignment)
+        r.get(":assignmentID", "files", "notebook", use: downloadCurrentNotebookFile)
+        r.get(":assignmentID", "files", "solution", use: downloadCurrentSolutionFile)
+        r.get(":assignmentID", "files", "item", use: downloadCurrentSetupItem)
         r.post(":assignmentID", "status",  use: updateStatus)
         r.post(":assignmentID", "open",    use: openAssignment)
         r.post(":assignmentID", "close",   use: closeAssignment)
@@ -207,6 +212,7 @@ struct AssignmentRoutes: RouteCollection {
         try assignmentNotebook.write(to: URL(fileURLWithPath: notebookPath))
         let setupPackage = try createRunnerSetupZip(
             assignmentNotebookData: assignmentNotebook,
+            solutionNotebookData: normalizeNotebookForJupyterLite(solutionNotebookRaw),
             suiteFiles: suiteFiles,
             suiteConfigJSON: suiteConfigRaw,
             zipPath: zipPath
@@ -468,9 +474,7 @@ struct AssignmentRoutes: RouteCollection {
         return req.redirect(to: "/assignments")
     }
 
-    // MARK: - GET /assignments/:assignmentID/edit  [Phase 8]
-    // Instructor-only notebook editor — loads JupyterLite, allows saving edits
-    // back to the server via PUT /api/v1/testsetups/:id/assignment.
+    // MARK: - GET /assignments/:assignmentID/edit
 
     @Sendable
     func editPage(req: Request) async throws -> View {
@@ -485,45 +489,291 @@ struct AssignmentRoutes: RouteCollection {
         else {
             throw Abort(.notFound)
         }
+        _ = setup // keep existence check explicit
 
-        // Materialize notebook into all likely JupyterLite file roots.
-        // Different entrypoints may resolve baseUrl differently and look under
-        // /files, /jupyterlite/files, /jupyterlite/lab/files, or /jupyterlite/notebooks/files.
-        let fileRoots = [
-            req.application.directory.publicDirectory + "files/",
-            req.application.directory.publicDirectory + "jupyterlite/files/",
-            req.application.directory.publicDirectory + "jupyterlite/lab/files/",
-            req.application.directory.publicDirectory + "jupyterlite/notebooks/files/"
-        ]
-        let nbData: Data
-        do {
-            nbData = try notebookData(for: setup)
-        } catch {
-            // Keep the editor reachable even if setup artifacts are temporarily missing.
-            req.logger.warning("Falling back to default notebook for edit page: \(error)")
-            nbData = normalizeNotebookForJupyterLite(defaultNotebookData(title: assignment.title))
+        struct EditQuery: Content {
+            var assignmentName: String?
+            var dueAt: String?
+            var error: String?
+            var notice: String?
         }
-        let digest = SHA256.hash(data: nbData)
-        let version = digest
-            .prefix(8)
-            .map { String(format: "%02x", $0) }
-            .joined()
-        let jupyterLiteNotebookPath = "\(assignment.testSetupID)-assignment-\(version).ipynb"
-        for root in fileRoots {
-            try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
-            try nbData.write(to: URL(fileURLWithPath: root + jupyterLiteNotebookPath))
-        }
-        let editorURL = "/jupyterlite/lab/index.html?workspace=\(assignment.testSetupID)&reset&path=\(jupyterLiteNotebookPath)"
-
-        let ctx = EditContext(
-            currentUser:  req.currentUserContext,
+        let q = try? req.query.decode(EditQuery.self)
+        let hasKnownSolution = assignment.validationStatus == "passed"
+            || assignment.validationSubmissionID != nil
+        let currentFiles = currentSetupFiles(
+            for: setup,
             assignmentID: idStr,
-            setupID:      assignment.testSetupID,
-            title:        assignment.title,
-            editorURL:    editorURL,
-            notebookURL:  "/api/v1/testsetups/\(assignment.testSetupID)/assignment"
+            hasValidationSolution: hasKnownSolution
         )
-        return try await req.view.render("setup-edit", ctx)
+        let currentDueAt = dueAtLocalInputString(assignment.dueAt)
+        let ctx = EditAssignmentContext(
+            currentUser: req.currentUserContext,
+            assignmentID: idStr,
+            assignmentName: (q?.assignmentName ?? assignment.title).trimmingCharacters(in: .whitespacesAndNewlines),
+            dueAt: q?.dueAt ?? currentDueAt,
+            currentAssignmentFile: currentFiles.assignmentFile.name,
+            currentAssignmentURL: currentFiles.assignmentFile.url,
+            currentSolutionFile: currentFiles.solutionFile?.name,
+            currentSolutionURL: currentFiles.solutionFile?.url,
+            existingSuiteRows: currentFiles.existingSuiteRows,
+            notice: q?.notice,
+            error: q?.error
+        )
+        return try await req.view.render("assignment-edit", ctx)
+    }
+
+    // MARK: - GET /assignments/:assignmentID/files/notebook
+
+    @Sendable
+    func downloadCurrentNotebookFile(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard user.isInstructor else { throw Abort(.forbidden) }
+
+        guard
+            let idStr = req.parameters.get("assignmentID"),
+            let uuid = UUID(uuidString: idStr),
+            let assignment = try await APIAssignment.find(uuid, on: req.db),
+            let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        let data = try notebookData(for: setup)
+        let downloadName = currentSetupFiles(
+            for: setup,
+            assignmentID: idStr,
+            hasValidationSolution: assignment.validationSubmissionID != nil
+        ).assignmentFile.name
+        return buildFileResponse(data: data, filename: downloadName)
+    }
+
+    // MARK: - GET /assignments/:assignmentID/files/item?name=<filename>
+
+    @Sendable
+    func downloadCurrentSetupItem(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard user.isInstructor else { throw Abort(.forbidden) }
+
+        guard
+            let idStr = req.parameters.get("assignmentID"),
+            let uuid = UUID(uuidString: idStr),
+            let assignment = try await APIAssignment.find(uuid, on: req.db),
+            let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        struct FileQuery: Content {
+            let name: String
+        }
+        let q = try req.query.decode(FileQuery.self)
+        let fileName = (q.name as NSString).lastPathComponent
+        guard !fileName.isEmpty, fileName == q.name else {
+            throw Abort(.badRequest, reason: "Invalid file name")
+        }
+
+        guard let data = extractZipEntry(zipPath: setup.zipPath, entryName: fileName) else {
+            throw Abort(.notFound, reason: "File '\(fileName)' not found in setup")
+        }
+        return buildFileResponse(data: data, filename: fileName)
+    }
+
+    // MARK: - GET /assignments/:assignmentID/files/solution
+
+    @Sendable
+    func downloadCurrentSolutionFile(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard user.isInstructor else { throw Abort(.forbidden) }
+
+        guard
+            let idStr = req.parameters.get("assignmentID"),
+            let uuid = UUID(uuidString: idStr),
+            let assignment = try await APIAssignment.find(uuid, on: req.db),
+            let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        if let data = extractZipEntry(zipPath: setup.zipPath, entryName: "solution.ipynb") {
+            return buildFileResponse(data: data, filename: "solution.ipynb")
+        }
+
+        if let validationID = assignment.validationSubmissionID,
+           let validationSubmission = try await APISubmission.find(validationID, on: req.db),
+           let data = try? Data(contentsOf: URL(fileURLWithPath: validationSubmission.zipPath)),
+           !data.isEmpty {
+            return buildFileResponse(data: data, filename: "solution.ipynb")
+        }
+
+        if let fallbackSubmission = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == assignment.testSetupID)
+            .filter(\.$filename == "solution.ipynb")
+            .sort(\.$submittedAt, .descending)
+            .first(),
+           let data = try? Data(contentsOf: URL(fileURLWithPath: fallbackSubmission.zipPath)),
+           !data.isEmpty {
+            return buildFileResponse(data: data, filename: "solution.ipynb")
+        }
+
+        throw Abort(.notFound, reason: "No solution notebook is available for this assignment yet")
+    }
+
+    // MARK: - POST /assignments/:assignmentID/edit/save
+
+    @Sendable
+    func saveEditedAssignment(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard user.isInstructor else { throw Abort(.forbidden) }
+
+        guard
+            let idStr = req.parameters.get("assignmentID"),
+            let uuid = UUID(uuidString: idStr),
+            let assignment = try await APIAssignment.find(uuid, on: req.db),
+            let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        struct SaveBodyMany: Content {
+            var assignmentName: String?
+            var dueAt: String?
+            var assignmentNotebookFile: File?
+            var solutionNotebookFile: File?
+            var suiteFiles: [File]?
+            var suiteConfig: String?
+        }
+        struct SaveBodySingle: Content {
+            var assignmentName: String?
+            var dueAt: String?
+            var assignmentNotebookFile: File?
+            var solutionNotebookFile: File?
+            var suiteFiles: File?
+            var suiteConfig: String?
+        }
+
+        let bodyMany = try? req.content.decode(SaveBodyMany.self)
+        let bodySingle = bodyMany == nil ? (try? req.content.decode(SaveBodySingle.self)) : nil
+        guard bodyMany != nil || bodySingle != nil else {
+            throw Abort(.badRequest, reason: "Invalid assignment upload payload")
+        }
+
+        let assignmentName = bodyMany?.assignmentName ?? bodySingle?.assignmentName
+        let dueAtRaw = bodyMany?.dueAt ?? bodySingle?.dueAt
+        let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
+        let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
+        let suiteFilesRaw = bodyMany?.suiteFiles ?? (bodySingle?.suiteFiles.map { [$0] } ?? [])
+        let suiteConfigRaw = bodyMany?.suiteConfig ?? bodySingle?.suiteConfig
+
+        let title = (assignmentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let due = parseDueDate(dueAtRaw)
+
+        guard !title.isEmpty else {
+            let q = "assignmentName=&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20name%20is%20required"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
+
+        let uploadedSuiteFiles = suiteFilesRaw.filter { $0.data.readableBytes > 0 }
+
+        let assignmentNotebookRaw: Data = {
+            guard let assignmentNotebookFile, assignmentNotebookFile.data.readableBytes > 0 else {
+                return (try? notebookData(for: setup)) ?? Data()
+            }
+            return Data(assignmentNotebookFile.data.readableBytesView)
+        }()
+        guard !assignmentNotebookRaw.isEmpty,
+              (try? JSONSerialization.jsonObject(with: assignmentNotebookRaw)) != nil else {
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20notebook%20(.ipynb)%20is%20required%20and%20must%20be%20valid%20JSON"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
+
+        let solutionNotebookRaw: Data = {
+            if let solutionNotebookFile, solutionNotebookFile.data.readableBytes > 0 {
+                return Data(solutionNotebookFile.data.readableBytesView)
+            }
+            return extractZipEntry(zipPath: setup.zipPath, entryName: "solution.ipynb") ?? Data()
+        }()
+        var resolvedSolutionNotebookRaw = solutionNotebookRaw
+        if resolvedSolutionNotebookRaw.isEmpty,
+           let existingSolution = try await loadExistingSolutionNotebook(req: req, assignment: assignment) {
+            resolvedSolutionNotebookRaw = existingSolution
+        }
+        guard !resolvedSolutionNotebookRaw.isEmpty,
+              (try? JSONSerialization.jsonObject(with: resolvedSolutionNotebookRaw)) != nil else {
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20(.ipynb)%20is%20required%20for%20validation"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
+
+        let resolvedSuite: ResolvedEditSuiteFiles
+        do {
+            resolvedSuite = try resolveEditSuiteFiles(
+                setupZipPath: setup.zipPath,
+                setupManifestJSON: setup.manifest,
+                uploadedSuiteFiles: uploadedSuiteFiles,
+                suiteConfigJSON: suiteConfigRaw
+            )
+        } catch {
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=\(urlEncode(error.localizedDescription))"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
+        guard !resolvedSuite.files.isEmpty else {
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Add%20or%20keep%20at%20least%20one%20test%20suite%20or%20support%20file"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
+
+        let assignmentNotebook = normalizeNotebookForJupyterLite(assignmentNotebookRaw)
+        let notebookPath = setup.notebookPath ?? (req.application.testSetupsDirectory + "\(setup.id!).ipynb")
+        try assignmentNotebook.write(to: URL(fileURLWithPath: notebookPath))
+
+        let setupPackage = try createRunnerSetupZip(
+            assignmentNotebookData: assignmentNotebook,
+            solutionNotebookData: normalizeNotebookForJupyterLite(resolvedSolutionNotebookRaw),
+            suiteFiles: resolvedSuite.files,
+            suiteConfigJSON: resolvedSuite.reindexedSuiteConfigJSON,
+            zipPath: setup.zipPath
+        )
+        guard !setupPackage.testSuites.isEmpty else {
+            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Select%20at%20least%20one%20test%20file%20in%20the%20suite%20list"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
+        setup.manifest = try makeWorkerManifestJSON(
+            testSuites: setupPackage.testSuites,
+            includeMakefile: setupPackage.hasMakefile
+        )
+        setup.notebookPath = notebookPath
+        try await setup.save(on: req.db)
+
+        assignment.title = title
+        assignment.dueAt = due
+        assignment.isOpen = false
+        assignment.validationStatus = "pending"
+
+        let validationSubmissionID = try await enqueueRunnerValidationSubmission(
+            req: req,
+            setupID: setup.id!,
+            solutionNotebookData: normalizeNotebookForJupyterLite(resolvedSolutionNotebookRaw)
+        )
+        assignment.validationSubmissionID = validationSubmissionID
+        try await assignment.save(on: req.db)
+
+        await ensureValidationRunnerAvailability(req: req)
+        let validation = try await waitForRunnerValidation(req: req, submissionID: validationSubmissionID)
+        switch validation {
+        case .passed(let summary):
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: req.db)
+            req.logger.info("Assignment updated and validated for setup \(setup.id ?? ""): \(summary)")
+            return req.redirect(to: "/assignments")
+        case .failed(let summary):
+            assignment.validationStatus = "failed"
+            try await assignment.save(on: req.db)
+            req.logger.warning("Assignment edit validation failed for setup \(setup.id ?? ""): \(summary) (submission \(validationSubmissionID))")
+            return req.redirect(to: "/submissions/\(validationSubmissionID)")
+        case .timedOut:
+            assignment.validationStatus = "pending"
+            try await assignment.save(on: req.db)
+            let q = "notice=\(urlEncode("Assignment updated and validation started. It is still pending; refresh shortly."))"
+            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+        }
     }
 }
 
@@ -564,6 +814,33 @@ private struct NewAssignmentContext: Encodable {
     let error: String?
 }
 
+private struct EditAssignmentContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let assignmentID: String
+    let assignmentName: String
+    let dueAt: String
+    let currentAssignmentFile: String
+    let currentAssignmentURL: String
+    let currentSolutionFile: String?
+    let currentSolutionURL: String?
+    let existingSuiteRows: [EditableSuiteRow]
+    let notice: String?
+    let error: String?
+}
+
+private struct CurrentFileLink {
+    let name: String
+    let url: String
+}
+
+private struct EditableSuiteRow: Encodable {
+    let name: String
+    let url: String
+    let isTest: Bool
+    let tier: String
+    let order: Int
+}
+
 private func parseDueDate(_ raw: String?) -> Date? {
     guard let raw, !raw.isEmpty else { return nil }
 
@@ -574,6 +851,313 @@ private func parseDueDate(_ raw: String?) -> Date? {
     fmt.locale = Locale(identifier: "en_US_POSIX")
     fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
     return fmt.date(from: raw)
+}
+
+private func dueAtLocalInputString(_ date: Date?) -> String {
+    guard let date else { return "" }
+    let fmt = DateFormatter()
+    fmt.locale = Locale(identifier: "en_US_POSIX")
+    fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
+    return fmt.string(from: date)
+}
+
+private func currentSetupFiles(for setup: APITestSetup, assignmentID: String, hasValidationSolution: Bool) -> (
+    assignmentFile: CurrentFileLink,
+    solutionFile: CurrentFileLink?,
+    existingSuiteRows: [EditableSuiteRow]
+) {
+    let assignmentFile: CurrentFileLink = {
+        let fileName: String
+        if let path = setup.notebookPath, !path.isEmpty {
+            fileName = URL(fileURLWithPath: path).lastPathComponent
+        } else {
+            fileName = "assignment.ipynb"
+        }
+        return CurrentFileLink(
+            name: fileName,
+            url: "/assignments/\(assignmentID)/files/notebook"
+        )
+    }()
+
+    let manifestSuites: [(script: String, tier: String, order: Int)] = {
+        guard let data = setup.manifest.data(using: .utf8),
+              let props = try? JSONDecoder().decode(TestProperties.self, from: data) else {
+            return []
+        }
+        return props.testSuites.enumerated().map { (idx, item) in
+            (script: item.script, tier: item.tier.rawValue, order: idx + 1)
+        }
+    }()
+    let testMap = Dictionary(uniqueKeysWithValues: manifestSuites.map { ($0.script, $0) })
+
+    let archiveFiles = listZipEntries(zipPath: setup.zipPath)
+    let solutionFile: CurrentFileLink? = (archiveFiles.contains("solution.ipynb") || hasValidationSolution)
+        ? CurrentFileLink(name: "solution.ipynb", url: "/assignments/\(assignmentID)/files/solution")
+        : nil
+
+    let nonNotebookFiles = archiveFiles
+        .filter { $0 != "assignment.ipynb" && $0 != "solution.ipynb" }
+        .sorted { lhs, rhs in
+            let l = testMap[lhs]?.order ?? Int.max
+            let r = testMap[rhs]?.order ?? Int.max
+            if l != r { return l < r }
+            return lhs < rhs
+        }
+
+    let existingSuiteRows = nonNotebookFiles.enumerated().map { idx, name in
+        let entry = testMap[name]
+        return EditableSuiteRow(
+            name: name,
+            url: "/assignments/\(assignmentID)/files/item?name=\(urlEncode(name))",
+            isTest: entry != nil,
+            tier: entry?.tier ?? "support",
+            order: entry?.order ?? (idx + 1)
+        )
+    }
+
+    return (assignmentFile, solutionFile, existingSuiteRows)
+}
+
+private func listZipEntries(zipPath: String) -> [String] {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+    process.arguments = ["-Z1", zipPath]
+
+    let out = Pipe()
+    process.standardOutput = out
+    process.standardError = Pipe()
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        return []
+    }
+    guard process.terminationStatus == 0 else { return [] }
+
+    let data = out.fileHandleForReading.readDataToEndOfFile()
+    guard let text = String(data: data, encoding: .utf8) else { return [] }
+    return text
+        .split(separator: "\n")
+        .map(String.init)
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty && !$0.hasSuffix("/") }
+}
+
+private func extractZipEntry(zipPath: String, entryName: String) -> Data? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+    process.arguments = ["-p", zipPath, entryName]
+    let out = Pipe()
+    process.standardOutput = out
+    process.standardError = Pipe()
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        return nil
+    }
+    guard process.terminationStatus == 0 else { return nil }
+    return out.fileHandleForReading.readDataToEndOfFile()
+}
+
+private func buildFileResponse(data: Data, filename: String) -> Response {
+    var headers = HTTPHeaders()
+    headers.contentType = contentType(for: filename)
+    headers.add(name: .contentDisposition, value: "attachment; filename=\"\(filename)\"")
+    return Response(status: .ok, headers: headers, body: .init(data: data))
+}
+
+private func contentType(for filename: String) -> HTTPMediaType {
+    switch URL(fileURLWithPath: filename).pathExtension.lowercased() {
+    case "ipynb", "json":
+        return .json
+    case "py", "sh", "bash", "zsh", "rb", "pl", "js", "php", "txt", "md", "csv":
+        return .plainText
+    default:
+        return HTTPMediaType(type: "application", subType: "octet-stream")
+    }
+}
+
+private struct EditSuiteConfigRow: Decodable {
+    let source: String?
+    let name: String?
+    let index: Int?
+    let isIncluded: Bool?
+    let isTest: Bool?
+    let tier: String?
+    let order: Int?
+}
+
+private struct ReindexedSuiteConfigRow: Encodable {
+    let index: Int
+    let isTest: Bool
+    let tier: String
+    let order: Int?
+}
+
+private struct ResolvedEditSuiteFiles {
+    let files: [File]
+    let reindexedSuiteConfigJSON: String?
+}
+
+private func resolveEditSuiteFiles(
+    setupZipPath: String,
+    setupManifestJSON: String,
+    uploadedSuiteFiles: [File],
+    suiteConfigJSON: String?
+) throws -> ResolvedEditSuiteFiles {
+    let parsedRows: [EditSuiteConfigRow] = {
+        guard let raw = suiteConfigJSON?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty,
+              let data = raw.data(using: .utf8),
+              let rows = try? JSONDecoder().decode([EditSuiteConfigRow].self, from: data) else {
+            return []
+        }
+        return rows
+    }()
+
+    // Backward compatibility: no table config submitted.
+    // Preserve existing suite/support files and append any new uploads.
+    if parsedRows.isEmpty {
+        let existingEntries = listZipEntries(zipPath: setupZipPath)
+            .filter { $0 != "assignment.ipynb" && $0 != "solution.ipynb" }
+            .sorted()
+
+        var resolvedFiles: [File] = []
+        var configRows: [ReindexedSuiteConfigRow] = []
+        var nextOrder = 1
+
+        let manifestTests: [String: (tier: String, order: Int)] = {
+            guard let data = setupManifestJSON.data(using: .utf8),
+                  let props = try? JSONDecoder().decode(TestProperties.self, from: data) else {
+                return [:]
+            }
+            var map: [String: (tier: String, order: Int)] = [:]
+            for (idx, entry) in props.testSuites.enumerated() {
+                map[entry.script] = (entry.tier.rawValue, idx + 1)
+            }
+            return map
+        }()
+
+        for name in existingEntries {
+            guard let data = extractZipEntry(zipPath: setupZipPath, entryName: name) else { continue }
+            var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+            buffer.writeBytes(data)
+            resolvedFiles.append(File(data: buffer, filename: name))
+
+            let testInfo = manifestTests[name]
+            let tier = testInfo?.tier ?? "support"
+            configRows.append(ReindexedSuiteConfigRow(
+                index: resolvedFiles.count - 1,
+                isTest: testInfo != nil && tier != "support",
+                tier: tier,
+                order: testInfo?.order ?? nextOrder
+            ))
+            nextOrder += 1
+        }
+
+        let appendedUploads = uploadedSuiteFiles.filter { $0.data.readableBytes > 0 }
+        for (idx, file) in appendedUploads.enumerated() {
+            let rawName = file.filename.isEmpty ? "suite-file-\(idx + 1)" : file.filename
+            let cleanName = sanitizeSuiteFilename(rawName)
+            let data = Data(file.data.readableBytesView)
+            guard !data.isEmpty else { continue }
+            var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+            buffer.writeBytes(data)
+            resolvedFiles.append(File(data: buffer, filename: cleanName))
+
+            let ext = URL(fileURLWithPath: cleanName).pathExtension.lowercased()
+            let likelyTest = ["sh","bash","zsh","py","rb","pl","js","php"].contains(ext)
+            configRows.append(ReindexedSuiteConfigRow(
+                index: resolvedFiles.count - 1,
+                isTest: likelyTest,
+                tier: likelyTest ? "public" : "support",
+                order: nextOrder
+            ))
+            nextOrder += 1
+        }
+
+        let configJSON: String? = {
+            guard let data = try? JSONEncoder().encode(configRows) else { return nil }
+            return String(data: data, encoding: .utf8)
+        }()
+        return ResolvedEditSuiteFiles(
+            files: resolvedFiles,
+            reindexedSuiteConfigJSON: configJSON
+        )
+    }
+
+    var resolvedFiles: [File] = []
+    var configRows: [ReindexedSuiteConfigRow] = []
+    var nextOrder = 1
+
+    for row in parsedRows {
+        let included = row.isIncluded ?? true
+        guard included else { continue }
+
+        let source = (row.source ?? "").lowercased()
+        let dataAndName: (Data, String)?
+        if source == "existing" {
+            guard let rawName = row.name, !rawName.isEmpty else { continue }
+            let cleanName = (rawName as NSString).lastPathComponent
+            guard cleanName == rawName, !cleanName.isEmpty else { continue }
+            guard let data = extractZipEntry(zipPath: setupZipPath, entryName: cleanName) else { continue }
+            dataAndName = (data, cleanName)
+        } else if source == "upload" {
+            guard let idx = row.index, uploadedSuiteFiles.indices.contains(idx) else { continue }
+            let file = uploadedSuiteFiles[idx]
+            let data = Data(file.data.readableBytesView)
+            guard !data.isEmpty else { continue }
+            let rawName = file.filename.isEmpty ? "suite-file-\(idx + 1)" : file.filename
+            dataAndName = (data, sanitizeSuiteFilename(rawName))
+        } else {
+            continue
+        }
+
+        guard let (data, name) = dataAndName else { continue }
+
+        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        resolvedFiles.append(File(data: buffer, filename: name))
+
+        let tier = normalizeTier(row.tier)
+        let isTest = (row.isTest ?? false) && tier != "support"
+        configRows.append(ReindexedSuiteConfigRow(
+            index: resolvedFiles.count - 1,
+            isTest: isTest,
+            tier: tier,
+            order: row.order ?? nextOrder
+        ))
+        nextOrder += 1
+    }
+
+    let configJSON: String? = {
+        guard let data = try? JSONEncoder().encode(configRows) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }()
+    return ResolvedEditSuiteFiles(files: resolvedFiles, reindexedSuiteConfigJSON: configJSON)
+}
+
+private func loadExistingSolutionNotebook(req: Request, assignment: APIAssignment) async throws -> Data? {
+    if let validationID = assignment.validationSubmissionID,
+       let validationSubmission = try await APISubmission.find(validationID, on: req.db),
+       let data = try? Data(contentsOf: URL(fileURLWithPath: validationSubmission.zipPath)),
+       !data.isEmpty {
+        return data
+    }
+
+    if let fallbackSubmission = try await APISubmission.query(on: req.db)
+        .filter(\.$testSetupID == assignment.testSetupID)
+        .filter(\.$filename == "solution.ipynb")
+        .sort(\.$submittedAt, .descending)
+        .first(),
+       let data = try? Data(contentsOf: URL(fileURLWithPath: fallbackSubmission.zipPath)),
+       !data.isEmpty {
+        return data
+    }
+
+    return nil
 }
 
 private func urlEncode(_ s: String) -> String {
@@ -619,6 +1203,7 @@ private func defaultNotebookData(title: String) -> Data {
 
 private func createRunnerSetupZip(
     assignmentNotebookData: Data,
+    solutionNotebookData: Data?,
     suiteFiles: [File],
     suiteConfigJSON: String?,
     zipPath: String
@@ -656,6 +1241,10 @@ private func createRunnerSetupZip(
 
     let notebookURL = tempDir.appendingPathComponent("assignment.ipynb")
     try assignmentNotebookData.write(to: notebookURL)
+    if let solutionNotebookData {
+        let solutionURL = tempDir.appendingPathComponent("solution.ipynb")
+        try solutionNotebookData.write(to: solutionURL)
+    }
 
     let testSuites = try buildSuiteEntries(
         suiteFiles: suiteFiles,
@@ -900,15 +1489,4 @@ private func removeMaterializedNotebookFiles(req: Request, setupID: String) {
             try? FileManager.default.removeItem(atPath: root + name)
         }
     }
-}
-
-private struct EditContext: Encodable {
-    let currentUser:  CurrentUserContext?
-    let assignmentID: String
-    let setupID:      String
-    let title:        String
-    /// Fully qualified JupyterLite editor URL with workspace and notebook path.
-    let editorURL:    String
-    /// URL of the canonical notebook JSON endpoint used for save + validation.
-    let notebookURL:  String
 }

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -140,6 +140,9 @@ actor WorkerDaemon {
         // Copy or unzip the submission depending on whether it is a raw file or a zip.
         if let filename = job.submissionFilename {
             let dest = testSetupDir.appendingPathComponent(filename)
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try FileManager.default.removeItem(at: dest)
+            }
             try FileManager.default.copyItem(at: submissionZip, to: dest)
         } else {
             try unzip(submissionZip, to: testSetupDir)


### PR DESCRIPTION
## Summary\n- replace instructor edit-notebook flow with full assignment edit form mirroring create-new\n- add inline current assignment/solution file links and editable suite file table with delete actions\n- support preserving existing files on no-change save and regenerate manifest/setup zip on save\n- add robust solution fallback loading for legacy validated assignments\n- fix runner submission copy conflict when destination file already exists\n- redirect successful Save & Validate back to instructor dashboard\n\n## Validation\n- swift build\n