### PR TITLE
feat: warn instructors when due date is near a UWaterloo important date

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -28,8 +28,9 @@ Edit Assignment
 
     <label class="form-label">
         Due Date (optional)
-        <input class="form-input" type="datetime-local" name="dueAt" value="#(dueAt)">
+        <input class="form-input" type="datetime-local" name="dueAt" id="dueAt" value="#(dueAt)">
     </label>
+    <div id="uw-date-warning" class="card-meta" style="display:none;color:#c05000;margin-top:-.5rem;margin-bottom:.5rem"></div>
 
     <div class="form-label">
         <span style="white-space:nowrap">Assignment Notebook (<a href="#(currentAssignmentURL)"><code>#(currentAssignmentFile)</code></a>)</span>
@@ -211,7 +212,45 @@ Edit Assignment
 
     // Native form submission is intentionally left unmodified.
     // Hidden suiteConfig is kept in sync by change/input listeners above.
+
+    // UWaterloo important-date proximity warning
+    (function () {
+        var dueAtInput = document.getElementById('dueAt');
+        var warning = document.getElementById('uw-date-warning');
+        if (!dueAtInput || !warning) return;
+        dueAtInput.addEventListener('change', function () {
+            checkUWDates(dueAtInput.value, warning);
+        });
+        // Check the pre-filled value on page load
+        if (dueAtInput.value) { checkUWDates(dueAtInput.value, warning); }
+    })();
 })();
+</script>
+<script>
+function checkUWDates(dateTimeValue, warningEl) {
+    if (!dateTimeValue) { warningEl.style.display = 'none'; return; }
+    var selected = new Date(dateTimeValue);
+    if (isNaN(selected.getTime())) { warningEl.style.display = 'none'; return; }
+    fetch('/api/v1/uw-dates').then(function (resp) {
+        if (!resp.ok) return;
+        return resp.json();
+    }).then(function (dates) {
+        if (!dates) return;
+        var threeDays = 3 * 86400000;
+        var near = dates.filter(function (d) {
+            var start = new Date(d.startDate);
+            var end = new Date(d.endDate);
+            return selected >= new Date(start.getTime() - threeDays)
+                && selected < new Date(end.getTime() + threeDays);
+        });
+        if (near.length > 0) {
+            warningEl.textContent = '\u26a0 Due date is near: ' + near.map(function (d) { return d.title; }).join(', ');
+            warningEl.style.display = '';
+        } else {
+            warningEl.style.display = 'none';
+        }
+    }).catch(function () { /* silently ignore */ });
+}
 </script>
 #endexport
 #endextend

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -28,8 +28,9 @@ Create Assignment
 
     <label class="form-label">
         Due Date (optional)
-        <input class="form-input" type="datetime-local" name="dueAt" value="#(dueAt)">
+        <input class="form-input" type="datetime-local" name="dueAt" id="dueAt" value="#(dueAt)">
     </label>
+    <div id="uw-date-warning" class="card-meta" style="display:none;color:#c05000;margin-top:-.5rem;margin-bottom:.5rem"></div>
 
     <label class="form-label">
         <span style="white-space:nowrap">Assignment Notebook (<code>assignment.ipynb</code>)</span>
@@ -189,7 +190,43 @@ Create Assignment
             }
         });
     }
+
+    // UWaterloo important-date proximity warning
+    (function () {
+        var dueAtInput = document.getElementById('dueAt');
+        var warning = document.getElementById('uw-date-warning');
+        if (!dueAtInput || !warning) return;
+        dueAtInput.addEventListener('change', function () {
+            checkUWDates(dueAtInput.value, warning);
+        });
+    })();
 })();
