### PR TITLE
fix: script filename opens editor in dynamically re-rendered rows

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -350,7 +350,10 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         // File link shown below the name input as a hint
         var fileHint = isNew
             ? '<div class="suite-file-hint"><code>' + escHtml(item.name) + '</code> <span class="card-meta">(new)</span>' + errBadge + '</div>'
-            : '<div class="suite-file-hint"><a href="' + escAttr(item.url || '#') + '"><code>' + escHtml(item.name) + '</code></a></div>';
+            : '<div class="suite-file-hint">'
+                + '<button class="btn-link suite-edit-btn" type="button" data-filename="' + escAttr(item.name) + '" style="font-size:inherit;padding:0;color:var(--blue)" title="Edit script in browser"><code>' + escHtml(item.name) + '</code></button>'
+                + '<a href="' + escAttr(item.url || '#') + '" style="font-size:.7rem;margin-left:.4rem;color:var(--gray-500)" title="Download script" download>\u2193</a>'
+                + '</div>';
         var indent    = depth > 0 ? ' class="suite-child-indent"' : '';
         var connector = depth > 0 ? '<span class="suite-child-connector">&#9492;</span>' : '';
         var checked   = item.isTest ? ' checked' : '';


### PR DESCRIPTION
## Root cause

`initFromDOM()` runs on page load, reads the Leaf-rendered rows, then calls `renderTree()` which replaces **all** rows with HTML from `rowHTML()`. The previous fix correctly updated the Leaf template, but `rowHTML()` still used `<a href>` for filenames — so the Leaf-rendered buttons were immediately overwritten by download links.

## Fix

`rowHTML()` now renders `<button class="suite-edit-btn" data-filename="...">` matching the Leaf template and the existing click handler. The download `↓` anchor is kept alongside, and `initFromDOM()`'s URL extraction via `row.querySelector('a')` still works because the download `<a>` is present.

## Test plan
- Load assignment edit page → click any existing script filename → editor modal opens
- Click the ↓ arrow → file downloads
- No change in drag-reorder behaviour (rowHTML is used there too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)