### PR TITLE
Fix notebook fallback and empty assignment test setup

### DIFF
--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -163,20 +163,55 @@ func notebookData(for setup: APITestSetup) throws -> Data {
        !data.isEmpty {
         return normalizeNotebookForJupyterLite(data)
     }
-    // Fall back to zip extraction.
-    let proc = Process()
-    proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-    proc.arguments     = ["-p", setup.zipPath, "assignment.ipynb"]
-    let pipe = Pipe()
-    proc.standardOutput = pipe
-    proc.standardError  = Pipe()    // discard stderr
-    try proc.run()
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    proc.waitUntilExit()
-    guard proc.terminationStatus == 0, !data.isEmpty else {
-        throw Abort(.notFound, reason: "No assignment.ipynb in this test setup")
+
+    let entries = listZipEntries(zipPath: setup.zipPath)
+    let preferredEntryNames = notebookCandidateEntryNames(for: setup, entries: entries)
+    for entryName in preferredEntryNames {
+        guard let data = extractZipEntry(zipPath: setup.zipPath, entryName: entryName),
+              !data.isEmpty else { continue }
+        return normalizeNotebookForJupyterLite(data)
     }
-    return normalizeNotebookForJupyterLite(data)
+
+    throw Abort(.notFound, reason: "No assignment notebook in this test setup")
+}
+
+private func notebookCandidateEntryNames(for setup: APITestSetup, entries: [String]) -> [String] {
+    let manifestStarterName: String? = {
+        guard let data = setup.manifest.data(using: .utf8),
+              let props = try? JSONDecoder().decode(TestProperties.self, from: data) else {
+            return nil
+        }
+        return props.starterNotebook?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }()
+
+    var candidates: [String] = []
+    var seen: Set<String> = []
+
+    func appendCandidate(_ entry: String?) {
+        guard let entry, !entry.isEmpty, !seen.contains(entry) else { return }
+        seen.insert(entry)
+        candidates.append(entry)
+    }
+
+    func appendMatchingEntries(named filename: String?) {
+        guard let filename, !filename.isEmpty else { return }
+        let exactMatches = entries.filter { $0 == filename }
+        if !exactMatches.isEmpty {
+            exactMatches.forEach(appendCandidate)
+            return
+        }
+        entries
+            .filter { ($0 as NSString).lastPathComponent == filename }
+            .forEach(appendCandidate)
+    }
+
+    appendMatchingEntries(named: manifestStarterName)
+    appendMatchingEntries(named: "assignment.ipynb")
+    entries
+        .filter { URL(fileURLWithPath: $0).pathExtension.lowercased() == "ipynb" }
+        .forEach(appendCandidate)
+
+    return candidates
 }
 
 // MARK: - Route collection
@@ -427,15 +462,12 @@ func zipContainsNotebook(_ zipData: Data) -> Bool {
 /// Extracts `assignment.ipynb` from the zip at `zipPath` and returns its Data,
 /// or nil if the file is not present or unzip fails.
 func extractNotebookFromZip(zipPath: String) -> Data? {
-    let proc = Process()
-    proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-    proc.arguments     = ["-p", zipPath, "assignment.ipynb"]
-    let pipe = Pipe()
-    proc.standardOutput = pipe
-    proc.standardError  = Pipe()
-    guard (try? proc.run()) != nil else { return nil }
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    proc.waitUntilExit()
-    guard proc.terminationStatus == 0 else { return nil }
-    return data.isEmpty ? nil : data
+    let entries = listZipEntries(zipPath: zipPath)
+    let candidate = entries.first {
+        ($0 as NSString).lastPathComponent == "assignment.ipynb"
+    } ?? entries.first {
+        URL(fileURLWithPath: $0).pathExtension.lowercased() == "ipynb"
+    }
+    guard let candidate else { return nil }
+    return extractZipEntry(zipPath: zipPath, entryName: candidate)
 }

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -68,6 +68,10 @@ enum RunnerValidationOutcome {
     case timedOut
 }
 
+func minimalEmptyNotebookData() -> Data {
+    Data(#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#.utf8)
+}
+
 // MARK: - Free functions
 
 /// Validates a sectionID string (UUID) against the given course and returns the UUID if valid.
@@ -831,24 +835,37 @@ func createRunnerSetupZip(
         storedNameByIndex: storedNameByIndex,
         suiteConfigJSON: suiteConfigJSON
     )
-    guard !testSuites.isEmpty else {
-        throw Abort(.badRequest, reason: "Select at least one test file in the suite file list")
-    }
 
-    let zip = Process()
-    zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-    zip.currentDirectoryURL = tempDir
-    zip.arguments = ["-q", "-r", zipPath, "."]
-    try zip.run()
-    zip.waitUntilExit()
-    guard zip.terminationStatus == 0 else {
-        throw Abort(.internalServerError, reason: "Failed to package setup zip")
+    if storedNameByIndex.isEmpty {
+        try writeEmptyZip(to: zipPath)
+    } else {
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = tempDir
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        try zip.run()
+        zip.waitUntilExit()
+        guard zip.terminationStatus == 0 else {
+            throw Abort(.internalServerError, reason: "Failed to package setup zip")
+        }
     }
     let hasMakefile = storedNameByIndex.values.contains {
         let n = $0.lowercased()
         return n == "makefile" || n == "gnumakefile"
     }
     return RunnerSetupPackage(testSuites: testSuites, hasMakefile: hasMakefile)
+}
+
+private func writeEmptyZip(to path: String) throws {
+    let emptyZip = Data([
+        0x50, 0x4b, 0x05, 0x06,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00
+    ])
+    try emptyZip.write(to: URL(fileURLWithPath: path))
 }
 
 func sanitizeSuiteFilename(_ raw: String) -> String {

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -388,10 +388,6 @@ struct AssignmentRoutes: RouteCollection {
             return req.redirect(to: "/instructor/new?\(q)")
         }
         let suiteFiles = suiteFilesRaw.filter { $0.data.readableBytes > 0 }
-        guard !suiteFiles.isEmpty else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=At%20least%20one%20test%20suite%20file%20is%20required"
-            return req.redirect(to: "/instructor/new?\(q)")
-        }
 
         let assignmentNotebookRaw = Data(assignmentNotebookFile.data.readableBytesView)
         let solutionNotebookRaw = Data(solutionNotebookFile.data.readableBytesView)
@@ -422,10 +418,6 @@ struct AssignmentRoutes: RouteCollection {
             suiteConfigJSON: suiteConfigRaw,
             zipPath: zipPath
         )
-        guard !setupPackage.testSuites.isEmpty else {
-            let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Select%20at%20least%20one%20test%20file%20in%20the%20suite%20list"
-            return req.redirect(to: "/instructor/new?\(q)")
-        }
 
         // Resolve the section up front so we can inherit its grading mode.
         let resolvedSectionID: UUID? = try await resolveSectionID(sectionIDRaw, courseID: courseID, db: req.db)
@@ -457,6 +449,7 @@ struct AssignmentRoutes: RouteCollection {
             testSetupsDirectory: req.application.testSetupsDirectory
         )
 
+        let shouldQueueValidation = !setupPackage.testSuites.isEmpty
         let assignment = try await createAssignmentWithUniquePublicID(
             req: req,
             testSetupID: setupID,
@@ -464,22 +457,23 @@ struct AssignmentRoutes: RouteCollection {
             dueAt: due,
             isOpen: false,
             sortOrder: try await nextAssignmentSortOrder(req: req),
-            validationStatus: "pending",
+            validationStatus: shouldQueueValidation ? "pending" : nil,
             validationSubmissionID: nil,
             sectionID: resolvedSectionID,
             courseID: courseID
         )
 
-        let validationSubmissionID = try await enqueueRunnerValidationSubmission(
-            req: req,
-            setupID: setupID,
-            solutionNotebookData: normalizeNotebookForJupyterLite(solutionNotebookRaw),
-            filename: solutionNotebookFile.filename
-        )
-        assignment.validationSubmissionID = validationSubmissionID
-        try await assignment.save(on: req.db)
-
-        await ensureValidationRunnerAvailability(req: req)
+        if shouldQueueValidation {
+            let validationSubmissionID = try await enqueueRunnerValidationSubmission(
+                req: req,
+                setupID: setupID,
+                solutionNotebookData: normalizeNotebookForJupyterLite(solutionNotebookRaw),
+                filename: solutionNotebookFile.filename
+            )
+            assignment.validationSubmissionID = validationSubmissionID
+            try await assignment.save(on: req.db)
+            await ensureValidationRunnerAvailability(req: req)
+        }
         return req.redirect(to: "/instructor")
     }
 
@@ -925,11 +919,9 @@ struct AssignmentRoutes: RouteCollection {
         // requiring the instructor to upload one on every save.
         // The empty notebook produces no .py code when extractNotebooksToCode
         // runs, so it doesn't conflict with the student submission.
-        let minimalEmptyNotebook = Data(
-            #"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#.utf8)
         let assignmentNotebookRaw: Data = {
             guard let assignmentNotebookFile, hasUploadedAssignmentNotebook else {
-                return (try? notebookData(for: setup)) ?? minimalEmptyNotebook
+                return (try? notebookData(for: setup)) ?? minimalEmptyNotebookData()
             }
             return Data(assignmentNotebookFile.data.readableBytesView)
         }()

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -383,7 +383,8 @@ func latestNotebookSubmissionData(
         let name = URL(fileURLWithPath: path).lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
         return name.isEmpty ? nil : name
     }()
-    return (try notebookData(for: fallbackSetup), fallbackFilename)
+    let fallbackData = (try? notebookData(for: fallbackSetup)) ?? minimalEmptyNotebookData()
+    return (fallbackData, fallbackFilename)
 }
 
 /// Creates read-only symlinks for support files (zip entries that are not test suite

--- a/Sources/APIServer/Utilities/MarmosetImportParser.swift
+++ b/Sources/APIServer/Utilities/MarmosetImportParser.swift
@@ -274,9 +274,12 @@ private func extractFileFromZip(zipPath: String, filename: String) throws -> Dat
     guard FileManager.default.fileExists(atPath: "/usr/bin/unzip") else {
         throw ZipArchiverError.executableNotFound("/usr/bin/unzip")
     }
+    let entryName = try listZipContents(zipPath: zipPath).first(where: { entry in
+        entry == filename || (entry as NSString).lastPathComponent == filename
+    }) ?? filename
     let proc = Process()
     proc.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
-    proc.arguments = ["-p", zipPath, filename]
+    proc.arguments = ["-p", zipPath, entryName]
     let outPipe = Pipe()
     let errPipe = Pipe()
     proc.standardOutput = outPipe

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -14,6 +14,7 @@ import XCTVapor
 @testable import chickadee_server
 import FluentSQLiteDriver
 import Foundation
+import Core
 
 final class AssignmentRoutesTests: XCTestCase {
 
@@ -109,6 +110,46 @@ final class AssignmentRoutesTests: XCTestCase {
         return student
     }
 
+    private func multipartAssignmentBody(
+        boundary: String,
+        csrf: String,
+        assignmentName: String,
+        assignmentNotebook: String,
+        solutionNotebook: String
+    ) -> ByteBuffer {
+        var body = ByteBufferAllocator().buffer(capacity: 4096)
+
+        func appendField(_ name: String, _ value: String) {
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            body.writeString(value)
+            body.writeString("\r\n")
+        }
+
+        func appendFile(_ name: String, filename: String, contentType: String = "application/json", data: Data) {
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+            body.writeString("Content-Type: \(contentType)\r\n\r\n")
+            body.writeBytes(data)
+            body.writeString("\r\n")
+        }
+
+        appendField("_csrf", csrf)
+        appendField("assignmentName", assignmentName)
+        appendFile(
+            "assignmentNotebookFile",
+            filename: "assignment.ipynb",
+            data: Data(assignmentNotebook.utf8)
+        )
+        appendFile(
+            "solutionNotebookFile",
+            filename: "solution.ipynb",
+            data: Data(solutionNotebook.utf8)
+        )
+        body.writeString("--\(boundary)--\r\n")
+        return body
+    }
+
     // MARK: - GET /instructor
 
     func testStudentCannotAccessAssignments() async throws {
@@ -198,6 +239,47 @@ final class AssignmentRoutesTests: XCTestCase {
             .filter(\.$testSetupID == "setup_dup")
             .count()
         XCTAssertEqual(count, 1)
+    }
+
+    func testSaveNewAssignmentAllowsMissingTestSuites() async throws {
+        _ = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
+        let boundary = "Boundary-New-NoSuites"
+        let notebook = #"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#
+
+        try await app.asyncTest(.POST, "/instructor/new/save", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart",
+                subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: self.multipartAssignmentBody(
+                boundary: boundary,
+                csrf: csrf,
+                assignmentName: "No Tests Yet",
+                assignmentNotebook: notebook,
+                solutionNotebook: notebook
+            ))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertEqual(res.headers.first(name: .location), "/instructor")
+        })
+
+        let assignment = try await APIAssignment.query(on: app.db)
+            .filter(\.$title == "No Tests Yet")
+            .first()
+        XCTAssertNotNil(assignment)
+        XCTAssertNil(assignment?.validationStatus)
+        XCTAssertNil(assignment?.validationSubmissionID)
+
+        let setupID = try XCTUnwrap(assignment?.testSetupID)
+        let setup = try await APITestSetup.find(setupID, on: app.db)
+        XCTAssertNotNil(setup)
+        let setupManifest = try XCTUnwrap(setup?.manifest.data(using: .utf8))
+        let props = try JSONDecoder().decode(TestProperties.self, from: setupManifest)
+        XCTAssertTrue(props.testSuites.isEmpty)
     }
 
     // MARK: - POST /instructor/:id/open

--- a/Tests/APITests/MarmosetImportParserTests.swift
+++ b/Tests/APITests/MarmosetImportParserTests.swift
@@ -9,6 +9,31 @@ import Core
 
 final class MarmosetImportParserTests: XCTestCase {
 
+    private func makeZip(entries: [(name: String, content: String)]) throws -> String {
+        let zipPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("marmoset-parser-\(UUID().uuidString).zip")
+            .path
+        let entriesCode = entries.map { entry in
+            "z.writestr(\(entry.name.debugDescription), \(entry.content.debugDescription))"
+        }.joined(separator: "\n    ")
+        let script = """
+import zipfile
+with zipfile.ZipFile(\(zipPath.debugDescription), "w") as z:
+    \(entriesCode)
+"""
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["python3", "-c", script]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw XCTSkip("python3 not available or failed to create zip")
+        }
+        return zipPath
+    }
+
     // MARK: - parseJavaProperties
 
     func testParseSimpleProperties() {
@@ -317,5 +342,29 @@ final class MarmosetImportParserTests: XCTestCase {
         XCTAssertTrue(p.secretTests.isEmpty)
         XCTAssertTrue(p.hasMakefile)
         XCTAssertEqual(p.suggestedTitle, "Test Project")
+    }
+
+    func testFirstNotebookInZipFindsNestedNotebook() throws {
+        let zipPath = try makeZip(entries: [
+            ("starter-files/Lab 1.ipynb", "{}"),
+            ("starter-files/readme.txt", "hello")
+        ])
+        defer { try? FileManager.default.removeItem(atPath: zipPath) }
+
+        XCTAssertEqual(try firstNotebookInZip(zipPath: zipPath), "Lab 1.ipynb")
+        let extracted = try extractNotebookFromZip(zipPath: zipPath, filename: "Lab 1.ipynb")
+        XCTAssertEqual(String(data: try XCTUnwrap(extracted), encoding: .utf8), "{}")
+    }
+
+    func testExtractSolutionFromCanonicalZipHandlesNestedEntry() throws {
+        let zipPath = try makeZip(entries: [
+            ("canonical/solution.py", "print('ok')\n")
+        ])
+        defer { try? FileManager.default.removeItem(atPath: zipPath) }
+
+        let solution = try extractSolutionFromCanonicalZip(zipPath: zipPath)
+        XCTAssertEqual(solution?.originalFilename, "solution.py")
+        XCTAssertEqual(solution?.ext, "py")
+        XCTAssertEqual(String(data: try XCTUnwrap(solution?.data), encoding: .utf8), "print('ok')\n")
     }
 }

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -476,4 +476,41 @@ with zipfile.ZipFile('\(zipPath)', 'w') as z:
             XCTAssertEqual(res.status, .forbidden)
         })
     }
+
+    func testNotebookPageSeedsEmptyWorkingCopyWhenSetupHasNoStarterNotebookYet() async throws {
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        let userID = try user.requireID()
+        try await enroll(user)
+
+        let setupID = "setup_nb_empty_seed"
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        try makeZipAt(zipPath: zipPath, entries: [("readme.txt", "starter files pending")])
+
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#,
+            zipPath: zipPath,
+            notebookPath: nil,
+            courseID: try await makeCourse().requireID()
+        )
+        try await setup.save(on: app.db)
+
+        try await app.asyncTest(.GET, "/testsetups/\(setupID)/notebook/source", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let json = try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8)) as? [String: Any]
+            let cells = json?["cells"] as? [[String: Any]]
+            XCTAssertEqual(cells?.count, 0)
+        })
+
+        let workingCopy = try String(
+            contentsOfFile: workingCopyPath(setupID: setupID, userID: userID),
+            encoding: .utf8
+        )
+        let workingCopyJSON = try JSONSerialization.jsonObject(with: Data(workingCopy.utf8)) as? [String: Any]
+        let workingCells = workingCopyJSON?["cells"] as? [[String: Any]]
+        XCTAssertEqual(workingCells?.count, 0)
+    }
 }


### PR DESCRIPTION
## Summary
- seed a fresh working notebook when a student edits an assignment without a prior submission
- allow instructors to create assignments without uploading test cases yet
- harden notebook and Marmoset zip extraction for nested paths

## Validation
- swift test --filter NotebookWebRoutesTests
- swift test --filter AssignmentRoutesTests/testSaveNewAssignmentAllowsMissingTestSuites
- swift test --filter MarmosetImportParserTests

Version bump intentionally excluded for now; we'll handle 0.4.7 later tonight once we're ready.