### PR TITLE
Fix Marmoset validation: duplicate function error from injected solution file

### DIFF
--- a/Sources/APIServer/Routes/Web/MarmosetImportRoutes.swift
+++ b/Sources/APIServer/Routes/Web/MarmosetImportRoutes.swift
@@ -148,15 +148,18 @@ struct MarmosetImportRoutes: RouteCollection {
                     at: stagingDir.appendingPathComponent(name))
             }
 
-            // ── 4b. Inject solution.ipynb from canonical zip (if any) ──
+            // ── 4b. Read canonical solution for validation (NOT injected into test setup zip) ──
+            //
+            // We intentionally do NOT add the canonical file to the test setup zip.
+            // Test suites that use chickadee.py's load_submission_modules() scan the working
+            // directory for all .py files; adding solution.<ext> here would create a duplicate
+            // when the runner also places the validation submission in the same directory,
+            // causing "Multiple definitions of '<func>' found" errors.
 
             var canonicalSolution: (data: Data, originalFilename: String)? = nil
             let canonicalSrcPath = projectsDir.appendingPathComponent("\(n)-canonical.zip").path
             if FileManager.default.fileExists(atPath: canonicalSrcPath),
                let solution = try? extractSolutionFromCanonicalZip(zipPath: canonicalSrcPath) {
-                let solutionExt = solution.ext.isEmpty ? "py" : solution.ext
-                let solutionFilename = "solution.\(solutionExt)"
-                try solution.data.write(to: stagingDir.appendingPathComponent(solutionFilename))
                 canonicalSolution = (data: solution.data, originalFilename: solution.originalFilename)
             }
             let hasCanonical = canonicalSolution != nil


### PR DESCRIPTION
## Problem

Assignment 3 (and any Marmoset import with a notebook canonical solution) was failing validation with:

> Multiple definitions of 'bmi' found (student_Assignment_3_Solution, student_solution). Keep exactly one.

The import was injecting `solution.ipynb` into the test setup zip (renamed from the original `Assignment_3_Solution.ipynb`). When the runner validated, it placed both the test setup files *and* the validation submission (`Assignment_3_Solution.ipynb`) in the same working directory, then ran `extractNotebooksToCode()` on all notebooks. This produced two `.py` files (`solution.py` and `Assignment_3_Solution.py`), both defining the same functions. `chickadee.py`'s `load_submission_modules()` found both and raised the duplicate error on every test.

## Fix

Stop injecting the canonical file into the test setup zip entirely. The canonical is only needed for the validation submission — the test setup zip should contain only test scripts and helper modules. The `canonicalSolution` variable is still read and used to enqueue the validation submission with its original filename.

## Test plan

- [ ] Re-import `3-HLTH230-Winter2026-export.zip` and confirm Assignment 3 validation passes
- [ ] Confirm Assignment 1 and 2 validation still passes
- [ ] Confirm the test setup zip for a re-imported assignment no longer contains `solution.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)