### PR TITLE
Release 0.4.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.4.16] - 2026-03-28
+
+### Fixed
+
+- **Notebook/browser result labels and output formatting**: in-browser notebook grading now keeps each script's saved human-readable display name separate from its result summary, so the `Test` column shows the configured label, the `Output` column shows the actual error summary, and `Show output` displays the extracted traceback instead of the raw structured JSON blob.
+- **Notebook result cache busting**: the notebook page now references refreshed static asset versions so deployed browsers pick up the latest `notebook.js` and `browser-runner.js` formatting fixes immediately after upgrade.
+
 ## [0.4.15] - 2026-03-28
 
 ### Fixed

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -225,6 +225,10 @@ for _module_name in student_module_names_in_load_order():
                         null, 0);
                 }
 
+                outcome.scriptName = script;
+                outcome.displayName = (typeof entry.name === 'string' && entry.name.trim())
+                    ? entry.name.trim()
+                    : null;
                 outcomes.push(outcome);
                 if (outcome.status === 'pass') passedScripts.add(script);
             }
@@ -379,6 +383,7 @@ sys.stderr = sys.__stderr__
         let status      = 'pass';
         let shortResult = 'passed';
         let longResult  = null;
+        let parsedPayload = null;
 
         // Determine status: prefer the Python-side exit code (caught SystemExit),
         // fall back to JS-side pyErr if the wrapper itself threw.
@@ -399,8 +404,12 @@ sys.stderr = sys.__stderr__
         // Prefer the JSON result the script printed (same protocol as native runner).
         if (lastLine) {
             try {
-                const parsed = JSON.parse(lastLine);
-                shortResult = parsed.shortResult || (status === 'pass' ? 'passed' : status);
+                parsedPayload = JSON.parse(lastLine);
+                if (typeof parsedPayload.status === 'string' && parsedPayload.status.trim()) {
+                    status = parsedPayload.status.trim();
+                }
+                shortResult = structuredSummaryText(parsedPayload, status)
+                    || (status === 'pass' ? 'passed' : status);
             } catch (_) {
                 shortResult = lastLine;
             }
@@ -409,15 +418,14 @@ sys.stderr = sys.__stderr__
         }
 
         if (status !== 'pass') {
-            const parts      = [];
             const stdoutTrim = (stdout || '').trim();
             const stderrTrim = (stderr || '').trim();
-            if (stdoutTrim) parts.push(`stdout:\n${stdoutTrim}`);
-            if (stderrTrim) parts.push(`stderr:\n${stderrTrim}`);
-            if (pyErr && !String(pyErr.message || '').includes('SystemExit')) {
-                parts.push(`exception:\n${pyErr.message || pyErr}`);
-            }
-            if (parts.length) longResult = parts.join('\n\n');
+            longResult = detailedOutputFromParts({
+                parsedPayload,
+                stdout: stdoutTrim,
+                stderr: stderrTrim,
+                pyErr,
+            });
         } else if ((stderr || '').trim()) {
             // For passing tests, only include stderr if it has real content
             // (not just SystemExit tracebacks).
@@ -472,6 +480,88 @@ sys.stderr = sys.__stderr__
             runnerVersion:   'browser-wasm-runner/1.0',
             timestamp:       new Date().toISOString(),
         };
