### PR TITLE
feat(sections): per-course section grouping for instructor and student dashboards

### DIFF
--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -32,6 +32,21 @@ Create Assignment
     </label>
     <div id="uw-date-warning" class="card-meta" style="display:none;color:#c05000;margin-top:-.5rem;margin-bottom:.5rem"></div>
 
+    #if(!sections.isEmpty):
+    <label class="form-label">
+        Section (optional)
+        <select class="form-input" name="sectionID" id="sectionID">
+            <option value="" #if(!preselectedSectionID):selected#endif>— Ungrouped —</option>
+            #for(section in sections):
+            <option value="#(section.sectionID)"
+                    data-grading-mode="#(section.defaultGradingMode)"
+                    #if(preselectedSectionID == section.sectionID):selected#endif>#(section.name)</option>
+            #endfor
+        </select>
+    </label>
+    <p id="grading-mode-hint" class="card-meta" style="margin-top:-.4rem;margin-bottom:.25rem;display:none"></p>
+    #endif
+
     <label class="form-label">
         <span style="white-space:nowrap">Assignment Notebook (<code>assignment.ipynb</code>)</span>
         <input class="form-input" type="file" name="assignmentNotebookFile" accept=".ipynb" required>
@@ -199,6 +214,28 @@ Create Assignment
         dueAtInput.addEventListener('change', function () {
             checkUWDates(dueAtInput.value, warning);
         });
+    })();
+
+    // Grading mode hint when a section is selected
+    (function () {
+        var sectionSelect = document.getElementById('sectionID');
+        var hint = document.getElementById('grading-mode-hint');
+        if (!sectionSelect || !hint) return;
+        function updateHint() {
+            var selected = sectionSelect.options[sectionSelect.selectedIndex];
+            var mode = selected ? selected.getAttribute('data-grading-mode') : null;
+            if (mode === 'browser') {
+                hint.textContent = '\u24d8 This section uses browser grading by default.';
+                hint.style.display = '';
+            } else if (mode === 'worker') {
+                hint.textContent = '\u24d8 This section uses server-side (worker) grading by default.';
+                hint.style.display = '';
+            } else {
+                hint.style.display = 'none';
+            }
+        }
+        sectionSelect.addEventListener('change', updateHint);
+        updateHint();
     })();
 })();
 </script>

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -7,149 +7,389 @@ Assignments
     <h1 style="margin:0">Instructor</h1>
     <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
         <a class="btn action-btn" href="/assignments/grades.csv">Export Grades CSV</a>
+        <!-- Add Section inline form -->
+        <details class="add-section-details" id="add-section-details">
+            <summary class="btn action-btn" style="cursor:pointer;list-style:none">+ Add Section</summary>
+            <div class="add-section-popup card" style="position:absolute;z-index:100;right:0;margin-top:.5rem;padding:1rem;min-width:18rem;box-shadow:0 4px 16px rgba(0,0,0,.15)">
+                <form method="post" action="/assignments/sections" class="form" style="margin:0;gap:.6rem">
+                    <label class="form-label" style="margin:0">
+                        Section name
+                        <input class="form-input" type="text" name="name" placeholder="e.g. Labs" required
+                               style="font-size:.85rem;padding:.3rem .5rem">
+                    </label>
+                    <label class="form-label" style="margin:0">
+                        Default grading mode
+                        <select class="form-input" name="defaultGradingMode"
+                                style="font-size:.85rem;padding:.3rem .5rem">
+                            <option value="worker">worker (server-side)</option>
+                            <option value="browser">browser (in-browser)</option>
+                        </select>
+                    </label>
+                    <button class="btn btn-primary" type="submit"
+                            style="font-size:.85rem;padding:.3rem .6rem">Create section</button>
+                </form>
+            </div>
+        </details>
         <a class="btn btn-primary" href="/assignments/new">Create New</a>
     </div>
 </div>
 
-#if(rows.isEmpty):
+#if(!hasSections && ungroupedRows.isEmpty):
 <p class="empty">No assignments yet. <a href="/assignments/new">Create one to get started.</a></p>
 #else:
