### PR TITLE
fix: fixed-width due date column for consistent table layout

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -381,6 +381,7 @@ textarea.form-input {
 .results-table .due-col {
     text-align: left;
     white-space: nowrap;
+    width: 11rem;
 }
 
 /* Status colour strips */


### PR DESCRIPTION
## Summary
- Adds `width: 11rem` to `.results-table .due-col` so the Due column takes up a fixed amount of space on both student and instructor assignment tables
- Prevents table column widths from shifting depending on whether a due date is set or the cell shows "—"

## Test plan
- [ ] View student dashboard with a mix of assignments that have and don't have due dates — Due column should be the same width in all cases
- [ ] View instructor assignments page — same consistent Due column width

🤖 Generated with [Claude Code](https://claude.com/claude-code)