### PR TITLE
Add per-cell grading support for notebooks

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -273,6 +273,9 @@ for _module_name in student_module_names_in_load_order():
         const stem    = filename.replace(/\.ipynb$/i, '');
         const outPath = `${workDir}/${stem}.${ext}`;
 
+        // Per-cell marker regex: # CELL: name=<identifier>
+        const cellNameRe = /^#\s*CELL:\s*name=(\w+)/;
+
         let code = `# Generated from ${filename}\n\n`;
         for (const cell of (notebook.cells || [])) {
             if (cell.cell_type !== 'code') continue;
@@ -281,6 +284,16 @@ for _module_name in student_module_names_in_load_order():
                 : (cell.source || '');
             const trimmed = src.replace(/\s+$/, '');
             if (trimmed.trim()) code += trimmed + '\n\n';
+
+            // If the first non-empty line carries a # CELL: name=<id> marker,
+            // also write the cell source to cell_<name>.<ext> for per-cell grading.
+            const firstLine = src.split('\n').find(l => l.trim() !== '');
+            if (firstLine) {
+                const m = cellNameRe.exec(firstLine);
+                if (m) {
+                    py.FS.writeFile(`${workDir}/cell_${m[1]}.${ext}`, trimmed);
+                }
+            }
         }
 
         py.FS.writeFile(outPath, code);

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -682,9 +682,10 @@ let testRuntimeR = #"""
 # Source at the top of each R test script: source("test_runtime.R")
 #
 # API:
-#   passed(message = NULL)     — exit 0  (pass)
-#   failed(message = "failed") — exit 1  (fail)
-#   errored(message = "error") — exit 2  (error)
+#   passed(message = NULL)          — exit 0  (pass)
+#   failed(message = "failed")      — exit 1  (fail)
+#   errored(message = "error")      — exit 2  (error)
+#   load_cell(name, env = NULL)     — exec cell_<name>.R, return its environment
 #
 # No external package dependencies; JSON is hand-formatted so this works
 # on bare R installs without jsonlite.
@@ -742,6 +743,17 @@ errored <- function(message = "error") {
     .chickadee_emit("error", paste0(label, ": ", msg), error = msg)
     quit(status = 2L, save = "no")
 }
+
+load_cell <- function(name, env = NULL) {
+    cell_file <- paste0("cell_", name, ".R")
+    if (!file.exists(cell_file)) {
+        errored(paste0("Cell '", name, "' not found (expected file: ", cell_file, ")"))
+    }
+    parent <- if (!is.null(env)) env else baseenv()
+    e      <- new.env(parent = parent)
+    source(cell_file, local = e)
+    e
+}
 """#
 
 // MARK: - Notebook extraction
@@ -784,6 +796,11 @@ func extractNotebooksToCode(in directory: URL) throws {
         let stem   = item.deletingPathExtension().lastPathComponent
         let outURL = directory.appendingPathComponent("\(stem).\(ext)")
 
+        // Regex for the per-cell naming marker: # CELL: name=<identifier>
+        let cellNamePattern = try? NSRegularExpression(
+            pattern: #"^#\s*CELL:\s*name=(\w+)"#
+        )
+
         var output = "# Generated from \(item.lastPathComponent)\n\n"
         for cell in cells {
             guard cell["cell_type"] as? String == "code" else { continue }
@@ -799,6 +816,20 @@ func extractNotebooksToCode(in directory: URL) throws {
             while src.last?.isWhitespace == true { src.removeLast() }
             guard !src.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
             output += src + "\n\n"
+
+            // If the first non-empty line carries a # CELL: name=<id> marker,
+            // also write the cell source to cell_<name>.<ext> for per-cell grading.
+            if let pattern = cellNamePattern,
+               let firstLine = raw.components(separatedBy: "\n")
+                   .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) {
+                let nsRange = NSRange(firstLine.startIndex..., in: firstLine)
+                if let match = pattern.firstMatch(in: firstLine, range: nsRange),
+                   let nameRange = Range(match.range(at: 1), in: firstLine) {
+                    let cellName = String(firstLine[nameRange])
+                    let cellURL = directory.appendingPathComponent("cell_\(cellName).\(ext)")
+                    try src.write(to: cellURL, atomically: true, encoding: .utf8)
+                }
+            }
         }
 
         try output.write(to: outURL, atomically: true, encoding: .utf8)

--- a/Tools/runner-support/nb_to_r.py
+++ b/Tools/runner-support/nb_to_r.py
@@ -1,21 +1,29 @@
 """nb_to_r.py — Extract R code cells from a Jupyter notebook (.ipynb → .R).
 
 Usage: python3 nb_to_r.py notebook.ipynb
