### PR TITLE
Enforce coverage floor in CI

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -11,6 +11,8 @@ jobs:
     container:
       image: swift:6.0-jammy
       options: --privileged
+    env:
+      MIN_COVERAGE_PERCENT: "60.0"
 
     steps:
       - uses: actions/checkout@v6
@@ -32,6 +34,49 @@ jobs:
             "$XCTEST" \
             -ignore-filename-regex='.build/|Tests/' \
             > coverage.lcov
+
+      - name: Enforce coverage floor
+        id: enforce_coverage_floor
+        run: |
+          COVERAGE_PERCENT=$(awk '
+            BEGIN { hit = 0; found = 0 }
+            /^DA:/ {
+              split($0, parts, ",")
+              found += 1
+              if ((parts[2] + 0) > 0) {
+                hit += 1
+              }
+            }
+            END {
+              if (found == 0) {
+                print "0.00"
+              } else {
+                printf "%.2f", (hit / found) * 100
+              }
+            }
+          ' coverage.lcov)
+
+          echo "Coverage: ${COVERAGE_PERCENT}%"
+          echo "Minimum required: ${MIN_COVERAGE_PERCENT}%"
+          echo "coverage_percent=${COVERAGE_PERCENT}" >> "$GITHUB_OUTPUT"
+
+          awk -v actual="$COVERAGE_PERCENT" -v minimum="$MIN_COVERAGE_PERCENT" '
+            BEGIN {
+              if (actual + 0 < minimum + 0) {
+                printf "Coverage %.2f%% is below required floor %.2f%%\n", actual + 0, minimum + 0
+                exit 1
+              }
+            }
+          '
+
+      - name: Write coverage summary
+        run: |
+          {
+            echo "## Coverage"
+            echo
+            echo "- Total line coverage: ${{ steps.enforce_coverage_floor.outputs.coverage_percent }}%"
+            echo "- Required floor: ${MIN_COVERAGE_PERCENT}%"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- add a coverage floor gate to the Test Coverage workflow
- compute total line coverage from the generated lcov report
- fail the workflow if coverage drops below the configured 60.0% floor
- publish the measured coverage in the GitHub Actions step summary

## Notes
- this sets 60% as the current floor based on the latest coverage baseline
- the floor can be raised over time by updating MIN_COVERAGE_PERCENT in the workflow

## Testing
- workflow change only