### PR TITLE
Release 0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Swift 6.3 toolchain upgrade**: `Package.swift` tools version bumped to 6.3, CI images updated from `swift:6.0-jammy` to `swift:6.3-jammy`, and Dockerfile build stage updated to match. Runner stderr logging switched from `fputs`/`stderr` to `FileHandle.standardError` to resolve a Swift 6.3 ambiguity; `WorkerCommand.configuration` changed from `static var` to `static let` for strict concurrency compliance. `swift-subprocess` adoption deferred — the Linux fork/exec path requires no changes for the toolchain upgrade.
 
+## [0.4.13] - 2026-03-28
+
+### Fixed
+
+- **Assignment editor display-name saves**: editing the student-facing test name on an existing suite row now always refreshes `suiteConfig` at form submit time, so renamed tests persist reliably after save.
+- **Submission page traceback extraction for browser lab errors**: expanded failure output now extracts the traceback from `stdout:`-wrapped structured JSON browser payloads instead of showing the raw JSON object.
+
 ## [0.4.12] - 2026-03-28
 
 ### Fixed

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -243,6 +243,8 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 (function () {
     'use strict';
 
+    var form = document.querySelector('form.form');
+
     // ── Header view/edit toggle ────────────────────────────────────────────────
     var headerView   = document.getElementById('assign-header-view');
     var headerEdit   = document.getElementById('assign-header-edit');
@@ -568,6 +570,11 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     body.addEventListener('input',  function () { syncConfig(); });
 
     filesInput.addEventListener('change', addUploadedFiles);
+    if (form) {
+        form.addEventListener('submit', function () {
+            syncConfig();
+        });
+    }
 
     var addTestBtn = document.getElementById('add-test-btn');
     if (addTestBtn) {

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -405,7 +405,7 @@ func parseSkip(shortResult: String) -> (isSkipped: Bool, blockerName: String?) {
     return (true, name.isEmpty ? nil : name)
 }
 
-func stderrScriptOutput(from raw: String?, status: TestStatus) -> String? {
+func detailedScriptOutput(from raw: String?, status: TestStatus) -> String? {
     guard status != .pass else { return nil }
     guard let raw else { return nil }
     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -414,15 +414,15 @@ func stderrScriptOutput(from raw: String?, status: TestStatus) -> String? {
     if let stderr = extractLabeledOutputSection("stderr", in: trimmed) {
         return stderr
     }
-    if extractLabeledOutputSection("stdout", in: trimmed) != nil {
-        return nil
+    if let stdout = extractLabeledOutputSection("stdout", in: trimmed) {
+        return stdout
     }
     return trimmed
 }
 
 func formattedDetailedOutput(from raw: String?, status: TestStatus) -> String? {
     guard status != .pass else { return nil }
-    guard let base = stderrScriptOutput(from: raw, status: status) else { return nil }
+    guard let base = detailedScriptOutput(from: raw, status: status) else { return nil }
 
     if let extracted = extractStructuredErrorText(from: base) {
         return extracted

--- a/Sources/Core/ChickadeeVersion.swift
+++ b/Sources/Core/ChickadeeVersion.swift
@@ -1,3 +1,3 @@
 public enum ChickadeeVersion {
-    public static let current = "0.4.12"
+    public static let current = "0.4.13"
 }

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -163,6 +163,72 @@ final class AssignmentRoutesTests: XCTestCase {
         return body
     }
 
+    private func multipartEditBody(
+        boundary: String,
+        csrf: String,
+        assignmentName: String,
+        assignmentNotebook: String,
+        solutionNotebook: String,
+        suiteConfig: String
+    ) -> ByteBuffer {
+        var body = ByteBufferAllocator().buffer(capacity: 4096)
+
+        func appendField(_ name: String, _ value: String) {
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            body.writeString(value)
+            body.writeString("\r\n")
+        }
+
+        func appendFile(_ name: String, filename: String, contentType: String = "application/json", data: Data) {
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+            body.writeString("Content-Type: \(contentType)\r\n\r\n")
+            body.writeBytes(data)
+            body.writeString("\r\n")
+        }
+
+        appendField("_csrf", csrf)
+        appendField("assignmentName", assignmentName)
+        appendFile(
+            "assignmentNotebookFile",
+            filename: "assignment.ipynb",
+            data: Data(assignmentNotebook.utf8)
+        )
+        appendFile(
+            "solutionNotebookFile",
+            filename: "solution.ipynb",
+            data: Data(solutionNotebook.utf8)
+        )
+        appendField("suiteConfig", suiteConfig)
+        body.writeString("--\(boundary)--\r\n")
+        return body
+    }
+
+    private func makeZip(at path: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("assignment-routes-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for (name, contents) in entries {
+            let fileURL = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try contents.data(using: .utf8)?.write(to: fileURL)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        process.currentDirectoryURL = root
+        process.arguments = ["-q", "-r", path, "."]
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+    }
+
     // MARK: - GET /instructor
 
     func testStudentCannotAccessAssignments() async throws {
@@ -351,6 +417,81 @@ final class AssignmentRoutesTests: XCTestCase {
         XCTAssertTrue(zipEntries.contains("test_q1.py"))
         XCTAssertTrue(zipEntries.contains("test_q2.py"))
         XCTAssertTrue(zipEntries.contains("test.properties.json"))
+    }
+
+    func testSaveEditedAssignmentPersistsDisplayNameForExistingSuiteFile() async throws {
+        let courseID = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+        let setupID = "setup_edit_display"
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
+        """
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(publicID: "ABC123", testSetupID: setupID, title: "Practice Lab", dueAt: nil, isOpen: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/ABC123/edit", cookie: cookie, on: app)
+        let boundary = "Boundary-Edit-DisplayName"
+        let notebook = #"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#
+        let suiteConfig = """
+        [
+          {"source":"existing","name":"test_q1.py","tier":"public","order":1,"points":1,"displayName":"BMI check"}
+        ]
+        """
+
+        try await app.asyncTest(.POST, "/instructor/ABC123/edit/save", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart",
+                subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: self.multipartEditBody(
+                boundary: boundary,
+                csrf: csrf,
+                assignmentName: "Practice Lab",
+                assignmentNotebook: notebook,
+                solutionNotebook: notebook,
+                suiteConfig: suiteConfig
+            ))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+        })
+
+        let savedSetup = try await APITestSetup.find(setupID, on: app.db)
+        let props = try JSONDecoder().decode(
+            TestProperties.self,
+            from: try XCTUnwrap(savedSetup?.manifest.data(using: .utf8))
+        )
+        XCTAssertEqual(props.testSuites.count, 1)
+        XCTAssertEqual(props.testSuites[0].name, "BMI check")
+    }
+
+    func testEditPageSyncsSuiteConfigOnSubmit() async throws {
+        let courseID = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+        let setupID = "setup_edit_submit_sync"
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
+        """
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(publicID: "DEF456", testSetupID: setupID, title: "Practice Lab", dueAt: nil, isOpen: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+
+        try await app.asyncTest(.GET, "/instructor/DEF456/edit", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("form.addEventListener('submit'"))
+            XCTAssertTrue(html.contains("syncConfig();"))
+        })
     }
 
     func testNewAssignmentPageOmitsLegacyTestColumn() async throws {

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -475,6 +475,48 @@ final class WebRoutesTests: XCTestCase {
         })
     }
 
+    func testSubmissionPageShowsTracebackWhenStructuredJSONIsWrappedInStdout() async throws {
+        let wrapped = #"""
+        stdout:
+        {"shortResult": "Q1: BMI Calculation: Could not test calculate_bmi", "status": "error", "test": "Q1: BMI Calculation", "error": "Could not test calculate_bmi", "exception": "NotImplementedError('Implement calculate_bmi')", "traceback": "Traceback (most recent call last):\n  File \"test_q1_bmi.py\", line 12, in <module>\n    result = fn(*args)\n             ^^^^^^^^^\n  File \"/chickadee_work_1774744743040/submission.py\", line 27, in calculate_bmi\n    raise NotImplementedError(\"Implement calculate_bmi\")\nNotImplementedError: Implement calculate_bmi\n"}
+        """#
+        let formatted = formattedDetailedOutput(from: wrapped, status: .error)
+        XCTAssertEqual(
+            formatted,
+            """
+            Traceback (most recent call last):
+              File "test_q1_bmi.py", line 12, in <module>
+                result = fn(*args)
+                         ^^^^^^^^^
+              File "/chickadee_work_1774744743040/submission.py", line 27, in calculate_bmi
+                raise NotImplementedError("Implement calculate_bmi")
+            NotImplementedError: Implement calculate_bmi
+            """
+        )
+
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        let userID = try user.requireID()
+        try await insertSetup(id: "setup_stdout_traceback")
+        try await insertSubmission(id: "sub_stdout_traceback", testSetupID: "setup_stdout_traceback", userID: userID)
+        try await insertResult(
+            submissionID: "sub_stdout_traceback",
+            outcomes: [makeOutcome(name: "Q1: BMI Calculation", tier: .pub, status: .error, longResult: wrapped)],
+            source: "browser"
+        )
+
+        try await app.asyncTest(.GET, "/submissions/sub_stdout_traceback", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("Traceback (most recent call last):"))
+            XCTAssertTrue(html.contains("NotImplementedError: Implement calculate_bmi"))
+            XCTAssertFalse(html.contains("\"shortResult\""))
+            XCTAssertFalse(html.contains("\"exception\""))
+        })
+    }
+
     func testStudentCannotViewOtherStudentsSubmission() async throws {
         let cookie = try await loginAsStudent()
         // Create a submission owned by a different user


### PR DESCRIPTION
## Summary
- sync edited suite display names at submit time so renamed tests persist reliably
- extract traceback-only output from stdout-wrapped browser JSON error payloads
- bump version metadata and changelog for 0.4.13

## Testing
- timeout 120 swift test --filter AssignmentRoutesTests/testSaveEditedAssignmentPersistsDisplayNameForExistingSuiteFile
- timeout 120 swift test --filter AssignmentRoutesTests/testEditPageSyncsSuiteConfigOnSubmit
- timeout 120 swift test --filter WebRoutesTests/testSubmissionPageShowsTracebackWhenStructuredJSONIsWrappedInStdout