### PR TITLE
feat(beta): health check, auto-enroll, lastLoginAt, deploy artifacts

### DIFF
--- a/Sources/APIServer/Routes/HealthRoutes.swift
+++ b/Sources/APIServer/Routes/HealthRoutes.swift
@@ -1,0 +1,65 @@
+// APIServer/Routes/HealthRoutes.swift
+//
+// Public health check endpoint used by nginx, load balancers, and monitoring tools.
+//
+//   GET /health  → 200 OK (all systems operational)
+//              → 503 Service Unavailable (DB unreachable)
+
+import Vapor
+import Fluent
+import SQLKit
+import Core
+
+struct HealthRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get("health", use: health)
+    }
+
+    @Sendable
+    func health(req: Request) async throws -> Response {
+        // DB check: run a trivial query and catch errors.
+        let dbStatus: String
+        do {
+            guard let sql = req.db as? SQLDatabase else {
+                dbStatus = "error"
+                throw Abort(.internalServerError)
+            }
+            _ = try await sql.raw("SELECT 1").all()
+            dbStatus = "ok"
+        } catch {
+            let payload = HealthResponse(
+                status: "degraded",
+                version: ChickadeeVersion.current,
+                db: "error",
+                runner: .init(recentActivity: false)
+            )
+            var headers = HTTPHeaders()
+            headers.contentType = .json
+            let body = try JSONEncoder().encode(payload)
+            return Response(status: .serviceUnavailable, headers: headers, body: .init(data: body))
+        }
+
+        let hasRunnerActivity = await req.application.workerActivityStore.hasRecentActivity(within: 120)
+
+        let payload = HealthResponse(
+            status: "ok",
+            version: ChickadeeVersion.current,
+            db: dbStatus,
+            runner: .init(recentActivity: hasRunnerActivity)
+        )
+        return try await payload.encodeResponse(status: .ok, for: req)
+    }
+}
+
+// MARK: - Response types
+
+private struct HealthResponse: Content {
+    var status: String   // "ok" | "degraded"
+    var version: String
+    var db: String       // "ok" | "error"
+    var runner: RunnerHealth
+
+    struct RunnerHealth: Content {
+        var recentActivity: Bool
+    }
+}

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -72,6 +72,9 @@ struct AuthRoutes: RouteCollection {
             return req.redirect(to: "/login?error=invalid")
         }
 
+        user.lastLoginAt = Date()
+        try await user.save(on: req.db)
+
         req.auth.login(user)
         req.session.authenticate(user)
         return try await postLoginRedirect(for: user, req: req)
