### PR TITLE
Add admin course-enrollment management and CSV bulk enrol

### DIFF
--- a/Resources/Views/admin-enroll-csv-result.leaf
+++ b/Resources/Views/admin-enroll-csv-result.leaf
@@ -1,0 +1,38 @@
+#extend("base"):
+#export("title"):
+CSV Enrollment Result
+#endexport
+#export("content"):
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
+    <a href="/admin" class="btn">← Admin</a>
+    <h1 style="margin:0">CSV Enrollment — #(courseCode)</h1>
+</div>
+<p style="color:var(--gray-600);margin-top:-.75rem;margin-bottom:1.5rem">#(courseName)</p>
+
+<section class="admin-section">
+    <h2>Results</h2>
+    <dl style="display:grid;grid-template-columns:auto 1fr;gap:.4rem 1.5rem;max-width:400px;margin:0">
+        <dt style="font-weight:600">Enrolled</dt>
+        <dd style="margin:0">#(enrolledCount)</dd>
+        <dt style="font-weight:600">Already enrolled (skipped)</dt>
+        <dd style="margin:0">#(alreadyEnrolledCount)</dd>
+        <dt style="font-weight:600">Not found</dt>
+        <dd style="margin:0">#(notFoundCount)</dd>
+    </dl>
+</section>
+
+#if(hasNotFound):
+<section class="admin-section">
+    <h2>Usernames not found</h2>
+    <p style="font-size:.875rem;color:var(--gray-600);margin-top:0">
+        These usernames from the CSV did not match any account in the system:
+    </p>
+    <ul style="font-family:monospace;margin:.25rem 0 0 1.25rem;padding:0">
+    #for(name in notFoundUsernames):
+        <li>#(name)</li>
+    #endfor
+    </ul>
+</section>
+#endif
+#endexport
+#endextend

--- a/Resources/Views/admin-user.leaf
+++ b/Resources/Views/admin-user.leaf
@@ -1,0 +1,73 @@
+#extend("base"):
+#export("title"):
+Courses — #if(displayName):#(displayName)#else:#(username)#endif
+#endexport
+#export("content"):
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
+    <a href="/admin" class="btn">← Admin</a>
+    <h1 style="margin:0">
+        #if(displayName):#(displayName)#else:#(username)#endif — Courses
+    </h1>
+</div>
+<p style="color:var(--gray-600);margin-top:-.75rem;margin-bottom:1.5rem">
+    @#(username) · #(role)
+</p>
+
+<section class="admin-section">
+    <h2>Enrolled courses</h2>
+    #if(enrolledCourses.isEmpty):
+    <p class="empty">Not enrolled in any courses.</p>
+    #else:
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>Code</th>
+                <th>Name</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        #for(course in enrolledCourses):
+            <tr>
+                <td><strong>#(course.code)</strong></td>
+                <td>#(course.name)</td>
+                <td>
+                    <form method="post"
+                          action="/admin/users/#(targetUserID)/unenroll/#(course.id)"
+                          style="display:inline">
+                        <button class="btn" type="submit"
+                                style="padding:.25rem .6rem;font-size:.8rem">Remove</button>
+                    </form>
+                </td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+    #endif
+</section>
+
+<section class="admin-section">
+    <h2>Add to course</h2>
+    #if(availableCourses.isEmpty):
+    <p class="empty">
+        #if(enrolledCourses.isEmpty):
+        No active courses are available.
+        #else:
+        Enrolled in all active courses.
+        #endif
+    </p>
+    #else:
+    <form method="post"
+          action="/admin/users/#(targetUserID)/enroll"
+          style="display:flex;gap:.5rem;align-items:center;max-width:500px">
+        <select name="courseID" class="form-input" style="flex:1">
+            #for(course in availableCourses):
+            <option value="#(course.id)">#(course.code) — #(course.name)</option>
+            #endfor
+        </select>
+        <button class="btn btn-primary" type="submit">Add</button>
+    </form>
+    #endif
+</section>
+#endexport
+#endextend

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -113,6 +113,35 @@ Admin
         </tbody>
     </table>
     #endif
