### PR TITLE
Implement UWaterloo DUO OIDC SSO authentication

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -55,6 +55,24 @@
       }
     },
     {
+      "identity" : "jwt",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/jwt.git",
+      "state" : {
+        "revision" : "af1c59762d70d1065ddbc0d7902ea9b3dacd1a26",
+        "version" : "5.1.2"
+      }
+    },
+    {
+      "identity" : "jwt-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/jwt-kit.git",
+      "state" : {
+        "revision" : "2033b3e661238dda3d30e36a2d40987499d987de",
+        "version" : "5.2.0"
+      }
+    },
+    {
       "identity" : "leaf",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/leaf.git",
@@ -151,6 +169,15 @@
       "state" : {
         "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
+        "version" : "1.18.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "4.9.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.6.0"),
         .package(url: "https://github.com/vapor/leaf.git", from: "4.3.0"),
+        .package(url: "https://github.com/vapor/jwt.git", from: "5.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
     ],
     targets: [
@@ -31,6 +32,7 @@ let package = Package(
                 .product(name: "Fluent", package: "fluent"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "Leaf", package: "leaf"),
+                .product(name: "JWT", package: "jwt"),
             ],
             path: "Sources/APIServer",
             exclude: ["README.md"]

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -20,6 +20,13 @@ struct APIServerApp {
         
         do {
             try configure(app, cliWorkerSecret: cliWorkerSecret)
+
+            // Load OIDC configuration after configure() so app.client is ready.
+            if app.authMode != .local {
+                let oidcConfig = try await OIDCConfiguration.load(from: app)
+                app.oidcConfig = oidcConfig
+            }
+
             try await app.execute()
         } catch {
             await app.localRunnerManager.stopIfRunning(logger: app.logger)
@@ -136,6 +143,12 @@ func configure(_ app: Application, cliWorkerSecret: String?, authModeOverride: A
         }
         if !securityConfiguration.sessionCookieSecure {
             app.logger.warning("AUTH_MODE is \(authMode.rawValue), but session cookies are not marked Secure.")
+        }
+        if Environment.get("OIDC_CLIENT_ID")?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+            app.logger.warning("AUTH_MODE is \(authMode.rawValue), but OIDC_CLIENT_ID is not set.")
+        }
+        if Environment.get("OIDC_CLIENT_SECRET")?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+            app.logger.warning("AUTH_MODE is \(authMode.rawValue), but OIDC_CLIENT_SECRET is not set.")
         }
     }
 

--- a/Sources/APIServer/Auth/OIDCConfiguration.swift
+++ b/Sources/APIServer/Auth/OIDCConfiguration.swift
@@ -1,0 +1,145 @@
+// APIServer/Auth/OIDCConfiguration.swift
+//
+// OIDC discovery + runtime configuration for UWaterloo DUO OIDC.
+// Loaded once at startup (from main()) and stored in app.oidcConfig.
+//
+// Environment variables:
+//   OIDC_CLIENT_ID     — required when AUTH_MODE is 'sso' or 'dual'
+//   OIDC_CLIENT_SECRET — required when AUTH_MODE is 'sso' or 'dual'
+//
+// Discovery URL pattern (DUO OIDC at UWaterloo):
+//   https://sso-4ccc589b.sso.duosecurity.com/oidc/{CLIENT_ID}/.well-known/openid-configuration
+
+import Vapor
+import JWT
+import Foundation
+
+// MARK: - OIDC Discovery Response
+
+/// Decoded from the IdP's /.well-known/openid-configuration endpoint.
+struct OIDCDiscovery: Codable, Sendable {
+    let issuer: String
+    let authorizationEndpoint: String
+    let tokenEndpoint: String
+    let jwksURI: String
+
+    enum CodingKeys: String, CodingKey {
+        case issuer
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint         = "token_endpoint"
+        case jwksURI               = "jwks_uri"
+    }
+}
+
+// MARK: - Token Endpoint Response
+
+/// Decoded from the IdP's token endpoint after code exchange.
+struct OIDCTokenResponse: Codable, Sendable {
+    let accessToken: String
+    let idToken: String
+    let tokenType: String
+    let expiresIn: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case idToken     = "id_token"
+        case tokenType   = "token_type"
+        case expiresIn   = "expires_in"
+    }
+}
+
+// MARK: - Runtime Configuration
+
+/// Resolved OIDC configuration, stored in app.oidcConfig after startup.
+struct OIDCConfiguration: Sendable {
+    let clientID: String
+    let clientSecret: String
+    /// The absolute redirect URI registered with the IdP.
+    let redirectURI: String
+    let discovery: OIDCDiscovery
+
+    // MARK: Startup loader
+
+    /// Reads env vars, fetches the DUO OIDC discovery document, loads JWKS into
+    /// app.jwt.keys, and returns a ready-to-use configuration.
+    ///
+    /// Throws `Abort(.internalServerError)` if required env vars are missing or
+    /// if either network request fails. Intended to be called once from `main()`
+    /// before the server begins serving requests.
+    static func load(from app: Application) async throws -> OIDCConfiguration {
+        guard
+            let clientID = Environment.get("OIDC_CLIENT_ID")?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !clientID.isEmpty
+        else {
+            throw Abort(
+                .internalServerError,
+                reason: "OIDC_CLIENT_ID is required when AUTH_MODE is not 'local'"
+            )
+        }
+
+        guard
+            let clientSecret = Environment.get("OIDC_CLIENT_SECRET")?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !clientSecret.isEmpty
+        else {
+            throw Abort(
+                .internalServerError,
+                reason: "OIDC_CLIENT_SECRET is required when AUTH_MODE is not 'local'"
+            )
+        }
+
+        let baseURL = app.securityConfiguration.publicBaseURL?.absoluteString
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            ?? "http://localhost:8080"
+        let redirectURI = baseURL + "/auth/sso/callback"
+
+        // Fetch discovery document
+        let discoveryURL = "https://sso-4ccc589b.sso.duosecurity.com/oidc/\(clientID)/.well-known/openid-configuration"
+        app.logger.info("Fetching OIDC discovery document: \(discoveryURL)")
+        let discoveryResponse = try await app.client.get(URI(string: discoveryURL))
+        guard discoveryResponse.status == .ok else {
+            throw Abort(
+                .internalServerError,
+                reason: "OIDC discovery failed: HTTP \(discoveryResponse.status.code)"
+            )
+        }
+        let discovery = try discoveryResponse.content.decode(OIDCDiscovery.self)
+
+        // Fetch JWKS and register keys for JWT verification
+        app.logger.info("Fetching OIDC JWKS: \(discovery.jwksURI)")
+        let jwksResponse = try await app.client.get(URI(string: discovery.jwksURI))
+        guard jwksResponse.status == .ok else {
+            throw Abort(
+                .internalServerError,
+                reason: "OIDC JWKS fetch failed: HTTP \(jwksResponse.status.code)"
+            )
+        }
+        var jwksBuffer = jwksResponse.body ?? ByteBuffer()
+        let jwksJSON = jwksBuffer.readString(length: jwksBuffer.readableBytes) ?? ""
+        try await app.jwt.keys.add(jwksJSON: jwksJSON)
+
+        app.logger.info("OIDC configured: issuer=\(discovery.issuer), redirectURI=\(redirectURI)")
+
+        return OIDCConfiguration(
+            clientID: clientID,
+            clientSecret: clientSecret,
+            redirectURI: redirectURI,
+            discovery: discovery
+        )
+    }
+}
+
+// MARK: - Application Storage
+
+private struct OIDCConfigurationKey: StorageKey {
+    typealias Value = OIDCConfiguration
+}
+
+extension Application {
+    /// The active OIDC configuration. Nil when AUTH_MODE is `.local` or before startup loading.
+    var oidcConfig: OIDCConfiguration? {
+        get { storage[OIDCConfigurationKey.self] }
+        set { storage[OIDCConfigurationKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Auth/OIDCIDTokenClaims.swift
+++ b/Sources/APIServer/Auth/OIDCIDTokenClaims.swift
@@ -1,0 +1,58 @@
+// APIServer/Auth/OIDCIDTokenClaims.swift
+//
+// JWT payload struct for UWaterloo DUO OIDC ID tokens.
+//
+// Standard claims (sub, iss, aud, exp, iat) are declared using JWTKit wrapper
+// types. UWaterloo-specific claims (winaccountname, given_name, family_name)
+// are plain optionals decoded from the JWT body.
+//
+// Signature verification and exp validation are performed by JWTKit when
+// app.jwt.keys.verify(_:as:) is called. Issuer and audience are checked
+// manually in SSOAuthRoutes.ssoCallback after decoding.
+
+import JWT
+import Foundation
+
+struct OIDCIDTokenClaims: JWTPayload, Sendable {
+
+    // MARK: Standard claims
+
+    var sub: SubjectClaim
+    var iss: IssuerClaim
+    var aud: AudienceClaim
+    var exp: ExpirationClaim
+    var iat: IssuedAtClaim
+
+    // MARK: UWaterloo DUO OIDC claims
+
+    /// WatIAM username (e.g. "jdoe"). Used as the local username for new SSO users.
+    var winaccountname: String?
+
+    /// Display name, e.g. "Jane Doe"
+    var name: String?
+
+    var givenName: String?   // "given_name"
+    var familyName: String?  // "family_name"
+
+    var email: String?
+
+    // MARK: Coding keys
+
+    enum CodingKeys: String, CodingKey {
+        case sub, iss, aud, exp, iat
+        case winaccountname
+        case name
+        case givenName   = "given_name"
+        case familyName  = "family_name"
+        case email
+    }
+
+    // MARK: JWTPayload
+
+    func verify(using algorithm: some JWTAlgorithm) async throws {
+        // exp is the only claim that requires active validation here;
+        // the signature has already been checked by JWTKit before this is called.
+        // Issuer and audience are validated in the route handler.
+        try self.exp.verifyNotExpired()
+    }
+}

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -1,12 +1,19 @@
 // APIServer/Routes/Web/SSOAuthRoutes.swift
 //
 // SSO authentication routes — registered only when AUTH_MODE is `sso` or `dual`.
-// Handlers return 501 until a real OIDC/OAuth provider is wired in.
 //
-//   GET /auth/sso/start     → redirect browser to identity provider
-//   GET /auth/sso/callback  → receive IdP callback, establish session
+// Implements the OAuth 2.0 Authorization Code Flow with PKCE against UWaterloo's
+// DUO OIDC provider. After a successful callback, the user is upserted in the
+// local database and a Vapor session is established (same mechanism as local login).
+//
+//   GET /auth/sso/start     → generate PKCE + state, redirect to IdP authorization URL
+//   GET /auth/sso/callback  → validate state, exchange code, verify ID token, upsert user
 
 import Vapor
+import Fluent
+import JWT
+import Crypto
+import Foundation
 
 struct SSOAuthRoutes: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
@@ -18,13 +25,198 @@ struct SSOAuthRoutes: RouteCollection {
 
     @Sendable
     func ssoStart(req: Request) async throws -> Response {
-        throw Abort(.notImplemented, reason: "SSO provider not yet configured")
+        guard let config = req.application.oidcConfig else {
+            req.logger.error("SSO start called but oidcConfig is not loaded")
+            return req.redirect(to: "/login?error=sso_not_configured")
+        }
+
+        // PKCE: generate random 32-byte code_verifier, then SHA-256 → base64url code_challenge
+        var rng = SystemRandomNumberGenerator()
+        let codeVerifierBytes = (0..<32).map { _ in UInt8.random(in: 0...255, using: &rng) }
+        let codeVerifier = Data(codeVerifierBytes).base64URLEncoded()
+        let codeChallenge = Data(SHA256.hash(data: Data(codeVerifier.utf8))).base64URLEncoded()
+
+        // State token for CSRF protection
+        let stateBytes = (0..<32).map { _ in UInt8.random(in: 0...255, using: &rng) }
+        let state = Data(stateBytes).base64URLEncoded()
+
+        // Persist in session so callback can validate
+        req.session.data["oidc_state"]    = state
+        req.session.data["oidc_verifier"] = codeVerifier
+
+        // Build the IdP authorization URL
+        var components = URLComponents(string: config.discovery.authorizationEndpoint)
+        components?.queryItems = [
+            URLQueryItem(name: "client_id",             value: config.clientID),
+            URLQueryItem(name: "response_type",         value: "code"),
+            URLQueryItem(name: "scope",                 value: "openid profile email groups"),
+            URLQueryItem(name: "redirect_uri",          value: config.redirectURI),
+            URLQueryItem(name: "state",                 value: state),
+            URLQueryItem(name: "code_challenge",        value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+
+        guard let authURL = components?.url?.absoluteString else {
+            req.logger.error("Failed to build authorization URL from: \(config.discovery.authorizationEndpoint)")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        return req.redirect(to: authURL)
     }
 
     // MARK: - GET /auth/sso/callback
 
     @Sendable
     func ssoCallback(req: Request) async throws -> Response {
-        throw Abort(.notImplemented, reason: "SSO provider not yet configured")
+        guard let config = req.application.oidcConfig else {
+            req.logger.error("SSO callback called but oidcConfig is not loaded")
+            return req.redirect(to: "/login?error=sso_not_configured")
+        }
+
+        // Handle IdP-side errors (e.g., user denied consent)
+        if let idpError = req.query[String.self, at: "error"] {
+            let description = req.query[String.self, at: "error_description"] ?? idpError
+            req.logger.warning("IdP returned error in SSO callback: \(description)")
+            return req.redirect(to: "/login?error=sso_denied")
+        }
+
+        // CSRF: validate state matches what we stored in the session
+        let returnedState = req.query[String.self, at: "state"] ?? ""
+        let storedState   = req.session.data["oidc_state"] ?? ""
+        let codeVerifier  = req.session.data["oidc_verifier"] ?? ""
+
+        // Always clear session values — whether we succeed or fail below
+        req.session.data["oidc_state"]    = nil
+        req.session.data["oidc_verifier"] = nil
+
+        guard !returnedState.isEmpty, returnedState == storedState else {
+            req.logger.warning("SSO callback: state mismatch (possible CSRF or stale session)")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        guard let code = req.query[String.self, at: "code"] else {
+            req.logger.warning("SSO callback: missing authorization code")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        // Exchange authorization code for tokens
+        let tokenResponse: OIDCTokenResponse
+        do {
+            let response = try await req.client.post(
+                URI(string: config.discovery.tokenEndpoint)
+            ) { tokenReq in
+                tokenReq.headers.contentType = .urlEncodedForm
+                try tokenReq.content.encode([
+                    "grant_type":    "authorization_code",
+                    "code":          code,
+                    "redirect_uri":  config.redirectURI,
+                    "client_id":     config.clientID,
+                    "client_secret": config.clientSecret,
+                    "code_verifier": codeVerifier,
+                ] as [String: String])
+            }
+            guard response.status == .ok else {
+                req.logger.error("Token exchange returned HTTP \(response.status.code)")
+                return req.redirect(to: "/login?error=sso_failed")
+            }
+            tokenResponse = try response.content.decode(OIDCTokenResponse.self)
+        } catch {
+            req.logger.error("Token exchange failed: \(error)")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        // Verify ID token signature + expiry, then decode claims
+        let claims: OIDCIDTokenClaims
+        do {
+            claims = try await req.application.jwt.keys.verify(
+                tokenResponse.idToken,
+                as: OIDCIDTokenClaims.self
+            )
+        } catch {
+            req.logger.error("ID token verification failed: \(error)")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        // Validate issuer and audience manually (JWTKit verifies signature + exp only)
+        guard claims.iss.value == config.discovery.issuer else {
+            req.logger.error("ID token issuer mismatch: got \(claims.iss.value), expected \(config.discovery.issuer)")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+        guard claims.aud.value.contains(config.clientID) else {
+            req.logger.error("ID token audience does not contain client_id")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        // Upsert user in the local database
+        let user: APIUser
+        do {
+            user = try await upsertUser(claims: claims, on: req)
+        } catch {
+            req.logger.error("Failed to upsert SSO user (sub=\(claims.sub.value)): \(error)")
+            return req.redirect(to: "/login?error=sso_failed")
+        }
+
+        // Establish session — identical to local login
+        req.auth.login(user)
+        req.session.authenticate(user)
+        return req.redirect(to: "/")
+    }
+
+    // MARK: - User upsert
+
+    /// Look up a user by (auth_provider, external_subject); create if not found.
+    /// Updates mutable profile fields (email, display_name, last_login_at) on every login.
+    private func upsertUser(claims: OIDCIDTokenClaims, on req: Request) async throws -> APIUser {
+        let subject = claims.sub.value
+        let username = claims.winaccountname?.nilIfEmpty() ?? subject
+
+        // Prefer full name from 'name' claim; fall back to given + family
+        let displayName: String? = {
+            if let n = claims.name?.nilIfEmpty() { return n }
+            let parts = [claims.givenName, claims.familyName].compactMap { $0?.nilIfEmpty() }
+            return parts.isEmpty ? nil : parts.joined(separator: " ")
+        }()
+
+        if let existing = try await APIUser.query(on: req.db)
+            .filter(\.$authProvider == "duo-oidc")
+            .filter(\.$externalSubject == subject)
+            .first()
+        {
+            existing.email        = claims.email
+            existing.displayName  = displayName ?? existing.displayName
+            existing.lastLoginAt  = Date()
+            try await existing.save(on: req.db)
+            return existing
+        }
+
+        let newUser = APIUser(
+            username:        username,
+            passwordHash:    "",            // SSO users have no local password
+            role:            "student",
+            authProvider:    "duo-oidc",
+            externalSubject: subject,
+            email:           claims.email,
+            displayName:     displayName,
+            lastLoginAt:     Date()
+        )
+        try await newUser.save(on: req.db)
+        return newUser
+    }
+}
+
+// MARK: - Helpers
+
+private extension String {
+    /// Returns nil when the string is empty, self otherwise.
+    func nilIfEmpty() -> String? { isEmpty ? nil : self }
+}
+
+private extension Data {
+    /// Base64url encoding (RFC 4648 §5): replaces +/→-_, strips padding.
+    func base64URLEncoded() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/Tests/APITests/AuthModeGatingTests.swift
+++ b/Tests/APITests/AuthModeGatingTests.swift
@@ -2,8 +2,8 @@
 //
 // Verify that SSO routes are gated by authMode:
 //   - .local → /auth/sso/start and /auth/sso/callback return 404 (not registered)
-//   - .sso   → both routes return 501 (stub registered, provider not yet wired)
-//   - .dual  → same as .sso
+//   - .sso   → both routes return 303 redirect (registered; no oidcConfig → error redirect)
+//   - .dual  → same as .sso; local login routes still present
 
 import XCTest
 import XCTVapor
@@ -53,34 +53,42 @@ final class AuthModeGatingTests: XCTestCase {
         })
     }
 
-    // MARK: - SSO mode: routes present (501 until provider is wired)
+    // MARK: - SSO mode: routes present (redirect to error page when oidcConfig not loaded)
 
-    func testSSOMode_ssoStartReturns501() async throws {
+    func testSSOMode_ssoStartRedirectsWhenNotConfigured() async throws {
         let app = try makeApp(authMode: .sso)
         defer { app.shutdown() }
 
+        // oidcConfig is nil → handler redirects to error page (303, not 404)
         try await app.test(.GET, "/auth/sso/start", afterResponse: { res in
-            XCTAssertEqual(res.status, .notImplemented)
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertTrue(
+                res.headers.first(name: .location)?.contains("sso_not_configured") == true
+            )
         })
     }
 
-    func testSSOMode_ssoCallbackReturns501() async throws {
+    func testSSOMode_ssoCallbackRedirectsWhenNotConfigured() async throws {
         let app = try makeApp(authMode: .sso)
         defer { app.shutdown() }
 
         try await app.test(.GET, "/auth/sso/callback", afterResponse: { res in
-            XCTAssertEqual(res.status, .notImplemented)
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertTrue(
+                res.headers.first(name: .location)?.contains("sso_not_configured") == true
+            )
         })
     }
 
     // MARK: - Dual mode: SSO routes present alongside local login
 
-    func testDualMode_ssoStartReturns501() async throws {
+    func testDualMode_ssoStartRedirectsWhenNotConfigured() async throws {
         let app = try makeApp(authMode: .dual)
         defer { app.shutdown() }
 
         try await app.test(.GET, "/auth/sso/start", afterResponse: { res in
-            XCTAssertEqual(res.status, .notImplemented)
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertNotEqual(res.status, .notFound)
         })
     }
 

--- a/Tests/APITests/SSOAuthFlowTests.swift
+++ b/Tests/APITests/SSOAuthFlowTests.swift
@@ -1,0 +1,143 @@
+// Tests/APITests/SSOAuthFlowTests.swift
+//
+// Tests for the real OIDC authorization code flow in SSOAuthRoutes.
+//
+// These tests inject a mock OIDCConfiguration (no network calls) and cover the
+// controllable parts of the flow: redirect generation, PKCE/state storage, and
+// callback error paths. End-to-end token exchange requires real IdP credentials
+// and is out of scope for unit tests.
+
+import XCTest
+import XCTVapor
+@testable import chickadee_server
+import FluentSQLiteDriver
+
+final class SSOAuthFlowTests: XCTestCase {
+
+    // MARK: - App factory
+
+    private func makeApp(authMode: AuthMode = .sso) throws -> Application {
+        let app = Application(.testing)
+        app.authMode = authMode
+
+        app.sessions.use(.memory)
+        app.middleware.use(app.sessions.middleware)
+        app.middleware.use(UserSessionAuthenticator())
+
+        app.databases.use(.sqlite(.memory), as: .sqlite)
+        app.migrations.add(CreateTestSetups())
+        app.migrations.add(CreateSubmissions())
+        app.migrations.add(CreateResults())
+        app.migrations.add(CreateUsers())
+        app.migrations.add(AddUserSSOFields())
+        app.migrations.add(CreateAssignments())
+        app.migrations.add(CreatePerformanceIndexes())
+        try app.autoMigrate().wait()
+
+        // Inject mock OIDC config — no network calls needed
+        app.oidcConfig = Self.mockOIDCConfig
+
+        try routes(app)
+        return app
+    }
+
+    private static let mockOIDCConfig = OIDCConfiguration(
+        clientID:     "test-client-id",
+        clientSecret: "test-client-secret",
+        redirectURI:  "http://localhost:8080/auth/sso/callback",
+        discovery: OIDCDiscovery(
+            issuer:                "https://duo-test.example.com/oidc/test-client-id",
+            authorizationEndpoint: "https://duo-test.example.com/oidc/test-client-id/authorize",
+            tokenEndpoint:         "https://duo-test.example.com/oidc/test-client-id/token",
+            jwksURI:               "https://duo-test.example.com/oidc/test-client-id/keys"
+        )
+    )
+
+    // MARK: - ssoStart: redirect to IdP
+
+    func testSSOStart_redirectsToAuthorizationEndpoint() async throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try await app.test(.GET, "/auth/sso/start", afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            let location = res.headers.first(name: .location) ?? ""
+            XCTAssertTrue(
+                location.hasPrefix("https://duo-test.example.com"),
+                "Expected redirect to DUO test host, got: \(location)"
+            )
+            XCTAssertTrue(location.contains("client_id=test-client-id"))
+            XCTAssertTrue(location.contains("response_type=code"))
+            XCTAssertTrue(location.contains("code_challenge_method=S256"))
+            XCTAssertTrue(location.contains("scope=openid"))
+        })
+    }
+
+    func testSSOStart_includesRedirectURI() async throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try await app.test(.GET, "/auth/sso/start", afterResponse: { res in
+            let location = res.headers.first(name: .location) ?? ""
+            // redirect_uri must be percent-encoded in the query string
+            XCTAssertTrue(location.contains("redirect_uri="))
+        })
+    }
+
+    // MARK: - ssoCallback: error paths
+
+    func testSSOCallback_missingStateFails() async throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        // No prior ssoStart → empty session → state mismatch
+        try await app.test(.GET, "/auth/sso/callback?code=abc&state=wrong", afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertTrue(
+                res.headers.first(name: .location)?.contains("sso_failed") == true,
+                "Expected sso_failed redirect"
+            )
+        })
+    }
+
+    func testSSOCallback_missingCodeFails() async throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        // state present in query but no code (also no matching session state)
+        try await app.test(.GET, "/auth/sso/callback?state=somestate", afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertTrue(
+                res.headers.first(name: .location)?.contains("sso_failed") == true
+            )
+        })
+    }
+
+    func testSSOCallback_idpErrorRedirectsToDenied() async throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        // IdP signals that user denied consent
+        try await app.test(
+            .GET,
+            "/auth/sso/callback?error=access_denied&error_description=User+denied+consent",
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+                XCTAssertTrue(
+                    res.headers.first(name: .location)?.contains("sso_denied") == true
+                )
+            }
+        )
+    }
+
+    // MARK: - Local mode: SSO routes absent
+
+    func testLocalMode_ssoStartNotRegistered() async throws {
+        let app = try makeApp(authMode: .local)
+        defer { app.shutdown() }
+
+        try await app.test(.GET, "/auth/sso/start", afterResponse: { res in
+            XCTAssertEqual(res.status, .notFound)
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the 501 SSO stubs with a full OAuth 2.0 Authorization Code Flow + PKCE implementation targeting UWaterloo's DUO OIDC provider
- Adds `vapor/jwt` 5.x for JWKS loading and RS256 ID token verification
- OIDC configuration (discovery document + JWKS) is loaded once at startup and stored in `app.oidcConfig`; server fails fast if env vars are missing
- `ssoStart` generates PKCE verifier/challenge and state token, stores them in the session, then redirects to the IdP authorization endpoint
- `ssoCallback` validates state (CSRF), exchanges the code for tokens, verifies the ID token (signature + exp + issuer + audience), and upserts the user into the local DB before establishing a session
- SSO users are stored with `auth_provider = "duo-oidc"` and looked up by `(auth_provider, external_subject)` on subsequent logins; `winaccountname` claim becomes their local username
- 5 new `SSOAuthFlowTests`; `AuthModeGatingTests` updated for new 303 behaviour

## Activation

Once IST grants client credentials, set:
```
AUTH_MODE=sso
OIDC_CLIENT_ID=<from IST>
OIDC_CLIENT_SECRET=<from IST>
PUBLIC_BASE_URL=https://your-domain.uwaterloo.ca
```
Register redirect URI: `{PUBLIC_BASE_URL}/auth/sso/callback`  
For local dev: `http://localhost:8080/auth/sso/callback` (port pre-approved by UWaterloo).

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 113 tests, 0 failures
- [ ] Manual smoke test with real credentials once available from IST

🤖 Generated with [Claude Code](https://claude.com/claude-code)