### PR TITLE
Improve notebook submit capture and submission UI

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -30,11 +30,15 @@
 
     // Point the iframe at the embedded JupyterLite distribution.
     // The server provides a concrete JupyterLite file path via data-editor-url.
-    // Fall back to a default lab path only if the attribute is missing.
+    // Fall back to the notebook-focused app only if the attribute is missing.
     const notebookURL = frame.dataset.notebookUrl || `/api/v1/testsetups/${setupID}/assignment`;
     const editorURL = frame.dataset.editorUrl ||
         frame.getAttribute('src') ||
-        `/jupyterlite/lab/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
+        `/jupyterlite/notebooks/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
+    const lockedNotebookPath = normalizeJupyterPath(extractPathFromEditorURL(editorURL));
+    let lastForcedEditorResetMs = 0;
+    let serverSyncInFlight = false;
+    let serverSyncComplete = false;
     frame.src = editorURL;
 
     // Quick reachability check helps explain blank/failed editor loads.
@@ -53,7 +57,16 @@
     frame.addEventListener('load', () => {
         loaded = true;
         if (frameError) frameError.style.display = 'none';
+        if (!serverSyncComplete && !serverSyncInFlight) {
+            void syncNotebookFromServerSnapshot();
+        }
+        applyLockedNotebookUI();
+        enforceLockedNotebookPath();
     });
