### PR TITLE
Prep for UWaterloo beta deployment

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,56 @@
+name: Build and Push Docker Image
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+env:
+  IMAGE: ghcr.io/jimwallace/chickadee
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            # :latest on every push to main
+            type=raw,value=latest,enable={{is_default_branch}}
+            # :sha-<short-commit> on every push (immutable, good for rollback)
+            type=sha,prefix=sha-
+            # :v0.4.1 etc. on version tags
+            type=semver,pattern={{version}}
+
+      - name: Build (and push on main/tags)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # BuildKit layer cache: dependency fetch is cached across runs
+          # unless Package.swift or Package.resolved changes.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -108,7 +108,7 @@
                     #endif
                 </td>
                 <td>
-                    <a href="/assignments/#(assignment.id)/submissions"
+                    <a href="/instructor/#(assignment.id)/submissions"
                        class="btn action-btn">Submissions</a>
                 </td>
             </tr>

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -463,5 +463,8 @@ Admin
     });
 })();
 </script>
+<p style="margin-top:2rem;text-align:right;font-size:.75rem;color:var(--gray-400)">
+    Chickadee v#(version)
+</p>
 #endexport
 #endextend

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -27,7 +27,7 @@
     </button>
 </div>
 
-<form class="form" method="post" action="/assignments/#(assignmentID)/edit/save" enctype="multipart/form-data" novalidate>
+<form class="form" method="post" action="/instructor/#(assignmentID)/edit/save" enctype="multipart/form-data" novalidate>
     <!-- Inline edit mode (hidden by default; shown when pencil clicked) -->
     <div id="assign-header-edit" style="display:none;margin-bottom:1.25rem;padding:.75rem 1rem;border:1px solid var(--border,#ddd);border-radius:.5rem;background:var(--gray-50,#fafafa)">
         <div style="display:flex;align-items:center;margin-bottom:.6rem">
@@ -113,7 +113,7 @@
 
     <div style="display:flex;gap:.6rem;flex-wrap:wrap">
         <button class="btn btn-primary" type="submit">Save</button>
-        <a class="btn" href="/assignments">Cancel</a>
+        <a class="btn" href="/instructor">Cancel</a>
     </div>
 </form>
 <style>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -18,7 +18,7 @@ Create Assignment
 </div>
 #endif
 
-<form class="form" method="post" action="/assignments/new/save" enctype="multipart/form-data">
+<form class="form" method="post" action="/instructor/new/save" enctype="multipart/form-data">
     <label class="form-label">
         Assignment Name
         <input class="form-input" type="text" name="assignmentName" required
@@ -88,7 +88,7 @@ Create Assignment
 
     <div style="display:flex;gap:.6rem;flex-wrap:wrap">
         <button class="btn btn-primary" type="submit">Create &amp; Validate</button>
-        <a class="btn" href="/assignments">Cancel</a>
+        <a class="btn" href="/instructor">Cancel</a>
     </div>
 </form>
 <style>

--- a/Resources/Views/assignment-student-history.leaf
+++ b/Resources/Views/assignment-student-history.leaf
@@ -5,7 +5,7 @@
 #export("content"):
 <div style="display:flex;justify-content:space-between;align-items:baseline;flex-wrap:wrap;gap:.75rem;margin-bottom:1rem">
     <h1 style="margin:0">#(assignmentTitle)</h1>
-    <a class="btn action-btn" href="/assignments/#(assignmentID)/submissions">Back to Assignment Summary</a>
+    <a class="btn action-btn" href="/instructor/#(assignmentID)/submissions">Back to Assignment Summary</a>
 </div>
 <p style="margin-top:0;color:var(--gray-700)">Student ID: <strong>#(studentID)</strong></p>
 
@@ -32,7 +32,7 @@
             <td><strong>#(row.gradeText)</strong></td>
             <td><a href="/submissions/#(row.submissionID)">Open</a></td>
             <td>
-                <form method="post" action="/assignments/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
+                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
                     <input type="hidden" name="returnTo" value="#(historyPath)">
                     <button class="btn action-btn" type="submit">Re-test</button>
                 </form>

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -9,7 +9,7 @@
         <input id="submissions-filter" class="form-input" type="search"
                placeholder="Filter by name or ID…"
                style="width:220px" aria-label="Filter students">
-        <a class="btn action-btn" href="/assignments">Back to Instructor</a>
+        <a class="btn action-btn" href="/instructor">Back to Instructor</a>
     </div>
 </div>
 
@@ -50,8 +50,8 @@
             </td>
             <td>
                 #if(row.hasLatestSubmission):
-                    <form method="post" action="/assignments/#(assignmentID)/submissions/#(row.latestSubmissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
-                        <input type="hidden" name="returnTo" value="/assignments/#(assignmentID)/submissions">
+                    <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.latestSubmissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
+                        <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
                         <button class="btn action-btn" type="submit">Re-test</button>
                     </form>
                 #else:

--- a/Resources/Views/assignment-validate.leaf
+++ b/Resources/Views/assignment-validate.leaf
@@ -32,10 +32,10 @@ Validate — #(title)
 <div id="go-live-panel" hidden style="margin-top:1.5rem;padding:1rem;background:#F0FDF4;border:1px solid var(--green);border-radius:6px">
     <p style="margin:0 0 .75rem;color:var(--green);font-weight:600">✓ All tests passed — ready to go live!</p>
     <div style="display:flex;gap:.75rem;align-items:center;flex-wrap:wrap">
-        <form method="post" action="/assignments/#(assignmentID)/open">
+        <form method="post" action="/instructor/#(assignmentID)/open">
             <button class="btn btn-primary" type="submit">Go live</button>
         </form>
-        <a class="btn" href="/assignments">Not yet — back to assignments</a>
+        <a class="btn" href="/instructor">Not yet — back to assignments</a>
     </div>
 </div>
 

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -9,12 +9,12 @@
 <h1 style="margin-bottom:1.25rem">Assignments</h1>
 #endif
 <div style="display:flex;justify-content:flex-end;align-items:center;flex-wrap:wrap;gap:.5rem;margin-bottom:1.5rem">
-    <a class="btn action-btn" href="/assignments/grades.csv">Export Grades CSV</a>
+    <a class="btn action-btn" href="/instructor/grades.csv">Export Grades CSV</a>
     <!-- Add Section inline form -->
     <details class="add-section-details" id="add-section-details" style="position:relative">
         <summary class="btn action-btn" style="cursor:pointer;list-style:none">+ Add Section</summary>
         <div class="add-section-popup card" style="position:absolute;z-index:100;top:100%;right:0;margin-top:.25rem;padding:1rem;min-width:18rem;box-shadow:0 4px 16px rgba(0,0,0,.15)">
-            <form method="post" action="/assignments/sections" class="form" style="margin:0;gap:.6rem">
+            <form method="post" action="/instructor/sections" class="form" style="margin:0;gap:.6rem">
                 <label class="form-label" style="margin:0">
                     Section name
                     <input class="form-input" type="text" name="name" placeholder="e.g. Labs" required
@@ -36,7 +36,7 @@
 </div>
 
 #if(!hasSections && !hasUngrouped):
-<p class="empty">No assignments yet. <a href="/assignments/new">Create one to get started.</a></p>
+<p class="empty">No assignments yet. <a href="/instructor/new">Create one to get started.</a></p>
 #else:
 
 <!-- Sections -->
@@ -56,15 +56,15 @@
                     style="display:inline-flex;align-items:center;padding:.1rem .25rem;color:var(--gray-500)">
                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
             </button>
-            <a class="btn action-btn" href="/assignments/new?sectionID=#(section.sectionID)"
+            <a class="btn action-btn" href="/instructor/new?sectionID=#(section.sectionID)"
                style="font-size:.8rem;padding:.2rem .55rem;margin-left:auto">+ Create New</a>
