### PR TITLE
Admin courses table polish + delete archived courses

### DIFF
--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -108,18 +108,16 @@ Admin
                 <th data-sort-key="code" data-sort-type="text" tabindex="0" aria-sort="none">Code</th>
                 <th data-sort-key="name" data-sort-type="text" tabindex="0" aria-sort="none">Name</th>
                 <th data-sort-key="students" data-sort-type="text" tabindex="0" aria-sort="none">Students</th>
-                <th data-sort-key="assignments" data-sort-type="text" tabindex="0" aria-sort="none">Assignments</th>
                 <th data-sort-key="status" data-sort-type="text" tabindex="0" aria-sort="none">Status</th>
                 <th>Actions</th>
             </tr>
         </thead>
         <tbody>
         #for(course in courses):
-            <tr>
+            <tr class="#if(course.isArchived):status-closed#else:status-open#endif">
                 <td><a href="/admin/courses/#(course.id)"><strong>#(course.code)</strong></a></td>
                 <td>#(course.name)</td>
                 <td>#(course.enrollmentCount)</td>
-                <td>#(course.assignmentCount)</td>
                 <td>
                     #if(course.isArchived):
                     <span class="tier tier-closed">archived</span>
@@ -128,6 +126,19 @@ Admin
                     #endif
                 </td>
                 <td style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    #if(course.isArchived):
+                    <a class="btn action-btn" href="/admin/courses/#(course.id)/export">Export</a>
+                    <form method="post" action="/admin/courses/#(course.id)/delete" style="display:inline;margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger" type="submit"
+                                onclick="return confirm('Permanently delete #(course.code) and all its data? This cannot be undone.')">Delete</button>
+                    </form>
+                    <form method="post" action="/admin/courses/#(course.id)/archive" style="display:inline;margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn" type="submit"
+                                onclick="return confirm('Unarchive #(course.code)? Students will be able to see it again.')">Unarchive</button>
+                    </form>
+                    #else:
                     <form method="post" action="/admin/courses/#(course.id)/copy" style="display:inline;margin:0">
                         #csrfFormField()
                         <button class="btn action-btn" type="submit"
@@ -135,14 +146,10 @@ Admin
                     </form>
                     <form method="post" action="/admin/courses/#(course.id)/archive" style="display:inline;margin:0">
                         #csrfFormField()
-                        #if(course.isArchived):
-                        <button class="btn action-btn action-danger" type="submit"
-                                onclick="return confirm('Unarchive #(course.code)? Students will be able to see it again.')">Unarchive</button>
-                        #else:
                         <button class="btn action-btn action-danger" type="submit"
                                 onclick="return confirm('Archive #(course.code)? Students will no longer see this course.')">Archive</button>
-                        #endif
                     </form>
+                    #endif
                 </td>
             </tr>
         #endfor

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -30,6 +30,7 @@ struct AdminRoutes: RouteCollection {
         admin.post("courses", ":courseID", "edit", use: editCourse)
         admin.post("courses", ":courseID", "archive", use: toggleCourseArchive)
         admin.post("courses", ":courseID", "copy",    use: copyCourse)
+        admin.post("courses", ":courseID", "delete",  use: deleteCourse)
         admin.post("courses", ":courseID", "open-enrollment", use: toggleOpenEnrollment)
         admin.post("courses", ":courseID", "enroll-csv", use: adminBulkEnrollCSV)
         admin.post("courses", ":courseID", "unenroll", ":userID", use: unenrollUserFromCourse)
@@ -336,6 +337,68 @@ struct AdminRoutes: RouteCollection {
 
         req.logger.info("Admin copied course \(source.code) → \(newCode) (new ID: \(newCourseID))")
         return req.redirect(to: "/admin/courses/\(newCourseID.uuidString)")
+    }
+
+    // MARK: - POST /admin/courses/:courseID/delete
+
+    @Sendable
+    func deleteCourse(req: Request) async throws -> Response {
+        guard
+            let idString = req.parameters.get("courseID"),
+            let courseID = UUID(uuidString: idString),
+            let course   = try await APICourse.find(courseID, on: req.db)
+        else { throw Abort(.notFound) }
+        guard course.isArchived else {
+            throw Abort(.badRequest, reason: "Only archived courses can be deleted.")
+        }
+
+        let setupsDir = req.application.testSetupsDirectory
+
+        try await req.db.transaction { db in
+            // 1. Test setups for this course.
+            let setups = try await APITestSetup.query(on: db)
+                .filter(\.$courseID == courseID).all()
+            let setupIDs = setups.compactMap { $0.id }
+
+            // 2. Submissions → results → delete.
+            let submissions = try await APISubmission.query(on: db)
+                .filter(\.$testSetupID ~~ setupIDs).all()
+            let subIDs = submissions.compactMap { $0.id }
+            if !subIDs.isEmpty {
+                try await APIResult.query(on: db)
+                    .filter(\.$submissionID ~~ subIDs).delete()
+            }
+
+            // 3. Delete submission zip files then submission records.
+            for sub in submissions {
+                try? FileManager.default.removeItem(atPath: sub.zipPath)
+            }
+            if !setupIDs.isEmpty {
+                try await APISubmission.query(on: db)
+                    .filter(\.$testSetupID ~~ setupIDs).delete()
+            }
+
+            // 4. Assignments.
+            try await APIAssignment.query(on: db)
+                .filter(\.$courseID == courseID).delete()
+
+            // 5. Test setup files then setup records.
+            for setup in setups {
+                guard let sid = setup.id else { continue }
+                try? FileManager.default.removeItem(atPath: setupsDir + "\(sid).zip")
+                try? FileManager.default.removeItem(atPath: setupsDir + "\(sid).ipynb")
+            }
+            try await APITestSetup.query(on: db)
+                .filter(\.$courseID == courseID).delete()
+
+            // 6. Enrollments then course record.
+            try await APICourseEnrollment.query(on: db)
+                .filter(\.$course.$id == courseID).delete()
+            try await course.delete(on: db)
+        }
+
+        req.logger.info("Admin permanently deleted course \(course.code) (\(idString))")
+        return req.redirect(to: "/admin")
     }
 
     // MARK: - POST /admin/courses/:courseID/edit


### PR DESCRIPTION
## Summary
- Remove Assignments column from admin courses table to reduce visual clutter
- Add status stripe (teal = active, gray = archived) matching the instructor assignment view
- Archived courses now show **Export**, **Delete**, and **Unarchive** actions; active courses show **Copy** and **Archive**
- Implement `deleteCourse` route (`POST /admin/courses/:id/delete`): guards non-archived, cascades deletion through results → submissions+files → assignments → test setups+files → enrollments → course record

## Test plan
- [ ] Admin courses table shows teal left border for active courses, gray for archived
- [ ] Assignments column is gone
- [ ] Active course row shows Copy + Archive buttons only
- [ ] Archived course row shows Export + Delete + Unarchive buttons
- [ ] Delete prompts confirmation dialog before submitting
- [ ] Deleting an archived course removes it and all associated data; redirects to /admin
- [ ] Attempting to delete a non-archived course returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)