### PR TITLE
[codex] Refine instructor assignment edit tables

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -16,90 +16,116 @@
 </div>
 #endif
 
-<!-- View mode header (outside form) -->
-<div id="assign-header-view" style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;margin-bottom:1.25rem">
-    <h1 style="margin:0">#(assignmentName)</h1>
-    <span class="card-meta" id="assign-due-display" style="font-size:.9rem"></span>
-    <button class="btn-link" id="assign-edit-toggle" type="button"
-            title="Edit name and due date" aria-label="Edit assignment name and due date"
-            style="display:inline-flex;align-items:center;padding:.1rem .25rem;color:var(--gray-500)">
-        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-    </button>
-</div>
-
 <form class="form" method="post" action="/instructor/#(assignmentID)/edit/save" enctype="multipart/form-data" novalidate>
     #csrfFormField()
-    <!-- Inline edit mode (hidden by default; shown when pencil clicked) -->
-    <div id="assign-header-edit" style="display:none;margin-bottom:1.25rem;padding:.75rem 1rem;border:1px solid var(--border,#ddd);border-radius:.5rem;background:var(--gray-50,#fafafa)">
-        <div style="display:flex;align-items:center;margin-bottom:.6rem">
-            <strong style="font-size:.875rem">Name &amp; Due Date</strong>
-            <button class="btn-link" id="assign-edit-cancel" type="button"
-                    aria-label="Cancel" title="Cancel"
-                    style="margin-left:auto;font-size:.85rem;padding:.1rem .25rem;color:var(--gray-500)">✕</button>
+    <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin-bottom:1.25rem">
+        <div style="flex:1;min-width:16rem">
+            <!-- View mode header -->
+            <div id="assign-header-view" style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap">
+                <h1 style="margin:0">#(assignmentName)</h1>
+                <span class="card-meta" id="assign-due-display" style="font-size:.9rem"></span>
+                <button class="btn-link" id="assign-edit-toggle" type="button"
+                        title="Edit name and due date" aria-label="Edit assignment name and due date"
+                        style="display:inline-flex;align-items:center;padding:.1rem .25rem;color:var(--gray-500)">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+                </button>
+            </div>
+
+            <!-- Inline edit mode (hidden by default; shown when pencil clicked) -->
+            <div id="assign-header-edit" style="display:none;padding:.75rem 1rem;border:1px solid var(--border,#ddd);border-radius:.5rem;background:var(--gray-50,#fafafa)">
+                <div style="display:flex;align-items:center;margin-bottom:.6rem">
+                    <strong style="font-size:.875rem">Name &amp; Due Date</strong>
+                    <button class="btn-link" id="assign-edit-cancel" type="button"
+                            aria-label="Cancel" title="Cancel"
+                            style="margin-left:auto;font-size:.85rem;padding:.1rem .25rem;color:var(--gray-500)">✕</button>
+                </div>
+                <label class="form-label" style="margin-bottom:.5rem">
+                    Assignment Name
+                    <input class="form-input" type="text" name="assignmentName" id="assignmentNameInput" required
+                           value="#(assignmentName)"
+                           placeholder="e.g. Lab 2 - Linked Lists">
+                </label>
+                <label class="form-label" style="margin:0">
+                    Due Date (optional)
+                    <input class="form-input" type="datetime-local" name="dueAt" id="dueAt" value="#(dueAt)">
+                </label>
+                <div id="uw-date-warning" class="card-meta" style="display:none;color:#c05000;margin-top:.4rem;margin-bottom:0"></div>
+            </div>
         </div>
-        <label class="form-label" style="margin-bottom:.5rem">
-            Assignment Name
-            <input class="form-input" type="text" name="assignmentName" id="assignmentNameInput" required
-                   value="#(assignmentName)"
-                   placeholder="e.g. Lab 2 - Linked Lists">
-        </label>
-        <label class="form-label" style="margin:0">
-            Due Date (optional)
-            <input class="form-input" type="datetime-local" name="dueAt" id="dueAt" value="#(dueAt)">
-        </label>
-        <div id="uw-date-warning" class="card-meta" style="display:none;color:#c05000;margin-top:.4rem;margin-bottom:0"></div>
+
+        <div style="display:flex;gap:.6rem;flex-wrap:wrap;align-items:center;justify-content:flex-end">
+            <button class="btn btn-primary" type="submit">Save</button>
+            <a class="btn" href="/instructor">Cancel</a>
+        </div>
     </div>
 