-            <a class="btn action-btn" href="/assignments/import-marmoset?sectionID=#(section.sectionID)"
+            <a class="btn action-btn" href="/instructor/import-marmoset?sectionID=#(section.sectionID)"
                style="font-size:.8rem;padding:.2rem .55rem">Import from Marmoset</a>
         </div>
 
         <!-- Edit mode (hidden by default) -->
         <div class="section-edit" style="display:none;align-items:center;gap:.5rem;flex:1;flex-wrap:wrap">
-            <form class="section-rename-form" method="post" action="/assignments/sections/#(section.sectionID)/rename"
+            <form class="section-rename-form" method="post" action="/instructor/sections/#(section.sectionID)/rename"
                   style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;flex:1">
                 <input class="form-input section-name-input" type="text" name="name" value="#(section.name)" required
                        style="font-size:.85rem;padding:.25rem .45rem;flex:1;min-width:8rem">
@@ -77,7 +77,7 @@
                         style="font-size:.8rem;padding:.25rem .5rem">Save</button>
             </form>
             <button class="btn action-btn action-danger section-delete-btn" type="button"
-                    data-action="/assignments/sections/#(section.sectionID)/delete"
+                    data-action="/instructor/sections/#(section.sectionID)/delete"
                     data-name="#(section.name)"
                     style="font-size:.8rem;padding:.25rem .5rem">Delete</button>
             <button class="btn-link section-edit-cancel" type="button"
@@ -100,7 +100,7 @@
         #if(section.rows.isEmpty):
         <tr class="section-empty-row">
             <td colspan="5" style="color:var(--gray-500);font-style:italic;padding:.6rem .75rem;text-align:center">
-                Drag items here or use <a href="/assignments/new?sectionID=#(section.sectionID)">+ Create New</a>
+                Drag items here or use <a href="/instructor/new?sectionID=#(section.sectionID)">+ Create New</a>
             </td>
         </tr>
         #else:
@@ -117,7 +117,7 @@
                     #endif
                     #if(row.title):
                     #if(row.assignmentID):
-                    <a href="/assignments/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
+                    <a href="/instructor/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
                     #else:
                     <strong>#(row.title)</strong>
                     #endif
@@ -127,7 +127,7 @@
                 </td>
                 <td>
                     #if(row.assignmentID && row.validationStatus == "passed"):
-                    <form method="post" action="/assignments/#(row.assignmentID)/status">
+                    <form method="post" action="/instructor/#(row.assignmentID)/status">
                         <select class="form-input" name="status" onchange="this.form.submit()"
                                 style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
                             <option value="open" #if(row.status == "open"):selected#endif>open</option>
@@ -170,7 +170,7 @@
                     #if(row.status == "unpublished"):
                     <details class="publish-details">
                         <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
-                        <form class="publish-form" method="post" action="/assignments">
+                        <form class="publish-form" method="post" action="/instructor">
                             <input type="hidden" name="testSetupID" value="#(row.setupID)">
                             <label class="form-label" style="font-size:.8rem">
                                 Title
@@ -190,8 +190,8 @@
                     </details>
                     #elseif(row.status == "closed"):
                     <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
-                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                        <a class="btn action-btn" href="/instructor/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment">Delete</button>
@@ -199,8 +199,8 @@
                     </div>
                     #elseif(row.status == "open"):
                     <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
-                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                        <a class="btn action-btn" href="/instructor/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment">Delete</button>
@@ -208,8 +208,8 @@
                     </div>
                     #else:
                     <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                        <a class="btn btn-primary" href="/assignments/#(row.assignmentID)/validate">Validate &amp; open →</a>
-                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                        <a class="btn btn-primary" href="/instructor/#(row.assignmentID)/validate">Validate &amp; open →</a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment">Delete</button>
@@ -256,7 +256,7 @@
                     #endif
                     #if(row.title):
                     #if(row.assignmentID):
-                    <a href="/assignments/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
+                    <a href="/instructor/#(row.assignmentID)/submissions"><strong>#(row.title)</strong></a>
                     #else:
                     <strong>#(row.title)</strong>
                     #endif
@@ -266,7 +266,7 @@
                 </td>
                 <td>
                     #if(row.assignmentID && row.validationStatus == "passed"):
-                    <form method="post" action="/assignments/#(row.assignmentID)/status">
+                    <form method="post" action="/instructor/#(row.assignmentID)/status">
                         <select class="form-input" name="status" onchange="this.form.submit()"
                                 style="font-size:.8rem;padding:.25rem .45rem;min-width:7.5rem">
                             <option value="open" #if(row.status == "open"):selected#endif>open</option>
@@ -309,7 +309,7 @@
                     #if(row.status == "unpublished"):
                     <details class="publish-details">
                         <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
-                        <form class="publish-form" method="post" action="/assignments">
+                        <form class="publish-form" method="post" action="/instructor">
                             <input type="hidden" name="testSetupID" value="#(row.setupID)">
                             <label class="form-label" style="font-size:.8rem">
                                 Title
@@ -329,8 +329,8 @@
                     </details>
                     #elseif(row.status == "closed"):
                     <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
-                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                        <a class="btn action-btn" href="/instructor/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment">Delete</button>
@@ -338,8 +338,8 @@
                     </div>
                     #elseif(row.status == "open"):
                     <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                        <a class="btn action-btn" href="/assignments/#(row.assignmentID)/edit">Edit</a>
-                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                        <a class="btn action-btn" href="/instructor/#(row.assignmentID)/edit">Edit</a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment">Delete</button>
@@ -347,8 +347,8 @@
                     </div>
                     #else:
                     <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                        <a class="btn btn-primary" href="/assignments/#(row.assignmentID)/validate">Validate &amp; open →</a>