+    setInterval(() => {
+        applyLockedNotebookUI();
+        enforceLockedNotebookPath();
+    }, 1500);
     setTimeout(() => {
         if (!loaded && frameError) {
             frameError.style.display = '';
@@ -92,9 +105,23 @@
         const liveNotebook = await readNotebookFromJupyterFrame();
         if (liveNotebook) return liveNotebook;
 
+        const snapshotNotebook = await fetchNotebookSnapshot();
+        const domNotebook = readNotebookFromVisibleDOM(snapshotNotebook);
+        if (domNotebook) return domNotebook;
+
+        const pathFromURL = lockedNotebookPath || extractPathFromEditorURL(editorURL);
+        const apiNotebook = await readNotebookViaContentsAPI(pathFromURL);
+        if (apiNotebook) return apiNotebook;
+
+        if (snapshotNotebook) return snapshotNotebook;
+        throw new Error('Failed to capture notebook contents');
+    }
+
+    async function fetchNotebookSnapshot() {
         const nbRes = await fetch(notebookURL);
-        if (!nbRes.ok) throw new Error(`Failed to fetch notebook: ${nbRes.status}`);
-        return nbRes.json();
+        if (!nbRes.ok) return null;
+        const notebook = await nbRes.json();
+        return looksLikeNotebook(notebook) ? notebook : null;
     }
 
     async function readNotebookFromJupyterFrame() {
@@ -106,22 +133,23 @@
             // Best effort: flush edits to the notebook model/context before reading.
             if (app.commands && typeof app.commands.execute === 'function') {
                 try { await app.commands.execute('docmanager:save'); } catch (_) {}
+                try { await app.commands.execute('docmanager:save-all'); } catch (_) {}
             }
+            // Allow save handlers to settle before reading back from contents.
+            await delay(125);
 
-            const widget = app.shell.currentWidget;
+            const widget = notebookWidgetFromShell(app.shell, lockedNotebookPath);
             const modelNotebook = notebookFromWidget(widget);
             if (modelNotebook) return modelNotebook;
 
-            const pathFromWidget = widget && widget.context && widget.context.path;
-            const pathFromURL = extractPathFromEditorURL(editorURL);
+            const pathFromWidget = normalizeJupyterPath(widget && widget.context && widget.context.path);
+            const pathFromURL = lockedNotebookPath || normalizeJupyterPath(extractPathFromEditorURL(editorURL));
             const notebookPath = pathFromWidget || pathFromURL;
 
             const contents = app.serviceManager && app.serviceManager.contents;
-            if (!contents || typeof contents.get !== 'function' || !notebookPath) {
-                return null;
-            }
+            if (!contents || typeof contents.get !== 'function' || !notebookPath) return null;
 
-            const contentModel = await contents.get(notebookPath, { content: true });
+            const contentModel = await contents.get(notebookPath, { content: true, format: 'json' });
             const contentNotebook = contentModel && contentModel.content;
             if (looksLikeNotebook(contentNotebook)) {
                 return toPlainNotebook(contentNotebook);
@@ -130,6 +158,37 @@
             // Fall back to server-provided notebook URL below.
         }
         return null;
+    }
+
+    function notebookWidgetFromShell(shell, preferredPath) {
+        if (!shell) return null;
+        const preferred = normalizeJupyterPath(preferredPath);
+        let firstNotebook = null;
+        const pathLooksNotebook = (path) => !!path && path.toLowerCase().endsWith('.ipynb');
+
+        try {
+            if (typeof shell.widgets === 'function') {
+                const widgets = shell.widgets('main');
+                for (const widget of widgets) {
+                    const path = normalizeJupyterPath(widget && widget.context && widget.context.path);
+                    const modelNotebook = notebookFromWidget(widget);
+                    const isNotebookWidget = pathLooksNotebook(path) || !!modelNotebook;
+                    if (!isNotebookWidget) continue;
+                    if (!firstNotebook) firstNotebook = widget;
+                    if (preferred && path === preferred) return widget;
+                }
+            }
+        } catch (_) {
+            // Ignore shell traversal errors.
+        }
+
+        const current = shell.currentWidget || null;
+        const currentPath = normalizeJupyterPath(current && current.context && current.context.path);
+        const currentNotebook = notebookFromWidget(current);
+        if (pathLooksNotebook(currentPath) || currentNotebook) {
+            return current;
+        }
+        return firstNotebook;
     }
 
     function notebookFromWidget(widget) {
@@ -162,6 +221,150 @@
         }
     }
 
+    function normalizeJupyterPath(path) {
+        if (!path) return '';
+        return String(path).replace(/^\/+/, '').trim();
+    }
+
+    function readNotebookFromVisibleDOM(baseNotebook) {
+        if (!baseNotebook || !looksLikeNotebook(baseNotebook) || !frame.contentDocument) return null;
+        try {
+            const doc = frame.contentDocument;
+            const codeCellNodes = Array.from(doc.querySelectorAll('.jp-CodeCell'));
+            if (!codeCellNodes.length) return null;
+
+            const visibleCodeSources = codeCellNodes.map(extractVisibleCodeCellText);
+            const notebook = toPlainNotebook(baseNotebook);
+            const codeCellIndexes = [];
+            for (let i = 0; i < notebook.cells.length; i += 1) {
+                const cell = notebook.cells[i];
+                if (cell && cell.cell_type === 'code') codeCellIndexes.push(i);
+            }
+            if (!codeCellIndexes.length || !visibleCodeSources.length) return null;
+
+            const pairCount = Math.min(codeCellIndexes.length, visibleCodeSources.length);
+            for (let i = 0; i < pairCount; i += 1) {
+                const cellIndex = codeCellIndexes[i];
+                notebook.cells[cellIndex].source = sourceArrayFromText(visibleCodeSources[i]);
+            }
+
+            for (let i = codeCellIndexes.length; i < visibleCodeSources.length; i += 1) {
+                notebook.cells.push({
+                    cell_type: 'code',
+                    execution_count: null,
+                    metadata: {},
+                    outputs: [],
+                    source: sourceArrayFromText(visibleCodeSources[i])
+                });
+            }
+            return notebook;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    function extractVisibleCodeCellText(cellNode) {
+        if (!cellNode) return '';
+        const lineNodes = Array.from(cellNode.querySelectorAll('.cm-content .cm-line'));
+        if (!lineNodes.length) return '';
+        return lineNodes
+            .map(node => normalizeEditorText(node.textContent || ''))
+            .join('\n');
+    }
+
+    function normalizeEditorText(text) {
+        return String(text)
+            .replace(/\u200b/g, '')
+            .replace(/\r\n/g, '\n');
+    }
+
+    function sourceArrayFromText(text) {
+        const normalized = normalizeEditorText(text);
+        if (!normalized.length) return [];
+        const lines = normalized.split('\n');
+        return lines.map((line, idx) => (idx < lines.length - 1 ? `${line}\n` : line));
+    }
+
+    function enforceLockedNotebookPath() {
+        if (!lockedNotebookPath || !frame.contentWindow) return;
+        try {
+            const currentURL = new URL(frame.contentWindow.location.href, window.location.origin);
+            const currentPath = normalizeJupyterPath(currentURL.searchParams.get('path'));
+            const inNotebookApp = currentURL.pathname.includes('/jupyterlite/notebooks/');
+
+            if (inNotebookApp && currentPath === lockedNotebookPath) return;
+
+            const now = Date.now();
+            if (now - lastForcedEditorResetMs < 1000) return;
+            lastForcedEditorResetMs = now;
+            frame.src = editorURL;
+        } catch (_) {
+            // Ignore transient cross-frame navigation states.
+        }
+    }
+
+    async function syncNotebookFromServerSnapshot() {
+        if (!lockedNotebookPath || serverSyncInFlight || serverSyncComplete) return;
+        serverSyncInFlight = true;
+        try {
+            const snapshotRes = await fetch(notebookURL, { method: 'GET' });
+            if (!snapshotRes.ok) return;
+            const snapshotNotebook = await snapshotRes.json();
+            if (!looksLikeNotebook(snapshotNotebook)) return;
+
+            const app = await waitForJupyterApp(8000);
+            if (!app) return;
+
+            const contents = app.serviceManager && app.serviceManager.contents;
+            if (!contents || typeof contents.save !== 'function') return;
+
+            await contents.save(lockedNotebookPath, {
+                type: 'notebook',
+                format: 'json',
+                content: snapshotNotebook
+            });
+
+            if (app.commands && typeof app.commands.execute === 'function') {
+                try {
+                    await app.commands.execute('docmanager:open', { path: lockedNotebookPath });
+                } catch (_) {
+                    // Best-effort open only; save above is the critical sync step.
+                }
+            }
+
+            serverSyncComplete = true;
+        } catch (_) {
+            // Retry on the next load tick if synchronization fails.
+        } finally {
+            serverSyncInFlight = false;
+        }
+    }
+
+    async function waitForJupyterApp(timeoutMs) {
+        const started = Date.now();
+        while (Date.now() - started < timeoutMs) {
+            const app = frame.contentWindow && frame.contentWindow.jupyterapp;
+            const contents = app && app.serviceManager && app.serviceManager.contents;
+            if (app && contents) return app;
+            await delay(100);
+        }
+        return null;
+    }
+
+    function applyLockedNotebookUI() {
+        if (!frame.contentDocument) return;
+        const doc = frame.contentDocument;
+        if (doc.getElementById('chickadee-notebook-lock-style')) return;
+
+        const style = doc.createElement('style');
+        style.id = 'chickadee-notebook-lock-style';
+        style.textContent = [
+            '.jp-SideBar, .jp-SidePanel, .jp-FileBrowser, .jp-FileBrowser-Panel, .jp-DirListing { display: none !important; }',
+            '.lm-MenuBar, .jp-MenuBar, .jp-TopBar { display: none !important; }'
+        ].join('\n');
+        doc.head.appendChild(style);
+    }
+
     function looksLikeNotebook(value) {
         return !!value && typeof value === 'object' && Array.isArray(value.cells);
     }
@@ -172,6 +375,32 @@
         } catch (_) {
             return notebook;
         }
+    }
+
+    async function readNotebookViaContentsAPI(path) {
+        if (!path) return null;
+        const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+        const candidates = [
+            `/jupyterlite/api/contents/${encodedPath}?content=1`,
+            `/jupyterlite/lab/api/contents/${encodedPath}?content=1`,
+            `/jupyterlite/notebooks/api/contents/${encodedPath}?content=1`,
+            `/notebooks/api/contents/${encodedPath}?content=1`,
+            `/api/contents/${encodedPath}?content=1`
+        ];
+
+        for (const url of candidates) {
+            try {
+                const res = await fetch(url);
+                if (!res.ok) continue;
+                const payload = await res.json();
+                if (looksLikeNotebook(payload && payload.content)) {
+                    return toPlainNotebook(payload.content);
+                }
+            } catch (_) {
+                // Try the next candidate URL.
+            }
+        }
+        return null;
     }
 
     // -------------------------------------------------------------------------
@@ -561,5 +790,9 @@ else:
             s.onerror = () => reject(new Error(`Failed to load ${src}`));
             document.head.appendChild(s);
         });