+    }
+
+    function structuredSummaryText(payload, status) {
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+
+        if (status !== 'pass') {
+            for (const key of ['error', 'message', 'detail', 'reason']) {
+                const text = trimmedString(payload[key]);
+                if (text) return text;
+            }
+        }
+
+        const shortResult = trimmedString(payload.shortResult);
+        if (shortResult) {
+            const testLabel = trimmedString(payload.test);
+            return stripLeadingLabel(shortResult, testLabel) || shortResult;
+        }
+
+        return trimmedString(payload.status) || null;
+    }
+
+    function detailedOutputFromParts({ parsedPayload, stdout, stderr, pyErr }) {
+        const traceback = extractTracebackText(parsedPayload)
+            || extractTracebackText(stdout)
+            || extractTracebackText(stderr);
+        if (traceback) return traceback;
+
+        const exceptionText = pyErr && !String(pyErr.message || '').includes('SystemExit')
+            ? trimmedString(pyErr.message || String(pyErr))
+            : null;
+        return stderr || stdout || exceptionText || null;
+    }
+
+    function extractTracebackText(value) {
+        if (!value) return null;
+        if (typeof value === 'object' && !Array.isArray(value)) {
+            return trimmedString(value.traceback) || null;
+        }
+
+        const text = trimmedString(value);
+        if (!text) return null;
+
+        const structured = parseStructuredPayload(text);
+        if (structured) {
+            const traceback = extractTracebackText(structured);
+            if (traceback) return traceback;
+        }
+
+        const marker = text.indexOf('Traceback (most recent call last):');
+        return marker >= 0 ? text.slice(marker).trim() : null;
+    }
+
+    function parseStructuredPayload(text) {
+        const trimmed = trimmedString(text);
+        if (!trimmed) return null;
+
+        const candidates = [trimmed];
+        const stdoutMatch = trimmed.match(/(?:^|\n)stdout:\n([\s\S]*?)(?:\n\nstderr:\n|$)/);
+        if (stdoutMatch && stdoutMatch[1]) candidates.unshift(stdoutMatch[1].trim());
+        const stderrMatch = trimmed.match(/(?:^|\n)stderr:\n([\s\S]*)$/);
+        if (stderrMatch && stderrMatch[1]) candidates.push(stderrMatch[1].trim());
+
+        for (const candidate of candidates) {
+            try {
+                return JSON.parse(candidate);
+            } catch (_) {
+                // Try the next candidate shape.
+            }
+        }
+        return null;
+    }
+
+    function stripLeadingLabel(text, label) {
+        const trimmedText = trimmedString(text);
+        const trimmedLabel = trimmedString(label);
+        if (!trimmedText || !trimmedLabel) return null;
+        const prefix = `${trimmedLabel}: `;
+        return trimmedText.startsWith(prefix) ? trimmedText.slice(prefix.length).trim() : null;
+    }
+
+    function trimmedString(value) {
+        return typeof value === 'string' ? value.trim() : '';
     }
 
     // -------------------------------------------------------------------------
@@ -827,6 +917,10 @@ for _module_name in _tr.student_module_names_in_load_order():
             runPyScript,
             buildCollection,
             makeOutcome,
