### PR TITLE
Split worker CI and expand notebook zip coverage

### DIFF
--- a/.github/workflows/worker-tests.yml
+++ b/.github/workflows/worker-tests.yml
@@ -7,7 +7,7 @@ on:
     - cron: "30 6 * * *"
 
 jobs:
-  worker-tests:
+  worker-tests-stable:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
@@ -17,5 +17,57 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Run WorkerTests
-        run: swift test --filter WorkerTests
+      - name: Run stable worker test targets
+        run: |
+          swift test --filter ScriptInvocationTests
+          swift test --filter WorkerRequestSignerTests
+          swift test --filter WorkerDaemonTests
+          swift test --filter RunnerWorkDirTests
+
+  worker-tests-runner-core:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: swift:6.0-jammy
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run core runner behavior tests
+        run: |
+          swift test \
+            --filter 'WorkerTests.WorkerTests' \
+            --skip 'WorkerTests.WorkerTests/testScriptTimesOut' \
+            --skip 'WorkerTests.WorkerTests/testScriptTimeoutReapsBackgroundChildProcess' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerExitZero' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerExitOne' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStdout' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStderr' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerTimesOut' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerTimeoutReapsBackgroundChildProcess' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerWorkDir' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerBlocksNetworkAccess'
+
+  worker-tests-timeouts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: swift:6.0-jammy
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run timeout and sandbox-focused worker tests
+        run: |
+          swift test --filter 'WorkerTests.WorkerTests/testScriptTimesOut'
+          swift test --filter 'WorkerTests.WorkerTests/testScriptTimeoutReapsBackgroundChildProcess'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerExitZero'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerExitOne'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStdout'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStderr'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerTimesOut'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerTimeoutReapsBackgroundChildProcess'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerWorkDir'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerBlocksNetworkAccess'

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -513,4 +513,72 @@ with zipfile.ZipFile('\(zipPath)', 'w') as z:
         let workingCells = workingCopyJSON?["cells"] as? [[String: Any]]
         XCTAssertEqual(workingCells?.count, 0)
     }
+
+    func testNotebookSourceFallsBackToNestedManifestStarterNotebookWhenZipOnlySetupHasNoFlatNotebook() async throws {
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enroll(user)
+
+        let setupID = "setup_nb_nested_manifest"
+        let nestedNotebook = notebookJSON(markdown: "Nested manifest starter")
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        try makeZipAt(
+            zipPath: zipPath,
+            entries: [
+                ("materials/starter.ipynb", nestedNotebook),
+                ("readme.txt", "nested zip")
+            ]
+        )
+
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: #"{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null,"starterNotebook":"starter.ipynb"}"#,
+            zipPath: zipPath,
+            notebookPath: nil,
+            courseID: try await makeCourse().requireID()
+        )
+        try await setup.save(on: app.db)
+
+        try await app.asyncTest(.GET, "/testsetups/\(setupID)/notebook/source", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertTrue(res.body.string.contains("Nested manifest starter"))
+            XCTAssertTrue(res.body.string.contains("\"display_name\":\"Python (Pyodide)\""))
+        })
+    }
+
+    func testNotebookSourceFallsBackToFirstNestedNotebookWhenZipOnlySetupHasNoManifestStarter() async throws {
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enroll(user)
+
+        let setupID = "setup_nb_nested_first"
+        let nestedNotebook = notebookJSON(markdown: "First nested notebook")
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        try makeZipAt(
+            zipPath: zipPath,
+            entries: [
+                ("nested/assignment.ipynb", nestedNotebook),
+                ("nested/support.py", "value = 1")
+            ]
+        )
+
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: #"{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#,
+            zipPath: zipPath,
+            notebookPath: nil,
+            courseID: try await makeCourse().requireID()
+        )
+        try await setup.save(on: app.db)
+
+        try await app.asyncTest(.GET, "/testsetups/\(setupID)/notebook/source", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertTrue(res.body.string.contains("First nested notebook"))
+            XCTAssertTrue(res.body.string.contains("\"display_name\":\"Python (Pyodide)\""))
+        })
+    }
 }


### PR DESCRIPTION
## Summary
- split the worker test workflow into stable, runner-core, and timeout/sandbox shards for clearer Linux CI signal
- add notebook route coverage for zip-only setups whose starter notebook lives under nested paths

## Validation
- swift test --filter NotebookWebRoutesTests
- workflow selectors updated to documented swift test specifier format

## Notes
- this keeps the existing release timing unchanged and does not touch versioning.