### PR TITLE
Fix WCAG quick-audit accessibility gaps

### DIFF
--- a/Public/setup-edit.js
+++ b/Public/setup-edit.js
@@ -6,7 +6,7 @@
 //
 // 1. SAVE — The instructor edits the notebook in JupyterLite, downloads it via
 //    JupyterLite's built-in "File → Download" menu, then uploads the .ipynb
-//    here. Clicking the "Save notebook…" label opens a file picker; on change
+//    here. Clicking the "Save notebook…" button opens a file picker; on change
 //    the file is PUT to /api/v1/testsetups/:id/assignment.
 //
 // 2. RUN TESTS — Re-uses the Pyodide engine from assignment-validate.js for
@@ -27,6 +27,7 @@
 
     // ── DOM refs ─────────────────────────────────────────────────────────────
     const frame          = document.getElementById('jl-frame');
+    const saveBtn        = document.getElementById('save-btn');
     const saveFile       = document.getElementById('save-file');
     const editStatus     = document.getElementById('edit-status');
     const runBtn         = document.getElementById('run-btn');
@@ -48,8 +49,14 @@
     // Workflow:
     //   a. Instructor edits in JupyterLite.
     //   b. Instructor chooses File → Download in JupyterLite to get the .ipynb.
-    //   c. Instructor clicks "Save notebook…" label → file picker opens.
+    //   c. Instructor clicks "Save notebook…" button → file picker opens.
     //   d. On file selected: PUT raw JSON to /api/v1/testsetups/:id/assignment.
