### PR TITLE
fix: hide archived courses from instructor and student dashboards

### DIFF
--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -191,6 +191,7 @@ extension Request {
         return enrollments
             .compactMap { e -> CourseContext? in
                 guard let id = e.course.id else { return nil }
+                guard !e.course.isArchived else { return nil }   // hide archived courses everywhere
                 return CourseContext(id: id.uuidString, code: e.course.code, name: e.course.name, isActive: false)
             }
             .sorted { $0.code < $1.code }

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -47,10 +47,12 @@ struct WebRoutes: RouteCollection {
             enrolledCourses: courseState.all
         )
 
-        // If multiple courses exist but user has no enrollments → redirect to /enroll.
+        // If active (non-archived) courses exist but user has no active enrollment → redirect to /enroll.
         if courseState.active == nil {
-            let courseCount = try await APICourse.query(on: req.db).count()
-            if courseCount > 0 {
+            let activeCourseCount = try await APICourse.query(on: req.db)
+                .filter(\.$isArchived == false)
+                .count()
+            if activeCourseCount > 0 {
                 return req.redirect(to: "/enroll")
             }
         }


### PR DESCRIPTION
## Summary

Archived courses are now fully invisible to both students and instructors:

- **`loadEnrolledCourseContexts()`** — filters out archived courses, so they never appear as course tabs or as the active course. Previously, a user enrolled in an archived course would still see it in their nav and could switch to it.
- **`index()` redirect guard** — now counts only non-archived courses when deciding whether to send a user to `/enroll`. Previously, if every course was archived, users with no active enrollments would be stuck in an `/enroll` redirect loop showing no courses.
- Auto-enroll logic in `postLoginRedirect` and `resolveActiveCourse` already filtered for `isArchived == false` — no change needed there.

## Test plan

- [ ] Archive a course → it disappears from the course tab bar for both instructors and students immediately on next page load
- [ ] A user enrolled only in archived courses lands on `/` with an empty state (no redirect loop)
- [ ] Non-archived courses still appear and function normally
- [ ] Auto-enroll still works when exactly one non-archived course exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)