### PR TITLE
feat(grading): instructor UI for per-test point weights

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -62,12 +62,13 @@ Edit Assignment
                 <th>File</th>
                 <th>Test?</th>
                 <th>Tier</th>
+                <th title="Grade point weight for this test (default 1)">Pts</th>
                 <th class="time">Delete</th>
             </tr>
         </thead>
         <tbody id="suite-config-body">
             #for(row in existingSuiteRows):
-            <tr data-source="existing" data-name="#(row.name)" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)">
+            <tr data-source="existing" data-name="#(row.name)" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)" data-points="#(row.points)">
                 <td><span class="suite-drag-handle" title="Drag to reorder or adopt">&#10783;</span><a href="#(row.url)"><code>#(row.name)</code></a></td>
                 <td><input type="checkbox" class="suite-test-toggle" #if(row.isTest):checked#endif></td>
                 <td>
@@ -78,6 +79,7 @@ Edit Assignment
                         <option value="release" #if(row.tier == "release"):selected#endif>release</option>
                     </select>
                 </td>
+                <td><input type="number" class="form-input suite-points" min="1" max="100" value="#(row.points)" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>
                 <td class="time"><button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button></td>
             </tr>
             #endfor
@@ -114,7 +116,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     var body        = document.getElementById('suite-config-body');
     if (!filesInput || !configField || !body) return;
 
-    // items: { name, source, index?, isTest, tier, dependsOn[], url? }
+    // items: { name, source, index?, isTest, tier, dependsOn[], points, url? }
     var items = [];
     var dragName = null;
     var uploadCount = 0;  // running count of uploaded files added
@@ -165,6 +167,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         var indent    = depth > 0 ? ' class="suite-child-indent"' : '';
         var connector = depth > 0 ? '<span class="suite-child-connector">&#9492;</span>' : '';
         var checked   = item.isTest ? ' checked' : '';
+        var pts       = item.points || 1;
         return '<tr data-name="' + escAttr(item.name) + '" data-source="' + escAttr(item.source) + '">'
             + '<td' + indent + '>'
             +   '<span class="suite-drag-handle" title="Drag to reorder or adopt">&#10783;</span>'
@@ -174,6 +177,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             + '<td><select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">'
             +   tierOptions(item.tier)
             + '</select></td>'
+            + '<td><input type="number" class="form-input suite-points" min="1" max="100" value="' + pts + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
             + '<td class="time"><button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button></td>'
             + '</tr>';
     }
@@ -181,7 +185,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     function renderTree() {
         var visual = visualOrder();
         body.innerHTML = visual.map(function (v) { return rowHTML(v.item, v.depth); }).join('')
-            + '<tr class="suite-root-drop"><td colspan="4">&#9660; Drop here to remove dependency</td></tr>';
+            + '<tr class="suite-root-drop"><td colspan="5">&#9660; Drop here to remove dependency</td></tr>';
     }
 
     function syncConfig() {
@@ -192,10 +196,12 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             if (row) {
                 var tierEl   = row.querySelector('.suite-tier');
                 var toggleEl = row.querySelector('.suite-test-toggle');
+                var ptsEl    = row.querySelector('.suite-points');
                 if (tierEl)   item.tier   = tierEl.value;
                 if (toggleEl) item.isTest = toggleEl.checked && item.tier !== 'support';
+                if (ptsEl)    item.points = Math.max(1, parseInt(ptsEl.value) || 1);
             }
-            var base = { source: item.source, isIncluded: true, isTest: item.isTest, tier: item.tier, order: i + 1, dependsOn: item.dependsOn };
+            var base = { source: item.source, isIncluded: true, isTest: item.isTest, tier: item.tier, order: i + 1, dependsOn: item.dependsOn, points: item.points || 1 };
             if (item.source === 'upload') { base.index = item.index; }
             else                          { base.name  = item.name;  }
             return base;
@@ -214,7 +220,8 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             var depsRaw   = row.getAttribute('data-depends-on') || '[]';
             var dependsOn = [];
             try { dependsOn = JSON.parse(depsRaw); } catch (_) {}
-            items.push({ name: name, source: 'existing', isTest: isTest, tier: tier, dependsOn: dependsOn, url: url });
+            var points = Math.max(1, parseInt(row.getAttribute('data-points')) || 1);
+            items.push({ name: name, source: 'existing', isTest: isTest, tier: tier, dependsOn: dependsOn, points: points, url: url });
         });
         renderTree();
         syncConfig();
@@ -236,7 +243,8 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
                 index:     idx,
                 isTest:    isLikelyScript(name),
                 tier:      isLikelyScript(name) ? 'public' : 'support',
-                dependsOn: []
+                dependsOn: [],
+                points:    1
             });
         });
         renderTree();

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -74,6 +74,7 @@ Create Assignment
                     <th>File</th>
                     <th>Test?</th>
                     <th>Tier</th>
+                    <th title="Grade point weight for this test (default 1)">Pts</th>
                 </tr>
             </thead>
             <tbody id="suite-config-body"></tbody>