+
+    if (saveBtn && saveFile) {
+        saveBtn.addEventListener('click', () => {
+            saveFile.click();
+        });
+    }
 
     if (saveFile) {
         saveFile.addEventListener('change', async () => {

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -115,6 +115,18 @@ a { color: var(--blue); }
     text-decoration: none;
 }
 
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* ── Nav ─────────────────────────────────────────────── */
 
 .nav {

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -4,18 +4,19 @@ Admin
 #endexport
 #export("content"):
 <section class="admin-section">
+<<<<<<< HEAD
     <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
         <div style="display:flex;align-items:center;gap:.75rem">
             <h2 style="margin:0">Runners</h2>
-            <form method="post" action="/admin/runner-autostart">
+            <form method="post" action="/admin/runner-autostart" style="display:flex;align-items:center;gap:.4rem">
                 #csrfFormField()
                 <label style="display:inline-flex;align-items:center;gap:.4rem;white-space:nowrap;font-size:.875rem;cursor:pointer">
                     <input type="checkbox"
                            name="localRunnerAutoStart"
-                           onchange="this.form.submit()"
                            #if(localRunnerAutoStartEnabled):checked#endif>
                     Auto-start local
                 </label>
+                <button class="btn" type="submit" style="font-size:.8rem;padding:.2rem .5rem">Save</button>
             </form>
         </div>
         <form method="post" action="/admin/runner-secret" style="display:flex;gap:.5rem;align-items:center">
@@ -30,6 +31,32 @@ Admin
             <button class="btn" type="submit">Save secret</button>
         </form>
     </div>
+=======
+    <h2>Runners</h2>
+    <form method="post" action="/admin/runner-secret" style="max-width:700px">
+        <label class="form-label">
+            Runner shared secret
+            <div style="display:flex;gap:.5rem;align-items:center">
+                <input class="form-input"
+                       type="text"
+                       name="secret"
+                       value="#(workerSecret)"
+                       autocomplete="off"
+                       style="flex:1">
+                <button class="btn" type="submit">Save</button>
+            </div>
+        </label>
+    </form>
+    <form method="post" action="/admin/runner-autostart" style="margin-top:.75rem;max-width:700px">
+        <label class="form-label" style="display:inline-flex;flex-direction:row;align-items:center;gap:.5rem;white-space:nowrap">
+            <input type="checkbox"
+                   name="localRunnerAutoStart"
+                   #if(localRunnerAutoStartEnabled):checked#endif>
+            <span>Auto-start one local runner when none are connected</span>
+        </label>
+        <button class="btn" type="submit" style="margin-top:.5rem">Save</button>
+    </form>
+>>>>>>> 30c9a0f (Fix WCAG quick-audit issues in instructor/admin flows)
 
     <table id="workers-table" class="results-table">
             <thead>
@@ -158,8 +185,14 @@ Admin
                 <td>
                     <form method="post" action="/admin/users/#(user.id)/role"
                           style="display:flex;gap:.4rem;align-items:center">
+<<<<<<< HEAD
                         #csrfFormField()
-                        <select name="role" class="form-input" style="padding:.25rem .5rem;font-size:.8rem">
+                        <label class="visually-hidden" for="role-#(user.id)">Role for #(user.username)</label>
+                        <select id="role-#(user.id)" name="role" class="form-input" style="padding:.25rem .5rem;font-size:.8rem">
+=======
+                        <label class="visually-hidden" for="role-#(user.id)">Role for #(user.username)</label>
+                        <select id="role-#(user.id)" name="role" class="form-input" style="padding:.25rem .5rem;font-size:.8rem">
+>>>>>>> 30c9a0f (Fix WCAG quick-audit issues in instructor/admin flows)
                             <option value="student"    #if(user.role == "student"):selected#endif>student</option>
                             <option value="instructor" #if(user.role == "instructor"):selected#endif>instructor</option>
                             <option value="admin"      #if(user.role == "admin"):selected#endif>admin</option>

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -131,11 +131,13 @@
                     #if(row.assignmentID && row.validationStatus == "passed"):
                     <form method="post" action="/instructor/#(row.assignmentID)/status">
                         #csrfFormField()
-                        <select class="form-input" name="status" onchange="this.form.submit()"
+                        <label class="visually-hidden" for="status-#(row.assignmentID)">Status for #(row.title)</label>
+                        <select id="status-#(row.assignmentID)" class="form-input" name="status"
                                 style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
                             <option value="open" #if(row.status == "open"):selected#endif>open</option>
                             <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
                         </select>
+                        <button class="btn action-btn" type="submit" style="margin-left:.35rem">Save</button>
                     </form>
                     #elseif(row.assignmentID):
                     <span class="tier tier-closed">closed</span>
@@ -273,11 +275,14 @@
                 <td>
                     #if(row.assignmentID && row.validationStatus == "passed"):
                     <form method="post" action="/instructor/#(row.assignmentID)/status">
-                        <select class="form-input" name="status" onchange="this.form.submit()"
+                        #csrfFormField()
+                        <label class="visually-hidden" for="status-u-#(row.assignmentID)">Status for #(row.title)</label>
+                        <select id="status-u-#(row.assignmentID)" class="form-input" name="status"
                                 style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
                             <option value="open" #if(row.status == "open"):selected#endif>open</option>
                             <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
                         </select>
+                        <button class="btn action-btn" type="submit" style="margin-left:.35rem">Save</button>
                     </form>
                     #elseif(row.assignmentID):
                     <span class="tier tier-closed">closed</span>
@@ -382,18 +387,18 @@
             <label style="display:flex;align-items:center;gap:.4rem;font-size:.875rem;cursor:pointer;user-select:none">
                 <input type="checkbox" name="openEnrollment" value="on"
                        #if(courseOpenEnrollment):checked#endif
-                       onchange="this.form.submit()">
+                       >
                 Open enrolment
             </label>
+            <button class="btn" type="submit" style="font-size:.8rem;padding:.2rem .5rem">Save</button>
         </form>
         <form method="post" action="/courses/#(currentUser.activeCourse.id)/enroll-csv"
               enctype="multipart/form-data" style="margin:0;margin-left:auto">
             #csrfFormField()
-            <label class="btn btn-primary" style="cursor:pointer;margin:0">
-                Enrol from CSV
-                <input type="file" name="file" accept=".csv,.txt" required
-                       style="display:none" onchange="this.closest('form').submit()">
-            </label>
+            <label class="visually-hidden" for="enroll-csv-file">CSV file</label>
+            <input id="enroll-csv-file" type="file" name="file" accept=".csv,.txt" required
+                   style="font-size:.8rem;max-width:12rem">
+            <button class="btn btn-primary" type="submit" style="margin:0">Enrol</button>
         </form>
         #endif
         #endif


### PR DESCRIPTION
## Summary\n- replace non-keyboard-friendly save label with a real button in setup editor\n- remove auto-submit-on-change patterns and require explicit Save action\n- add explicit programmatic labels for status/role selects\n- add shared visually-hidden utility class for accessible labels\n\n## WCAG areas addressed\n- 2.1.1 Keyboard\n- 3.2.2 On Input\n- 1.3.1 Info and Relationships\n- 3.3.2 Labels or Instructions\n\n## Notes\n- commit intentionally excludes unrelated untracked JupyterLite build artifacts in the working tree