### PR TITLE
Prepare API server for HTTPS-backed SSO rollout

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -38,6 +38,7 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
     let workerSecretWordlistFile = workDir + "Resources/wordlists/eff_large_wordlist.txt"
     let localRunnerAutoStartFile = workDir + ".local-runner-autostart"
     let authMode = AuthMode.fromEnvironment() ?? .local
+    let securityConfiguration = AppSecurityConfiguration.fromEnvironment(authMode: authMode)
 
     // MARK: - Directories
 
@@ -69,10 +70,28 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
     )
     app.storage[LocalRunnerManagerKey.self] = LocalRunnerManager()
     app.storage[AuthModeKey.self] = authMode
+    app.storage[SecurityConfigurationKey.self] = securityConfiguration
 
     // MARK: - Sessions (in-memory; swap to .fluent for multi-process deployments)
 
     app.sessions.use(.memory)
+    var sessionConfig = app.sessions.configuration
+    sessionConfig.cookieFactory = { sessionID in
+        HTTPCookies.Value(
+            string: sessionID.string,
+            expires: Date(timeIntervalSinceNow: 60 * 60 * 24 * 7), // one week
+            maxAge: nil,
+            domain: nil,
+            path: "/",
+            isSecure: securityConfiguration.sessionCookieSecure,
+            isHTTPOnly: true,
+            sameSite: .lax
+        )
+    }
+    app.sessions.configuration = sessionConfig
+    if securityConfiguration.enforceHTTPS {
+        app.middleware.use(HTTPSRedirectMiddleware(configuration: securityConfiguration))
+    }
     app.middleware.use(app.sessions.middleware)
     app.middleware.use(UserSessionAuthenticator())
     app.middleware.use(UserFileNamespaceMiddleware())
