### PR TITLE
Release 0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Swift 6.3 toolchain upgrade**: `Package.swift` tools version bumped to 6.3, CI images updated from `swift:6.0-jammy` to `swift:6.3-jammy`, and Dockerfile build stage updated to match. Runner stderr logging switched from `fputs`/`stderr` to `FileHandle.standardError` to resolve a Swift 6.3 ambiguity; `WorkerCommand.configuration` changed from `static var` to `static let` for strict concurrency compliance. `swift-subprocess` adoption deferred — the Linux fork/exec path requires no changes for the toolchain upgrade.
 
+## [0.4.12] - 2026-03-28
+
+### Fixed
+
+- **Submission page test names for browser-graded labs**: saved human-readable test names are now shown in the `Test` column even when browser results report the full script filename (for example `test_q1_bmi.py`) instead of a filename stem.
+- **Submission page detailed failure output**: expanding `Show output` now prefers a cleaned traceback/error view instead of dumping raw JSON-wrapped runner payloads, making browser and worker grading failures much easier for students to read and debug.
+
 ## [0.4.11] - 2026-03-28
 
 ### Fixed

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -69,7 +69,7 @@ Submission #(submissionID)
                 #else:
                 #(outcome.shortResult)
                 #if(outcome.longResult):
-                <details><summary>Show output ▸</summary><pre>#(outcome.longResult)</pre></details>
+                <details class="test-output-details"><summary>Show output ▸</summary><pre class="test-output-pre">#(outcome.longResult)</pre></details>
                 #endif
                 #endif
             </td>
@@ -113,5 +113,27 @@ Submission #(submissionID)
 #endif
 
 </div>
