### PR TITLE
Migrate CoreTests and ScriptInvocationTests to Swift Testing

### DIFF
--- a/Tests/CoreTests/CoreModelTests.swift
+++ b/Tests/CoreTests/CoreModelTests.swift
@@ -1,7 +1,8 @@
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-final class CoreModelTests: XCTestCase {
+struct CoreModelTests {
 
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
@@ -17,67 +18,60 @@ final class CoreModelTests: XCTestCase {
 
     // MARK: - TestStatus
 
-    func testTestStatusRoundTrip() throws {
-        for status in [TestStatus.pass, .fail, .error, .timeout] {
-            let data = try encoder.encode(status)
-            let decoded = try decoder.decode(TestStatus.self, from: data)
-            XCTAssertEqual(status, decoded)
-        }
+    @Test(arguments: [TestStatus.pass, .fail, .error, .timeout])
+    func testStatusRoundTrip(status: TestStatus) throws {
+        let data = try encoder.encode(status)
+        let decoded = try decoder.decode(TestStatus.self, from: data)
+        #expect(status == decoded)
     }
 
     // MARK: - TestTier
 
-    func testTestTierRoundTrip() throws {
-        for tier in [TestTier.pub, .release, .secret] {
-            let data = try encoder.encode(tier)
-            let decoded = try decoder.decode(TestTier.self, from: data)
-            XCTAssertEqual(tier, decoded)
-        }
+    @Test(arguments: [TestTier.pub, .release, .secret])
+    func testTierRoundTrip(tier: TestTier) throws {
+        let data = try encoder.encode(tier)
+        let decoded = try decoder.decode(TestTier.self, from: data)
+        #expect(tier == decoded)
     }
 
-    func testTestTierRawValues() {
-        XCTAssertEqual(TestTier.pub.rawValue, "public")
-        XCTAssertEqual(TestTier.release.rawValue, "release")
-        XCTAssertEqual(TestTier.secret.rawValue, "secret")
+    @Test(arguments: zip(
+        [TestTier.pub, .release, .secret],
+        ["public",     "release", "secret"]
+    ))
+    func testTierRawValue(tier: TestTier, expectedRaw: String) {
+        #expect(tier.rawValue == expectedRaw)
     }
 
     // MARK: - GradingMode
 
-    func testGradingModeDefaultsWorkerWhenAbsent() throws {
-        let json = """
-        { "schemaVersion": 1 }
-        """.data(using: .utf8)!
+    @Test func gradingModeDefaultsWorkerWhenAbsent() throws {
+        let json = #"{ "schemaVersion": 1 }"#.data(using: .utf8)!
         let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertEqual(manifest.gradingMode, .worker)
+        #expect(manifest.gradingMode == .worker)
     }
 
-    func testGradingModeExplicitBrowser() throws {
-        let json = """
-        { "schemaVersion": 1, "gradingMode": "browser" }
-        """.data(using: .utf8)!
-        let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertEqual(manifest.gradingMode, .browser)
+    @Test(arguments: zip(
+        [
+            #"{ "schemaVersion": 1, "gradingMode": "browser" }"#,
+            #"{ "schemaVersion": 1, "gradingMode": "worker"  }"#
+        ],
+        [GradingMode.browser, GradingMode.worker]
+    ))
+    func gradingModeExplicit(json: String, expected: GradingMode) throws {
+        let manifest = try decoder.decode(TestProperties.self, from: json.data(using: .utf8)!)
+        #expect(manifest.gradingMode == expected)
     }
 
-    func testGradingModeExplicitWorker() throws {
-        let json = """
-        { "schemaVersion": 1, "gradingMode": "worker" }
-        """.data(using: .utf8)!
-        let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertEqual(manifest.gradingMode, .worker)
-    }
-
-    func testGradingModeRoundTrip() throws {
-        for mode in [GradingMode.browser, .worker] {
-            let data = try encoder.encode(mode)
-            let decoded = try decoder.decode(GradingMode.self, from: data)
-            XCTAssertEqual(mode, decoded)
-        }
+    @Test(arguments: [GradingMode.browser, .worker])
+    func gradingModeRoundTrip(mode: GradingMode) throws {
+        let data = try encoder.encode(mode)
+        let decoded = try decoder.decode(GradingMode.self, from: data)
+        #expect(mode == decoded)
     }
 
     // MARK: - TestProperties (no Makefile)
 
-    func testTestPropertiesRoundTrip() throws {
+    @Test func testPropertiesRoundTrip() throws {
         let json = """
         {
           "schemaVersion": 1,
@@ -92,23 +86,23 @@ final class CoreModelTests: XCTestCase {
         """.data(using: .utf8)!
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertEqual(manifest.schemaVersion, 1)
-        XCTAssertEqual(manifest.gradingMode, .worker)
-        XCTAssertEqual(manifest.requiredFiles, ["warmup.py"])
-        XCTAssertEqual(manifest.testSuites.count, 2)
-        XCTAssertEqual(manifest.testSuites[0].script, "test_bit_count.sh")
-        XCTAssertEqual(manifest.testSuites[0].tier, .pub)
-        XCTAssertEqual(manifest.timeLimitSeconds, 10)
-        XCTAssertNil(manifest.makefile)
+        #expect(manifest.schemaVersion == 1)
+        #expect(manifest.gradingMode == .worker)
+        #expect(manifest.requiredFiles == ["warmup.py"])
+        #expect(manifest.testSuites.count == 2)
+        #expect(manifest.testSuites[0].script == "test_bit_count.sh")
+        #expect(manifest.testSuites[0].tier == .pub)
+        #expect(manifest.timeLimitSeconds == 10)
+        #expect(manifest.makefile == nil)
 
         let reencoded = try encoder.encode(manifest)
         let redecoded = try decoder.decode(TestProperties.self, from: reencoded)
-        XCTAssertEqual(manifest, redecoded)
+        #expect(manifest == redecoded)
     }
 
     // MARK: - TestProperties (with Makefile)
 
-    func testTestPropertiesWithMakefileRoundTrip() throws {
+    @Test func testPropertiesWithMakefileRoundTrip() throws {
         let json = """
         {
           "schemaVersion": 1,
@@ -123,15 +117,15 @@ final class CoreModelTests: XCTestCase {
         """.data(using: .utf8)!
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertNotNil(manifest.makefile)
-        XCTAssertEqual(manifest.makefile?.target, "build")
+        #expect(manifest.makefile != nil)
+        #expect(manifest.makefile?.target == "build")
 
         let reencoded = try encoder.encode(manifest)
         let redecoded = try decoder.decode(TestProperties.self, from: reencoded)
-        XCTAssertEqual(manifest, redecoded)
+        #expect(manifest == redecoded)
     }
 
-    func testTestPropertiesWithDefaultMakeTarget() throws {
+    @Test func testPropertiesWithDefaultMakeTarget() throws {
         let json = """
         {
           "schemaVersion": 1,
@@ -146,34 +140,31 @@ final class CoreModelTests: XCTestCase {
         """.data(using: .utf8)!
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertNotNil(manifest.makefile)
-        XCTAssertNil(manifest.makefile?.target)  // bare `make`, no target
+        #expect(manifest.makefile != nil)
+        #expect(manifest.makefile?.target == nil)  // bare `make`, no target
     }
 
     // MARK: - TestSuiteEntry dependsOn
 
-    func testTestSuiteEntryDefaultsEmptyDependsOn() throws {
-        let json = """
-        { "tier": "public", "script": "test_foo.sh" }
-        """.data(using: .utf8)!
+    @Test func testSuiteEntryDefaultsEmptyDependsOn() throws {
+        let json = #"{ "tier": "public", "script": "test_foo.sh" }"#.data(using: .utf8)!
         let entry = try decoder.decode(TestSuiteEntry.self, from: json)
-        XCTAssertEqual(entry.dependsOn, [])
+        #expect(entry.dependsOn == [])
     }
 
-    func testTestSuiteEntryWithDependsOnRoundTrip() throws {
-        let json = """
-        { "tier": "release", "script": "test_bar.sh", "dependsOn": ["test_foo.sh"] }
-        """.data(using: .utf8)!
+    @Test func testSuiteEntryWithDependsOnRoundTrip() throws {
+        let json = #"{ "tier": "release", "script": "test_bar.sh", "dependsOn": ["test_foo.sh"] }"#
+            .data(using: .utf8)!
         let entry = try decoder.decode(TestSuiteEntry.self, from: json)
-        XCTAssertEqual(entry.script, "test_bar.sh")
-        XCTAssertEqual(entry.dependsOn, ["test_foo.sh"])
+        #expect(entry.script == "test_bar.sh")
+        #expect(entry.dependsOn == ["test_foo.sh"])
 
         let reencoded = try encoder.encode(entry)
         let redecoded = try decoder.decode(TestSuiteEntry.self, from: reencoded)
-        XCTAssertEqual(entry, redecoded)
+        #expect(entry == redecoded)
     }
 
-    func testTestPropertiesWithDependencyChainRoundTrip() throws {
+    @Test func testPropertiesWithDependencyChainRoundTrip() throws {
         let json = """
         {
           "schemaVersion": 1,
@@ -188,19 +179,19 @@ final class CoreModelTests: XCTestCase {
         """.data(using: .utf8)!
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
-        XCTAssertEqual(manifest.testSuites.count, 3)
-        XCTAssertEqual(manifest.testSuites[0].dependsOn, [])
-        XCTAssertEqual(manifest.testSuites[1].dependsOn, ["test_build.sh"])
-        XCTAssertEqual(manifest.testSuites[2].dependsOn, ["test_build.sh"])
+        #expect(manifest.testSuites.count == 3)
+        #expect(manifest.testSuites[0].dependsOn == [])
+        #expect(manifest.testSuites[1].dependsOn == ["test_build.sh"])
+        #expect(manifest.testSuites[2].dependsOn == ["test_build.sh"])
 
         let reencoded = try encoder.encode(manifest)
         let redecoded = try decoder.decode(TestProperties.self, from: reencoded)
-        XCTAssertEqual(manifest, redecoded)
+        #expect(manifest == redecoded)
     }
 
     // MARK: - TestOutcomeCollection
 
-    func testTestOutcomeCollectionRoundTrip() throws {
+    @Test func testOutcomeCollectionRoundTrip() throws {
         let outcome = TestOutcome(
             testName: "test_foo",
             testClass: nil,
@@ -232,14 +223,14 @@ final class CoreModelTests: XCTestCase {
 
         let data = try encoder.encode(collection)
         let decoded = try decoder.decode(TestOutcomeCollection.self, from: data)
-        XCTAssertEqual(decoded.submissionID, "sub_001")
-        XCTAssertEqual(decoded.buildStatus, .passed)
-        XCTAssertEqual(decoded.outcomes.count, 1)
-        XCTAssertEqual(decoded.outcomes[0].testName, "test_foo")
-        XCTAssertTrue(decoded.outcomes[0].isFirstPassSuccess)
+        #expect(decoded.submissionID == "sub_001")
+        #expect(decoded.buildStatus == .passed)
+        #expect(decoded.outcomes.count == 1)
+        #expect(decoded.outcomes[0].testName == "test_foo")
+        #expect(decoded.outcomes[0].isFirstPassSuccess)
     }
 
-    func testFailedCollectionHasNoOutcomes() throws {
+    @Test func failedCollectionHasNoOutcomes() throws {
         let collection = TestOutcomeCollection(
             submissionID: "sub_002",
             testSetupID: "setup_001",
@@ -259,8 +250,8 @@ final class CoreModelTests: XCTestCase {
 
         let data = try encoder.encode(collection)
         let decoded = try decoder.decode(TestOutcomeCollection.self, from: data)
-        XCTAssertEqual(decoded.buildStatus, .failed)
-        XCTAssertTrue(decoded.outcomes.isEmpty)
-        XCTAssertEqual(decoded.compilerOutput, "Script not found: test_foo.sh")
+        #expect(decoded.buildStatus == .failed)
+        #expect(decoded.outcomes.isEmpty)
+        #expect(decoded.compilerOutput == "Script not found: test_foo.sh")
     }
 }

--- a/Tests/CoreTests/NotebookFunctionScannerTests.swift
+++ b/Tests/CoreTests/NotebookFunctionScannerTests.swift
@@ -2,10 +2,11 @@
 //
 // Unit tests for NotebookFunctionScanner.
 
-import XCTest
+import Testing
+import Foundation
 @testable import Core
 
-final class NotebookFunctionScannerTests: XCTestCase {
+struct NotebookFunctionScannerTests {
 
     // MARK: - Helpers
 
@@ -60,116 +61,114 @@ final class NotebookFunctionScannerTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testEmptyNotebook() {
+    @Test func emptyNotebook() {
         let nb = Data("""
         {"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}
         """.utf8)
-        let fns = scanNotebookForFunctions(nb)
-        XCTAssertTrue(fns.isEmpty)
+        #expect(scanNotebookForFunctions(nb).isEmpty)
     }
 
-    func testInvalidJSON() {
-        let fns = scanNotebookForFunctions(Data("not json".utf8))
-        XCTAssertTrue(fns.isEmpty)
+    @Test func invalidJSON() {
+        #expect(scanNotebookForFunctions(Data("not json".utf8)).isEmpty)
     }
 
-    func testSingleSimpleFunction() {
+    @Test func singleSimpleFunction() {
         let nb = notebook(code: "def foo(a, b):\n    return a + b\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].name, "foo")
-        XCTAssertEqual(fns[0].paramNames, ["a", "b"])
-        XCTAssertFalse(fns[0].hasTypeHints)
-        XCTAssertFalse(fns[0].hasDocstring)
+        #expect(fns.count == 1)
+        #expect(fns[0].name == "foo")
+        #expect(fns[0].paramNames == ["a", "b"])
+        #expect(!fns[0].hasTypeHints)
+        #expect(!fns[0].hasDocstring)
     }
 
-    func testFunctionWithTypeHints() {
+    @Test func functionWithTypeHints() {
         let nb = notebook(code: "def bar(x: int, y: str) -> bool:\n    return True\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].name, "bar")
-        XCTAssertEqual(fns[0].paramNames, ["x", "y"])
-        XCTAssertTrue(fns[0].hasTypeHints)
+        #expect(fns.count == 1)
+        #expect(fns[0].name == "bar")
+        #expect(fns[0].paramNames == ["x", "y"])
+        #expect(fns[0].hasTypeHints)
     }
 
-    func testFunctionWithReturnTypeHintOnly() {
+    @Test func functionWithReturnTypeHintOnly() {
         let nb = notebook(code: "def baz(n) -> list:\n    return []\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertTrue(fns[0].hasTypeHints)
+        #expect(fns.count == 1)
+        #expect(fns[0].hasTypeHints)
     }
 
-    func testFunctionWithDocstring() {
+    @Test func functionWithDocstring() {
         let nb = notebook(code: "def greet(name):\n    \"\"\"Greet someone.\"\"\"\n    return 'Hi ' + name\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertTrue(fns[0].hasDocstring)
+        #expect(fns.count == 1)
+        #expect(fns[0].hasDocstring)
     }
 
-    func testPrivateFunctionExcluded() {
+    @Test func privateFunctionExcluded() {
         let nb = notebook(code: "def _helper(x):\n    pass\ndef public_fn(x):\n    pass\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].name, "public_fn")
+        #expect(fns.count == 1)
+        #expect(fns[0].name == "public_fn")
     }
 
-    func testSelfAndClsExcluded() {
+    @Test func selfAndClsExcluded() {
         let nb = notebook(code: "def method(self, x, y):\n    pass\n")
         // Top-level def with self — unusual but the scanner just strips self
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].paramNames, ["x", "y"])
+        #expect(fns.count == 1)
+        #expect(fns[0].paramNames == ["x", "y"])
     }
 
-    func testNoParameters() {
+    @Test func noParameters() {
         let nb = notebook(code: "def get_count():\n    return 0\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].paramNames, [])
+        #expect(fns.count == 1)
+        #expect(fns[0].paramNames == [])
     }
 
-    func testVarargsExcluded() {
+    @Test func varargsExcluded() {
         let nb = notebook(code: "def variadic(a, *args, **kwargs):\n    pass\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].paramNames, ["a"])
+        #expect(fns.count == 1)
+        #expect(fns[0].paramNames == ["a"])
     }
 
-    func testDefaultValueStripped() {
+    @Test func defaultValueStripped() {
         let nb = notebook(code: "def increment(n, step=1):\n    return n + step\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].paramNames, ["n", "step"])
+        #expect(fns.count == 1)
+        #expect(fns[0].paramNames == ["n", "step"])
     }
 
-    func testMultipleFunctionsInOneCell() {
+    @Test func multipleFunctionsInOneCell() {
         let nb = notebook(code: "def add(a, b):\n    return a + b\n\ndef subtract(a, b):\n    return a - b\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 2)
-        XCTAssertEqual(fns[0].name, "add")
-        XCTAssertEqual(fns[1].name, "subtract")
+        #expect(fns.count == 2)
+        #expect(fns[0].name == "add")
+        #expect(fns[1].name == "subtract")
     }
 
-    func testFunctionsAcrossMultipleCells() {
+    @Test func functionsAcrossMultipleCells() {
         let nb = notebook(cells: [
             "def foo(x):\n    return x\n",
             "x = 1  # not a function",
             "def bar(y):\n    return y\n"
         ])
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.count, 2)
-        XCTAssertEqual(fns[0].name, "foo")
-        XCTAssertEqual(fns[1].name, "bar")
+        #expect(fns.count == 2)
+        #expect(fns[0].name == "foo")
+        #expect(fns[1].name == "bar")
     }
 
-    func testIndentedFunctionNotTopLevel() {
+    @Test func indentedFunctionNotTopLevel() {
         // Class methods or nested functions — indented, not top-level.
         let nb = notebook(code: "class MyClass:\n    def method(self, x):\n        pass\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertTrue(fns.isEmpty, "Indented method should not be treated as top-level")
+        #expect(fns.isEmpty, "Indented method should not be treated as top-level")
     }
 
-    func testMarkdownCellIgnored() {
+    @Test func markdownCellIgnored() {
         let json = """
         {
           "cells": [
@@ -184,17 +183,16 @@ final class NotebookFunctionScannerTests: XCTestCase {
           "nbformat_minor": 5
         }
         """
-        let fns = scanNotebookForFunctions(Data(json.utf8))
-        XCTAssertTrue(fns.isEmpty)
+        #expect(scanNotebookForFunctions(Data(json.utf8)).isEmpty)
     }
 
-    func testParamCount() {
+    @Test func paramCount() {
         let nb = notebook(code: "def triple(a, b, c):\n    pass\n")
         let fns = scanNotebookForFunctions(nb)
-        XCTAssertEqual(fns.first?.paramCount, 3)
+        #expect(fns.first?.paramCount == 3)
     }
 
-    func testSourceAsArrayOfLines() {
+    @Test func sourceAsArrayOfLines() {
         // JupyterLite stores source as an array of strings, one per line.
         let json = """
         {
@@ -211,7 +209,7 @@ final class NotebookFunctionScannerTests: XCTestCase {
         }
         """
         let fns = scanNotebookForFunctions(Data(json.utf8))
-        XCTAssertEqual(fns.count, 1)
-        XCTAssertEqual(fns[0].name, "greet")
+        #expect(fns.count == 1)
+        #expect(fns[0].name == "greet")
     }
 }

--- a/Tests/WorkerTests/ScriptInvocationTests.swift
+++ b/Tests/WorkerTests/ScriptInvocationTests.swift
@@ -4,21 +4,22 @@
 // interpreter is selected for each file extension, shebang line, and
 // Python-heuristic fallback.
 
-import XCTest
+import Testing
 @testable import chickadee_runner
 import Foundation
 
-final class ScriptInvocationTests: XCTestCase {
+// final class so deinit can remove the per-test temp directory.
+final class ScriptInvocationTests {
 
-    private var tmpDir: URL!
+    private let tmpDir: URL
 
-    override func setUp() async throws {
+    init() throws {
         tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("script-inv-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
     }
 
-    override func tearDown() async throws {
+    deinit {
         try? FileManager.default.removeItem(at: tmpDir)
     }
 
@@ -30,117 +31,76 @@ final class ScriptInvocationTests: XCTestCase {
         return url
     }
 
-    // MARK: - Extension-based dispatch
+    // MARK: - Extension-based dispatch: env-wrapper interpreters
 
-    func testShExtension_usesSh() {
+    @Test(arguments: zip(
+        ["test.bash", "test.zsh", "test.rb", "test.pl", "test.js"],
+        ["bash",      "zsh",      "ruby",    "perl",    "node"]
+    ))
+    func extensionUsesEnvWrapper(filename: String, interpreter: String) {
+        let inv = scriptInvocation(for: makeScript(name: filename))
+        #expect(inv.executableURL.path.hasSuffix("env"))
+        #expect(inv.arguments.first == interpreter)
+    }
+
+    // .sh is a direct /bin/sh invocation, not an env wrapper.
+    @Test func shExtensionUsesSh() {
         let script = makeScript(name: "test.sh")
         let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.executableURL.path, "/bin/sh")
-        XCTAssertEqual(inv.arguments, [script.path])
+        #expect(inv.executableURL.path == "/bin/sh")
+        #expect(inv.arguments == [script.path])
     }
 
-    func testBashExtension_usesBash() {
-        let script = makeScript(name: "test.bash")
-        let inv = scriptInvocation(for: script)
-        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"),
-                      "Expected env wrapper, got \(inv.executableURL.path)")
-        XCTAssertEqual(inv.arguments.first, "bash")
-    }
-
-    func testZshExtension_usesZsh() {
-        let script = makeScript(name: "test.zsh")
-        let inv = scriptInvocation(for: script)
-        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
-        XCTAssertEqual(inv.arguments.first, "zsh")
-    }
-
-    func testPyExtension_usesPython3() {
+    // .py passes a bootstrap via -c and appends the script path last.
+    @Test func pyExtensionUsesPython3() {
         let script = makeScript(name: "test.py")
         let inv = scriptInvocation(for: script)
-        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
-        XCTAssertEqual(inv.arguments.first, "python3")
-        // Python invocation uses -c <bootstrap> <script>
-        XCTAssertTrue(inv.arguments.contains("-c"),
-                      "Python invocation should pass bootstrap via -c")
-        XCTAssertTrue(inv.arguments.last == script.path,
-                      "Script path should be last argument")
-    }
-
-    func testRbExtension_usesRuby() {
-        let script = makeScript(name: "test.rb")
-        let inv = scriptInvocation(for: script)
-        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
-        XCTAssertEqual(inv.arguments.first, "ruby")
-    }
-
-    func testPlExtension_usesPe() {
-        let script = makeScript(name: "test.pl")
-        let inv = scriptInvocation(for: script)
-        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
-        XCTAssertEqual(inv.arguments.first, "perl")
-    }
-
-    func testJsExtension_usesNode() {
-        let script = makeScript(name: "test.js")
-        let inv = scriptInvocation(for: script)
-        XCTAssertTrue(inv.executableURL.path.hasSuffix("env"))
-        XCTAssertEqual(inv.arguments.first, "node")
+        #expect(inv.executableURL.path.hasSuffix("env"))
+        #expect(inv.arguments.first == "python3")
+        #expect(inv.arguments.contains("-c"), "Python invocation should pass bootstrap via -c")
+        #expect(inv.arguments.last == script.path, "Script path should be last argument")
     }
 
     // MARK: - Shebang dispatch (extensionless files)
 
-    func testShebangPython_usesPython3() {
+    @Test(arguments: zip(
+        ["#!/bin/bash\necho hi",               "#!/usr/bin/env node\nconsole.log('hi')", "#!/usr/bin/env ruby\nputs 'hi'"],
+        ["bash",                               "node",                                    "ruby"]
+    ))
+    func shebangUsesEnvWrapper(content: String, interpreter: String) {
+        let inv = scriptInvocation(for: makeScript(name: "test_script", content: content))
+        #expect(inv.arguments.first == interpreter)
+    }
+
+    @Test func shebangPythonUsesPython3() {
         let script = makeScript(name: "test_nopy", content: "#!/usr/bin/env python3\nprint('hi')")
         let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.arguments.first, "python3")
-        XCTAssertTrue(inv.arguments.contains("-c"))
+        #expect(inv.arguments.first == "python3")
+        #expect(inv.arguments.contains("-c"))
     }
 
-    func testShebangBash_usesBash() {
-        let script = makeScript(name: "test_nobash", content: "#!/bin/bash\necho hi")
-        let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.arguments.first, "bash")
-    }
-
-    func testShebangSh_usesSh() {
+    @Test func shebangShUsesSh() {
         let script = makeScript(name: "test_nosh", content: "#!/bin/sh\necho hi")
         let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.executableURL.path, "/bin/sh")
-    }
-
-    func testShebangNode_usesNode() {
-        let script = makeScript(name: "test_nojs", content: "#!/usr/bin/env node\nconsole.log('hi')")
-        let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.arguments.first, "node")
-    }
-
-    func testShebangRuby_usesRuby() {
-        let script = makeScript(name: "test_norb", content: "#!/usr/bin/env ruby\nputs 'hi'")
-        let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.arguments.first, "ruby")
+        #expect(inv.executableURL.path == "/bin/sh")
     }
 
     // MARK: - Python heuristic (no extension, no shebang)
 
-    func testPythonImport_heuristicDetectsPython() {
-        let script = makeScript(name: "test_heuristic", content: "import os\nprint(os.getcwd())")
-        let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.arguments.first, "python3",
-                       "Script starting with 'import' should be detected as Python")
-    }
-
-    func testPythonDef_heuristicDetectsPython() {
-        let script = makeScript(name: "test_heuristic2", content: "def foo():\n    pass\n\nfoo()")
-        let inv = scriptInvocation(for: script)
-        XCTAssertEqual(inv.arguments.first, "python3")
+    @Test(arguments: [
+        "import os\nprint(os.getcwd())",
+        "def foo():\n    pass\n\nfoo()"
+    ])
+    func pythonHeuristic(content: String) {
+        let inv = scriptInvocation(for: makeScript(name: "test_heuristic", content: content))
+        #expect(inv.arguments.first == "python3", "Script starting with 'import' or 'def' should be detected as Python")
     }
 
     // MARK: - Fallback
 
-    func testUnknownExtension_fallsBackToSh() {
+    @Test func unknownExtensionFallsBackToSh() {
         let script = makeScript(name: "test.unknown", content: "echo hi")
         let inv = scriptInvocation(for: script)
-        // Non-executable file with unknown extension should fall back to /bin/sh
-        XCTAssertEqual(inv.executableURL.path, "/bin/sh")
+        #expect(inv.executableURL.path == "/bin/sh")
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `XCTestCase` + `XCTAssert*` with `@Test` + `#expect` in the two test targets that have no XCTVapor dependency (`CoreTests`, `WorkerTests/ScriptInvocationTests`)
- `APITests` stays on XCTest — XCTVapor has no Swift Testing equivalent yet
- Net: −51 lines (more signal, less boilerplate)

## Key changes

**Parameterized tests** replace hand-rolled loops:
- `testStatusRoundTrip` → 4 individually-reported cases (`pass`, `fail`, `error`, `timeout`)
- `testTierRoundTrip` / `testTierRawValue` → 3 cases each
- `gradingModeRoundTrip` / `gradingModeExplicit` → 2 cases each
- `extensionUsesEnvWrapper` → 5 cases (bash, zsh, ruby, perl, js)
- `shebangUsesEnvWrapper` → 3 cases
- `pythonHeuristic` → 2 cases

**Type shape** matches Swift Testing idioms:
- `CoreModelTests` and `NotebookFunctionScannerTests` → `struct` (no lifecycle)
- `ScriptInvocationTests` → `final class` with `init()`/`deinit` for per-test `tmpDir` cleanup

## What was left alone

`APITests` (42 files) remain on XCTest. They depend on `XCTVapor`, which is built on XCTest and has no Swift Testing port yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)