### PR TITLE
fix(ui): remove browser-complete preview info box from submission page

### DIFF
--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -5,8 +5,7 @@ Submission #(submissionID)
 #export("content"):
 <div id="submission-root"
      data-submission-id="#(submissionID)"
-     data-pending="#(isPending)"
-     data-browser-complete="#(isBrowserComplete)">
+     data-pending="#(isPending)">
 
 <div class="submission-header">
     <div class="submission-header-row">
@@ -31,14 +30,6 @@ Submission #(submissionID)
 </div>
 
 #else:
-
-#if(isBrowserComplete):
-<div class="info-box">
-    <strong>Preview result</strong> — your code ran in the browser.
-    The official grade is being computed by the server and will appear here automatically.
-    <div class="spinner spinner-inline"></div>
-</div>
-#endif
 
 #if(buildFailed):
 <div class="error-box">


### PR DESCRIPTION
## Summary

- Removes the `#if(isBrowserComplete)` info box ("Preview result — your code ran in the browser…") from `submission.leaf`
- Removes the now-unused `data-browser-complete` attribute from the submission root div
- This block is dead code: browser submissions now go straight to `status=complete` (set in `BrowserResultRoutes.swift`), so `isBrowserComplete` is always `false`

## Test plan

- [ ] Submit a browser-graded (Pyodide) assignment — results page shows immediately with no info box
- [ ] Existing native-runner submissions still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)