### PR TITLE
Release 0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.15] - 2026-03-28
+
+### Fixed
+
+- **Assignment edit display names on reload**: the instructor edit page now encodes its computed suite-row fields into the Leaf context, so saved human-readable test names and dependency metadata actually reappear after reopening the assignment instead of falling back to blank or stale values.
+- **Multipart assignment saves in real browser submits**: assignment create/edit routes now read multipart text fields like `suiteConfig` directly from the multipart body instead of relying solely on Vapor’s multipart text decoding, making the browser `FormData` save path match the tested server-side behavior.
+- **Submission results JSON cleanup**: submission pages now normalize structured JSON payloads found in either `shortResult` or `longResult`, so students see readable summaries in the `Output` column and traceback-only details in the expanded view instead of raw JSON blobs.
+- **Notebook asset cache busting**: notebook/editor pages now reference refreshed static asset versions so browsers stop reusing stale `app.js`, `notebook.js`, and `browser-runner.js` after deploys.
+
 ## [0.4.14] - 2026-03-28
 
 ### Changed

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
     <link rel="shortcut icon" href="/favicon.png" type="image/png">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-    <link rel="stylesheet" href="/styles.css?v=0.4.4">
+    <link rel="stylesheet" href="/styles.css?v=0.4.15">
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -61,7 +61,7 @@
 <main class="main" id="main-content">
     #import("content")
 </main>
-<script src="/app.js?v=0.4.4"></script>
+<script src="/app.js?v=0.4.15"></script>
 <script>
 // All multipart/form-data uploads bypass the hidden _csrf body field because
 // the body stream is not collected before CSRF middleware runs.  Intercept

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -38,7 +38,7 @@ Notebook
 </p>
 <div id="nb-results" class="nb-results" hidden></div>
 <div id="browser-runner-status" class="nb-status" role="status" aria-live="polite" aria-atomic="true" hidden></div>
-<script src="/notebook.js?v=0.4.6"></script>
-<script src="/browser-runner.js?v=0.4.6" data-setup-id="#(testSetupID)" data-grading-mode="#(gradingMode)"></script>
+<script src="/notebook.js?v=0.4.15"></script>
+<script src="/browser-runner.js?v=0.4.15" data-setup-id="#(testSetupID)" data-grading-mode="#(gradingMode)"></script>
 #endexport
 #endextend

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -137,6 +137,35 @@ struct EditableSuiteRow: Encodable {
         let data = (try? JSONEncoder().encode(dependsOn)) ?? Data("[]".utf8)
         return String(data: data, encoding: .utf8) ?? "[]"
     }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case url
+        case isTest
+        case tier
+        case order
+        case dependsOn
+        case points
+        case displayName
+        case displayNameOrEmpty
+        case displayNameOrStem
+        case dependsOnJSON
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(url, forKey: .url)
+        try container.encode(isTest, forKey: .isTest)
+        try container.encode(tier, forKey: .tier)
+        try container.encode(order, forKey: .order)
+        try container.encode(dependsOn, forKey: .dependsOn)
+        try container.encode(points, forKey: .points)
+        try container.encodeIfPresent(displayName, forKey: .displayName)
+        try container.encode(displayNameOrEmpty, forKey: .displayNameOrEmpty)
+        try container.encode(displayNameOrStem, forKey: .displayNameOrStem)
+        try container.encode(dependsOnJSON, forKey: .dependsOnJSON)
+    }
 }
 
 struct AssignmentStudentHistoryContext: Encodable {

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -735,6 +735,17 @@ func multipartFiles(named names: [String], from req: Request) throws -> [File]? 
     return files.isEmpty ? nil : files
 }
 
