### PR TITLE
test: add high-priority coverage for validation, parsing, middleware

### DIFF
--- a/Sources/APIServer/Services/UWImportantDatesService.swift
+++ b/Sources/APIServer/Services/UWImportantDatesService.swift
@@ -38,7 +38,7 @@ actor UWImportantDatesCache {
             }
             var body = response.body ?? ByteBuffer()
             let text = body.readString(length: body.readableBytes) ?? ""
-            let parsed = parseICS(text).filter { isRelevantEvent($0.title) }
+            let parsed = parseICSEvents(text).filter { isRelevantUWEvent($0.title) }
             cached = parsed
             cachedAt = Date()
             return parsed
@@ -48,109 +48,96 @@ actor UWImportantDatesCache {
         }
     }
 
-    // MARK: - iCalendar Parser
 
-    /// Extracts VEVENT blocks and returns one UWImportantDate per event.
-    /// Handles both DATE-only (DTSTART;VALUE=DATE:YYYYMMDD) and DATE-TIME forms.
-    private func parseICS(_ text: String) -> [UWImportantDate] {
-        var results: [UWImportantDate] = []
+}
 
-        // Split on VEVENT boundaries
-        let blocks = text.components(separatedBy: "BEGIN:VEVENT")
-        for block in blocks.dropFirst() {
-            guard let startDate = extractDate(key: "DTSTART", from: block),
-                  let title = extractSummary(from: block) else {
-                continue
+// MARK: - iCalendar Parsing (free functions, testable)
+
+/// Extracts VEVENT blocks and returns one UWImportantDate per event.
+func parseICSEvents(_ text: String) -> [UWImportantDate] {
+    var results: [UWImportantDate] = []
+    let blocks = text.components(separatedBy: "BEGIN:VEVENT")
+    for block in blocks.dropFirst() {
+        guard let startDate = extractICSDate(key: "DTSTART", from: block),
+              let title = extractICSSummary(from: block) else {
+            continue
+        }
+        let endDate = extractICSDate(key: "DTEND", from: block) ?? nextDayISO(startDate)
+        results.append(UWImportantDate(startDate: startDate, endDate: endDate, title: title))
+    }
+    return results
+}
+
+/// Extracts a line like DTSTART;VALUE=DATE:20260321 or DTSTART:20260321 → "2026-03-21"
+func extractICSDate(key: String, from block: String) -> String? {
+    for line in block.components(separatedBy: "\n") {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix(key) else { continue }
+        let colonIdx = trimmed.firstIndex(of: ":") ?? trimmed.endIndex
+        let raw = String(trimmed[trimmed.index(after: colonIdx)...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = raw.prefix(8)
+        guard digits.count == 8, digits.allSatisfy(\.isNumber) else { continue }
+        let y = digits.prefix(4)
+        let m = digits.dropFirst(4).prefix(2)
+        let d = digits.dropFirst(6).prefix(2)
+        return "\(y)-\(m)-\(d)"
+    }
+    return nil
+}
+
+/// Extracts SUMMARY, handling folded lines (continuation lines start with a space/tab).
+func extractICSSummary(from block: String) -> String? {
+    let lines = block.components(separatedBy: "\n")
+    var inSummary = false
+    var accumulated = ""
+    for line in lines {
+        let raw = line.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
+        if raw.hasPrefix("SUMMARY:") || raw.hasPrefix("SUMMARY;") {
+            if let colonIdx = raw.firstIndex(of: ":") {
+                accumulated = String(raw[raw.index(after: colonIdx)...])
             }
-            // DTEND is exclusive in iCalendar; default to startDate + 1 day if absent
-            let endDate = extractDate(key: "DTEND", from: block) ?? nextDay(startDate)
-            results.append(UWImportantDate(startDate: startDate, endDate: endDate, title: title))
-        }
-
-        return results
-    }
-
-    /// Extracts a line like DTSTART;VALUE=DATE:20260321 or DTSTART:20260321 → "2026-03-21"
-    private func extractDate(key: String, from block: String) -> String? {
-        for line in block.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            // Match e.g. "DTSTART;VALUE=DATE:20260321" or "DTSTART:20260321"
-            guard trimmed.hasPrefix(key) else { continue }
-            let colonIdx = trimmed.firstIndex(of: ":") ?? trimmed.endIndex
-            let raw = String(trimmed[trimmed.index(after: colonIdx)...])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            // Take the date portion (first 8 digits)
-            let digits = raw.prefix(8)
-            guard digits.count == 8, digits.allSatisfy(\.isNumber) else { continue }
-            let y = digits.prefix(4)
-            let m = digits.dropFirst(4).prefix(2)
-            let d = digits.dropFirst(6).prefix(2)
-            return "\(y)-\(m)-\(d)"
-        }
-        return nil
-    }
-
-    /// Extracts SUMMARY, handling folded lines (continuation lines start with a space/tab).
-    private func extractSummary(from block: String) -> String? {
-        let lines = block.components(separatedBy: "\n")
-        var inSummary = false
-        var accumulated = ""
-        for line in lines {
-            let raw = line.trimmingCharacters(in: CharacterSet(charactersIn: "\r"))
-            if raw.hasPrefix("SUMMARY:") || raw.hasPrefix("SUMMARY;") {
-                // Drop the property name
-                if let colonIdx = raw.firstIndex(of: ":") {
-                    accumulated = String(raw[raw.index(after: colonIdx)...])
-                }
-                inSummary = true
-            } else if inSummary {
-                if raw.hasPrefix(" ") || raw.hasPrefix("\t") {
-                    // Folded continuation line
-                    accumulated += raw.dropFirst()
-                } else {
-                    break
-                }
+            inSummary = true
+        } else if inSummary {
+            if raw.hasPrefix(" ") || raw.hasPrefix("\t") {
+                accumulated += raw.dropFirst()
+            } else {
+                break
             }
         }
-        let trimmed = accumulated.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Unescape iCalendar backslash sequences
-        let unescaped = trimmed
-            .replacingOccurrences(of: "\\,", with: ",")
-            .replacingOccurrences(of: "\\;", with: ";")
-            .replacingOccurrences(of: "\\n", with: " ")
-            .replacingOccurrences(of: "\\N", with: " ")
-            .replacingOccurrences(of: "\\\\", with: "\\")
-        return unescaped.isEmpty ? nil : unescaped
     }
+    let trimmed = accumulated.trimmingCharacters(in: .whitespacesAndNewlines)
+    let unescaped = trimmed
+        .replacingOccurrences(of: "\\,", with: ",")
+        .replacingOccurrences(of: "\\;", with: ";")
+        .replacingOccurrences(of: "\\n", with: " ")
+        .replacingOccurrences(of: "\\N", with: " ")
+        .replacingOccurrences(of: "\\\\", with: "\\")
+    return unescaped.isEmpty ? nil : unescaped
+}
 
-    /// Returns true if the event title represents a closure, holiday, break, or exam period
-    /// that would make it unreasonable to set an assignment due date on or near that date.
-    private func isRelevantEvent(_ title: String) -> Bool {
-        let lower = title.lowercased()
-        let keywords: [String] = [
-            // Statutory holidays
-            "good friday", "easter", "victoria day", "canada day", "civic holiday",
-            "labour day", "thanksgiving", "remembrance day", "christmas", "boxing day",
-            "new year",
-            // University closures
-            "university closed", "holiday", "closure",
-            // Academic breaks
-            "reading week", "spring vacation", "spring break", "winter break",
-            "study break", "intersession",
-            // Exam periods
-            "final examination", "final exam", "exam period",
-        ]
-        return keywords.contains { lower.contains($0) }
-    }
+/// Returns true if the event title represents a closure, holiday, break, or exam period.
+func isRelevantUWEvent(_ title: String) -> Bool {
+    let lower = title.lowercased()
+    let keywords: [String] = [
+        "good friday", "easter", "victoria day", "canada day", "civic holiday",
+        "labour day", "thanksgiving", "remembrance day", "christmas", "boxing day",
+        "new year",
+        "university closed", "holiday", "closure",
+        "reading week", "spring vacation", "spring break", "winter break",
+        "study break", "intersession",
+        "final examination", "final exam", "exam period",
+    ]
+    return keywords.contains { lower.contains($0) }
+}
 
-    private func nextDay(_ isoDate: String) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        guard let date = formatter.date(from: isoDate) else { return isoDate }
-        let next = Calendar(identifier: .gregorian).date(byAdding: .day, value: 1, to: date) ?? date
-        return formatter.string(from: next)
-    }
+func nextDayISO(_ isoDate: String) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    guard let date = formatter.date(from: isoDate) else { return isoDate }
+    let next = Calendar(identifier: .gregorian).date(byAdding: .day, value: 1, to: date) ?? date
+    return formatter.string(from: next)
 }
 
 // MARK: - Application Storage

--- a/Tests/APITests/EnrollCSVHelperTests.swift
+++ b/Tests/APITests/EnrollCSVHelperTests.swift
@@ -1,0 +1,119 @@
+// Tests/APITests/EnrollCSVHelperTests.swift
+//
+// Unit tests for parseUsernamesFromCSV — header detection, quote stripping,
+// encoding fallback, and edge cases.
+
+import XCTest
+@testable import chickadee_server
+import Foundation
+
+final class EnrollCSVHelperTests: XCTestCase {
+
+    // MARK: - Basic parsing
+
+    func testSimpleOneColumnList() {
+        let csv = "alice\nbob\ncharlie\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob", "charlie"])
+    }
+
+    func testMultiColumnTakesFirstOnly() {
+        let csv = "alice,Alice Smith,alice@example.com\nbob,Bob Jones,bob@example.com\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob"])
+    }
+
+    func testStripsQuotes() {
+        let csv = "\"alice\"\n'bob'\n\"charlie\"\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob", "charlie"])
+    }
+
+    func testStripsWhitespace() {
+        let csv = "  alice  \n  bob  \n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob"])
+    }
+
+    func testSkipsBlankLines() {
+        let csv = "alice\n\n\nbob\n\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob"])
+    }
+
+    // MARK: - Header detection
+
+    func testSkipsUsernameHeader() {
+        let csv = "username\nalice\nbob\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob"])
+    }
+
+    func testSkipsUserHeader() {
+        let csv = "User\nalice\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice"])
+    }
+
+    func testSkipsStudentIdHeader() {
+        let csv = "student_id\nalice\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice"])
+    }
+
+    func testSkipsLoginIdHeader() {
+        let csv = "\"login_id\",\"name\"\nalice,Alice\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice"])
+    }
+
+    func testSkipsUserIdHeaderWithSpaces() {
+        // "user id" → normalized to "userid" → matches
+        let csv = "User ID\nalice\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice"])
+    }
+
+    func testDoesNotSkipNonHeaderFirstRow() {
+        let csv = "alice\nbob\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob"])
+    }
+
+    // MARK: - Edge cases
+
+    func testEmptyData() {
+        let result = parseUsernamesFromCSV(Data())
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testOnlyHeader() {
+        let csv = "username\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testOnlyBlankLines() {
+        let csv = "\n\n\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testISOLatin1Fallback() {
+        // Create data that is valid ISO-8859-1 but not valid UTF-8
+        // The é in "José" encoded as ISO-8859-1 is byte 0xE9
+        var bytes: [UInt8] = Array("Jos".utf8)
+        bytes.append(0xE9)  // é in ISO-8859-1
+        bytes.append(contentsOf: Array("\n".utf8))
+        let data = Data(bytes)
+        let result = parseUsernamesFromCSV(data)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertTrue(result[0].hasPrefix("Jos"))
+    }
+
+    func testWindowsLineEndings() {
+        let csv = "alice\r\nbob\r\ncharlie\r\n"
+        let result = parseUsernamesFromCSV(Data(csv.utf8))
+        XCTAssertEqual(result, ["alice", "bob", "charlie"])
+    }
+}

