### PR TITLE
Assignment row borders: teal/gray not green/red

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -17,6 +17,7 @@
     --gray-50: #F7F7F7;
     --gray-100: #F3F4F6;
     --gray-200: #E5E7EB;
+    --gray-300: #D1D5DB;
     --gray-400: #9CA3AF;
     --gray-500: #6B7280;
     --gray-600: #4B5563;
@@ -409,12 +410,16 @@ textarea.form-input {
     width: 11rem;
 }
 
-/* Status colour strips */
+/* Status colour strips — test outcome rows */
 .status-pass    td:first-child { border-left: 3px solid var(--green); }
 .status-fail    td:first-child { border-left: 3px solid var(--red); }
 .status-error   td:first-child { border-left: 3px solid var(--purple); }
 .status-timeout td:first-child { border-left: 3px solid var(--amber); }
 .status-skipped td:first-child { border-left: 3px solid var(--gray-400); }
+
+/* Assignment open/closed strips — teal/gray, not traffic-light colours */
+.status-open   td:first-child { border-left: 3px solid var(--health-teal); }
+.status-closed td:first-child { border-left: 3px solid var(--gray-300); }
 
 /* Tier badge */
 .tier {

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -105,7 +105,7 @@
         </tr>
         #else:
         #for(row in section.rows):
-            <tr class="#if(row.status == "open"):status-pass#elseif(row.status == "closed"):status-fail#endif"
+            <tr class="#if(row.status == "open"):status-open#elseif(row.status == "closed"):status-closed#endif"
                 #if(row.assignmentID):data-assignment-id="#(row.assignmentID)"#endif>
                 <td>
                     #if(row.assignmentID):
@@ -244,7 +244,7 @@
         </thead>
         <tbody id="assignments-body" data-section-id="">
         #for(row in ungroupedRows):
-            <tr class="#if(row.status == "open"):status-pass#elseif(row.status == "closed"):status-fail#endif"
+            <tr class="#if(row.status == "open"):status-open#elseif(row.status == "closed"):status-closed#endif"
                 #if(row.assignmentID):data-assignment-id="#(row.assignmentID)"#endif>
                 <td>
                     #if(row.assignmentID):


### PR DESCRIPTION
## Summary

- Add `.status-open` (health-teal `#0098A5` left border) and `.status-closed` (gray-300 `#D1D5DB` left border) CSS classes
- Add `--gray-300: #D1D5DB` token
- Update `assignments.leaf`: assignment rows now use `status-open`/`status-closed` instead of the test-outcome classes `status-pass`/`status-fail`

`status-pass` and `status-fail` (green/red) remain unchanged — they are semantically correct for test result rows.

## Test plan
- [ ] Instructor assignments page: open assignment rows should have a teal left border, not green
- [ ] Instructor assignments page: closed assignment rows should have a subtle gray left border, not red
- [ ] Student submission results table: pass rows still have green border, fail rows still have red border (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)