### PR TITLE
Restore worker coverage in required CI

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -31,4 +31,66 @@ jobs:
         run: apt-get update -qq && apt-get install -y --no-install-recommends zip unzip
 
       - name: Run APITests
-        run: swift test --parallel --filter APITests
+        run: swift test --filter APITests
+
+  worker-tests-stable:
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.0-jammy
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run stable worker test targets
+        run: |
+          swift test --filter ScriptInvocationTests
+          swift test --filter WorkerRequestSignerTests
+          swift test --filter WorkerDaemonTests
+          swift test --filter RunnerWorkDirTests
+
+  worker-tests-runner-core:
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.0-jammy
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run core runner behavior tests
+        run: |
+          swift test \
+            --filter 'WorkerTests.WorkerTests' \
+            --skip 'WorkerTests.WorkerTests/testScriptTimesOut' \
+            --skip 'WorkerTests.WorkerTests/testScriptTimeoutReapsBackgroundChildProcess' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerExitZero' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerExitOne' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStdout' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStderr' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerTimesOut' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerTimeoutReapsBackgroundChildProcess' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerWorkDir' \
+            --skip 'WorkerTests.WorkerTests/testSandboxedRunnerBlocksNetworkAccess'
+
+  worker-tests-timeouts:
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.0-jammy
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run timeout and sandbox-focused worker tests
+        run: |
+          swift test --filter 'WorkerTests.WorkerTests/testScriptTimesOut'
+          swift test --filter 'WorkerTests.WorkerTests/testScriptTimeoutReapsBackgroundChildProcess'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerExitZero'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerExitOne'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStdout'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerCapturesStderr'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerTimesOut'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerTimeoutReapsBackgroundChildProcess'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerWorkDir'
+          swift test --filter 'WorkerTests.WorkerTests/testSandboxedRunnerBlocksNetworkAccess'

--- a/Tests/APITests/AssignmentHelpersTests.swift
+++ b/Tests/APITests/AssignmentHelpersTests.swift
@@ -646,7 +646,7 @@ final class AssignmentHelpersTests: XCTestCase {
         XCTAssertNil(inferredOrder(from: "notes.txt"))
     }
 
-    func testCreateRunnerSetupZipRejectsConfigsWithoutSelectedTests() throws {
+    func testCreateRunnerSetupZipAllowsConfigsWithoutSelectedTests() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("runner-setup-empty-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
@@ -667,16 +667,13 @@ final class AssignmentHelpersTests: XCTestCase {
             ]
             """
 
-        do {
-            _ = try createRunnerSetupZip(
-                suiteFiles: suiteFiles,
-                suiteConfigJSON: configJSON,
-                zipPath: zipPath
-            )
-            XCTFail("Expected createRunnerSetupZip to reject configs without selected tests")
-        } catch let error as AbortError {
-            XCTAssertEqual(error.status, .badRequest)
-            XCTAssertEqual(error.reason, "Select at least one test file in the suite file list")
-        }
+        let setupZip = try createRunnerSetupZip(
+            suiteFiles: suiteFiles,
+            suiteConfigJSON: configJSON,
+            zipPath: zipPath
+        )
+
+        XCTAssertEqual(setupZip.testSuites.count, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: zipPath))
     }
 }


### PR DESCRIPTION
## Summary
- put worker test shards back into the required `Swift Tests` workflow on push and pull request
- run APITests non-parallel in CI to avoid the SQLite transaction race seen on GitHub Linux
- update the stale AssignmentHelpers expectation for the no-tests-selected flow

## Why
- closes the gap behind issues #208 and #209 by restoring Linux worker coverage to required CI
- fixes the current red APITests failure on main so the gate can go green again
- aligns test expectations with the recently shipped empty-test-suite support

Fixes #208
Fixes #209
Refs #207

## Validation
- local notebook regression suite already green on main
- focused CI fix is now queued for GitHub Linux validation

## Notes
- if this PR goes green, we should be in a much stronger position to close #208 and #209 tonight
- issue #207 still depends on whether the remaining warning scan stays clean in CI/logs