### PR TITLE
Simplify runner secret configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,13 @@
 # For VM / systemd: copy to /opt/chickadee/.env (see deploy/README.md).
 
 # ----------------------------------------------------------------
-# Runner shared secret (REQUIRED)
-# Used to authenticate the runner daemon against the server.
-# Generate a strong secret: openssl rand -base64 32
+# Runner shared secret (OPTIONAL)
+# Leave unset to use the auto-generated three-word .worker-secret shared by
+# the Docker Compose server and runner containers.
+# Set this explicitly if you want a fixed secret across redeploys or non-Docker
+# runners. Example: openssl rand -base64 32
 # ----------------------------------------------------------------
-RUNNER_SHARED_SECRET=
+# RUNNER_SHARED_SECRET=
 
 # ----------------------------------------------------------------
 # Auth mode

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ git clone https://github.com/JimWallace/Chickadee.git
 cd Chickadee
 
 cp .env.example .env
-# Edit .env: set RUNNER_SHARED_SECRET (required) and any other vars
+# Edit .env for auth / URL settings as needed
 
 docker compose up -d --build
 ```
 
 The first build compiles Swift — expect 5–15 minutes. Subsequent builds with no source changes use the cached layers and are nearly instant.
+
+In Docker Compose, the server auto-generates a three-word `.worker-secret` on
+the shared data volume and the runner reads that file automatically. You can
+still set `RUNNER_SHARED_SECRET` explicitly in `.env` if you want a fixed secret.
 
 ```bash
 # Verify

--- a/Sources/Worker/README.md
+++ b/Sources/Worker/README.md
@@ -31,6 +31,10 @@ Environment variables:
 - `RUNNER_SHARED_SECRET` (preferred) — shared secret used when `--worker-secret` is omitted.
 - `WORKER_SHARED_SECRET` (legacy fallback) — still accepted for compatibility.
 
+When neither CLI nor environment provides a secret, the runner falls back to a
+local `.worker-secret` file. In Docker Compose, this comes from the shared
+`/data/.worker-secret` file created by the server.
+
 ---
 
 ## Test script contract

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -38,12 +38,11 @@ struct WorkerCommand: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        let cliSecret = workerSecret?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let env = ProcessInfo.processInfo.environment
-        let envSecret = (env["RUNNER_SHARED_SECRET"] ?? env["WORKER_SHARED_SECRET"] ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let effectiveWorkerSecret = cliSecret.isEmpty ? envSecret : cliSecret
-        guard !effectiveWorkerSecret.isEmpty else {
+        guard let effectiveWorkerSecret = resolveWorkerSharedSecret(
+            cliWorkerSecret: workerSecret,
+            environment: env
+        ) else {
             fputs("Error: missing runner secret. Use --worker-secret or set RUNNER_SHARED_SECRET.\n", stderr)
             throw ExitCode.failure
         }
@@ -65,6 +64,52 @@ struct WorkerCommand: AsyncParsableCommand {
         fputs("Runner \(workerID) starting — polling \(apiBaseURL) (max \(maxJobs) concurrent jobs, \(sandboxLabel))\n", stderr)
         try await daemon.run()
     }
+}
+
+func resolveWorkerSharedSecret(
+    cliWorkerSecret: String?,
+    environment: [String: String]
+) -> String? {
+    let cliSecret = cliWorkerSecret?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if !cliSecret.isEmpty { return cliSecret }
+
+    let envSecret = (environment["RUNNER_SHARED_SECRET"] ?? environment["WORKER_SHARED_SECRET"] ?? "")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    if !envSecret.isEmpty { return envSecret }
+
+    for path in defaultWorkerSecretFilePaths() {
+        if let fileSecret = readWorkerSecretFromFile(path: path) {
+            return fileSecret
+        }
+    }
+
+    return nil
+}
+
+func defaultWorkerSecretFilePaths() -> [String] {
+    var paths: [String] = []
+
+    let cwd = FileManager.default.currentDirectoryPath
+    if !cwd.isEmpty {
+        paths.append(URL(fileURLWithPath: cwd).appendingPathComponent(".worker-secret").path)
+    }
+
+    let dockerSharedPath = "/data/.worker-secret"
+    if !paths.contains(dockerSharedPath) {
+        paths.append(dockerSharedPath)
+    }
+
+    return paths
+}
+
+func readWorkerSecretFromFile(path: String) -> String? {
+    guard !path.isEmpty,
+          let raw = try? String(contentsOfFile: path, encoding: .utf8) else {
+        return nil
+    }
+
+    let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
 }
 
 // MARK: - WorkerDaemon actor

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -28,6 +28,12 @@ final class WorkerTests: XCTestCase {
         return url
     }
 
+    private func writeSecretFile(_ value: String, name: String = ".worker-secret") throws -> String {
+        let url = tmpDir.appendingPathComponent(name)
+        try value.write(to: url, atomically: true, encoding: .utf8)
+        return url.path
+    }
+
     // MARK: - UnsandboxedScriptRunner: exit code mapping
 
     func testScriptExitZeroReportsExitCodeZero() async throws {
@@ -179,6 +185,68 @@ final class WorkerTests: XCTestCase {
             output.exitCode, 0,
             "Sandboxed runner should block outbound network access (exit 0 means connection succeeded)"
         )
+    }
+
+    // MARK: - Worker secret resolution
+
+    func testResolveWorkerSharedSecretPrefersCLISecret() throws {
+        _ = try writeSecretFile("file-secret")
+        let resolved = resolveWorkerSharedSecret(
+            cliWorkerSecret: " cli-secret ",
+            environment: ["RUNNER_SHARED_SECRET": "env-secret"]
+        )
+
+        XCTAssertEqual(resolved, "cli-secret")
+    }
+
+    func testResolveWorkerSharedSecretUsesEnvSecretBeforeFile() throws {
+        _ = try writeSecretFile("file-secret")
+        let resolved = resolveWorkerSharedSecret(
+            cliWorkerSecret: nil,
+            environment: ["RUNNER_SHARED_SECRET": "env-secret"]
+        )
+
+        XCTAssertEqual(resolved, "env-secret")
+    }
+
+    func testResolveWorkerSharedSecretUsesDefaultFileWhenSecretsUnset() throws {
+        let previous = FileManager.default.currentDirectoryPath
+        XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(tmpDir.path))
+        defer { XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(previous)) }
+
+        _ = try writeSecretFile("shared-file-secret\n")
+        let resolved = resolveWorkerSharedSecret(
+            cliWorkerSecret: nil,
+            environment: [:]
+        )
+
+        XCTAssertEqual(resolved, "shared-file-secret")
+    }
+
+    func testDefaultWorkerSecretFilePathsIncludesCurrentDirectoryFileFirst() throws {
+        let previous = FileManager.default.currentDirectoryPath
+        XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(tmpDir.path))
+        defer { XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(previous)) }
+
+        let paths = defaultWorkerSecretFilePaths()
+
+        XCTAssertEqual(paths.first, tmpDir.appendingPathComponent(".worker-secret").path)
+        XCTAssertTrue(paths.contains("/data/.worker-secret"))
+    }
+
+    func testResolveWorkerSharedSecretReturnsNilWhenAllSourcesMissing() {
+        let emptyDir = tmpDir.appendingPathComponent("empty", isDirectory: true)
+        try? FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
+        let previous = FileManager.default.currentDirectoryPath
+        XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(emptyDir.path))
+        defer { XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(previous)) }
+
+        let resolved = resolveWorkerSharedSecret(
+            cliWorkerSecret: nil,
+            environment: [:]
+        )
+
+        XCTAssertNil(resolved)
     }
 
     // MARK: - ScriptInvocation: R extension

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -40,7 +40,7 @@ Edit `.env`:
 
 | Variable | What to set |
 |---|---|