+func multipartTextField(named names: [String], from req: Request) throws -> String? {
+    guard let parts = try multipartParts(from: req) else { return nil }
+    for name in names {
+        if let part = parts.firstPart(named: name),
+           let value = String(multipart: part) {
+            return value
+        }
+    }
+    return nil
+}
+
 func nextAssignmentSortOrder(req: Request) async throws -> Int {
     let maxOrder = try await APIAssignment.query(on: req.db)
         .all()

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -361,15 +361,23 @@ struct AssignmentRoutes: RouteCollection {
             throw Abort(.badRequest, reason: "Invalid assignment upload payload")
         }
 
-        let assignmentName = bodyMany?.assignmentName ?? bodySingle?.assignmentName
-        let dueAtRaw = bodyMany?.dueAt ?? bodySingle?.dueAt
-        let sectionIDRaw = bodyMany?.sectionID ?? bodySingle?.sectionID
+        let assignmentName = try multipartTextField(named: ["assignmentName"], from: req)
+            ?? bodyMany?.assignmentName
+            ?? bodySingle?.assignmentName
+        let dueAtRaw = try multipartTextField(named: ["dueAt"], from: req)
+            ?? bodyMany?.dueAt
+            ?? bodySingle?.dueAt
+        let sectionIDRaw = try multipartTextField(named: ["sectionID"], from: req)
+            ?? bodyMany?.sectionID
+            ?? bodySingle?.sectionID
         let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
         let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
         let suiteFilesRaw = try multipartFiles(named: ["suiteFiles[]", "suiteFiles"], from: req)
             ?? bodyMany?.suiteFiles
             ?? (bodySingle?.suiteFiles.map { [$0] } ?? [])
-        let suiteConfigRaw = bodyMany?.suiteConfig ?? bodySingle?.suiteConfig
+        let suiteConfigRaw = try multipartTextField(named: ["suiteConfig"], from: req)
+            ?? bodyMany?.suiteConfig
+            ?? bodySingle?.suiteConfig
 
         let title = (assignmentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let due = parseDueDate(dueAtRaw)
@@ -898,14 +906,20 @@ struct AssignmentRoutes: RouteCollection {
             throw Abort(.badRequest, reason: "Invalid assignment upload payload")
         }
 
-        let assignmentName = bodyMany?.assignmentName ?? bodySingle?.assignmentName
-        let dueAtRaw = bodyMany?.dueAt ?? bodySingle?.dueAt
+        let assignmentName = try multipartTextField(named: ["assignmentName"], from: req)
+            ?? bodyMany?.assignmentName
+            ?? bodySingle?.assignmentName
+        let dueAtRaw = try multipartTextField(named: ["dueAt"], from: req)
+            ?? bodyMany?.dueAt
+            ?? bodySingle?.dueAt
         let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
         let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
         let suiteFilesRaw = try multipartFiles(named: ["suiteFiles[]", "suiteFiles"], from: req)
             ?? bodyMany?.suiteFiles
             ?? (bodySingle?.suiteFiles.map { [$0] } ?? [])
-        let suiteConfigRaw = bodyMany?.suiteConfig ?? bodySingle?.suiteConfig
+        let suiteConfigRaw = try multipartTextField(named: ["suiteConfig"], from: req)
+            ?? bodyMany?.suiteConfig
+            ?? bodySingle?.suiteConfig
 
         let title = (assignmentName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let due = parseDueDate(dueAtRaw)

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -300,7 +300,12 @@ extension WebRoutes {
                 let weighted = totalPoints != visible.totalTests
                 outcomes = visible.outcomes.map { o in
                     let skip = parseSkip(shortResult: o.shortResult)
-                    let longOutput = formattedDetailedOutput(from: o.longResult, status: o.status)
+                    let shortOutput = formattedShortResult(from: o.shortResult, status: o.status)
+                    let longOutput = formattedDetailedOutput(
+                        primary: o.longResult,
+                        fallback: o.shortResult,
+                        status: o.status
+                    )
                     let (markLabel, markClass): (String, String) = {
                         if skip.isSkipped { return ("—", "skipped") }
                         switch o.status {
@@ -321,7 +326,7 @@ extension WebRoutes {
                         testName:       displayNameMap[o.testName] ?? o.testName,
                         tier:           o.tier.rawValue,
                         status:         o.status.rawValue,
-                        shortResult:    o.shortResult,
+                        shortResult:    shortOutput,
                         longResult:     longOutput,
                         markLabel:      markLabel,
                         markClass:      markClass,
@@ -421,9 +426,26 @@ func detailedScriptOutput(from raw: String?, status: TestStatus) -> String? {
     return trimmed
 }
 
-func formattedDetailedOutput(from raw: String?, status: TestStatus) -> String? {
+func formattedShortResult(from raw: String, status: TestStatus) -> String {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return defaultShortResult(for: status) }
+
+    if let summary = extractStructuredSummaryText(from: trimmed) {
+        return summary
+    }
+    if let summary = detailedScriptOutput(from: trimmed, status: status)
+        .flatMap(extractStructuredSummaryText(from:)) {
+        return summary
+    }
+
+    return trimmed
+}
+
+func formattedDetailedOutput(primary raw: String?, fallback: String?, status: TestStatus) -> String? {
     guard status != .pass else { return nil }
-    guard let base = detailedScriptOutput(from: raw, status: status) else { return nil }
+    let base = detailedScriptOutput(from: raw, status: status)
+        ?? detailedScriptOutput(from: fallback, status: status)
+    guard let base else { return nil }
 
     if let extracted = extractStructuredErrorText(from: base) {
         return extracted
@@ -432,6 +454,50 @@ func formattedDetailedOutput(from raw: String?, status: TestStatus) -> String? {
         return traceback
     }
     return base
+}
+
+func extractStructuredSummaryText(from text: String) -> String? {
+    guard let data = text.data(using: .utf8),
+          let object = try? JSONSerialization.jsonObject(with: data) else {
+        return nil
+    }
+    return structuredSummaryText(from: object)
+}
+
+private func structuredSummaryText(from value: Any) -> String? {
+    if let string = value as? String {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    if let dict = value as? [String: Any] {
+        let preferredKeys = ["shortResult", "error", "message", "detail", "reason", "status"]
+        for key in preferredKeys {
+            if let nested = dict[key],
+               let text = structuredSummaryText(from: nested) {
+                return text
+            }
+        }
+    }
+
+    if let array = value as? [Any] {
+        for nested in array {
+            if let text = structuredSummaryText(from: nested) {
+                return text
+            }
+        }
+    }
+
+    return nil
+}
+
+private func defaultShortResult(for status: TestStatus) -> String {
+    switch status {
+    case .pass:    return "passed"
+    case .fail:    return "failed"
+    case .error:   return "error"
+    case .timeout: return "timed out"
+    }
 }
 
 func extractTraceback(in text: String) -> String? {

--- a/Sources/Core/ChickadeeVersion.swift
+++ b/Sources/Core/ChickadeeVersion.swift
@@ -1,3 +1,3 @@
 public enum ChickadeeVersion {
-    public static let current = "0.4.14"
+    public static let current = "0.4.15"
 }

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -470,6 +470,58 @@ final class AssignmentRoutesTests: XCTestCase {
         XCTAssertEqual(props.testSuites[0].name, "BMI check")
     }
 
+    func testSaveEditedAssignmentShowsUpdatedDisplayNameOnReopen() async throws {
+        let courseID = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+        let setupID = "setup_edit_display_reload"
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
+        """
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(publicID: "GHI789", testSetupID: setupID, title: "Practice Lab", dueAt: nil, isOpen: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/GHI789/edit", cookie: cookie, on: app)
+        let boundary = "Boundary-Edit-Reload"
+        let notebook = #"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#
+        let suiteConfig = """
+        [
+          {"source":"existing","name":"test_q1.py","tier":"public","order":1,"points":1,"displayName":"BMI check"}
+        ]
+        """
+
+        try await app.asyncTest(.POST, "/instructor/GHI789/edit/save", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart",
+                subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: self.multipartEditBody(
+                boundary: boundary,
+                csrf: csrf,
+                assignmentName: "Practice Lab",
+                assignmentNotebook: notebook,
+                solutionNotebook: notebook,
+                suiteConfig: suiteConfig
+            ))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+        })
+
+        try await app.asyncTest(.GET, "/instructor/GHI789/edit", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("value=\"BMI check\""), html)
+            XCTAssertFalse(html.contains("value=\"test_q1\""), html)
+        })
+    }
+
     func testEditPageSyncsSuiteConfigOnSubmit() async throws {
         let courseID = try await makeTestCourseID()
         let cookie = try await loginAsInstructor()

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -443,7 +443,7 @@ final class WebRoutesTests: XCTestCase {
         let rawJSON = #"""
         {"error":"PythonError","stderr":"Traceback (most recent call last):\n  File \"test_q1.py\", line 7, in <module>\n    assert answer == 42\nAssertionError","headers":{"content-type":"application/json"}}
         """#
-        let formatted = formattedDetailedOutput(from: rawJSON, status: .fail)
+        let formatted = formattedDetailedOutput(primary: rawJSON, fallback: nil, status: .fail)
         XCTAssertEqual(
             formatted,
             """
@@ -480,7 +480,7 @@ final class WebRoutesTests: XCTestCase {
         stdout:
         {"shortResult": "Q1: BMI Calculation: Could not test calculate_bmi", "status": "error", "test": "Q1: BMI Calculation", "error": "Could not test calculate_bmi", "exception": "NotImplementedError('Implement calculate_bmi')", "traceback": "Traceback (most recent call last):\n  File \"test_q1_bmi.py\", line 12, in <module>\n    result = fn(*args)\n             ^^^^^^^^^\n  File \"/chickadee_work_1774744743040/submission.py\", line 27, in calculate_bmi\n    raise NotImplementedError(\"Implement calculate_bmi\")\nNotImplementedError: Implement calculate_bmi\n"}
         """#
-        let formatted = formattedDetailedOutput(from: wrapped, status: .error)
+        let formatted = formattedDetailedOutput(primary: wrapped, fallback: nil, status: .error)
         XCTAssertEqual(
             formatted,
             """
@@ -525,7 +525,7 @@ final class WebRoutesTests: XCTestCase {
         stderr:
         Browser runner reported a structured failure payload
         """#
-        let formatted = formattedDetailedOutput(from: wrapped, status: .error)
+        let formatted = formattedDetailedOutput(primary: wrapped, fallback: nil, status: .error)
         XCTAssertEqual(
             formatted,
             """
@@ -536,6 +536,61 @@ final class WebRoutesTests: XCTestCase {
             NotImplementedError: Implement calculate_bmi
             """
         )
+    }
+
+    func testSubmissionPageFormatsStructuredShortResultInsteadOfShowingJSONBlob() async throws {
+        let shortJSON = #"""
+        {"shortResult":"Q1: BMI Calculation: Could not test calculate_bmi","status":"error","error":"Could not test calculate_bmi","traceback":"Traceback (most recent call last):\n  File \"test_q1_bmi.py\", line 12, in <module>\n    result = fn(*args)\nNotImplementedError: Implement calculate_bmi\n"}
+        """#
+
+        XCTAssertEqual(
+            formattedShortResult(from: shortJSON, status: .error),
+            "Q1: BMI Calculation: Could not test calculate_bmi"
+        )
+        XCTAssertEqual(
+            formattedDetailedOutput(primary: nil, fallback: shortJSON, status: .error),
+            """
+            Traceback (most recent call last):
+              File "test_q1_bmi.py", line 12, in <module>
+                result = fn(*args)
+            NotImplementedError: Implement calculate_bmi
+            """
+        )
+
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        let userID = try user.requireID()
+        try await insertSetup(id: "setup_short_json")
+        try await insertSubmission(id: "sub_short_json", testSetupID: "setup_short_json", userID: userID)
+        try await insertResult(
+            submissionID: "sub_short_json",
+            outcomes: [
+                TestOutcome(
+                    testName: "Q1: BMI Calculation",
+                    testClass: nil,
+                    tier: .pub,
+                    status: .error,
+                    shortResult: shortJSON,
+                    longResult: nil,
+                    executionTimeMs: 10,
+                    memoryUsageBytes: nil,
+                    attemptNumber: 1,
+                    isFirstPassSuccess: false
+                )
+            ],
+            source: "browser"
+        )
+
+        try await app.asyncTest(.GET, "/submissions/sub_short_json", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("Q1: BMI Calculation: Could not test calculate_bmi"))
+            XCTAssertTrue(html.contains("Traceback (most recent call last):"))
+            XCTAssertFalse(html.contains("\"shortResult\""))
+            XCTAssertFalse(html.contains("\"traceback\""))
+        })
     }
 
     func testStudentCannotViewOtherStudentsSubmission() async throws {


### PR DESCRIPTION
## Summary
- fix assignment edit reloads so saved human-readable suite names actually come back on the page
- parse multipart text fields like `suiteConfig` directly from browser `FormData` submits
- normalize structured JSON blobs in submission result rendering so the page shows readable output and traceback-only details
- refresh notebook/static asset cache-busting for the deployed frontend files
- bump version and changelog for `0.4.15`

## Root Cause
- the assignment editor had two separate problems: browser multipart saves still relied on Vapor's multipart text decoding, and the edit page's computed suite-row fields were never encoded into the Leaf context, so re-opened pages could render blank/stale names even when the manifest was correct
- submission rendering handled some structured JSON in `longResult`, but not all of the real payload shapes we saw in production, especially when structured data appeared in `shortResult`
- notebook pages were still referencing stale static asset version strings, which could leave deployed browsers running mismatched frontend code

## Validation
- `timeout 240 swift test --skip-build --filter 'AssignmentRoutesTests/testSaveEditedAssignmentPersistsDisplayNameForExistingSuiteFile|AssignmentRoutesTests/testSaveEditedAssignmentShowsUpdatedDisplayNameOnReopen|AssignmentRoutesTests/testEditPageSyncsSuiteConfigOnSubmit|WebRoutesTests/testSubmissionPageShowsConfiguredDisplayNameForBrowserResultScriptFilename|WebRoutesTests/testSubmissionPageShowsTracebackWhenStructuredJSONIsWrappedInStdout|WebRoutesTests/testSubmissionPagePrefersStdoutTracebackOverUnhelpfulStderrSection|WebRoutesTests/testSubmissionPageFormatsStructuredShortResultInsteadOfShowingJSONBlob'`
