### PR TITLE
test: add parser and submission route tests

### DIFF
--- a/Tests/APITests/MarmosetImportParserTests.swift
+++ b/Tests/APITests/MarmosetImportParserTests.swift
@@ -1,0 +1,321 @@
+// Tests/APITests/MarmosetImportParserTests.swift
+//
+// Unit tests for the MarmosetImportParser utility functions.
+
+import XCTest
+@testable import chickadee_server
+import Foundation
+import Core
+
+final class MarmosetImportParserTests: XCTestCase {
+
+    // MARK: - parseJavaProperties
+
+    func testParseSimpleProperties() {
+        let input = "key1=value1\nkey2=value2\n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["key1"], "value1")
+        XCTAssertEqual(result["key2"], "value2")
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testParseColonSeparator() {
+        let input = "key1:value1\nkey2: value2\n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["key1"], "value1")
+        XCTAssertEqual(result["key2"], "value2")
+    }
+
+    func testParseComments() {
+        let input = """
+        # This is a comment
+        ! This too
+        key1=value1
+        # Another comment
+        key2=value2
+        """
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result["key1"], "value1")
+        XCTAssertEqual(result["key2"], "value2")
+    }
+
+    func testParseEmptyLines() {
+        let input = "key1=value1\n\n\nkey2=value2\n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testParseBackslashContinuation() {
+        let input = "key1=val1,\\\n  val2,\\\n  val3\nkey2=simple\n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["key1"], "val1,val2,val3")
+        XCTAssertEqual(result["key2"], "simple")
+    }
+
+    func testParseWhitespaceTrimming() {
+        let input = "  key1  =  value1  \n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["key1"], "value1")
+    }
+
+    func testParseEqualsInValue() {
+        // Only split on first =
+        let input = "key1=a=b=c\n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["key1"], "a=b=c")
+    }
+
+    func testParseEmptyValue() {
+        let input = "key1=\nkey2=value\n"
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["key1"], "")
+        XCTAssertEqual(result["key2"], "value")
+    }
+
+    func testParseEmptyData() {
+        let result = parseJavaProperties(Data())
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testParseTypicalMarmosetTestProperties() {
+        let input = """
+        # Marmoset test properties
+        test.class.public=TestPublicA,TestPublicB
+        test.class.release=TestReleaseA
+        test.class.secret=TestSecretA,\
+          TestSecretB
+        build.language=python
+        """
+        let result = parseJavaProperties(Data(input.utf8))
+        XCTAssertEqual(result["test.class.public"], "TestPublicA,TestPublicB")
+        XCTAssertEqual(result["test.class.release"], "TestReleaseA")
+        XCTAssertEqual(result["test.class.secret"], "TestSecretA,  TestSecretB")
+        XCTAssertEqual(result["build.language"], "python")
+    }
+
+    // MARK: - parseTestClassList
+
+    func testParseTestClassListSimple() {
+        let result = parseTestClassList("TestA,TestB,TestC")
+        XCTAssertEqual(result, ["TestA", "TestB", "TestC"])
+    }
+
+    func testParseTestClassListWithWhitespace() {
+        let result = parseTestClassList("TestA , TestB , TestC")
+        XCTAssertEqual(result, ["TestA", "TestB", "TestC"])
+    }
+
+    func testParseTestClassListWithNewlines() {
+        let result = parseTestClassList("TestA,\n  TestB,\n  TestC")
+        XCTAssertEqual(result, ["TestA", "TestB", "TestC"])
+    }
+
+    func testParseTestClassListEmpty() {
+        let result = parseTestClassList("")
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testParseTestClassListSingle() {
+        let result = parseTestClassList("OnlyOne")
+        XCTAssertEqual(result, ["OnlyOne"])
+    }
+
+    func testParseTestClassListTrailingComma() {
+        let result = parseTestClassList("TestA,TestB,")
+        XCTAssertEqual(result, ["TestA", "TestB"])
+    }
+
+    // MARK: - extractTitleFromProjectOut
+
+    func testExtractTitleFromValidData() {
+        // Encode a 2-byte big-endian length + UTF-8 string
+        var data = Data()
+        let title = "Assignment 1 BMI Calculator"
+        let titleBytes = Array(title.utf8)
+        data.append(UInt8(titleBytes.count >> 8))
+        data.append(UInt8(titleBytes.count & 0xFF))
+        data.append(contentsOf: titleBytes)
+        // Add some padding bytes before/after
+        var fullData = Data(repeating: 0x00, count: 10)
+        fullData.append(data)
+        fullData.append(Data(repeating: 0x00, count: 10))
+
+        let result = extractTitleFromProjectOut(fullData)
+        XCTAssertEqual(result, "Assignment 1 BMI Calculator")
+    }
+
+    func testExtractTitlePrefersSpaceContaining() {
+        var data = Data()
+        // First: a capitalized word without space
+        let word = "SomeClass"
+        let wordBytes = Array(word.utf8)
+        data.append(UInt8(wordBytes.count >> 8))
+        data.append(UInt8(wordBytes.count & 0xFF))
+        data.append(contentsOf: wordBytes)
+        // Then: a title with a space
+        let title = "Project One"
+        let titleBytes = Array(title.utf8)
+        data.append(UInt8(titleBytes.count >> 8))
+        data.append(UInt8(titleBytes.count & 0xFF))
+        data.append(contentsOf: titleBytes)
+
+        let result = extractTitleFromProjectOut(data)
+        XCTAssertEqual(result, "Project One")
+    }
+
+    func testExtractTitleRejectsNumbers() {
+        var data = Data()
+        let number = "12345"
+        let bytes = Array(number.utf8)
+        data.append(UInt8(bytes.count >> 8))
+        data.append(UInt8(bytes.count & 0xFF))
+        data.append(contentsOf: bytes)
+
+        let result = extractTitleFromProjectOut(data)
+        XCTAssertNil(result)
+    }
+
+    func testExtractTitleRejectsDotPaths() {
+        var data = Data()
+        let path = "com.example.Test"
+        let bytes = Array(path.utf8)
+        data.append(UInt8(bytes.count >> 8))
+        data.append(UInt8(bytes.count & 0xFF))
+        data.append(contentsOf: bytes)
+
+        let result = extractTitleFromProjectOut(data)
+        XCTAssertNil(result)
+    }
+
+    func testExtractTitleRejectsSlashPaths() {
+        var data = Data()
+        let path = "src/main/Test"
+        let bytes = Array(path.utf8)
+        data.append(UInt8(bytes.count >> 8))
+        data.append(UInt8(bytes.count & 0xFF))
+        data.append(contentsOf: bytes)
+
+        let result = extractTitleFromProjectOut(data)
+        XCTAssertNil(result)
+    }
+
+    func testExtractTitleEmptyData() {
+        let result = extractTitleFromProjectOut(Data())
+        XCTAssertNil(result)
+    }
+
+    func testExtractTitleTooShortStrings() {
+        // String of length 2 should be rejected (minimum is 3)
+        var data = Data()
+        let short = "Hi"
+        let bytes = Array(short.utf8)
+        data.append(UInt8(bytes.count >> 8))
+        data.append(UInt8(bytes.count & 0xFF))
+        data.append(contentsOf: bytes)
+
+        let result = extractTitleFromProjectOut(data)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - convertToChickadeeManifest
+
+    func testConvertManifestBasic() throws {
+        let project = MarmosetProject(
+            number: 1,
+            publicTests: ["test_public.sh"],
+            releaseTests: ["test_release.sh"],
+            secretTests: [],
+            hasMakefile: false,
+            suggestedTitle: nil
+        )
+        let json = try convertToChickadeeManifest(project: project)
+        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+
+        XCTAssertEqual(decoded["schemaVersion"] as? Int, 1)
+        XCTAssertEqual(decoded["gradingMode"] as? String, "worker")
+        XCTAssertEqual(decoded["timeLimitSeconds"] as? Int, 10)
+        XCTAssertEqual(decoded["starterNotebook"] as? String, "assignment.ipynb")
+
+        let suites = decoded["testSuites"] as! [[String: String]]
+        XCTAssertEqual(suites.count, 2)
+        XCTAssertTrue(suites.contains { $0["tier"] == "public" && $0["script"] == "test_public.sh" })
+        XCTAssertTrue(suites.contains { $0["tier"] == "release" && $0["script"] == "test_release.sh" })
+    }
+
+    func testConvertManifestAllTiers() throws {
+        let project = MarmosetProject(
+            number: 2,
+            publicTests: ["pub1.sh", "pub2.sh"],
+            releaseTests: ["rel1.sh"],
+            secretTests: ["sec1.sh", "sec2.sh"],
+            hasMakefile: true,
+            suggestedTitle: "Project 2"
+        )
+        let json = try convertToChickadeeManifest(project: project)
+        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+
+        let suites = decoded["testSuites"] as! [[String: String]]
+        XCTAssertEqual(suites.count, 5)
+        let pubCount = suites.filter { $0["tier"] == "public" }.count
+        let relCount = suites.filter { $0["tier"] == "release" }.count
+        let secCount = suites.filter { $0["tier"] == "secret" }.count
+        XCTAssertEqual(pubCount, 2)
+        XCTAssertEqual(relCount, 1)
+        XCTAssertEqual(secCount, 2)
+    }
+
+    func testConvertManifestEmptyTests() throws {
+        let project = MarmosetProject(
+            number: 1,
+            publicTests: [],
+            releaseTests: [],
+            secretTests: [],
+            hasMakefile: false,
+            suggestedTitle: nil
+        )
+        let json = try convertToChickadeeManifest(project: project)
+        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+
+        let suites = decoded["testSuites"] as! [[String: String]]
+        XCTAssertEqual(suites.count, 0)
+    }
+
+    func testConvertManifestProducesValidTestProperties() throws {
+        let project = MarmosetProject(
+            number: 1,
+            publicTests: ["test.sh"],
+            releaseTests: [],
+            secretTests: [],
+            hasMakefile: false,
+            suggestedTitle: nil
+        )
+        let json = try convertToChickadeeManifest(project: project)
+        // Verify it round-trips through TestProperties decoder
+        let props = try JSONDecoder().decode(TestProperties.self, from: Data(json.utf8))
+        XCTAssertEqual(props.schemaVersion, 1)
+        XCTAssertEqual(props.testSuites.count, 1)
+        XCTAssertEqual(props.testSuites.first?.script, "test.sh")
+        XCTAssertEqual(props.testSuites.first?.tier, .pub)
+        XCTAssertEqual(props.timeLimitSeconds, 10)
+    }
+
+    // MARK: - MarmosetProject struct
+
+    func testMarmosetProjectStoresAllFields() {
+        let p = MarmosetProject(
+            number: 3,
+            publicTests: ["a", "b"],
+            releaseTests: ["c"],
+            secretTests: [],
+            hasMakefile: true,
+            suggestedTitle: "Test Project"
+        )
+        XCTAssertEqual(p.number, 3)
+        XCTAssertEqual(p.publicTests, ["a", "b"])
+        XCTAssertEqual(p.releaseTests, ["c"])
+        XCTAssertTrue(p.secretTests.isEmpty)
+        XCTAssertTrue(p.hasMakefile)
+        XCTAssertEqual(p.suggestedTitle, "Test Project")
+    }
+}

--- a/Tests/APITests/SubmissionRoutesTests.swift
+++ b/Tests/APITests/SubmissionRoutesTests.swift
@@ -1,0 +1,376 @@
+// Tests/APITests/SubmissionRoutesTests.swift
+//
+// Integration tests for SubmissionRoutes (instructor create endpoints)
+// and SubmissionDownloadRoute (authenticated download with access control).
+
+import XCTest
+import XCTVapor
+@testable import chickadee_server
+@testable import Core
+import FluentSQLiteDriver
+import Foundation
+
+final class SubmissionRoutesTests: XCTestCase {
+
+    private var app: Application!
+    private var tmpDir: String!
+
+    override func setUp() async throws {
+        app = Application(.testing)
+
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-subr-\(UUID().uuidString)/")
+            .path
+
+        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
+        for dir in dirs {
+            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        }
+        app.resultsDirectory     = dirs[0]
+        app.testSetupsDirectory  = dirs[1]
+        app.submissionsDirectory = dirs[2]
+
+        app.sessions.use(.memory)
+        app.middleware.use(app.sessions.middleware)
+
+        app.databases.use(.sqlite(.memory), as: .sqlite)
+        app.migrations.add(CreateUsers())
+        app.migrations.add(CreateCourses())
+        app.migrations.add(CreateCourseEnrollments())
+        app.migrations.add(CreateTestSetups())
+        app.migrations.add(CreateSubmissions())
+        app.migrations.add(CreateResults())
+        app.migrations.add(CreateAssignments())
+        app.migrations.add(CreatePerformanceIndexes())
+        app.migrations.add(AddCourseSections())
+        app.migrations.add(AddCourseOpenEnrollment())
+        try await app.autoMigrate().get()
+
+        configureLeaf(app)
+        try routes(app)
+    }
+
+    override func tearDown() async throws {
+        app.shutdown()
+        try? FileManager.default.removeItem(atPath: tmpDir)
+    }
+
+    // MARK: - Auth helpers
+
+    /// Logs in as instructor and returns (sessionCookie, csrfToken).
+    private func loginAsInstructor(username: String = "test_instructor") async throws -> (cookie: String, csrf: String) {
+        let cookie = try await loginUser(username: username, password: "pass", role: "instructor", on: app)
+        let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+        return (sessionCookie, csrf)
+    }
+
+    /// Logs in as student and returns (sessionCookie, csrfToken).
+    private func loginAsStudent(username: String = "test_student") async throws -> (cookie: String, csrf: String) {
+        let cookie = try await loginUser(username: username, password: "pass", role: "student", on: app)
+        let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+        return (sessionCookie, csrf)
+    }
+
+    // MARK: - Data helpers
+
+    private func makeTestCourseID() async throws -> UUID {
+        if let existing = try await APICourse.query(on: app.db).filter(\.$code == "TEST101").first() {
+            return try existing.requireID()
+        }
+        let course = APICourse(code: "TEST101", name: "Test Course")
+        try await course.save(on: app.db)
+        return try course.requireID()
+    }
+
+    @discardableResult
+    private func ensureSetup(id: String) async throws -> APITestSetup {
+        if let existing = try await APITestSetup.find(id, on: app.db) {
+            return existing
+        }
+        let courseID = try await makeTestCourseID()
+        let setup = APITestSetup(
+            id: id,
+            manifest: #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
+            zipPath: tmpDir + "testsetups/\(id).zip",
+            courseID: courseID
+        )
+        try await setup.save(on: app.db)
+        return setup
+    }
+
+    private func userID(for username: String) async throws -> UUID {
+        let user = try await APIUser.query(on: app.db).filter(\.$username == username).first()
+        return try XCTUnwrap(user).id!
+    }
+
+    // MARK: - POST /api/v1/submissions
+
+    func testCreateSubmissionWithValidBase64() async throws {
+        let auth = try await loginAsInstructor()
+        try await ensureSetup(id: "setup_001")
+
+        let zipData = Data("PK\u{03}\u{04}fake-zip-content".utf8)
+        let base64 = zipData.base64EncodedString()
+
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "setup_001", zipBase64: base64))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = try res.content.decode(SubmissionCreatedResponse.self)
+            XCTAssertTrue(body.submissionID.hasPrefix("sub_"))
+        })
+    }
+
+    func testCreateSubmissionWritesFileToDisk() async throws {
+        let auth = try await loginAsInstructor()
+        try await ensureSetup(id: "setup_disk")
+
+        let zipData = Data("PK\u{03}\u{04}test-content-12345".utf8)
+        let base64 = zipData.base64EncodedString()
+
+        var submissionID = ""
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "setup_disk", zipBase64: base64))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            submissionID = try res.content.decode(SubmissionCreatedResponse.self).submissionID
+        })
+
+        let sub = try await APISubmission.find(submissionID, on: app.db)
+        let subUnwrapped = try XCTUnwrap(sub)
+        let fileData = try Data(contentsOf: URL(fileURLWithPath: subUnwrapped.zipPath))
+        XCTAssertEqual(fileData, zipData)
+    }
+
+    func testCreateSubmissionIncrementsAttemptNumber() async throws {
+        let auth = try await loginAsInstructor()
+        try await ensureSetup(id: "setup_inc")
+
+        let base64 = Data("PK".utf8).base64EncodedString()
+
+        // First submission
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "setup_inc", zipBase64: base64))
+        }, afterResponse: { _ in })
+
+        // Second submission
+        var secondID = ""
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "setup_inc", zipBase64: base64))
+        }, afterResponse: { res in
+            secondID = try res.content.decode(SubmissionCreatedResponse.self).submissionID
+        })
+
+        let sub = try await APISubmission.find(secondID, on: app.db)
+        XCTAssertEqual(try XCTUnwrap(sub).attemptNumber, 2)
+    }
+
+    func testCreateSubmissionRejectsBadSetupID() async throws {
+        let auth = try await loginAsInstructor()
+
+        let base64 = Data("PK".utf8).base64EncodedString()
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "nonexistent", zipBase64: base64))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .badRequest)
+        })
+    }
+
+    func testCreateSubmissionRejectsInvalidBase64() async throws {
+        let auth = try await loginAsInstructor()
+        try await ensureSetup(id: "setup_b64")
+
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "setup_b64", zipBase64: "!!!not-base64!!!"))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .badRequest)
+        })
+    }
+
+    func testCreateSubmissionRequiresInstructorRole() async throws {
+        let auth = try await loginAsStudent()
+        try await ensureSetup(id: "setup_role")
+
+        let base64 = Data("PK".utf8).base64EncodedString()
+        try await app.test(.POST, "/api/v1/submissions", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(CreateSubmissionBody(testSetupID: "setup_role", zipBase64: base64))
+        }, afterResponse: { res in
+            XCTAssertTrue([.forbidden, .unauthorized].contains(res.status),
+                "Expected 401 or 403, got \(res.status)")
+        })
+    }
+
+    // MARK: - POST /api/v1/submissions/file
+
+    func testCreateSubmissionFileWithPython() async throws {
+        let auth = try await loginAsInstructor()
+        try await ensureSetup(id: "setup_py")
+
+        let pyContent = Data("print('hello')".utf8)
+        try await app.test(.POST, "/api/v1/submissions/file", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(SubmitFileBody(testSetupID: "setup_py", filename: "solution.py", file: pyContent))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = try res.content.decode(SubmissionCreatedResponse.self)
+            XCTAssertTrue(body.submissionID.hasPrefix("sub_"))
+        })
+    }
+
+    func testCreateSubmissionFileSavesWithCorrectExtension() async throws {
+        let auth = try await loginAsInstructor()
+        try await ensureSetup(id: "setup_ext")
+
+        let content = Data("x = 1".utf8)
+        var subID = ""
+        try await app.test(.POST, "/api/v1/submissions/file", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(SubmitFileBody(testSetupID: "setup_ext", filename: "homework.py", file: content))
+        }, afterResponse: { res in
+            subID = try res.content.decode(SubmissionCreatedResponse.self).submissionID
+        })
+
+        let sub = try await APISubmission.find(subID, on: app.db)
+        let path = try XCTUnwrap(sub).zipPath
+        XCTAssertTrue(path.hasSuffix(".py"), "Expected .py extension, got \(path)")
+        XCTAssertEqual(try XCTUnwrap(sub).filename, "homework.py")
+    }
+
+    func testCreateSubmissionFileRejectsBadSetupID() async throws {
+        let auth = try await loginAsInstructor()
+
+        try await app.test(.POST, "/api/v1/submissions/file", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+            req.headers.add(name: "x-csrf-token", value: auth.csrf)
+            try req.content.encode(SubmitFileBody(testSetupID: "bogus", filename: "test.py", file: Data("x".utf8)))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .badRequest)
+        })
+    }
+
+    // MARK: - GET /api/v1/submissions/:id/download
+
+    func testDownloadAsOwner() async throws {
+        let auth = try await loginAsStudent(username: "dl_owner")
+        let ownerID = try await userID(for: "dl_owner")
+        try await ensureSetup(id: "setup_dl")
+
+        let sub = APISubmission(
+            id: "sub_dl_own",
+            testSetupID: "setup_dl",
+            zipPath: tmpDir + "submissions/sub_dl_own.zip",
+            attemptNumber: 1,
+            userID: ownerID
+        )
+        try await sub.save(on: app.db)
+
+        let fileContent = Data("fake-zip-bytes".utf8)
+        try fileContent.write(to: URL(fileURLWithPath: sub.zipPath))
+
+        try await app.test(.GET, "/api/v1/submissions/sub_dl_own/download", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(Data(res.body.readableBytesView), fileContent)
+        })
+    }
+
+    func testDownloadAsInstructorForAnySubmission() async throws {
+        let studentAuth = try await loginAsStudent(username: "dl_student2")
+        let studentID = try await userID(for: "dl_student2")
+        let instrAuth = try await loginAsInstructor(username: "dl_instructor")
+        _ = studentAuth
+
+        try await ensureSetup(id: "setup_dl2")
+        let sub = APISubmission(
+            id: "sub_dl_instr",
+            testSetupID: "setup_dl2",
+            zipPath: tmpDir + "submissions/sub_dl_instr.zip",
+            attemptNumber: 1,
+            userID: studentID
+        )
+        try await sub.save(on: app.db)
+        try Data("instructor-download".utf8).write(to: URL(fileURLWithPath: sub.zipPath))
+
+        try await app.test(.GET, "/api/v1/submissions/sub_dl_instr/download", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: instrAuth.cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(Data(res.body.readableBytesView), Data("instructor-download".utf8))
+        })
+    }
+
+    func testDownloadForbiddenForNonOwnerStudent() async throws {
+        let authA = try await loginAsStudent(username: "dl_studentA")
+        let idA = try await userID(for: "dl_studentA")
+        _ = authA
+
+        try await ensureSetup(id: "setup_dl3")
+        let sub = APISubmission(
+            id: "sub_dl_forbid",
+            testSetupID: "setup_dl3",
+            zipPath: tmpDir + "submissions/sub_dl_forbid.zip",
+            attemptNumber: 1,
+            userID: idA
+        )
+        try await sub.save(on: app.db)
+        try Data("private".utf8).write(to: URL(fileURLWithPath: sub.zipPath))
+
+        let authB = try await loginAsStudent(username: "dl_studentB")
+        try await app.test(.GET, "/api/v1/submissions/sub_dl_forbid/download", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: authB.cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+        })
+    }
+
+    func testDownloadNotFoundForMissingSubmission() async throws {
+        let auth = try await loginAsInstructor()
+
+        try await app.test(.GET, "/api/v1/submissions/nonexistent/download", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .notFound)
+        })
+    }
+
+    func testDownloadUsesCustomFilename() async throws {
+        let auth = try await loginAsInstructor(username: "dl_fname_instr")
+        try await ensureSetup(id: "setup_fname")
+
+        let sub = APISubmission(
+            id: "sub_dl_fname",
+            testSetupID: "setup_fname",
+            zipPath: tmpDir + "submissions/sub_dl_fname.ipynb",
+            attemptNumber: 1,
+            filename: "my_notebook.ipynb"
+        )
+        try await sub.save(on: app.db)
+        try Data("{}".utf8).write(to: URL(fileURLWithPath: sub.zipPath))
+
+        try await app.test(.GET, "/api/v1/submissions/sub_dl_fname/download", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: auth.cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let disposition = res.headers.first(name: .contentDisposition) ?? ""
+            XCTAssertTrue(disposition.contains("my_notebook.ipynb"),
+                "Expected filename in Content-Disposition, got: \(disposition)")
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- 28 unit tests for `MarmosetImportParser` covering `parseJavaProperties`, `parseTestClassList`, `extractTitleFromProjectOut`, and `convertToChickadeeManifest`
- 14 integration tests for `SubmissionRoutes` (POST create with base64/file) and `SubmissionDownloadRoute` (GET download with owner/instructor/forbidden access control)
- Total test count: 227 → 269

## Test plan
- [x] `swift test --filter MarmosetImportParserTests` — 28/28 pass
- [x] `swift test --filter SubmissionRoutesTests` — 14/14 pass
- [x] Full `swift test` — 269 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)