-| `RUNNER_SHARED_SECRET` | A strong random secret: `openssl rand -base64 32` |
+| `RUNNER_SHARED_SECRET` | Optional. Leave unset to use Chickadee's auto-generated three-word `.worker-secret`, or set a fixed secret explicitly (for example `openssl rand -base64 32`). |
 | `AUTH_MODE` | `local` for username/password; `sso` for OIDC |
 | `PUBLIC_BASE_URL` | Your public URL, e.g. `https://chickadee.example.com` |
 
@@ -54,6 +54,11 @@ docker compose up -d
 The image is built automatically by GitHub Actions on every push to `main` — no
 Swift toolchain is required on the server. The first pull downloads ~500 MB;
 subsequent pulls only fetch changed layers.
+
+By default, the Compose runner reads `/data/.worker-secret` from the shared
+named volume, so the server's auto-generated three-word secret works without
+copying it into `.env`. If you set `RUNNER_SHARED_SECRET`, that explicit value
+still overrides the generated file.
 
 Check status:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 #
 # Quick start (local / dev):
 #   cp .env.example .env
-#   # Edit .env: set RUNNER_SHARED_SECRET and any other vars you need
+#   # Edit .env for auth / URL settings as needed
 #   docker compose up -d
 #   open http://localhost:8080
 #
@@ -33,10 +33,6 @@ services:
       AUTH_MODE:                    ${AUTH_MODE:-local}
       ENABLE_NON_SSO_AUTH_MODES:    ${ENABLE_NON_SSO_AUTH_MODES:-true}
 
-      # Required: shared secret between server and runner.
-      # Generate one with: openssl rand -base64 32
-      RUNNER_SHARED_SECRET:         ${RUNNER_SHARED_SECRET:?RUNNER_SHARED_SECRET must be set in .env}
-
       # Public URL — set to your domain in production (e.g. https://chickadee.example.com)
       PUBLIC_BASE_URL:              ${PUBLIC_BASE_URL:-}
       ENFORCE_HTTPS:                ${ENFORCE_HTTPS:-false}
@@ -66,6 +62,8 @@ services:
   runner:
     image: ghcr.io/jimwallace/chickadee:latest
     entrypoint: ["/app/chickadee-runner"]
+    volumes:
+      - chickadee-data:/data:ro
     command:
       - --api-base-url
       - http://server:8080
@@ -78,7 +76,6 @@ services:
       # To enable OS-level sandboxing (Linux unshare namespaces),
       # add "--sandbox" here and "cap_add: [SYS_ADMIN]" to this service.
     environment:
-      RUNNER_SHARED_SECRET: ${RUNNER_SHARED_SECRET:?RUNNER_SHARED_SECRET must be set in .env}
     networks:
       - chickadee
     depends_on:


### PR DESCRIPTION
## Summary
- simplify runner secret configuration to prefer just CLI/env inputs plus an internal `.worker-secret` fallback
- keep Docker Compose using the shared three-word `.worker-secret` without exposing extra file-specific knobs
- add focused WorkerTests coverage for the fallback order

## Testing
- `swift test --filter WorkerTests/testResolveWorkerSharedSecret`