+            structuredSummaryText,
+            detailedOutputFromParts,
+            extractTracebackText,
+            parseStructuredPayload,
             removeRecursive,
             fetchBytes,
             fetchText,

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -723,6 +723,7 @@ else:
 
     function renderResults(outcomes, response) {
         if (!resultsEl) return;
+        const displayNameMap = buildOutcomeDisplayNameMap(outcomes);
 
         const pass    = outcomes.filter(o => o.status === 'pass').length;
         const fail    = outcomes.filter(o => o.status === 'fail').length;
@@ -758,9 +759,13 @@ else:
             const isSkipped  = !!skipMatch;
             const blockerRaw = isSkipped ? skipMatch[1] : null;
             // Strip file extension: "test_build.py" → "test_build"
-            const blockerName = blockerRaw
+            const blockerKey = blockerRaw
                 ? (blockerRaw.includes('.') ? blockerRaw.replace(/\.[^.]+$/, '') : blockerRaw)
                 : null;
+            const blockerName = blockerKey ? (displayNameMap.get(blockerKey) || blockerKey) : null;
+            const displayName = bestOutcomeDisplayName(o);
+            const shortResult = formattedOutcomeShortResult(o);
+            const longResult = formattedOutcomeDetailedOutput(o);
 
             const tr = document.createElement('tr');
             tr.className = isSkipped ? 'status-skipped' : `status-${o.status}`;
@@ -787,16 +792,16 @@ else:
             // Output cell
             let outputHtml;
             if (isSkipped) {
-                outputHtml = `<span class="skip-reason">${escHtml(o.shortResult)}</span>`;
+                outputHtml = `<span class="skip-reason">${escHtml(shortResult)}</span>`;
             } else {
-                const longHtml = o.longResult
-                    ? `<details><summary>Show output ▸</summary><pre>${escHtml(o.longResult)}</pre></details>`
+                const longHtml = longResult
+                    ? `<details><summary>Show output ▸</summary><pre>${escHtml(longResult)}</pre></details>`
                     : '';
-                outputHtml = escHtml(o.shortResult) + longHtml;
+                outputHtml = escHtml(shortResult) + longHtml;
             }
 
             tr.innerHTML = `
-                <td><code>${escHtml(o.testName)}</code>${blockerHtml}</td>
+                <td><code>${escHtml(displayName)}</code>${blockerHtml}</td>
                 <td><span class="tier">${escHtml(o.tier)}</span></td>
                 <td>${outputHtml}</td>
                 <td><span class="result-mark result-mark-${markClass}">${escHtml(markLabel)}</span></td>`;
@@ -819,6 +824,127 @@ else:
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;');
+    }
+
+    function buildOutcomeDisplayNameMap(outcomes) {
+        const map = new Map();
+        for (const outcome of outcomes || []) {
+            const displayName = bestOutcomeDisplayName(outcome);
+            const keys = [outcome && outcome.scriptName, outcome && outcome.testName];
+            for (const key of keys) {
+                if (typeof key === 'string' && key.trim()) {
+                    map.set(key.trim(), displayName);
+                    const stem = key.replace(/\.[^.]+$/, '').trim();
+                    if (stem) map.set(stem, displayName);
+                }
+            }
+        }
+        return map;
+    }
+
+    function bestOutcomeDisplayName(outcome) {
+        const explicit = trimmedString(outcome && outcome.displayName);
+        if (explicit) return explicit;
+        const testName = trimmedString(outcome && outcome.testName);
+        if (testName) return testName;
+        return trimmedString(outcome && outcome.scriptName) || 'test';
+    }
+
+    function formattedOutcomeShortResult(outcome) {
+        const shortResult = trimmedString(outcome && outcome.shortResult);
+        const parsed = parseStructuredPayload(shortResult)
+            || parseStructuredPayload(trimmedString(outcome && outcome.longResult));
+        if (parsed) {
+            const summary = structuredSummaryText(parsed, outcome && outcome.status);
+            if (summary) return summary;
+        }
+        return shortResult || defaultShortResult(outcome && outcome.status);
+    }
+
+    function formattedOutcomeDetailedOutput(outcome) {
+        const longResult = trimmedString(outcome && outcome.longResult);
+        const shortResult = trimmedString(outcome && outcome.shortResult);
+        const parsed = parseStructuredPayload(longResult) || parseStructuredPayload(shortResult);
+        const traceback = extractTracebackText(parsed)
+            || extractTracebackText(longResult)
+            || extractTracebackText(shortResult);
+        if (traceback) return traceback;
+        return longResult || null;
+    }
+
+    function structuredSummaryText(payload, status) {
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+
+        if (status && status !== 'pass') {
+            for (const key of ['error', 'message', 'detail', 'reason']) {
+                const text = trimmedString(payload[key]);
+                if (text) return text;
+            }
+        }
+
+        const shortResult = trimmedString(payload.shortResult);
+        if (shortResult) {
+            const label = trimmedString(payload.test);
+            return stripLeadingLabel(shortResult, label) || shortResult;
+        }
+
+        return trimmedString(payload.status) || null;
+    }
+
+    function extractTracebackText(value) {
+        if (!value) return null;
+        if (typeof value === 'object' && !Array.isArray(value)) {
+            return trimmedString(value.traceback) || null;
+        }
+
+        const text = trimmedString(value);
+        if (!text) return null;
+        const parsed = parseStructuredPayload(text);
+        if (parsed) {
+            const traceback = extractTracebackText(parsed);
+            if (traceback) return traceback;
+        }
+        const marker = text.indexOf('Traceback (most recent call last):');
+        return marker >= 0 ? text.slice(marker).trim() : null;
+    }
+
+    function parseStructuredPayload(text) {
+        const trimmed = trimmedString(text);
+        if (!trimmed) return null;
+
+        const candidates = [trimmed];
+        const stdoutMatch = trimmed.match(/(?:^|\n)stdout:\n([\s\S]*?)(?:\n\nstderr:\n|$)/);
+        if (stdoutMatch && stdoutMatch[1]) candidates.unshift(stdoutMatch[1].trim());
+        const stderrMatch = trimmed.match(/(?:^|\n)stderr:\n([\s\S]*)$/);
+        if (stderrMatch && stderrMatch[1]) candidates.push(stderrMatch[1].trim());
+
+        for (const candidate of candidates) {
+            try {
+                return JSON.parse(candidate);
+            } catch (_) {
+                // Try the next shape.
+            }
+        }
+        return null;
+    }
+
+    function stripLeadingLabel(text, label) {
+        const trimmedText = trimmedString(text);
+        const trimmedLabel = trimmedString(label);
+        if (!trimmedText || !trimmedLabel) return null;
+        const prefix = `${trimmedLabel}: `;
+        return trimmedText.startsWith(prefix) ? trimmedText.slice(prefix.length).trim() : null;
+    }
+
+    function trimmedString(value) {
+        return typeof value === 'string' ? value.trim() : '';
+    }
+
+    function defaultShortResult(status) {
+        if (status === 'pass') return 'passed';
+        if (status === 'fail') return 'failed';
+        if (status === 'timeout') return 'timed out';
+        return 'error';
     }
 
     // -------------------------------------------------------------------------
