### PR TITLE
Release 0.4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.14] - 2026-03-28
+
 ### Changed
 
 - **Swift 6.3 toolchain upgrade**: `Package.swift` tools version bumped to 6.3, CI images updated from `swift:6.0-jammy` to `swift:6.3-jammy`, and Dockerfile build stage updated to match. Runner stderr logging switched from `fputs`/`stderr` to `FileHandle.standardError` to resolve a Swift 6.3 ambiguity; `WorkerCommand.configuration` changed from `static var` to `static let` for strict concurrency compliance. `swift-subprocess` adoption deferred — the Linux fork/exec path requires no changes for the toolchain upgrade.
+
+### Fixed
+
+- **Assignment editor multipart submit sync**: global multipart form interception now gives assignment create/edit pages a final chance to refresh `suiteConfig` before `FormData` is captured, so saved human-readable test names persist reliably.
+- **Submission page traceback rendering**: expanded browser-lab failure output now prefers the best traceback-bearing payload from either `stdout` or `stderr` and extracts only the traceback text instead of showing wrapped JSON blobs.
 
 ## [0.4.13] - 2026-03-28
 

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -574,6 +574,9 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         form.addEventListener('submit', function () {
             syncConfig();
         });
+        form.addEventListener('chickadee:before-multipart-submit', function () {
+            syncConfig();
+        });
     }
 
     var addTestBtn = document.getElementById('add-test-btn');

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -477,6 +477,9 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
                 window.alert('Add at least one non-support file to run as a test.');
             }
         });
+        form.addEventListener('chickadee:before-multipart-submit', function () {
+            syncConfig();
+        });
     }
 
     function escHtml(v) {

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -70,7 +70,9 @@
     document.addEventListener('submit', function (e) {
         var form = e.target;
         if (!form || form.enctype !== 'multipart/form-data') return;
+        if (e.defaultPrevented) return;
         e.preventDefault();
+        form.dispatchEvent(new CustomEvent('chickadee:before-multipart-submit', { bubbles: false }));
         var meta = document.querySelector('meta[name="csrf-token"]');
         var csrfToken = meta ? meta.getAttribute('content') : '';
         var btn = form.querySelector('[type="submit"]');
@@ -84,7 +86,7 @@
         }).catch(function () {
             if (btn) btn.disabled = false;
         });
-    }, true);
+    });
 }());
 </script>
 </body>

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -411,12 +411,13 @@ func detailedScriptOutput(from raw: String?, status: TestStatus) -> String? {
     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
 
-    if let stderr = extractLabeledOutputSection("stderr", in: trimmed) {
-        return stderr
+    let stderr = extractLabeledOutputSection("stderr", in: trimmed)
+    let stdout = extractLabeledOutputSection("stdout", in: trimmed)
+
+    if let best = bestDetailedSection(stderr: stderr, stdout: stdout) {
+        return best
     }
-    if let stdout = extractLabeledOutputSection("stdout", in: trimmed) {
-        return stdout
-    }
+
     return trimmed
 }
 
@@ -454,6 +455,24 @@ func extractTraceback(in text: String) -> String? {
     }
 
     return nil
+}
+
+private func bestDetailedSection(stderr: String?, stdout: String?) -> String? {
+    let candidates = [stderr, stdout].compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+    guard !candidates.isEmpty else { return nil }
+
+    for candidate in candidates {
+        if extractStructuredErrorText(from: candidate) != nil {
+            return candidate
+        }
+    }
+    for candidate in candidates {
+        if extractTraceback(in: candidate) != nil {
+            return candidate
+        }
+    }
+    return stderr ?? stdout
 }
 
 func extractStructuredErrorText(from text: String) -> String? {

--- a/Sources/Core/ChickadeeVersion.swift
+++ b/Sources/Core/ChickadeeVersion.swift
@@ -1,3 +1,3 @@
 public enum ChickadeeVersion {
-    public static let current = "0.4.13"
+    public static let current = "0.4.14"
 }

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -490,7 +490,24 @@ final class AssignmentRoutesTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
             let html = res.body.string
             XCTAssertTrue(html.contains("form.addEventListener('submit'"))
+            XCTAssertTrue(html.contains("form.addEventListener('chickadee:before-multipart-submit'"))
             XCTAssertTrue(html.contains("syncConfig();"))
+            XCTAssertTrue(html.contains("chickadee:before-multipart-submit"))
+        })
+    }
+
+    func testNewAssignmentPageSyncsSuiteConfigBeforeMultipartSubmit() async throws {
+        _ = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+
+        try await app.asyncTest(.GET, "/instructor/new", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("chickadee:before-multipart-submit"))
+            XCTAssertTrue(html.contains("syncConfig();"))
+            XCTAssertTrue(html.contains("if (e.defaultPrevented) return;"))
         })
     }
 

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -517,6 +517,27 @@ final class WebRoutesTests: XCTestCase {
         })
     }
 
+    func testSubmissionPagePrefersStdoutTracebackOverUnhelpfulStderrSection() async throws {
+        let wrapped = #"""
+        stdout:
+        {"shortResult": "Q1: BMI Calculation: Could not test calculate_bmi", "status": "error", "traceback": "Traceback (most recent call last):\n  File \"test_q1_bmi.py\", line 12, in <module>\n    result = fn(*args)\n             ^^^^^^^^^\nNotImplementedError: Implement calculate_bmi\n"}
+
+        stderr:
+        Browser runner reported a structured failure payload
+        """#
+        let formatted = formattedDetailedOutput(from: wrapped, status: .error)
+        XCTAssertEqual(
+            formatted,
+            """
+            Traceback (most recent call last):
+              File "test_q1_bmi.py", line 12, in <module>
+                result = fn(*args)
+                         ^^^^^^^^^
+            NotImplementedError: Implement calculate_bmi
+            """
+        )
+    }
+
     func testStudentCannotViewOtherStudentsSubmission() async throws {
         let cookie = try await loginAsStudent()
         // Create a submission owned by a different user


### PR DESCRIPTION
## Summary
- fix multipart submit interception so assignment create/edit pages can refresh `suiteConfig` before `FormData` is captured
- preserve edited human-readable test names for assignment suite files after save
- render cleaned traceback text for browser lab failures instead of raw wrapped JSON blobs
- bump the app version and changelog for `0.4.14`

## Root Cause
- the global multipart submit handler in `base.leaf` captured multipart forms before page-level submit handlers had a chance to sync hidden fields like `suiteConfig`
- submission output formatting still preferred less useful sections in some browser-lab payload shapes, so students could see wrapped JSON instead of the traceback they needed

## Validation
- `timeout 180 swift test --skip-build --filter 'AssignmentRoutesTests/testEditPageSyncsSuiteConfigOnSubmit|AssignmentRoutesTests/testNewAssignmentPageSyncsSuiteConfigBeforeMultipartSubmit|WebRoutesTests/testSubmissionPageShowsTracebackWhenStructuredJSONIsWrappedInStdout|WebRoutesTests/testSubmissionPagePrefersStdoutTracebackOverUnhelpfulStderrSection'`
