### PR TITLE
Apply UWaterloo visual identity

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1,11 +1,14 @@
 :root {
     color-scheme: light;
-    --blue:    #2563EB;
+    --blue:    #115E6B;   /* AHS teal — interactive elements */
+    --gold:    #EAAB00;   /* UW gold — brand, primary actions */
+    --gold-hover: #C8960A;
+    --teal-hover: #009CAB;
     --green:   #16A34A;
     --red:     #DC2626;
     --purple:  #9333EA;
     --amber:   #D97706;
-    --gray-50: #F9FAFB;
+    --gray-50: #F7F7F7;
     --gray-100: #F3F4F6;
     --gray-200: #E5E7EB;
     --gray-400: #9CA3AF;
@@ -17,9 +20,9 @@
     --surface-muted: #F8FAFC;
     --danger-bg: #FEF2F2;
     --danger-border: #FECACA;
-    --accent-bg: #DBEAFE;
-    --accent-fg: #1D4ED8;
-    --hover-bg: #EFF6FF;
+    --accent-bg: #FEF3CC;   /* gold tint — badges, pills */
+    --accent-fg: #7A5000;   /* dark gold — readable on gold tint */
+    --hover-bg: #FEF7DC;    /* gold tint — hover backgrounds */
     --open-bg: #DCFCE7;
     --closed-bg: #FEE2E2;
     --open-fg: #166534;
@@ -31,7 +34,10 @@
 @media (prefers-color-scheme: dark) {
     :root {
         color-scheme: dark;
-        --blue: #60A5FA;
+        --blue: #00B8C8;        /* bright teal — readable on dark backgrounds */
+        --gold: #EAAB00;
+        --gold-hover: #C8960A;
+        --teal-hover: #00D4E8;
         --green: #4ADE80;
         --red: #F87171;
         --purple: #C084FC;
@@ -48,9 +54,9 @@
         --surface-muted: #0F172A;
         --danger-bg: #3B1217;
         --danger-border: #7F1D1D;
-        --accent-bg: #1E3A8A;
-        --accent-fg: #BFDBFE;
-        --hover-bg: #1E3A8A;
+        --accent-bg: #3D2800;   /* dark gold tint */
+        --accent-fg: #FED34C;   /* soft gold — readable on dark gold tint */
+        --hover-bg: #3D2800;
         --open-bg: #052E1A;
         --closed-bg: #3B1217;
         --open-fg: #86EFAC;
@@ -109,8 +115,7 @@ a { color: var(--blue); }
     align-items: center;
     gap: 1.5rem;
     padding: .75rem 1.5rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--gray-200);
+    background: #000000;
 }
 
 .nav-brand {
@@ -120,7 +125,7 @@ a { color: var(--blue); }
     font-weight: 700;
     font-size: 1.05rem;
     text-decoration: none;
-    color: var(--gray-900);
+    color: #EAAB00;
 }
 
 .nav-brand-logo {
@@ -130,11 +135,14 @@ a { color: var(--blue); }
     display: block;
 }
 
-
 .nav-link {
     font-size: .875rem;
     text-decoration: none;
-    color: var(--blue);
+    color: rgba(255,255,255,.85);
+}
+
+.nav-link:hover {
+    color: #EAAB00;
 }
 
 /* ── Main container ──────────────────────────────────── */
@@ -169,9 +177,14 @@ h2 { font-size: 1rem;   margin-bottom: .4rem; }
 }
 
 .btn-primary {
-    background: var(--blue);
-    border-color: var(--blue);
-    color: white;
+    background: #EAAB00;
+    border-color: #EAAB00;
+    color: #000000;
+}
+
+.btn-primary:hover {
+    background: #C8960A;
+    border-color: #C8960A;
 }
 
 .btn + .btn { margin-left: .5rem; }
@@ -632,10 +645,10 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 /* ── Nav username + logout button ────────────────────── */
 
 /* Also applied alongside .nav-link on the account <a>; color intentionally
-   overrides nav-link's blue — username appears gray, Log out stays blue. */
+   overrides nav-link's white — username appears dimmed, less prominent than nav actions. */
 .nav-username {
     font-size: .875rem;
-    color: var(--gray-600);
+    color: rgba(255,255,255,.6);
     margin-left: auto;
 }
 
@@ -670,8 +683,8 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 }
 
 .course-tab-active {
-    color: var(--blue);
-    border-bottom-color: var(--blue);
+    color: var(--blue);          /* teal */
+    border-bottom-color: #EAAB00; /* gold underline */
     font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary

- **Colour tokens**: Replace generic blue (`#2563EB`) with AHS teal (`#115E6B`) for all interactive elements (links, focus rings, spinner, active tabs) and UW gold (`#EAAB00`) for brand/primary-action elements
- **Nav bar**: Black background, gold "Chickadee" wordmark, white nav links with gold hover — matches the uwaterloo.ca institutional pattern
- **Primary button**: Gold fill (`#EAAB00`), black text (WCAG AA ✓), darker gold on hover
- **Course tabs**: Teal text + gold underline on active tab
- **Grade pills / accent tokens**: Gold-tinted background with dark-gold text; dark-mode equivalents (`#3D2800` bg / `#FED34C` text)
- **Page background**: `#F7F7F7` (slightly cleaner near-white)
- **Dark mode**: All tokens adjusted (bright teal `#00B8C8`, dark-gold tint backgrounds, soft-gold `#FED34C` text)

No layout, template, component semantics, or accessibility features changed — purely CSS tokens and the four named component rules above.

## Test plan
- [ ] Load the student dashboard — nav should be black with gold "Chickadee" wordmark and white links
- [ ] Hover a nav link — should turn gold
- [ ] Find any primary button (Submit, Save, etc.) — should be gold fill with black text
- [ ] Hover primary button — should darken to `#C8960A`
- [ ] If enrolled in multiple courses, active course tab should have gold underline + teal text
- [ ] Check a grade pill / score badge — should be gold-tinted background
- [ ] Links in page body should be teal, not blue
- [ ] Toggle dark mode — nav stays black, accent colours shift to bright teal and soft gold
- [ ] Run a submission — spinner border-top should be teal
- [ ] Check accessibility: tab through the page, focus rings should be teal

🤖 Generated with [Claude Code](https://claude.com/claude-code)