+</script>
+<script>
+function checkUWDates(dateTimeValue, warningEl) {
+    if (!dateTimeValue) { warningEl.style.display = 'none'; return; }
+    var selected = new Date(dateTimeValue);
+    if (isNaN(selected.getTime())) { warningEl.style.display = 'none'; return; }
+    fetch('/api/v1/uw-dates').then(function (resp) {
+        if (!resp.ok) return;
+        return resp.json();
+    }).then(function (dates) {
+        if (!dates) return;
+        var threeDays = 3 * 86400000;
+        var near = dates.filter(function (d) {
+            var start = new Date(d.startDate);
+            var end = new Date(d.endDate);
+            return selected >= new Date(start.getTime() - threeDays)
+                && selected < new Date(end.getTime() + threeDays);
+        });
+        if (near.length > 0) {
+            warningEl.textContent = '\u26a0 Due date is near: ' + near.map(function (d) { return d.title; }).join(', ');
+            warningEl.style.display = '';
+        } else {
+            warningEl.style.display = 'none';
+        }
+    }).catch(function () { /* silently ignore */ });
+}
 </script>
 #endexport
 #endextend

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -102,9 +102,10 @@ Assignments
                         </label>
                         <label class="form-label" style="font-size:.8rem">
                             Due date (optional)
-                            <input class="form-input" type="datetime-local" name="dueAt"
+                            <input class="form-input publish-due-date" type="datetime-local" name="dueAt"
                                    style="font-size:.85rem;padding:.3rem .5rem">
                         </label>
+                        <div class="publish-uw-warning card-meta" style="display:none;color:#c05000;font-size:.8rem;margin-top:-.25rem;margin-bottom:.25rem"></div>
                         <button class="btn btn-primary" type="submit"
                                 style="font-size:.8rem;padding:.3rem .6rem">Create draft</button>
                     </form>
@@ -265,6 +266,40 @@ tr.assignment-draggable td {
         dragged.classList.remove('dragging');
         dragged = null;
         persistOrderIfChanged();
+    });
+})();
+
+// UWaterloo important-date proximity warning for inline publish forms
+(function () {
+    function checkUWDates(dateTimeValue, warningEl) {
+        if (!dateTimeValue) { warningEl.style.display = 'none'; return; }
+        var selected = new Date(dateTimeValue);
+        if (isNaN(selected.getTime())) { warningEl.style.display = 'none'; return; }
+        fetch('/api/v1/uw-dates').then(function (resp) {
+            if (!resp.ok) return;
+            return resp.json();
+        }).then(function (dates) {
+            if (!dates) return;
+            var threeDays = 3 * 86400000;
+            var near = dates.filter(function (d) {
+                var start = new Date(d.startDate);
+                var end = new Date(d.endDate);
+                return selected >= new Date(start.getTime() - threeDays)
+                    && selected < new Date(end.getTime() + threeDays);
+            });
+            if (near.length > 0) {
+                warningEl.textContent = '\u26a0 Near: ' + near.map(function (d) { return d.title; }).join(', ');
+                warningEl.style.display = '';
+            } else {
+                warningEl.style.display = 'none';
+            }
+        }).catch(function () { /* silently ignore */ });
+    }
+
+    document.querySelectorAll('.publish-due-date').forEach(function (input) {
+        var warning = input.closest('form')?.querySelector('.publish-uw-warning');
+        if (!warning) return;
+        input.addEventListener('change', function () { checkUWDates(input.value, warning); });
     });
 })();
 </script>

--- a/Sources/APIServer/Routes/UWDatesRoute.swift
+++ b/Sources/APIServer/Routes/UWDatesRoute.swift
@@ -1,0 +1,27 @@
+// APIServer/Routes/UWDatesRoute.swift
+//
+// GET /api/v1/uw-dates
+// Returns upcoming UWaterloo important dates as JSON for client-side due-date warnings.
+// Registered under the instructor middleware group (only instructors set due dates).
+
+import Vapor
+
+struct UWDatesRoute: RouteCollection {
+    func boot(routes: any RoutesBuilder) throws {
+        routes.get("api", "v1", "uw-dates", use: handle)
+    }
+
+    @Sendable
+    func handle(req: Request) async throws -> Response {
+        let dates = await req.application.uwImportantDatesCache.fetchDates(
+            client: req.client,
+            logger: req.logger
+        )
+        let body = try JSONEncoder().encode(dates)
+        return Response(
+            status: .ok,
+            headers: ["Content-Type": "application/json"],
+            body: .init(data: body)
+        )
+    }
+}

