### PR TITLE
Fix JupyterLite notebook frame isolation

### DIFF
--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -27,7 +27,6 @@ Notebook
     data-notebook-url="#(notebookURL)"
     data-editor-url="#(jupyterLiteEditorURL)"
     src="#(jupyterLiteEditorURL)"
-    allow="cross-origin-isolated"
     loading="eager">
 </iframe>
 <p id="nb-frame-error" class="empty" role="alert" style="display:none;margin-top:.6rem">
@@ -35,7 +34,7 @@ Notebook
 </p>
 <div id="nb-results" class="nb-results" hidden></div>
 <div id="browser-runner-status" class="nb-status" role="status" aria-live="polite" aria-atomic="true" hidden></div>
-<script src="/notebook.js?v=0.4.4"></script>
-<script src="/browser-runner.js?v=0.4.4" data-setup-id="#(testSetupID)" data-grading-mode="#(gradingMode)"></script>
+<script src="/notebook.js?v=0.5.0"></script>
+<script src="/browser-runner.js?v=0.5.0" data-setup-id="#(testSetupID)" data-grading-mode="#(gradingMode)"></script>
 #endexport
 #endextend

--- a/Sources/APIServer/Middleware/COEPMiddleware.swift
+++ b/Sources/APIServer/Middleware/COEPMiddleware.swift
@@ -1,12 +1,11 @@
 // APIServer/Middleware/COEPMiddleware.swift
 //
 // Adds Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers
-// to responses for paths that use SharedArrayBuffer (Pyodide / WebR).
+// to responses that still require cross-origin isolation.
 //
 // Without these headers on the relevant pages:
 //   • WebR cannot start (SharedArrayBuffer unavailable)
 //   • jupyterlite-webr will not function (Issue #77)
-//   • The browser WASM runner cannot use WebR for R test scripts
 //
 // The headers are intentionally scoped to paths that need them rather than
 // applied globally.  COEP require-corp forces every cross-origin resource on
@@ -15,13 +14,14 @@
 // SharedArrayBuffer (e.g. the assignment editor at /instructor/:id/edit).
 //
 // Paths that need COEP:
-//   /jupyterlite/…   — JupyterLite static files (WASM kernels)
-//   /testsetups/…    — student notebook page (browser-runner.js / Pyodide)
-//   /instructor/…/validate — validation page (assignment-validate.js / Pyodide)
+//   /instructor/…/validate — reserved for browser-side validation if a future
+//                            runtime requires SharedArrayBuffer again
 //
-// Note: COEP require-corp requires all cross-origin resources (CDN scripts,
-// images, etc.) on scoped pages to respond with appropriate CORP/CORS headers.
-// Pyodide and JSZip CDN resources already include these headers.
+// The student notebook page at /testsetups/… must NOT receive COEP. It embeds
+// the bundled JupyterLite app in an iframe, and JupyterLite intentionally runs
+// without COEP so its service worker can serve synthetic in-browser filesystem
+// responses. Applying COEP to the parent page causes Chromium to block the
+// iframe navigation with ERR_BLOCKED_BY_RESPONSE.
 
 import Vapor
 
@@ -43,13 +43,8 @@ struct COEPMiddleware: AsyncMiddleware {
         return response
     }
 
-    /// Returns true for paths whose pages load Pyodide, WebR, or JupyterLite
-    /// (all of which require `SharedArrayBuffer`).
+    /// Returns true for paths whose pages still require cross-origin isolation.
     private func needsCOEP(path: String) -> Bool {
-        // JupyterLite static files and lab UI.
-        if path == "/jupyterlite" || path.hasPrefix("/jupyterlite/") { return true }
-        // Student notebook submission page — loads browser-runner.js (Pyodide/WebR).
-        if path.hasPrefix("/testsetups/") { return true }
         // Instructor validate page — loads assignment-validate.js (Pyodide).
         // Matched by last path component to avoid affecting /instructor/:id/edit
         // and other instructor pages that load CDN resources.

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+import XCTVapor
+@testable import chickadee_server
+
+final class COEPMiddlewareTests: XCTestCase {
+
+    private func makeApp() throws -> Application {
+        let app = Application(.testing)
+        app.middleware.use(COEPMiddleware())
+
+        app.get("testsetups", ":testSetupID", "notebook") { _ in
+            "notebook"
+        }
+        app.get("instructor", ":assignmentID", "validate") { _ in
+            "validate"
+        }
+        app.get("plain") { _ in
+            "plain"
+        }
+
+        return app
+    }
+
+    func testNotebookPageDoesNotReceiveCOEPHeaders() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/testsetups/setup_123/notebook") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertNil(res.headers.first(name: "Cross-Origin-Opener-Policy"))
+            XCTAssertNil(res.headers.first(name: "Cross-Origin-Embedder-Policy"))
+        }
+    }
+
+    func testValidatePageStillReceivesCOEPHeaders() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/instructor/assignment_123/validate") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.headers.first(name: "Cross-Origin-Opener-Policy"), "same-origin")
+            XCTAssertEqual(res.headers.first(name: "Cross-Origin-Embedder-Policy"), "require-corp")
+        }
+    }
+
+    func testUnrelatedPageDoesNotReceiveCOEPHeaders() throws {
+        let app = try makeApp()
+        defer { app.shutdown() }
+
+        try app.test(.GET, "/plain") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertNil(res.headers.first(name: "Cross-Origin-Opener-Policy"))
+            XCTAssertNil(res.headers.first(name: "Cross-Origin-Embedder-Policy"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- stop applying cross-origin isolation to the student notebook page so the embedded JupyterLite app can load
- remove the stale iframe cross-origin-isolated permission from the notebook template
- add regression tests covering COEP header scoping

## Testing
- swift test --filter COEPMiddlewareTests
- Playwright repro against /testsetups/setup_419260b6/notebook confirmed the iframe now renders notebook content instead of a blocked frame