@@ -106,6 +125,18 @@ func configure(_ app: Application, cliWorkerSecret: String?) throws {
     app.migrations.add(CreatePerformanceIndexes())
 
     try app.autoMigrate().wait()
+
+    if authMode != .local {
+        if securityConfiguration.publicBaseURL == nil {
+            app.logger.warning("AUTH_MODE is \(authMode.rawValue), but PUBLIC_BASE_URL is not set.")
+        } else if securityConfiguration.publicBaseURL?.scheme?.lowercased() != "https" {
+            let configured = securityConfiguration.publicBaseURL?.absoluteString ?? "(unset)"
+            app.logger.warning("AUTH_MODE is \(authMode.rawValue), but PUBLIC_BASE_URL is not https: \(configured)")
+        }
+        if !securityConfiguration.sessionCookieSecure {
+            app.logger.warning("AUTH_MODE is \(authMode.rawValue), but session cookies are not marked Secure.")
+        }
+    }
 
     // MARK: - Routes
 
@@ -144,6 +175,9 @@ struct LocalRunnerManagerKey: StorageKey {
 struct AuthModeKey: StorageKey {
     typealias Value = AuthMode
 }
+struct SecurityConfigurationKey: StorageKey {
+    typealias Value = AppSecurityConfiguration
+}
 
 enum AuthMode: String, Sendable {
     case local
@@ -166,6 +200,47 @@ extension Application {
     var authMode: AuthMode {
         get { storage[AuthModeKey.self] ?? .local }
         set { storage[AuthModeKey.self] = newValue }
+    }
+
+    var securityConfiguration: AppSecurityConfiguration {
+        get { storage[SecurityConfigurationKey.self] ?? .default }
+        set { storage[SecurityConfigurationKey.self] = newValue }
+    }
+}
+
+struct AppSecurityConfiguration: Sendable {
+    let publicBaseURL: URL?
+    let enforceHTTPS: Bool
+    let trustForwardedProto: Bool
+    let sessionCookieSecure: Bool
+
+    static let `default` = AppSecurityConfiguration(
+        publicBaseURL: nil,
+        enforceHTTPS: false,
+        trustForwardedProto: true,
+        sessionCookieSecure: false
+    )
+
+    static func fromEnvironment(authMode: AuthMode) -> Self {
+        let publicBaseURL = Environment.get("PUBLIC_BASE_URL")
+            .flatMap { raw -> URL? in
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : URL(string: trimmed)
+            }
+        let publicBaseIsHTTPS = (publicBaseURL?.scheme?.lowercased() == "https")
+
+        let enforceHTTPS = environmentBool("ENFORCE_HTTPS")
+            ?? (authMode != .local && publicBaseIsHTTPS)
+        let trustForwardedProto = environmentBool("TRUST_X_FORWARDED_PROTO") ?? true
+        let sessionCookieSecure = environmentBool("SESSION_COOKIE_SECURE")
+            ?? (publicBaseIsHTTPS || authMode != .local)
+
+        return AppSecurityConfiguration(
+            publicBaseURL: publicBaseURL,
+            enforceHTTPS: enforceHTTPS,
+            trustForwardedProto: trustForwardedProto,
+            sessionCookieSecure: sessionCookieSecure
+        )
     }
 }
 
@@ -344,6 +419,25 @@ private func runnerSharedSecretFromEnvironment() -> String? {
     if let legacy, !legacy.isEmpty { return legacy }
 
     return nil
+}
+
+private func environmentBool(_ key: String) -> Bool? {
+    guard let raw = Environment.get(key)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .lowercased(),
+        !raw.isEmpty
+    else {
+        return nil
+    }
+
+    switch raw {
+    case "1", "true", "yes", "on":
+        return true
+    case "0", "false", "no", "off":
+        return false
+    default:
+        return nil
+    }
 }
 
 extension Application {

--- a/Sources/APIServer/Middleware/HTTPSRedirectMiddleware.swift
+++ b/Sources/APIServer/Middleware/HTTPSRedirectMiddleware.swift
@@ -1,0 +1,85 @@
+import Vapor
+
+/// Enforces HTTPS at the application layer when enabled.
+///
+/// In production, this is commonly used behind a reverse proxy / load balancer
+/// that terminates TLS and forwards `X-Forwarded-Proto: https`.
+struct HTTPSRedirectMiddleware: AsyncMiddleware {
+    let configuration: AppSecurityConfiguration
+
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        guard configuration.enforceHTTPS else {
+            return try await next.respond(to: request)
+        }
+        guard !request.isHTTPSRequest(trustForwardedProto: configuration.trustForwardedProto) else {
+            return try await next.respond(to: request)
+        }
+
+        // Safe redirect for idempotent requests. Non-idempotent requests should be retried over HTTPS.
+        if request.method == .GET || request.method == .HEAD {
+            return request.redirect(
+                to: redirectURL(for: request, configuration: configuration),
+                redirectType: .temporary
+            )
+        }
+
+        throw Abort(.upgradeRequired, reason: "HTTPS is required for this endpoint.")
+    }
+}
+
+private extension Request {
+    func isHTTPSRequest(trustForwardedProto: Bool) -> Bool {
+        if trustForwardedProto,
+           let forwarded = firstForwardedValue(for: .init("X-Forwarded-Proto"))?.lowercased(),
+           !forwarded.isEmpty {
+            return forwarded == "https"
+        }
+
+        if let scheme = url.scheme?.lowercased() {
+            return scheme == "https"
+        }
+        return false
+    }
+
+    func firstForwardedValue(for name: HTTPHeaders.Name) -> String? {
+        guard let raw = headers.first(name: name) else { return nil }
+        let first = raw.split(separator: ",").first.map(String.init) ?? raw
+        let cleaned = first.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+}
+
+private func redirectURL(for request: Request, configuration: AppSecurityConfiguration) -> String {
+    let path = request.url.path
+    let query = request.url.query
+
+    if let baseURL = configuration.publicBaseURL {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) ?? URLComponents()
+        components.scheme = "https"
+        components.path = path
+        components.percentEncodedQuery = query
+        return components.string ?? "https://\(fallbackHost(for: request))\(path)"
+    }
+
+    var url = "https://\(fallbackHost(for: request))\(path)"
+    if let query, !query.isEmpty {
+        url += "?\(query)"
+    }
+    return url
+}
+
+private func fallbackHost(for request: Request) -> String {
+    if let forwardedHost = request.headers.first(name: .init("X-Forwarded-Host"))?
+        .split(separator: ",")
+        .first?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+       !forwardedHost.isEmpty {
+        return forwardedHost
+    }
+    if let host = request.headers.first(name: .host)?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+       !host.isEmpty {
+        return host
+    }
+    return "localhost"
+}

--- a/Sources/APIServer/README.md
+++ b/Sources/APIServer/README.md
@@ -16,6 +16,19 @@ chickadee-server serve --port 8080 --worker-secret your-secret
 
 ---
 
+## HTTPS / proxy settings
+
+For production SSO rollouts, run Chickadee behind HTTPS (typically terminated at a reverse proxy/load balancer) and set:
+
+- `PUBLIC_BASE_URL` (example: `https://chickadee.example.edu`) for externally-visible absolute URL construction.
+- `ENFORCE_HTTPS=true` to redirect plain-HTTP GET/HEAD requests to HTTPS and reject other insecure requests.
+- `TRUST_X_FORWARDED_PROTO=true` (default) when TLS is terminated upstream and `X-Forwarded-Proto` is forwarded.
+- `SESSION_COOKIE_SECURE=true` to force the session cookie `Secure` attribute.
+
+If unset, defaults preserve current local development behavior.
+
+---
+
 ## REST API
 
 Base path: `/api/v1`


### PR DESCRIPTION
## Summary
- add environment-driven security configuration for API server startup
- harden session cookies for secure/httpOnly/sameSite defaults and optional secure-only behavior
- add HTTPS enforcement middleware for redirect/reject behavior behind proxies
- document HTTPS and proxy environment variables for production SSO prep

## Testing
- swift test