### PR TITLE
Ignore local backup sqlite files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Tools/jupyterlite/.jupyterlite.doit.db
 chickadee.sqlite
 chickadee.sqlite-wal
 chickadee.sqlite-shm
+chickadee.backup_*.sqlite
 
 # Runtime-generated app data
 results/


### PR DESCRIPTION
## Summary\n- add a gitignore rule for local backup sqlite artifacts ()\n\n## Why\n- keeps local backup files out of git status and prevents accidental commits