### PR TITLE
Add Python 3 and R to Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,19 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install C runtime dependencies only (Swift stdlib is statically linked).
+# System dependencies:
+#   - C runtime libs (Swift stdlib is statically linked)
+#   - Python 3 + common scientific packages (for Python test scripts / submissions)
+#   - R base (for R test scripts / submissions)
+#
+# If your courses need additional Python packages, extend this image:
+#   FROM chickadee:latest
+#   USER root
+#   RUN pip3 install --no-cache-dir <your-packages>
+#   USER chickadee
+#
+# For additional R packages:
+#   RUN Rscript -e "install.packages(c('tidyverse', ...), repos='https://cloud.r-project.org')"
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -38,6 +50,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libsqlite3-0 \
         libssl3 \
         libcurl4 \
+        python3 \
+        python3-pip \
+        python3-numpy \
+        python3-pandas \
+        python3-scipy \
+        python3-matplotlib \
+        r-base \
     && rm -rf /var/lib/apt/lists/*
 
 # Non-root user for the application processes.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -14,6 +14,19 @@ Two deployment paths are documented here:
 - Docker Engine 24+ and Docker Compose v2 (`docker compose version`)
 - A domain name (for HTTPS / production)
 
+> **Language runtimes:** The Docker image includes Python 3 (with numpy, pandas,
+> scipy, matplotlib) and R base out of the box. If your test scripts require
+> additional packages, create a `Dockerfile.local` that extends the image:
+> ```dockerfile
+> FROM chickadee:latest
+> USER root
+> RUN pip3 install --no-cache-dir mypackage
+> RUN Rscript -e "install.packages('tidyverse', repos='https://cloud.r-project.org')"
+> USER chickadee
+> ```
+> Then set `build: { context: ., dockerfile: Dockerfile.local }` on both the
+> `server` and `runner` services in `docker-compose.yml`.
+
 ### 1. Clone and configure
 
 ```bash
@@ -135,6 +148,7 @@ service management, and nginx as the reverse proxy.
 - Swift 6.0+ installed ([swift.org/download](https://swift.org/download/))
 - nginx installed (`apt install nginx`)
 - Your OIDC credentials from your identity provider (e.g. Duo, Okta, Entra)
+- Python 3 and R for the runner (`apt install python3 python3-pip python3-numpy python3-pandas python3-scipy python3-matplotlib r-base`). Install additional packages as needed for your courses.
 
 ---
 


### PR DESCRIPTION
## Problem

The Docker runtime image only had C runtime libraries — Python 3 and R were missing entirely. Any test script that executes Python or R code would fail immediately with a "command not found" error.

## Changes

**`Dockerfile`** — adds to the runtime stage:
- `python3`, `python3-pip`
- `python3-numpy`, `python3-pandas`, `python3-scipy`, `python3-matplotlib` (common scientific packages available as fast apt packages)
- `r-base`

Includes a comment block explaining how to extend the image with additional packages for course-specific needs (e.g. tidyverse for R, or custom pip packages).

**`deploy/README.md`** — documents the language runtimes in both:
- Docker Compose prerequisites (with a `Dockerfile.local` extension example)
- VM/systemd prerequisites (apt install command)

## Test plan

- [ ] `docker compose build` completes without errors
- [ ] `docker run --rm chickadee:latest python3 --version` shows Python 3.x
- [ ] `docker run --rm chickadee:latest Rscript --version` shows R version
- [ ] Import and validate a Python-based Marmoset assignment — runner should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)