### PR TITLE
fix(browser-runner): hide loading status bar after tests complete

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -217,6 +217,9 @@ for _module_name in student_module_names_in_load_order():
             const collection = buildCollection(setupID, outcomes);
             const response   = await postBrowserResult(notebookBytes, collection, setupID);
 
+            // Hide the loading-progress status bar — results are now in #nb-results.
+            if (statusEl) statusEl.hidden = true;
+
             return { outcomes, response };
 
         } finally {


### PR DESCRIPTION
## Summary
- After tests run and results are rendered in `#nb-results`, the `#browser-runner-status` element was left showing "Loading test configuration…" because it was never hidden on a successful run
- Added `statusEl.hidden = true` immediately before returning from `runAndSubmit()` so the loading progress bar disappears once results are displayed

## Test plan
- [ ] Submit a browser-graded assignment — verify test results appear and the "Loading test configuration…" text is gone
- [ ] Verify error case still shows the error message in the status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)