### PR TITLE
Auto-start SSO from login page in SSO mode

### DIFF
--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -35,6 +35,14 @@ struct AuthRoutes: RouteCollection {
         }
         let error = req.query[String.self, at: "error"]
         let authMode = req.application.authMode
+
+        // In SSO-only mode, start the SSO flow immediately so users do not
+        // need to click a button. Keep error states on /login so the message
+        // can be shown instead of creating a redirect loop.
+        if authMode == .sso, error == nil {
+            return req.redirect(to: "/auth/sso/start")
+        }
+
         return try await req.view.render(
             "login",
             LoginContext(

--- a/Tests/APITests/AuthModeGatingTests.swift
+++ b/Tests/APITests/AuthModeGatingTests.swift
@@ -99,6 +99,16 @@ final class AuthModeGatingTests: XCTestCase {
         })
     }
 
+    func testSSOMode_loginAutoRedirectsToSSOStart() async throws {
+        let app = try makeApp(authMode: .sso)
+        defer { app.shutdown() }
+
+        try await app.test(.GET, "/login", afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertEqual(res.headers.first(name: .location), "/auth/sso/start")
+        })
+    }
+
     func testSSOMode_customCallbackRouteRegisteredFromEnv() async throws {
         setenv("OIDC_CALLBACK", "/oidc/duo/callback/", 1)
         defer { unsetenv("OIDC_CALLBACK") }


### PR DESCRIPTION
## Summary
- auto-redirect `GET /login` to `/auth/sso/start` when `AUTH_MODE` is `sso` and no error is present
- preserve rendering of `/login` when an `error` query param exists so SSO failure messages still display
- add auth mode gating test coverage for SSO login auto-redirect

## Testing
- swift test --filter AuthModeGatingTests