+
+    <div style="margin-top:1.5rem">
+        <h3 style="margin:.5rem 0">Bulk enroll from CSV</h3>
+        <p style="font-size:.875rem;color:var(--gray-600);margin:.25rem 0 .75rem">
+            Upload a plain-text or CSV file with one username per line. A header row is detected and skipped automatically.
+        </p>
+        #if(activeCourses.isEmpty):
+        <p class="empty">No active courses to enroll into.</p>
+        #else:
+        <form method="post" action="/admin/courses/enroll-csv"
+              enctype="multipart/form-data"
+              style="display:flex;gap:.5rem;align-items:flex-end;flex-wrap:wrap;max-width:700px">
+            <label class="form-label" style="flex:0 0 auto">
+                Course
+                <select name="courseID" class="form-input" style="display:block">
+                    #for(course in activeCourses):
+                    <option value="#(course.id)">#(course.code) — #(course.name)</option>
+                    #endfor
+                </select>
+            </label>
+            <label class="form-label" style="flex:1 1 220px">
+                CSV file
+                <input type="file" name="file" accept=".csv,.txt" required
+                       class="form-input" style="display:block">
+            </label>
+            <button class="btn btn-primary" type="submit" style="align-self:flex-end">Enroll from CSV</button>
+        </form>
+        #endif
+    </div>
 </section>
 
 <!-- ── Users ──────────────────────────────────────────── -->
@@ -126,6 +155,7 @@ Admin
                 <th data-sort-key="role" data-sort-type="text" tabindex="0" aria-sort="none">Role</th>
                 <th class="time" data-sort-key="last-login" data-sort-type="date" tabindex="0" aria-sort="none">Last Login</th>
                 <th class="time" data-sort-key="joined" data-sort-type="date" tabindex="0" aria-sort="none">Joined</th>
+                <th>Courses</th>
             </tr>
         </thead>
         <tbody>
@@ -159,6 +189,11 @@ Admin
                     #endif
                 </td>
                 <td class="time js-relative-time" data-iso="#(user.createdAt)">#(user.createdAt)</td>
+                <td>
+                    <a href="/admin/users/#(user.id)"
+                       class="btn"
+                       style="padding:.25rem .6rem;font-size:.8rem">Manage</a>
+                </td>
             </tr>
         #endfor
         </tbody>

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -22,7 +22,11 @@ struct AdminRoutes: RouteCollection {
         admin.post("worker-secret", use: updateWorkerSecret)
         admin.post("runner-autostart", use: updateLocalRunnerAutoStart)
         admin.post("courses", use: createCourse)
+        admin.post("courses", "enroll-csv", use: adminBulkEnrollCSV)
         admin.post("courses", ":courseID", "archive", use: toggleCourseArchive)
+        admin.get("users", ":userID", use: userDetail)
+        admin.post("users", ":userID", "enroll", use: adminEnrollUser)
+        admin.post("users", ":userID", "unenroll", ":courseID", use: adminUnenrollUser)
     }
 
     // MARK: - GET /admin
@@ -65,13 +69,16 @@ struct AdminRoutes: RouteCollection {
             )
         }
 
+        let activeCourseRows = courseRows.filter { !$0.isArchived }
+
         let ctx = AdminContext(
             currentUser: req.currentUserContext,
             users:       userRows,
             workers:     workerRows,
             workerSecret: effectiveSecret,
             localRunnerAutoStartEnabled: localRunnerAutoStartEnabled,
-            courses: courseRows
+            courses: courseRows,
+            activeCourses: activeCourseRows
         )
         return try await req.view.render("admin", ctx)
     }
@@ -191,6 +198,174 @@ struct AdminRoutes: RouteCollection {
         return req.redirect(to: "/admin")
     }
 