@@ -851,5 +977,18 @@ else:
 
     function delay(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    const testHooks = globalThis.__CHICKADEE_NOTEBOOK_TEST_HOOKS__;
+    if (testHooks) {
+        testHooks.exports = {
+            buildOutcomeDisplayNameMap,
+            bestOutcomeDisplayName,
+            formattedOutcomeShortResult,
+            formattedOutcomeDetailedOutput,
+            structuredSummaryText,
+            extractTracebackText,
+            parseStructuredPayload,
+        };
     }
 })();

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -9,7 +9,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png">
     <link rel="shortcut icon" href="/favicon.png" type="image/png">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
-    <link rel="stylesheet" href="/styles.css?v=0.4.15">
+    <link rel="stylesheet" href="/styles.css?v=0.4.16">
 </head>
 <body>
 <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -61,7 +61,7 @@
 <main class="main" id="main-content">
     #import("content")
 </main>
-<script src="/app.js?v=0.4.15"></script>
+<script src="/app.js?v=0.4.16"></script>
 <script>
 // All multipart/form-data uploads bypass the hidden _csrf body field because
 // the body stream is not collected before CSRF middleware runs.  Intercept

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -38,7 +38,7 @@ Notebook
 </p>
 <div id="nb-results" class="nb-results" hidden></div>
 <div id="browser-runner-status" class="nb-status" role="status" aria-live="polite" aria-atomic="true" hidden></div>
-<script src="/notebook.js?v=0.4.15"></script>
-<script src="/browser-runner.js?v=0.4.15" data-setup-id="#(testSetupID)" data-grading-mode="#(gradingMode)"></script>
+<script src="/notebook.js?v=0.4.16"></script>
+<script src="/browser-runner.js?v=0.4.16" data-setup-id="#(testSetupID)" data-grading-mode="#(gradingMode)"></script>
 #endexport
 #endextend

--- a/Sources/Core/ChickadeeVersion.swift
+++ b/Sources/Core/ChickadeeVersion.swift
@@ -1,3 +1,3 @@
 public enum ChickadeeVersion {
-    public static let current = "0.4.15"
+    public static let current = "0.4.16"
 }

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -500,6 +500,58 @@ test('timeouts and unsupported script types are surfaced in outcomes', async () 
   assert.match(result.outcomes[2].shortResult, /WebR/);
 });
 
