### PR TITLE
Add Marmoset export import feature

### DIFF
--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -54,6 +54,7 @@
                     onclick="return confirm('Archive #(course.code)? Students will no longer see this course.')">Archive</button>
             #endif
         </form>
+        <a href="/admin/courses/#(course.id)/import-marmoset" class="btn">Import from Marmoset</a>
         <a href="/admin/courses/#(course.id)/export" class="btn">Export bundle</a>
     </div>
 </div>

--- a/Resources/Views/marmoset-import-result.leaf
+++ b/Resources/Views/marmoset-import-result.leaf
@@ -1,0 +1,63 @@
+#extend("base"):
+#export("title"):
+Marmoset import result — #(courseCode) — Admin
+#endexport
+#export("content"):
+<div style="display:flex;align-items:center;gap:.75rem;margin-bottom:1.5rem;flex-wrap:wrap">
+    <h1 style="margin:0">Marmoset import complete</h1>
+    <span class="tier tier-open">success</span>
+    <span style="color:var(--text-secondary)">#(courseCode) — #(courseName)</span>
+</div>
+
+<section class="admin-section">
+    #if(assignments.isEmpty):
+    <p class="empty">No assignments were imported. The archive may not contain any valid project groups.</p>
+    #else:
+    <p style="margin-bottom:1rem;color:var(--text-secondary);font-size:.9rem">
+        #count(assignments) assignment(s) imported. All are closed and pending validation.
+        Edit each assignment to set <strong>requiredFiles</strong>, then validate and open.
+    </p>
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Test suites</th>
+                <th>Notebook</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        #for(a in assignments):
+            <tr>
+                <td>#(a.title)</td>
+                <td>#(a.suiteCount)</td>
+                <td>
+                    #if(a.hasNotebook):
+                    <span class="tier tier-open">yes</span>
+                    #else:
+                    <span style="color:var(--text-secondary)">—</span>
+                    #endif
+                </td>
+                <td style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    <a href="/assignments/#(a.publicID)/validate" class="btn action-btn btn-primary">Validate</a>
+                    <a href="/assignments/#(a.publicID)/edit" class="btn action-btn">Edit</a>
+                    #if(a.hasCanonical):
+                    <a href="/admin/courses/#(courseID)/import-marmoset/canonical/#(a.setupID)"
+                       class="btn action-btn">Download canonical</a>
+                    #endif
+                </td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+    #endif
+
+    <div style="display:flex;gap:.75rem;margin-top:1.25rem;flex-wrap:wrap">
+        <a href="/assignments" class="btn btn-primary">Assignments</a>
+        <a href="/admin/courses/#(courseID)" class="btn">Course detail</a>
+        <a href="/admin/courses/#(courseID)/import-marmoset" class="btn">Import another</a>
+    </div>
+</section>
+
+#endexport
+#endextend

