### PR TITLE
fix: CSRF token via meta tag for reliable JS access

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -1,7 +1,9 @@
-// Returns the CSRF token embedded by #csrfFormField() in the page.
+// Returns the CSRF token from the <meta name="csrf-token"> tag in <head>.
 // Used by JS fetch calls to satisfy the CSRF middleware on POST endpoints.
 function getCsrfToken() {
-    return document.querySelector('input[name="_csrf"]')?.value ?? '';
+    return document.querySelector('meta[name="csrf-token"]')?.content
+        ?? document.querySelector('input[name="_csrf"]')?.value
+        ?? '';
 }
 
 // Drag-drop zone on the submission form

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -488,7 +488,7 @@ sys.stderr = sys.__stderr__
 
         const res = await fetch('/api/v1/submissions/browser-result', {
             method:  'POST',
-            headers: { 'X-CSRF-Token': getCsrfToken() },
+            headers: { 'x-csrf-token': getCsrfToken() },
             body:    formData,
         });
         if (!res.ok) {

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -697,7 +697,7 @@ else:
 
         const res = await fetch('/api/v1/submissions/runner-submit', {
             method:  'POST',
-            headers: { 'X-CSRF-Token': getCsrfToken() },
+            headers: { 'x-csrf-token': getCsrfToken() },
             body:    formData,
         });
         if (!res.ok) {

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light dark">
+    <meta name="csrf-token" content="#csrfToken()">
     <title>#import("title") — Chickadee</title>
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
     <link rel="shortcut icon" href="/favicon.png" type="image/png">

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -123,6 +123,7 @@ func configure(_ app: Application, cliWorkerSecret: String?, authModeOverride: A
 
     app.views.use(.leaf)
     app.leaf.tags["csrfFormField"] = CSRFFormFieldTag()
+    app.leaf.tags["csrfToken"] = CSRFTokenTag()
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     // COOP/COEP headers enable SharedArrayBuffer in browsers, required for
     // WebR (R WASM kernel) and the browser-side WASM runner (Issue #96/#77).

--- a/Sources/APIServer/Helpers/CSRFTokenTag.swift
+++ b/Sources/APIServer/Helpers/CSRFTokenTag.swift
@@ -1,0 +1,22 @@
+// APIServer/Helpers/CSRFTokenTag.swift
+//
+// Leaf tag that outputs the raw CSRF token string (no HTML wrapper).
+// Used as: <meta name="csrf-token" content="#csrfToken()">
+//
+// JavaScript reads the meta tag to include the token in fetch() headers,
+// which is the standard approach for AJAX-heavy pages (same pattern as
+// Rails, Django, and Laravel).
+
+import Vapor
+import Leaf
+import CSRF
+
+struct CSRFTokenTag: UnsafeUnescapedLeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        try ctx.requireParameterCount(0)
+        guard let req = ctx.request else {
+            return LeafData.string("")
+        }
+        return LeafData.string(CSRF.createToken(from: req))
+    }
+}


### PR DESCRIPTION
## Problem

#154 tried to read the CSRF token from the hidden `<input name="_csrf">` in the logout form, but that element lives inside `#if(currentUser)` in `base.leaf` and wasn't reliably in the DOM when fetch calls executed. Submissions still returned 403 "No CSRF token provided."

## Fix

- **New `CSRFTokenTag` Leaf tag** — outputs the raw token string (no HTML wrapper), registered as `#csrfToken()`
- **`<meta name="csrf-token">` in `base.leaf` `<head>`** — always present, unconditional, standard industry pattern (same as Rails/Django/Laravel)
- **`getCsrfToken()`** reads from the meta tag first, falls back to hidden input
- **Lowercase `x-csrf-token` header** matches the CSRF package's case-sensitive key set

## Test plan

- [ ] Submit notebook from student view — no 403
- [ ] Browser-graded and runner-graded submissions both work
- [ ] View page source: `<meta name="csrf-token" content="...">` present in `<head>`
- [ ] CSRF still blocks requests without valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)