-<table class="results-table">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Status</th>
-            <th>Validation</th>
-            <th class="due-col">Due</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody id="assignments-body">
-    #for(row in rows):
-        <tr class="#if(row.status == "open"):status-pass#elseif(row.status == "closed"):status-fail#endif"
-            #if(row.assignmentID):data-assignment-id="#(row.assignmentID)"#endif>
-            <td>
-                #if(row.assignmentID):
-                <span class="reorder-controls">
-                    <button class="btn-link reorder-btn" type="button" draggable="false" data-reorder="up" aria-label="Move assignment up">↑</button>
-                    <button class="btn-link reorder-btn" type="button" draggable="false" data-reorder="down" aria-label="Move assignment down">↓</button>
-                </span>
-                <span class="assignment-drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
-                #endif
-                #if(row.title):
-                #if(row.assignmentID):
-                <a href="/assignments/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
-                #else:
-                <strong>#(row.title)</strong>
-                #endif
-                #else:
-                <span style="color:var(--gray-600)">Unpublished</span>
-                #endif
-            </td>
-            <td>
-                #if(row.assignmentID && row.validationStatus == "passed"):
-                <form method="post" action="/assignments/#(row.assignmentID)/status">
-                    <select class="form-input" name="status" onchange="this.form.submit()"
-                            style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
-                        <option value="open" #if(row.status == "open"):selected#endif>open</option>
-                        <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
-                    </select>
+
+<!-- Sections -->
+<div id="sections-container">
+#for(section in sections):
+<div class="section-block" data-section-id="#(section.sectionID)" style="margin-bottom:1.5rem">
+    <div class="section-header" style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:.4rem;padding:.4rem .6rem;background:var(--gray-100,#f5f5f5);border-radius:.4rem">
+        <span class="section-drag-handle" title="Drag to reorder section" aria-hidden="true"
+              style="color:var(--gray-500);font-weight:700;cursor:grab;user-select:none;font-size:1rem">⋮⋮</span>
+        <strong style="flex:1;min-width:0">#(section.name)</strong>
+        <span class="tier" style="font-size:.75rem">#(section.defaultGradingMode)</span>
+        <!-- Rename -->
+        <details class="rename-details">
+            <summary class="btn action-btn" style="list-style:none;cursor:pointer;font-size:.8rem;padding:.2rem .5rem">Rename…</summary>
+            <div class="rename-popup card" style="position:absolute;z-index:50;margin-top:.25rem;padding:.75rem;min-width:16rem;box-shadow:0 4px 12px rgba(0,0,0,.12)">
+                <form method="post" action="/assignments/sections/#(section.sectionID)/rename" class="form" style="margin:0;gap:.5rem">
+                    <label class="form-label" style="margin:0;font-size:.85rem">
+                        Name
+                        <input class="form-input" type="text" name="name" value="#(section.name)" required
+                               style="font-size:.85rem;padding:.25rem .45rem">
+                    </label>
+                    <label class="form-label" style="margin:0;font-size:.85rem">
+                        Default grading mode
+                        <select class="form-input" name="defaultGradingMode"
+                                style="font-size:.85rem;padding:.25rem .45rem">
+                            <option value="worker" #if(section.defaultGradingMode == "worker"):selected#endif>worker (server-side)</option>
+                            <option value="browser" #if(section.defaultGradingMode == "browser"):selected#endif>browser (in-browser)</option>
+                        </select>
+                    </label>
+                    <button class="btn btn-primary" type="submit"
+                            style="font-size:.8rem;padding:.25rem .5rem">Save</button>
                 </form>
-                #elseif(row.assignmentID):
-                <span class="tier tier-closed">closed</span>
-                #else:
-                <span class="tier
-                    #if(row.status == "open"):tier-open
-                    #elseif(row.status == "closed"):tier-closed
-                    #elseif(row.status == "unpublished"):tier-unpublished
-                #endif">#(row.status)</span>
-                #endif
-            </td>
-            <td>
-                #if(row.validationStatus == "passed"):
-                <span class="tier tier-open">passed</span>
-                #elseif(row.validationStatus == "failed"):
-                <span class="tier tier-closed">failed</span>
-                #if(row.validationSubmissionID):
-                <div style="margin-top:.25rem">
-                    <a href="/submissions/#(row.validationSubmissionID)">View results</a>
-                </div>
-                #endif
-                #elseif(row.validationStatus == "pending"):
-                <span class="tier">pending</span>
-                #if(row.validationSubmissionID):
-                <div style="margin-top:.25rem">
-                    <a href="/submissions/#(row.validationSubmissionID)">Track status</a>
-                </div>
-                #endif
-                #else:
-                <span class="tier">—</span>
-                #endif
-            </td>
-            <td class="due-col">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
-            <td>
-                #if(row.status == "unpublished"):
-                <!-- Publish inline form, toggled open with <details> (no JS needed) -->
-                <details class="publish-details">
-                    <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
-                    <form class="publish-form" method="post" action="/assignments">
-                        <input type="hidden" name="testSetupID" value="#(row.setupID)">
-                        <label class="form-label" style="font-size:.8rem">
-                            Title
-                            <input class="form-input" type="text" name="title"
-                                   placeholder="e.g. Lab 1 — Warmup" required
-                                   style="font-size:.85rem;padding:.3rem .5rem">
-                        </label>
-                        <label class="form-label" style="font-size:.8rem">
-                            Due date (optional)
-                            <input class="form-input publish-due-date" type="datetime-local" name="dueAt"
-                                   style="font-size:.85rem;padding:.3rem .5rem">
-                        </label>
-                        <div class="publish-uw-warning card-meta" style="display:none;color:#c05000;font-size:.8rem;margin-top:-.25rem;margin-bottom:.25rem"></div>
-                        <button class="btn btn-primary" type="submit"
-                                style="font-size:.8rem;padding:.3rem .6rem">Create draft</button>
+            </div>
+        </details>
+        <!-- Delete -->
+        <form method="post" action="/assignments/sections/#(section.sectionID)/delete"
+              onsubmit="return confirm('Delete section \u201c#(section.name)\u201d? Its assignments will become ungrouped.')">
+            <button class="btn action-btn action-danger" type="submit"
+                    style="font-size:.8rem;padding:.2rem .5rem">Delete</button>
+        </form>
+    </div>
+
+    #if(section.rows.isEmpty):
+    <p class="empty" style="margin:.25rem 0 .5rem">No items in this section yet.</p>
+    #else:
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Status</th>
+                <th>Validation</th>
+                <th class="due-col">Due</th>
+                <th>Move</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody class="assignments-body" data-section-id="#(section.sectionID)">
+        #for(row in section.rows):
+            <tr class="#if(row.status == "open"):status-pass#elseif(row.status == "closed"):status-fail#endif"
+                #if(row.assignmentID):data-assignment-id="#(row.assignmentID)"#endif>
+                <td>
+                    #if(row.assignmentID):
+                    <span class="reorder-controls">
+                        <button class="btn-link reorder-btn" type="button" draggable="false" data-reorder="up" aria-label="Move assignment up">↑</button>
+                        <button class="btn-link reorder-btn" type="button" draggable="false" data-reorder="down" aria-label="Move assignment down">↓</button>
+                    </span>
+                    <span class="assignment-drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+                    #endif
+                    #if(row.title):
+                    #if(row.assignmentID):
+                    <a href="/assignments/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
+                    #else:
+                    <strong>#(row.title)</strong>
+                    #endif
+                    #else:
+                    <span style="color:var(--gray-600)">Unpublished</span>
+                    #endif
+                </td>
+                <td>
+                    #if(row.assignmentID && row.validationStatus == "passed"):
+                    <form method="post" action="/assignments/#(row.assignmentID)/status">
+                        <select class="form-input" name="status" onchange="this.form.submit()"
+                                style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
+                            <option value="open" #if(row.status == "open"):selected#endif>open</option>
+                            <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
+                        </select>
                     </form>
-                </details>
-                #elseif(row.status == "closed"):
-                <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
-                    <form method="post" action="/assignments/#(row.assignmentID)/delete"
-                          onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
-                        <button class="btn action-btn action-danger" type="submit"
-                                aria-label="Delete assignment"
-                                title="Delete assignment">Delete
-                        </button>
+                    #elseif(row.assignmentID):
+                    <span class="tier tier-closed">closed</span>
+                    #else:
+                    <span class="tier
+                        #if(row.status == "open"):tier-open
+                        #elseif(row.status == "closed"):tier-closed
+                        #elseif(row.status == "unpublished"):tier-unpublished
+                    #endif">#(row.status)</span>
+                    #endif
+                </td>
+                <td>
+                    #if(row.validationStatus == "passed"):
+                    <span class="tier tier-open">passed</span>
+                    #elseif(row.validationStatus == "failed"):
+                    <span class="tier tier-closed">failed</span>
+                    #if(row.validationSubmissionID):
+                    <div style="margin-top:.25rem">
+                        <a href="/submissions/#(row.validationSubmissionID)">View results</a>
+                    </div>
+                    #endif
+                    #elseif(row.validationStatus == "pending"):
+                    <span class="tier">pending</span>
+                    #if(row.validationSubmissionID):
+                    <div style="margin-top:.25rem">
+                        <a href="/submissions/#(row.validationSubmissionID)">Track status</a>
+                    </div>
+                    #endif
+                    #else:
+                    <span class="tier">—</span>
+                    #endif
+                </td>
+                <td class="due-col">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
+                <td>
+                    #if(row.assignmentID):
+                    <select class="form-input move-section-select" data-assignment-id="#(row.assignmentID)"
+                            style="font-size:.75rem;padding:.15rem .35rem;min-width:6rem"
+                            aria-label="Move to section">
+                        <option value="#(section.sectionID)" selected>#(section.name)</option>
+                        #for(s in sections):
+                        #if(s.sectionID != section.sectionID):
+                        <option value="#(s.sectionID)">#(s.name)</option>
+                        #endif
+                        #endfor
+                        <option value="">Ungrouped</option>
+                    </select>
+                    #else:
+                    <span style="color:var(--gray-400)">—</span>
+                    #endif
+                </td>
+                <td>
+                    #if(row.status == "unpublished"):
+                    <details class="publish-details">
+                        <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
+                        <form class="publish-form" method="post" action="/assignments">
+                            <input type="hidden" name="testSetupID" value="#(row.setupID)">
+                            <label class="form-label" style="font-size:.8rem">
+                                Title
+                                <input class="form-input" type="text" name="title"
+                                       placeholder="e.g. Lab 1 — Warmup" required
+                                       style="font-size:.85rem;padding:.3rem .5rem">
+                            </label>
+                            <label class="form-label" style="font-size:.8rem">
+                                Due date (optional)
+                                <input class="form-input publish-due-date" type="datetime-local" name="dueAt"
+                                       style="font-size:.85rem;padding:.3rem .5rem">
+                            </label>
+                            <div class="publish-uw-warning card-meta" style="display:none;color:#c05000;font-size:.8rem;margin-top:-.25rem;margin-bottom:.25rem"></div>
+                            <button class="btn btn-primary" type="submit"
+                                    style="font-size:.8rem;padding:.3rem .6rem">Create draft</button>
+                        </form>
+                    </details>
+                    #elseif(row.status == "closed"):
+                    <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                              onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
+                            <button class="btn action-btn action-danger" type="submit"
+                                    aria-label="Delete assignment" title="Delete assignment">Delete</button>
+                        </form>
+                    </div>
+                    #elseif(row.status == "open"):
+                    <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                              onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
+                            <button class="btn action-btn action-danger" type="submit"
+                                    aria-label="Delete assignment" title="Delete assignment">Delete</button>
+                        </form>
+                    </div>
+                    #else:
+                    <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                        <a class="btn btn-primary" href="/assignments/#(row.assignmentID)/validate">Validate &amp; open →</a>
+                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                              onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
+                            <button class="btn action-btn action-danger" type="submit"
+                                    aria-label="Delete assignment" title="Delete assignment">Delete</button>
+                        </form>
+                    </div>
+                    #endif
+                </td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+    #endif
+    <div style="margin-top:.5rem">
+        <a class="btn action-btn" href="/assignments/new?sectionID=#(section.sectionID)"
+           style="font-size:.8rem;padding:.25rem .6rem">+ Add item to #(section.name)</a>
+    </div>
+</div>
+#endfor
+</div><!-- #sections-container -->
+
+<!-- Ungrouped bucket -->
+#if(!ungroupedRows.isEmpty || !hasSections):
+<div style="margin-bottom:1.5rem">
+    #if(hasSections):
+    <h2 style="font-size:1rem;font-weight:600;color:var(--gray-600);margin-bottom:.4rem">Ungrouped</h2>
+    #endif
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Status</th>
+                <th>Validation</th>
+                <th class="due-col">Due</th>
+                #if(hasSections):<th>Move</th>#endif
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody id="assignments-body">
+        #for(row in ungroupedRows):
+            <tr class="#if(row.status == "open"):status-pass#elseif(row.status == "closed"):status-fail#endif"
+                #if(row.assignmentID):data-assignment-id="#(row.assignmentID)"#endif>
+                <td>
+                    #if(row.assignmentID):
+                    <span class="reorder-controls">
+                        <button class="btn-link reorder-btn" type="button" draggable="false" data-reorder="up" aria-label="Move assignment up">↑</button>
+                        <button class="btn-link reorder-btn" type="button" draggable="false" data-reorder="down" aria-label="Move assignment down">↓</button>
+                    </span>
+                    <span class="assignment-drag-handle" title="Drag to reorder" aria-hidden="true">⋮⋮</span>
+                    #endif
+                    #if(row.title):
+                    #if(row.assignmentID):
+                    <a href="/assignments/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
+                    #else:
+                    <strong>#(row.title)</strong>
+                    #endif
+                    #else:
+                    <span style="color:var(--gray-600)">Unpublished</span>
+                    #endif
+                </td>
+                <td>
+                    #if(row.assignmentID && row.validationStatus == "passed"):
+                    <form method="post" action="/assignments/#(row.assignmentID)/status">
+                        <select class="form-input" name="status" onchange="this.form.submit()"
+                                style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
+                            <option value="open" #if(row.status == "open"):selected#endif>open</option>
+                            <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
+                        </select>
                     </form>
-                </div>
-                #elseif(row.status == "open"):
-                <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
-                    <form method="post" action="/assignments/#(row.assignmentID)/delete"
-                          onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
-                        <button class="btn action-btn action-danger" type="submit"
-                                aria-label="Delete assignment"
-                                title="Delete assignment">Delete
-                        </button>
-                    </form>
-                </div>
-                #else:
-                <!-- draft — not yet validated/opened -->
-                <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    <a class="btn btn-primary" href="/assignments/#(row.assignmentID)/validate">Validate &amp; open →</a>
-                    <form method="post" action="/assignments/#(row.assignmentID)/delete"
-                          onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
-                        <button class="btn action-btn action-danger" type="submit"
-                                aria-label="Delete assignment"
-                                title="Delete assignment">Delete
-                        </button>
-                    </form>
-                </div>
+                    #elseif(row.assignmentID):
+                    <span class="tier tier-closed">closed</span>
+                    #else:
+                    <span class="tier
+                        #if(row.status == "open"):tier-open
+                        #elseif(row.status == "closed"):tier-closed
+                        #elseif(row.status == "unpublished"):tier-unpublished
+                    #endif">#(row.status)</span>
+                    #endif
+                </td>
+                <td>
+                    #if(row.validationStatus == "passed"):
+                    <span class="tier tier-open">passed</span>
+                    #elseif(row.validationStatus == "failed"):
+                    <span class="tier tier-closed">failed</span>
+                    #if(row.validationSubmissionID):
+                    <div style="margin-top:.25rem">
+                        <a href="/submissions/#(row.validationSubmissionID)">View results</a>
+                    </div>
+                    #endif
+                    #elseif(row.validationStatus == "pending"):
+                    <span class="tier">pending</span>
+                    #if(row.validationSubmissionID):
+                    <div style="margin-top:.25rem">
+                        <a href="/submissions/#(row.validationSubmissionID)">Track status</a>
+                    </div>
+                    #endif
+                    #else:
+                    <span class="tier">—</span>
+                    #endif
+                </td>
+                <td class="due-col">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
+                #if(hasSections):
+                <td>
+                    #if(row.assignmentID):
+                    <select class="form-input move-section-select" data-assignment-id="#(row.assignmentID)"
+                            style="font-size:.75rem;padding:.15rem .35rem;min-width:6rem"
+                            aria-label="Move to section">
+                        <option value="" selected>Ungrouped</option>
+                        #for(s in sections):
+                        <option value="#(s.sectionID)">#(s.name)</option>
+                        #endfor
+                    </select>
+                    #else:
+                    <span style="color:var(--gray-400)">—</span>
+                    #endif
+                </td>
                 #endif
-            </td>
-        </tr>
-    #endfor
-    </tbody>
-</table>
+                <td>
+                    #if(row.status == "unpublished"):
+                    <details class="publish-details">
+                        <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
+                        <form class="publish-form" method="post" action="/assignments">
+                            <input type="hidden" name="testSetupID" value="#(row.setupID)">
+                            <label class="form-label" style="font-size:.8rem">
+                                Title
+                                <input class="form-input" type="text" name="title"
+                                       placeholder="e.g. Lab 1 — Warmup" required
+                                       style="font-size:.85rem;padding:.3rem .5rem">
+                            </label>
+                            <label class="form-label" style="font-size:.8rem">
+                                Due date (optional)
+                                <input class="form-input publish-due-date" type="datetime-local" name="dueAt"
+                                       style="font-size:.85rem;padding:.3rem .5rem">
+                            </label>
+                            <div class="publish-uw-warning card-meta" style="display:none;color:#c05000;font-size:.8rem;margin-top:-.25rem;margin-bottom:.25rem"></div>
+                            <button class="btn btn-primary" type="submit"
+                                    style="font-size:.8rem;padding:.3rem .6rem">Create draft</button>
+                        </form>
+                    </details>
+                    #elseif(row.status == "closed"):
+                    <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                              onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
+                            <button class="btn action-btn action-danger" type="submit"
+                                    aria-label="Delete assignment" title="Delete assignment">Delete</button>
+                        </form>
+                    </div>
+                    #elseif(row.status == "open"):
+                    <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                              onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
+                            <button class="btn action-btn action-danger" type="submit"
+                                    aria-label="Delete assignment" title="Delete assignment">Delete</button>
+                        </form>
+                    </div>
+                    #else:
+                    <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                        <a class="btn btn-primary" href="/assignments/#(row.assignmentID)/validate">Validate &amp; open →</a>
+                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                              onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
+                            <button class="btn action-btn action-danger" type="submit"
+                                    aria-label="Delete assignment" title="Delete assignment">Delete</button>
+                        </form>
+                    </div>
+                    #endif
+                </td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+</div>
+#endif
+
 #endif
 <style>
 .assignment-drag-handle {
@@ -166,111 +406,207 @@ tr.assignment-draggable.dragging {
 tr.assignment-draggable td {
     cursor: grab;
 }
+.section-block.section-dragging {
+    opacity: .55;
+}
+.rename-details[open] .rename-popup,
+.add-section-details[open] .add-section-popup {
+    display: block;
+}
 </style>
 <script>
 (function () {
-    var body = document.getElementById('assignments-body');
-    if (!body) return;
+    'use strict';
 
-    var draggableRows = Array.from(body.querySelectorAll('tr[data-assignment-id]'));
-    if (draggableRows.length < 2) return;
+    // ── Assignment drag-and-drop (within each tbody) ──────────────────────────
+    function initAssignmentDragDrop(body) {
+        var draggableRows = Array.from(body.querySelectorAll('tr[data-assignment-id]'));
+        if (draggableRows.length < 2) return;
 
-    var dragged = null;
-    var dragStartOrder = '';
+        var dragged = null;
+        var dragStartOrder = '';
 
-    function currentOrder() {
-        return Array.from(body.querySelectorAll('tr[data-assignment-id]'))
-            .map(function (row) { return row.getAttribute('data-assignment-id'); })
-            .filter(function (v) { return !!v; });
-    }
+        function currentOrder() {
+            return Array.from(body.querySelectorAll('tr[data-assignment-id]'))
+                .map(function (row) { return row.getAttribute('data-assignment-id'); })
+                .filter(function (v) { return !!v; });
+        }
 
-    async function persistOrderIfChanged() {
-        var order = currentOrder();
-        var joined = order.join(',');
-        if (joined === dragStartOrder) return;
-        try {
-            var res = await fetch('/assignments/reorder', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ assignmentIDs: order })
-            });
-            if (!res.ok) {
-                window.location.reload();
+        async function persistOrderIfChanged() {
+            var order = currentOrder();
+            var joined = order.join(',');
+            if (joined === dragStartOrder) return;
+            try {
+                var res = await fetch('/assignments/reorder', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ assignmentIDs: order })
+                });
+                if (!res.ok) { window.location.reload(); }
+            } catch (_) { window.location.reload(); }
+        }
+
+        draggableRows.forEach(function (row) {
+            row.classList.add('assignment-draggable');
+            row.setAttribute('draggable', 'true');
+        });
+
+        body.addEventListener('dragstart', function (event) {
+            var target = event.target;
+            if (!(target instanceof Element)) return;
+            if (target.closest('.reorder-btn')) { event.preventDefault(); return; }
+            var row = target.closest('tr[data-assignment-id]');
+            if (!row) return;
+            dragged = row;
+            dragStartOrder = currentOrder().join(',');
+            row.classList.add('dragging');
+            if (event.dataTransfer) {
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', row.getAttribute('data-assignment-id') || '');
             }
-        } catch (_) {
-            window.location.reload();
-        }
+        });
+        body.addEventListener('dragover', function (event) {
+            if (!dragged) return;
+            event.preventDefault();
+            var target = event.target;
+            if (!(target instanceof Element)) return;
+            var overRow = target.closest('tr[data-assignment-id]');
+            if (!overRow || overRow === dragged) return;
+            var rect = overRow.getBoundingClientRect();
+            var after = event.clientY > rect.top + rect.height / 2;
+            body.insertBefore(dragged, after ? overRow.nextSibling : overRow);
+        });
+        body.addEventListener('drop', function (event) {
+            if (!dragged) return;
+            event.preventDefault();
+        });
+        body.addEventListener('click', function (event) {
+            var target = event.target;
+            if (!(target instanceof Element)) return;
+            if (!target.classList.contains('reorder-btn')) return;
+            event.preventDefault();
+            event.stopPropagation();
+            var row = target.closest('tr[data-assignment-id]');
+            if (!row) return;
+            var dir = target.getAttribute('data-reorder');
+            if (dir === 'up' && row.previousElementSibling) {
+                body.insertBefore(row, row.previousElementSibling);
+                persistOrderIfChanged();
+            } else if (dir === 'down' && row.nextElementSibling) {
+                body.insertBefore(row.nextElementSibling, row);
+                persistOrderIfChanged();
+            }
+        });
+        body.addEventListener('dragend', function () {
+            if (!dragged) return;
+            dragged.classList.remove('dragging');
+            dragged = null;
+            persistOrderIfChanged();
+        });
     }
 
-    draggableRows.forEach(function (row) {
-        row.classList.add('assignment-draggable');
-        row.setAttribute('draggable', 'true');
-    });
+    // Init drag-drop for all assignment tables on the page.
+    document.querySelectorAll('.assignments-body, #assignments-body').forEach(initAssignmentDragDrop);
 
-    body.addEventListener('dragstart', function (event) {
-        var target = event.target;
-        if (!(target instanceof Element)) return;
-        if (target.closest('.reorder-btn')) {
+    // ── Section drag-and-drop ─────────────────────────────────────────────────
+    var sectionsContainer = document.getElementById('sections-container');
+    if (sectionsContainer) {
+        var draggedSection = null;
+        var sectionDragStartOrder = '';
+
+        function currentSectionOrder() {
+            return Array.from(sectionsContainer.querySelectorAll('.section-block[data-section-id]'))
+                .map(function (el) { return el.getAttribute('data-section-id'); })
+                .filter(function (v) { return !!v; });
+        }
+
+        async function persistSectionOrderIfChanged() {
+            var order = currentSectionOrder();
+            var joined = order.join(',');
+            if (joined === sectionDragStartOrder) return;
+            try {
+                var res = await fetch('/assignments/sections/reorder', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ sectionIDs: order })
+                });
+                if (!res.ok) { window.location.reload(); }
+            } catch (_) { window.location.reload(); }
+        }
+
+        sectionsContainer.querySelectorAll('.section-drag-handle').forEach(function (handle) {
+            var block = handle.closest('.section-block');
+            if (!block) return;
+            block.setAttribute('draggable', 'true');
+        });
+
+        sectionsContainer.addEventListener('dragstart', function (event) {
+            var target = event.target;
+            if (!(target instanceof Element)) return;
+            var block = target.closest('.section-block[data-section-id]');
+            if (!block) return;
+            // Only start section drag if the handle was clicked.
+            var handle = target.closest('.section-drag-handle');
+            if (!handle) { return; }
+            draggedSection = block;
+            sectionDragStartOrder = currentSectionOrder().join(',');
+            block.classList.add('section-dragging');
+            if (event.dataTransfer) {
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', block.getAttribute('data-section-id') || '');
+            }
+        });
+
+        sectionsContainer.addEventListener('dragover', function (event) {
+            if (!draggedSection) return;
             event.preventDefault();
-            return;
-        }
-        var row = target.closest('tr[data-assignment-id]');
-        if (!row) return;
-        dragged = row;
-        dragStartOrder = currentOrder().join(',');
-        row.classList.add('dragging');
-        if (event.dataTransfer) {
-            event.dataTransfer.effectAllowed = 'move';
-            event.dataTransfer.setData('text/plain', row.getAttribute('data-assignment-id') || '');
-        }
+            var target = event.target;
+            if (!(target instanceof Element)) return;
+            var overBlock = target.closest('.section-block[data-section-id]');
+            if (!overBlock || overBlock === draggedSection) return;
+            var rect = overBlock.getBoundingClientRect();
+            var after = event.clientY > rect.top + rect.height / 2;
+            sectionsContainer.insertBefore(draggedSection, after ? overBlock.nextSibling : overBlock);
+        });
+
+        sectionsContainer.addEventListener('drop', function (event) {
+            if (!draggedSection) return;
+            event.preventDefault();
+        });
+
+        sectionsContainer.addEventListener('dragend', function () {
+            if (!draggedSection) return;
+            draggedSection.classList.remove('section-dragging');
+            draggedSection = null;
+            persistSectionOrderIfChanged();
+        });
+    }
+
+    // ── Move assignment between sections ─────────────────────────────────────
+    document.querySelectorAll('.move-section-select').forEach(function (select) {
+        var originalValue = select.value;
+        select.addEventListener('change', async function () {
+            var assignmentID = select.getAttribute('data-assignment-id');
+            var newSectionID = select.value;
+            if (!assignmentID) return;
+            try {
+                var res = await fetch('/assignments/' + assignmentID + '/section', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ sectionID: newSectionID })
+                });
+                if (res.ok) {
+                    window.location.reload();
+                } else {
+                    select.value = originalValue;
+                }
+            } catch (_) {
+                select.value = originalValue;
+            }
+        });
     });
 