--- a/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
+++ b/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
@@ -1,0 +1,173 @@
+// Tests/APITests/HTTPSRedirectMiddlewareTests.swift
+//
+// Unit tests for HTTPSRedirectMiddleware — redirect logic, proxy header trust,
+// GET vs POST handling, and publicBaseURL override.
+
+import XCTest
+import XCTVapor
+@testable import chickadee_server
+import Foundation
+
+final class HTTPSRedirectMiddlewareTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeApp(
+        enforceHTTPS: Bool = true,
+        trustForwardedProto: Bool = true,
+        publicBaseURL: String? = nil
+    ) throws -> Application {
+        let app = Application(.testing)
+        let config = AppSecurityConfiguration(
+            publicBaseURL: publicBaseURL.flatMap { URL(string: $0) },
+            enforceHTTPS: enforceHTTPS,
+            trustForwardedProto: trustForwardedProto,
+            sessionCookieSecure: false
+        )
+        app.middleware.use(HTTPSRedirectMiddleware(configuration: config))
+        app.get("test") { _ in "ok" }
+        app.post("submit") { _ in "submitted" }
+        return app
+    }
+
+    // MARK: - Enforcement disabled
+
+    func testNoRedirectWhenEnforcementDisabled() throws {
+        let app = try makeApp(enforceHTTPS: false)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "ok")
+        }
+    }
+
+    // MARK: - HTTPS pass-through
+
+    func testHTTPSRequestPassesThrough() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test", beforeRequest: { req in
+            req.headers.add(name: "X-Forwarded-Proto", value: "https")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
+
+    // MARK: - GET redirect
+
+    func testGETRedirectsToHTTPS() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test", beforeRequest: { req in
+            req.headers.add(name: .host, value: "example.com")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .temporaryRedirect)
+            let location = res.headers.first(name: .location) ?? ""
+            XCTAssertTrue(location.hasPrefix("https://"), "Expected https redirect, got: \(location)")
+            XCTAssertTrue(location.contains("example.com"), "Expected host in redirect, got: \(location)")
+            XCTAssertTrue(location.contains("/test"), "Expected path in redirect, got: \(location)")
+        })
+    }
+
+    // MARK: - POST returns 426
+
+    func testPOSTReturns426() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.POST, "/submit", beforeRequest: { req in
+            req.headers.add(name: .host, value: "example.com")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .upgradeRequired)
+        })
+    }
+
+    // MARK: - X-Forwarded-Proto trust
+
+    func testForwardedProtoHTTPSPassesThrough() throws {
+        let app = try makeApp(trustForwardedProto: true)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test", beforeRequest: { req in
+            req.headers.add(name: "X-Forwarded-Proto", value: "https")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
+
+    func testForwardedProtoHTTPRedirects() throws {
+        let app = try makeApp(trustForwardedProto: true)
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test", beforeRequest: { req in
+            req.headers.add(name: "X-Forwarded-Proto", value: "http")
+            req.headers.add(name: .host, value: "example.com")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .temporaryRedirect)
+        })
+    }
+
+    // MARK: - X-Forwarded-Host in redirect
+
+    func testRedirectUsesForwardedHost() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test", beforeRequest: { req in
+            req.headers.add(name: "X-Forwarded-Host", value: "public.example.com")
+            req.headers.add(name: .host, value: "internal.local")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .temporaryRedirect)
+            let location = res.headers.first(name: .location) ?? ""
+            XCTAssertTrue(location.contains("public.example.com"),
+                "Expected forwarded host in redirect, got: \(location)")
+        })
+    }
+
+    // MARK: - publicBaseURL override
+
+    func testRedirectUsesPublicBaseURL() throws {
+        let app = try makeApp(publicBaseURL: "https://chickadee.example.edu")
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/test", beforeRequest: { req in
+            req.headers.add(name: .host, value: "internal.local")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .temporaryRedirect)
+            let location = res.headers.first(name: .location) ?? ""
+            XCTAssertTrue(location.hasPrefix("https://chickadee.example.edu/test"),
+                "Expected publicBaseURL in redirect, got: \(location)")
+        })
+    }
+
+    // MARK: - Fallback host
+
+    func testRedirectFallsBackToLocalhost() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        // No Host, no X-Forwarded-Host
+        try app.test(.GET, "/test", afterResponse: { res in
+            XCTAssertEqual(res.status, .temporaryRedirect)
+            let location = res.headers.first(name: .location) ?? ""
+            XCTAssertTrue(location.contains("localhost"),
+                "Expected localhost fallback, got: \(location)")
+        })
+    }
+
+    // MARK: - HEAD treated same as GET
+
+    func testHEADRedirectsLikeGET() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.HEAD, "/test", beforeRequest: { req in
+            req.headers.add(name: .host, value: "example.com")
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .temporaryRedirect)
+        })
+    }
+}

