### PR TITLE
fix: include CSRF token in browser submission fetch calls

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -1,3 +1,9 @@
+// Returns the CSRF token embedded by #csrfFormField() in the page.
+// Used by JS fetch calls to satisfy the CSRF middleware on POST endpoints.
+function getCsrfToken() {
+    return document.querySelector('input[name="_csrf"]')?.value ?? '';
+}
+
 // Drag-drop zone on the submission form
 const dropZone   = document.getElementById('drop-zone');
 const fileInput  = document.getElementById('file-input');

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -487,8 +487,9 @@ sys.stderr = sys.__stderr__
         formData.append('testSetupID', setupID);
 
         const res = await fetch('/api/v1/submissions/browser-result', {
-            method: 'POST',
-            body:   formData,
+            method:  'POST',
+            headers: { 'X-CSRF-Token': getCsrfToken() },
+            body:    formData,
         });
         if (!res.ok) {
             const text = await res.text();

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -696,8 +696,9 @@ else:
         formData.append('filename', filename);
 
         const res = await fetch('/api/v1/submissions/runner-submit', {
-            method: 'POST',
-            body:   formData,
+            method:  'POST',
+            headers: { 'X-CSRF-Token': getCsrfToken() },
+            body:    formData,
         });
         if (!res.ok) {
             const text = await res.text();


### PR DESCRIPTION
## Problem

Submitting an assignment from the notebook page returned:

```
Error: Server error 403: {"error":true,"reason":"No CSRF token provided."}
```

`POST /api/v1/submissions/browser-result` and `runner-submit` are in the `auth` route group which includes CSRF middleware, but the `fetch()` calls in `browser-runner.js` and `notebook.js` never sent the token.

## Fix

- Add `getCsrfToken()` helper to `app.js` (loaded globally via `base.leaf`) that reads the token already in the DOM from `#csrfFormField()` in the nav logout form
- Pass it as `X-CSRF-Token` header in both POST fetch calls

## Test plan

- [ ] Submit an assignment from the notebook page — no 403
- [ ] Both browser-graded and runner-graded notebooks submit successfully
- [ ] CSRF still blocks forged cross-site POST requests (token absent = 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)