### PR TITLE
fix: surface editor init errors and show actual server error reason

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -669,16 +669,25 @@ let view = null;
 let currentFilename = null;  // null when creating a new file
 let isCreating = false;
 
+function initView(content, filename) {
+    if (view) { view.destroy(); view = null; }
+    try {
+        view = new EditorView({ state: makeEditorState(content, filename), parent: mount });
+    } catch (e) {
+        statusEl.textContent = 'Editor failed to load: ' + e.message;
+        console.error('EditorView init error:', e);
+    }
+}
+
 function openEditor(filename, content) {
     currentFilename = filename;
     isCreating = false;
     titleEl.textContent = 'Edit: ' + filename;
     newControls.style.display = 'none';
     statusEl.textContent = '';
-    if (view) { view.destroy(); }
-    view = new EditorView({ state: makeEditorState(content, filename), parent: mount });
     overlay.style.display = 'flex';
-    view.focus();
+    initView(content, filename);
+    if (view) view.focus();
 }
 
 function openCreator() {
@@ -688,9 +697,8 @@ function openCreator() {
     newControls.style.display = '';
     newNameInput.value = '';
     statusEl.textContent = '';
-    if (view) { view.destroy(); }
-    view = new EditorView({ state: makeEditorState('', ''), parent: mount });
     overlay.style.display = 'flex';
+    initView('', '');
     newNameInput.focus();
 }
 
@@ -711,9 +719,9 @@ document.addEventListener('click', function(e) {
     fetch('/instructor/' + assignmentID + '/scripts/' + encodeURIComponent(filename), {
         headers: { 'x-csrf-token': csrfToken }
     })
-        .then(r => r.ok ? r.text() : Promise.reject(r.statusText))
+        .then(r => r.ok ? r.text() : r.text().then(t => Promise.reject(r.status + ' ' + t)))
         .then(content => openEditor(filename, content))
-        .catch(err => { statusEl.textContent = 'Error: ' + err; });
+        .catch(err => { statusEl.textContent = 'Error: ' + err; console.error('getScript error:', err); });
 });
 
 // ── New Script button ──────────────────────────────────────────────────────
@@ -793,7 +801,7 @@ applyTplBtn.addEventListener('click', function() {
 // ── Save ───────────────────────────────────────────────────────────────────
 
 saveBtn.addEventListener('click', function() {
-    if (!view) return;
+    if (!view) { statusEl.textContent = 'Editor not ready — try closing and reopening.'; return; }
     const content = view.state.doc.toString();
 
     if (isCreating) {


### PR DESCRIPTION
## Changes

- Wraps `new EditorView()` in `try/catch` via new `initView()` helper — if CodeMirror fails to initialise, the error message appears in the modal status line instead of silently leaving `view = null`
- Replaces the silent `if (!view) return` bail-out in the save handler with a visible error message
- Changes the GET fetch error path from `r.statusText` (always "Bad Request") to the actual response body text so the real server error reason is visible
- Adds `console.error` for easier debugging

## Why

The previous code had two silent failure modes: EditorView construction errors were swallowed (leaving `view = null`, causing save to do nothing), and fetch errors only showed the HTTP status phrase rather than the server's reason string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)