-Produces: notebook.R  (all code cells concatenated, preserving order)
+Produces:
+  notebook.R          — all code cells concatenated, preserving order
+  cell_<name>.R       — one file per cell marked with # CELL: name=<name>
 
 This mirrors nb_to_py.py for R notebooks. The runner-support Makefile generates
 both .py and .R files from every .ipynb; test scripts source whichever is
 appropriate for their language.
 """
+import re
 import sys
 import json
+import os
+
+CELL_NAME_RE = re.compile(r'^#\s*CELL:\s*name=(\w+)')
 
 p = sys.argv[1]
 with open(p, "r", encoding="utf-8") as f:
     nb = json.load(f)
 
-out = p[:-6] + ".R"
-with open(out, "w", encoding="utf-8") as w:
+out_dir = os.path.dirname(p) or "."
+stem    = os.path.splitext(os.path.basename(p))[0]
+
+with open(os.path.join(out_dir, stem + ".R"), "w", encoding="utf-8") as w:
     w.write(f"# Generated from {p}\n\n")
     for cell in nb.get("cells", []):
         if cell.get("cell_type") == "code":
@@ -25,3 +33,14 @@ with open(out, "w", encoding="utf-8") as w:
             src = src.rstrip()
             if src:
                 w.write(src + "\n\n")
+
+                # Write per-cell file if a # CELL: name=<id> marker is present
+                # on the first non-empty line of the cell.
+                first_line = next((l for l in src.split("\n") if l.strip()), None)
+                if first_line:
+                    m = CELL_NAME_RE.match(first_line)
+                    if m:
+                        cell_name = m.group(1)
+                        cell_path = os.path.join(out_dir, f"cell_{cell_name}.R")
+                        with open(cell_path, "w", encoding="utf-8") as cw:
+                            cw.write(src + "\n")

--- a/Tools/runner-support/test_runtime.R
+++ b/Tools/runner-support/test_runtime.R
@@ -2,9 +2,10 @@
 # Source at the top of each R test script: source("test_runtime.R")
 #
 # API:
-#   passed(message = NULL)     — exit 0  (pass)
-#   failed(message = "failed") — exit 1  (fail)
-#   errored(message = "error") — exit 2  (error)
+#   passed(message = NULL)          — exit 0  (pass)
+#   failed(message = "failed")      — exit 1  (fail)
+#   errored(message = "error")      — exit 2  (error)
+#   load_cell(name, env = NULL)     — exec cell_<name>.R, return its environment
 #
 # No external package dependencies; JSON is hand-formatted so this works
 # on bare R installs without jsonlite.
@@ -65,4 +66,26 @@ errored <- function(message = "error") {
     msg   <- as.character(message)
     .chickadee_emit("error", paste0(label, ": ", msg), error = msg)
     quit(status = 2L, save = "no")
+}
+
+load_cell <- function(name, env = NULL) {
+    # Load and eval a named cell by its # CELL: name=<name> marker.
+    #
+    # The cell must have been extracted to cell_<name>.R by the runner before
+    # this is called.  Returns the environment in which the cell was evaluated
+    # so callers can inspect variables the cell produced.
+    #
+    # Pass a prior environment via env to chain cells — the later cell will
+    # see the earlier cell's variables through the parent environment chain:
+    #   e1 <- load_cell("setup")
+    #   e2 <- load_cell("warmup", env = e1)
+    #   stopifnot(e2$result == 17)
+    cell_file <- paste0("cell_", name, ".R")
+    if (!file.exists(cell_file)) {
+        errored(paste0("Cell '", name, "' not found (expected file: ", cell_file, ")"))
+    }
+    parent <- if (!is.null(env)) env else baseenv()
+    e      <- new.env(parent = parent)
+    source(cell_file, local = e)
+    e
 }

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -182,6 +182,29 @@ def load_student_module():
     return modules.get(_loaded_student_order[0])
 
 
+def load_cell(name: str, namespace: Optional[dict] = None) -> dict:
+    """Load and exec a named cell by its ``# CELL: name=<name>`` marker.
+
+    The cell must have been extracted to ``cell_<name>.py`` by the runner or
+    browser grader before this is called.  Returns the resulting namespace
+    dict so callers can inspect variables the cell produced.
+
+    Pass a prior namespace dict via *namespace* to chain cells — the later
+    cell will see the earlier cell's variables in its execution environment::
+
+        ns = load_cell("setup")
+        ns = load_cell("warmup", namespace=ns)
+        assert ns["result"] == 17
+    """
+    cell_file = Path(f"cell_{name}.py")
+    if not cell_file.exists():
+        errored(f"Cell '{name}' not found (expected file: cell_{name}.py)")
+    ns: dict = dict(namespace) if namespace else {}
+    code = cell_file.read_text(encoding="utf-8")
+    exec(compile(code, str(cell_file), "exec"), ns)  # noqa: S102
+    return ns
+
+
 def require_function(name: str):
     modules = load_student_modules()
     for key in _loaded_student_order:


### PR DESCRIPTION
## Summary

- **`# CELL: name=<id>` marker**: instructors add this comment as the first line of any solution cell they want to test in isolation. The extractor writes `cell_<name>.py` (or `.R`) alongside the merged notebook file — no change to how unmarked cells or existing test scripts behave.
- **Three extractor paths kept in sync**: `RunnerDaemon.swift` (worker grading), `browser-runner.js` (Pyodide/browser grading), `nb_to_r.py` (build-time script).
- **`load_cell()` in Python** (`test_runtime.py`): execs a named cell in a fresh namespace and returns the namespace dict. An optional `namespace` parameter lets callers chain cells when later cells depend on earlier ones.
- **`load_cell()` in R** (`test_runtime.R` + its mirror in `RunnerDaemon.swift`): same idea — sources the cell file into a new environment; `env` parameter sets the parent environment for chaining.

Typical instructor test script:
```python
# test_warmup.py
from test_runtime import load_cell, passed, failed

ns = load_cell("warmup")
if ns.get("result") == 17:
    passed()
else:
    failed(f"Expected 17, got {ns.get('result')}")
```

Chaining when a later cell uses variables from an earlier one:
```python
ns = load_cell("setup")
ns = load_cell("warmup", namespace=ns)
```

## Test plan

- [ ] Create a Python notebook with two named cells (`# CELL: name=setup`, `# CELL: name=warmup`); run through worker grading; confirm `cell_setup.py` and `cell_warmup.py` are created alongside the merged `.py`
- [ ] Write a test script using `load_cell("warmup")` and confirm it runs in isolation (setup cell variables not visible unless chained)
- [ ] Run through browser grading; confirm same files appear in Pyodide FS and test passes
- [ ] Submit a notebook with no `# CELL:` markers; confirm merged-file behaviour is unchanged
- [ ] Submit a notebook where a cell defines a function; confirm no wrapping occurs and the function is testable normally via `load_cell`
- [ ] Run `swift test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)