@@ -112,7 +113,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     var body        = document.getElementById('suite-config-body');
     if (!filesInput || !configField || !panel || !body) return;
 
-    // items: [{ name, index, isTest, tier, dependsOn: [] }]
+    // items: [{ name, index, isTest, tier, dependsOn: [], points: 1 }]
     // Ordered by desired root-level sequence; children group under their parent visually.
     var items = [];
     var dragName = null;
@@ -161,6 +162,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         var indentStyle = depth > 0 ? ' class="suite-child-indent"' : '';
         var connector   = depth > 0 ? '<span class="suite-child-connector">&#9492;</span>' : '';
         var checked     = item.isTest ? ' checked' : '';
+        var pts         = item.points || 1;
         return '<tr data-name="' + escAttr(item.name) + '">'
             + '<td' + indentStyle + '>'
             +   '<span class="suite-drag-handle" title="Drag to reorder or adopt">&#10783;</span>'
@@ -171,6 +173,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             + '<td><select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">'
             +   tierOptions(item.tier)
             + '</select></td>'
+            + '<td><input type="number" class="form-input suite-points" min="1" max="100" value="' + pts + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
             + '</tr>';
     }
 
@@ -184,7 +187,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         }
         panel.style.display = '';
         body.innerHTML = visual.map(function (v) { return rowHTML(v.item, v.depth); }).join('')
-            + '<tr class="suite-root-drop"><td colspan="3">&#9660; Drop here to remove dependency</td></tr>';
+            + '<tr class="suite-root-drop"><td colspan="4">&#9660; Drop here to remove dependency</td></tr>';
     }
 
     function syncConfig() {
@@ -195,10 +198,12 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             if (row) {
                 var tierEl   = row.querySelector('.suite-tier');
                 var toggleEl = row.querySelector('.suite-test-toggle');
+                var ptsEl    = row.querySelector('.suite-points');
                 if (tierEl)   item.tier   = tierEl.value;
                 if (toggleEl) item.isTest = toggleEl.checked && item.tier !== 'support';
+                if (ptsEl)    item.points = Math.max(1, parseInt(ptsEl.value) || 1);
             }
-            return { index: item.index, isTest: item.isTest, tier: item.tier, order: i + 1, dependsOn: item.dependsOn };
+            return { index: item.index, isTest: item.isTest, tier: item.tier, order: i + 1, dependsOn: item.dependsOn, points: item.points || 1 };
         });
         configField.value = JSON.stringify(config);
     }
