### PR TITLE
Prep auth/data model for future SSO switch

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -37,6 +37,7 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
     let workerSecretFile = workDir + ".worker-secret"
     let workerSecretWordlistFile = workDir + "Resources/wordlists/eff_large_wordlist.txt"
     let localRunnerAutoStartFile = workDir + ".local-runner-autostart"
+    let authMode = AuthMode.fromEnvironment() ?? .local
 
     // MARK: - Directories
 
@@ -67,6 +68,7 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
         initialEnabled: localRunnerAutoStartEnabled
     )
     app.storage[LocalRunnerManagerKey.self] = LocalRunnerManager()
+    app.storage[AuthModeKey.self] = authMode
 
     // MARK: - Sessions (in-memory; swap to .fluent for multi-process deployments)
 
@@ -99,6 +101,7 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
     app.migrations.add(CreateSubmissions())
     app.migrations.add(CreateResults())
     app.migrations.add(CreateUsers())
+    app.migrations.add(AddUserSSOFields())
     app.migrations.add(CreateAssignments())
     app.migrations.add(CreatePerformanceIndexes())
 
@@ -137,6 +140,33 @@ struct LocalRunnerAutoStartStoreKey: StorageKey {
 }
 struct LocalRunnerManagerKey: StorageKey {
     typealias Value = LocalRunnerManager
+}
+struct AuthModeKey: StorageKey {
+    typealias Value = AuthMode
+}
+
+enum AuthMode: String, Sendable {
+    case local
+    case sso
+    case dual
+
+    static func fromEnvironment() -> Self? {
+        guard let raw = Environment.get("AUTH_MODE")?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !raw.isEmpty
+        else {
+            return nil
+        }
+        return Self(rawValue: raw)
+    }
+}
+
+extension Application {
+    var authMode: AuthMode {
+        get { storage[AuthModeKey.self] ?? .local }
+        set { storage[AuthModeKey.self] = newValue }
+    }
 }
 
 actor WorkerSecretStore {

--- a/Sources/APIServer/Migrations/AddUserSSOFields.swift
+++ b/Sources/APIServer/Migrations/AddUserSSOFields.swift
@@ -1,0 +1,72 @@
+import Fluent
+import SQLKit
+
+struct AddUserSSOFields: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("users")
+            .field("auth_provider", .string)
+            .update()
+        try await database.schema("users")
+            .field("external_subject", .string)
+            .update()
+        try await database.schema("users")
+            .field("email", .string)
+            .update()
+        try await database.schema("users")
+            .field("display_name", .string)
+            .update()
+        try await database.schema("users")
+            .field("last_login_at", .datetime)
+            .update()
+
+        guard let sql = database as? SQLDatabase else { return }
+        try await sql.raw(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_users_auth_provider_external_subject
+            ON users(auth_provider, external_subject)
+            WHERE auth_provider IS NOT NULL AND external_subject IS NOT NULL
+            """
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else {
+            try await database.schema("users")
+                .deleteField("last_login_at")
+                .update()
+            try await database.schema("users")
+                .deleteField("display_name")
+                .update()
+            try await database.schema("users")
+                .deleteField("email")
+                .update()
+            try await database.schema("users")
+                .deleteField("external_subject")
+                .update()
+            try await database.schema("users")
+                .deleteField("auth_provider")
+                .update()
+            return
+        }
+
+        try await sql.raw(
+            "DROP INDEX IF EXISTS idx_users_auth_provider_external_subject"
+        ).run()
+
+        try await database.schema("users")
+            .deleteField("last_login_at")
+            .update()
+        try await database.schema("users")
+            .deleteField("display_name")
+            .update()
+        try await database.schema("users")
+            .deleteField("email")
+            .update()
+        try await database.schema("users")
+            .deleteField("external_subject")
+            .update()
+        try await database.schema("users")
+            .deleteField("auth_provider")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -22,6 +22,21 @@ final class APIUser: Model, Content, @unchecked Sendable {
     @Field(key: "password_hash")
     var passwordHash: String
 
+    @OptionalField(key: "auth_provider")
+    var authProvider: String?
+
+    @OptionalField(key: "external_subject")
+    var externalSubject: String?
+
+    @OptionalField(key: "email")
+    var email: String?
+
+    @OptionalField(key: "display_name")
+    var displayName: String?
+
+    @OptionalField(key: "last_login_at")
+    var lastLoginAt: Date?
+
     /// "student" | "instructor" | "admin"
     @Field(key: "role")
     var role: String
@@ -31,10 +46,25 @@ final class APIUser: Model, Content, @unchecked Sendable {
 
     init() {}
 
-    init(id: UUID? = nil, username: String, passwordHash: String, role: String) {
+    init(
+        id: UUID? = nil,
+        username: String,
+        passwordHash: String,
+        role: String,
+        authProvider: String? = nil,
+        externalSubject: String? = nil,
+        email: String? = nil,
+        displayName: String? = nil,
+        lastLoginAt: Date? = nil
+    ) {
         self.id           = id
         self.username     = username
         self.passwordHash = passwordHash
+        self.authProvider = authProvider
+        self.externalSubject = externalSubject
+        self.email = email
+        self.displayName = displayName
+        self.lastLoginAt = lastLoginAt
         self.role         = role
     }
 }

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -43,6 +43,7 @@ final class AssignmentRoutesTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
         app.migrations.add(CreateAssignments())
         app.migrations.add(CreatePerformanceIndexes())
         try await app.autoMigrate().get()

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -35,6 +35,7 @@ final class AuthRoutesTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
         app.migrations.add(CreateAssignments())
         app.migrations.add(CreatePerformanceIndexes())
         try await app.autoMigrate().get()

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -51,6 +51,7 @@ final class NotebookDownloadTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
         app.migrations.add(CreateAssignments())
         app.migrations.add(CreatePerformanceIndexes())
         try await app.autoMigrate().get()

--- a/Tests/APITests/ResultRoutesTests.swift
+++ b/Tests/APITests/ResultRoutesTests.swift
@@ -35,6 +35,7 @@ final class ResultRoutesTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
         app.migrations.add(CreateAssignments())
         app.migrations.add(CreatePerformanceIndexes())
         try await app.autoMigrate().get()

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -42,6 +42,7 @@ final class SubmissionQueryRoutesTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
         app.migrations.add(CreateAssignments())
         app.migrations.add(CreatePerformanceIndexes())
         try await app.autoMigrate().get()

--- a/Tests/APITests/TestSetupEditTests.swift
+++ b/Tests/APITests/TestSetupEditTests.swift
@@ -40,6 +40,7 @@ final class TestSetupEditTests: XCTestCase {
         app.migrations.add(CreateSubmissions())
         app.migrations.add(CreateResults())
         app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
         app.migrations.add(CreateAssignments())
         app.migrations.add(CreatePerformanceIndexes())
         try await app.autoMigrate().get()


### PR DESCRIPTION
## Summary
- add `AuthMode` (`local`/`sso`/`dual`) with `AUTH_MODE` env parsing and `Application.authMode` storage
- add `AddUserSSOFields` migration to extend `users` with nullable SSO identity/profile fields
- add unique index on (`auth_provider`, `external_subject`) for future external identity linking
- extend `APIUser` with optional SSO-related fields (no behavior change to current local auth)
- update APITests migration setup to include the new migration

## Validation
- `swift test`

## Follow-ups logged as issues
- #42 (auth provider abstraction)
- #43 (SSO route stubs + mode gating)
- #44 (tests/docs for auth mode migration)
