### PR TITLE
Add filter inputs to Users and submissions tables

### DIFF
--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -122,11 +122,11 @@ Admin
 
 <!-- ── Users ──────────────────────────────────────────── -->
 <section class="admin-section">
-    <h2>Users</h2>
-    <div style="margin-bottom:.75rem">
+    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
+        <h2 style="margin:0">Users</h2>
         <input id="users-filter" class="form-input" type="search"
                placeholder="Filter by name, username or role…"
-               style="max-width:340px" aria-label="Filter users">
+               style="width:280px" aria-label="Filter users">
     </div>
     <table class="results-table" id="users-table">
         <thead>

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -3,9 +3,14 @@
 #(assignmentTitle) — Submissions
 #endexport
 #export("content"):
-<div style="display:flex;justify-content:space-between;align-items:baseline;flex-wrap:wrap;gap:.75rem;margin-bottom:1rem">
+<div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:.75rem;margin-bottom:1rem">
     <h1 style="margin:0">#(assignmentTitle)</h1>
-    <a class="btn action-btn" href="/assignments">Back to Instructor</a>
+    <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
+        <input id="submissions-filter" class="form-input" type="search"
+               placeholder="Filter by name or ID…"
+               style="width:220px" aria-label="Filter students">
+        <a class="btn action-btn" href="/assignments">Back to Instructor</a>
+    </div>
 </div>
 
 #if(rows.isEmpty):
@@ -153,6 +158,18 @@
     });
 
     sortByHeader(headers[0], 'asc');
+
+    var filter = document.getElementById('submissions-filter');
+    if (filter && tbody) {
+        filter.addEventListener('input', function () {
+            var query = filter.value.trim().toLowerCase();
+            Array.from(tbody.querySelectorAll('tr')).forEach(function (row) {
+                if (!query) { row.hidden = false; return; }
+                var text = (row.textContent || '').toLowerCase();
+                row.hidden = !text.includes(query);
+            });
+        });
+    }
 })();
 </script>
 #endexport


### PR DESCRIPTION
## Summary

- **admin.leaf**: restores the user-filter search input to the Users section header row (h2 on the left, filter on the right), matching the visual pattern of the Courses section
- **assignment-submissions.leaf**: adds a live filter input to the page header (between the assignment title and the Back to Instructor button); rows are hidden client-side when the student name or ID doesn't match the query

## Test plan

- [ ] Admin panel → Users section: search input appears inline with the "Users" heading; typing filters the table rows in real time
- [ ] Instructor → assignment submissions page: search input appears in the top-right header area; typing filters rows by name / student ID
- [ ] Empty query restores all rows in both tables
- [ ] Sorting and filtering work together on the submissions table

🤖 Generated with [Claude Code](https://claude.com/claude-code)