--- a/Resources/Views/marmoset-import.leaf
+++ b/Resources/Views/marmoset-import.leaf
@@ -1,0 +1,73 @@
+#extend("base"):
+#export("title"):
+Import from Marmoset — #(courseCode) — Admin
+#endexport
+#export("content"):
+<div style="display:flex;align-items:center;gap:.75rem;margin-bottom:1.5rem;flex-wrap:wrap">
+    <h1 style="margin:0">Import from Marmoset</h1>
+    <span style="color:var(--text-secondary)">#(courseCode) — #(courseName)</span>
+</div>
+
+#if(error):
+<div class="form-error" style="margin-bottom:1rem">#(error)</div>
+#endif
+
+<section class="admin-section">
+    <h2>Upload Marmoset export</h2>
+    <p style="margin-bottom:1rem;color:var(--text-secondary);font-size:.9rem">
+        Upload a Marmoset course export zip (e.g. <code>COURSE-export.zip</code>).
+        One assignment will be created for each project found in the archive.
+        Assignments will be closed and require validation before opening.
+    </p>
+    <form method="post"
+          action="/admin/courses/#(courseID)/import-marmoset"
+          enctype="multipart/form-data"
+          style="display:flex;flex-direction:column;gap:1rem;max-width:480px">
+        <label class="form-label">
+            Marmoset export zip
+            <input class="form-input" type="file" name="file" accept=".zip" required
+                   style="display:block;margin-top:.25rem">
+        </label>
+        <div style="display:flex;gap:.75rem">
+            <button class="btn btn-primary" type="submit">Import</button>
+            <a href="/admin/courses/#(courseID)" class="btn">Cancel</a>
+        </div>
+    </form>
+</section>
+
+<section class="admin-section" style="margin-top:1.5rem">
+    <h2>What gets imported</h2>
+    <table class="results-table" style="max-width:640px">
+        <thead>
+            <tr>
+                <th>Marmoset file</th>
+                <th>Chickadee action</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>&lt;n&gt;-test-setup.zip</code></td>
+                <td>Creates a test setup. <code>test.properties</code> is converted to a Chickadee manifest; all other files are kept.</td>
+            </tr>
+            <tr>
+                <td><code>&lt;n&gt;-canonical.zip</code></td>
+                <td>Stored for download. Use it on the validate page to run the test suite against the reference solution.</td>
+            </tr>
+            <tr>
+                <td><code>&lt;n&gt;-project-starter-files.zip</code></td>
+                <td>If a <code>.ipynb</code> is found, it becomes the JupyterLite notebook for the assignment.</td>
+            </tr>
+            <tr>
+                <td><code>&lt;n&gt;.project.out</code></td>
+                <td>Assignment title is extracted if possible; otherwise defaults to "Imported Assignment N".</td>
+            </tr>
+        </tbody>
+    </table>
+    <p style="margin-top:.75rem;color:var(--text-secondary);font-size:.85rem">
+        After import, edit each assignment to set <strong>requiredFiles</strong>
+        (the file students must submit) and then run validation before opening.
+    </p>
+</section>
+
+#endexport
+#endextend

