### PR TITLE
Fix suite drag and bfcache stale page on edit assignment

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -85,7 +85,7 @@
         </thead>
         <tbody id="suite-config-body">
             #for(row in existingSuiteRows):
-            <tr data-source="existing" data-name="#(row.name)" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)" data-points="#(row.points)">
+            <tr draggable="true" data-source="existing" data-name="#(row.name)" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)" data-points="#(row.points)">
                 <td><span class="suite-drag-handle" title="Drag to reorder or adopt">⋮⋮</span><a href="#(row.url)"><code>#(row.name)</code></a></td>
                 <td><input type="checkbox" class="suite-test-toggle" #if(row.isTest):checked#endif></td>
                 <td>
@@ -253,7 +253,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         var connector = depth > 0 ? '<span class="suite-child-connector">&#9492;</span>' : '';
         var checked   = item.isTest ? ' checked' : '';
         var pts       = item.points || 1;
-        return '<tr data-name="' + escAttr(item.name) + '" data-source="' + escAttr(item.source) + '">'
+        return '<tr draggable="true" data-name="' + escAttr(item.name) + '" data-source="' + escAttr(item.source) + '">'
             + '<td' + indent + '>'
             +   '<span class="suite-drag-handle" title="Drag to reorder or adopt">⋮⋮</span>'
             +   connector + label
@@ -443,6 +443,12 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     function escAttr(v) { return String(v).replaceAll('"','&quot;'); }
 
     initFromDOM();
+
+    // Reload when restored from bfcache (browser back/forward) so the page
+    // always reflects the server's current state rather than a cached snapshot.
+    window.addEventListener('pageshow', function (e) {
+        if (e.persisted) window.location.reload();
+    });
 
 })();
 </script>


### PR DESCRIPTION
## Summary

- **Drag:** `<tr>` rows were missing `draggable="true"`, so `dragstart` never fired and the ⋮⋮ handle was cosmetic-only. Added to both server-rendered Leaf rows and the JS `rowHTML()` function. The existing `dragstart` handler already gates on the handle element, so dragging from other cells cancels gracefully.
- **Delete appears to revert:** After a successful save the server redirects to `/assignments`. Pressing the browser Back button restored the bfcache snapshot of the *pre-save* edit page, making deleted files appear to come back. A `pageshow` listener reloads the page whenever `event.persisted` is true, ensuring the live server state is always shown.

## Test plan
- [ ] Open Edit Assignment — drag a row by its ⋮⋮ handle; it should reorder
- [ ] Delete a file, click Save, get redirected to Assignments list, press Back — edit page reloads fresh and the deleted file is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)