### PR TITLE
Show hidden tier summaries on student result page

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -402,6 +402,47 @@ textarea.form-input {
     font-weight: 500;
 }
 
+/* Hidden-tier summary (release before deadline, secret always) */
+.hidden-tiers-summary {
+    margin-top: 1.25rem;
+    border: 1px solid var(--gray-100);
+    border-radius: .5rem;
+    padding: .75rem 1rem;
+    background: var(--gray-100);
+}
+
+.hidden-tiers-heading {
+    font-size: .8rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--gray-600);
+    margin: 0 0 .5rem;
+}
+
+.tier-summary-row {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    border-left: 3px solid var(--gray-400);
+    padding: .35rem 0 .35rem .6rem;
+    margin-bottom: .3rem;
+    font-size: .9rem;
+}
+
+.tier-summary-row:last-child { margin-bottom: 0; }
+
+.tier-summary-release { border-left-color: var(--amber); }
+.tier-summary-secret  { border-left-color: var(--purple); }
+
+.tier-summary-counts { font-weight: 500; }
+
+.tier-summary-note {
+    color: var(--gray-600);
+    font-style: italic;
+    font-size: .85rem;
+}
+
 /* Long result expand */
 details > summary {
     cursor: pointer;

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -84,6 +84,27 @@ Submission #(submissionID)
     #endfor
     </tbody>
 </table>
+
+#if(releaseSummary || secretSummary):
+<div class="hidden-tiers-summary">
+    <h3 class="hidden-tiers-heading">Additional Tests</h3>
+    #if(releaseSummary):
+    <div class="tier-summary-row tier-summary-release">
+        <span class="tier tier-release-badge">release</span>
+        <span class="tier-summary-counts">#(releaseSummary.passCount) passed, #(releaseSummary.failCount) failed#if(releaseSummary.errorCount): , #(releaseSummary.errorCount) error(s)#endif</span>
+        <span class="tier-summary-note">— details available after the deadline</span>
+    </div>
+    #endif
+    #if(secretSummary):
+    <div class="tier-summary-row tier-summary-secret">
+        <span class="tier tier-secret-badge">secret</span>
+        <span class="tier-summary-counts">#(secretSummary.total) test#if(secretSummary.total != 1):s#endif</span>
+        <span class="tier-summary-note">— results not shown</span>
+    </div>
+    #endif
+</div>
+#endif
+
 #endif
 
 #endif

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -671,11 +671,28 @@ struct WebRoutes: RouteCollection {
             }
         }
 
+        // Summaries for hidden tiers (students only; instructors see everything directly).
+        var releaseSummary: TierSummary? = nil
+        var secretSummary:  TierSummary? = nil
+
         if let result = displayResult {
             resultSource = result.source ?? "worker"
             if let data       = result.collectionJSON.data(using: .utf8),
                let collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
             {
+                // Compute per-tier summaries from the full (unfiltered) collection.
+                if !user.isInstructor {
+                    let releaseOutcomes = collection.outcomes.filter { $0.tier == .release }
+                    let secretOutcomes  = collection.outcomes.filter { $0.tier == .secret }
+                    let releaseVisible  = allowedTiers.contains("release")
+                    if !releaseVisible, !releaseOutcomes.isEmpty {
+                        releaseSummary = TierSummary(outcomes: releaseOutcomes, isRelease: true)
+                    }
+                    if !secretOutcomes.isEmpty {
+                        secretSummary = TierSummary(outcomes: secretOutcomes, isRelease: false)
+                    }
+                }
+
                 let visible     = collection.filtering(tiers: allowedTiers)
                 buildFailed     = collection.buildStatus == .failed
                 compilerOutput  = collection.compilerOutput
@@ -762,6 +779,8 @@ struct WebRoutes: RouteCollection {
             earnedPoints:      earnedPoints,
             hasDelta:          hasDelta,
             deltaHeaderText:   deltaHeaderText,
+            releaseSummary:    releaseSummary,
+            secretSummary:     secretSummary,
             currentUser:       req.currentUserContext
         )
         return try await req.view.render("submission", ctx)
@@ -855,6 +874,27 @@ private struct OutcomeRow: Encodable {
     let pointsLabel: String?     // e.g. "2 pts" when assignment is weighted; nil otherwise
 }
 
+/// Aggregate summary for a hidden test tier (release before deadline, or secret).
+/// No individual test names or output are included — only counts.
+private struct TierSummary: Encodable {
+    let total: Int
+    let passCount: Int
+    let failCount: Int
+    let errorCount: Int
+    let timeoutCount: Int
+    /// true = release tier hidden until deadline; false = secret (never shown)
+    let isRelease: Bool
+
+    init(outcomes: [TestOutcome], isRelease: Bool) {
+        total        = outcomes.count
+        passCount    = outcomes.filter { $0.status == .pass }.count
+        failCount    = outcomes.filter { $0.status == .fail }.count
+        errorCount   = outcomes.filter { $0.status == .error }.count
+        timeoutCount = outcomes.filter { $0.status == .timeout }.count
+        self.isRelease = isRelease
+    }
+}
+
 private struct SubmissionContext: Encodable {
     let submissionID: String
     let testSetupID: String
@@ -883,6 +923,10 @@ private struct SubmissionContext: Encodable {
     let hasDelta: Bool
     /// E.g. "↑ fixed 2 tests · ↓ broke 1 test since attempt 3"; nil on first attempt.
     let deltaHeaderText: String?
+    /// Non-nil for students when release tests exist but are not yet visible (before deadline).
+    let releaseSummary: TierSummary?
+    /// Non-nil for students when secret tests exist (always hidden).
+    let secretSummary: TierSummary?
     let currentUser: CurrentUserContext?
 }
 


### PR DESCRIPTION
Closes #134

## Summary

Students now always see that release and secret tests exist on their result page, without leaking any test names, script names, or individual test output:

- **Release tests (before deadline):** "Release tests: 2 passed, 1 failed — details available after the deadline"
- **Secret tests (always):** "Secret tests: 3 — results not shown" (count only, no pass/fail breakdown)
- Both sections are omitted for instructors, who already see all tiers directly in the main table
- After the deadline passes, release outcomes move into the main results table as usual and the summary row disappears automatically

## Implementation

- `WebRoutes.swift`: Added `TierSummary` struct; computed per-tier summaries from the full unfiltered `TestOutcomeCollection` *before* `visibleTiers()` filtering is applied; added `releaseSummary` and `secretSummary` optional fields to `SubmissionContext`
- `submission.leaf`: Added a "Additional Tests" section after the outcomes table, rendered only when one or both summaries are present
- `styles.css`: Added `.hidden-tiers-summary`, `.tier-summary-row`, `.tier-summary-release`, `.tier-summary-secret` styles with amber/purple left-border accents matching the existing tier colour scheme

No changes to `TierFilter.swift`, Core models, or the API endpoint — aggregation is at the render layer.

## Test plan

- [ ] Submit to an assignment with public + release + secret tests and a future deadline; as a student, confirm the result page shows public outcomes in full, a release aggregate row, and a secret count row
- [ ] View same result as instructor — confirm no summary section appears
- [ ] Advance past the deadline (or remove it) — confirm release outcomes move into the main table and the release summary row disappears
- [ ] Confirm no test names, script output, or `longResult` content appears in either summary row

🤖 Generated with [Claude Code](https://claude.com/claude-code)