### PR TITLE
Fix suite management on edit page; inline file validation

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -67,9 +67,6 @@
         <span style="white-space:nowrap">Add Test Suite Files (scripts/support files like <code>.py</code> or <code>.r</code>)</span>
         <input class="form-input" id="suite-files-input" type="file" name="suiteFiles" multiple>
     </label>
-    <div id="upload-errors" style="display:none;margin-top:-.4rem;margin-bottom:.5rem;padding:.5rem .75rem;border-radius:.4rem;border:1px solid var(--red,#c0392b);background:var(--error-bg,#fff5f5)">
-        <ul id="upload-errors-list" style="margin:0;padding-left:1.2rem;font-size:.85rem;color:var(--red,#c0392b)"></ul>
-    </div>
     <input type="hidden" id="suite-config-field" name="suiteConfig" value="">
 
     <p class="card-meta" style="margin-bottom:.4rem">
@@ -111,7 +108,7 @@
     </p>
 
     <div style="display:flex;gap:.6rem;flex-wrap:wrap">
-        <button class="btn btn-primary" type="submit">Save &amp; Validate</button>
+        <button class="btn btn-primary" type="submit">Save</button>
         <a class="btn" href="/assignments">Cancel</a>
     </div>
 </form>
@@ -126,6 +123,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 .suite-root-drop.drop-hover { background: var(--hover-bg, #f5f5f5); }
 .suite-child-indent { padding-left: 2rem; white-space: nowrap; }
 .suite-child-connector { color: var(--meta); margin-right: .25rem; font-size: .85em; }
+.suite-upload-error { font-size: .78rem; color: var(--red,#c0392b); margin-top: .2rem; }
 </style>
 <script>
 (function () {
@@ -178,9 +176,6 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 
     // Initialise the due-date display on load
     refreshDueDisplay();
-    if (dueInput && dueInput.value) {
-        checkUWDates(dueInput.value, document.getElementById('uw-date-warning'));
-    }
 
     // ── Suite file management ─────────────────────────────────────────────────
 
@@ -203,30 +198,13 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
                        'png','jpg','jpeg','gif','bmp','svg','pdf','doc','docx',
                        'xls','xlsx','ppt','pptx','mp3','mp4','mov','avi'];
 
-    function validateUploads(files, existingNames) {
-        var errors = [];
-        files.forEach(function (file) {
-            var ext = (file.name || '').toLowerCase().split('.').pop();
-            if (BINARY_EXTS.indexOf(ext) >= 0) {
-                errors.push('\u201c' + escHtml(file.name) + '\u201d looks like a binary file and is unlikely to work as a test script.');
-            }
-            if (!file.name.includes('.')) {
-                errors.push('\u201c' + escHtml(file.name) + '\u201d has no file extension.');
-            }
-            if (file.size === 0) {
-                errors.push('\u201c' + escHtml(file.name) + '\u201d is empty.');
-            }
-        });
-        var errDiv  = document.getElementById('upload-errors');
-        var errList = document.getElementById('upload-errors-list');
-        if (!errDiv || !errList) return;
-        if (errors.length > 0) {
-            errList.innerHTML = errors.map(function (e) { return '<li>' + e + '</li>'; }).join('');
-            errDiv.style.display = '';
-        } else {
-            errDiv.style.display = 'none';
-            errList.innerHTML = '';
-        }
+    function fileErrors(file) {
+        var errs = [];
+        var ext = (file.name || '').toLowerCase().split('.').pop();
+        if (BINARY_EXTS.indexOf(ext) >= 0) errs.push('Binary file — unlikely to work as a test script');
+        if (!file.name.includes('.'))       errs.push('No file extension');
+        if (file.size === 0)                errs.push('Empty file');
+        return errs;
     }
 
     function hasChildren(name) {
@@ -265,7 +243,11 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 
     function rowHTML(item, depth) {
         var isNew     = item.source === 'upload';
-        var label     = isNew ? '<code>' + escHtml(item.name) + '</code> <span class="card-meta">(new)</span>'
+        var errs      = (item.errors && item.errors.length > 0) ? item.errors : [];
+        var errBadge  = errs.length > 0
+            ? '<div class="suite-upload-error">\u26a0 ' + errs.map(escHtml).join(' · ') + '</div>'
+            : '';
+        var label     = isNew ? '<code>' + escHtml(item.name) + '</code> <span class="card-meta">(new)</span>' + errBadge
                                : '<a href="' + escAttr(item.url || '#') + '"><code>' + escHtml(item.name) + '</code></a>';
         var indent    = depth > 0 ? ' class="suite-child-indent"' : '';
         var connector = depth > 0 ? '<span class="suite-child-connector">&#9492;</span>' : '';
@@ -333,22 +315,19 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     // Add newly uploaded files to the items list (appended as root items)
     function addUploadedFiles() {
         var files = Array.from(filesInput.files || []);
-        validateUploads(files, new Set(items.filter(function (it) { return it.source !== 'upload'; }).map(function (it) { return it.name; })));
         // Remove previously added upload items (re-add fresh)
         items = items.filter(function (it) { return it.source !== 'upload'; });
-        var existingNames = new Set(items.map(function (it) { return it.name; }));
         files.forEach(function (file, idx) {
             var name = file.name;
-            // Avoid name collision with existing files
-            var finalName = existingNames.has(name) ? name : name;
             items.push({
-                name:      finalName,
+                name:      name,
                 source:    'upload',
                 index:     idx,
                 isTest:    isLikelyScript(name),
                 tier:      isLikelyScript(name) ? 'public' : 'support',
                 dependsOn: [],
-                points:    1
+                points:    1,
+                errors:    fileErrors(file)
             });
         });
         renderTree();


### PR DESCRIPTION
## Summary

- **Bug fix:** The synchronous `checkUWDates()` call introduced in #121 ran before that function was defined (it lives in a later `<script>` block). The resulting `ReferenceError` aborted the IIFE before any event listeners were registered — delete, drag-and-drop, and file-change handling were all broken. Removing the synchronous call fixes everything; the `change`-event listener is sufficient for the UW date warning.
- **Inline validation:** File validation errors (binary extension, empty file, no extension) are now shown as a ⚠ badge directly under the filename in the table row, computed immediately when files are selected. The separate error-list div above the table is removed.
- **Button rename:** "Save & Validate" → "Save".

## Test plan
- [ ] Open an existing assignment's Edit page — existing rows appear and Delete buttons work
- [ ] Pick files via the file input — they appear in the table immediately
- [ ] Pick a `.png` or zero-byte file — ⚠ warning appears inline in that row
- [ ] Pick a `.py` file — no warning badge
- [ ] Submit form — saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)