--- a/Sources/APIServer/Services/UWImportantDatesService.swift
+++ b/Sources/APIServer/Services/UWImportantDatesService.swift
@@ -1,0 +1,154 @@
+// APIServer/Services/UWImportantDatesService.swift
+//
+// Fetches and caches the University of Waterloo important dates iCalendar feed.
+// Results are cached for 24 hours to avoid hammering the UW server on every
+// instructor due-date change.
+
+import Vapor
+import Foundation
+
+// MARK: - Model
+
+struct UWImportantDate: Codable, Sendable {
+    /// ISO-8601 date string, e.g. "2026-03-21"
+    let startDate: String
+    /// ISO-8601 date string (exclusive end per iCalendar convention), e.g. "2026-03-22"
+    let endDate: String
+    let title: String
+}
+
+// MARK: - Actor
+
+actor UWImportantDatesCache {
+    private let feedURL = "https://uwaterloo.ca/important-dates/important-dates/important_dates_ical.ics"
+    private let cacheDuration: TimeInterval = 60 * 60 * 24 // 24 hours
+
+    private var cached: [UWImportantDate] = []
+    private var cachedAt: Date?
+
+    func fetchDates(client: Client, logger: Logger) async -> [UWImportantDate] {
+        if let cachedAt, Date().timeIntervalSince(cachedAt) < cacheDuration {
+            return cached
+        }
+        do {
+            let response = try await client.get(URI(string: feedURL))
+            guard response.status == .ok else {
+                logger.warning("UW important dates fetch returned HTTP \(response.status.code)")
+                return cached
+            }
+            var body = response.body ?? ByteBuffer()
+            let text = body.readString(length: body.readableBytes) ?? ""
+            let parsed = parseICS(text)
+            cached = parsed
+            cachedAt = Date()
+            return parsed
+        } catch {
+            logger.warning("UW important dates fetch failed: \(error)")
+            return cached
+        }
+    }
+
+    // MARK: - iCalendar Parser
+
+    /// Extracts VEVENT blocks and returns one UWImportantDate per event.
+    /// Handles both DATE-only (DTSTART;VALUE=DATE:YYYYMMDD) and DATE-TIME forms.
+    private func parseICS(_ text: String) -> [UWImportantDate] {
+        var results: [UWImportantDate] = []
+
+        // Split on VEVENT boundaries
+        let blocks = text.components(separatedBy: "BEGIN:VEVENT")
+        for block in blocks.dropFirst() {
+            guard let startDate = extractDate(key: "DTSTART", from: block),
+                  let title = extractSummary(from: block) else {
+                continue
+            }
+            // DTEND is exclusive in iCalendar; default to startDate + 1 day if absent
+            let endDate = extractDate(key: "DTEND", from: block) ?? nextDay(startDate)
+            results.append(UWImportantDate(startDate: startDate, endDate: endDate, title: title))
+        }
+
+        return results
+    }
+
+    /// Extracts a line like DTSTART;VALUE=DATE:20260321 or DTSTART:20260321 → "2026-03-21"
+    private func extractDate(key: String, from block: String) -> String? {
+        for line in block.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            // Match e.g. "DTSTART;VALUE=DATE:20260321" or "DTSTART:20260321"
+            guard trimmed.hasPrefix(key) else { continue }
+            let colonIdx = trimmed.firstIndex(of: ":") ?? trimmed.endIndex
+            let raw = String(trimmed[trimmed.index(after: colonIdx)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            // Take the date portion (first 8 digits)
+            let digits = raw.prefix(8)
+            guard digits.count == 8, digits.allSatisfy(\.isNumber) else { continue }
+            let y = digits.prefix(4)
+            let m = digits.dropFirst(4).prefix(2)
+            let d = digits.dropFirst(6).prefix(2)
+            return "\(y)-\(m)-\(d)"
+        }
+        return nil
+    }
+
+    /// Extracts SUMMARY, handling folded lines (continuation lines start with a space/tab).
+    private func extractSummary(from block: String) -> String? {
+        let lines = block.components(separatedBy: "\n")
+        var inSummary = false
+        var accumulated = ""
+        for line in lines {
+            let raw = line.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+            if raw.hasPrefix("SUMMARY:") || raw.hasPrefix("SUMMARY;") {
+                // Drop the property name
+                if let colonIdx = raw.firstIndex(of: ":") {
+                    accumulated = String(raw[raw.index(after: colonIdx)...])
+                }
+                inSummary = true
+            } else if inSummary {
+                if raw.hasPrefix(" ") || raw.hasPrefix("\t") {
+                    // Folded continuation line
+                    accumulated += raw.dropFirst()
+                } else {
+                    break
+                }
+            }
+        }
+        let trimmed = accumulated.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Unescape iCalendar backslash sequences
+        let unescaped = trimmed
+            .replacingOccurrences(of: "\\,", with: ",")
+            .replacingOccurrences(of: "\\;", with: ";")
+            .replacingOccurrences(of: "\\n", with: " ")
+            .replacingOccurrences(of: "\\N", with: " ")
+            .replacingOccurrences(of: "\\\\", with: "\\")
+        return unescaped.isEmpty ? nil : unescaped
+    }
+
+    private func nextDay(_ isoDate: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        guard let date = formatter.date(from: isoDate) else { return isoDate }
+        let next = Calendar(identifier: .gregorian).date(byAdding: .day, value: 1, to: date) ?? date
+        return formatter.string(from: next)
+    }
+}
+
+// MARK: - Application Storage
+
+private struct UWImportantDatesCacheKey: StorageKey {
+    typealias Value = UWImportantDatesCache
+}
+
+extension Application {
+    var uwImportantDatesCache: UWImportantDatesCache {
+        get {
+            if let existing = storage[UWImportantDatesCacheKey.self] {
+                return existing
+            }
+            let created = UWImportantDatesCache()
+            storage[UWImportantDatesCacheKey.self] = created
+            return created
+        }
+        set { storage[UWImportantDatesCacheKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -37,6 +37,7 @@ func routes(_ app: Application) throws {
     try instructor.register(collection: AssignmentRoutes())
     // Worker job polling is instructor-tier: only the server operator runs workers.
     try instructor.register(collection: SubmissionRoutes())
+    try instructor.register(collection: UWDatesRoute())
 
     // MARK: - Admin only
 


### PR DESCRIPTION
## Summary

- Fetches the UWaterloo important dates iCalendar feed and caches results for 24 hours in a Swift actor (`UWImportantDatesCache`)
- Adds `GET /api/v1/uw-dates` (instructor-only) that returns parsed dates as JSON
- Shows a non-blocking inline warning on all three due-date inputs (new assignment, edit assignment, inline Publish form) when the selected date falls within 3 days of an academic event

## Test plan

- [ ] Log in as an instructor and open `/assignments/new`
- [ ] Set the due date to a date near a known UWaterloo academic event (e.g. March 21 2026 — "Drop with WD ends") and confirm the warning appears
- [ ] Set a date with no nearby events and confirm the warning hides
- [ ] Verify the form still submits normally with the warning visible
- [ ] Open an existing assignment's edit page with a pre-filled due date near an event — confirm warning appears on load
- [ ] Test with the inline Publish form on `/assignments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)