### PR TITLE
[codex] Fix deleted assignment files reappearing after save

### DIFF
--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -839,6 +839,11 @@ func createRunnerSetupZip(
     if storedNameByIndex.isEmpty {
         try writeEmptyZip(to: zipPath)
     } else {
+        // Rebuilding an existing setup zip must start from a clean archive.
+        // `zip -r existing.zip .` updates/adds entries but does not remove files
+        // that are absent from the new source directory, which makes deleted
+        // suite/support files reappear on the next edit.
+        try? fm.removeItem(atPath: zipPath)
         let zip = Process()
         zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
         zip.currentDirectoryURL = tempDir

--- a/Tests/APITests/AssignmentHelpersTests.swift
+++ b/Tests/APITests/AssignmentHelpersTests.swift
@@ -676,4 +676,45 @@ final class AssignmentHelpersTests: XCTestCase {
         XCTAssertEqual(setupZip.testSuites.count, 0)
         XCTAssertTrue(FileManager.default.fileExists(atPath: zipPath))
     }
+
+    func testCreateRunnerSetupZipReplacesExistingArchiveInsteadOfMergingRemovedFiles() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("runner-setup-replace-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let zipPath = tempRoot.appendingPathComponent("setup.zip").path
+
+        _ = try createRunnerSetupZip(
+            suiteFiles: [
+                makeFile(named: "keep.py", contents: "print('keep')"),
+                makeFile(named: "remove.py", contents: "print('remove')")
+            ],
+            suiteConfigJSON: """
+            [
+              {"index":0,"isTest":true,"tier":"public","points":1},
+              {"index":1,"isTest":true,"tier":"public","points":1}
+            ]
+            """,
+            zipPath: zipPath
+        )
+
+        _ = try createRunnerSetupZip(
+            suiteFiles: [
+                makeFile(named: "keep.py", contents: "print('keep-updated')")
+            ],
+            suiteConfigJSON: """
+            [
+              {"index":0,"isTest":true,"tier":"public","points":1}
+            ]
+            """,
+            zipPath: zipPath
+        )
+
+        let entries = Set(listZipEntries(zipPath: zipPath))
+        XCTAssertEqual(entries, ["keep.py"])
+        XCTAssertNil(extractZipEntry(zipPath: zipPath, entryName: "remove.py"))
+        let keepData = try XCTUnwrap(extractZipEntry(zipPath: zipPath, entryName: "keep.py"))
+        XCTAssertEqual(String(data: keepData, encoding: .utf8), "print('keep-updated')")
+    }
 }


### PR DESCRIPTION
## What changed
This PR fixes a regression in the assignment edit flow where deleting suite/support files, saving, and then reopening the editor would show the deleted files again.

## Root cause
The edit/save path rebuilds the setup zip by running `zip -r` against the existing archive path. That updates and adds entries, but it does not remove old entries that are no longer present in the temporary rebuild directory. As a result, deleted files stayed in the archive and reappeared on the next edit.

## Fix
- remove the existing setup archive before recreating it in `createRunnerSetupZip`
- add a regression test that rewrites the same zip twice and verifies removed files do not survive into the rebuilt archive

## Validation
- `swift test --filter AssignmentHelpersTests`

## Testing notes
The new regression test covers the archive-level root cause directly. A higher-level edit/save/edit integration test would add extra confidence, but I don't think it is required to land this fix because the failure mechanism is now explicitly covered in the helper test.