+<style>
+.test-output-details {
+    margin-top: .4rem;
+}
+.test-output-details summary {
+    cursor: pointer;
+    color: var(--blue, #0b63ce);
+    font-size: .9rem;
+}
+.test-output-pre {
+    margin-top: .5rem;
+    padding: .85rem 1rem;
+    border-radius: .5rem;
+    background: var(--gray-50, #f7f8fa);
+    border: 1px solid var(--border, #d9dce1);
+    color: var(--gray-900, #1f2937);
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+    line-height: 1.45;
+}
+</style>
 #endexport
 #endextend

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -246,9 +246,11 @@ extension WebRoutes {
             }
         }
 
-        // Build a stem→displayName map from the current manifest so the page
-        // shows friendly names for both new submissions (where the runner already
-        // embedded the name) and old ones (where testName is still the filename stem).
+        // Build a script/stem→displayName map from the current manifest so the page
+        // shows friendly names for:
+        //  - worker results that already use the display name directly
+        //  - older worker results where testName is the filename stem
+        //  - browser results where testName is the full script filename
         var displayNameMap: [String: String] = [:]
         if let setup = try? await APITestSetup.find(submission.testSetupID, on: req.db),
            let manifestData = setup.manifest.data(using: .utf8),
@@ -257,6 +259,7 @@ extension WebRoutes {
                 guard let displayName = entry.name,
                       !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
                 let stem = (entry.script as NSString).deletingPathExtension
+                displayNameMap[entry.script] = displayName
                 displayNameMap[stem.isEmpty ? entry.script : stem] = displayName
             }
         }
@@ -297,11 +300,7 @@ extension WebRoutes {
                 let weighted = totalPoints != visible.totalTests
                 outcomes = visible.outcomes.map { o in
                     let skip = parseSkip(shortResult: o.shortResult)
-                    let longOutput: String? = {
-                        guard o.status != .pass else { return nil }
-                        let s = (o.longResult ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-                        return s.isEmpty ? nil : s
-                    }()
+                    let longOutput = formattedDetailedOutput(from: o.longResult, status: o.status)
                     let (markLabel, markClass): (String, String) = {
                         if skip.isSkipped { return ("—", "skipped") }
                         switch o.status {
@@ -419,6 +418,119 @@ func stderrScriptOutput(from raw: String?, status: TestStatus) -> String? {
         return nil
     }
     return trimmed
+}
+
+func formattedDetailedOutput(from raw: String?, status: TestStatus) -> String? {
+    guard status != .pass else { return nil }
+    guard let base = stderrScriptOutput(from: raw, status: status) else { return nil }
+
+    if let extracted = extractStructuredErrorText(from: base) {
+        return extracted
+    }
+    if let traceback = extractTraceback(in: base) {
+        return traceback
+    }
+    return base
+}
+
+func extractTraceback(in text: String) -> String? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    let markers = [
+        "Traceback (most recent call last):",
+        "Traceback (most recent call last)",
+        "RRuntimeError:",
+        "PythonError:"
+    ]
+
+    for marker in markers {
+        if let range = trimmed.range(of: marker) {
+            let traceback = String(trimmed[range.lowerBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !traceback.isEmpty {
+                return traceback
+            }
+        }
+    }
+
+    return nil
+}
+
+func extractStructuredErrorText(from text: String) -> String? {
+    guard let data = text.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) else {
+        return nil
+    }
+
+    if let traceback = extractTracebackFromJSONObject(object) {
+        return traceback
+    }
+    if let messages = extractStructuredMessages(from: object), !messages.isEmpty {
+        return messages.joined(separator: "\n\n")
+    }
+    return nil
+}
+
+private func extractTracebackFromJSONObject(_ value: Any) -> String? {
+    if let string = value as? String {
+        return extractTraceback(in: string)
+    }
+
+    if let dict = value as? [String: Any] {
+        let preferredKeys = [
+            "traceback", "stackTrace", "stack", "stderr", "error",
+            "message", "detail", "reason", "longResult"
+        ]
+        for key in preferredKeys {
+            if let nested = dict[key],
+               let traceback = extractTracebackFromJSONObject(nested) {
+                return traceback
+            }
+        }
+        for nested in dict.values {
+            if let traceback = extractTracebackFromJSONObject(nested) {
+                return traceback
+            }
+        }
+    }
+
+    if let array = value as? [Any] {
+        for nested in array {
+            if let traceback = extractTracebackFromJSONObject(nested) {
+                return traceback
+            }
+        }
+    }
+
+    return nil
+}
+
+private func extractStructuredMessages(from value: Any) -> [String]? {
+    if let string = value as? String {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : [trimmed]
+    }
+
+    if let dict = value as? [String: Any] {
+        let preferredKeys = ["stderr", "error", "message", "detail", "reason", "longResult"]
+        var messages: [String] = []
+        for key in preferredKeys {
+            guard let nested = dict[key],
+                  let nestedMessages = extractStructuredMessages(from: nested) else { continue }
+            messages.append(contentsOf: nestedMessages)
+        }
+        if !messages.isEmpty {
+            var seen: Set<String> = []
+            return messages.filter { seen.insert($0).inserted }
+        }
+    }
+
+    if let array = value as? [Any] {
+        let messages = array.compactMap { extractStructuredMessages(from: $0) }.flatMap { $0 }
+        return messages.isEmpty ? nil : messages
+    }
+
+    return nil
 }
 
 func extractLabeledOutputSection(_ label: String, in text: String) -> String? {

--- a/Sources/Core/ChickadeeVersion.swift
+++ b/Sources/Core/ChickadeeVersion.swift
@@ -1,3 +1,3 @@
 public enum ChickadeeVersion {
-    public static let current = "0.4.11"
+    public static let current = "0.4.12"
 }

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -150,7 +150,8 @@ final class WebRoutesTests: XCTestCase {
     private func makeOutcome(
         name: String,
         tier: TestTier = .pub,
-        status: TestStatus = .pass
+        status: TestStatus = .pass,
+        longResult: String? = nil
     ) -> TestOutcome {
         TestOutcome(
             testName: name,
@@ -158,7 +159,7 @@ final class WebRoutesTests: XCTestCase {
             tier: tier,
             status: status,
             shortResult: status == .pass ? "passed" : "failed",
-            longResult: status == .pass ? nil : "test output here",
+            longResult: status == .pass ? nil : (longResult ?? "test output here"),
             executionTimeMs: 10,
             memoryUsageBytes: nil,
             attemptNumber: 1,
@@ -401,6 +402,76 @@ final class WebRoutesTests: XCTestCase {
             XCTAssertTrue(html.contains("test_add"), "Should show test name")
             XCTAssertTrue(html.contains("Pass") || html.contains("pass"), "Should show pass status")
             XCTAssertTrue(html.contains("Fail") || html.contains("fail"), "Should show fail status")
+        })
+    }
+
+    func testSubmissionPageShowsConfiguredDisplayNameForBrowserResultScriptFilename() async throws {
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        let userID = try user.requireID()
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1_bmi.py","name":"BMI check"}],"timeLimitSeconds":10}
+        """
+        let course = try await makeCourse()
+        let courseID = try course.requireID()
+        let setup = APITestSetup(
+            id: "setup_browser_names",
+            manifest: manifest,
+            zipPath: tmpDir + "testsetups/setup_browser_names.zip",
+            courseID: courseID
+        )
+        try await setup.save(on: app.db)
+        try await insertAssignment(testSetupID: "setup_browser_names", title: "Practice Lab", isOpen: true)
+        try await insertSubmission(id: "sub_browser_names", testSetupID: "setup_browser_names", userID: userID)
+        try await insertResult(
+            submissionID: "sub_browser_names",
+            outcomes: [makeOutcome(name: "test_q1_bmi.py", status: .pass)],
+            source: "browser"
+        )
+
+        try await app.asyncTest(.GET, "/submissions/sub_browser_names", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("BMI check"), "Should show saved display name")
+            XCTAssertFalse(html.contains(">test_q1_bmi.py<"), "Should not fall back to raw script filename")
+        })
+    }
+
+    func testSubmissionPageShowsTracebackInsteadOfStructuredJSONBlob() async throws {
+        let rawJSON = #"""
+        {"error":"PythonError","stderr":"Traceback (most recent call last):\n  File \"test_q1.py\", line 7, in <module>\n    assert answer == 42\nAssertionError","headers":{"content-type":"application/json"}}
+        """#
+        let formatted = formattedDetailedOutput(from: rawJSON, status: .fail)
+        XCTAssertEqual(
+            formatted,
+            """
+            Traceback (most recent call last):
+              File "test_q1.py", line 7, in <module>
+                assert answer == 42
+            AssertionError
+            """
+        )
+
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        let userID = try user.requireID()
+        try await insertSetup(id: "setup_traceback")
+        try await insertSubmission(id: "sub_traceback", testSetupID: "setup_traceback", userID: userID)
+        try await insertResult(
+            submissionID: "sub_traceback",
+            outcomes: [makeOutcome(name: "test_q1", status: .fail, longResult: rawJSON)]
+        )
+
+        try await app.asyncTest(.GET, "/submissions/sub_traceback", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("Traceback (most recent call last):"))
+            XCTAssertTrue(html.contains("AssertionError"))
+            XCTAssertFalse(html.contains("test output here"))
         })
     }
 


### PR DESCRIPTION
## Summary
- show saved human-readable test names on browser-graded submission pages
- format expanded failure output as cleaned traceback/error text instead of raw JSON blobs
- bump version metadata and changelog for 0.4.12

## Testing
- timeout 120 swift test --filter WebRoutesTests/testSubmissionPageShowsTracebackInsteadOfStructuredJSONBlob
- timeout 120 swift test --filter WebRoutesTests/testSubmissionPageShowsConfiguredDisplayNameForBrowserResultScriptFilename