@@ -144,20 +147,27 @@ struct AuthRoutes: RouteCollection {
 
 // MARK: - Post-login redirect helper
 
-/// Redirects to /enroll when multiple courses exist and the user has no enrollments;
-/// otherwise redirects to /.
-private func postLoginRedirect(for user: APIUser, req: Request) async throws -> Response {
+/// Called after any successful login (local or SSO).
+/// - If the user has no enrollments and exactly one active course exists, auto-enroll them silently.
+/// - If the user has no enrollments and multiple courses exist, redirect to /enroll.
+/// - Otherwise redirect to /.
+func postLoginRedirect(for user: APIUser, req: Request) async throws -> Response {
     guard let userID = user.id else { return req.redirect(to: "/") }
 
-    let courseCount = try await APICourse.query(on: req.db)
-        .filter(\.$isArchived == false)
+    let enrollmentCount = try await APICourseEnrollment.query(on: req.db)
+        .filter(\.$userID == userID)
         .count()
 
-    if courseCount > 1 {
-        let enrollmentCount = try await APICourseEnrollment.query(on: req.db)
-            .filter(\.$userID == userID)
-            .count()
-        if enrollmentCount == 0 {
+    if enrollmentCount == 0 {
+        let courses = try await APICourse.query(on: req.db)
+            .filter(\.$isArchived == false)
+            .all()
+
+        if courses.count == 1, let course = courses.first, let courseID = course.id {
+            // Exactly one active course: silently auto-enroll the user.
+            let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
+            try? await enrollment.save(on: req.db)
+        } else if courses.count > 1 {
             return req.redirect(to: "/enroll")
         }
     }

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -151,7 +151,7 @@ struct SSOAuthRoutes: RouteCollection {
         // Establish session — identical to local login
         req.auth.login(user)
         req.session.authenticate(user)
-        return req.redirect(to: "/")
+        return try await postLoginRedirect(for: user, req: req)
     }
 
     // MARK: - User upsert

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -7,6 +7,7 @@ func routes(_ app: Application) throws {
 
     // MARK: - Public routes (no auth required)
 
+    try app.register(collection: HealthRoutes())
     try app.register(collection: AuthRoutes())
     if app.authMode != .local {
         try app.register(collection: SSOAuthRoutes())

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,51 @@
+# Chickadee environment configuration — copy to /opt/chickadee/.env and fill in values.
+# Lines beginning with # are comments and are ignored.
+
+# ---------------------------------------------------------------------------
+# Auth mode
+# ---------------------------------------------------------------------------
+# "sso"   — OIDC/OAuth only (production default)
+# "local" — username/password only (development)
+# "dual"  — both (local login + SSO button shown)
+AUTH_MODE=sso
+
+# Required when AUTH_MODE is not "local":
+ENABLE_NON_SSO_AUTH_MODES=true
+
+# ---------------------------------------------------------------------------
+# URL and HTTPS
+# ---------------------------------------------------------------------------
+PUBLIC_BASE_URL=https://your-vm.example.com
+
+# Redirect HTTP → HTTPS (set to true when nginx handles TLS termination)
+ENFORCE_HTTPS=true
+
+# Trust X-Forwarded-Proto from nginx (leave true when behind a reverse proxy)
+TRUST_X_FORWARDED_PROTO=true
+
+# Mark session cookies Secure (should match whether you're serving over HTTPS)
+SESSION_COOKIE_SECURE=true
+
+# ---------------------------------------------------------------------------
+# OIDC / SSO credentials
+# ---------------------------------------------------------------------------
+OIDC_AUTH_SERVER=https://your-idp.example.com/oidc/
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+
+# Callback path registered with your IdP (default: /auth/sso/callback)
+# OIDC_CALLBACK=/auth/sso/callback
+
+# ---------------------------------------------------------------------------
+# Role promotion
+# Comma-separated list of SSO usernames/email addresses to auto-promote.
+# ---------------------------------------------------------------------------
+SSO_ADMIN_USERS=yourusername
+SSO_INSTRUCTOR_USERS=instructor1,instructor2
+
+# ---------------------------------------------------------------------------
+# Runner shared secret
+# If omitted, a passphrase is auto-generated and saved to .worker-secret.
+# The runner reads this as RUNNER_SHARED_SECRET.
+# ---------------------------------------------------------------------------
+# RUNNER_SHARED_SECRET=your-secret-passphrase

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,157 @@
+# Chickadee — VM Deployment Guide
+
+This guide covers a standard Linux VM deployment: native Swift binaries, systemd
+service management, and nginx as the reverse proxy.
+
+---
+
+## Prerequisites
+
+- Ubuntu 22.04 / 24.04 (or equivalent Linux distro)
+- Swift 6.0+ installed ([swift.org/download](https://swift.org/download/))
+- nginx installed (`apt install nginx`)
+- Your OIDC credentials from your identity provider (e.g. Duo, Okta, Entra)
+
+---
+
+## 1. Build
+
+On your development machine (or on the VM if Swift is installed there):
+
+```bash
+swift build -c release
+```
+
+This produces two binaries:
+- `.build/release/chickadee-server`
+- `.build/release/chickadee-runner`
+
+---
+
+## 2. Copy Files to the VM
+
+```bash
+# Create the deploy directory
+ssh your-vm "sudo mkdir -p /opt/chickadee && sudo useradd -r -s /bin/false chickadee && sudo chown chickadee:chickadee /opt/chickadee"
+
+# Copy binaries and assets
+rsync -av \
+  .build/release/chickadee-server \
+  .build/release/chickadee-runner \
+  Public/ Resources/ \
+  your-vm:/opt/chickadee/
+```
+
+The `Public/` directory contains JupyterLite and other static assets.
+The `Resources/` directory contains Leaf templates, wordlists, and other server assets.
+
+---
+
+## 3. Configure Environment
+
+```bash
+# On the VM:
+cp /opt/chickadee/deploy/.env.example /opt/chickadee/.env
+nano /opt/chickadee/.env   # fill in OIDC credentials, PUBLIC_BASE_URL, etc.
+sudo chown chickadee:chickadee /opt/chickadee/.env
+sudo chmod 640 /opt/chickadee/.env
+```
+
+Key values to set:
+- `PUBLIC_BASE_URL` — your VM's public URL (e.g. `https://chickadee.cs.example.com`)
+- `OIDC_AUTH_SERVER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` — from your IdP
+- `SSO_ADMIN_USERS` — your username, so the first login gives you admin access
+
+---
+
+## 4. Install systemd Services
+
+```bash
+sudo cp /opt/chickadee/deploy/chickadee-server.service /etc/systemd/system/
+sudo cp /opt/chickadee/deploy/chickadee-runner.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable chickadee-server chickadee-runner
+sudo systemctl start chickadee-server chickadee-runner
+```
+
+Check status:
+```bash
+sudo systemctl status chickadee-server
+sudo systemctl status chickadee-runner
+sudo journalctl -u chickadee-server -f   # live logs
+```
+
+---
+
+## 5. Configure nginx
+
+```bash
+sudo cp /opt/chickadee/deploy/nginx.conf /etc/nginx/sites-available/chickadee
+sudo ln -s /etc/nginx/sites-available/chickadee /etc/nginx/sites-enabled/chickadee
+# Edit the file — replace "your-vm.example.com" with your actual domain
+sudo nano /etc/nginx/sites-available/chickadee
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### HTTPS (recommended)
+
+```bash
+sudo apt install certbot python3-certbot-nginx
+sudo certbot --nginx -d your-vm.example.com
+```
+
+After certbot runs, update your `.env`:
+```bash
+ENFORCE_HTTPS=true
+SESSION_COOKIE_SECURE=true
+PUBLIC_BASE_URL=https://your-vm.example.com
+```
+
+Then restart the server: `sudo systemctl restart chickadee-server`
+
+---
+
+## 6. First Login
+
+1. Navigate to `https://your-vm.example.com`
+2. You'll be redirected to your IdP for SSO login
+3. Your username (listed in `SSO_ADMIN_USERS`) will be promoted to admin on first login
+4. Go to `/admin` to create courses, manage users, and configure the runner
+
+---
+
+## 7. Health Check
+
+```bash
+curl https://your-vm.example.com/health
+# → {"status":"ok","version":"0.3.0","db":"ok","runner":{"recentActivity":false}}
+```
+
+Returns HTTP 503 if the database is unreachable.
+
+---
+
+## Updating
+
+```bash
+# On dev machine: build and copy new binaries
+swift build -c release
+rsync -av .build/release/chickadee-server .build/release/chickadee-runner your-vm:/opt/chickadee/
+
+# On the VM: restart services
+sudo systemctl restart chickadee-server chickadee-runner
+```
+
+If you also changed templates or static assets, rsync `Public/` and `Resources/` as well.
+
+---
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| 502 Bad Gateway | `systemctl status chickadee-server` — is it running? |
+| SSO redirect loop | Verify `OIDC_CALLBACK` matches the redirect URI registered with your IdP |
+| Students not auto-enrolled | Make sure exactly one non-archived course exists in `/admin/courses` |
+| Runner not picking up jobs | Check `journalctl -u chickadee-runner`; verify `RUNNER_SHARED_SECRET` matches `.worker-secret` |
+| JupyterLite broken | Ensure nginx passes `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy` headers |

--- a/deploy/chickadee-runner.service
+++ b/deploy/chickadee-runner.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Chickadee Runner
+After=network.target chickadee-server.service
+
+[Service]
+Type=simple
+User=chickadee
+WorkingDirectory=/opt/chickadee
+ExecStart=/opt/chickadee/.build/release/chickadee-runner \
+    --api-base-url http://127.0.0.1:8080 \
+    --worker-id runner-01 \
+    --max-jobs 2
+Restart=on-failure
+RestartSec=10
+EnvironmentFile=/opt/chickadee/.env
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/chickadee-server.service
+++ b/deploy/chickadee-server.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Chickadee Server
+After=network.target
+
+[Service]
+Type=simple
+User=chickadee
+WorkingDirectory=/opt/chickadee
+ExecStart=/opt/chickadee/.build/release/chickadee-server serve --hostname 127.0.0.1 --port 8080
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=/opt/chickadee/.env
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,34 @@
+# Example nginx virtual host for Chickadee.
+# Copy to /etc/nginx/sites-available/chickadee and symlink to sites-enabled/.
+# Replace your-vm.example.com with your actual domain.
+#
+# For HTTPS, use certbot or add ssl_certificate / ssl_certificate_key directives.
+
+server {
+    listen 80;
+    server_name your-vm.example.com;
+
+    # Increase body size limit to allow test-setup zip uploads (default 1m is too small).
+    client_max_body_size 50m;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+
+        # Required for JupyterLite / WebAssembly (SharedArrayBuffer).
+        # Chickadee sets these headers itself; nginx just passes them through.
+        proxy_hide_header  Cross-Origin-Opener-Policy;
+        proxy_hide_header  Cross-Origin-Embedder-Policy;
+        add_header         Cross-Origin-Opener-Policy  "same-origin" always;
+        add_header         Cross-Origin-Embedder-Policy "require-corp" always;
+    }
+
+    location /health {
+        proxy_pass       http://127.0.0.1:8080/health;
+        access_log       off;
+    }
+}


### PR DESCRIPTION
## Summary

Beta deployment readiness for a student-facing Linux VM deployment:

- **`GET /health`** — JSON health check endpoint (no auth). Returns `db: ok/error` and `runner: { recentActivity }`. Returns HTTP 503 if DB is unreachable. Suitable for nginx `location /health` probes.
- **Auto-enroll on login** — If a user has no enrollments and exactly one active course exists, they're silently enrolled instead of being redirected to `/enroll`. Works for both local and SSO login.
- **`lastLoginAt` tracking** — Written on successful local username/password login (SSO already tracked this via `upsertUser`).
- **SSO callback** — Now calls `postLoginRedirect()` (shared with local login) so auto-enroll applies to SSO users too.
- **`deploy/` directory** — `chickadee-server.service`, `chickadee-runner.service`, `nginx.conf`, `.env.example`, and `README.md` covering the full Linux VM setup flow.

## Test plan

- [ ] `curl http://localhost:8080/health` → `{"status":"ok","version":"...","db":"ok","runner":{"recentActivity":false}}`
- [ ] Log in via SSO with one active course → land on `/` already enrolled, no `/enroll` redirect
- [ ] Log in via local auth → `/admin` shows current timestamp in "Last Login" column
- [ ] `systemctl start chickadee-server` using the provided unit file → server starts and stays up

🤖 Generated with [Claude Code](https://claude.com/claude-code)