### PR TITLE
[codex] Fix worker HMAC auth for streamed result bodies

### DIFF
--- a/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
+++ b/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
@@ -56,9 +56,11 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
 
         // Collect the request body before hashing so it is available in middleware
         // even if Vapor delivers it as a stream (defence-in-depth).
-        _ = try? await request.body.collect(upTo: request.application.routes.defaultMaxBodySize.value)
+        let collectedBody = try? await request.body.collect(
+            upTo: request.application.routes.defaultMaxBodySize.value
+        )
 
-        let bodyHash = sha256Hex(bodyBytes(request))
+        let bodyHash = sha256Hex(bodyBytes(request, collectedBody: collectedBody))
         let signedPayload = [
             request.method.rawValue.uppercased(),
             request.url.path,
@@ -128,7 +130,10 @@ private extension Request {
     }
 }
 
-private func bodyBytes(_ request: Request) -> [UInt8] {
+private func bodyBytes(_ request: Request, collectedBody: ByteBuffer?) -> [UInt8] {
+    if var collectedBody {
+        return collectedBody.readBytes(length: collectedBody.readableBytes) ?? []
+    }
     guard var data = request.body.data else { return [] }
     return data.readBytes(length: data.readableBytes) ?? []
 }

--- a/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
+++ b/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
@@ -187,6 +187,35 @@ final class WorkerHMACAuthMiddlewareTests: XCTestCase {
         }
     }
 
+    func testAcceptsLargeValidSignatureOverRealHTTP() async throws {
+        let path = "/internal/worker/ping"
+        let now = Int64(Date().timeIntervalSince1970)
+        let largeValue = String(repeating: "abcdefghijklmnopqrstuvwxyz0123456789", count: 4096)
+        let body = ByteBuffer(string: #"{"workerID":"test","details":"\#(largeValue)"}"#)
+        let headers = signedHeaders(
+            method: .POST,
+            path: path,
+            body: body,
+            timestamp: now,
+            nonce: UUID().uuidString
+        )
+
+        try await withApp(try await makeApp()) { app in
+            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+                .POST,
+                path,
+                headers: headers,
+                body: body
+            ) { res async in
+                XCTAssertEqual(
+                    res.status,
+                    .ok,
+                    "HMAC with a large streamed body must succeed over real HTTP"
+                )
+            }
+        }
+    }
+
     private func hmacSHA256Hex(message: String, secret: String) -> String {
         let key = SymmetricKey(data: Data(secret.utf8))
         let mac = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: key)


### PR DESCRIPTION
## What changed
Fix worker HMAC body hashing so streamed `POST /api/v1/worker/results` requests are authenticated against the actual collected request body instead of `request.body.data`, which can be empty for larger real-HTTP uploads.

## Why
Locally, Marmoset imports `1` and `3` failed while `2` and `4` passed because the failing assignments produced larger result payloads. The runner successfully claimed the job, downloaded both artifacts, and ran the tests, but the initial results upload was rejected with `Invalid worker signature.` Server tracing showed the middleware hashing `SHA256("")` for that request even though the runner had signed a non-empty JSON body.

## Impact
This removes the size-sensitive auth failure on worker result uploads and prevents assignment-specific false negatives during validation/import.

## Regression coverage
Added a real-HTTP large-body HMAC middleware test so future streamed request bodies continue to authenticate correctly.

## Validation
Attempted: `swift test --filter WorkerHMACAuthMiddlewareTests`

Note: local SwiftPM rebuilds under Swift 6.3 were unusually heavy in this environment, but the fix was isolated via local server/runner repro and the added regression test covers the exact streamed-body failure mode.