### PR TITLE
test: add RoleMiddleware, ScriptInvocation, and ZipArchiver tests

### DIFF
--- a/Tests/APITests/RoleMiddlewareTests.swift
+++ b/Tests/APITests/RoleMiddlewareTests.swift
@@ -1,0 +1,198 @@
+// Tests/APITests/RoleMiddlewareTests.swift
+//
+// Integration tests for RoleMiddleware — verifies redirect vs 401 for
+// unauthenticated requests, and 403 for insufficient-role requests.
+
+import XCTest
+import XCTVapor
+@testable import chickadee_server
+import FluentSQLiteDriver
+import Foundation
+
+final class RoleMiddlewareTests: XCTestCase {
+
+    private var app: Application!
+    private var tmpDir: String!
+
+    override func setUp() async throws {
+        app = Application(.testing)
+
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-role-\(UUID().uuidString)", isDirectory: true)
+            .path + "/"
+        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
+        for dir in dirs {
+            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        }
+        app.resultsDirectory     = dirs[0]
+        app.testSetupsDirectory  = dirs[1]
+        app.submissionsDirectory = dirs[2]
+
+        app.sessions.use(.memory)
+        app.middleware.use(app.sessions.middleware)
+
+        app.databases.use(.sqlite(.memory), as: .sqlite)
+        app.migrations.add(CreateUsers())
+        app.migrations.add(CreateCourses())
+        app.migrations.add(CreateCourseEnrollments())
+        app.migrations.add(CreateTestSetups())
+        app.migrations.add(CreateSubmissions())
+        app.migrations.add(CreateResults())
+        app.migrations.add(CreateAssignments())
+        app.migrations.add(CreatePerformanceIndexes())
+        app.migrations.add(AddCourseSections())
+        app.migrations.add(AddCourseOpenEnrollment())
+        try await app.autoMigrate().get()
+
+        configureLeaf(app)
+        try routes(app)
+
+        // Register lightweight test-only routes with each protection level.
+        // Browser-style paths (no /api/ prefix) → unauthenticated → 303 /login.
+        // API-style paths (/api/ prefix)          → unauthenticated → 401.
+        let sessionAuth = UserSessionAuthenticator()
+
+        app.grouped(sessionAuth, RoleMiddleware(required: .authenticated))
+            .get("__test_auth") { _ in "auth-ok" }
+
+        app.grouped(sessionAuth, RoleMiddleware(required: .instructor))
+            .get("__test_instructor") { _ in "instructor-ok" }
+
+        app.grouped(sessionAuth, RoleMiddleware(required: .admin))
+            .get("__test_admin") { _ in "admin-ok" }
+
+        // API-prefixed equivalents to exercise the 401 (non-browser) path.
+        app.grouped(sessionAuth, RoleMiddleware(required: .instructor))
+            .get("api", "__test_instructor") { _ in "api-instructor-ok" }
+
+        app.grouped(sessionAuth, RoleMiddleware(required: .admin))
+            .get("api", "__test_admin") { _ in "api-admin-ok" }
+    }
+
+    override func tearDown() async throws {
+        app.shutdown()
+        try? FileManager.default.removeItem(atPath: tmpDir)
+    }
+
+    // MARK: - Unauthenticated
+
+    func testUnauthenticated_browserRoute_redirectsToLogin() throws {
+        try app.test(.GET, "/__test_auth") { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertEqual(res.headers.first(name: .location), "/login")
+        }
+    }
+
+    func testUnauthenticated_apiRoute_returns401() throws {
+        try app.test(.GET, "/api/__test_instructor") { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        }
+    }
+
+    func testUnauthenticated_adminApiRoute_returns401() throws {
+        try app.test(.GET, "/api/__test_admin") { res in
+            XCTAssertEqual(res.status, .unauthorized)
+        }
+    }
+
+    // MARK: - Student role
+
+    func testStudent_authenticatedRoute_returns200() async throws {
+        let cookie = try await loginUser(username: "role_student", password: "pw",
+                                         role: "student", on: app)
+        try await app.test(.GET, "/__test_auth", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "auth-ok")
+        })
+    }
+
+    func testStudent_instructorRoute_returns403() async throws {
+        let cookie = try await loginUser(username: "role_student2", password: "pw",
+                                         role: "student", on: app)
+        try await app.test(.GET, "/__test_instructor", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+        })
+    }
+
+    func testStudent_adminRoute_returns403() async throws {
+        let cookie = try await loginUser(username: "role_student3", password: "pw",
+                                         role: "student", on: app)
+        try await app.test(.GET, "/__test_admin", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+        })
+    }
+
+    // MARK: - Instructor role
+
+    func testInstructor_authenticatedRoute_returns200() async throws {
+        let cookie = try await loginUser(username: "role_instructor", password: "pw",
+                                         role: "instructor", on: app)
+        try await app.test(.GET, "/__test_auth", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
+
+    func testInstructor_instructorRoute_returns200() async throws {
+        let cookie = try await loginUser(username: "role_instructor2", password: "pw",
+                                         role: "instructor", on: app)
+        try await app.test(.GET, "/__test_instructor", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "instructor-ok")
+        })
+    }
+
+    func testInstructor_adminRoute_returns403() async throws {
+        let cookie = try await loginUser(username: "role_instructor3", password: "pw",
+                                         role: "instructor", on: app)
+        try await app.test(.GET, "/__test_admin", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+        })
+    }
+
+    // MARK: - Admin role
+
+    func testAdmin_authenticatedRoute_returns200() async throws {
+        let cookie = try await loginUser(username: "role_admin", password: "pw",
+                                         role: "admin", on: app)
+        try await app.test(.GET, "/__test_auth", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+        })
+    }
+
+    func testAdmin_instructorRoute_returns200() async throws {
+        // Admin implies instructor — should be granted access.
+        let cookie = try await loginUser(username: "role_admin2", password: "pw",
+                                         role: "admin", on: app)
+        try await app.test(.GET, "/__test_instructor", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "instructor-ok")
+        })
+    }
+
+    func testAdmin_adminRoute_returns200() async throws {
+        let cookie = try await loginUser(username: "role_admin3", password: "pw",
+                                         role: "admin", on: app)
+        try await app.test(.GET, "/__test_admin", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "admin-ok")
+        })
+    }
+}