-    body.addEventListener('dragover', function (event) {
-        if (!dragged) return;
-        event.preventDefault();
-        var target = event.target;
-        if (!(target instanceof Element)) return;
-        var overRow = target.closest('tr[data-assignment-id]');
-        if (!overRow || overRow === dragged) return;
-
-        var rect = overRow.getBoundingClientRect();
-        var after = event.clientY > rect.top + rect.height / 2;
-        body.insertBefore(dragged, after ? overRow.nextSibling : overRow);
-    });
-
-    body.addEventListener('drop', function (event) {
-        if (!dragged) return;
-        event.preventDefault();
-    });
-
-    body.addEventListener('click', function (event) {
-        var target = event.target;
-        if (!(target instanceof Element)) return;
-        if (!target.classList.contains('reorder-btn')) return;
-        event.preventDefault();
-        event.stopPropagation();
-        var row = target.closest('tr[data-assignment-id]');
-        if (!row) return;
-        var dir = target.getAttribute('data-reorder');
-        if (dir === 'up' && row.previousElementSibling) {
-            body.insertBefore(row, row.previousElementSibling);
-            persistOrderIfChanged();
-        } else if (dir === 'down' && row.nextElementSibling) {
-            body.insertBefore(row.nextElementSibling, row);
-            persistOrderIfChanged();
-        }
-    });
-
-    body.addEventListener('dragend', function () {
-        if (!dragged) return;
-        dragged.classList.remove('dragging');
-        dragged = null;
-        persistOrderIfChanged();
-    });
-})();
-
-// UWaterloo important-date proximity warning for inline publish forms
-(function () {
+    // ── UWaterloo important-date proximity warning ────────────────────────────
     function checkUWDates(dateTimeValue, warningEl) {
         if (!dateTimeValue) { warningEl.style.display = 'none'; return; }
         var selected = new Date(dateTimeValue);

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -4,10 +4,17 @@ Assignments
 #endexport
 #export("content"):
 <h1>Assignments</h1>
-#if(setups.isEmpty):
+#if(!hasSections && ungroupedSetups.isEmpty):
 <p class="empty">No assignments available yet.</p>
 #else:
-<table class="results-table">
+
+#if(hasSections):
+
+<!-- Sections layout -->
+#for(section in sections):
+#if(!section.setups.isEmpty):
+<h2 style="font-size:1.05rem;font-weight:600;margin-top:1.5rem;margin-bottom:.4rem">#(section.name)</h2>
+<table class="results-table" style="margin-bottom:.5rem">
     <thead>
         <tr>
             <th>Name</th>
@@ -19,7 +26,7 @@ Assignments
         </tr>
     </thead>
     <tbody>
-    #for(setup in setups):
+    #for(setup in section.setups):
         <tr>
             <td>
                 #if(setup.title):
@@ -71,6 +78,148 @@ Assignments
     #endfor
     </tbody>
 </table>
+#endif
+#endfor
+
+<!-- Ungrouped items (shown under "Other" heading when sections exist) -->
+#if(!ungroupedSetups.isEmpty):
+<h2 style="font-size:1.05rem;font-weight:600;margin-top:1.5rem;margin-bottom:.4rem">Other</h2>
+<table class="results-table" style="margin-bottom:.5rem">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th class="due-col">Due</th>
+            <th>Grade</th>
+            <th>History</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(setup in ungroupedSetups):
+        <tr>
+            <td>
+                #if(setup.title):
+                    <strong>#(setup.title)</strong>
+                #else:
+                <span style="color:var(--gray-600)">Unpublished</span>
+                #endif
+            </td>
+            <td>
+                <span class="tier
+                    #if(setup.status == "open"):tier-open
+                    #elseif(setup.status == "closed"):tier-closed
+                    #elseif(setup.status == "unpublished"):tier-unpublished
+                    #endif">#(setup.status)</span>
+            </td>
+            <td class="due-col">#if(setup.dueAt):#(setup.dueAt)#else:—#endif</td>
+            <td>
+                #if(setup.bestGradeText):
+                    <strong>#(setup.bestGradeText)</strong>
+                #else:
+                    <span class="empty">—</span>
+                #endif
+            </td>
+            <td>
+                #if(setup.submissionCount > 0):
+                    <div style="display:flex;flex-direction:column;gap:.2rem">
+                        #if(setup.hasLatestSubmission):
+                            <a href="/submissions/#(setup.latestSubmissionID)" style="font-size:.82rem">#(setup.latestSubmittedAtText)</a>
+                        #endif
+                        #if(setup.additionalSubmissionCount > 0):
+                            <a href="/testsetups/#(setup.id)/history" style="font-size:.78rem;color:var(--gray-600)">+#(setup.additionalSubmissionCount) more</a>
+                        #endif
+                    </div>
+                #else:
+                    <span class="empty">No submissions yet</span>
+                #endif
+            </td>
+            <td>
+                <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    #if(setup.isOpen):
+                    <a class="btn btn-primary" href="/testsetups/#(setup.id)/submit"
+                       style="font-size:.8rem;padding:.25rem .6rem">Submit</a>
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
+                       style="font-size:.8rem;padding:.25rem .6rem">Edit</a>
+                    #endif
+                </div>
+            </td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+#endif
+
+#else:
+
+<!-- Flat layout (no sections defined) -->
+<table class="results-table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th class="due-col">Due</th>
+            <th>Grade</th>
+            <th>History</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(setup in ungroupedSetups):
+        <tr>
+            <td>
+                #if(setup.title):
+                    <strong>#(setup.title)</strong>
+                #else:
+                <span style="color:var(--gray-600)">Unpublished</span>
+                #endif
+            </td>
+            <td>
+                <span class="tier
+                    #if(setup.status == "open"):tier-open
+                    #elseif(setup.status == "closed"):tier-closed
+                    #elseif(setup.status == "unpublished"):tier-unpublished
+                    #endif">#(setup.status)</span>
+            </td>
+            <td class="due-col">#if(setup.dueAt):#(setup.dueAt)#else:—#endif</td>
+            <td>
+                #if(setup.bestGradeText):
+                    <strong>#(setup.bestGradeText)</strong>
+                #else:
+                    <span class="empty">—</span>
+                #endif
+            </td>
+            <td>
+                #if(setup.submissionCount > 0):
+                    <div style="display:flex;flex-direction:column;gap:.2rem">
+                        #if(setup.hasLatestSubmission):
+                            <a href="/submissions/#(setup.latestSubmissionID)" style="font-size:.82rem">#(setup.latestSubmittedAtText)</a>
+                        #endif
+                        #if(setup.additionalSubmissionCount > 0):
+                            <a href="/testsetups/#(setup.id)/history" style="font-size:.78rem;color:var(--gray-600)">+#(setup.additionalSubmissionCount) more</a>
+                        #endif
+                    </div>
+                #else:
+                    <span class="empty">No submissions yet</span>
+                #endif
+            </td>
+            <td>
+                <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    #if(setup.isOpen):
+                    <a class="btn btn-primary" href="/testsetups/#(setup.id)/submit"
+                       style="font-size:.8rem;padding:.25rem .6rem">Submit</a>
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
+                       style="font-size:.8rem;padding:.25rem .6rem">Edit</a>
+                    #endif
+                </div>
+            </td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+
+#endif
+
 #endif
 #endexport
 #endextend

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -144,6 +144,7 @@ func configure(_ app: Application, cliWorkerSecret: String?, authModeOverride: A
     app.migrations.add(CreateResults())
     app.migrations.add(CreateAssignments())
     app.migrations.add(CreatePerformanceIndexes())
+    app.migrations.add(AddCourseSections())
 
     try app.autoMigrate().wait()
 

--- a/Sources/APIServer/Migrations/AddCourseSections.swift
+++ b/Sources/APIServer/Migrations/AddCourseSections.swift
@@ -1,0 +1,39 @@
+// APIServer/Migrations/AddCourseSections.swift
+//
+// Adds the course_sections table and a nullable section_id column to assignments.
+// Existing assignments have section_id = NULL (ungrouped) — no data loss.
+
+import Fluent
+
+struct AddCourseSections: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("course_sections")
+            .id()
+            .field("name",                  .string, .required)
+            .field("default_grading_mode",  .string, .required)
+            .field("sort_order",            .int,    .required)
+            .field(
+                "course_id",
+                .uuid,
+                .required,
+                .references("courses", "id", onDelete: .cascade)
+            )
+            .field("created_at", .datetime)
+            .create()
+
+        try await database.schema("assignments")
+            .field(
+                "section_id",
+                .uuid,
+                .references("course_sections", "id", onDelete: .setNull)
+            )
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("assignments")
+            .deleteField("section_id")
+            .update()
+        try await database.schema("course_sections").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -52,6 +52,10 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
     @OptionalField(key: "validation_submission_id")
     var validationSubmissionID: String?
 
+    /// The section this assignment belongs to (nil = ungrouped).
+    @OptionalField(key: "section_id")
+    var sectionID: UUID?
+
     /// The course this assignment belongs to.
     @Field(key: "course_id")
     var courseID: UUID
@@ -72,6 +76,7 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
          sortOrder: Int? = nil,
          validationStatus: String? = nil,
          validationSubmissionID: String? = nil,
+         sectionID: UUID? = nil,
          courseID: UUID) {
         self.id          = id
         self.publicID    = publicID
@@ -82,6 +87,7 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
         self.sortOrder   = sortOrder
         self.validationStatus = validationStatus
         self.validationSubmissionID = validationSubmissionID
+        self.sectionID   = sectionID
         self.courseID    = courseID
     }
 }

--- a/Sources/APIServer/Models/APICourseSection.swift
+++ b/Sources/APIServer/Models/APICourseSection.swift
@@ -1,0 +1,50 @@
+// APIServer/Models/APICourseSection.swift
+//
+// A course section groups assignments under a named heading (e.g. "Labs", "Exams").
+// Each section has a default grading mode that pre-populates the creation form for
+// new items added to that section.
+//
+// Assignments reference their section via a nullable section_id FK (SET NULL on delete),
+// so deleting a section drops its assignments into the "ungrouped" bucket — no data loss.
+
+import Fluent
+import Vapor
+
+final class APICourseSection: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context.
+    static let schema = "course_sections"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    /// Instructor-defined label shown in both the instructor dashboard and the student view.
+    @Field(key: "name")
+    var name: String
+
+    /// Default grading mode for new items created in this section.
+    /// Values: "browser" | "worker"
+    @Field(key: "default_grading_mode")
+    var defaultGradingMode: String
+
+    /// Ordering among sections within the course (lower = shown first).
+    @Field(key: "sort_order")
+    var sortOrder: Int
+
+    /// The course this section belongs to.
+    @Field(key: "course_id")
+    var courseID: UUID
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(id: UUID? = nil, name: String, defaultGradingMode: String = "worker",
+         sortOrder: Int, courseID: UUID) {
+        self.id                 = id
+        self.name               = name
+        self.defaultGradingMode = defaultGradingMode
+        self.sortOrder          = sortOrder
+        self.courseID           = courseID
+    }
+}

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -3,17 +3,22 @@
 // Instructor-facing assignment management routes.
 // Requires instructor or admin role (enforced by routes.swift).
 //
-//   GET  /assignments                        → assignments.leaf (all setups + status)
-//   GET  /assignments/new                    → assignment-new.leaf
-//   POST /assignments/new/save               → save draft assignment, redirect to /assignments
-//   POST /assignments                        → create draft assignment → redirect to validate
-//   GET  /assignments/:assignmentID/validate → assignment-validate.leaf
-//   GET  /assignments/:assignmentID/edit     → assignment-edit.leaf
-//   POST /assignments/:assignmentID/edit/save → update assignment content + validate
-//   POST /assignments/:assignmentID/status   → set open/closed status → redirect to /assignments
-//   POST /assignments/:assignmentID/open     → set isOpen=true → redirect to /assignments
-//   POST /assignments/:assignmentID/close    → set isOpen=false → redirect to /assignments
-//   POST /assignments/:assignmentID/delete   → remove assignment record → redirect to /assignments
+//   GET  /assignments                               → assignments.leaf (all setups + status)
+//   GET  /assignments/new                           → assignment-new.leaf
+//   POST /assignments/new/save                      → save draft assignment, redirect to /assignments
+//   POST /assignments                               → create draft assignment → redirect to validate
+//   GET  /assignments/:assignmentID/validate        → assignment-validate.leaf
+//   GET  /assignments/:assignmentID/edit            → assignment-edit.leaf
+//   POST /assignments/:assignmentID/edit/save       → update assignment content + validate
+//   POST /assignments/:assignmentID/status          → set open/closed status → redirect to /assignments
+//   POST /assignments/:assignmentID/open            → set isOpen=true → redirect to /assignments
+//   POST /assignments/:assignmentID/close           → set isOpen=false → redirect to /assignments
+//   POST /assignments/:assignmentID/delete          → remove assignment record → redirect to /assignments
+//   POST /assignments/:assignmentID/section         → move assignment to a section (or ungrouped)
+//   POST /assignments/sections                      → create a new course section
+//   POST /assignments/sections/reorder              → reorder sections
+//   POST /assignments/sections/:sectionID/rename    → rename/reconfigure a section
+//   POST /assignments/sections/:sectionID/delete    → delete a section
 
 import Vapor
 import Fluent
@@ -32,6 +37,11 @@ struct AssignmentRoutes: RouteCollection {
         r.get("new", use: newAssignmentPage)
         r.post("new", "save", use: saveNewAssignment)
         r.post("reorder", use: reorderAssignments)
+        r.post("sections", use: createSection)
+        r.post("sections", "reorder", use: reorderSections)
+        r.post("sections", ":sectionID", "rename", use: renameSection)
+        r.post("sections", ":sectionID", "delete", use: deleteSection)
+        r.post(":assignmentID", "section", use: moveToSection)
         r.post(use: publish)
         r.get(":assignmentID", "validate", use: validatePage)
         r.get(":assignmentID", "edit",     use: editPage)
@@ -140,7 +150,7 @@ struct AssignmentRoutes: RouteCollection {
             )
         }
 
-        let rows = unsortedRows.sorted { lhs, rhs in
+        let sortedRows = unsortedRows.sorted { lhs, rhs in
             let lhsPublished = lhs.assignmentID != nil
             let rhsPublished = rhs.assignmentID != nil
             if lhsPublished != rhsPublished {
@@ -165,9 +175,55 @@ struct AssignmentRoutes: RouteCollection {
             return lhsIndex < rhsIndex
         }
 
+        // Fetch sections for the active course, sorted by sort_order.
+        let allSections: [APICourseSection]
+        if let activeCourseUUID = courseState.activeCourseUUID {
+            allSections = try await APICourseSection.query(on: req.db)
+                .filter(\.$courseID == activeCourseUUID)
+                .sort(\.$sortOrder, .ascending)
+                .all()
+        } else {
+            allSections = try await APICourseSection.query(on: req.db)
+                .sort(\.$sortOrder, .ascending)
+                .all()
+        }
+
+        // Build a lookup: assignment publicID → section UUID
+        let sectionByPublicID: [String: UUID] = Dictionary(
+            allAssignments.compactMap { a -> (String, UUID)? in
+                guard let sid = a.sectionID else { return nil }
+                return (a.publicID, sid)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        // Group sorted rows by section; rows without a matching section → ungrouped.
+        var rowsBySectionID: [UUID: [AssignmentRow]] = [:]
+        var ungroupedRows: [AssignmentRow] = []
+        for row in sortedRows {
+            if let aID = row.assignmentID, let sID = sectionByPublicID[aID] {
+                rowsBySectionID[sID, default: []].append(row)
+            } else {
+                ungroupedRows.append(row)
+            }
+        }
+
+        let sectionContexts: [CourseSectionRow] = allSections.map { section in
+            let sID = section.id ?? UUID()
+            return CourseSectionRow(
+                sectionID: sID.uuidString,
+                name: section.name,
+                defaultGradingMode: section.defaultGradingMode,
+                sortOrder: section.sortOrder,
+                rows: rowsBySectionID[sID] ?? []
+            )
+        }
+
         let ctx = AssignmentsContext(
             currentUser: userContext,
-            rows: rows
+            sections: sectionContexts,
+            ungroupedRows: ungroupedRows,
+            hasSections: !allSections.isEmpty
         )
         return try await req.view.render("assignments", ctx).encodeResponse(for: req)
     }
@@ -535,12 +591,35 @@ struct AssignmentRoutes: RouteCollection {
             var dueAt: String?
             var error: String?
             var notice: String?
+            var sectionID: String?
         }
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
         let q = (try? req.query.decode(NewQuery.self))
+
+        let sections: [CourseSectionRow]
+        if let activeCourseUUID = courseState.activeCourseUUID {
+            sections = try await APICourseSection.query(on: req.db)
+                .filter(\.$courseID == activeCourseUUID)
+                .sort(\.$sortOrder, .ascending)
+                .all()
+                .map { s in CourseSectionRow(
+                    sectionID: s.id?.uuidString ?? "",
+                    name: s.name,
+                    defaultGradingMode: s.defaultGradingMode,
+                    sortOrder: s.sortOrder,
+                    rows: []
+                )}
+        } else {
+            sections = []
+        }
+
         let ctx = NewAssignmentContext(
             currentUser: req.currentUserContext,
             assignmentName: (q?.assignmentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
             dueAt: q?.dueAt ?? "",
+            sections: sections,
+            preselectedSectionID: q?.sectionID ?? "",
             notice: q?.notice,
             error: q?.error
         )
@@ -560,6 +639,7 @@ struct AssignmentRoutes: RouteCollection {
         struct SaveBodyMany: Content {
             var assignmentName: String?
             var dueAt: String?
+            var sectionID: String?
             var assignmentNotebookFile: File?
             var solutionNotebookFile: File?
             var suiteFiles: [File]?
@@ -568,6 +648,7 @@ struct AssignmentRoutes: RouteCollection {
         struct SaveBodySingle: Content {
             var assignmentName: String?
             var dueAt: String?
+            var sectionID: String?
             var assignmentNotebookFile: File?
             var solutionNotebookFile: File?
             var suiteFiles: File?
@@ -582,6 +663,7 @@ struct AssignmentRoutes: RouteCollection {
 
         let assignmentName = bodyMany?.assignmentName ?? bodySingle?.assignmentName
         let dueAtRaw = bodyMany?.dueAt ?? bodySingle?.dueAt
+        let sectionIDRaw = bodyMany?.sectionID ?? bodySingle?.sectionID
         let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
         let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
         let suiteFilesRaw = bodyMany?.suiteFiles ?? (bodySingle?.suiteFiles.map { [$0] } ?? [])
@@ -660,6 +742,9 @@ struct AssignmentRoutes: RouteCollection {
         )
         try await setup.save(on: req.db)
 
+        // Resolve the section ID from the form field, validating it belongs to the active course.
+        let resolvedSectionID: UUID? = try await resolveSectionID(sectionIDRaw, courseID: courseID, db: req.db)
+
         let assignment = try await createAssignmentWithUniquePublicID(
             req: req,
             testSetupID: setupID,
@@ -669,6 +754,7 @@ struct AssignmentRoutes: RouteCollection {
             sortOrder: try await nextAssignmentSortOrder(req: req),
             validationStatus: "pending",
             validationSubmissionID: nil,
+            sectionID: resolvedSectionID,
             courseID: courseID
         )
 
@@ -841,6 +927,152 @@ struct AssignmentRoutes: RouteCollection {
             assignment.sortOrder = index + 1
             try await assignment.save(on: req.db)
         }
+        return .ok
+    }
+
+    // MARK: - POST /assignments/sections
+
+    @Sendable
+    func createSection(req: Request) async throws -> Response {
+        struct CreateSectionBody: Content {
+            var name: String
+            var defaultGradingMode: String
+        }
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseID = courseState.activeCourseUUID else {
+            throw Abort(.badRequest, reason: "No active course selected.")
+        }
+        let body = try req.content.decode(CreateSectionBody.self)
+        let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw Abort(.badRequest, reason: "Section name must not be empty.")
+        }
+        let mode = body.defaultGradingMode
+        guard mode == "browser" || mode == "worker" else {
+            throw Abort(.badRequest, reason: "defaultGradingMode must be 'browser' or 'worker'.")
+        }
+        let maxOrder = try await APICourseSection.query(on: req.db)
+            .filter(\.$courseID == courseID)
+            .max(\.$sortOrder) ?? 0
+        let section = APICourseSection(name: name, defaultGradingMode: mode, sortOrder: maxOrder + 1, courseID: courseID)
+        try await section.save(on: req.db)
+        return req.redirect(to: "/assignments")
+    }
+
+    // MARK: - POST /assignments/sections/reorder
+
+    @Sendable
+    func reorderSections(req: Request) async throws -> HTTPStatus {
+        struct ReorderBody: Content {
+            var sectionIDs: [String]
+        }
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseID = courseState.activeCourseUUID else { return .ok }
+        let body = try req.content.decode(ReorderBody.self)
+        let uuids = body.sectionIDs.compactMap { UUID(uuidString: $0) }
+        guard uuids.count == body.sectionIDs.count, !uuids.isEmpty else {
+            throw Abort(.badRequest, reason: "Invalid section ID in reorder payload.")
+        }
+        let sections = try await APICourseSection.query(on: req.db)
+            .filter(\.$courseID == courseID)
+            .filter(\.$id ~~ uuids)
+            .all()
+        guard sections.count == uuids.count else {
+            throw Abort(.badRequest, reason: "Section set mismatch in reorder payload.")
+        }
+        let byID = Dictionary(uniqueKeysWithValues: sections.compactMap { s -> (UUID, APICourseSection)? in
+            guard let id = s.id else { return nil }
+            return (id, s)
+        })
+        for (index, uuid) in uuids.enumerated() {
+            guard let section = byID[uuid] else { continue }
+            section.sortOrder = index + 1
+            try await section.save(on: req.db)
+        }
+        return .ok
+    }
+
+    // MARK: - POST /assignments/sections/:sectionID/rename
+
+    @Sendable
+    func renameSection(req: Request) async throws -> Response {
+        struct RenameSectionBody: Content {
+            var name: String
+            var defaultGradingMode: String
+        }
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseID = courseState.activeCourseUUID else {
+            throw Abort(.badRequest, reason: "No active course selected.")
+        }
+        guard let sectionIDStr = req.parameters.get("sectionID"),
+              let sectionUUID = UUID(uuidString: sectionIDStr) else {
+            throw Abort(.notFound)
+        }
+        guard let section = try await APICourseSection.find(sectionUUID, on: req.db),
+              section.courseID == courseID else {
+            throw Abort(.notFound)
+        }
+        let body = try req.content.decode(RenameSectionBody.self)
+        let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw Abort(.badRequest, reason: "Section name must not be empty.")
+        }
+        let mode = body.defaultGradingMode
+        guard mode == "browser" || mode == "worker" else {
+            throw Abort(.badRequest, reason: "defaultGradingMode must be 'browser' or 'worker'.")
+        }
+        section.name = name
+        section.defaultGradingMode = mode
+        try await section.save(on: req.db)
+        return req.redirect(to: "/assignments")
+    }
+
+    // MARK: - POST /assignments/sections/:sectionID/delete
+
+    @Sendable
+    func deleteSection(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseID = courseState.activeCourseUUID else {
+            throw Abort(.badRequest, reason: "No active course selected.")
+        }
+        guard let sectionIDStr = req.parameters.get("sectionID"),
+              let sectionUUID = UUID(uuidString: sectionIDStr) else {
+            throw Abort(.notFound)
+        }
+        guard let section = try await APICourseSection.find(sectionUUID, on: req.db),
+              section.courseID == courseID else {
+            throw Abort(.notFound)
+        }
+        // FK SET NULL: assignments in this section will have section_id → NULL (ungrouped).
+        try await section.delete(on: req.db)
+        return req.redirect(to: "/assignments")
+    }
+
+    // MARK: - POST /assignments/:assignmentID/section
+
+    @Sendable
+    func moveToSection(req: Request) async throws -> HTTPStatus {
+        struct MoveBody: Content {
+            var sectionID: String?  // UUID string, or "" / absent = ungrouped
+        }
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseID = courseState.activeCourseUUID else {
+            throw Abort(.badRequest, reason: "No active course selected.")
+        }
+        let idStr = try assignmentPublicIDParameter(from: req)
+        guard let assignment = try await assignmentByPublicID(idStr, on: req.db),
+              assignment.courseID == courseID else {
+            throw Abort(.notFound)
+        }
+        let body = (try? req.content.decode(MoveBody.self))
+        let newSectionID: UUID? = try await resolveSectionID(body?.sectionID, courseID: courseID, db: req.db)
+        assignment.sectionID = newSectionID
+        try await assignment.save(on: req.db)
         return .ok
     }
 
@@ -1259,9 +1491,20 @@ struct AssignmentRow: Encodable {
     let createdAt:    String
 }
 
+/// A course section with its grouped assignment rows, used in instructor and student views.
+struct CourseSectionRow: Encodable {
+    let sectionID: String           // UUID as string
+    let name: String
+    let defaultGradingMode: String  // "browser" | "worker"
+    let sortOrder: Int
+    let rows: [AssignmentRow]       // assignments in this section, sorted
+}
+
 private struct AssignmentsContext: Encodable {
     let currentUser: CurrentUserContext?
-    let rows: [AssignmentRow]
+    let sections: [CourseSectionRow]    // sections with their assignments
+    let ungroupedRows: [AssignmentRow]  // assignments/setups not in any section
+    let hasSections: Bool
 }
 
 private struct AssignmentSubmissionsContext: Encodable {
@@ -1297,6 +1540,8 @@ private struct NewAssignmentContext: Encodable {
     let currentUser: CurrentUserContext?
     let assignmentName: String
     let dueAt: String
+    let sections: [CourseSectionRow]    // available sections for the section picker
+    let preselectedSectionID: String    // from ?sectionID= query param
     let notice: String?
     let error: String?
 }
@@ -1345,6 +1590,21 @@ private struct SubmissionHistoryRow: Encodable {
     let gradeText: String
 }
 
+/// Validates a sectionID string (UUID) against the given course and returns the UUID if valid.
+/// Returns nil for absent, empty, or "none" values (meaning "ungrouped").
+private func resolveSectionID(_ raw: String?, courseID: UUID, db: Database) async throws -> UUID? {
+    guard let raw, !raw.isEmpty, raw.lowercased() != "none" else { return nil }
+    guard let uuid = UUID(uuidString: raw) else {
+        throw Abort(.badRequest, reason: "Invalid sectionID format.")
+    }
+    guard let section = try await APICourseSection.find(uuid, on: db),
+          section.courseID == courseID else {
+        // Section not found or belongs to a different course — silently ignore.
+        return nil
+    }
+    return uuid
+}
+
 private func parseDueDate(_ raw: String?) -> Date? {
     guard let raw, !raw.isEmpty else { return nil }
 
@@ -1384,6 +1644,7 @@ private func createAssignmentWithUniquePublicID(
     sortOrder: Int?,
     validationStatus: String? = nil,
     validationSubmissionID: String? = nil,
+    sectionID: UUID? = nil,
     courseID: UUID
 ) async throws -> APIAssignment {
     for _ in 0..<32 {
@@ -1402,6 +1663,7 @@ private func createAssignmentWithUniquePublicID(
             sortOrder: sortOrder,
             validationStatus: validationStatus,
             validationSubmissionID: validationSubmissionID,
+            sectionID: sectionID,
             courseID: courseID
         )
         do {

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -93,7 +93,7 @@ struct WebRoutes: RouteCollection {
             let publishedIDs = Set(openAssignments.map(\.testSetupID))
             guard !publishedIDs.isEmpty else {
                 return try await req.view.render("index",
-                    IndexContext(setups: [], currentUser: userContext)).encodeResponse(for: req)
+                    IndexContext(sections: [], ungroupedSetups: [], hasSections: false, currentUser: userContext)).encodeResponse(for: req)
             }
             setups = try await APITestSetup.query(on: req.db)
                 .filter(\.$id ~~ publishedIDs)
@@ -217,8 +217,52 @@ struct WebRoutes: RouteCollection {
             )
         }
 
+        // Fetch sections for the active course to enable grouped display.
+        let allSections: [APICourseSection]
+        if let activeCourseUUID = courseState.activeCourseUUID {
+            allSections = try await APICourseSection.query(on: req.db)
+                .filter(\.$courseID == activeCourseUUID)
+                .sort(\.$sortOrder, .ascending)
+                .all()
+        } else {
+            allSections = []
+        }
+
+        // Build lookup: testSetupID → section UUID
+        let sectionBySetupID: [String: UUID] = Dictionary(
+            allAssignments.compactMap { a -> (String, UUID)? in
+                guard let sid = a.sectionID else { return nil }
+                return (a.testSetupID, sid)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        // Group rows by section; rows without a matching section → ungrouped.
+        var rowsBySectionID: [UUID: [TestSetupRow]] = [:]
+        var ungroupedSetups: [TestSetupRow] = []
+        for row in rows {
+            if let sID = sectionBySetupID[row.id] {
+                rowsBySectionID[sID, default: []].append(row)
+            } else {
+                ungroupedSetups.append(row)
+            }
+        }
+
+        // Build per-section contexts, skipping sections with no visible items.
+        let sectionContexts: [IndexSectionContext] = allSections.compactMap { section in
+            guard let sID = section.id else { return nil }
+            let sectionRows = rowsBySectionID[sID] ?? []
+            guard !sectionRows.isEmpty else { return nil }
+            return IndexSectionContext(sectionID: sID.uuidString, name: section.name, setups: sectionRows)
+        }
+
         return try await req.view.render("index",
-            IndexContext(setups: rows, currentUser: userContext)).encodeResponse(for: req)
+            IndexContext(
+                sections: sectionContexts,
+                ungroupedSetups: ungroupedSetups,
+                hasSections: !allSections.isEmpty,
+                currentUser: userContext
+            )).encodeResponse(for: req)
     }
 
     // MARK: - GET /testsetups/new
@@ -651,8 +695,16 @@ private struct LatestSubmissionItem: Encodable {
     let submittedAtText: String
 }
 
-private struct IndexContext: Encodable {
+private struct IndexSectionContext: Encodable {
+    let sectionID: String
+    let name: String
     let setups: [TestSetupRow]
+}
+
+private struct IndexContext: Encodable {
+    let sections: [IndexSectionContext]     // named sections with their visible items
+    let ungroupedSetups: [TestSetupRow]     // items not assigned to any section
+    let hasSections: Bool                   // true if the course has any defined sections
     let currentUser: CurrentUserContext?
 }
 


### PR DESCRIPTION
## Summary

- Adds a `course_sections` table with name, default grading mode, sort order, and course FK (cascade delete)
- Adds nullable `section_id` FK on `assignments` (SET NULL on section delete — no data loss)
- 5 new section management endpoints: create, rename, delete, reorder sections, move assignment between sections
- Instructor dashboard (`/assignments`) rewritten with section blocks — inline rename/delete, drag-to-reorder sections, per-row section move dropdown, per-section "Add item" shortcut link
- Student dashboard (`/`) groups assignments under section headings; falls back to flat table when no sections exist
- Assignment creation form gains a section picker pre-filled from `?sectionID=` with a grading mode hint

Fully backward-compatible: existing assignments appear in the Ungrouped bucket.

## Test plan

- [ ] Run migration: `course_sections` table created, `section_id` column added to `assignments`
- [ ] Visit `/assignments` — existing assignments appear in Ungrouped; no data loss
- [ ] Create a section ("Labs", grading mode "browser") — section header appears
- [ ] Click "Add item to Labs" — creation form opens with Labs pre-selected and browser hint shown
- [ ] Submit creation form — new assignment appears under Labs section
- [ ] Move an existing assignment to a section via the row dropdown — assignment moves on reload
- [ ] Drag section headers to reorder — new order persists after reload
- [ ] Rename a section — name updates
- [ ] Delete a section — section removed; its assignments drop into Ungrouped
- [ ] Student view: assignments grouped under section headings; only open items shown
- [ ] Course with no sections: student sees flat table (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)