### PR TITLE
Polish nav hover and danger button colours

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -148,7 +148,7 @@ a { color: var(--blue); }
 }
 
 .nav-link:hover {
-    color: #EAAB00;
+    color: #97DFEF;  /* health-teal-light — AHS palette, pale teal on black */
 }
 
 /* ── AHS colour bar ──────────────────────────────────── */
@@ -219,9 +219,9 @@ h2 { font-size: 1rem;   margin-bottom: .4rem; }
 }
 
 .action-danger {
-    color: var(--red);
-    border-color: var(--danger-border);
-    background: var(--danger-bg);
+    color: var(--gray-600);
+    border-color: var(--gray-400);
+    background: var(--gray-100);
 }
 
 /* ── Forms ───────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- **Nav link hover**: was gold (`#EAAB00`) → now `#97DFEF` (health-teal-light). This is the exact colour AHS uses for subtitle text on their black header — stays fully within palette, no more gold flash on hover.
- **Danger/destructive buttons**: was red fill (`--danger-bg` / `--red`) → now muted charcoal (`gray-100` bg, `gray-400` border, `gray-600` text). Communicates "this requires care" without a traffic-light red that clashes with the teal identity.

## Test plan
- [ ] Hover any nav link — should turn pale teal, not gold
- [ ] On Instructor page: find a Delete/Remove action button — should be gray-outlined, not red
- [ ] On Admin page: same check for any destructive action buttons
- [ ] Dark mode: danger buttons should still read as clearly secondary (gray tones adapt via CSS vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)