--- a/Tests/APITests/ManifestValidationTests.swift
+++ b/Tests/APITests/ManifestValidationTests.swift
@@ -1,0 +1,141 @@
+// Tests/APITests/ManifestValidationTests.swift
+//
+// Unit tests for validateManifestDependencies — cycle detection,
+// unknown references, and self-references in test suite dependency graphs.
+
+import XCTest
+import Vapor
+@testable import chickadee_server
+@testable import Core
+
+final class ManifestValidationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a TestProperties from a list of (script, dependsOn) pairs.
+    private func manifest(_ suites: [(String, [String])]) throws -> TestProperties {
+        let entries = suites.map { script, deps -> [String: Any] in
+            var d: [String: Any] = ["tier": "public", "script": script]
+            if !deps.isEmpty { d["dependsOn"] = deps }
+            return d
+        }
+        let dict: [String: Any] = [
+            "schemaVersion": 1,
+            "testSuites": entries,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        return try JSONDecoder().decode(TestProperties.self, from: data)
+    }
+
+    // MARK: - Valid graphs
+
+    func testNoDependencies() throws {
+        let m = try manifest([("a.sh", []), ("b.sh", []), ("c.sh", [])])
+        XCTAssertNoThrow(try validateManifestDependencies(m))
+    }
+
+    func testLinearChain() throws {
+        let m = try manifest([
+            ("build.sh", []),
+            ("unit.sh", ["build.sh"]),
+            ("integration.sh", ["unit.sh"]),
+        ])
+        XCTAssertNoThrow(try validateManifestDependencies(m))
+    }
+
+    func testDiamondDependency() throws {
+        let m = try manifest([
+            ("a.sh", []),
+            ("b.sh", ["a.sh"]),
+            ("c.sh", ["a.sh"]),
+            ("d.sh", ["b.sh", "c.sh"]),
+        ])
+        XCTAssertNoThrow(try validateManifestDependencies(m))
+    }
+
+    func testSingleSuiteNoDeps() throws {
+        let m = try manifest([("only.sh", [])])
+        XCTAssertNoThrow(try validateManifestDependencies(m))
+    }
+
+    func testEmptySuites() throws {
+        let m = try manifest([])
+        XCTAssertNoThrow(try validateManifestDependencies(m))
+    }
+
+    // MARK: - Self-references
+
+    func testSelfReferenceThrows() throws {
+        let m = try manifest([("a.sh", ["a.sh"])])
+        XCTAssertThrowsError(try validateManifestDependencies(m)) { error in
+            let abort = error as? Abort
+            XCTAssertEqual(abort?.status, .unprocessableEntity)
+            XCTAssertTrue(abort?.reason.contains("cannot depend on itself") ?? false,
+                "Expected self-reference error, got: \(abort?.reason ?? "")")
+        }
+    }
+
+    // MARK: - Unknown references
+
+    func testUnknownDependencyThrows() throws {
+        let m = try manifest([("a.sh", ["nonexistent.sh"])])
+        XCTAssertThrowsError(try validateManifestDependencies(m)) { error in
+            let abort = error as? Abort
+            XCTAssertEqual(abort?.status, .unprocessableEntity)
+            XCTAssertTrue(abort?.reason.contains("nonexistent.sh") ?? false,
+                "Expected unknown dep error, got: \(abort?.reason ?? "")")
+        }
+    }
+
+    // MARK: - Cycles
+
+    func testSimpleCycleThrows() throws {
+        let m = try manifest([
+            ("a.sh", ["b.sh"]),
+            ("b.sh", ["a.sh"]),
+        ])
+        XCTAssertThrowsError(try validateManifestDependencies(m)) { error in
+            let abort = error as? Abort
+            XCTAssertEqual(abort?.status, .unprocessableEntity)
+            XCTAssertTrue(abort?.reason.contains("cycle") ?? false,
+                "Expected cycle error, got: \(abort?.reason ?? "")")
+        }
+    }
+
+    func testThreeNodeCycleThrows() throws {
+        let m = try manifest([
+            ("a.sh", ["c.sh"]),
+            ("b.sh", ["a.sh"]),
+            ("c.sh", ["b.sh"]),
+        ])
+        XCTAssertThrowsError(try validateManifestDependencies(m)) { error in
+            let abort = error as? Abort
+            XCTAssertTrue(abort?.reason.contains("cycle") ?? false)
+        }
+    }
+
+    func testCycleInSubgraphWithValidNode() throws {
+        // d is fine; a → b → c → a is a cycle
+        let m = try manifest([
+            ("d.sh", []),
+            ("a.sh", ["c.sh"]),
+            ("b.sh", ["a.sh"]),
+            ("c.sh", ["b.sh"]),
+        ])
+        XCTAssertThrowsError(try validateManifestDependencies(m)) { error in
+            let abort = error as? Abort
+            XCTAssertTrue(abort?.reason.contains("cycle") ?? false)
+        }
+    }
+
+    func testMultipleDepsOneUnknownThrows() throws {
+        let m = try manifest([
+            ("a.sh", []),
+            ("b.sh", ["a.sh", "missing.sh"]),
+        ])
+        XCTAssertThrowsError(try validateManifestDependencies(m)) { error in
+            let abort = error as? Abort
+            XCTAssertTrue(abort?.reason.contains("missing.sh") ?? false)
+        }
+    }
+}

