### PR TITLE
[codex] Update 0.4.7 changelog notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Notebook edit fallback**: students who open an assignment in notebook view before uploading any work now get a fresh working copy instead of a `404`.
 - **Assignment creation without uploaded tests**: instructors can now create assignments with a notebook and solution before adding test cases in the UI.
 - **Nested-path notebook and Marmoset imports**: zip extraction now tolerates nested notebook paths more reliably, including Linux-generated archives from Marmoset.
+- **Assignment notebook scan CSRF**: scanning a solution notebook for functions on the new/edit assignment pages now submits the required CSRF token instead of failing or hanging in the UI.
 - **Linux worker timeout handling**: worker subprocess timeout cleanup was hardened and the worker test suite was restored to required CI coverage with clearer sharding.
+- **Browser/WASM runner execution coverage**: the browser runner now has execution-focused CI coverage for manifest loading, dependency skips, timeouts, unsupported scripts, result submission, and notebook extraction.
 
 ## [0.4.5] - 2026-03-23
 


### PR DESCRIPTION
## What changed
- updated the `0.4.7` changelog entry to include the final release-night fixes that landed after the version bump commit

## Why
The version metadata was already correct, but the `0.4.7` changelog entry was missing the assignment notebook scan CSRF fix and the new browser runner execution test coverage. This keeps the release notes aligned with what actually shipped on `main`.

## Validation
- reviewed `git log v0.4.6..main`
- confirmed `./scripts/check-version.sh` still passes
