### PR TITLE
Apply test display names retroactively on submission results page

### DIFF
--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -656,6 +656,21 @@ struct WebRoutes: RouteCollection {
             }
         }
 
+        // Build a stem→displayName map from the current manifest so the page
+        // shows friendly names for both new submissions (where the runner already
+        // embedded the name) and old ones (where testName is still the filename stem).
+        var displayNameMap: [String: String] = [:]
+        if let setup = try? await APITestSetup.find(submission.testSetupID, on: req.db),
+           let manifestData = setup.manifest.data(using: .utf8),
+           let props = try? JSONDecoder().decode(TestProperties.self, from: manifestData) {
+            for entry in props.testSuites {
+                guard let displayName = entry.name,
+                      !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+                let stem = (entry.script as NSString).deletingPathExtension
+                displayNameMap[stem.isEmpty ? entry.script : stem] = displayName
+            }
+        }
+
         if let result = displayResult {
             resultSource = result.source ?? "worker"
             if let data       = result.collectionJSON.data(using: .utf8),
@@ -697,7 +712,7 @@ struct WebRoutes: RouteCollection {
                     }()
                     let pointsLabel: String? = weighted && o.points > 1 ? "\(o.points) pts" : nil
                     return OutcomeRow(
-                        testName:       o.testName,
+                        testName:       displayNameMap[o.testName] ?? o.testName,
                         tier:           o.tier.rawValue,
                         status:         o.status.rawValue,
                         shortResult:    o.shortResult,


### PR DESCRIPTION
## Summary

The runner now embeds display names in new `TestOutcome` records, but submissions that ran before this feature was added have the raw filename stem baked into `collectionJSON`. This fix loads the test setup manifest at render time on `/submissions/:id` and overlays any display names — so both old and new submissions show friendly test names.

- Builds a `stem → displayName` map from the manifest
- Applies it when constructing `OutcomeRow.testName` (`displayNameMap[o.testName] ?? o.testName`)
- No-ops cleanly when no display names are set in the manifest

## Test plan
- [ ] View an old submission (stored before display names were added) — friendly names now shown
- [ ] View a new submission — friendly names shown (same as before via runner)
- [ ] View a submission for an assignment with no display names — filename stems shown unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)