@@ -213,9 +218,10 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             return {
                 name:      file.name,
                 index:     idx,
-                isTest:    old ? old.isTest : isLikelyScript(file.name),
-                tier:      old ? old.tier   : (isLikelyScript(file.name) ? 'public' : 'support'),
-                dependsOn: old ? old.dependsOn.filter(function (d) { return newNames.has(d); }) : []
+                isTest:    old ? old.isTest  : isLikelyScript(file.name),
+                tier:      old ? old.tier    : (isLikelyScript(file.name) ? 'public' : 'support'),
+                dependsOn: old ? old.dependsOn.filter(function (d) { return newNames.has(d); }) : [],
+                points:    old ? old.points  : 1
             };
         });
         renderRows();

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -115,6 +115,7 @@ struct EditableSuiteRow: Encodable {
     let tier: String
     let order: Int
     let dependsOn: [String]    // script names of prerequisites; empty == none
+    let points: Int            // grade weight; 1 = default (unweighted)
 
     /// JSON-encoded `dependsOn` array for use as an HTML data attribute in Leaf templates.
     var dependsOnJSON: String {

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -19,6 +19,7 @@ struct EditSuiteConfigRow: Decodable {
     let tier: String?
     let order: Int?
     let dependsOn: [String]?   // script names of prerequisites
+    let points: Int?           // grade weight; nil decoded as 1
 }
 
 struct ReindexedSuiteConfigRow: Encodable {
@@ -27,6 +28,7 @@ struct ReindexedSuiteConfigRow: Encodable {
     let tier: String
     let order: Int?
     let dependsOn: [String]?   // script names of prerequisites
+    let points: Int            // grade weight; 1 = default (unweighted)
 }
 
 struct ResolvedEditSuiteFiles {
@@ -40,6 +42,7 @@ struct SuiteConfigRow: Decodable {
     let tier: String?
     let order: Int?
     let dependsOn: [String]?   // script names of prerequisites
+    let points: Int?           // grade weight; nil decoded as 1
 }
 
 struct ConfiguredSuiteEntry {
@@ -47,6 +50,7 @@ struct ConfiguredSuiteEntry {
     let tier: String
     let order: Int
     let dependsOn: [String]    // script names of prerequisites; empty == none
+    let points: Int            // grade weight; 1 = default (unweighted)
 }
 
 struct RunnerSetupPackage {
@@ -214,13 +218,13 @@ func currentSetupFiles(for setup: APITestSetup, assignmentID: String, hasValidat
         )
     }()
 
-    let manifestSuites: [(script: String, tier: String, order: Int, dependsOn: [String])] = {
+    let manifestSuites: [(script: String, tier: String, order: Int, dependsOn: [String], points: Int)] = {
         guard let data = setup.manifest.data(using: .utf8),
               let props = try? JSONDecoder().decode(TestProperties.self, from: data) else {
             return []
         }
         return props.testSuites.enumerated().map { (idx, item) in
-            (script: item.script, tier: item.tier.rawValue, order: idx + 1, dependsOn: item.dependsOn)
+            (script: item.script, tier: item.tier.rawValue, order: idx + 1, dependsOn: item.dependsOn, points: item.points)
         }
     }()
     let testMap = Dictionary(uniqueKeysWithValues: manifestSuites.map { ($0.script, $0) })
@@ -256,7 +260,8 @@ func currentSetupFiles(for setup: APITestSetup, assignmentID: String, hasValidat
             isTest: entry != nil,
             tier: entry?.tier ?? "support",
             order: entry?.order ?? (idx + 1),
-            dependsOn: entry?.dependsOn ?? []
+            dependsOn: entry?.dependsOn ?? [],
+            points: entry?.points ?? 1
         )
     }
 
@@ -351,14 +356,14 @@ func resolveEditSuiteFiles(
         var configRows: [ReindexedSuiteConfigRow] = []
         var nextOrder = 1
 
-        let manifestTests: [String: (tier: String, order: Int, dependsOn: [String])] = {
+        let manifestTests: [String: (tier: String, order: Int, dependsOn: [String], points: Int)] = {
             guard let data = setupManifestJSON.data(using: .utf8),
                   let props = try? JSONDecoder().decode(TestProperties.self, from: data) else {
                 return [:]
             }
-            var map: [String: (tier: String, order: Int, dependsOn: [String])] = [:]
+            var map: [String: (tier: String, order: Int, dependsOn: [String], points: Int)] = [:]
             for (idx, entry) in props.testSuites.enumerated() {
-                map[entry.script] = (entry.tier.rawValue, idx + 1, entry.dependsOn)
+                map[entry.script] = (entry.tier.rawValue, idx + 1, entry.dependsOn, entry.points)
             }
             return map
         }()
@@ -376,7 +381,8 @@ func resolveEditSuiteFiles(
                 isTest: testInfo != nil && tier != "support",
                 tier: tier,
                 order: testInfo?.order ?? nextOrder,
-                dependsOn: testInfo?.dependsOn
+                dependsOn: testInfo?.dependsOn,
+                points: testInfo?.points ?? 1
             ))
             nextOrder += 1
         }
@@ -398,7 +404,8 @@ func resolveEditSuiteFiles(
                 isTest: likelyTest,
                 tier: likelyTest ? "public" : "support",
                 order: nextOrder,
-                dependsOn: nil
+                dependsOn: nil,
+                points: 1
             ))
             nextOrder += 1
         }
@@ -453,7 +460,8 @@ func resolveEditSuiteFiles(
             isTest: isTest,
             tier: tier,
             order: row.order ?? nextOrder,
-            dependsOn: row.dependsOn
+            dependsOn: row.dependsOn,
+            points: row.points ?? 1
         ))
         nextOrder += 1
     }
@@ -686,7 +694,8 @@ func buildSuiteEntries(
                 script: script,
                 tier: tier,
                 order: row.order ?? (index + 1),
-                dependsOn: row.dependsOn ?? []
+                dependsOn: row.dependsOn ?? [],
+                points: row.points ?? 1
             ))
         }
         return selected
@@ -707,7 +716,8 @@ func buildSuiteEntries(
             script: script,
             tier: "public",
             order: inferredOrder(from: script) ?? (index + 1),
-            dependsOn: []
+            dependsOn: [],
+            points: 1
         ))
     }
     return defaults
@@ -751,6 +761,9 @@ func makeWorkerManifestJSON(
         var dict: [String: Any] = ["tier": entry.tier, "script": entry.script]
         if !entry.dependsOn.isEmpty {
             dict["dependsOn"] = entry.dependsOn
+        }
+        if entry.points > 1 {
+            dict["points"] = entry.points
         }
         return dict
     }


### PR DESCRIPTION
## Summary

- Adds a **Pts** column to the test suite editor (new and edit assignment pages) so instructors can set integer grade weights directly in the UI
- Wires the value end-to-end: form → `suiteConfig` JSON → `ConfiguredSuiteEntry` → manifest → runner → `TestOutcome` (backend was wired in the previous commit)
- Omits `"points"` from the manifest JSON when the value is 1, keeping unweighted manifests terse and backward compatible
- Existing assignments open in edit mode with their current `points` values pre-populated from the manifest

## Test plan

- [ ] Create a new assignment — verify each test row shows a Pts input defaulting to 1
- [ ] Set Pts to 2 on one test, submit; open the saved manifest and confirm `"points": 2` appears on that entry only
- [ ] Open an existing weighted assignment in edit mode; confirm Pts fields are pre-populated correctly
- [ ] Save without changing any Pts values; confirm manifest is unchanged
- [ ] Submit a student answer; confirm grade % uses weighted points (e.g. 2-pt test passing → "2 / 3 points" header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)