+    }
+
+    function delay(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
     }
 })();

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -278,6 +278,14 @@ textarea.form-input {
 
 .submission-header { margin-bottom: 1.25rem; }
 
+.submission-header-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: .75rem;
+    flex-wrap: wrap;
+}
+
 .submission-meta {
     font-size: .875rem;
     color: var(--gray-600);
@@ -288,6 +296,12 @@ textarea.form-input {
     font-size: 1.2rem;
     font-weight: 600;
     margin-bottom: 1rem;
+}
+
+.score-header {
+    margin-top: .5rem;
+    margin-bottom: .6rem;
+    font-size: 1.05rem;
 }
 
 .grade-pill {
@@ -392,6 +406,33 @@ details pre {
     padding: .55rem .7rem;
     border-radius: .25rem;
     border: 1px solid var(--gray-200);
+}
+
+.script-output-error {
+    background: var(--danger-bg);
+    border-color: var(--danger-border);
+}
+
+.result-mark {
+    display: inline-block;
+    font-size: .76rem;
+    font-weight: 600;
+    padding: .12rem .5rem;
+    border-radius: 9999px;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+
+.result-mark-pass {
+    color: var(--green);
+    background: var(--open-bg);
+    border-color: var(--green);
+}
+
+.result-mark-fail {
+    color: var(--red);
+    background: var(--danger-bg);
+    border-color: var(--danger-border);
 }
 
 /* ── Misc ────────────────────────────────────────────── */

--- a/Resources/Views/submission-history.leaf
+++ b/Resources/Views/submission-history.leaf
@@ -5,6 +5,7 @@ Submission History
 #export("content"):
 <h1>#(assignmentTitle)</h1>
 <p style="margin-top:-.35rem"><a href="/">← Back to assignments</a></p>
+<p class="empty" style="margin-top:.35rem">Use <em>Open in notebook</em> to load a past notebook submission, inspect it, edit it, and submit again.</p>
 #if(rows.isEmpty):
 <p class="empty">No submissions yet for this assignment.</p>
 #else:
@@ -16,6 +17,7 @@ Submission History
             <th>Status</th>
             <th>Grade</th>
             <th>Details</th>
+            <th>Notebook</th>
         </tr>
     </thead>
     <tbody>
@@ -26,6 +28,13 @@ Submission History
             <td>#(row.status)</td>
             <td>#(row.gradeText)</td>
             <td><a href="/submissions/#(row.submissionID)">View</a></td>
+            <td>
+                #if(row.canOpenInNotebook):
+                <a href="#(row.openInNotebookURL)">Open in notebook</a>
+                #else:
+                —
+                #endif
+            </td>
         </tr>
     #endfor
     </tbody>

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -9,11 +9,19 @@ Submission #(submissionID)
      data-browser-complete="#(isBrowserComplete)">
 
 <div class="submission-header">
-    <h1>Submission <code>#(submissionID)</code></h1>
-    <p class="submission-meta">
-        Attempt #(attemptNumber) ·
-        <a href="/testsetups/#(testSetupID)/submit">← Submit again</a>
-    </p>
+    <div class="submission-header-row">
+        <h1>Submission</h1>
+        #if(openInNotebookURL):
+        <a class="btn action-btn" href="#(openInNotebookURL)">Open in notebook</a>
+        #endif
+    </div>
+    #if(isPending):
+    #else:
+    #if(buildFailed):
+    #else:
+    <p class="score score-header">Grade: <span class="grade-pill">#(gradePercent)%</span> · #(passCount) / #(totalTests) tests passed</p>
+    #endif
+    #endif
 </div>
 
 #if(isPending):
@@ -41,22 +49,13 @@ Submission #(submissionID)
 </div>
 
 #else:
-<p class="score">Grade: <span class="grade-pill">#(gradePercent)%</span> · #(passCount) / #(totalTests) scripts passed
-    <span class="exec-time">(#(executionTimeMs) ms total)</span>
-    #if(isBrowserComplete):
-    <span class="result-source">(browser preview)</span>
-    #else:
-    <span class="result-source">(official)</span>
-    #endif
-</p>
-<h2>Per-script marks</h2>
 <table class="results-table">
     <thead>
         <tr>
             <th>Script</th>
             <th>Tier</th>
+            <th>Output</th>
             <th>Mark</th>
-            <th>ms</th>
         </tr>
     </thead>
     <tbody>
@@ -66,17 +65,13 @@ Submission #(submissionID)
             <td><span class="tier">#(outcome.tier)</span></td>
             <td>
                 #(outcome.shortResult)
-                #if(outcome.readableOutput):
-                <pre class="script-output-inline">#(outcome.readableOutput)</pre>
-                #endif
-                #if(outcome.longResult):
-                <details>
-                    <summary>Raw output</summary>
-                    <pre>#(outcome.longResult)</pre>
-                </details>
+                #if(outcome.stderrOutput):
+                <pre class="script-output-inline script-output-error">#(outcome.stderrOutput)</pre>
                 #endif
             </td>
-            <td class="time">#(outcome.executionTimeMs)</td>
+            <td>
+                <span class="result-mark result-mark-#(outcome.markClass)">#(outcome.markLabel)</span>
+            </td>
         </tr>
     #endfor
     </tbody>

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -358,12 +358,20 @@ struct WebRoutes: RouteCollection {
             } else {
                 gradeText = "—"
             }
+            let pathExt = URL(fileURLWithPath: submission.zipPath).pathExtension.lowercased()
+            let nameExt = (submission.filename ?? "").lowercased()
+            let canOpenInNotebook = pathExt == "ipynb" || nameExt.hasSuffix(".ipynb")
+            let openInNotebookURL = canOpenInNotebook
+                ? "/testsetups/\(setupID)/notebook?submissionID=\(subID)"
+                : nil
             return SubmissionHistoryRow(
                 submissionID: subID,
                 attemptNumber: submission.attemptNumber ?? 1,
                 status: submission.status,
                 submittedAt: submission.submittedAt.map { fmt.string(from: $0) } ?? "—",
-                gradeText: gradeText
+                gradeText: gradeText,
+                canOpenInNotebook: canOpenInNotebook,
+                openInNotebookURL: openInNotebookURL
             )
         }
 
@@ -382,6 +390,7 @@ struct WebRoutes: RouteCollection {
     func notebookPage(req: Request) async throws -> View {
         struct NotebookQuery: Content {
             var title: String?
+            var submissionID: String?
         }
         let user = try req.auth.require(APIUser.self)
         guard let userID = user.id else { throw Abort(.unauthorized) }
@@ -402,40 +411,35 @@ struct WebRoutes: RouteCollection {
             if !dbTitle.isEmpty { return dbTitle }
             return "Assignment"
         }()
-        let fallbackNotebookFilename = notebookFilenameForJupyterLite(title: assignmentTitle)
-        let selectedNotebook = try await latestNotebookSubmissionData(
-            req: req,
-            setupID: setupID,
-            userID: userID,
-            fallbackSetup: setup
-        )
-        let displayFilename = safeNotebookFilename(
-            preferred: selectedNotebook.filename,
-            fallbackTitle: fallbackNotebookFilename
-        )
-        let userSlug = userID.uuidString.lowercased()
-        let jupyterLiteNotebookPath = "users/\(userSlug)/\(displayFilename)"
-
-        // Materialize notebook into all likely JupyterLite file roots.
-        // Different entrypoints may resolve baseUrl differently and look under
-        // /files, /jupyterlite/files, /jupyterlite/lab/files, or /jupyterlite/notebooks/files.
-        let fileRoots = [
-            req.application.directory.publicDirectory + "files/",
-            req.application.directory.publicDirectory + "jupyterlite/files/",
-            req.application.directory.publicDirectory + "jupyterlite/lab/files/",
-            req.application.directory.publicDirectory + "jupyterlite/notebooks/files/"
-        ]
-        let nbData = selectedNotebook.data
-        for root in fileRoots {
-            let userDir = root + "users/\(userSlug)/"
-            try FileManager.default.createDirectory(atPath: userDir, withIntermediateDirectories: true)
-            try nbData.write(to: URL(fileURLWithPath: userDir + displayFilename))
-            try nbData.write(to: URL(fileURLWithPath: userDir + "assignment.ipynb"))
+        let requestedSubmissionID = (query?.submissionID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !requestedSubmissionID.isEmpty {
+            let notebookData = try await notebookDataForHistorySelection(
+                req: req,
+                submissionID: requestedSubmissionID,
+                setupID: setupID,
+                userID: userID
+            )
+            _ = try await ensureUserNotebookWorkingCopy(
+                req: req,
+                setupID: setupID,
+                userID: userID,
+                fallbackSetup: setup,
+                overwriteWith: notebookData
+            )
+        } else {
+            _ = try await ensureUserNotebookWorkingCopy(
+                req: req,
+                setupID: setupID,
+                userID: userID,
+                fallbackSetup: setup
+            )
         }
+        let jupyterLiteNotebookPath = userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID)
         let encodedPath = jupyterLiteNotebookPath.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
-            ?? "assignment.ipynb"
+            ?? jupyterLiteNotebookPath
+        let userSlug = userID.uuidString.lowercased()
         let workspaceID = "\(setupID)-\(userSlug)-student"
-        let editorURL = "/jupyterlite/lab/index.html?workspace=\(workspaceID)&reset=&path=\(encodedPath)"
+        let editorURL = "/jupyterlite/notebooks/index.html?workspace=\(workspaceID)&reset=&path=\(encodedPath)"
 
         return try await req.view.render("notebook",
             NotebookContext(
@@ -460,12 +464,12 @@ struct WebRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        let payload = try await latestNotebookSubmissionData(
+        let payload = try await ensureUserNotebookWorkingCopy(
             req: req,
             setupID: setupID,
             userID: userID,
             fallbackSetup: setup
-        ).data
+        )
 
         var headers = HTTPHeaders()
         headers.replaceOrAdd(name: .contentType, value: "application/json; charset=utf-8")
@@ -495,6 +499,11 @@ struct WebRoutes: RouteCollection {
         // "browser-complete" means the browser run finished but worker hasn't yet.
         let isPending         = submission.status == "pending" || submission.status == "assigned"
         let isBrowserComplete = submission.status == "browser-complete"
+        let pathExt = URL(fileURLWithPath: submission.zipPath).pathExtension.lowercased()
+        let nameExt = (submission.filename ?? "").lowercased()
+        let openInNotebookURL: String? = (pathExt == "ipynb" || nameExt.hasSuffix(".ipynb"))
+            ? "/testsetups/\(submission.testSetupID)/notebook?submissionID=\(subID)"
+            : nil
 
         var buildFailed     = false
         var compilerOutput: String? = nil
@@ -537,9 +546,9 @@ struct WebRoutes: RouteCollection {
                         tier:            o.tier.rawValue,
                         status:          o.status.rawValue,
                         shortResult:     o.shortResult,
-                        readableOutput:  readableScriptOutput(from: o.longResult),
-                        longResult:      o.longResult,
-                        executionTimeMs: o.executionTimeMs
+                        stderrOutput:    stderrScriptOutput(from: o.longResult, status: o.status),
+                        markLabel:       (o.status == .pass) ? "Pass" : "Fail",
+                        markClass:       (o.status == .pass) ? "pass" : "fail"
                     )
                 }
             }
@@ -550,6 +559,7 @@ struct WebRoutes: RouteCollection {
             testSetupID:       submission.testSetupID,
             status:            submission.status,
             attemptNumber:     submission.attemptNumber ?? 1,
+            openInNotebookURL: openInNotebookURL,
             isPending:         isPending,
             isBrowserComplete: isBrowserComplete,
             resultSource:      resultSource,
@@ -624,6 +634,8 @@ private struct SubmissionHistoryRow: Encodable {
     let status: String
     let submittedAt: String
     let gradeText: String
+    let canOpenInNotebook: Bool
+    let openInNotebookURL: String?
 }
 
 private struct OutcomeRow: Encodable {
@@ -631,9 +643,9 @@ private struct OutcomeRow: Encodable {
     let tier: String
     let status: String
     let shortResult: String
-    let readableOutput: String?
-    let longResult: String?
-    let executionTimeMs: Int
+    let stderrOutput: String?
+    let markLabel: String
+    let markClass: String
 }
 
 private struct SubmissionContext: Encodable {
@@ -641,6 +653,7 @@ private struct SubmissionContext: Encodable {
     let testSetupID: String
     let status: String
     let attemptNumber: Int
+    let openInNotebookURL: String?
     let isPending: Bool
     /// True when the browser run is done but the worker hasn't reported yet.
     let isBrowserComplete: Bool
@@ -656,34 +669,119 @@ private struct SubmissionContext: Encodable {
     let currentUser: CurrentUserContext?
 }
 
-private func notebookFilenameForJupyterLite(title: String) -> String {
-    let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    var value = trimmed.isEmpty ? "Assignment" : trimmed
-    value = value.replacingOccurrences(of: "/", with: "-")
-    value = value.replacingOccurrences(of: "\\", with: "-")
-    value = value.replacingOccurrences(of: ":", with: "-")
-    value = value.replacingOccurrences(of: "\n", with: " ")
-    value = value.replacingOccurrences(of: "\r", with: " ")
-    if !value.lowercased().hasSuffix(".ipynb") {
-        value += ".ipynb"
-    }
-    return value
+private func userNotebookWorkingCopyRelativePath(setupID: String, userID: UUID) -> String {
+    "users/\(userID.uuidString.lowercased())/\(setupID)/assignment.ipynb"
 }
 
-private func safeNotebookFilename(preferred: String?, fallbackTitle: String) -> String {
-    let fallback = notebookFilenameForJupyterLite(title: fallbackTitle)
-    guard var value = preferred?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
-        return fallback
+private func userNotebookWorkingCopyAbsolutePath(req: Request, setupID: String, userID: UUID) -> String {
+    req.application.directory.publicDirectory
+        + "jupyterlite/files/"
+        + userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID)
+}
+
+private func ensureUserNotebookWorkingCopy(
+    req: Request,
+    setupID: String,
+    userID: UUID,
+    fallbackSetup: APITestSetup,
+    overwriteWith: Data? = nil
+) async throws -> Data {
+    let fileManager = FileManager.default
+    let workingCopyPath = userNotebookWorkingCopyAbsolutePath(req: req, setupID: setupID, userID: userID)
+    let workingCopyDir = (workingCopyPath as NSString).deletingLastPathComponent
+
+    if let overwriteWith {
+        try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
+        try overwriteWith.write(to: URL(fileURLWithPath: workingCopyPath))
+        removeLegacyUserNotebookCopies(req: req, userID: userID)
+        return overwriteWith
     }
-    value = URL(fileURLWithPath: value).lastPathComponent
-    value = value.replacingOccurrences(of: "/", with: "-")
-    value = value.replacingOccurrences(of: "\\", with: "-")
-    value = value.replacingOccurrences(of: "\n", with: " ")
-    value = value.replacingOccurrences(of: "\r", with: " ")
-    if !value.lowercased().hasSuffix(".ipynb") {
-        value += ".ipynb"
+
+    if let existingData = try? Data(contentsOf: URL(fileURLWithPath: workingCopyPath)),
+       !existingData.isEmpty,
+       (try? JSONSerialization.jsonObject(with: existingData)) != nil {
+        removeLegacyUserNotebookCopies(req: req, userID: userID)
+        return existingData
     }
-    return value
+
+    let seedData = try await latestNotebookSubmissionData(
+        req: req,
+        setupID: setupID,
+        userID: userID,
+        fallbackSetup: fallbackSetup
+    ).data
+
+    try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
+    try seedData.write(to: URL(fileURLWithPath: workingCopyPath))
+
+    removeLegacyUserNotebookCopies(req: req, userID: userID)
+    return seedData
+}
+
+private func notebookDataForHistorySelection(
+    req: Request,
+    submissionID: String,
+    setupID: String,
+    userID: UUID
+) async throws -> Data {
+    guard let submission = try await APISubmission.find(submissionID, on: req.db) else {
+        throw Abort(.notFound, reason: "Submission not found")
+    }
+    guard submission.kind == APISubmission.Kind.student else {
+        throw Abort(.forbidden)
+    }
+    guard submission.userID == userID else {
+        throw Abort(.forbidden)
+    }
+    guard submission.testSetupID == setupID else {
+        throw Abort(.badRequest, reason: "Submission does not belong to this assignment")
+    }
+
+    let pathExt = URL(fileURLWithPath: submission.zipPath).pathExtension.lowercased()
+    let nameExt = (submission.filename ?? "").lowercased()
+    guard pathExt == "ipynb" || nameExt.hasSuffix(".ipynb") else {
+        throw Abort(.badRequest, reason: "Only notebook submissions can be opened in notebook view")
+    }
+
+    let dataURL = URL(fileURLWithPath: submission.zipPath)
+    guard let data = try? Data(contentsOf: dataURL),
+          (try? JSONSerialization.jsonObject(with: data)) != nil else {
+        throw Abort(.notFound, reason: "Notebook artifact is unavailable for this submission")
+    }
+    return normalizeNotebookForJupyterLite(data)
+}
+
+private func removeLegacyUserNotebookCopies(req: Request, userID: UUID) {
+    let userSlug = userID.uuidString.lowercased()
+    let roots = [
+        req.application.directory.publicDirectory + "files/",
+        req.application.directory.publicDirectory + "jupyterlite/files/",
+        req.application.directory.publicDirectory + "jupyterlite/lab/files/",
+        req.application.directory.publicDirectory + "jupyterlite/notebooks/files/"
+    ]
+
+    let fileManager = FileManager.default
+    for root in roots {
+        let userDir = root + "users/\(userSlug)/"
+        guard let entries = try? fileManager.contentsOfDirectory(atPath: userDir) else { continue }
+
+        for name in entries {
+            let path = userDir + name
+            var isDirectory = ObjCBool(false)
+            guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+                continue
+            }
+            guard URL(fileURLWithPath: name).pathExtension.lowercased() == "ipynb" else {
+                continue
+            }
+            let lower = name.lowercased()
+            let shouldRemove = lower == "assignment.ipynb"
+                || lower == "submission.ipynb"
+                || (lower.hasPrefix("sub_") && lower.hasSuffix(".ipynb"))
+            guard shouldRemove else { continue }
+            try? fileManager.removeItem(atPath: path)
+        }
+    }
 }
 
 private func latestNotebookSubmissionData(
@@ -731,70 +829,32 @@ private func gradePercentFromCollectionJSON(_ collectionJSON: String) -> Int? {
     return Int((Double(passCount) / Double(totalTests) * 100).rounded())
 }
 
-private func readableScriptOutput(from raw: String?) -> String? {
+private func stderrScriptOutput(from raw: String?, status: TestStatus) -> String? {
+    guard status != .pass else { return nil }
     guard let raw else { return nil }
     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
 
-    if let payload = firstJSONObject(in: trimmed) {
-        var lines: [String] = []
-        if let shortResult = payload["shortResult"] as? String,
-           !shortResult.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            lines.append(shortResult)
-        }
-        if let error = payload["error"] as? String,
-           !error.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            lines.append("Error: \(error)")
-        }
-        if let test = payload["test"] as? String,
-           !test.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            lines.append("Script: \(test)")
-        }
-        if let status = payload["status"] as? String,
-           !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            lines.append("Status: \(status)")
-        }
-        if !lines.isEmpty {
-            return lines.joined(separator: "\n")
-        }
-        if let pretty = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted]),
-           let text = String(data: pretty, encoding: .utf8) {
-            return text
-        }
+    if let stderr = extractLabeledOutputSection("stderr", in: trimmed) {
+        return stderr
     }
-
-    // Fallback: show first few meaningful lines inline.
-    let lines = trimmed
-        .split(separator: "\n", omittingEmptySubsequences: true)
-        .map { String($0).trimmingCharacters(in: .whitespaces) }
-        .filter { !$0.isEmpty }
-    guard !lines.isEmpty else { return nil }
-    let preview = Array(lines.prefix(3))
-    if lines.count > preview.count {
-        return preview.joined(separator: "\n") + "\n…"
-    }
-    return preview.joined(separator: "\n")
-}
-
-private func firstJSONObject(in text: String) -> [String: Any]? {
-    // Most runner JSON payloads are emitted as a single line near the end.
-    let lines = text
-        .split(separator: "\n", omittingEmptySubsequences: false)
-        .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
-    for line in lines.reversed() {
-        guard line.first == "{", line.last == "}" else { continue }
-        guard let data = line.data(using: .utf8),
-              let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            continue
-        }
-        return value
-    }
-    guard text.first == "{", text.last == "}",
-          let data = text.data(using: .utf8),
-          let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+    if extractLabeledOutputSection("stdout", in: trimmed) != nil {
         return nil
     }
-    return value
+    return trimmed
+}
+
+private func extractLabeledOutputSection(_ label: String, in text: String) -> String? {
+    let marker = "\(label):\n"
+    guard let start = text.range(of: marker) else { return nil }
+    let body = text[start.upperBound...]
+
+    if let nextSection = body.range(of: #"\n\n[a-zA-Z_]+:\n"#, options: .regularExpression) {
+        let section = String(body[..<nextSection.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return section.isEmpty ? nil : section
+    }
+    let section = String(body).trimmingCharacters(in: .whitespacesAndNewlines)
+    return section.isEmpty ? nil : section
 }
 
 // MARK: - Multipart body for code submission

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -473,11 +473,12 @@ def failed(message: str = "failed"):
 
 def errored(message: str = "error", err: Optional[Exception] = None):
     label = _first_comment_label()
+    summary = message.strip() if isinstance(message, str) and message.strip() else "error"
     payload = {
-        "shortResult": f"{label}: error",
+        "shortResult": f"{label}: {summary}",
         "status": "error",
         "test": label,
-        "error": message,
+        "error": summary,
     }
     if err is not None:
         payload["exception"] = repr(err)
@@ -538,15 +539,12 @@ def _module_name_for_path(path: Path) -> str:
 
 def _ordered_student_files() -> List[Path]:
     preferred = _preferred_student_module()
-    ordered: List[Path] = []
+    # When a specific submission module is hinted, only evaluate that file.
+    # This avoids accidentally resolving functions from setup-side helpers
+    # like solution.py/assignment.py.
     if preferred is not None:
-        ordered.append(preferred)
-
-    for path in _candidate_student_files():
-        if preferred is not None and path.name == preferred.name:
-            continue
-        ordered.append(path)
-    return ordered
+        return [preferred]
+    return _candidate_student_files()
 
 
 _loaded_student_modules: Optional[Dict[str, Any]] = None

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -57,11 +57,12 @@ def failed(message: str = "failed"):
 
 def errored(message: str = "error", err: Optional[Exception] = None):
     label = _first_comment_label()
+    summary = message.strip() if isinstance(message, str) and message.strip() else "error"
     payload = {
-        "shortResult": f"{label}: error",
+        "shortResult": f"{label}: {summary}",
         "status": "error",
         "test": label,
-        "error": message,
+        "error": summary,
     }
     if err is not None:
         payload["exception"] = repr(err)
@@ -122,15 +123,12 @@ def _module_name_for_path(path: Path) -> str:
 
 def _ordered_student_files() -> List[Path]:
     preferred = _preferred_student_module()
-    ordered: List[Path] = []
+    # When a specific submission module is hinted, only evaluate that file.
+    # This avoids accidentally resolving functions from setup-side helpers
+    # like solution.py/assignment.py.
     if preferred is not None:
-        ordered.append(preferred)
-
-    for path in _candidate_student_files():
-        if preferred is not None and path.name == preferred.name:
-            continue
-        ordered.append(path)
-    return ordered
+        return [preferred]
+    return _candidate_student_files()
 
 
 _loaded_student_modules: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary\n- harden notebook submit capture to read live JupyterLite state and better DOM fallbacks\n- lock notebook editor to a single assignment file path and hide file-browser affordances\n- simplify submission/submission-history views and move grade summary into header\n- improve runtime error messaging when required student functions are missing\n\n## Testing\n- swift test --filter SubmissionQueryRoutesTests/testGetSubmissionReturnsStatus