--- a/Sources/APIServer/Routes/Web/MarmosetImportRoutes.swift
+++ b/Sources/APIServer/Routes/Web/MarmosetImportRoutes.swift
@@ -1,0 +1,294 @@
+// APIServer/Routes/Web/MarmosetImportRoutes.swift
+//
+// Marmoset export import routes (admin only).
+//
+//   GET  /admin/courses/:courseID/import-marmoset              — upload form
+//   POST /admin/courses/:courseID/import-marmoset              — process import
+//   GET  /admin/courses/:courseID/import-marmoset/canonical/:setupID
+//                                                               — download stored canonical zip
+//
+// Import rules:
+//   - One assignment is created per project found in the export.
+//   - test.properties is parsed to build a Chickadee TestProperties manifest.
+//   - Makefile presence is detected from the inner zip, not from test.properties.
+//   - Canonical zip is stored alongside the test setup for manual validation.
+//   - Starter-files .ipynb (if present) becomes the JupyterLite notebook.
+//   - requiredFiles is left empty — instructor fills it in after import.
+//   - All assignments are created closed with validationStatus: nil.
+
+import Vapor
+import Fluent
+import Core
+import Foundation
+
+struct MarmosetImportRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let r = routes.grouped("admin", "courses", ":courseID", "import-marmoset")
+        r.get(use: importForm)
+        r.post(use: processImport)
+        r.get("canonical", ":setupID", use: downloadCanonical)
+    }
+
+    // MARK: - GET /admin/courses/:courseID/import-marmoset
+
+    @Sendable
+    func importForm(req: Request) async throws -> View {
+        let caller = try req.auth.require(APIUser.self)
+        guard caller.isAdmin else { throw Abort(.forbidden) }
+
+        guard let courseIDStr = req.parameters.get("courseID"),
+              let courseUUID  = UUID(uuidString: courseIDStr),
+              let course      = try await APICourse.find(courseUUID, on: req.db)
+        else { throw Abort(.notFound, reason: "Course not found") }
+
+        struct ImportFormContext: Encodable {
+            let currentUser: CurrentUserContext?
+            let courseID: String
+            let courseCode: String
+            let courseName: String
+            let error: String?
+        }
+
+        let errorMsg = req.query[String.self, at: "error"]
+        return try await req.view.render("marmoset-import", ImportFormContext(
+            currentUser: req.currentUserContext,
+            courseID:    courseIDStr,
+            courseCode:  course.code,
+            courseName:  course.name,
+            error:       errorMsg
+        ))
+    }
+
+    // MARK: - POST /admin/courses/:courseID/import-marmoset
+
+    @Sendable
+    func processImport(req: Request) async throws -> View {
+        let caller = try req.auth.require(APIUser.self)
+        guard caller.isAdmin else { throw Abort(.forbidden) }
+
+        guard let courseIDStr = req.parameters.get("courseID"),
+              let courseUUID  = UUID(uuidString: courseIDStr),
+              let course      = try await APICourse.find(courseUUID, on: req.db)
+        else { throw Abort(.notFound, reason: "Course not found") }
+
+        // ── 1. Receive uploaded zip ────────────────────────────────────
+
+        struct MarmosetUpload: Content {
+            let file: File
+        }
+        let upload = try req.content.decode(MarmosetUpload.self)
+        var buffer = upload.file.data
+        guard buffer.readableBytes > 0,
+              let fileBytes = buffer.readBytes(length: buffer.readableBytes)
+        else {
+            throw Abort(.badRequest, reason: "Empty file uploaded")
+        }
+
+        // ── 2. Save to temp file and extract ──────────────────────────
+
+        let tmpZipPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("marmoset-import-\(UUID().uuidString).zip").path
+        let extractDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("marmoset-import-ex-\(UUID().uuidString)", isDirectory: true)
+
+        defer {
+            try? FileManager.default.removeItem(atPath: tmpZipPath)
+            try? FileManager.default.removeItem(at: extractDir)
+        }
+
+        try Data(fileBytes).write(to: URL(fileURLWithPath: tmpZipPath))
+        try await extractZipArchive(zipPath: tmpZipPath, into: extractDir)
+
+        // ── 3. Parse projects ──────────────────────────────────────────
+
+        let projects: [MarmosetProject]
+        do {
+            projects = try parseMarmosetExport(from: extractDir)
+        } catch {
+            throw Abort(.badRequest, reason: "Failed to parse Marmoset export: \(error)")
+        }
+
+        guard !projects.isEmpty else {
+            throw Abort(.badRequest, reason: "No projects found in the Marmoset export. Expected files named <n>-test-setup.zip.")
+        }
+
+        // ── 4. Import each project ─────────────────────────────────────
+
+        var imported: [ImportedAssignment] = []
+
+        for project in projects {
+            let n = project.number
+            let setupsDir = req.application.testSetupsDirectory
+            let setupID   = "setup_\(UUID().uuidString.lowercased().prefix(8))"
+
+            // ── 4a. Build the Chickadee test setup zip ─────────────────
+
+            let innerZipPath = extractDir.appendingPathComponent("\(n)-test-setup.zip").path
+            guard FileManager.default.fileExists(atPath: innerZipPath) else { continue }
+
+            let stagingDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("marmoset-staging-\(UUID().uuidString)", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: stagingDir) }
+
+            try await extractZipArchive(zipPath: innerZipPath, into: stagingDir)
+
+            // Remove Marmoset-specific files that have no place in Chickadee.
+            let filesToRemove = ["test.properties"]
+            for name in filesToRemove {
+                let path = stagingDir.appendingPathComponent(name)
+                try? FileManager.default.removeItem(at: path)
+            }
+            // Remove __MACOSX resource fork directory if present.
+            let macosx = stagingDir.appendingPathComponent("__MACOSX")
+            try? FileManager.default.removeItem(at: macosx)
+
+            let setupZipPath = setupsDir + "\(setupID).zip"
+            try await createZipArchive(sourceDir: stagingDir, outputPath: setupZipPath)
+
+            // ── 4b. Build the manifest ─────────────────────────────────
+
+            let manifestJSON: String
+            do {
+                manifestJSON = try convertToChickadeeManifest(project: project)
+            } catch {
+                req.logger.warning("Marmoset import: failed to build manifest for project \(n): \(error)")
+                continue
+            }
+
+            let totalSuites = project.publicTests.count + project.releaseTests.count + project.secretTests.count
+            guard totalSuites > 0 else {
+                req.logger.warning("Marmoset import: project \(n) has no test cases, skipping")
+                continue
+            }
+
+            // ── 4c. Store the canonical zip ────────────────────────────
+
+            var hasCanonical = false
+            let canonicalSrcPath = extractDir.appendingPathComponent("\(n)-canonical.zip").path
+            if FileManager.default.fileExists(atPath: canonicalSrcPath) {
+                let canonicalDstPath = setupsDir + "\(setupID)-canonical.zip"
+                try? FileManager.default.copyItem(
+                    atPath: canonicalSrcPath,
+                    toPath: canonicalDstPath
+                )
+                hasCanonical = FileManager.default.fileExists(atPath: canonicalDstPath)
+            }
+
+            // ── 4d. Extract starter notebook (if any) ─────────────────
+
+            var notebookPath: String? = nil
+            let starterZipPath = extractDir.appendingPathComponent("\(n)-project-starter-files.zip").path
+            if FileManager.default.fileExists(atPath: starterZipPath),
+               let notebookFilename = try? firstNotebookInZip(zipPath: starterZipPath),
+               let notebookData = try? extractNotebookFromZip(zipPath: starterZipPath, filename: notebookFilename) {
+                let normalized = normalizeNotebookForJupyterLite(notebookData)
+                let notebookDir = setupsDir + "notebooks/\(setupID)/"
+                try FileManager.default.createDirectory(atPath: notebookDir,
+                                                        withIntermediateDirectories: true)
+                let nbPath = notebookDir + notebookFilename
+                try normalized.write(to: URL(fileURLWithPath: nbPath))
+                notebookPath = nbPath
+            }
+
+            // ── 4e. Save test setup to DB ──────────────────────────────
+
+            let setup = APITestSetup(
+                id: setupID,
+                manifest: manifestJSON,
+                zipPath: setupZipPath,
+                notebookPath: notebookPath,
+                courseID: courseUUID
+            )
+            try await setup.save(on: req.db)
+
+            // ── 4f. Create the assignment ──────────────────────────────
+
+            let title = project.suggestedTitle ?? "Imported Assignment \(n)"
+            let assignment = try await createAssignmentWithUniquePublicID(
+                req: req,
+                testSetupID: setupID,
+                title: title,
+                dueAt: nil,
+                isOpen: false,
+                sortOrder: try await nextAssignmentSortOrder(req: req),
+                validationStatus: nil,
+                validationSubmissionID: nil,
+                sectionID: nil,
+                courseID: courseUUID
+            )
+
+            imported.append(ImportedAssignment(
+                title:        title,
+                publicID:     assignment.publicID,
+                setupID:      setupID,
+                suiteCount:   totalSuites,
+                hasCanonical: hasCanonical,
+                hasNotebook:  notebookPath != nil
+            ))
+
+            req.logger.info("Marmoset import: created assignment '\(title)' (setup \(setupID)) for course \(courseUUID)")
+        }
+
+        // ── 5. Render result page ──────────────────────────────────────
+
+        struct ResultContext: Encodable {
+            let currentUser: CurrentUserContext?
+            let courseID: String
+            let courseCode: String
+            let courseName: String
+            let assignments: [ImportedAssignment]
+        }
+
+        return try await req.view.render("marmoset-import-result", ResultContext(
+            currentUser:  req.currentUserContext,
+            courseID:     courseIDStr,
+            courseCode:   course.code,
+            courseName:   course.name,
+            assignments:  imported
+        ))
+    }
+
+    // MARK: - GET /admin/courses/:courseID/import-marmoset/canonical/:setupID
+
+    @Sendable
+    func downloadCanonical(req: Request) async throws -> Response {
+        let caller = try req.auth.require(APIUser.self)
+        guard caller.isAdmin else { throw Abort(.forbidden) }
+
+        guard let courseIDStr = req.parameters.get("courseID"),
+              let courseUUID  = UUID(uuidString: courseIDStr)
+        else { throw Abort(.badRequest) }
+
+        guard let setupID = req.parameters.get("setupID"),
+              setupID.hasPrefix("setup_")
+        else { throw Abort(.badRequest) }
+
+        // Verify the test setup belongs to this course.
+        guard let setup = try await APITestSetup.find(setupID, on: req.db),
+              setup.courseID == courseUUID
+        else { throw Abort(.notFound) }
+
+        let canonicalPath = req.application.testSetupsDirectory + "\(setupID)-canonical.zip"
+        guard FileManager.default.fileExists(atPath: canonicalPath),
+              let zipData = try? Data(contentsOf: URL(fileURLWithPath: canonicalPath))
+        else { throw Abort(.notFound, reason: "Canonical zip not found") }
+
+        var headers = HTTPHeaders()
+        headers.add(name: .contentType, value: "application/zip")
+        headers.add(name: .contentDisposition,
+                    value: "attachment; filename=\"\(setupID)-canonical.zip\"")
+        headers.add(name: .contentLength, value: "\(zipData.count)")
+        return Response(status: .ok, headers: headers, body: .init(data: zipData))
+    }
+}
+
+// MARK: - Supporting types
+
+struct ImportedAssignment: Encodable, Sendable {
+    let title: String
+    let publicID: String
+    let setupID: String
+    let suiteCount: Int
+    let hasCanonical: Bool
+    let hasNotebook: Bool
+}