+test('browser runner keeps display names separate from output and extracts traceback-only details', async () => {
+  const harness = await loadRunnerHarness({
+    zipFiles: {
+      'test_q1_bmi.py': '# q1\n',
+    },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 5,
+      testSuites: [
+        { script: 'test_q1_bmi.py', tier: 'public', name: 'Q1: BMI Calculation' },
+      ],
+    },
+    scriptBehaviors: {
+      'test_q1_bmi.py': {
+        stdout: `${JSON.stringify({
+          shortResult: 'Q1: BMI Calculation: Could not test calculate_bmi',
+          status: 'error',
+          test: 'Q1: BMI Calculation',
+          error: 'Could not test calculate_bmi',
+          exception: "NotImplementedError('Implement calculate_bmi')",
+          traceback: 'Traceback (most recent call last):\n  File "test_q1_bmi.py", line 12, in <module>\n    result = fn(*args)\nNotImplementedError: Implement calculate_bmi\n',
+        })}\n`,
+        stderr: '',
+        exitCode: 2,
+      },
+    },
+  });
+
+  const result = await harness.window.BrowserRunner.runAndSubmit(
+    new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+    'setup_q1',
+  );
+
+  assert.deepEqual(
+    plain(result.outcomes[0]),
+    {
+      testName: 'test_q1_bmi',
+      testClass: null,
+      tier: 'public',
+      status: 'error',
+      shortResult: 'Could not test calculate_bmi',
+      longResult: 'Traceback (most recent call last):\n  File "test_q1_bmi.py", line 12, in <module>\n    result = fn(*args)\nNotImplementedError: Implement calculate_bmi',
+      executionTimeMs: result.outcomes[0].executionTimeMs,
+      memoryUsageBytes: null,
+      attemptNumber: 1,
+      isFirstPassSuccess: false,
+      scriptName: 'test_q1_bmi.py',
+      displayName: 'Q1: BMI Calculation',
+    },
+  );
+});
+
 test('manifest and setup download failures bubble up with browser-runner context', async () => {
   const manifestHarness = await loadRunnerHarness({
     zipFiles: {},

--- a/Tests/BrowserRunnerJSTests/notebook.test.mjs
+++ b/Tests/BrowserRunnerJSTests/notebook.test.mjs
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const notebookSource = await fs.readFile(
+  path.resolve('Public/notebook.js'),
+  'utf8',
+);
+
+async function loadNotebookHarness() {
+  const hooks = {};
+  const elements = new Map();
+
+  const frame = {
+    dataset: {
+      setupId: 'setup_123',
+      gradingMode: 'browser',
+      notebookUrl: '/api/v1/testsetups/setup_123/assignment',
+      editorUrl: '/jupyterlite/notebooks/index.html?path=assignment.ipynb',
+    },
+    addEventListener() {},
+    getAttribute(name) {
+      return name === 'src' ? this.dataset.editorUrl : null;
+    },
+    contentWindow: null,
+    contentDocument: null,
+    src: '',
+  };
+
+  elements.set('jl-frame', frame);
+  elements.set('nb-status', { textContent: '', className: '' });
+  elements.set('nb-results', { hidden: true, innerHTML: '', appendChild() {}, scrollIntoView() {} });
+  elements.set('nb-frame-error', { style: { display: 'none' } });
+
+  const document = {
+    getElementById(id) {
+      return elements.get(id) ?? null;
+    },
+    createElement() {
+      return {
+        className: '',
+        textContent: '',
+        innerHTML: '',
+        appendChild() {},
+      };
+    },
+    head: { appendChild() {} },
+  };
+
+  const fetch = async () => ({ ok: true, async json() { return { cells: [] }; } });
+
+  const context = {
+    console,
+    document,
+    fetch,
+    setTimeout,
+    clearTimeout,
+    setInterval: () => 1,
+    clearInterval: () => {},
+    URL,
+    JSON,
+    Error,
+    Promise,
+    window: { location: { origin: 'https://example.test' } },
+    __CHICKADEE_NOTEBOOK_TEST_HOOKS__: hooks,
+  };
+  context.globalThis = context;
+
+  vm.runInNewContext(notebookSource, context, { filename: 'notebook.js' });
+  return hooks.exports;
+}
+
+test('notebook formatting uses human-readable labels and traceback-only details', async () => {
+  const notebook = await loadNotebookHarness();
+  const outcome = {
+    testName: 'test_q1_bmi',
+    scriptName: 'test_q1_bmi.py',
+    displayName: 'Q1: BMI Calculation',
+    tier: 'public',
+    status: 'error',
+    shortResult: '{"shortResult":"Q1: BMI Calculation: Could not test calculate_bmi","status":"error","error":"Could not test calculate_bmi","traceback":"Traceback (most recent call last):\\n  File \\"test_q1_bmi.py\\", line 12, in <module>\\n    result = fn(*args)\\nNotImplementedError: Implement calculate_bmi\\n"}',
+    longResult: 'stdout:\n{"shortResult":"Q1: BMI Calculation: Could not test calculate_bmi","status":"error","error":"Could not test calculate_bmi","traceback":"Traceback (most recent call last):\\n  File \\"test_q1_bmi.py\\", line 12, in <module>\\n    result = fn(*args)\\nNotImplementedError: Implement calculate_bmi\\n"}',
+  };
+
+  assert.equal(notebook.bestOutcomeDisplayName(outcome), 'Q1: BMI Calculation');
+  assert.equal(notebook.formattedOutcomeShortResult(outcome), 'Could not test calculate_bmi');
+  assert.equal(
+    notebook.formattedOutcomeDetailedOutput(outcome),
+    'Traceback (most recent call last):\n  File "test_q1_bmi.py", line 12, in <module>\n    result = fn(*args)\nNotImplementedError: Implement calculate_bmi'
+  );
+
+  const displayMap = notebook.buildOutcomeDisplayNameMap([outcome]);
+  assert.equal(displayMap.get('test_q1_bmi'), 'Q1: BMI Calculation');
+  assert.equal(displayMap.get('test_q1_bmi.py'), 'Q1: BMI Calculation');
+});


### PR DESCRIPTION
## Summary
- fix the notebook/browser grading path so saved human-readable test labels appear in the `Test` column instead of raw filenames
- show actual error summaries in the notebook `Output` column instead of repeating the label
- extract traceback-only details for `Show output` instead of rendering raw structured JSON blobs
- bump static asset cache-busting and release version to `0.4.16`
- add JS regression coverage for both browser-runner payload shaping and notebook-side rendering helpers

## Validation
- `node --test Tests/BrowserRunnerJSTests/*.mjs`