+    // MARK: - GET /admin/users/:userID
+
+    @Sendable
+    func userDetail(req: Request) async throws -> View {
+        guard
+            let idString = req.parameters.get("userID"),
+            let userID   = UUID(uuidString: idString),
+            let user     = try await APIUser.find(userID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        let allCourses = try await APICourse.query(on: req.db)
+            .filter(\.$isArchived == false)
+            .sort(\.$code)
+            .all()
+
+        let enrollments = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$userID == userID)
+            .with(\.$course)
+            .all()
+
+        let enrolledIDs = Set(enrollments.map { $0.$course.id })
+
+        let enrolledRows = enrollments
+            .compactMap { e -> AdminUserCourseRow? in
+                guard let id = e.course.id else { return nil }
+                return AdminUserCourseRow(id: id.uuidString, code: e.course.code, name: e.course.name)
+            }
+            .sorted { $0.code < $1.code }
+
+        let availableRows = allCourses.compactMap { c -> AdminUserCourseRow? in
+            guard let id = c.id, !enrolledIDs.contains(id) else { return nil }
+            return AdminUserCourseRow(id: id.uuidString, code: c.code, name: c.name)
+        }
+
+        return try await req.view.render("admin-user", AdminUserDetailContext(
+            currentUser:      req.currentUserContext,
+            targetUserID:     idString,
+            displayName:      user.displayName,
+            username:         user.username,
+            role:             user.role,
+            enrolledCourses:  enrolledRows,
+            availableCourses: availableRows
+        ))
+    }
+
+    // MARK: - POST /admin/users/:userID/enroll
+
+    @Sendable
+    func adminEnrollUser(req: Request) async throws -> Response {
+        guard
+            let idString = req.parameters.get("userID"),
+            let userID   = UUID(uuidString: idString),
+            let _        = try await APIUser.find(userID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        struct EnrollBody: Content { var courseID: String }
+        let body = try req.content.decode(EnrollBody.self)
+
+        guard
+            let courseID = UUID(uuidString: body.courseID),
+            let course   = try await APICourse.find(courseID, on: req.db),
+            !course.isArchived
+        else {
+            return req.redirect(to: "/admin/users/\(idString)?error=invalid_course")
+        }
+
+        let existing = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$userID == userID)
+            .filter(\.$course.$id == courseID)
+            .count()
+
+        if existing == 0 {
+            let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
+            try await enrollment.save(on: req.db)
+        }
+
+        return req.redirect(to: "/admin/users/\(idString)")
+    }
+
+    // MARK: - POST /admin/users/:userID/unenroll/:courseID
+
+    @Sendable
+    func adminUnenrollUser(req: Request) async throws -> Response {
+        guard
+            let idString       = req.parameters.get("userID"),
+            let userID         = UUID(uuidString: idString),
+            let courseIDString = req.parameters.get("courseID"),
+            let courseID       = UUID(uuidString: courseIDString)
+        else {
+            throw Abort(.badRequest)
+        }
+
+        try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$userID == userID)
+            .filter(\.$course.$id == courseID)
+            .delete()
+
+        return req.redirect(to: "/admin/users/\(idString)")
+    }
+
+    // MARK: - POST /admin/courses/enroll-csv
+
+    @Sendable
+    func adminBulkEnrollCSV(req: Request) async throws -> View {
+        struct BulkEnrollForm: Content {
+            var courseID: String
+            var file: Data
+        }
+
+        let form = try req.content.decode(BulkEnrollForm.self)
+
+        guard
+            let courseID = UUID(uuidString: form.courseID),
+            let course   = try await APICourse.find(courseID, on: req.db),
+            !course.isArchived
+        else {
+            throw Abort(.badRequest, reason: "Invalid or archived course.")
+        }
+
+        // Parse unique, non-empty usernames from the CSV (first column, header auto-skipped).
+        let rawUsernames = parseUsernamesFromCSV(form.file)
+        var seen = Set<String>()
+        let uniqueUsernames = rawUsernames.filter { seen.insert($0).inserted }
+
+        // Match against APIUser.username in-memory (simpler than a Fluent IN query).
+        let usernameSet = Set(uniqueUsernames)
+        let allUsers = try await APIUser.query(on: req.db).all()
+        let matchedUsers = allUsers.filter { usernameSet.contains($0.username) }
+
+        let matchedUsernameSet = Set(matchedUsers.map { $0.username })
+        let notFoundUsernames = uniqueUsernames
+            .filter { !matchedUsernameSet.contains($0) }
+            .sorted()
+
+        // Load existing enrollments for this course to detect already-enrolled users.
+        let existingEnrollments = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseID)
+            .all()
+        let alreadyEnrolledUserIDs = Set(existingEnrollments.map { $0.userID })
+
+        var enrolledCount = 0
+        var alreadyEnrolledCount = 0
+
+        for user in matchedUsers {
+            guard let userID = user.id else { continue }
+            if alreadyEnrolledUserIDs.contains(userID) {
+                alreadyEnrolledCount += 1
+            } else {
+                let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
+                try await enrollment.save(on: req.db)
+                enrolledCount += 1
+            }
+        }
+
+        return try await req.view.render("admin-enroll-csv-result", AdminEnrollCSVResultContext(
+            currentUser:          req.currentUserContext,
+            courseCode:           course.code,
+            courseName:           course.name,
+            enrolledCount:        enrolledCount,
+            alreadyEnrolledCount: alreadyEnrolledCount,
+            notFoundUsernames:    notFoundUsernames
+        ))
+    }
+
 }
 
 private func makeWorkerRows(req: Request) async throws -> [AdminWorkerRow] {
@@ -268,4 +443,75 @@ private struct AdminContext: Encodable {
     let workerSecret: String
     let localRunnerAutoStartEnabled: Bool
     let courses: [AdminCourseRow]
+    /// Non-archived courses only; used for the bulk-enroll CSV dropdown.
+    let activeCourses: [AdminCourseRow]
+}
+
+/// Parses a flat list of usernames from a CSV upload.
+/// - Takes the first column of every non-blank line.
+/// - Strips surrounding quotes and whitespace.
+/// - Auto-detects and skips a header row when the first column matches a known keyword.
+private func parseUsernamesFromCSV(_ data: Data) -> [String] {
+    guard let text = String(data: data, encoding: .utf8)
+                  ?? String(data: data, encoding: .isoLatin1) else {
+        return []
+    }
+
+    var lines = text.components(separatedBy: .newlines)
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+
+    // Skip an obvious header row.
+    if let firstLine = lines.first {
+        let firstCol = firstLine
+            .components(separatedBy: ",").first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: " ", with: "")
+            ?? ""
+        let headerKeywords = ["username", "user", "login", "id", "studentid", "userid", "loginid"]
+        if headerKeywords.contains(firstCol) {
+            lines.removeFirst()
+        }
+    }
+
+    // Extract first column, strip surrounding quotes/whitespace.
+    return lines.compactMap { line -> String? in
+        let col = line
+            .components(separatedBy: ",").first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        guard let col, !col.isEmpty else { return nil }
+        return col
+    }
+}
+
+private struct AdminUserDetailContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let targetUserID: String
+    let displayName: String?
+    let username: String
+    let role: String
+    let enrolledCourses: [AdminUserCourseRow]
+    let availableCourses: [AdminUserCourseRow]
+}
+
+private struct AdminUserCourseRow: Encodable {
+    let id: String
+    let code: String
+    let name: String
+}
+
+private struct AdminEnrollCSVResultContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let courseCode: String
+    let courseName: String
+    let enrolledCount: Int
+    let alreadyEnrolledCount: Int
+    let notFoundUsernames: [String]
+    // Precomputed for easy Leaf truthiness check.
+    var hasNotFound: Bool { !notFoundUsernames.isEmpty }
+    var notFoundCount: Int { notFoundUsernames.count }
 }


