### PR TITLE
feat: per-course open enrollment toggle

### DIFF
--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -40,6 +40,11 @@
         #else:
         <span class="tier tier-open">active</span>
         #endif
+        #if(course.openEnrollment):
+        <span class="tier tier-open">open enrolment</span>
+        #else:
+        <span class="tier tier-closed">closed enrolment</span>
+        #endif
     </div>
     <div style="display:flex;gap:.5rem;align-items:center">
         #if(!course.isArchived):
@@ -79,6 +84,11 @@
             Name
             <input class="form-input" type="text" name="name" value="#(course.name)"
                    required style="display:block;width:100%">
+        </label>
+        <label class="form-label" style="display:inline-flex;flex-direction:row;align-items:center;gap:.5rem;white-space:nowrap;align-self:flex-end;padding-bottom:.35rem">
+            <input type="checkbox" name="openEnrollment" value="on"
+                   #if(course.openEnrollment):checked#endif>
+            Open enrolment
         </label>
         <button class="btn btn-primary" type="submit" style="align-self:flex-end">Save</button>
     </form>

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -145,6 +145,7 @@ func configure(_ app: Application, cliWorkerSecret: String?, authModeOverride: A
     app.migrations.add(CreateAssignments())
     app.migrations.add(CreatePerformanceIndexes())
     app.migrations.add(AddCourseSections())
+    app.migrations.add(AddCourseOpenEnrollment())
 
     try app.autoMigrate().wait()
 

--- a/Sources/APIServer/Migrations/AddCourseOpenEnrollment.swift
+++ b/Sources/APIServer/Migrations/AddCourseOpenEnrollment.swift
@@ -1,0 +1,17 @@
+// APIServer/Migrations/AddCourseOpenEnrollment.swift
+
+import Fluent
+
+struct AddCourseOpenEnrollment: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("courses")
+            .field("open_enrollment", .bool, .required, .custom("DEFAULT TRUE"))
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("courses")
+            .deleteField("open_enrollment")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APICourse.swift
+++ b/Sources/APIServer/Models/APICourse.swift
@@ -24,9 +24,13 @@ final class APICourse: Model, Content, @unchecked Sendable {
     @Field(key: "name")
     var name: String
 
-    /// Archived courses are hidden from the enrollment picker but their data is preserved.
+    /// Archived courses are hidden from all users and their data is preserved.
     @Field(key: "is_archived")
     var isArchived: Bool
+
+    /// When false, students cannot self-enroll. Admin-managed enrollment still works.
+    @Field(key: "open_enrollment")
+    var openEnrollment: Bool
 
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
@@ -36,10 +40,12 @@ final class APICourse: Model, Content, @unchecked Sendable {
 
     init() {}
 
-    init(id: UUID? = nil, code: String, name: String, isArchived: Bool = false) {
-        self.id         = id
-        self.code       = code
-        self.name       = name
-        self.isArchived = isArchived
+    init(id: UUID? = nil, code: String, name: String,
+         isArchived: Bool = false, openEnrollment: Bool = true) {
+        self.id             = id
+        self.code           = code
+        self.name           = name
+        self.isArchived     = isArchived
+        self.openEnrollment = openEnrollment
     }
 }

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -153,9 +153,11 @@ extension Request {
         // Fetch current enrollments.
         var enrolledContexts = try await loadEnrolledCourseContexts(userID: userID)
 
-        // Auto-enroll when there is exactly one non-archived course.
+        // Auto-enroll when there is exactly one non-archived, open-enrollment course.
         if enrolledContexts.isEmpty, allCourses.count == 1,
-           let onlyCourse = allCourses.first, let courseID = onlyCourse.id {
+           let onlyCourse = allCourses.first,
+           onlyCourse.openEnrollment,
+           let courseID = onlyCourse.id {
             let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
             try? await enrollment.save(on: db)
             enrolledContexts = try await loadEnrolledCourseContexts(userID: userID)

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -72,6 +72,7 @@ struct AdminRoutes: RouteCollection {
                 code: course.code,
                 name: course.name,
                 isArchived: course.isArchived,
+                openEnrollment: course.openEnrollment,
                 enrollmentCount: enrollmentCounts[id] ?? 0,
                 assignmentCount: assignmentCounts[id] ?? 0,
                 createdAt: course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—"
@@ -178,6 +179,7 @@ struct AdminRoutes: RouteCollection {
             code:            "",
             name:            "",
             isArchived:      false,
+            openEnrollment:  true,
             enrollmentCount: 0,
             assignmentCount: 0,
             createdAt:       ""
@@ -318,7 +320,11 @@ struct AdminRoutes: RouteCollection {
 
     @Sendable
     func editCourse(req: Request) async throws -> Response {
-        struct EditCourseBody: Content { var code: String; var name: String }
+        struct EditCourseBody: Content {
+            var code: String
+            var name: String
+            var openEnrollment: String?   // checkbox: "on" when checked, absent when unchecked
+        }
 
         guard
             let idString = req.parameters.get("courseID"),
@@ -343,8 +349,9 @@ struct AdminRoutes: RouteCollection {
             return req.redirect(to: "/admin/courses/\(idString)?error=code_taken")
         }
 
-        course.code = code
-        course.name = name
+        course.code           = code
+        course.name           = name
+        course.openEnrollment = (body.openEnrollment == "on")
         try await course.save(on: req.db)
         return req.redirect(to: "/admin/courses/\(idString)")
     }
@@ -436,6 +443,7 @@ struct AdminRoutes: RouteCollection {
             code:            course.code,
             name:            course.name,
             isArchived:      course.isArchived,
+            openEnrollment:  course.openEnrollment,
             enrollmentCount: enrollmentCounts[courseID] ?? 0,
             assignmentCount: assignmentCounts[courseID] ?? 0,
             createdAt:       course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—"
@@ -705,6 +713,7 @@ private struct AdminCourseRow: Encodable {
     let code: String
     let name: String
     let isArchived: Bool
+    let openEnrollment: Bool
     let enrollmentCount: Int
     let assignmentCount: Int
     let createdAt: String

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -163,11 +163,14 @@ func postLoginRedirect(for user: APIUser, req: Request) async throws -> Response
             .filter(\.$isArchived == false)
             .all()
 
-        if courses.count == 1, let course = courses.first, let courseID = course.id {
-            // Exactly one active course: silently auto-enroll the user.
+        let openCourses = courses.filter { $0.openEnrollment }
+
+        if courses.count == 1, let course = courses.first,
+           course.openEnrollment, let courseID = course.id {
+            // Exactly one active course with open enrollment: silently auto-enroll.
             let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
             try? await enrollment.save(on: req.db)
-        } else if courses.count > 1 {
+        } else if openCourses.count > 1 {
             return req.redirect(to: "/enroll")
         }
     }

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -188,7 +188,8 @@ struct CourseBundleRoutes: RouteCollection {
             exportedAt:           Date(),
             exportedBy:           caller.username,
             chickadeeVersion:     ChickadeeVersion.current,
-            course:               BundledCourse(code: course.code, name: course.name),
+            course:               BundledCourse(code: course.code, name: course.name,
+                                               openEnrollment: course.openEnrollment),
             users:                bundledUsers,
             enrolledUserBundleIDs: enrolledBundleIDs,
             assignments:          bundledAssignments,
@@ -374,7 +375,8 @@ struct CourseBundleRoutes: RouteCollection {
             )
 
             // 7a. Create course
-            let newCourse = APICourse(code: manifest.course.code, name: manifest.course.name)
+            let newCourse = APICourse(code: manifest.course.code, name: manifest.course.name,
+                                      openEnrollment: manifest.course.openEnrollment ?? true)
             try await newCourse.save(on: db)
             t.courseID   = newCourse.id!
             t.courseCode = newCourse.code

--- a/Sources/APIServer/Routes/Web/EnrollmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/EnrollmentRoutes.swift
@@ -25,6 +25,7 @@ struct EnrollmentRoutes: RouteCollection {
 
         let allCourses = try await APICourse.query(on: req.db)
             .filter(\.$isArchived == false)
+            .filter(\.$openEnrollment == true)
             .sort(\.$code)
             .all()
 
@@ -70,6 +71,7 @@ struct EnrollmentRoutes: RouteCollection {
             : try await APICourse.query(on: req.db)
                 .filter(\.$id ~~ selectedIDs)
                 .filter(\.$isArchived == false)
+                .filter(\.$openEnrollment == true)
                 .all()
         let validIDs = Set(validCourses.compactMap(\.id))
 

--- a/Sources/Core/CourseBundleManifest.swift
+++ b/Sources/Core/CourseBundleManifest.swift
@@ -70,10 +70,13 @@ public struct CourseBundleManifest: Codable, Sendable {
 public struct BundledCourse: Codable, Sendable {
     public let code: String
     public let name: String
+    /// nil in bundles exported before this field was added; defaults to true on import.
+    public let openEnrollment: Bool?
 
-    public init(code: String, name: String) {
-        self.code = code
-        self.name = name
+    public init(code: String, name: String, openEnrollment: Bool? = nil) {
+        self.code           = code
+        self.name           = name
+        self.openEnrollment = openEnrollment
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an \`openEnrollment\` flag to each course (default \`true\`, backward-compatible). When set to \`false\`, students cannot self-enroll via \`/enroll\`; all admin-managed enrollment paths (CSV upload, manual enroll from user detail page) continue to work normally.

- **Migration** — \`ADD COLUMN open_enrollment BOOL NOT NULL DEFAULT TRUE\` (existing courses get \`true\`)
- **Enforcement** — both the \`/enroll\` page query and the \`POST /enroll\` validation filter out closed-enrollment courses, so a crafted POST cannot bypass it
- **Auto-enroll** — the single-course shortcut in \`postLoginRedirect\` and \`resolveActiveCourse\` now also checks the flag
- **Admin UI** — course detail page shows an "open enrolment / closed enrolment" badge; the Edit form has an "Open enrolment" checkbox
- **Bundle export/import** — \`BundledCourse\` gains \`openEnrollment: Bool?\` (optional for backward-compat with existing bundles, defaults to \`true\` on import)

## Test plan

- [ ] Existing courses still show \`openEnrollment = true\` after migration
- [ ] Admin unchecks "Open enrolment" on a course → badge changes to "closed enrolment", \`/enroll\` no longer lists that course
- [ ] Crafted \`POST /enroll\` with a closed-enrollment course UUID → rejected silently, \`?error=none_selected\`
- [ ] Auto-enroll (single course) respects the flag — closed course does not auto-enroll
- [ ] Re-checking the box reopens enrollment immediately
- [ ] Exporting and importing a bundle preserves the \`openEnrollment\` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)