-    <div class="form-label">
-        <span style="white-space:nowrap">Assignment Notebook (<a href="#(currentAssignmentURL)"><code>#(currentAssignmentFile)</code></a>)</span>
-        <input class="form-input" type="file" name="assignmentNotebookFile" accept=".ipynb">
+    <div style="margin:0 0 1.25rem">
+        <table class="results-table" id="notebook-files-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>File</th>
+                    <th class="time">Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>Assignment Notebook</strong></td>
+                    <td>
+                        <a href="#(currentAssignmentURL)"><code id="assignment-notebook-name">#(currentAssignmentFile)</code></a>
+                    </td>
+                    <td class="time">
+                        <a class="btn action-btn" id="assignment-notebook-edit-btn" href="#(assignmentNotebookEditURL)">Edit</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><strong>Solution Notebook</strong></td>
+                    <td>
+                        #if(currentSolutionURL):
+                        <a href="#(currentSolutionURL)"><code id="solution-notebook-name">#(currentSolutionFile)</code></a>
+                        #else:
+                        <code id="solution-notebook-name">not set</code>
+                        #endif
+                    </td>
+                    <td class="time">
+                        #if(solutionNotebookEditURL):
+                        <a class="btn action-btn" id="solution-notebook-edit-btn" href="#(solutionNotebookEditURL)">Edit</a>
+                        #else:
+                        <span class="card-meta">—</span>
+                        #endif
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </div>
 
-    <div class="form-label">
-        #if(currentSolutionURL):
-        <span style="white-space:nowrap">Solution Notebook (<a href="#(currentSolutionURL)"><code>#(currentSolutionFile)</code></a>)</span>
-        #else:
-        <span style="white-space:nowrap">Solution Notebook (<code>not set</code>)</span>
-        #endif
-        <input class="form-input" type="file" name="solutionNotebookFile" accept=".ipynb">
-    </div>
-
-    <label class="form-label">
-        <span style="white-space:nowrap">Add Test Suite Files (scripts/support files like <code>.py</code> or <code>.r</code>)</span>
-        <input class="form-input" id="suite-files-input" type="file" name="suiteFiles" multiple>
-    </label>
+    <label class="visually-hidden" for="suite-files-input">Add test suite files</label>
+    <input class="form-input" id="suite-files-input" type="file" name="suiteFiles" multiple style="display:none">
     <input type="hidden" id="suite-config-field" name="suiteConfig" value="">
 
-    <p class="card-meta" style="margin-bottom:.4rem">
-        Drag ⋮⋮ to reorder. Drag a file onto another to make it a dependent (child) test.
-        Drag to the strip at the bottom to remove a dependency.
-    </p>
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:.75rem;flex-wrap:wrap;margin:1.25rem 0 .75rem">
+        <h2 style="margin:0">Test Suite</h2>
+        <div style="display:flex;align-items:center;gap:.5rem;flex-wrap:wrap;justify-content:flex-end">
+            <button class="btn action-btn" type="button" id="new-script-btn">New Script</button>
+            <button class="btn action-btn" type="button" id="add-test-btn">Upload</button>
+        </div>
+    </div>
     <table class="results-table" id="suite-config-table">
         <thead>
             <tr>
                 <th title="Student-facing name (edit to override the filename)">Name</th>
-                <th>Test?</th>
-                <th>Tier</th>
+                <th>Visibility</th>
                 <th title="Grade point weight for this test (default 1)">Pts</th>
-                <th class="time">Delete</th>
+                <th class="time">Action</th>
             </tr>
         </thead>
         <tbody id="suite-config-body">
             #for(row in existingSuiteRows):
             <tr data-source="existing" data-name="#(row.name)" data-display-name="#(row.displayNameOrEmpty)" data-is-test="#(row.isTest)" data-tier="#(row.tier)" data-order="#(row.order)" data-depends-on="#(row.dependsOnJSON)" data-points="#(row.points)">
-                <td>
+                <td><div class="suite-name-cell">
                     <span class="suite-drag-handle" draggable="true" title="Drag to reorder or adopt">⋮⋮</span>
                     <input type="text" class="form-input suite-display-name" value="#(row.displayNameOrStem)" style="width:12rem;padding:.25rem .5rem;font-size:.8rem">
-                    <div class="suite-file-hint">
-                        <button class="btn-link suite-edit-btn" type="button"
-                                data-filename="#(row.name)"
-                                style="font-size:inherit;padding:0;color:var(--blue)"
-                                title="Edit script in browser"><code>#(row.name)</code></button>
-                        <a href="#(row.url)" style="font-size:.7rem;margin-left:.4rem;color:var(--gray-500)"
-                           title="Download script" download>↓</a>
-                    </div>
-                </td>
-                <td><input type="checkbox" class="suite-test-toggle" #if(row.isTest):checked#endif></td>
+                </div></td>
                 <td>
                     <select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">
                         <option value="support" #if(row.tier == "support"):selected#endif>support</option>
@@ -109,25 +135,16 @@
                     </select>
                 </td>
                 <td><input type="number" class="form-input suite-points" min="1" max="100" value="#(row.points)" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>
-                <td class="time"><button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button></td>
+                <td class="time">
+                    <div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">
+                        <button class="btn action-btn suite-edit-btn" type="button" data-filename="#(row.name)">Edit</button>
+                        <button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button>
+                    </div>
+                </td>
             </tr>
             #endfor
         </tbody>
     </table>
-
-    <p class="card-meta">
-        Use Delete to remove a file. Add more files above, or click <strong>New Script</strong> to create one from a template.
-        At least one row marked as a test is required.
-    </p>
-
-    <div style="display:flex;gap:.6rem;flex-wrap:wrap;margin-bottom:1rem">
-        <button class="btn" type="button" id="new-script-btn">+ New Script</button>
-    </div>
-
-    <div style="display:flex;gap:.6rem;flex-wrap:wrap">
-        <button class="btn btn-primary" type="submit">Save</button>
-        <a class="btn" href="/instructor">Cancel</a>
-    </div>
 </form>
 
 <!-- ── Script Editor Modal ──────────────────────────────────────────────── -->
@@ -212,6 +229,7 @@
 tr.drop-before td:first-child { border-top: 2px solid var(--blue,#0070c9); }
 tr.drop-after  td:first-child { border-bottom: 2px solid var(--blue,#0070c9); }
 tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
+.suite-name-cell { display: flex; align-items: center; gap: .4rem; }
 .suite-root-drop { height: 2rem; text-align: center; font-size: .75rem; color: var(--meta); cursor: default; }
 .suite-root-drop.drop-hover { background: var(--hover-bg, #f5f5f5); }
 .suite-child-indent { padding-left: 2rem; white-space: nowrap; }
@@ -219,6 +237,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 .suite-upload-error { font-size: .78rem; color: var(--red,#c0392b); margin-top: .2rem; }
 .suite-file-hint { font-size: .75rem; color: var(--meta); margin-top: .2rem; }
 .suite-file-hint a { color: inherit; }
+#suite-config-table td { vertical-align: top; }
 </style>
 <script>
 (function () {
@@ -232,7 +251,6 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     var nameInput    = document.getElementById('assignmentNameInput');
     var dueInput     = document.getElementById('dueAt');
     var dueDisplay   = document.getElementById('assign-due-display');
-
     function formatDueDate(val) {
         if (!val) return 'No deadline';
         // datetime-local format: "2024-03-15T09:00"
@@ -282,8 +300,6 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     // items: { name, source, index?, isTest, tier, dependsOn[], points, url? }
     var items = [];
     var dragName = null;
-    var uploadCount = 0;  // running count of uploaded files added
-
     function isLikelyScript(name) {
         var ext = (name || '').toLowerCase().split('.').pop();
         return ['sh','bash','zsh','py','r','rb','pl','js','php'].indexOf(ext) >= 0;
@@ -341,45 +357,44 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         return dot > 0 ? filename.slice(0, dot) : filename;
     }
 
+    function itemIsTest(item) {
+        return item.tier !== 'support';
+    }
+
     function rowHTML(item, depth) {
         var isNew    = item.source === 'upload';
         var errs     = (item.errors && item.errors.length > 0) ? item.errors : [];
         var errBadge = errs.length > 0
             ? '<div class="suite-upload-error">\u26a0 ' + errs.map(escHtml).join(' · ') + '</div>'
             : '';
-        // File link shown below the name input as a hint
-        var fileHint = isNew
-            ? '<div class="suite-file-hint"><code>' + escHtml(item.name) + '</code> <span class="card-meta">(new)</span>' + errBadge + '</div>'
-            : '<div class="suite-file-hint">'
-                + '<button class="btn-link suite-edit-btn" type="button" data-filename="' + escAttr(item.name) + '" style="font-size:inherit;padding:0;color:var(--blue)" title="Edit script in browser"><code>' + escHtml(item.name) + '</code></button>'
-                + '<a href="' + escAttr(item.url || '#') + '" style="font-size:.7rem;margin-left:.4rem;color:var(--gray-500)" title="Download script" download>\u2193</a>'
-                + '</div>';
+        var fileHint = isNew ? errBadge : '';
         var indent    = depth > 0 ? ' class="suite-child-indent"' : '';
         var connector = depth > 0 ? '<span class="suite-child-connector">&#9492;</span>' : '';
-        var checked   = item.isTest ? ' checked' : '';
         var pts       = item.points || 1;
         // Default input value to display name if set, otherwise the filename stem
         var nameVal   = escAttr(item.displayName || stemOf(item.name));
         return '<tr data-name="' + escAttr(item.name) + '" data-source="' + escAttr(item.source) + '">'
-            + '<td' + indent + '>'
+            + '<td' + indent + '><div class="suite-name-cell">'
             +   '<span class="suite-drag-handle" draggable="true" title="Drag to reorder or adopt">⋮⋮</span>'
             +   connector
             +   '<input type="text" class="form-input suite-display-name" value="' + nameVal + '" style="width:12rem;padding:.25rem .5rem;font-size:.8rem">'
             +   fileHint
-            + '</td>'
-            + '<td><input type="checkbox" class="suite-test-toggle"' + checked + '></td>'
+            + '</div></td>'
             + '<td><select class="form-input suite-tier" style="padding:.25rem .5rem;font-size:.8rem">'
             +   tierOptions(item.tier)
             + '</select></td>'
             + '<td><input type="number" class="form-input suite-points" min="1" max="100" value="' + pts + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
-            + '<td class="time"><button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button></td>'
+            + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
+            +   (isNew ? '' : '<button class="btn action-btn suite-edit-btn" type="button" data-filename="' + escAttr(item.name) + '">Edit</button>')
+            +   '<button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button>'
+            + '</div></td>'
             + '</tr>';
     }
 
     function renderTree() {
         var visual = visualOrder();
         body.innerHTML = visual.map(function (v) { return rowHTML(v.item, v.depth); }).join('')
-            + '<tr class="suite-root-drop"><td colspan="5">&#9660; Drop here to remove dependency</td></tr>';
+            + '<tr class="suite-root-drop"><td colspan="4">&#9660; Drop here to remove dependency</td></tr>';
     }
 
     function syncConfig() {
@@ -389,11 +404,10 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             var row  = body.querySelector('tr[data-name="' + CSS.escape(item.name) + '"]');
             if (row) {
                 var tierEl        = row.querySelector('.suite-tier');
-                var toggleEl      = row.querySelector('.suite-test-toggle');
                 var ptsEl         = row.querySelector('.suite-points');
                 var displayNameEl = row.querySelector('.suite-display-name');
                 if (tierEl)        item.tier        = tierEl.value;
-                if (toggleEl)      item.isTest      = toggleEl.checked && item.tier !== 'support';
+                item.isTest = itemIsTest(item);
                 if (ptsEl)         item.points      = Math.max(1, parseInt(ptsEl.value) || 1);
                 if (displayNameEl) {
                     var val = displayNameEl.value.trim();
@@ -554,6 +568,14 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     body.addEventListener('input',  function () { syncConfig(); });
 
     filesInput.addEventListener('change', addUploadedFiles);
+
+    var addTestBtn = document.getElementById('add-test-btn');
+    if (addTestBtn) {
+        addTestBtn.addEventListener('click', function () {
+            filesInput.value = '';
+            filesInput.click();
+        });
+    }
 
     function escHtml(v) {
         return String(v).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#39;');

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -11,10 +11,14 @@ Notebook
     <div class="notebook-toolbar">
         <span class="nb-status" id="nb-status" role="status" aria-live="polite" aria-atomic="true"></span>
         <div class="notebook-actions">
+            #if(showSubmit):
             <button class="btn btn-primary" id="nb-submit">Submit</button>
+            #endif
+            #if(downloadURL):
             <a class="btn"
-               href="/api/v1/testsetups/#(testSetupID)/assignment/download"
+               href="#(downloadURL)"
                download>Download</a>
+            #endif
         </div>
     </div>
 </div>

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -92,12 +92,15 @@ struct NewAssignmentContext: Encodable {
 struct EditAssignmentContext: Encodable {
     let currentUser: CurrentUserContext?
     let assignmentID: String
+    let testSetupID: String
     let assignmentName: String
     let dueAt: String
     let currentAssignmentFile: String
     let currentAssignmentURL: String
+    let assignmentNotebookEditURL: String
     let currentSolutionFile: String?
     let currentSolutionURL: String?
+    let solutionNotebookEditURL: String?
     let existingSuiteRows: [EditableSuiteRow]
     let notice: String?
     let error: String?

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -747,12 +747,17 @@ struct AssignmentRoutes: RouteCollection {
         let ctx = EditAssignmentContext(
             currentUser: req.currentUserContext,
             assignmentID: idStr,
+            testSetupID: setup.id!,
             assignmentName: (q?.assignmentName ?? assignment.title).trimmingCharacters(in: .whitespacesAndNewlines),
             dueAt: q?.dueAt ?? currentDueAt,
             currentAssignmentFile: currentFiles.assignmentFile.name,
             currentAssignmentURL: currentFiles.assignmentFile.url,
+            assignmentNotebookEditURL: "/testsetups/\(setup.id!)/notebook?title=\(urlEncode(assignment.title))",
             currentSolutionFile: currentFiles.solutionFile?.name,
             currentSolutionURL: currentFiles.solutionFile?.url,
+            solutionNotebookEditURL: currentFiles.solutionFile != nil
+                ? "/testsetups/\(setup.id!)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))"
+                : nil,
             existingSuiteRows: currentFiles.existingSuiteRows,
             notice: q?.notice,
             error: q?.error

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -63,7 +63,9 @@ struct NotebookContext: Encodable {
     let assignmentTitle: String
     let notebookURL: String
     let jupyterLiteEditorURL: String
+    let downloadURL: String?
     let gradingMode: String          // "browser" | "worker"
+    let showSubmit: Bool
     let currentUser: CurrentUserContext?
 }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -8,6 +8,11 @@ import Fluent
 import Core
 import Foundation
 
+enum NotebookFileKind: String {
+    case assignment
+    case solution
+}
+
 extension WebRoutes {
 
     // MARK: - GET /testsetups/:id/notebook
@@ -17,6 +22,7 @@ extension WebRoutes {
         struct NotebookQuery: Content {
             var title: String?
             var submissionID: String?
+            var file: String?
         }
         let user = try req.auth.require(APIUser.self)
         guard let userID = user.id else { throw Abort(.unauthorized) }
@@ -29,6 +35,7 @@ extension WebRoutes {
         try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
 
         let query = try? req.query.decode(NotebookQuery.self)
+        let fileKind = notebookFileKind(from: query?.file)
         let queryTitle = (query?.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == setupID)
@@ -54,6 +61,16 @@ extension WebRoutes {
                 fallbackSetup: setup,
                 overwriteWith: notebookData
             )
+        } else if fileKind == .solution {
+            let solutionData = try await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+            _ = try await ensureUserNotebookWorkingCopy(
+                req: req,
+                setupID: setupID,
+                userID: userID,
+                fallbackSetup: setup,
+                relativePath: userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: fileKind),
+                defaultData: solutionData
+            )
         } else {
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
@@ -62,12 +79,29 @@ extension WebRoutes {
                 fallbackSetup: setup
             )
         }
-        let jupyterLiteNotebookPath = userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID)
+        let jupyterLiteNotebookPath = userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: fileKind)
         let encodedPath = jupyterLiteNotebookPath.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
             ?? jupyterLiteNotebookPath
         let userSlug = userID.uuidString.lowercased()
-        let workspaceID = "\(setupID)-\(userSlug)-student"
+        let workspaceID = "\(setupID)-\(userSlug)-\(fileKind.rawValue)"
         let editorURL = "/jupyterlite/notebooks/index.html?workspace=\(workspaceID)&reset=&path=\(encodedPath)"
+        let notebookURL = {
+            switch fileKind {
+            case .assignment:
+                return "/testsetups/\(setupID)/notebook/source"
+            case .solution:
+                return "/testsetups/\(setupID)/notebook/source?file=solution"
+            }
+        }()
+        let downloadURL: String? = {
+            guard let assignment else { return nil }
+            switch fileKind {
+            case .assignment:
+                return "/api/v1/testsetups/\(setupID)/assignment/download"
+            case .solution:
+                return "/instructor/\(assignment.publicID)/files/solution"
+            }
+        }()
 
         // Decode gradingMode from the manifest so the template can load
         // browser-runner.js for browser-graded assignments.
@@ -83,9 +117,11 @@ extension WebRoutes {
             NotebookContext(
                 testSetupID: setupID,
                 assignmentTitle: assignmentTitle,
-                notebookURL: "/testsetups/\(setupID)/notebook/source",
+                notebookURL: notebookURL,
                 jupyterLiteEditorURL: editorURL,
+                downloadURL: downloadURL,
                 gradingMode: manifestGradingMode,
+                showSubmit: fileKind == .assignment,
                 currentUser: req.currentUserContext
             ))
     }
@@ -94,6 +130,9 @@ extension WebRoutes {
 
     @Sendable
     func notebookSource(req: Request) async throws -> Response {
+        struct NotebookSourceQuery: Content {
+            var file: String?
+        }
         let user = try req.auth.require(APIUser.self)
         guard let userID = user.id else { throw Abort(.unauthorized) }
         guard
@@ -105,11 +144,24 @@ extension WebRoutes {
 
         try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
 
+        let query = try? req.query.decode(NotebookSourceQuery.self)
+        let fileKind = notebookFileKind(from: query?.file)
+        let assignment = try await APIAssignment.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .first()
+        let defaultData: Data? = if fileKind == .solution {
+            try await solutionNotebookData(for: assignment, setup: setup, db: req.db)
+        } else {
+            nil
+        }
+
         let payload = try await ensureUserNotebookWorkingCopy(
             req: req,
             setupID: setupID,
             userID: userID,
-            fallbackSetup: setup
+            fallbackSetup: setup,
+            relativePath: userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: fileKind),
+            defaultData: defaultData
         )
 
         var headers = HTTPHeaders()
@@ -121,7 +173,26 @@ extension WebRoutes {
 // MARK: - Notebook helpers
 
 func userNotebookWorkingCopyRelativePath(setupID: String, userID: UUID) -> String {
-    "users/\(userID.uuidString.lowercased())/\(setupID)/assignment.ipynb"
+    userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID, fileKind: .assignment)
+}
+
+private func notebookFileKind(from rawValue: String?) -> NotebookFileKind {
+    NotebookFileKind(rawValue: (rawValue ?? "").lowercased()) ?? .assignment
+}
+
+private func userNotebookFilename(fileKind: NotebookFileKind) -> String {
+    switch fileKind {
+    case .assignment: return "assignment.ipynb"
+    case .solution: return "solution.ipynb"
+    }
+}
+
+func userNotebookWorkingCopyRelativePath(
+    setupID: String,
+    userID: UUID,
+    fileKind: NotebookFileKind
+) -> String {
+    "users/\(userID.uuidString.lowercased())/\(setupID)/\(userNotebookFilename(fileKind: fileKind))"
 }
 
 func userNotebookWorkingCopyAbsolutePath(req: Request, setupID: String, userID: UUID) -> String {
@@ -135,10 +206,15 @@ func ensureUserNotebookWorkingCopy(
     setupID: String,
     userID: UUID,
     fallbackSetup: APITestSetup,
+    relativePath: String? = nil,
+    defaultData: Data? = nil,
     overwriteWith: Data? = nil
 ) async throws -> Data {
     let fileManager = FileManager.default
-    let workingCopyPath = userNotebookWorkingCopyAbsolutePath(req: req, setupID: setupID, userID: userID)
+    let resolvedRelativePath = relativePath ?? userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID)
+    let workingCopyPath = req.application.directory.publicDirectory
+        + "jupyterlite/files/"
+        + resolvedRelativePath
     let workingCopyDir = (workingCopyPath as NSString).deletingLastPathComponent
 
     if let overwriteWith {
@@ -159,12 +235,16 @@ func ensureUserNotebookWorkingCopy(
         return existingData
     }
 
-    let seedData = try await latestNotebookSubmissionData(
-        req: req,
-        setupID: setupID,
-        userID: userID,
-        fallbackSetup: fallbackSetup
-    ).data
+    let seedData = if let defaultData {
+        defaultData
+    } else {
+        try await latestNotebookSubmissionData(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: fallbackSetup
+        ).data
+    }
 
     try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
     try seedData.write(to: URL(fileURLWithPath: workingCopyPath))
@@ -172,6 +252,38 @@ func ensureUserNotebookWorkingCopy(
 
     removeLegacyUserNotebookCopies(req: req, userID: userID)
     return seedData
+}
+
+private func solutionNotebookData(
+    for assignment: APIAssignment?,
+    setup: APITestSetup,
+    db: Database
+) async throws -> Data {
+    if let entryName = listZipEntries(zipPath: setup.zipPath).first(where: { $0.hasPrefix("solution.") }),
+       let data = extractZipEntry(zipPath: setup.zipPath, entryName: entryName),
+       !data.isEmpty {
+        return normalizeNotebookForJupyterLite(data)
+    }
+
+    if let validationID = assignment?.validationSubmissionID,
+       let validationSubmission = try await APISubmission.find(validationID, on: db),
+       let data = try? Data(contentsOf: URL(fileURLWithPath: validationSubmission.zipPath)),
+       !data.isEmpty {
+        return normalizeNotebookForJupyterLite(data)
+    }
+
+    if let setupID = assignment?.testSetupID,
+       let fallbackSubmission = try await APISubmission.query(on: db)
+        .filter(\.$testSetupID == setupID)
+        .filter(\.$kind == APISubmission.Kind.validation)
+        .sort(\.$submittedAt, .descending)
+        .first(),
+       let data = try? Data(contentsOf: URL(fileURLWithPath: fallbackSubmission.zipPath)),
+       !data.isEmpty {
+        return normalizeNotebookForJupyterLite(data)
+    }
+
+    throw Abort(.notFound, reason: "No solution notebook is available for this assignment yet")
 }
 
 func notebookDataForHistorySelection(


### PR DESCRIPTION
## What changed

This updates the instructor assignment edit UI to better match the admin and instructor table patterns already used elsewhere.

It:
- moves assignment save and cancel actions into the top header area
- reshapes the assignment and solution notebooks into a compact table with notebook-view edit links
- consolidates the test suite into a cleaner table layout with `Visibility`, `Pts`, and `Action` columns
- removes the old helper copy and test checkbox flow, using `support` visibility as the non-test state
- moves script editing into the action column and simplifies the name cell presentation
- adds notebook-view support for opening the solution notebook as well as the assignment notebook

## Why

The previous page mixed form fields, helper text, and test file controls in a way that felt inconsistent with the rest of the instructor/admin UI. This change makes the page feel more table-driven, more compact, and more aligned with the existing interface patterns.

## Impact

Instructors get a more consistent edit screen with clearer actions and less visual clutter. Notebook edits now open directly in the notebook view from the top table, and test-suite rows emphasize the editable human-readable name instead of the filename metadata.

## Validation

- `swift build`