### PR DESCRIPTION
## Summary

- **Per-user course management**: each row in the admin Users table now has a **Manage** button linking to `/admin/users/:userID`, a dedicated page where the admin can see a user's enrolled courses, remove them from a course, or add them to any non-enrolled active course
- **Bulk enrol from CSV**: a new form in the Courses section of `/admin` lets the admin choose a course and upload a plain-text/CSV file of usernames (one per line) to enrol a whole class in one step; a result page reports enrolled / already-enrolled / not-found counts and lists any unrecognised usernames
- Header row in the CSV is auto-detected and skipped; duplicate entries are deduplicated; already-enrolled users are counted but not re-inserted (idempotent)

## New files

- `Resources/Views/admin-user.leaf` — per-user course management page
- `Resources/Views/admin-enroll-csv-result.leaf` — CSV import result page

## Test plan

- [ ] Navigate to `/admin` → Users table has a Manage column with link buttons
- [ ] Click Manage for a user → `/admin/users/:id` loads with correct enrolled / available lists
- [ ] Add a course via the dropdown → appears in Enrolled, removed from Add list
- [ ] Remove an enrolled course → moves back to Add list
- [ ] Upload a CSV with valid usernames → result page shows correct enrolled count
- [ ] Upload a CSV with a mix of valid, already-enrolled, and unknown usernames → all three counts correct and not-found list accurate
- [ ] Upload a CSV with a header row → header is skipped, not treated as a username
- [ ] All 131 existing tests pass (`swift test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)