### PR TITLE
fix: CodeMirror editor broken by ?bundle duplicate state instances

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -574,16 +574,16 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 <script type="module">
 // ── CodeMirror 6 script editor ─────────────────────────────────────────────
 import { EditorView, keymap, lineNumbers, highlightActiveLine,
-         drawSelection, dropCursor } from 'https://esm.sh/@codemirror/view@6?bundle';
-import { EditorState, Compartment }  from 'https://esm.sh/@codemirror/state@6?bundle';
+         drawSelection, dropCursor } from 'https://esm.sh/@codemirror/view@6';
+import { EditorState, Compartment }  from 'https://esm.sh/@codemirror/state@6';
 import { defaultKeymap, history, historyKeymap, indentWithTab }
-                                      from 'https://esm.sh/@codemirror/commands@6?bundle';
+                                      from 'https://esm.sh/@codemirror/commands@6';
 import { syntaxHighlighting, defaultHighlightStyle }
-                                      from 'https://esm.sh/@codemirror/language@6?bundle';
-import { python }                     from 'https://esm.sh/@codemirror/lang-python@6?bundle';
-import { StreamLanguage }             from 'https://esm.sh/@codemirror/language@6?bundle';
-import { shell }                      from 'https://esm.sh/@codemirror/legacy-modes@6/mode/shell?bundle';
-import { r }                          from 'https://esm.sh/@codemirror/legacy-modes@6/mode/r?bundle';
+                                      from 'https://esm.sh/@codemirror/language@6';
+import { python }                     from 'https://esm.sh/@codemirror/lang-python@6';
+import { StreamLanguage }             from 'https://esm.sh/@codemirror/language@6';
+import { shell }                      from 'https://esm.sh/@codemirror/legacy-modes@6/mode/shell';
+import { r }                          from 'https://esm.sh/@codemirror/legacy-modes@6/mode/r';
 
 const langComp = new Compartment();
 


### PR DESCRIPTION
## Summary

- Each `?bundle` esm.sh import inlines its own copy of `@codemirror/state`, creating multiple distinct class instances
- CodeMirror detects the mismatch and throws silently at startup — the `type="module"` script never finishes, so clicking Edit or New Script did nothing
- Fix: remove `?bundle` from all esm.sh imports; without it, packages share a single `@codemirror/state` URL via the browser module cache

## Root cause

`https://esm.sh/@codemirror/state@6?bundle` returns a self-contained file with the state code inlined. `https://esm.sh/@codemirror/view@6?bundle` also inlines its own copy. Two copies → two `EditorState` classes with different identities → CodeMirror throws.

Without `?bundle`, esm.sh serves each package as a thin wrapper that re-exports from a pinned versioned URL (e.g. `/@codemirror/state@6.6.0/es2022/state.mjs`). All packages that depend on `@codemirror/state` import from that same URL, so the browser module cache ensures exactly one instance.

## Test plan
- Open an assignment edit page
- Click a script filename → CodeMirror editor opens with the script content
- Click **+ New Script** → editor opens with template picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)