### PR TITLE
fix: close editor on save; reduce validation timeout to 20s

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -839,7 +839,7 @@ saveBtn.addEventListener('click', function() {
         })
         .then(r => {
             if (r.ok || r.status === 204) {
-                statusEl.textContent = 'Saved.';
+                closeEditor();
             } else {
                 return r.text().then(t => Promise.reject(t));
             }

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -1059,7 +1059,7 @@ func enqueueRunnerValidationSubmission(
 func waitForRunnerValidation(
     req: Request,
     submissionID: String,
-    timeoutSeconds: TimeInterval = 45
+    timeoutSeconds: TimeInterval = 20
 ) async throws -> RunnerValidationOutcome {
     let started = Date()
     let decoder = JSONDecoder()


### PR DESCRIPTION
## Changes

- Successful script save (PUT) now calls `closeEditor()` — the modal closes automatically rather than staying open showing "Saved."
- Reduces `waitForRunnerValidation` default timeout from 45 s to 20 s — when no runner is processing jobs the assignment save form now redirects in 20 s instead of hanging for 45 s

## Note on assignment save freeze

The save-then-freeze behaviour when no runner is available is by design. Enable **Local Runner Autostart** at `/admin` to have the server spawn a runner automatically when validation is needed, eliminating the wait entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)