-                        <form method="post" action="/assignments/#(row.assignmentID)/delete"
+                        <a class="btn btn-primary" href="/instructor/#(row.assignmentID)/validate">Validate &amp; open →</a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Remove this assignment? Students will no longer see it.')">
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment">Delete</button>
@@ -476,7 +476,7 @@ tr.assignment-draggable td {
     }
 
     async function persistReorder(tbody) {
-        var res = await fetch('/assignments/reorder', {
+        var res = await fetch('/instructor/reorder', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ assignmentIDs: currentOrder(tbody) })
@@ -580,7 +580,7 @@ tr.assignment-draggable td {
             // Cross-section move.
             var newSectionID = currentTbody.getAttribute('data-section-id') || '';
             var assignmentID = row.getAttribute('data-assignment-id');
-            fetch('/assignments/' + assignmentID + '/section', {
+            fetch('/instructor/' + assignmentID + '/section', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ sectionID: newSectionID })
@@ -636,7 +636,7 @@ tr.assignment-draggable td {
             var order = currentSectionOrder();
             if (order.join(',') === sectionDragStartOrder) return;
             try {
-                var res = await fetch('/assignments/sections/reorder', {
+                var res = await fetch('/instructor/sections/reorder', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ sectionIDs: order })

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -20,7 +20,7 @@
 
     #if(currentUser):
         #if(currentUser.isInstructor):
-            <a class="nav-link" href="/assignments">Instructor</a>
+            <a class="nav-link" href="/instructor">Instructor</a>
         #endif
         #if(currentUser.isAdmin):
             <a class="nav-link" href="/admin">Admin</a>

--- a/Resources/Views/marmoset-import-result.leaf
+++ b/Resources/Views/marmoset-import-result.leaf
@@ -39,10 +39,10 @@ Marmoset import result — #(courseCode)
                     #endif
                 </td>
                 <td style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    <a href="/assignments/#(a.publicID)/validate" class="btn action-btn btn-primary">Validate</a>
-                    <a href="/assignments/#(a.publicID)/edit" class="btn action-btn">Edit</a>
+                    <a href="/instructor/#(a.publicID)/validate" class="btn action-btn btn-primary">Validate</a>
+                    <a href="/instructor/#(a.publicID)/edit" class="btn action-btn">Edit</a>
                     #if(a.hasCanonical):
-                    <a href="/assignments/import-marmoset/canonical/#(a.setupID)"
+                    <a href="/instructor/import-marmoset/canonical/#(a.setupID)"
                        class="btn action-btn">Download canonical</a>
                     #endif
                 </td>
@@ -53,8 +53,8 @@ Marmoset import result — #(courseCode)
     #endif
 
     <div style="display:flex;gap:.75rem;margin-top:1.25rem;flex-wrap:wrap">
-        <a href="/assignments" class="btn btn-primary">Assignments</a>
-        <a href="/assignments/import-marmoset" class="btn">Import another</a>
+        <a href="/instructor" class="btn btn-primary">Assignments</a>
+        <a href="/instructor/import-marmoset" class="btn">Import another</a>
     </div>
 </section>
 

--- a/Resources/Views/marmoset-import.leaf
+++ b/Resources/Views/marmoset-import.leaf
@@ -20,7 +20,7 @@ Import from Marmoset — #(courseCode)
         Assignments will be closed and require validation before opening.
     </p>
     <form method="post"
-          action="/assignments/import-marmoset"
+          action="/instructor/import-marmoset"
           enctype="multipart/form-data"
           style="display:flex;flex-direction:column;gap:1rem;max-width:480px">
         #if(sectionID):
@@ -33,7 +33,7 @@ Import from Marmoset — #(courseCode)
         </label>
         <div style="display:flex;gap:.75rem">
             <button class="btn btn-primary" type="submit">Import</button>
-            <a href="/assignments" class="btn">Cancel</a>
+            <a href="/instructor" class="btn">Cancel</a>
         </div>
     </form>
 </section>

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -86,7 +86,8 @@ struct AdminRoutes: RouteCollection {
             workers:     workerRows,
             workerSecret: effectiveSecret,
             localRunnerAutoStartEnabled: localRunnerAutoStartEnabled,
-            courses: courseRows
+            courses: courseRows,
+            version: ChickadeeVersion.current
         )
         return try await req.view.render("admin", ctx)
     }
@@ -740,6 +741,7 @@ private struct AdminContext: Encodable {
     let currentUser: CurrentUserContext?
     let users: [AdminUserRow]
     let workers: [AdminWorkerRow]
+    let version: String
     let workerSecret: String
     let localRunnerAutoStartEnabled: Bool
     let courses: [AdminCourseRow]
@@ -779,7 +781,7 @@ private struct AdminCourseEnrolledUserRow: Encodable {
 }
 
 private struct AdminCourseAssignmentRow: Encodable {
-    let id: String      // publicID — used in /assignments/:id/... URLs
+    let id: String      // publicID — used in /instructor/:id/... URLs
     let title: String
     let dueAt: String?
     let isOpen: Bool

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -170,7 +170,7 @@ func sanitizedAssignmentReturnPath(
         return fallbackPath
     }
 
-    let expectedPrefix = "/assignments/\(assignmentIDRaw)"
+    let expectedPrefix = "/instructor/\(assignmentIDRaw)"
     guard path == expectedPrefix || path.hasPrefix(expectedPrefix + "/") else {
         return fallbackPath
     }
@@ -218,7 +218,7 @@ func currentSetupFiles(for setup: APITestSetup, assignmentID: String, hasValidat
         }
         return CurrentFileLink(
             name: fileName,
-            url: "/assignments/\(assignmentID)/files/notebook"
+            url: "/instructor/\(assignmentID)/files/notebook"
         )
     }()
 
@@ -239,11 +239,11 @@ func currentSetupFiles(for setup: APITestSetup, assignmentID: String, hasValidat
         if let solutionEntry = archiveFiles.first(where: { $0.hasPrefix("solution.") }) {
             return CurrentFileLink(
                 name: solutionEntry,
-                url: "/assignments/\(assignmentID)/files/item?name=\(urlEncode(solutionEntry))"
+                url: "/instructor/\(assignmentID)/files/item?name=\(urlEncode(solutionEntry))"
             )
         }
         if hasValidationSolution {
-            return CurrentFileLink(name: "solution.ipynb", url: "/assignments/\(assignmentID)/files/solution")
+            return CurrentFileLink(name: "solution.ipynb", url: "/instructor/\(assignmentID)/files/solution")
         }
         return nil
     }()
@@ -261,7 +261,7 @@ func currentSetupFiles(for setup: APITestSetup, assignmentID: String, hasValidat
         let entry = testMap[name]
         return EditableSuiteRow(
             name: name,
-            url: "/assignments/\(assignmentID)/files/item?name=\(urlEncode(name))",
+            url: "/instructor/\(assignmentID)/files/item?name=\(urlEncode(name))",
             isTest: entry != nil,
             tier: entry?.tier ?? "support",
             order: entry?.order ?? (idx + 1),

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Enrollment.swift
@@ -24,7 +24,7 @@ extension AssignmentRoutes {
         let body = try? req.content.decode(Body.self)
         course.openEnrollment = (body?.openEnrollment == "on")
         try await course.save(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
     // MARK: - POST /courses/:courseID/enroll-csv
@@ -83,7 +83,7 @@ extension AssignmentRoutes {
             enrolledCount:        enrolledCount,
             alreadyEnrolledCount: alreadyEnrolledCount,
             notFoundUsernames:    notFoundUsernames,
-            returnURL:            "/assignments"
+            returnURL:            "/instructor"
         ))
     }
 }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Sections.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Sections.swift
@@ -8,7 +8,7 @@ import Fluent
 
 extension AssignmentRoutes {
 
-    // MARK: - POST /assignments/sections
+    // MARK: - POST /instructor/sections
 
     @Sendable
     func createSection(req: Request) async throws -> Response {
@@ -35,10 +35,10 @@ extension AssignmentRoutes {
             .max(\.$sortOrder) ?? 0
         let section = APICourseSection(name: name, defaultGradingMode: mode, sortOrder: maxOrder + 1, courseID: courseID)
         try await section.save(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - POST /assignments/sections/reorder
+    // MARK: - POST /instructor/sections/reorder
 
     @Sendable
     func reorderSections(req: Request) async throws -> HTTPStatus {
@@ -72,7 +72,7 @@ extension AssignmentRoutes {
         return .ok
     }
 
-    // MARK: - POST /assignments/sections/:sectionID/rename
+    // MARK: - POST /instructor/sections/:sectionID/rename
 
     @Sendable
     func renameSection(req: Request) async throws -> Response {
@@ -105,10 +105,10 @@ extension AssignmentRoutes {
         section.name = name
         section.defaultGradingMode = mode
         try await section.save(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - POST /assignments/sections/:sectionID/delete
+    // MARK: - POST /instructor/sections/:sectionID/delete
 
     @Sendable
     func deleteSection(req: Request) async throws -> Response {
@@ -127,10 +127,10 @@ extension AssignmentRoutes {
         }
         // FK SET NULL: assignments in this section will have section_id → NULL (ungrouped).
         try await section.delete(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - POST /assignments/:assignmentID/section
+    // MARK: - POST /instructor/:assignmentID/section
 
     @Sendable
     func moveToSection(req: Request) async throws -> HTTPStatus {

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension AssignmentRoutes {
 
-    // MARK: - GET /assignments/grades.csv
+    // MARK: - GET /instructor/grades.csv
 
     @Sendable
     func exportGradesCSV(req: Request) async throws -> Response {
@@ -144,7 +144,7 @@ extension AssignmentRoutes {
         return response
     }
 
-    // MARK: - GET /assignments/:assignmentID/submissions
+    // MARK: - GET /instructor/:assignmentID/submissions
 
     @Sendable
     func assignmentSubmissionsPage(req: Request) async throws -> View {
@@ -227,7 +227,7 @@ extension AssignmentRoutes {
                 latestSubmissionID: latest?.id ?? "",
                 latestSubmittedAtText: latest?.submittedAt.map { fmt.string(from: $0) } ?? "—",
                 additionalSubmissionCount: max(history.count - 1, 0),
-                fullHistoryURL: "/assignments/\(assignmentIDRaw)/students/\(studentID.uuidString)/history"
+                fullHistoryURL: "/instructor/\(assignmentIDRaw)/students/\(studentID.uuidString)/history"
             )
         }
 
@@ -242,7 +242,7 @@ extension AssignmentRoutes {
         )
     }
 
-    // MARK: - GET /assignments/:assignmentID/students/:studentID/history
+    // MARK: - GET /instructor/:assignmentID/students/:studentID/history
 
     @Sendable
     func studentSubmissionHistoryPage(req: Request) async throws -> View {
@@ -315,13 +315,13 @@ extension AssignmentRoutes {
                 assignmentID: assignmentIDRaw,
                 assignmentTitle: assignment.title,
                 studentID: student.username,
-                historyPath: "/assignments/\(assignmentIDRaw)/students/\(studentIDRaw)/history",
+                historyPath: "/instructor/\(assignmentIDRaw)/students/\(studentIDRaw)/history",
                 rows: rows
             )
         )
     }
 
-    // MARK: - POST /assignments/:assignmentID/submissions/:submissionID/retest
+    // MARK: - POST /instructor/:assignmentID/submissions/:submissionID/retest
 
     @Sendable
     func retestSubmission(req: Request) async throws -> Response {
@@ -354,7 +354,7 @@ extension AssignmentRoutes {
         }
 
         let body = try? req.content.decode(RetestBody.self)
-        let fallbackPath = "/assignments/\(assignmentIDRaw)/submissions"
+        let fallbackPath = "/instructor/\(assignmentIDRaw)/submissions"
         let redirectPath = sanitizedAssignmentReturnPath(
             body?.returnTo,
             assignmentIDRaw: assignmentIDRaw,

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -3,22 +3,22 @@
 // Instructor-facing assignment management routes.
 // Requires instructor or admin role (enforced by routes.swift).
 //
-//   GET  /assignments                               → assignments.leaf (all setups + status)
-//   GET  /assignments/new                           → assignment-new.leaf
-//   POST /assignments/new/save                      → save draft assignment, redirect to /assignments
-//   POST /assignments                               → create draft assignment → redirect to validate
-//   GET  /assignments/:assignmentID/validate        → assignment-validate.leaf
-//   GET  /assignments/:assignmentID/edit            → assignment-edit.leaf
-//   POST /assignments/:assignmentID/edit/save       → update assignment content + validate
-//   POST /assignments/:assignmentID/status          → set open/closed status → redirect to /assignments
-//   POST /assignments/:assignmentID/open            → set isOpen=true → redirect to /assignments
-//   POST /assignments/:assignmentID/close           → set isOpen=false → redirect to /assignments
-//   POST /assignments/:assignmentID/delete          → remove assignment record → redirect to /assignments
-//   POST /assignments/:assignmentID/section         → move assignment to a section (or ungrouped)
-//   POST /assignments/sections                      → create a new course section
-//   POST /assignments/sections/reorder              → reorder sections
-//   POST /assignments/sections/:sectionID/rename    → rename/reconfigure a section
-//   POST /assignments/sections/:sectionID/delete    → delete a section
+//   GET  /instructor                               → assignments.leaf (all setups + status)
+//   GET  /instructor/new                           → assignment-new.leaf
+//   POST /instructor/new/save                      → save draft assignment, redirect to /instructor
+//   POST /instructor                               → create draft assignment → redirect to validate
+//   GET  /instructor/:assignmentID/validate        → assignment-validate.leaf
+//   GET  /instructor/:assignmentID/edit            → assignment-edit.leaf
+//   POST /instructor/:assignmentID/edit/save       → update assignment content + validate
+//   POST /instructor/:assignmentID/status          → set open/closed status → redirect to /instructor
+//   POST /instructor/:assignmentID/open            → set isOpen=true → redirect to /instructor
+//   POST /instructor/:assignmentID/close           → set isOpen=false → redirect to /instructor
+//   POST /instructor/:assignmentID/delete          → remove assignment record → redirect to /instructor
+//   POST /instructor/:assignmentID/section         → move assignment to a section (or ungrouped)
+//   POST /instructor/sections                      → create a new course section
+//   POST /instructor/sections/reorder              → reorder sections
+//   POST /instructor/sections/:sectionID/rename    → rename/reconfigure a section
+//   POST /instructor/sections/:sectionID/delete    → delete a section
 
 import Vapor
 import Fluent
@@ -28,11 +28,11 @@ import Crypto
 
 struct AssignmentRoutes: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
-        // Course-scoped instructor actions (not under the /assignments prefix).
+        // Course-scoped instructor actions (not under the /instructor prefix).
         routes.post("courses", ":courseID", "open-enrollment", use: toggleCourseOpenEnrollment)
         routes.post("courses", ":courseID", "enroll-csv",      use: instructorBulkEnrollCSV)
 
-        let r = routes.grouped("assignments")
+        let r = routes.grouped("instructor")
         r.get(use: list)
         r.get("grades.csv", use: exportGradesCSV)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
@@ -59,7 +59,7 @@ struct AssignmentRoutes: RouteCollection {
         r.post(":assignmentID", "delete",  use: deleteAssignment)
     }
 
-    // MARK: - GET /assignments
+    // MARK: - GET /instructor
 
     @Sendable
     func list(req: Request) async throws -> Response {
@@ -275,7 +275,7 @@ struct AssignmentRoutes: RouteCollection {
         return try await req.view.render("assignments", ctx).encodeResponse(for: req)
     }
 
-    // MARK: - GET /assignments/new
+    // MARK: - GET /instructor/new
 
     @Sendable
     func newAssignmentPage(req: Request) async throws -> View {
@@ -319,7 +319,7 @@ struct AssignmentRoutes: RouteCollection {
         return try await req.view.render("assignment-new", ctx)
     }
 
-    // MARK: - POST /assignments/new/save
+    // MARK: - POST /instructor/new/save
 
     @Sendable
     func saveNewAssignment(req: Request) async throws -> Response {
@@ -367,34 +367,34 @@ struct AssignmentRoutes: RouteCollection {
 
         guard !title.isEmpty else {
             let q = "assignmentName=&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20name%20is%20required"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
 
         guard let assignmentNotebookFile,
               assignmentNotebookFile.data.readableBytes > 0 else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20notebook%20(.ipynb)%20is%20required"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
         guard let solutionNotebookFile,
               solutionNotebookFile.data.readableBytes > 0 else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20(.ipynb)%20is%20required"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
         let suiteFiles = suiteFilesRaw.filter { $0.data.readableBytes > 0 }
         guard !suiteFiles.isEmpty else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=At%20least%20one%20test%20suite%20file%20is%20required"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
 
         let assignmentNotebookRaw = Data(assignmentNotebookFile.data.readableBytesView)
         let solutionNotebookRaw = Data(solutionNotebookFile.data.readableBytesView)
         guard (try? JSONSerialization.jsonObject(with: assignmentNotebookRaw)) != nil else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20notebook%20is%20not%20valid%20JSON%20(.ipynb)"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
         guard (try? JSONSerialization.jsonObject(with: solutionNotebookRaw)) != nil else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20is%20not%20valid%20JSON%20(.ipynb)"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
 
         let assignmentNotebook = normalizeNotebookForJupyterLite(assignmentNotebookRaw)
@@ -419,7 +419,7 @@ struct AssignmentRoutes: RouteCollection {
         )
         guard !setupPackage.testSuites.isEmpty else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Select%20at%20least%20one%20test%20file%20in%20the%20suite%20list"
-            return req.redirect(to: "/assignments/new?\(q)")
+            return req.redirect(to: "/instructor/new?\(q)")
         }
 
         // Resolve the section up front so we can inherit its grading mode.
@@ -474,7 +474,7 @@ struct AssignmentRoutes: RouteCollection {
             assignment.validationStatus = "passed"
             try await assignment.save(on: req.db)
             req.logger.info("Assignment validation passed for setup \(setupID): \(summary)")
-            return req.redirect(to: "/assignments")
+            return req.redirect(to: "/instructor")
         case .failed(let summary):
             assignment.validationStatus = "failed"
             try await assignment.save(on: req.db)
@@ -483,11 +483,11 @@ struct AssignmentRoutes: RouteCollection {
         case .timedOut:
             assignment.validationStatus = "pending"
             try await assignment.save(on: req.db)
-            return req.redirect(to: "/assignments")
+            return req.redirect(to: "/instructor")
         }
     }
 
-    // MARK: - POST /assignments
+    // MARK: - POST /instructor
     // Creates a draft (isOpen: false) assignment and redirects to the validate page.
 
     @Sendable
@@ -512,7 +512,7 @@ struct AssignmentRoutes: RouteCollection {
             .count()
         if existing > 0 {
             // Already published — redirect back.
-            return req.redirect(to: "/assignments")
+            return req.redirect(to: "/instructor")
         }
 
         let due: Date?
@@ -545,10 +545,10 @@ struct AssignmentRoutes: RouteCollection {
             sortOrder: try await nextAssignmentSortOrder(req: req),
             courseID: courseID
         )
-        return req.redirect(to: "/assignments/\(assignment.publicID)/validate")
+        return req.redirect(to: "/instructor/\(assignment.publicID)/validate")
     }
 
-    // MARK: - GET /assignments/:assignmentID/validate
+    // MARK: - GET /instructor/:assignmentID/validate
 
     @Sendable
     func validatePage(req: Request) async throws -> View {
@@ -583,7 +583,7 @@ struct AssignmentRoutes: RouteCollection {
         return try await req.view.render("assignment-validate", ctx)
     }
 
-    // MARK: - POST /assignments/:assignmentID/open
+    // MARK: - POST /instructor/:assignmentID/open
 
     @Sendable
     func openAssignment(req: Request) async throws -> Response {
@@ -598,10 +598,10 @@ struct AssignmentRoutes: RouteCollection {
         }
         assignment.isOpen = true
         try await assignment.save(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - POST /assignments/reorder
+    // MARK: - POST /instructor/reorder
 
     @Sendable
     func reorderAssignments(req: Request) async throws -> HTTPStatus {
@@ -631,7 +631,7 @@ struct AssignmentRoutes: RouteCollection {
         return .ok
     }
 
-    // MARK: - POST /assignments/:assignmentID/status
+    // MARK: - POST /instructor/:assignmentID/status
 
     @Sendable
     func updateStatus(req: Request) async throws -> Response {
@@ -659,10 +659,10 @@ struct AssignmentRoutes: RouteCollection {
             throw Abort(.badRequest, reason: "Unsupported status '\(body.status)'")
         }
         try await assignment.save(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - POST /assignments/:assignmentID/close
+    // MARK: - POST /instructor/:assignmentID/close
 
     @Sendable
     func closeAssignment(req: Request) async throws -> Response {
@@ -674,10 +674,10 @@ struct AssignmentRoutes: RouteCollection {
         }
         assignment.isOpen = false
         try await assignment.save(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - POST /assignments/:assignmentID/delete
+    // MARK: - POST /instructor/:assignmentID/delete
 
     @Sendable
     func deleteAssignment(req: Request) async throws -> Response {
@@ -714,10 +714,10 @@ struct AssignmentRoutes: RouteCollection {
         }
 
         try await assignment.delete(on: req.db)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 
-    // MARK: - GET /assignments/:assignmentID/edit
+    // MARK: - GET /instructor/:assignmentID/edit
 
     @Sendable
     func editPage(req: Request) async throws -> View {
@@ -764,7 +764,7 @@ struct AssignmentRoutes: RouteCollection {
         return try await req.view.render("assignment-edit", ctx)
     }
 
-    // MARK: - GET /assignments/:assignmentID/files/notebook
+    // MARK: - GET /instructor/:assignmentID/files/notebook
 
     @Sendable
     func downloadCurrentNotebookFile(req: Request) async throws -> Response {
@@ -788,7 +788,7 @@ struct AssignmentRoutes: RouteCollection {
         return buildFileResponse(data: data, filename: downloadName)
     }
 
-    // MARK: - GET /assignments/:assignmentID/files/item?name=<filename>
+    // MARK: - GET /instructor/:assignmentID/files/item?name=<filename>
 
     @Sendable
     func downloadCurrentSetupItem(req: Request) async throws -> Response {
@@ -818,7 +818,7 @@ struct AssignmentRoutes: RouteCollection {
         return buildFileResponse(data: data, filename: fileName)
     }
 
-    // MARK: - GET /assignments/:assignmentID/files/solution
+    // MARK: - GET /instructor/:assignmentID/files/solution
 
     @Sendable
     func downloadCurrentSolutionFile(req: Request) async throws -> Response {
@@ -858,7 +858,7 @@ struct AssignmentRoutes: RouteCollection {
         throw Abort(.notFound, reason: "No solution notebook is available for this assignment yet")
     }
 
-    // MARK: - POST /assignments/:assignmentID/edit/save
+    // MARK: - POST /instructor/:assignmentID/edit/save
 
     @Sendable
     func saveEditedAssignment(req: Request) async throws -> Response {
@@ -908,7 +908,7 @@ struct AssignmentRoutes: RouteCollection {
 
         guard !title.isEmpty else {
             let q = "assignmentName=&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20name%20is%20required"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
 
         let uploadedSuiteFiles = suiteFilesRaw.filter { $0.data.readableBytes > 0 }
@@ -923,7 +923,7 @@ struct AssignmentRoutes: RouteCollection {
         guard !assignmentNotebookRaw.isEmpty,
               (try? JSONSerialization.jsonObject(with: assignmentNotebookRaw)) != nil else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Assignment%20notebook%20(.ipynb)%20is%20required%20and%20must%20be%20valid%20JSON"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
 
         // Resolve solution data + filename. Prefer newly uploaded file, then zip entry, then prior submission.
@@ -948,7 +948,7 @@ struct AssignmentRoutes: RouteCollection {
         }
         guard !resolvedSolutionNotebookRaw.isEmpty else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20(.ipynb)%20is%20required%20for%20validation"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
         let solutionIsNotebook = (try? JSONSerialization.jsonObject(with: resolvedSolutionNotebookRaw)) != nil
 
@@ -962,11 +962,11 @@ struct AssignmentRoutes: RouteCollection {
             )
         } catch {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=\(urlEncode(error.localizedDescription))"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
         guard !resolvedSuite.files.isEmpty else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Add%20or%20keep%20at%20least%20one%20test%20suite%20or%20support%20file"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
 
         let assignmentNotebook = normalizeNotebookForJupyterLite(assignmentNotebookRaw)
@@ -995,7 +995,7 @@ struct AssignmentRoutes: RouteCollection {
         )
         guard !setupPackage.testSuites.isEmpty else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Select%20at%20least%20one%20test%20file%20in%20the%20suite%20list"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
         // Preserve the grading mode already stored in the manifest — editing
         // the suite files must not silently reset it back to "worker".
@@ -1037,7 +1037,7 @@ struct AssignmentRoutes: RouteCollection {
             assignment.validationStatus = "passed"
             try await assignment.save(on: req.db)
             req.logger.info("Assignment updated and validated for setup \(setup.id ?? ""): \(summary)")
-            return req.redirect(to: "/assignments")
+            return req.redirect(to: "/instructor")
         case .failed(let summary):
             assignment.validationStatus = "failed"
             try await assignment.save(on: req.db)
@@ -1047,7 +1047,7 @@ struct AssignmentRoutes: RouteCollection {
             assignment.validationStatus = "pending"
             try await assignment.save(on: req.db)
             let q = "notice=\(urlEncode("Assignment updated and validation started. It is still pending; refresh shortly."))"
-            return req.redirect(to: "/assignments/\(idStr)/edit?\(q)")
+            return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
         }
     }
 }

--- a/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
+++ b/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
@@ -55,7 +55,7 @@ struct EnrollCSVResultContext: Encodable {
     let enrolledCount: Int
     let alreadyEnrolledCount: Int
     let notFoundUsernames: [String]
-    /// URL the back-button should link to (admin course page or /assignments).
+    /// URL the back-button should link to (admin course page or /instructor).
     let returnURL: String
     // Precomputed for easy Leaf truthiness check.
     var hasNotFound: Bool { !notFoundUsernames.isEmpty }

--- a/Sources/APIServer/Routes/Web/MarmosetImportRoutes.swift
+++ b/Sources/APIServer/Routes/Web/MarmosetImportRoutes.swift
@@ -2,9 +2,9 @@
 //
 // Marmoset export import routes (instructor+).
 //
-//   GET  /assignments/import-marmoset              — upload form
-//   POST /assignments/import-marmoset              — process import
-//   GET  /assignments/import-marmoset/canonical/:setupID
+//   GET  /instructor/import-marmoset              — upload form
+//   POST /instructor/import-marmoset              — process import
+//   GET  /instructor/import-marmoset/canonical/:setupID
 //                                                   — download stored canonical zip
 //
 // Both form routes accept an optional ?sectionID= / sectionID body field to
@@ -31,7 +31,7 @@ struct MarmosetImportRoutes: RouteCollection {
         r.post(use: processImport)
     }
 
-    // MARK: - GET /assignments/import-marmoset
+    // MARK: - GET /instructor/import-marmoset
 
     @Sendable
     func importForm(req: Request) async throws -> View {
@@ -62,7 +62,7 @@ struct MarmosetImportRoutes: RouteCollection {
         ))
     }
 
-    // MARK: - POST /assignments/import-marmoset
+    // MARK: - POST /instructor/import-marmoset
 
     @Sendable
     func processImport(req: Request) async throws -> Response {
@@ -246,6 +246,6 @@ struct MarmosetImportRoutes: RouteCollection {
         // ── 5. Kick the runner and redirect ───────────────────────────
 
         await ensureValidationRunnerAvailability(req: req)
-        return req.redirect(to: "/assignments")
+        return req.redirect(to: "/instructor")
     }
 }

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -2,12 +2,12 @@
 //
 // Integration tests for Phase 7 instructor assignment management routes.
 //
-//   GET  /assignments
-//   POST /assignments                       (publish → draft)
-//   GET  /assignments/:id/validate
-//   POST /assignments/:id/open
-//   POST /assignments/:id/close
-//   POST /assignments/:id/delete
+//   GET  /instructor
+//   POST /instructor                       (publish → draft)
+//   GET  /instructor/:id/validate
+//   POST /instructor/:id/open
+//   POST /instructor/:id/close
+//   POST /instructor/:id/delete
 
 import XCTest
 import XCTVapor
@@ -129,11 +129,11 @@ final class AssignmentRoutesTests: XCTestCase {
         return student
     }
 
-    // MARK: - GET /assignments
+    // MARK: - GET /instructor
 
     func testStudentCannotAccessAssignments() async throws {
         let cookie = try await loginAsStudent()
-        try await app.test(.GET, "/assignments", beforeRequest: { req in
+        try await app.test(.GET, "/instructor", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .forbidden)
@@ -142,7 +142,7 @@ final class AssignmentRoutesTests: XCTestCase {
 
     func testInstructorCanAccessAssignments() async throws {
         let cookie = try await loginAsInstructor()
-        try await app.test(.GET, "/assignments", beforeRequest: { req in
+        try await app.test(.GET, "/instructor", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             // 500 expected because Leaf is not configured in tests — but middleware passed (not 401/403).
@@ -151,24 +151,24 @@ final class AssignmentRoutesTests: XCTestCase {
         })
     }
 
-    // MARK: - POST /assignments (publish → creates draft)
+    // MARK: - POST /instructor (publish → creates draft)
 
     func testPublishCreatesDraftAssignment() async throws {
         let cookie = try await loginAsInstructor()
         try await insertSetup(id: "setup_pub1")
 
-        try await app.test(.POST, "/assignments", beforeRequest: { req in
+        try await app.test(.POST, "/instructor", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
             try req.content.encode(
                 ["testSetupID": "setup_pub1", "title": "Lab 1"],
                 as: .urlEncodedForm
             )
         }, afterResponse: { res in
-            // Redirects to /assignments/:id/validate
+            // Redirects to /instructor/:id/validate
             XCTAssertEqual(res.status, .seeOther)
             let location = res.headers.first(name: .location) ?? ""
-            XCTAssertTrue(location.contains("/assignments/") && location.contains("/validate"),
-                          "Expected redirect to /assignments/:id/validate, got \(location)")
+            XCTAssertTrue(location.contains("/instructor/") && location.contains("/validate"),
+                          "Expected redirect to /instructor/:id/validate, got \(location)")
         })
 
         // Assignment should be in DB as draft (isOpen: false)
@@ -183,7 +183,7 @@ final class AssignmentRoutesTests: XCTestCase {
     func testPublishUnknownSetupReturnsBadRequest() async throws {
         let cookie = try await loginAsInstructor()
 
-        try await app.test(.POST, "/assignments", beforeRequest: { req in
+        try await app.test(.POST, "/instructor", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
             try req.content.encode(
                 ["testSetupID": "does_not_exist", "title": "Oops"],
@@ -199,16 +199,16 @@ final class AssignmentRoutesTests: XCTestCase {
         try await insertSetup(id: "setup_dup")
         try await insertAssignment(testSetupID: "setup_dup", title: "Already Published", isOpen: false)
 
-        try await app.test(.POST, "/assignments", beforeRequest: { req in
+        try await app.test(.POST, "/instructor", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
             try req.content.encode(
                 ["testSetupID": "setup_dup", "title": "Duplicate"],
                 as: .urlEncodedForm
             )
         }, afterResponse: { res in
-            // Should redirect to /assignments without creating a second record
+            // Should redirect to /instructor without creating a second record
             XCTAssertEqual(res.status, .seeOther)
-            XCTAssertEqual(res.headers.first(name: .location), "/assignments")
+            XCTAssertEqual(res.headers.first(name: .location), "/instructor")
         })
 
         let count = try await APIAssignment.query(on: app.db)
@@ -217,7 +217,7 @@ final class AssignmentRoutesTests: XCTestCase {
         XCTAssertEqual(count, 1)
     }
 
-    // MARK: - POST /assignments/:id/open
+    // MARK: - POST /instructor/:id/open
 
     func testOpenAssignmentSetsIsOpenTrue() async throws {
         let cookie = try await loginAsInstructor()
@@ -225,18 +225,18 @@ final class AssignmentRoutesTests: XCTestCase {
         let a = try await insertAssignment(testSetupID: "setup_open", title: "Draft", isOpen: false)
         let id = a.publicID
 
-        try await app.test(.POST, "/assignments/\(id)/open", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(id)/open", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .seeOther)
-            XCTAssertEqual(res.headers.first(name: .location), "/assignments")
+            XCTAssertEqual(res.headers.first(name: .location), "/instructor")
         })
 
         let updated = try await APIAssignment.find(a.id, on: app.db)
         XCTAssertEqual(updated?.isOpen, true)
     }
 
-    // MARK: - POST /assignments/:id/close
+    // MARK: - POST /instructor/:id/close
 
     func testCloseAssignmentSetsIsOpenFalse() async throws {
         let cookie = try await loginAsInstructor()
@@ -244,7 +244,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let a = try await insertAssignment(testSetupID: "setup_close", title: "Open", isOpen: true)
         let id = a.publicID
 
-        try await app.test(.POST, "/assignments/\(id)/close", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(id)/close", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .seeOther)
@@ -254,7 +254,7 @@ final class AssignmentRoutesTests: XCTestCase {
         XCTAssertEqual(updated?.isOpen, false)
     }
 
-    // MARK: - POST /assignments/:id/delete
+    // MARK: - POST /instructor/:id/delete
 
     func testDeleteAssignmentRemovesRecord() async throws {
         let cookie = try await loginAsInstructor()
@@ -262,7 +262,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let a = try await insertAssignment(testSetupID: "setup_del", title: "To Remove", isOpen: false)
         let id = a.publicID
 
-        try await app.test(.POST, "/assignments/\(id)/delete", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(id)/delete", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .seeOther)
@@ -276,27 +276,27 @@ final class AssignmentRoutesTests: XCTestCase {
         let cookie = try await loginAsInstructor()
         let fakeID = "zzzzzz"
 
-        try await app.test(.POST, "/assignments/\(fakeID)/delete", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(fakeID)/delete", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
         })
     }
 
-    // MARK: - POST /assignments/:id/open — nonexistent
+    // MARK: - POST /instructor/:id/open — nonexistent
 
     func testOpenNonexistentAssignmentReturnsNotFound() async throws {
         let cookie = try await loginAsInstructor()
         let fakeID = "zzzzzz"
 
-        try await app.test(.POST, "/assignments/\(fakeID)/open", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(fakeID)/open", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
         })
     }
 
-    // MARK: - POST /assignments/:assignmentID/submissions/:submissionID/retest
+    // MARK: - POST /instructor/:assignmentID/submissions/:submissionID/retest
 
     func testRetestSubmissionRequeuesCompletedSubmission() async throws {
         let cookie = try await loginAsInstructor()
@@ -317,15 +317,15 @@ final class AssignmentRoutesTests: XCTestCase {
         submission.assignedAt = Date()
         try await submission.save(on: app.db)
 
-        try await app.test(.POST, "/assignments/\(assignmentID)/submissions/sub_retest_1/retest", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(assignmentID)/submissions/sub_retest_1/retest", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
             try req.content.encode(
-                ["returnTo": "/assignments/\(assignmentID)/submissions"],
+                ["returnTo": "/instructor/\(assignmentID)/submissions"],
                 as: .urlEncodedForm
             )
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .seeOther)
-            XCTAssertEqual(res.headers.first(name: .location), "/assignments/\(assignmentID)/submissions")
+            XCTAssertEqual(res.headers.first(name: .location), "/instructor/\(assignmentID)/submissions")
         })
 
         let updated = try await APISubmission.find("sub_retest_1", on: app.db)
@@ -352,7 +352,7 @@ final class AssignmentRoutesTests: XCTestCase {
         )
         try await submission.save(on: app.db)
 
-        try await app.test(.POST, "/assignments/\(assignmentID)/submissions/sub_retest_mismatch/retest", beforeRequest: { req in
+        try await app.test(.POST, "/instructor/\(assignmentID)/submissions/sub_retest_mismatch/retest", beforeRequest: { req in
             req.headers.add(name: .cookie, value: cookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -208,7 +208,7 @@ final class AuthRoutesTests: XCTestCase {
             sessionCookie = res.headers.first(name: .setCookie) ?? ""
         })
 
-        try await app.test(.GET, "/assignments", beforeRequest: { req in
+        try await app.test(.GET, "/instructor", beforeRequest: { req in
             req.headers.add(name: .cookie, value: sessionCookie)
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .forbidden)

--- a/Tests/APITests/TestSetupEditTests.swift
+++ b/Tests/APITests/TestSetupEditTests.swift
@@ -4,7 +4,7 @@
 //
 //   PUT  /api/v1/testsetups/:id/assignment  — save edited notebook
 //   GET  /api/v1/testsetups/:id/assignment  — serves flat file when present
-//   GET  /assignments/:id/edit              — instructor-only editor page
+//   GET  /instructor/:id/edit              — instructor-only editor page
 
 import XCTest
 import XCTVapor
@@ -357,7 +357,7 @@ final class TestSetupEditTests: XCTestCase {
         )
     }
 
-    // MARK: - GET /assignments/:id/edit
+    // MARK: - GET /instructor/:id/edit
 
     func testEditPageRequiresInstructor() async throws {
         let cookie = try await loginAsStudent()
@@ -365,7 +365,7 @@ final class TestSetupEditTests: XCTestCase {
         let a = try await insertAssignment(testSetupID: "setup_ep1", title: "Lab")
         let id = a.publicID
 
-        try await app.test(.GET, "/assignments/\(id)/edit",
+        try await app.test(.GET, "/instructor/\(id)/edit",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: cookie)
             }, afterResponse: { res in
@@ -378,7 +378,7 @@ final class TestSetupEditTests: XCTestCase {
         let cookie = try await loginAsInstructor()
         let fakeID = "zzzzzz"
 
-        try await app.test(.GET, "/assignments/\(fakeID)/edit",
+        try await app.test(.GET, "/instructor/\(fakeID)/edit",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: cookie)
             }, afterResponse: { res in
@@ -393,7 +393,7 @@ final class TestSetupEditTests: XCTestCase {
         let a = try await insertAssignment(testSetupID: "setup_ep2", title: "My Lab")
         let id = a.publicID
 
-        try await app.test(.GET, "/assignments/\(id)/edit",
+        try await app.test(.GET, "/instructor/\(id)/edit",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: cookie)
             }, afterResponse: { res in

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,7 +18,7 @@ Two deployment paths are documented here:
 > scipy, matplotlib) and R base out of the box. If your test scripts require
 > additional packages, create a `Dockerfile.local` that extends the image:
 > ```dockerfile
-> FROM chickadee:latest
+> FROM ghcr.io/jimwallace/chickadee:latest
 > USER root
 > RUN pip3 install --no-cache-dir mypackage
 > RUN Rscript -e "install.packages('tidyverse', repos='https://cloud.r-project.org')"
@@ -43,15 +43,16 @@ Edit `.env`:
 | `AUTH_MODE` | `local` for username/password; `sso` for OIDC |
 | `PUBLIC_BASE_URL` | Your public URL, e.g. `https://chickadee.example.com` |
 
-### 2. Build and start
+### 2. Pull and start
 
 ```bash
-docker compose up -d --build
+docker compose pull   # downloads the pre-built image from GitHub Container Registry
+docker compose up -d
 ```
 
-The first build compiles both Swift binaries inside the container — this takes
-5–15 minutes depending on your machine. Subsequent builds without source changes
-use the cached layers and are nearly instant.
+The image is built automatically by GitHub Actions on every push to `main` — no
+Swift toolchain is required on the server. The first pull downloads ~500 MB;
+subsequent pulls only fetch changed layers.
 
 Check status:
 
@@ -103,13 +104,41 @@ docker compose up -d
 
 ### 5. Updating
 
+Use the deploy script from the repo root — it backs up the database, pulls the
+new image, restarts services, and confirms the health check passes:
+
 ```bash
-git pull
-docker compose up -d --build
+scripts/server-deploy.sh
 ```
 
 The entrypoint script automatically syncs fresh templates and JupyterLite assets
-from the new image into the data volume on each restart.
+from the new image into the data volume on each restart. Fluent schema migrations
+also run automatically on startup.
+
+**Rollback** to a specific build (replace the SHA with one from the
+[GHCR package page](https://github.com/JimWallace/Chickadee/pkgs/container/chickadee)
+or the Actions run summary):
+
+```bash
+CHICKADEE_IMAGE=ghcr.io/jimwallace/chickadee:sha-abc1234 scripts/server-deploy.sh
+```
+
+### CI/CD pipeline
+
+Every push to `main` triggers `.github/workflows/docker-build.yml`, which:
+
+1. Builds the Docker image using BuildKit (Swift dependency layer is cached,
+   so incremental builds take ~5–7 minutes)
+2. Pushes two tags to GitHub Container Registry:
+   - `ghcr.io/jimwallace/chickadee:latest` — always the current `main` build
+   - `ghcr.io/jimwallace/chickadee:sha-<commit>` — immutable, used for rollback
+3. On version tags (`v0.x.y`): also pushes `ghcr.io/jimwallace/chickadee:v0.x.y`
+
+Pull requests build the image but do **not** push, catching build failures
+before they reach `main`.
+
+Browse available image tags at:
+https://github.com/JimWallace/Chickadee/pkgs/container/chickadee
 
 ### Scaling the runner
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
   # Server — Vapor API + Leaf web UI
   # ----------------------------------------------------------------
   server:
-    build: .
-    image: chickadee:latest
+    build: .                              # used by `docker compose up --build` (local dev)
+    image: ghcr.io/jimwallace/chickadee:latest  # pulled by `docker compose pull` (production)
     restart: unless-stopped
     ports:
       - "8080:8080"   # remove this if using the nginx service below
@@ -64,7 +64,7 @@ services:
   # Runner — polls the server for pending jobs and runs test scripts
   # ----------------------------------------------------------------
   runner:
-    image: chickadee:latest
+    image: ghcr.io/jimwallace/chickadee:latest
     entrypoint: ["/app/chickadee-runner"]
     command:
       - --api-base-url

--- a/scripts/server-deploy.sh
+++ b/scripts/server-deploy.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# server-deploy.sh — Pull the latest Chickadee image and restart services.
+#
+# Run this on the production server whenever you want to apply an update:
+#   scripts/server-deploy.sh
+#
+# To deploy a specific image (e.g., for rollback):
+#   CHICKADEE_IMAGE=ghcr.io/jimwallace/chickadee:sha-abc1234 scripts/server-deploy.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE="docker compose -f $REPO_ROOT/docker-compose.yml"
+HEALTH_URL="http://localhost:8080/health"
+BACKUP_DIR="$REPO_ROOT/backups"
+
+# ----------------------------------------------------------------
+# Optional image override (e.g. for rollback to a specific sha tag)
+# ----------------------------------------------------------------
+if [[ -n "${CHICKADEE_IMAGE:-}" ]]; then
+  echo "==> Overriding image to: $CHICKADEE_IMAGE"
+  export CHICKADEE_IMAGE
+  # Rewrite compose to use the override — simplest approach is a temp override file
+  OVERRIDE_FILE="$(mktemp /tmp/chickadee-override-XXXXXX.yml)"
+  cat > "$OVERRIDE_FILE" <<EOF
+services:
+  server:
+    image: $CHICKADEE_IMAGE
+  runner:
+    image: $CHICKADEE_IMAGE
+EOF
+  COMPOSE="$COMPOSE -f $OVERRIDE_FILE"
+  trap 'rm -f "$OVERRIDE_FILE"' EXIT
+fi
+
+# ----------------------------------------------------------------
+# 1. Back up the database
+# ----------------------------------------------------------------
+mkdir -p "$BACKUP_DIR"
+BACKUP_FILE="$BACKUP_DIR/chickadee-backup-$(date +%Y%m%d-%H%M%S).tar.gz"
+echo "==> Backing up data volume to $BACKUP_FILE ..."
+docker run --rm \
+  -v chickadee_chickadee-data:/data \
+  -v "$BACKUP_DIR":/backup \
+  ubuntu \
+  tar czf "/backup/$(basename "$BACKUP_FILE")" -C /data .
+echo "    Backup complete."
+
+# Prune backups older than 14 days
+find "$BACKUP_DIR" -name "chickadee-backup-*.tar.gz" -mtime +14 -delete
+
+# ----------------------------------------------------------------
+# 2. Pull the new image
+# ----------------------------------------------------------------
+echo "==> Pulling latest images..."
+$COMPOSE pull
+
+# ----------------------------------------------------------------
+# 3. Restart services (Compose handles stop → start in dependency order)
+# ----------------------------------------------------------------
+echo "==> Restarting services..."
+$COMPOSE up -d
+
+# ----------------------------------------------------------------
+# 4. Wait for the health check to pass
+# ----------------------------------------------------------------
+echo "==> Waiting for server to become healthy..."
+ATTEMPTS=0
+MAX_ATTEMPTS=20
+until curl -sf "$HEALTH_URL" > /dev/null 2>&1; do
+  ATTEMPTS=$((ATTEMPTS + 1))
+  if [[ $ATTEMPTS -ge $MAX_ATTEMPTS ]]; then
+    echo "ERROR: Server did not become healthy after $MAX_ATTEMPTS attempts."
+    echo "       Check logs with: docker compose logs server"
+    exit 1
+  fi
+  sleep 3
+done
+
+echo ""
+echo "==> Health check passed:"
+curl -sf "$HEALTH_URL" | python3 -m json.tool 2>/dev/null || curl -sf "$HEALTH_URL"
+echo ""
+echo "==> Deploy complete."


### PR DESCRIPTION
## Summary

- **CI/CD pipeline**: GitHub Actions workflow builds and pushes Docker image to GHCR (`ghcr.io/jimwallace/chickadee`) on every push to `main` and version tags; PRs build-only to catch failures early
- **docker-compose.yml**: Both `server` and `runner` now reference the GHCR image; `build: .` retained for local dev
- **`scripts/server-deploy.sh`**: One-command deploy — backs up data volume, pulls new image, restarts services, polls `/health`; supports `CHICKADEE_IMAGE=...` env var for rollback to any prior SHA tag
- **`deploy/README.md`**: Updated with GHCR-based startup, CI/CD section, and rollback instructions
- **Admin page footer**: Shows `Chickadee vX.Y.Z` in small muted text for post-deploy verification
- **`/assignments` → `/instructor`**: All route paths, redirects, templates, JS fetch calls, and test assertions updated

## Test plan

- [ ] Build passes in CI (Actions tab)
- [ ] `/instructor` loads for instructor/admin users; 404 for students
- [ ] Admin page footer shows correct version
- [ ] `scripts/server-deploy.sh` runs end-to-end on the target server
- [ ] Rollback with `CHICKADEE_IMAGE=ghcr.io/jimwallace/chickadee:sha-<hash>` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)