### PR TITLE
Fix Leaf lexer error in assignment editor (displayName ?? "")

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -86,9 +86,9 @@
         </thead>
         <tbody id="suite-config-body">
             #for(row in existingSuiteRows):
-            <tr draggable="true" data-source="existing" data-name="#(row.name)" data-display-name="#(row.displayName ?? "")" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)" data-points="#(row.points)">
+            <tr draggable="true" data-source="existing" data-name="#(row.name)" data-display-name="#(row.displayNameOrEmpty)" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)" data-points="#(row.points)">
                 <td><span class="suite-drag-handle" title="Drag to reorder or adopt">⋮⋮</span><a href="#(row.url)"><code>#(row.name)</code></a></td>
-                <td><input type="text" class="form-input suite-display-name" placeholder="e.g. Bit Count" value="#(row.displayName ?? "")" style="width:10rem;padding:.25rem .5rem;font-size:.8rem"></td>
+                <td><input type="text" class="form-input suite-display-name" placeholder="e.g. Bit Count" value="#(row.displayNameOrEmpty)" style="width:10rem;padding:.25rem .5rem;font-size:.8rem"></td>
                 <td><input type="checkbox" class="suite-test-toggle" #if(row.isTest):checked#endif></td>
                 <td>
                     <select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -118,6 +118,9 @@ struct EditableSuiteRow: Encodable {
     let points: Int            // grade weight; 1 = default (unweighted)
     let displayName: String?   // optional human-readable name shown to students
 
+    /// Empty string when displayName is nil — Leaf doesn't support `??` in templates.
+    var displayNameOrEmpty: String { displayName ?? "" }
+
     /// JSON-encoded `dependsOn` array for use as an HTML data attribute in Leaf templates.
     var dependsOnJSON: String {
         let data = (try? JSONEncoder().encode(dependsOn)) ?? Data("[]".utf8)


### PR DESCRIPTION
## Summary

- LeafKit doesn't support the `??` nil-coalescing operator in templates
- Adds a `displayNameOrEmpty: String` computed property to `EditableSuiteRow` (`displayName ?? ""`) and uses `#(row.displayNameOrEmpty)` in the template instead

Fixes the crash when loading the assignment edit page after #127.

## Test plan
- [ ] Open an assignment edit page — no more lexer error
- [ ] Display names still pre-populate correctly for existing assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)