### PR TITLE
fix(concurrency): return newCourseID from transaction closure

### DIFF
--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -255,13 +255,11 @@ struct AdminRoutes: RouteCollection {
             .sort(\.$sortOrder)
             .all()
 
-        var newCourseID = UUID()
-
-        try await req.db.transaction { db in
+        let newCourseID = try await req.db.transaction { db -> UUID in
             // 1. Create the new course.
             let newCourse = APICourse(code: newCode, name: "\(source.name) (Copy)")
             try await newCourse.save(on: db)
-            newCourseID = try newCourse.requireID()
+            let newCourseID = try newCourse.requireID()
 
             // 2. Copy each test setup (zip + optional notebook) to a new ID.
             var setupIDMap: [String: String] = [:]
@@ -310,6 +308,8 @@ struct AdminRoutes: RouteCollection {
                 )
                 try await newAssignment.save(on: db)
             }
+
+            return newCourseID
         }
 
         req.logger.info("Admin copied course \(source.code) → \(newCode) (new ID: \(newCourseID))")


### PR DESCRIPTION
## Summary

Fixes a Swift 6 `#SendableClosureCaptures` warning in `copyCourse()`:

```
// Before — mutating a captured var inside an async closure (error in Swift 6):
var newCourseID = UUID()
try await req.db.transaction { db in
    newCourseID = try newCourse.requireID()
    ...
    courseID: newCourseID
}

// After — closure returns the value, no captured mutation:
let newCourseID = try await req.db.transaction { db -> UUID in
    let newCourseID = try newCourse.requireID()
    ...
    courseID: newCourseID
    return newCourseID
}
```

## Test plan

- [ ] Build with no `#SendableClosureCaptures` warnings
- [ ] Copy a course via the admin UI → redirects to the correct new course page

🤖 Generated with [Claude Code](https://claude.com/claude-code)