### PR TITLE
[codex] Fix worker runner auth and add diagnostics

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -395,7 +395,7 @@ actor LocalRunnerManager {
             return
         }
 
-        let secret = (await app.workerSecretStore.runtimeOverrideValue() ?? "").trimmingCharacters(
+        let secret = (await app.workerSecretStore.effectiveSecret() ?? "").trimmingCharacters(
             in: .whitespacesAndNewlines
         )
         guard !secret.isEmpty else {
@@ -409,7 +409,10 @@ actor LocalRunnerManager {
         let apiBaseURL = "http://\(host):\(port)"
         let workerID = "autospawn-\(UUID().uuidString.lowercased().prefix(8))"
         let runnerBinary = workDir + ".build/debug/chickadee-runner"
-        let launchViaBinary = FileManager.default.isExecutableFile(atPath: runnerBinary)
+        let launchViaBinary = shouldLaunchLocalRunnerViaBinary(
+            workDir: workDir,
+            runnerBinaryPath: runnerBinary
+        )
         let argsPrefix = launchViaBinary ? [runnerBinary] : ["swift", "run", "chickadee-runner"]
 
         let proc = Process()
@@ -481,6 +484,32 @@ actor LocalRunnerManager {
         }
         process = nil
     }
+}
+
+func shouldLaunchLocalRunnerViaBinary(workDir: String, runnerBinaryPath: String) -> Bool {
+    guard FileManager.default.isExecutableFile(atPath: runnerBinaryPath) else {
+        return false
+    }
+
+    // In local development, `swift run chickadee-server` can rebuild the server
+    // target without refreshing the standalone runner executable. If the server
+    // binary is newer, prefer `swift run chickadee-runner` so autostart uses code
+    // that matches the current checkout instead of a stale cached binary.
+    let serverBinaryPath = workDir + ".build/debug/chickadee-server"
+    guard let runnerModifiedAt = fileModificationDate(path: runnerBinaryPath),
+          let serverModifiedAt = fileModificationDate(path: serverBinaryPath) else {
+        return true
+    }
+
+    return runnerModifiedAt >= serverModifiedAt
+}
+
+func fileModificationDate(path: String) -> Date? {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+          let modifiedAt = attributes[.modificationDate] as? Date else {
+        return nil
+    }
+    return modifiedAt
 }
 
 func normalizedHost(_ raw: String) -> String {

--- a/Sources/APIServer/Middleware/HTTPSRedirectMiddleware.swift
+++ b/Sources/APIServer/Middleware/HTTPSRedirectMiddleware.swift
@@ -11,6 +11,13 @@ struct HTTPSRedirectMiddleware: AsyncMiddleware {
         guard configuration.enforceHTTPS else {
             return try await next.respond(to: request)
         }
+        // Worker routes use HMAC authentication and commonly run over the
+        // private Docker/network path (`http://server:8080`). Exempt them from
+        // the app-layer HTTPS redirect so runners do not need to traverse the
+        // public TLS terminator to process jobs.
+        guard !request.url.path.hasPrefix("/api/v1/worker/") else {
+            return try await next.respond(to: request)
+        }
         guard !request.isHTTPSRequest(trustForwardedProto: configuration.trustForwardedProto) else {
             return try await next.respond(to: request)
         }

--- a/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
+++ b/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
@@ -27,23 +27,35 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         let sharedSecret = (await request.application.workerSecretStore.effectiveSecret() ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let workerID = request.headers.first(name: "X-Worker-Id")
 
         guard !sharedSecret.isEmpty else {
             request.logger.warning("Worker HMAC auth: RUNNER_SHARED_SECRET is not configured.")
             throw Abort(.unauthorized, reason: "Worker auth is not configured.")
         }
 
-        let timestampHeader = try request.requireWorkerHeader("X-Worker-Timestamp")
-        let nonce           = try request.requireWorkerHeader("X-Worker-Nonce")
-        let signature       = try request.requireWorkerHeader("X-Worker-Signature")
-        let workerID        = request.headers.first(name: "X-Worker-Id")
+        let timestampHeader = try request.requireWorkerHeader("X-Worker-Timestamp", request: request)
+        let nonce           = try request.requireWorkerHeader("X-Worker-Nonce", request: request)
+        let signature       = try request.requireWorkerHeader("X-Worker-Signature", request: request)
 
         guard let timestamp = Int64(timestampHeader) else {
+            logWorkerAuthFailure(
+                request: request,
+                workerID: workerID,
+                reason: "invalid_timestamp",
+                details: "value=\(timestampHeader)"
+            )
             throw Abort(.unauthorized, reason: "Invalid worker timestamp.")
         }
 
         let now = Int64(Date().timeIntervalSince1970)
         guard abs(now - timestamp) <= maxClockSkewSeconds else {
+            logWorkerAuthFailure(
+                request: request,
+                workerID: workerID,
+                reason: "timestamp_out_of_window",
+                details: "value=\(timestamp) now=\(now) skew=\(now - timestamp)"
+            )
             throw Abort(.unauthorized, reason: "Worker request timestamp is outside the accepted window.")
         }
 
@@ -51,6 +63,12 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
         let wasInserted = await request.application.workerNonceStore
             .insertIfNew(nonceKey, now: now, ttlSeconds: nonceTTLSeconds)
         guard wasInserted else {
+            logWorkerAuthFailure(
+                request: request,
+                workerID: workerID,
+                reason: "replay_detected",
+                details: "nonce=\(nonce)"
+            )
             throw Abort(.unauthorized, reason: "Replay detected.")
         }
 
@@ -69,6 +87,18 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
 
         let expectedSignature = hmacSHA256Hex(message: signedPayload, secret: sharedSecret)
         guard constantTimeEquals(expectedSignature.lowercased(), signature.lowercased()) else {
+            logWorkerAuthFailure(
+                request: request,
+                workerID: workerID,
+                reason: "invalid_signature",
+                details: [
+                    "bodyHash=\(bodyHash)",
+                    "timestamp=\(timestampHeader)",
+                    "nonce=\(nonce)",
+                    "expectedPrefix=\(signaturePrefix(expectedSignature))",
+                    "receivedPrefix=\(signaturePrefix(signature))"
+                ].joined(separator: " ")
+            )
             throw Abort(.unauthorized, reason: "Invalid worker signature.")
         }
 
@@ -120,12 +150,36 @@ actor WorkerNonceStore {
 // MARK: - Private helpers
 
 private extension Request {
-    func requireWorkerHeader(_ name: String) throws -> String {
+    func requireWorkerHeader(_ name: String, request: Request) throws -> String {
         guard let value = headers.first(name: name), !value.isEmpty else {
+            logWorkerAuthFailure(
+                request: request,
+                workerID: headers.first(name: "X-Worker-Id"),
+                reason: "missing_header",
+                details: "header=\(name)"
+            )
             throw Abort(.unauthorized, reason: "Missing worker auth header: \(name)")
         }
         return value
     }
+}
+
+private func logWorkerAuthFailure(
+    request: Request,
+    workerID: String?,
+    reason: String,
+    details: String
+) {
+    let workerLabel = (workerID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+        ? workerID!
+        : "_anonymous"
+    request.logger.warning(
+        "Worker HMAC auth failed: reason=\(reason) worker=\(workerLabel) method=\(request.method.rawValue.uppercased()) path=\(request.url.path) details=\(details)"
+    )
+}
+
+private func signaturePrefix(_ value: String, count: Int = 12) -> String {
+    String(value.prefix(count))
 }
 
 private func bodyBytes(_ request: Request) -> [UInt8] {

--- a/Sources/Worker/JobPoller.swift
+++ b/Sources/Worker/JobPoller.swift
@@ -8,6 +8,7 @@ import Foundation
 import FoundationNetworking  // URLSession, URLRequest on Linux
 #endif
 import Core
+import Crypto
 
 protocol JobPolling: Sendable {
     func requestJob() async throws -> Core.Job?
@@ -44,6 +45,7 @@ struct JobPoller: Sendable {
         )
         request.httpBody = try JSONEncoder().encode(body)
         signer.sign(&request)
+        logSignedRequest("claim", request: request)
 
         let (data, response) = try await Self.session.data(for: request)
 
@@ -55,7 +57,9 @@ struct JobPoller: Sendable {
         case 200:
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            return try decoder.decode(Core.Job.self, from: data)
+            let job = try decoder.decode(Core.Job.self, from: data)
+            fputs("[\(workerID)] Claimed job \(job.submissionID) submissionURL=\(job.submissionURL.absoluteString) testSetupURL=\(job.testSetupURL.absoluteString)\n", stderr)
+            return job
         case 204:
             return nil
         default:
@@ -74,6 +78,22 @@ private struct WorkerRequestPayload: Encodable {
     let hostname: String
 }
 
+private func logSignedRequest(_ label: String, request: URLRequest) {
+    let method = (request.httpMethod ?? "GET").uppercased()
+    let path = request.url?.path ?? "/"
+    let host = request.url?.host ?? "<nil>"
+    let scheme = request.url?.scheme ?? "<nil>"
+    let timestamp = request.value(forHTTPHeaderField: "X-Worker-Timestamp") ?? "<missing>"
+    let nonce = request.value(forHTTPHeaderField: "X-Worker-Nonce") ?? "<missing>"
+    let signature = request.value(forHTTPHeaderField: "X-Worker-Signature") ?? "<missing>"
+    let bodyHash = sha256Hex(request.httpBody.map(Array.init) ?? [])
+    fputs("[worker-http] \(label) \(method) \(scheme)://\(host)\(path) bodyHash=\(bodyHash) ts=\(timestamp) nonce=\(nonce) sigPrefix=\(String(signature.prefix(12)))\n", stderr)
+}
+
+private func sha256Hex(_ bytes: [UInt8]) -> String {
+    Data(SHA256.hash(data: Data(bytes))).hexEncodedString()
+}
+
 enum JobPollerError: Error, LocalizedError {
     case unexpectedResponse
     case httpError(Int, String)
@@ -85,5 +105,11 @@ enum JobPollerError: Error, LocalizedError {
         case .httpError(let code, let body):
             return "API server returned HTTP \(code): \(body)"
         }
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/Worker/Reporter.swift
+++ b/Sources/Worker/Reporter.swift
@@ -7,6 +7,7 @@ import Foundation
 import FoundationNetworking  // URLSession, URLRequest on Linux
 #endif
 import Core
+import Crypto
 
 protocol Reporting: Sendable {
     func report(_ collection: TestOutcomeCollection) async throws
@@ -40,6 +41,7 @@ struct Reporter: Sendable {
         encoder.dateEncodingStrategy = .iso8601
         request.httpBody = try encoder.encode(collection)
         signer.sign(&request)
+        logSignedRequest("report", request: request)
 
         let (data, response) = try await Self.session.data(for: request)
 
@@ -51,6 +53,22 @@ struct Reporter: Sendable {
             throw ReporterError.httpError(http.statusCode, body)
         }
     }
+}
+
+private func logSignedRequest(_ label: String, request: URLRequest) {
+    let method = (request.httpMethod ?? "GET").uppercased()
+    let path = request.url?.path ?? "/"
+    let host = request.url?.host ?? "<nil>"
+    let scheme = request.url?.scheme ?? "<nil>"
+    let timestamp = request.value(forHTTPHeaderField: "X-Worker-Timestamp") ?? "<missing>"
+    let nonce = request.value(forHTTPHeaderField: "X-Worker-Nonce") ?? "<missing>"
+    let signature = request.value(forHTTPHeaderField: "X-Worker-Signature") ?? "<missing>"
+    let bodyHash = sha256Hex(request.httpBody.map(Array.init) ?? [])
+    fputs("[worker-http] \(label) \(method) \(scheme)://\(host)\(path) bodyHash=\(bodyHash) ts=\(timestamp) nonce=\(nonce) sigPrefix=\(String(signature.prefix(12)))\n", stderr)
+}
+
+private func sha256Hex(_ bytes: [UInt8]) -> String {
+    Data(SHA256.hash(data: Data(bytes))).hexEncodedString()
 }
 
 extension Reporter: Reporting {}
@@ -66,5 +84,11 @@ enum ReporterError: Error, LocalizedError {
         case .httpError(let code, let body):
             return "API server returned HTTP \(code): \(body)"
         }
+    }
+}
+
+private extension Data {
+    func hexEncodedString() -> String {
+        map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -401,6 +401,10 @@ actor WorkerDaemon {
         request.httpMethod = "GET"
         request.timeoutInterval = 5
         signer.sign(&request)
+        let timestamp = request.value(forHTTPHeaderField: "X-Worker-Timestamp") ?? "<missing>"
+        let nonce = request.value(forHTTPHeaderField: "X-Worker-Nonce") ?? "<missing>"
+        let signature = request.value(forHTTPHeaderField: "X-Worker-Signature") ?? "<missing>"
+        fputs("[\(workerID)] Downloading \(url.absoluteString) ts=\(timestamp) nonce=\(nonce) sigPrefix=\(String(signature.prefix(12)))\n", stderr)
         let (tmpURL, response) = try await Self.downloadSession.download(for: request)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             throw WorkerDaemonError.downloadFailed(url)

--- a/Tests/APITests/APIServerAppTests.swift
+++ b/Tests/APITests/APIServerAppTests.swift
@@ -242,6 +242,54 @@ final class APIServerAppTests: XCTestCase {
         XCTAssertEqual(normalizedHost(" example.com "), "example.com")
     }
 
+    func testShouldLaunchLocalRunnerViaBinaryRejectsStaleRunnerBinary() throws {
+        let dir = try makeTempDir(named: "apiserver-runner-launch-stale")
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let buildDir = URL(fileURLWithPath: dir).appendingPathComponent(".build/debug", isDirectory: true)
+        try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+        let runnerPath = buildDir.appendingPathComponent("chickadee-runner").path
+        let serverPath = buildDir.appendingPathComponent("chickadee-server").path
+        XCTAssertTrue(FileManager.default.createFile(atPath: runnerPath, contents: Data()))
+        XCTAssertTrue(FileManager.default.createFile(atPath: serverPath, contents: Data()))
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755, .modificationDate: Date(timeIntervalSince1970: 100)],
+            ofItemAtPath: runnerPath
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: serverPath
+        )
+
+        XCTAssertFalse(shouldLaunchLocalRunnerViaBinary(workDir: dir + "/", runnerBinaryPath: runnerPath))
+    }
+
+    func testShouldLaunchLocalRunnerViaBinaryAcceptsFreshRunnerBinary() throws {
+        let dir = try makeTempDir(named: "apiserver-runner-launch-fresh")
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let buildDir = URL(fileURLWithPath: dir).appendingPathComponent(".build/debug", isDirectory: true)
+        try FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+
+        let runnerPath = buildDir.appendingPathComponent("chickadee-runner").path
+        let serverPath = buildDir.appendingPathComponent("chickadee-server").path
+        XCTAssertTrue(FileManager.default.createFile(atPath: runnerPath, contents: Data()))
+        XCTAssertTrue(FileManager.default.createFile(atPath: serverPath, contents: Data()))
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755, .modificationDate: Date(timeIntervalSince1970: 300)],
+            ofItemAtPath: runnerPath
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 200)],
+            ofItemAtPath: serverPath
+        )
+
+        XCTAssertTrue(shouldLaunchLocalRunnerViaBinary(workDir: dir + "/", runnerBinaryPath: runnerPath))
+    }
+
     func testEnvironmentBoolRecognizesSupportedValuesAndRejectsInvalidInput() {
         setEnv("BOOL_TRUE", " YeS ")
         setEnv("BOOL_FALSE", "0")

--- a/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
+++ b/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
@@ -27,6 +27,7 @@ final class HTTPSRedirectMiddlewareTests: XCTestCase {
         app.middleware.use(HTTPSRedirectMiddleware(configuration: config))
         app.get("test") { _ in "ok" }
         app.post("submit") { _ in "submitted" }
+        app.post("api", "v1", "worker", "request") { _ in "worker-ok" }
         return app
     }
 
@@ -77,6 +78,17 @@ final class HTTPSRedirectMiddlewareTests: XCTestCase {
                 req.headers.add(name: .host, value: "example.com")
             }, afterResponse: { res async in
                 XCTAssertEqual(res.status, .upgradeRequired)
+            })
+        }
+    }
+
+    func testWorkerPOSTBypassesHTTPSEnforcement() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.POST, "/api/v1/worker/request", beforeRequest: { req async in
+                req.headers.add(name: .host, value: "server:8080")
+            }, afterResponse: { res async in
+                XCTAssertEqual(res.status, .ok)
+                XCTAssertEqual(res.body.string, "worker-ok")
             })
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,9 @@ services:
       # To enable OS-level sandboxing (Linux unshare namespaces),
       # add "--sandbox" here and "cap_add: [SYS_ADMIN]" to this service.
     environment:
+      # If a fixed secret is configured in .env, pass it to the runner too.
+      # Otherwise the runner will fall back to /data/.worker-secret.
+      RUNNER_SHARED_SECRET:         ${RUNNER_SHARED_SECRET:-}
     networks:
       - chickadee
     depends_on:


### PR DESCRIPTION
## What changed
This PR packages the worker-auth and runner-path fixes we chased while debugging Marmoset assignment imports that were failing with `Invalid worker signature.`

It includes:
- a Docker Compose fix to restore the runner's shared `/data` mount and optional `RUNNER_SHARED_SECRET` passthrough
- an HTTPS redirect exemption for `/api/v1/worker/...` so Docker runners can use internal HTTP without being forced through the public TLS terminator
- more detailed server-side worker HMAC failure logging
- more detailed runner-side request logging for job claim, artifact download, and result upload
- autostart hardening for local development so stale debug runner binaries are not preferred over a newer server binary

## Why
The production failures turned out to be a mix of runner pathing and environment issues rather than assignment-package content:
- the deployed runner had lost its `/data` mount, so it could not see `.worker-secret`
- forcing worker traffic through public HTTPS made HMAC-authenticated internal requests harder to reason about
- when signatures failed, the existing logs were too sparse to show which worker endpoint was actually failing

## Impact
- Docker deployments can keep worker traffic on the internal network again
- worker auth failures now log method, path, worker ID, body hash, timestamp, nonce, and short signature prefixes to speed up diagnosis
- local runner autostart is less likely to pick an outdated debug runner executable

## Validation
- `swift test --filter APIServerAppTests`
- `swift test --filter HTTPSRedirectMiddlewareTests`
- `swift test --filter 'WorkerHMACAuthMiddlewareTests|WorkerRoutesTests|HTTPSRedirectMiddlewareTests|WorkerRequestSignerTests'`

## Notes
Claude has moved testing to Swift 6.3, so CI may need a follow-up adjustment if the current workflow is pinned to an older toolchain.