### PR TITLE
feat(admin): move open-enrolment toggle to enrolled-students section header

### DIFF
--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -85,11 +85,6 @@
             <input class="form-input" type="text" name="name" value="#(course.name)"
                    required style="display:block;width:100%">
         </label>
-        <label class="form-label" style="display:inline-flex;flex-direction:row;align-items:center;gap:.5rem;white-space:nowrap;align-self:flex-end;padding-bottom:.35rem">
-            <input type="checkbox" name="openEnrollment" value="on"
-                   #if(course.openEnrollment):checked#endif>
-            Open enrolment
-        </label>
         <button class="btn btn-primary" type="submit" style="align-self:flex-end">Save</button>
     </form>
 </section>
@@ -97,7 +92,19 @@
 
 <!-- ── Enrolled students ───────────────────────────────── -->
 <section class="admin-section">
-    <h2>Enrolled students (#(course.enrollmentCount))</h2>
+    <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;margin-bottom:1rem">
+        <h2 style="margin:0">Enrolled students (#(course.enrollmentCount))</h2>
+        #if(!isNew):
+        <form method="post" action="/admin/courses/#(course.id)/open-enrollment" style="margin:0">
+            <label style="display:flex;align-items:center;gap:.4rem;font-size:.875rem;cursor:pointer;user-select:none">
+                <input type="checkbox" name="openEnrollment" value="on"
+                       #if(course.openEnrollment):checked#endif
+                       onchange="this.form.submit()">
+                Open enrolment
+            </label>
+        </form>
+        #endif
+    </div>
     #if(enrolledUsers.isEmpty):
     <p class="empty">No students enrolled yet.</p>
     #else:

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -29,6 +29,7 @@ struct AdminRoutes: RouteCollection {
         admin.post("courses", ":courseID", "edit", use: editCourse)
         admin.post("courses", ":courseID", "archive", use: toggleCourseArchive)
         admin.post("courses", ":courseID", "copy",    use: copyCourse)
+        admin.post("courses", ":courseID", "open-enrollment", use: toggleOpenEnrollment)
         admin.post("courses", ":courseID", "enroll-csv", use: adminBulkEnrollCSV)
         admin.post("courses", ":courseID", "unenroll", ":userID", use: unenrollUserFromCourse)
         admin.get("users", ":userID", use: userDetail)
@@ -230,6 +231,24 @@ struct AdminRoutes: RouteCollection {
         return req.redirect(to: "/admin/courses/\(idString)")
     }
 
+    // MARK: - POST /admin/courses/:courseID/open-enrollment
+
+    @Sendable
+    func toggleOpenEnrollment(req: Request) async throws -> Response {
+        struct Body: Content { var openEnrollment: String? }
+        guard
+            let idString = req.parameters.get("courseID"),
+            let courseID = UUID(uuidString: idString),
+            let course   = try await APICourse.find(courseID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+        let body = try req.content.decode(Body.self)
+        course.openEnrollment = (body.openEnrollment == "on")
+        try await course.save(on: req.db)
+        return req.redirect(to: "/admin/courses/\(idString)")
+    }
+
     // MARK: - POST /admin/courses/:courseID/copy
 
     @Sendable
@@ -320,11 +339,7 @@ struct AdminRoutes: RouteCollection {
 
     @Sendable
     func editCourse(req: Request) async throws -> Response {
-        struct EditCourseBody: Content {
-            var code: String
-            var name: String
-            var openEnrollment: String?   // checkbox: "on" when checked, absent when unchecked
-        }
+        struct EditCourseBody: Content { var code: String; var name: String }
 
         guard
             let idString = req.parameters.get("courseID"),
@@ -349,9 +364,8 @@ struct AdminRoutes: RouteCollection {
             return req.redirect(to: "/admin/courses/\(idString)?error=code_taken")
         }
 
-        course.code           = code
-        course.name           = name
-        course.openEnrollment = (body.openEnrollment == "on")
+        course.code = code
+        course.name = name
         try await course.save(on: req.db)
         return req.redirect(to: "/admin/courses/\(idString)")
     }


### PR DESCRIPTION
## Summary

- Adds `POST /admin/courses/:courseID/open-enrollment` route and `toggleOpenEnrollment` handler — reads a single checkbox field and saves `course.openEnrollment` immediately
- Moves the Open enrolment checkbox from the Edit course form to the **Enrolled Students section header**, where it auto-submits on `onchange` (no Save button needed)
- Removes `openEnrollment` from `EditCourseBody` in `editCourse` — the Edit form now only manages code and name
- Status badge ("open enrolment" / "closed enrolment") in the page header is kept for at-a-glance visibility

## Test plan

- [ ] Load a course detail page; confirm checkbox appears beside "Enrolled students" heading, checked/unchecked per current state
- [ ] Toggle the checkbox — page reloads, state persists, status badge in header updates
- [ ] Submit the Edit form — open enrolment flag is unchanged
- [ ] New Course page — checkbox is absent (guarded by `#if(!isNew)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)