### PR TITLE
fix(uw-dates): filter warnings to closures, holidays, breaks, and exam periods

### DIFF
--- a/Sources/APIServer/Services/UWImportantDatesService.swift
+++ b/Sources/APIServer/Services/UWImportantDatesService.swift
@@ -38,7 +38,7 @@ actor UWImportantDatesCache {
             }
             var body = response.body ?? ByteBuffer()
             let text = body.readString(length: body.readableBytes) ?? ""
-            let parsed = parseICS(text)
+            let parsed = parseICS(text).filter { isRelevantEvent($0.title) }
             cached = parsed
             cachedAt = Date()
             return parsed
@@ -121,6 +121,26 @@ actor UWImportantDatesCache {
             .replacingOccurrences(of: "\\N", with: " ")
             .replacingOccurrences(of: "\\\\", with: "\\")
         return unescaped.isEmpty ? nil : unescaped
+    }
+
+    /// Returns true if the event title represents a closure, holiday, break, or exam period
+    /// that would make it unreasonable to set an assignment due date on or near that date.
+    private func isRelevantEvent(_ title: String) -> Bool {
+        let lower = title.lowercased()
+        let keywords: [String] = [
+            // Statutory holidays
+            "good friday", "easter", "victoria day", "canada day", "civic holiday",
+            "labour day", "thanksgiving", "remembrance day", "christmas", "boxing day",
+            "new year",
+            // University closures
+            "university closed", "holiday", "closure",
+            // Academic breaks
+            "reading week", "spring vacation", "spring break", "winter break",
+            "study break", "intersession",
+            // Exam periods
+            "final examination", "final exam", "exam period",
+        ]
+        return keywords.contains { lower.contains($0) }
     }
 
     private func nextDay(_ isoDate: String) -> String {


### PR DESCRIPTION
## Summary

- Adds `isRelevantEvent` filter to `UWImportantDatesCache` — the 137-event feed is now filtered server-side before being returned to the client
- Only events matching these categories trigger a warning:
  - **Statutory holidays**: Good Friday, Easter, Victoria Day, Canada Day, Civic Holiday, Labour Day, Thanksgiving, Remembrance Day, Christmas, Boxing Day, New Year
  - **University closures**: "university closed", "holiday", "closure"
  - **Academic breaks**: Reading Week, spring/winter break, study break
  - **Exam periods**: Final examinations, exam period
- Administrative dates (drop deadlines, registration windows, financial dates) are silently ignored

## Test plan

- [ ] Set a due date on Good Friday (April 3 2026) — warning should appear
- [ ] Set a due date during Reading Week — warning should appear
- [ ] Set a due date on a regular class day — no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)