--- a/Sources/APIServer/Utilities/MarmosetImportParser.swift
+++ b/Sources/APIServer/Utilities/MarmosetImportParser.swift
@@ -1,0 +1,286 @@
+// APIServer/Utilities/MarmosetImportParser.swift
+//
+// Utilities for parsing Marmoset export zips and converting them to
+// Chickadee test setups.
+//
+// Marmoset exports a zip containing per-project file groups:
+//   <n>-test-setup.zip          — test scripts, Makefile, support files, test.properties
+//   <n>-canonical.zip           — canonical reference solution
+//   <n>-project-starter-files.zip  — student starter template (may include .ipynb)
+//   <n>.project.out             — Java-serialised project metadata (title, IDs)
+//
+// Only `test.class.*` fields from test.properties are read; all `build.*`
+// fields are ignored — Chickadee always uses its own Makefile handling.
+
+import Foundation
+
+// MARK: - Parsed Marmoset project
+
+struct MarmosetProject: Sendable {
+    let number: Int
+    let publicTests: [String]
+    let releaseTests: [String]
+    let secretTests: [String]
+    let hasMakefile: Bool
+    let suggestedTitle: String?
+}
+
+// MARK: - Entry point
+
+/// Parses the contents of an extracted Marmoset export directory and returns
+/// one `MarmosetProject` per project number found.
+///
+/// `extractedDir` is the directory produced by extracting the outer export zip.
+func parseMarmosetExport(from extractedDir: URL) throws -> [MarmosetProject] {
+    let fm = FileManager.default
+    let entries = try fm.contentsOfDirectory(atPath: extractedDir.path)
+
+    // Find project numbers by looking for "<n>-test-setup.zip".
+    let projectNumbers: [Int] = entries.compactMap { name -> Int? in
+        guard name.hasSuffix("-test-setup.zip") else { return nil }
+        let prefix = name.dropLast("-test-setup.zip".count)
+        return Int(prefix)
+    }.sorted()
+
+    return try projectNumbers.map { n in
+        try parseProject(number: n, in: extractedDir, entries: entries)
+    }
+}
+
+// MARK: - Per-project parsing
+
+private func parseProject(number n: Int, in dir: URL, entries: [String]) throws -> MarmosetProject {
+    let fm = FileManager.default
+    let testSetupZip = dir.appendingPathComponent("\(n)-test-setup.zip").path
+    let projectOutPath = dir.appendingPathComponent("\(n).project.out").path
+
+    // ── 1. List inner zip contents ─────────────────────────────────────
+
+    let innerEntries: [String]
+    do {
+        innerEntries = try listZipContents(zipPath: testSetupZip)
+    } catch {
+        innerEntries = []
+    }
+
+    // ── 2. Check for Makefile ──────────────────────────────────────────
+
+    let hasMakefile = innerEntries.contains { entry in
+        let name = (entry as NSString).lastPathComponent
+        return name == "Makefile" || name == "makefile"
+    }
+
+    // ── 3. Extract and parse test.properties ──────────────────────────
+
+    let propsData = try extractFileFromZip(zipPath: testSetupZip, filename: "test.properties")
+    let props = propsData.flatMap { parseJavaProperties($0) } ?? [:]
+
+    let publicTests  = parseTestClassList(props["test.class.public"]  ?? "")
+    let releaseTests = parseTestClassList(props["test.class.release"] ?? "")
+    let secretTests  = parseTestClassList(props["test.class.secret"]  ?? "")
+
+    // ── 4. Try to extract title from project.out ───────────────────────
+
+    let suggestedTitle: String?
+    if fm.fileExists(atPath: projectOutPath),
+       let outData = try? Data(contentsOf: URL(fileURLWithPath: projectOutPath)) {
+        suggestedTitle = extractTitleFromProjectOut(outData)
+    } else {
+        suggestedTitle = nil
+    }
+
+    return MarmosetProject(
+        number:       n,
+        publicTests:  publicTests,
+        releaseTests: releaseTests,
+        secretTests:  secretTests,
+        hasMakefile:  hasMakefile,
+        suggestedTitle: suggestedTitle
+    )
+}
+
+// MARK: - Java Properties parser
+
+/// Parses a Java-style `.properties` file.
+///
+/// Handles:
+/// - `key=value` pairs
+/// - `#` and `!` line comments
+/// - Backslash line-continuation (trailing `\`)
+/// - Leading whitespace trimming on continuation lines
+func parseJavaProperties(_ data: Data) -> [String: String] {
+    guard let raw = String(data: data, encoding: .utf8) ??
+                    String(data: data, encoding: .isoLatin1) else { return [:] }
+
+    var result: [String: String] = [:]
+    var lines = raw.components(separatedBy: .newlines)
+    var i = 0
+
+    while i < lines.count {
+        var line = lines[i]
+        i += 1
+
+        // Join continuation lines.
+        while line.hasSuffix("\\") {
+            line = String(line.dropLast())  // remove trailing backslash
+            if i < lines.count {
+                let next = lines[i].drop(while: { $0 == " " || $0 == "\t" })
+                line += next
+                i += 1
+            }
+        }
+
+        // Strip leading whitespace and skip comments / empty lines.
+        line = line.trimmingCharacters(in: .whitespaces)
+        if line.isEmpty || line.hasPrefix("#") || line.hasPrefix("!") { continue }
+
+        // Split on first `=` or `:`.
+        if let eqRange = line.range(of: "=") {
+            let key = line[..<eqRange.lowerBound].trimmingCharacters(in: .whitespaces)
+            let val = line[eqRange.upperBound...].trimmingCharacters(in: .whitespaces)
+            if !key.isEmpty {
+                result[key] = val
+            }
+        } else if let colonRange = line.range(of: ":") {
+            let key = line[..<colonRange.lowerBound].trimmingCharacters(in: .whitespaces)
+            let val = line[colonRange.upperBound...].trimmingCharacters(in: .whitespaces)
+            if !key.isEmpty {
+                result[key] = val
+            }
+        }
+    }
+
+    return result
+}
+
+/// Splits a Marmoset `test.class.*` value (comma-separated, may contain
+/// whitespace and backslash-continuation artefacts) into individual test names.
+func parseTestClassList(_ raw: String) -> [String] {
+    raw.components(separatedBy: ",")
+       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+       .filter { !$0.isEmpty }
+}
+
+// MARK: - project.out title extraction
+
+/// Attempts to extract the assignment title from a Java-serialised `project.out`.
+///
+/// Java serialisation stores UTF-8 strings preceded by a 2-byte big-endian
+/// length. We scan for all such strings and return the first one that looks
+/// like an assignment title (3–80 printable ASCII chars, not a number alone).
+func extractTitleFromProjectOut(_ data: Data) -> String? {
+    let bytes = [UInt8](data)
+    var candidates: [String] = []
+    var idx = 0
+
+    while idx + 2 < bytes.count {
+        let high = bytes[idx]
+        let low  = bytes[idx + 1]
+        let len  = Int(high) << 8 | Int(low)
+
+        // Only bother with strings of length 3..80.
+        guard len >= 3, len <= 80, idx + 2 + len <= bytes.count else {
+            idx += 1
+            continue
+        }
+
+        let strBytes = bytes[(idx + 2)..<(idx + 2 + len)]
+        // Require all bytes to be printable ASCII (0x20–0x7E) or basic Latin.
+        let allPrintable = strBytes.allSatisfy { b in
+            (b >= 0x20 && b <= 0x7E) || b >= 0xC0
+        }
+        guard allPrintable,
+              let s = String(bytes: strBytes, encoding: .utf8),
+              !s.trimmingCharacters(in: .whitespaces).isEmpty
+        else {
+            idx += 1
+            continue
+        }
+
+        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        // Filter out pure numbers, single-character strings, and Java class names.
+        if Double(trimmed) == nil,
+           trimmed.count >= 3,
+           !trimmed.contains("."),
+           !trimmed.contains("/"),
+           trimmed.contains(" ") || trimmed.first?.isUppercase == true {
+            candidates.append(trimmed)
+        }
+        idx += 1
+    }
+
+    // Return the first candidate that looks most like a title (contains a space).
+    return candidates.first(where: { $0.contains(" ") }) ?? candidates.first
+}
+
+// MARK: - Manifest conversion
+
+/// Produces a Chickadee `TestProperties` manifest JSON string from a parsed
+/// `MarmosetProject`.
+///
+/// - `gradingMode` is always `"worker"` (Marmoset test scripts run server-side).
+/// - `requiredFiles` is always `[]` — instructor fills this in after import.
+/// - `dependsOn` is always `[]` — Marmoset has no dependency concept.
+func convertToChickadeeManifest(project: MarmosetProject) throws -> String {
+    var suites: [[String: Any]] = []
+
+    for name in project.publicTests {
+        suites.append(["tier": "public", "script": name])
+    }
+    for name in project.releaseTests {
+        suites.append(["tier": "release", "script": name])
+    }
+    for name in project.secretTests {
+        suites.append(["tier": "secret", "script": name])
+    }
+
+    let manifest: [String: Any] = [
+        "schemaVersion": 1,
+        "gradingMode":   "worker",
+        "requiredFiles": [],
+        "testSuites":    suites,
+        "timeLimitSeconds": 10,
+        "makefile": project.hasMakefile ? ["target": NSNull()] : NSNull()
+    ]
+
+    let data = try JSONSerialization.data(withJSONObject: manifest)
+    return String(data: data, encoding: .utf8) ?? "{}"
+}
+
+// MARK: - Zip helpers (private)
+
+/// Extracts a single named file from a zip archive using `unzip -p`.
+/// Returns `nil` if the file is not found.
+private func extractFileFromZip(zipPath: String, filename: String) throws -> Data? {
+    guard FileManager.default.fileExists(atPath: "/usr/bin/unzip") else {
+        throw ZipArchiverError.executableNotFound("/usr/bin/unzip")
+    }
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+    proc.arguments = ["-p", zipPath, filename]
+    let outPipe = Pipe()
+    let errPipe = Pipe()
+    proc.standardOutput = outPipe
+    proc.standardError  = errPipe
+    try proc.run()
+    let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+    proc.waitUntilExit()
+    // Exit 11 = file not found in archive; treat as nil.
+    guard proc.terminationStatus == 0 else { return nil }
+    return data.isEmpty ? nil : data
+}
+
+/// Returns the first `.ipynb` filename found in a zip archive, or `nil`.
+func firstNotebookInZip(zipPath: String) throws -> String? {
+    let entries = try listZipContents(zipPath: zipPath)
+    return entries.first { entry in
+        let name = (entry as NSString).lastPathComponent
+        return name.hasSuffix(".ipynb") && !name.hasPrefix(".")
+    }.map { ($0 as NSString).lastPathComponent }
+}
+
+/// Extracts a named file from a zip archive and returns its bytes.
+/// The filename is the last path component match (for nested paths).
+func extractNotebookFromZip(zipPath: String, filename: String) throws -> Data? {
+    return try extractFileFromZip(zipPath: zipPath, filename: filename)
+}

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -46,4 +46,5 @@ func routes(_ app: Application) throws {
     let admin = app.grouped(sessionAuth, RoleMiddleware(required: .admin))
     try admin.register(collection: AdminRoutes())
     try admin.register(collection: CourseBundleRoutes())
+    try admin.register(collection: MarmosetImportRoutes())
 }


### PR DESCRIPTION
## Summary

- Adds admin-only Marmoset export import at `GET/POST /admin/courses/:courseID/import-marmoset`
- Parses Marmoset's Java `.properties` format to extract public/release/secret test case lists
- Detects `Makefile` presence in the test-setup zip to set Chickadee's makefile config (ignores Marmoset's `build.*` fields — we always use our own handling)
- Rebuilds test setup zip without `test.properties` and `__MACOSX/` artifacts
- Stores canonical zip for instructor download on the validate page
- Extracts starter `.ipynb` and stores it as the JupyterLite notebook
- Attempts title extraction from Java-serialized `project.out` binary
- Assignments are created closed with `validationStatus: nil`; instructor validates before opening
- Adds "Import from Marmoset" button to the admin course detail page

## Test plan

- [ ] Upload `Marmoset/1-HLTH230-Winter2026-export.zip` via the import form for a test course
- [ ] Confirm one assignment is created with title "Assignment 1", 9 public test suites, and makefile config
- [ ] Confirm canonical zip download link works
- [ ] Submit canonical `bmi.py` on the validate page and confirm validation passes
- [ ] Open the assignment and confirm it appears in the student view

🤖 Generated with [Claude Code](https://claude.com/claude-code)