--- a/Tests/APITests/UWImportantDatesTests.swift
+++ b/Tests/APITests/UWImportantDatesTests.swift
@@ -1,0 +1,202 @@
+// Tests/APITests/UWImportantDatesTests.swift
+//
+// Unit tests for the iCalendar parsing functions used by UWImportantDatesCache.
+
+import XCTest
+@testable import chickadee_server
+import Foundation
+
+final class UWImportantDatesTests: XCTestCase {
+
+    // MARK: - extractICSDate
+
+    func testExtractDateValueDate() {
+        let block = "DTSTART;VALUE=DATE:20260321\nDTEND;VALUE=DATE:20260322\n"
+        XCTAssertEqual(extractICSDate(key: "DTSTART", from: block), "2026-03-21")
+        XCTAssertEqual(extractICSDate(key: "DTEND", from: block), "2026-03-22")
+    }
+
+    func testExtractDatePlainColon() {
+        let block = "DTSTART:20261225\n"
+        XCTAssertEqual(extractICSDate(key: "DTSTART", from: block), "2026-12-25")
+    }
+
+    func testExtractDateWithTimestamp() {
+        // Some feeds include a full datetime — we take the first 8 digits (the date)
+        let block = "DTSTART:20260101T090000Z\n"
+        XCTAssertEqual(extractICSDate(key: "DTSTART", from: block), "2026-01-01")
+    }
+
+    func testExtractDateMissing() {
+        let block = "SUMMARY:Some event\n"
+        XCTAssertNil(extractICSDate(key: "DTSTART", from: block))
+    }
+
+    func testExtractDateInvalidDigits() {
+        let block = "DTSTART:abcdefgh\n"
+        XCTAssertNil(extractICSDate(key: "DTSTART", from: block))
+    }
+
+    func testExtractDateTooShort() {
+        let block = "DTSTART:2026031\n"  // 7 digits
+        XCTAssertNil(extractICSDate(key: "DTSTART", from: block))
+    }
+
+    // MARK: - extractICSSummary
+
+    func testExtractSummarySimple() {
+        let block = "SUMMARY:Reading Week\nDTSTART:20260216\n"
+        XCTAssertEqual(extractICSSummary(from: block), "Reading Week")
+    }
+
+    func testExtractSummaryFoldedLines() {
+        // iCal folding: continuation lines start with a space that is stripped,
+        // so the content joins directly (no extra space added).
+        let block = "SUMMARY:University Closed\n - Holiday Observ\n ance Day\nDTSTART:20260101\n"
+        XCTAssertEqual(extractICSSummary(from: block), "University Closed- Holiday Observance Day")
+    }
+
+    func testExtractSummaryWithTabContinuation() {
+        let block = "SUMMARY:Final Exam\n\tination Period\nDTSTART:20260401\n"
+        XCTAssertEqual(extractICSSummary(from: block), "Final Examination Period")
+    }
+
+    func testExtractSummaryUnescapesBackslash() {
+        let block = "SUMMARY:Holiday\\, No Classes\\; Campus Closed\n"
+        XCTAssertEqual(extractICSSummary(from: block), "Holiday, No Classes; Campus Closed")
+    }
+
+    func testExtractSummaryUnescapesNewlines() {
+        let block = "SUMMARY:Line1\\nLine2\\NLine3\n"
+        XCTAssertEqual(extractICSSummary(from: block), "Line1 Line2 Line3")
+    }
+
+    func testExtractSummaryWithSemicolonParams() {
+        // SUMMARY;LANGUAGE=en:Christmas Day
+        let block = "SUMMARY;LANGUAGE=en:Christmas Day\n"
+        XCTAssertEqual(extractICSSummary(from: block), "Christmas Day")
+    }
+
+    func testExtractSummaryMissing() {
+        let block = "DTSTART:20260101\nDTEND:20260102\n"
+        XCTAssertNil(extractICSSummary(from: block))
+    }
+
+    func testExtractSummaryEmpty() {
+        let block = "SUMMARY:\nDTSTART:20260101\n"
+        XCTAssertNil(extractICSSummary(from: block))
+    }
+
+    // MARK: - isRelevantUWEvent
+
+    func testRelevantHolidays() {
+        XCTAssertTrue(isRelevantUWEvent("Good Friday"))
+        XCTAssertTrue(isRelevantUWEvent("CHRISTMAS DAY"))
+        XCTAssertTrue(isRelevantUWEvent("New Year's Day"))
+        XCTAssertTrue(isRelevantUWEvent("Civic Holiday"))
+        XCTAssertTrue(isRelevantUWEvent("Thanksgiving Day"))
+    }
+
+    func testRelevantBreaks() {
+        XCTAssertTrue(isRelevantUWEvent("Reading Week"))
+        XCTAssertTrue(isRelevantUWEvent("Spring Break"))
+        XCTAssertTrue(isRelevantUWEvent("Winter Break begins"))
+    }
+
+    func testRelevantExams() {
+        XCTAssertTrue(isRelevantUWEvent("Final Examination Period"))
+        XCTAssertTrue(isRelevantUWEvent("Final Exam Period Begins"))
+    }
+
+    func testRelevantClosures() {
+        XCTAssertTrue(isRelevantUWEvent("University Closed"))
+        XCTAssertTrue(isRelevantUWEvent("Holiday Closure"))
+    }
+
+    func testIrrelevantEvents() {
+        XCTAssertFalse(isRelevantUWEvent("Classes begin"))
+        XCTAssertFalse(isRelevantUWEvent("Last day to add courses"))
+        XCTAssertFalse(isRelevantUWEvent("Convocation"))
+        XCTAssertFalse(isRelevantUWEvent("Fee payment deadline"))
+    }
+
+    // MARK: - nextDayISO
+
+    func testNextDayNormal() {
+        XCTAssertEqual(nextDayISO("2026-03-21"), "2026-03-22")
+    }
+
+    func testNextDayMonthBoundary() {
+        XCTAssertEqual(nextDayISO("2026-01-31"), "2026-02-01")
+    }
+
+    func testNextDayYearBoundary() {
+        XCTAssertEqual(nextDayISO("2025-12-31"), "2026-01-01")
+    }
+
+    func testNextDayLeapYear() {
+        XCTAssertEqual(nextDayISO("2024-02-28"), "2024-02-29")
+        XCTAssertEqual(nextDayISO("2024-02-29"), "2024-03-01")
+    }
+
+    func testNextDayInvalidDate() {
+        // Invalid input returns the input unchanged
+        XCTAssertEqual(nextDayISO("not-a-date"), "not-a-date")
+    }
+
+    // MARK: - parseICSEvents (full VEVENT parsing)
+
+    func testParseFullICS() {
+        let ics = """
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        BEGIN:VEVENT
+        DTSTART;VALUE=DATE:20260216
+        DTEND;VALUE=DATE:20260221
+        SUMMARY:Reading Week
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART;VALUE=DATE:20260403
+        SUMMARY:Good Friday
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART;VALUE=DATE:20260901
+        SUMMARY:Classes begin
+        END:VEVENT
+        END:VCALENDAR
+        """
+        let events = parseICSEvents(ics)
+        XCTAssertEqual(events.count, 3)
+
+        XCTAssertEqual(events[0].startDate, "2026-02-16")
+        XCTAssertEqual(events[0].endDate, "2026-02-21")
+        XCTAssertEqual(events[0].title, "Reading Week")
+
+        XCTAssertEqual(events[1].startDate, "2026-04-03")
+        XCTAssertEqual(events[1].title, "Good Friday")
+        // No DTEND → defaults to next day
+        XCTAssertEqual(events[1].endDate, "2026-04-04")
+    }
+
+    func testParseICSEmptyInput() {
+        XCTAssertTrue(parseICSEvents("").isEmpty)
+    }
+
+    func testParseICSNoEvents() {
+        let ics = "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR"
+        XCTAssertTrue(parseICSEvents(ics).isEmpty)
+    }
+
+    func testParseICSSkipsEventsWithoutDateOrSummary() {
+        let ics = """
+        BEGIN:VEVENT
+        SUMMARY:No date event
+        END:VEVENT
+        BEGIN:VEVENT
+        DTSTART:20260101
+        END:VEVENT
+        """
+        // First has no date, second has no summary — both skipped
+        XCTAssertTrue(parseICSEvents(ics).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- 11 tests for `ManifestValidation` — cycle detection (Kahn's algorithm), unknown dependency refs, self-references, valid graph shapes (diamond, linear, empty)
- 28 tests for UW iCal parser — date extraction (VALUE=DATE, plain colon, timestamps), summary folding/unescaping, relevance filtering, `nextDay` edge cases (month/year boundaries, leap year)
- 16 tests for `EnrollCSVHelper` — header keyword detection (username, student_id, login_id, etc.), quote stripping, whitespace handling, ISO-8859-1 fallback, Windows line endings
- 10 tests for `HTTPSRedirectMiddleware` — GET→307 redirect, POST→426, `X-Forwarded-Proto` trust, `X-Forwarded-Host` in redirect URL, `publicBaseURL` override, localhost fallback

Refactored UW iCal parsing from private actor methods to internal free functions for testability (no behavior change).

Total test count: 269 → 334.

## Test plan
- [x] `swift test --filter ManifestValidationTests` — 11/11 pass
- [x] `swift test --filter UWImportantDatesTests` — 28/28 pass
- [x] `swift test --filter EnrollCSVHelperTests` — 16/16 pass
- [x] `swift test --filter HTTPSRedirectMiddlewareTests` — 10/10 pass
- [x] Full `swift test` — 334 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)