--- a/Tests/APITests/ZipArchiverTests.swift
+++ b/Tests/APITests/ZipArchiverTests.swift
@@ -1,0 +1,178 @@
+// Tests/APITests/ZipArchiverTests.swift
+//
+// Tests for ZipArchiver — round-trip extraction, zip-slip path traversal
+// detection, and error descriptions.
+
+import XCTest
+@testable import chickadee_server
+import Foundation
+
+final class ZipArchiverTests: XCTestCase {
+
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a zip archive at `zipPath` containing entries with the given names
+    /// and content using Python's zipfile module. Skips if Python3 is unavailable.
+    private func makePythonZip(at zipPath: String, entries: [(name: String, content: String)]) throws {
+        guard FileManager.default.fileExists(atPath: "/usr/bin/env") else {
+            throw XCTSkip("env not available")
+        }
+        let entriesCode = entries.map { e in
+            "z.writestr(\(e.name.debugDescription), \(e.content.debugDescription))"
+        }.joined(separator: "\n    ")
+        let script = """
+import zipfile
+with zipfile.ZipFile('\(zipPath)', 'w') as z:
+    \(entriesCode)
+"""
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["python3", "-c", script]
+        proc.standardOutput = Pipe()
+        proc.standardError  = Pipe()
+        try proc.run()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else {
+            throw XCTSkip("python3 not available or failed to create zip")
+        }
+    }
+
+    // MARK: - Error descriptions
+
+    func testErrorDescription_processFailed() {
+        let e = ZipArchiverError.processFailed("/usr/bin/zip", 1)
+        XCTAssertEqual(e.description, "/usr/bin/zip exited with status 1")
+    }
+
+    func testErrorDescription_executableNotFound() {
+        let e = ZipArchiverError.executableNotFound("/usr/bin/zip")
+        XCTAssertEqual(e.description, "Executable not found: /usr/bin/zip")
+    }
+
+    func testErrorDescription_pathTraversalDetected() {
+        let e = ZipArchiverError.pathTraversalDetected("../evil.txt")
+        XCTAssertEqual(e.description, "Zip entry would escape destination directory: ../evil.txt")
+    }
+
+    // MARK: - Happy path round-trip
+
+    func testCreateAndExtract_roundTrip() async throws {
+        guard FileManager.default.fileExists(atPath: "/usr/bin/zip"),
+              FileManager.default.fileExists(atPath: "/usr/bin/unzip") else {
+            throw XCTSkip("zip/unzip not available")
+        }
+
+        // Create a source directory with two files.
+        let srcDir = tmpDir.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+        try "hello".write(to: srcDir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "world".write(to: srcDir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+
+        // Zip it up.
+        let zipPath = tmpDir.appendingPathComponent("archive.zip").path
+        try await createZipArchive(sourceDir: srcDir, outputPath: zipPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: zipPath), "Zip file should be created")
+
+        // Extract into a new directory.
+        let destDir = tmpDir.appendingPathComponent("dest")
+        try await extractZipArchive(zipPath: zipPath, into: destDir)
+
+        // Verify both files are present with correct content.
+        let aContent = try String(contentsOf: destDir.appendingPathComponent("a.txt"), encoding: .utf8)
+        let bContent = try String(contentsOf: destDir.appendingPathComponent("b.txt"), encoding: .utf8)
+        XCTAssertEqual(aContent, "hello")
+        XCTAssertEqual(bContent, "world")
+    }
+
+    // MARK: - Path traversal detection
+
+    func testDotDotTraversal_throws() async throws {
+        let zipPath = tmpDir.appendingPathComponent("traversal.zip").path
+        try makePythonZip(at: zipPath, entries: [
+            (name: "../evil.txt", content: "pwned"),
+            (name: "safe.txt",    content: "ok"),
+        ])
+
+        let destDir = tmpDir.appendingPathComponent("dest_traversal")
+        do {
+            try await extractZipArchive(zipPath: zipPath, into: destDir)
+            XCTFail("Expected pathTraversalDetected to be thrown")
+        } catch ZipArchiverError.pathTraversalDetected(let entry) {
+            XCTAssertEqual(entry, "../evil.txt")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testDeepDotDotTraversal_throws() async throws {
+        let zipPath = tmpDir.appendingPathComponent("deep_traversal.zip").path
+        try makePythonZip(at: zipPath, entries: [
+            (name: "subdir/../../evil.txt", content: "pwned"),
+        ])
+
+        let destDir = tmpDir.appendingPathComponent("dest_deep")
+        do {
+            try await extractZipArchive(zipPath: zipPath, into: destDir)
+            XCTFail("Expected pathTraversalDetected to be thrown")
+        } catch ZipArchiverError.pathTraversalDetected {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testAbsolutePathEntry_throws() async throws {
+        let zipPath = tmpDir.appendingPathComponent("absolute.zip").path
+        try makePythonZip(at: zipPath, entries: [
+            (name: "/etc/evil.txt", content: "pwned"),
+        ])
+
+        let destDir = tmpDir.appendingPathComponent("dest_abs")
+        do {
+            try await extractZipArchive(zipPath: zipPath, into: destDir)
+            XCTFail("Expected pathTraversalDetected to be thrown")
+        } catch ZipArchiverError.pathTraversalDetected {
+            // Expected — absolute path entry rejected
+        } catch {
+            // Some unzip versions strip leading / rather than reporting it via -Z1.
+            // If unzip normalises the path, extraction may succeed; that's acceptable.
+            // Only fail if we get a completely unexpected error type.
+            if !(error is ZipArchiverError) {
+                XCTFail("Unexpected error type: \(error)")
+            }
+        }
+    }
+
+    // MARK: - listZipContents
+
+    func testListZipContents_returnsEntryNames() async throws {
+        guard FileManager.default.fileExists(atPath: "/usr/bin/zip"),
+              FileManager.default.fileExists(atPath: "/usr/bin/unzip") else {
+            throw XCTSkip("zip/unzip not available")
+        }
+
+        let srcDir = tmpDir.appendingPathComponent("list_src")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+        try "x".write(to: srcDir.appendingPathComponent("alpha.txt"), atomically: true, encoding: .utf8)
+        try "y".write(to: srcDir.appendingPathComponent("beta.txt"),  atomically: true, encoding: .utf8)
+
+        let zipPath = tmpDir.appendingPathComponent("list.zip").path
+        try await createZipArchive(sourceDir: srcDir, outputPath: zipPath)
+
+        let entries = try listZipContents(zipPath: zipPath)
+        XCTAssertTrue(entries.contains(where: { $0.hasSuffix("alpha.txt") }))
+        XCTAssertTrue(entries.contains(where: { $0.hasSuffix("beta.txt") }))
+    }
+}

--- a/Tests/WorkerTests/ScriptInvocationTests.swift
+++ b/Tests/WorkerTests/ScriptInvocationTests.swift
@@ -1,0 +1,146 @@
+// Tests/WorkerTests/ScriptInvocationTests.swift
+//
+// Unit tests for scriptInvocation(for:) — verifies that the correct
+// interpreter is selected for each file extension, shebang line, and
+// Python-heuristic fallback.
+
+import XCTest
+@testable import chickadee_runner
+import Foundation
+
+final class ScriptInvocationTests: XCTestCase {
+
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("script-inv-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    // MARK: - Helpers
+
+    private func makeScript(name: String, content: String = "echo hi") -> URL {
+        let url = tmpDir.appendingPathComponent(name)
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Extension-based dispatch
+
+    func testShExtension_usesSh() {
+        let script = makeScript(name: "test.sh")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.executableURL.path, "/bin/sh")
+        XCTAssertEqual(inv.arguments, [script.path])
+    }
+
+    func testBashExtension_usesBash() {
+        let script = makeScript(name: "test.bash")
+        let inv = scriptInvocation(for: script)
+        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"),
+                      "Expected env wrapper, got \(inv.executableURL.path)")
+        XCTAssertEqual(inv.arguments.first, "bash")
+    }
+
+    func testZshExtension_usesZsh() {
+        let script = makeScript(name: "test.zsh")
+        let inv = scriptInvocation(for: script)
+        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
+        XCTAssertEqual(inv.arguments.first, "zsh")
+    }
+
+    func testPyExtension_usesPython3() {
+        let script = makeScript(name: "test.py")
+        let inv = scriptInvocation(for: script)
+        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
+        XCTAssertEqual(inv.arguments.first, "python3")
+        // Python invocation uses -c <bootstrap> <script>
+        XCTAssertTrue(inv.arguments.contains("-c"),
+                      "Python invocation should pass bootstrap via -c")
+        XCTAssertTrue(inv.arguments.last == script.path,
+                      "Script path should be last argument")
+    }
+
+    func testRbExtension_usesRuby() {
+        let script = makeScript(name: "test.rb")
+        let inv = scriptInvocation(for: script)
+        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
+        XCTAssertEqual(inv.arguments.first, "ruby")
+    }
+
+    func testPlExtension_usesPe() {
+        let script = makeScript(name: "test.pl")
+        let inv = scriptInvocation(for: script)
+        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
+        XCTAssertEqual(inv.arguments.first, "perl")
+    }
+
+    func testJsExtension_usesNode() {
+        let script = makeScript(name: "test.js")
+        let inv = scriptInvocation(for: script)
+        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
+        XCTAssertEqual(inv.arguments.first, "node")
+    }
+
+    // MARK: - Shebang dispatch (extensionless files)
+
+    func testShebangPython_usesPython3() {
+        let script = makeScript(name: "test_nopy", content: "#!/usr/bin/env python3\nprint('hi')")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.arguments.first, "python3")
+        XCTAssertTrue(inv.arguments.contains("-c"))
+    }
+
+    func testShebangBash_usesBash() {
+        let script = makeScript(name: "test_nobash", content: "#!/bin/bash\necho hi")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.arguments.first, "bash")
+    }
+
+    func testShebangSh_usesSh() {
+        let script = makeScript(name: "test_nosh", content: "#!/bin/sh\necho hi")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.executableURL.path, "/bin/sh")
+    }
+
+    func testShebangNode_usesNode() {
+        let script = makeScript(name: "test_nojs", content: "#!/usr/bin/env node\nconsole.log('hi')")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.arguments.first, "node")
+    }
+
+    func testShebangRuby_usesRuby() {
+        let script = makeScript(name: "test_norb", content: "#!/usr/bin/env ruby\nputs 'hi'")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.arguments.first, "ruby")
+    }
+
+    // MARK: - Python heuristic (no extension, no shebang)
+
+    func testPythonImport_heuristicDetectsPython() {
+        let script = makeScript(name: "test_heuristic", content: "import os\nprint(os.getcwd())")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.arguments.first, "python3",
+                       "Script starting with 'import' should be detected as Python")
+    }
+
+    func testPythonDef_heuristicDetectsPython() {
+        let script = makeScript(name: "test_heuristic2", content: "def foo():\n    pass\n\nfoo()")
+        let inv = scriptInvocation(for: script)
+        XCTAssertEqual(inv.arguments.first, "python3")
+    }
+
+    // MARK: - Fallback
+
+    func testUnknownExtension_fallsBackToSh() {
+        let script = makeScript(name: "test.unknown", content: "echo hi")
+        let inv = scriptInvocation(for: script)
+        // Non-executable file with unknown extension should fall back to /bin/sh
+        XCTAssertEqual(inv.executableURL.path, "/bin/sh")
+    }
+}


### PR DESCRIPTION
## Summary
35 new tests (334 → 369 total) covering three previously-untested areas:

- **RoleMiddlewareTests** (12 tests): unauthenticated browser → 303 redirect, unauthenticated API → 401, student/instructor/admin role enforcement, admin-implies-instructor
- **ScriptInvocationTests** (15 tests): extension dispatch (.sh/.bash/.zsh/.py/.rb/.pl/.js), shebang detection, Python heuristic, unknown-extension fallback
- **ZipArchiverTests** (8 tests): create+extract round-trip, zip-slip `../` and deep `../` traversal rejection, absolute path entry rejection, `listZipContents`, all three `ZipArchiverError` descriptions

## Test plan
- [x] All 369 tests pass locally (0 failures, 4 skipped)
- [ ] CI passes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)