### PR TITLE
Fix assignment notebook scan stuck state

### DIFF
--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -352,6 +352,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 
     // ── Generate Tests from Solution ─────────────────────────────────────────
 
+    var csrfToken = (document.querySelector('meta[name="csrf-token"]') || {}).content || '';
     var solutionInput   = document.querySelector('input[name="solutionNotebookFile"]');
     var genPanel        = document.getElementById('gen-tests-panel');
     var scanBtn         = document.getElementById('scan-solution-btn');


### PR DESCRIPTION
## Summary
- define the page-level CSRF token used by the new-assignment notebook scan fetch
- prevent the scan UI from getting stuck on "Scanning…" before the request is sent

## Validation
- code-path verification against the create-assignment scan flow
- the scan request now has the same CSRF token wiring as the rest of the instructor UI