### PR TITLE
Auto-close assignments at deadline

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -148,6 +148,7 @@ func configure(_ app: Application, cliWorkerSecret: String?, authModeOverride: A
 
     try app.autoMigrate().wait()
     app.lifecycle.use(ObservabilityLifecycleHandler())
+    app.lifecycle.use(AssignmentDeadlineLifecycleHandler())
 
     if authMode != .local {
         if !nonSSOModesEnabled {

--- a/Sources/APIServer/Migrations/AddAssignmentDeadlineOverrideActive.swift
+++ b/Sources/APIServer/Migrations/AddAssignmentDeadlineOverrideActive.swift
@@ -1,0 +1,15 @@
+import Fluent
+
+struct AddAssignmentDeadlineOverrideActive: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignments")
+            .field("deadline_override_active", .bool)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("assignments")
+            .deleteField("deadline_override_active")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -39,6 +39,11 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
     @Field(key: "is_open")
     var isOpen: Bool
 
+    /// True when an instructor manually re-opened a past-due assignment.
+    /// Nil/false means normal deadline auto-close behavior applies.
+    @OptionalField(key: "deadline_override_active")
+    var deadlineOverrideActive: Bool?
+
     /// Instructor-defined ordering for dashboard display (lower first).
     @OptionalField(key: "sort_order")
     var sortOrder: Int?
@@ -73,6 +78,7 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
 
     init(id: UUID? = nil, publicID: String = APIAssignment.generatePublicID(), testSetupID: String, title: String,
          dueAt: Date? = nil, isOpen: Bool = true,
+         deadlineOverrideActive: Bool = false,
          sortOrder: Int? = nil,
          validationStatus: String? = nil,
          validationSubmissionID: String? = nil,
@@ -84,6 +90,7 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
         self.title       = title
         self.dueAt       = dueAt
         self.isOpen      = isOpen
+        self.deadlineOverrideActive = deadlineOverrideActive
         self.sortOrder   = sortOrder
         self.validationStatus = validationStatus
         self.validationSubmissionID = validationSubmissionID

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -36,6 +36,7 @@ struct BrowserResultRoutes: RouteCollection {
         }
 
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        _ = try await requireOpenStudentAssignment(for: body.testSetupID, on: req)
 
         // Decode the TestOutcomeCollection the browser sent.
         let decoder = JSONDecoder()
@@ -119,6 +120,7 @@ struct BrowserResultRoutes: RouteCollection {
         }
 
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        _ = try await requireOpenStudentAssignment(for: body.testSetupID, on: req)
 
         let manifestData = Data(setup.manifest.utf8)
         if let manifest = try? JSONDecoder().decode(TestProperties.self, from: manifestData),

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -97,6 +97,7 @@ func parseDueDate(_ raw: String?) -> Date? {
 
     let fmt = DateFormatter()
     fmt.locale = Locale(identifier: "en_US_POSIX")
+    fmt.timeZone = TimeZone(identifier: "America/Toronto")
     fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
     return fmt.date(from: raw)
 }
@@ -225,8 +226,25 @@ func dueAtLocalInputString(_ date: Date?) -> String {
     guard let date else { return "" }
     let fmt = DateFormatter()
     fmt.locale = Locale(identifier: "en_US_POSIX")
+    fmt.timeZone = TimeZone(identifier: "America/Toronto")
     fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
     return fmt.string(from: date)
+}
+
+func deadlineOverrideValueForInstructorOpen(
+    dueAt: Date?,
+    now: Date = Date()
+) -> Bool {
+    guard let dueAt else { return false }
+    return dueAt <= now
+}
+
+func normalizedDeadlineOverrideAfterDueDateChange(
+    dueAt: Date?,
+    existingOverride: Bool
+) -> Bool {
+    guard let dueAt else { return false }
+    return dueAt <= Date() ? existingOverride : false
 }
 
 func notebookFilenameForStorage(uploadedName: String?, fallback: String) -> String {

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
@@ -287,6 +287,10 @@ extension AssignmentRoutes {
 
         assignment.title = title
         assignment.dueAt = due
+        assignment.deadlineOverrideActive = normalizedDeadlineOverrideAfterDueDateChange(
+            dueAt: due,
+            existingOverride: assignment.deadlineOverrideActive ?? false
+        )
         assignment.isOpen = false
         assignment.validationStatus = "pending"
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -1243,6 +1243,7 @@ struct AssignmentRoutes: RouteCollection {
             throw Abort(.badRequest, reason: "Assignment cannot be opened until runner validation passes.")
         }
         assignment.isOpen = true
+        assignment.deadlineOverrideActive = deadlineOverrideValueForInstructorOpen(dueAt: assignment.dueAt)
         try await assignment.save(on: req.db)
         return req.redirect(to: "/instructor")
     }
@@ -1299,6 +1300,7 @@ struct AssignmentRoutes: RouteCollection {
                 throw Abort(.badRequest, reason: "Assignment cannot be opened until runner validation passes.")
             }
             assignment.isOpen = true
+            assignment.deadlineOverrideActive = deadlineOverrideValueForInstructorOpen(dueAt: assignment.dueAt)
         case "closed":
             assignment.isOpen = false
         default:

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -37,6 +37,8 @@ extension WebRoutes {
             throw Abort(.notFound)
         }
 
+        _ = try await requireOpenStudentAssignment(for: setupID, on: req)
+
         let body    = try req.content.decode(SubmitFormBody.self)
         let subsDir = req.application.submissionsDirectory
         let subID   = "sub_\(UUID().uuidString.lowercased().prefix(8))"

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -1,0 +1,171 @@
+import Fluent
+import Vapor
+import Foundation
+
+enum AssignmentSubmissionGateError: AbortError {
+    case unavailable
+    case closed
+
+    var status: HTTPResponseStatus {
+        switch self {
+        case .unavailable:
+            return .forbidden
+        case .closed:
+            return .forbidden
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case .unavailable:
+            return "This assignment is not available for student submissions."
+        case .closed:
+            return "This assignment is closed and no longer accepts submissions."
+        }
+    }
+}
+
+func assignmentDeadlineHasPassed(_ assignment: APIAssignment, now: Date = Date()) -> Bool {
+    guard let dueAt = assignment.dueAt else { return false }
+    return dueAt <= now
+}
+
+func assignmentDeadlineOverrideIsActive(_ assignment: APIAssignment) -> Bool {
+    assignment.deadlineOverrideActive ?? false
+}
+
+func isAssignmentEffectivelyOpen(_ assignment: APIAssignment, now: Date = Date()) -> Bool {
+    guard assignment.isOpen else { return false }
+    guard assignmentDeadlineHasPassed(assignment, now: now) else { return true }
+    return assignmentDeadlineOverrideIsActive(assignment)
+}
+
+@discardableResult
+func closeAssignmentIfExpired(
+    _ assignment: APIAssignment,
+    on db: Database,
+    logger: Logger,
+    now: Date = Date()
+) async throws -> Bool {
+    guard assignment.isOpen else { return false }
+    guard assignmentDeadlineHasPassed(assignment, now: now) else { return false }
+    guard !assignmentDeadlineOverrideIsActive(assignment) else { return false }
+
+    assignment.isOpen = false
+    try await assignment.save(on: db)
+    logger.info("Auto-closed assignment '\(assignment.title)' (\(assignment.publicID)) at deadline")
+    return true
+}
+
+@discardableResult
+func closeExpiredAssignments(
+    on db: Database,
+    logger: Logger,
+    now: Date = Date()
+) async throws -> Int {
+    let assignments = try await APIAssignment.query(on: db)
+        .filter(\.$isOpen == true)
+        .group(.or) { group in
+            group.filter(\.$deadlineOverrideActive == nil)
+            group.filter(\.$deadlineOverrideActive == false)
+        }
+        .filter(\.$dueAt <= now)
+        .all()
+
+    var closedCount = 0
+    for assignment in assignments {
+        if try await closeAssignmentIfExpired(assignment, on: db, logger: logger, now: now) {
+            closedCount += 1
+        }
+    }
+    return closedCount
+}
+
+func requireOpenStudentAssignment(
+    for testSetupID: String,
+    on req: Request,
+    now: Date = Date()
+) async throws -> APIAssignment {
+    guard let assignment = try await APIAssignment.query(on: req.db)
+        .filter(\.$testSetupID == testSetupID)
+        .first() else {
+        throw AssignmentSubmissionGateError.unavailable
+    }
+
+    _ = try await closeAssignmentIfExpired(assignment, on: req.db, logger: req.logger, now: now)
+    guard isAssignmentEffectivelyOpen(assignment, now: now) else {
+        throw AssignmentSubmissionGateError.closed
+    }
+    return assignment
+}
+
+final class AssignmentDeadlineMonitor: @unchecked Sendable {
+    private var task: Task<Void, Never>?
+    private let intervalNanoseconds: UInt64
+
+    init(interval: TimeInterval = 60) {
+        intervalNanoseconds = UInt64(max(interval, 1) * 1_000_000_000)
+    }
+
+    func start(application: Application) {
+        guard task == nil else { return }
+        task = Task {
+            while !Task.isCancelled {
+                do {
+                    _ = try await closeExpiredAssignments(
+                        on: application.db,
+                        logger: application.logger
+                    )
+                } catch {
+                    application.logger.error("Assignment deadline sweep failed: \(error.localizedDescription)")
+                }
+
+                do {
+                    try await Task.sleep(nanoseconds: intervalNanoseconds)
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+}
+
+struct AssignmentDeadlineMonitorKey: StorageKey {
+    typealias Value = AssignmentDeadlineMonitor
+}
+
+struct AssignmentDeadlineLifecycleHandler: LifecycleHandler {
+    func didBoot(_ application: Application) throws {
+        Task {
+            do {
+                _ = try await closeExpiredAssignments(on: application.db, logger: application.logger)
+            } catch {
+                application.logger.error("Initial assignment deadline sweep failed: \(error.localizedDescription)")
+            }
+        }
+        application.assignmentDeadlineMonitor.start(application: application)
+    }
+
+    func shutdown(_ application: Application) {
+        application.assignmentDeadlineMonitor.stop()
+    }
+}
+
+extension Application {
+    var assignmentDeadlineMonitor: AssignmentDeadlineMonitor {
+        get {
+            if let existing = storage[AssignmentDeadlineMonitorKey.self] { return existing }
+            let created = AssignmentDeadlineMonitor()
+            storage[AssignmentDeadlineMonitorKey.self] = created
+            return created
+        }
+        set {
+            storage[AssignmentDeadlineMonitorKey.self] = newValue
+        }
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -197,5 +197,6 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateRunnerProfiles())
     app.migrations.add(CreateAssignmentRequirements())
     app.migrations.add(AddSubmissionRetestedAt())
+    app.migrations.add(AddAssignmentDeadlineOverrideActive())
     app.migrations.add(SessionRecord.migration)
 }

--- a/Tests/APITests/AssignmentHelpersTests.swift
+++ b/Tests/APITests/AssignmentHelpersTests.swift
@@ -527,6 +527,20 @@ final class AssignmentHelpersTests: XCTestCase {
         XCTAssertEqual(dueAtLocalInputString(nil), "")
     }
 
+    func testDeadlineOverrideHelpersRespectPastAndFutureDueDates() {
+        let past = Date().addingTimeInterval(-60)
+        let future = Date().addingTimeInterval(60)
+
+        XCTAssertTrue(deadlineOverrideValueForInstructorOpen(dueAt: past))
+        XCTAssertFalse(deadlineOverrideValueForInstructorOpen(dueAt: future))
+        XCTAssertFalse(deadlineOverrideValueForInstructorOpen(dueAt: nil))
+
+        XCTAssertFalse(normalizedDeadlineOverrideAfterDueDateChange(dueAt: future, existingOverride: true))
+        XCTAssertFalse(normalizedDeadlineOverrideAfterDueDateChange(dueAt: nil, existingOverride: true))
+        XCTAssertTrue(normalizedDeadlineOverrideAfterDueDateChange(dueAt: past, existingOverride: true))
+        XCTAssertFalse(normalizedDeadlineOverrideAfterDueDateChange(dueAt: past, existingOverride: false))
+    }
+
     func testCurrentSetupFilesUsesManifestOrderingAndSolutionFallbacks() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("current-setup-files-\(UUID().uuidString)")

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -83,9 +83,22 @@ final class AssignmentRoutesTests: XCTestCase {
     }
 
     @discardableResult
-    private func insertAssignment(testSetupID: String, title: String, isOpen: Bool) async throws -> APIAssignment {
+    private func insertAssignment(
+        testSetupID: String,
+        title: String,
+        isOpen: Bool,
+        dueAt: Date? = nil,
+        deadlineOverrideActive: Bool = false
+    ) async throws -> APIAssignment {
         let courseID = try await makeTestCourseID()
-        let a = APIAssignment(testSetupID: testSetupID, title: title, dueAt: nil, isOpen: isOpen, courseID: courseID)
+        let a = APIAssignment(
+            testSetupID: testSetupID,
+            title: title,
+            dueAt: dueAt,
+            isOpen: isOpen,
+            deadlineOverrideActive: deadlineOverrideActive,
+            courseID: courseID
+        )
         try await a.save(on: app.db)
         return a
     }
@@ -238,6 +251,81 @@ final class AssignmentRoutesTests: XCTestCase {
         files.forEach(appendFile)
         body.writeString("--\(boundary)--\r\n")
         return body
+    }
+
+    func testCloseExpiredAssignmentsClosesOnlyEligibleAssignments() async throws {
+        _ = try await insertSetup(id: "setup_deadline_close")
+        let overdue = try await insertAssignment(
+            testSetupID: "setup_deadline_close",
+            title: "Overdue",
+            isOpen: true,
+            dueAt: Date().addingTimeInterval(-60)
+        )
+
+        _ = try await insertSetup(id: "setup_deadline_open")
+        let noDeadline = try await insertAssignment(
+            testSetupID: "setup_deadline_open",
+            title: "No Deadline",
+            isOpen: true
+        )
+
+        _ = try await insertSetup(id: "setup_deadline_override")
+        let overridden = try await insertAssignment(
+            testSetupID: "setup_deadline_override",
+            title: "Override",
+            isOpen: true,
+            dueAt: Date().addingTimeInterval(-60),
+            deadlineOverrideActive: true
+        )
+
+        let closedCount = try await closeExpiredAssignments(on: app.db, logger: app.logger)
+        XCTAssertEqual(closedCount, 1)
+
+        let overdueReloadedOptional = try await APIAssignment.find(overdue.id, on: app.db)
+        XCTAssertNotNil(overdueReloadedOptional)
+        let overdueReloaded = overdueReloadedOptional!
+        XCTAssertFalse(overdueReloaded.isOpen)
+
+        let noDeadlineReloadedOptional = try await APIAssignment.find(noDeadline.id, on: app.db)
+        XCTAssertNotNil(noDeadlineReloadedOptional)
+        let noDeadlineReloaded = noDeadlineReloadedOptional!
+        XCTAssertTrue(noDeadlineReloaded.isOpen)
+
+        let overriddenReloadedOptional = try await APIAssignment.find(overridden.id, on: app.db)
+        XCTAssertNotNil(overriddenReloadedOptional)
+        let overriddenReloaded = overriddenReloadedOptional!
+        XCTAssertTrue(overriddenReloaded.isOpen)
+    }
+
+    func testInstructorCanReopenPastDueAssignmentWithOverride() async throws {
+        _ = try await insertSetup(id: "setup_reopen_deadline")
+        let assignment = try await insertAssignment(
+            testSetupID: "setup_reopen_deadline",
+            title: "Past Due",
+            isOpen: false,
+            dueAt: Date().addingTimeInterval(-60)
+        )
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+        try await app.asyncTest(.POST, "/instructor/\(assignment.publicID)/open", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.add(name: "x-csrf-token", value: csrf)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+        })
+
+        let reopenedOptional = try await APIAssignment.find(assignment.id, on: app.db)
+        XCTAssertNotNil(reopenedOptional)
+        let reopened = reopenedOptional!
+        XCTAssertTrue(reopened.isOpen)
+        XCTAssertEqual(reopened.deadlineOverrideActive, true)
+
+        _ = try await closeExpiredAssignments(on: app.db, logger: app.logger)
+        let stillOpenOptional = try await APIAssignment.find(assignment.id, on: app.db)
+        XCTAssertNotNil(stillOpenOptional)
+        let stillOpen = stillOpenOptional!
+        XCTAssertTrue(stillOpen.isOpen)
     }
 
     private func makeZip(at path: String, entries: [(String, String)]) throws {

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -78,6 +78,28 @@ final class BrowserRunnerRoutesTests: XCTestCase {
         return setupID
     }
 
+    @discardableResult
+    private func insertAssignment(
+        testSetupID: String,
+        isOpen: Bool,
+        dueAt: Date? = nil,
+        deadlineOverrideActive: Bool = false
+    ) async throws -> APIAssignment {
+        let setupOptional = try await APITestSetup.find(testSetupID, on: app.db)
+        XCTAssertNotNil(setupOptional)
+        let setup = setupOptional!
+        let assignment = APIAssignment(
+            testSetupID: testSetupID,
+            title: "Browser Assignment",
+            dueAt: dueAt,
+            isOpen: isOpen,
+            deadlineOverrideActive: deadlineOverrideActive,
+            courseID: setup.courseID
+        )
+        try await assignment.save(on: app.db)
+        return assignment
+    }
+
     // MARK: - Manifest endpoint
 
     func testManifestRequiresAuthentication() async throws {
@@ -230,6 +252,7 @@ final class BrowserRunnerRoutesTests: XCTestCase {
     /// server without error.
     func testBrowserResultAcceptsDependencySkippedOutcomes() async throws {
         let setupID = try await insertSetup(manifest: simpleManifest())
+        _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
         let cookie  = try await loginAsStudent()
         let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
         let nb      = minimalNotebook()
@@ -315,6 +338,7 @@ final class BrowserRunnerRoutesTests: XCTestCase {
 
     func testRunnerSubmitRejectsBrowserGradedAssignments() async throws {
         let setupID = try await insertSetup(manifest: simpleManifest())
+        _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
         let cookie  = try await loginAsStudent()
         let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
         let nb      = minimalNotebook()
@@ -340,6 +364,87 @@ final class BrowserRunnerRoutesTests: XCTestCase {
 
         let allSubs = try await APISubmission.query(on: app.db).all()
         XCTAssertTrue(allSubs.isEmpty, "runner-submit should not create queued submissions for browser-mode setups")
+    }
+
+    func testBrowserResultRejectsOverdueAssignmentsAndClosesThem() async throws {
+        let setupID = try await insertSetup(manifest: simpleManifest())
+        let assignment = try await insertAssignment(
+            testSetupID: setupID,
+            isOpen: true,
+            dueAt: Date().addingTimeInterval(-60)
+        )
+        let cookie  = try await loginAsStudent()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+        let nb      = minimalNotebook()
+        let collection = """
+        {"submissionID":"","testSetupID":"\(setupID)","attemptNumber":1,"buildStatus":"passed","compilerOutput":null,"outcomes":[],"totalTests":0,"passCount":0,"failCount":0,"errorCount":0,"timeoutCount":0,"executionTimeMs":0,"runnerVersion":"browser-wasm-runner/1.0","timestamp":"2026-01-01T00:00:00Z"}
+        """
+
+        try await app.asyncTest(.POST, "/api/v1/submissions/browser-result",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                req.body = .init(buffer: multipartBody(
+                    boundary: "browser-result-overdue-boundary",
+                    fields: [("_csrf", csrf), ("collection", collection), ("testSetupID", setupID)],
+                    file: ("notebook", "notebook.ipynb", nb)
+                ))
+                req.headers.contentType = HTTPMediaType(
+                    type: "multipart", subType: "form-data",
+                    parameters: ["boundary": "browser-result-overdue-boundary"])
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .forbidden)
+                XCTAssertTrue(res.body.string.contains("closed"))
+            })
+
+        let refreshedOptional = try await APIAssignment.find(assignment.id, on: app.db)
+        XCTAssertNotNil(refreshedOptional)
+        let refreshed = refreshedOptional!
+        XCTAssertFalse(refreshed.isOpen)
+    }
+
+    func testRunnerSubmitRejectsOverdueAssignmentsAndClosesThem() async throws {
+        let manifest = """
+        {
+          "schemaVersion": 1,
+          "gradingMode": "worker",
+          "requiredFiles": [],
+          "testSuites": [
+            { "tier": "public", "script": "test_public.py" }
+          ],
+          "timeLimitSeconds": 10,
+          "makefile": null
+        }
+        """
+        let setupID = try await insertSetup(manifest: manifest)
+        let assignment = try await insertAssignment(
+            testSetupID: setupID,
+            isOpen: true,
+            dueAt: Date().addingTimeInterval(-60)
+        )
+        let cookie  = try await loginAsStudent()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+        let nb      = minimalNotebook()
+
+        try await app.asyncTest(.POST, "/api/v1/submissions/runner-submit",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                req.body = .init(buffer: multipartBody(
+                    boundary: "runner-submit-overdue-boundary",
+                    fields: [("_csrf", csrf), ("testSetupID", setupID), ("filename", "submission.ipynb")],
+                    file: ("notebook", "submission.ipynb", nb)
+                ))
+                req.headers.contentType = HTTPMediaType(
+                    type: "multipart", subType: "form-data",
+                    parameters: ["boundary": "runner-submit-overdue-boundary"])
+            }, afterResponse: { res in
+                XCTAssertEqual(res.status, .forbidden)
+                XCTAssertTrue(res.body.string.contains("closed"))
+            })
+
+        let refreshedOptional = try await APIAssignment.find(assignment.id, on: app.db)
+        XCTAssertNotNil(refreshedOptional)
+        let refreshed = refreshedOptional!
+        XCTAssertFalse(refreshed.isOpen)
     }
 
     // MARK: - Private fixtures

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -123,6 +123,7 @@ private func registerBaseTestMigrations(on app: Application) {
     app.migrations.add(AddCourseOpenEnrollment())
     app.migrations.add(AddCourseEnrollmentMode())
     app.migrations.add(AddSubmissionRetestedAt())
+    app.migrations.add(AddAssignmentDeadlineOverrideActive())
 }
 
 private func registerObservabilityTestMigrations(on app: Application) {

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -201,6 +201,21 @@ final class WebRoutesTests: XCTestCase {
         return result
     }
 
+    private func submitMultipartBody(boundary: String, csrfToken: String) -> ByteBuffer {
+        var buf = ByteBufferAllocator().buffer(capacity: 1024)
+        buf.writeString("--\(boundary)\r\n")
+        buf.writeString("Content-Disposition: form-data; name=\"_csrf\"\r\n\r\n")
+        buf.writeString(csrfToken)
+        buf.writeString("\r\n")
+        buf.writeString("--\(boundary)\r\n")
+        buf.writeString("Content-Disposition: form-data; name=\"files\"; filename=\"submission.py\"\r\n")
+        buf.writeString("Content-Type: text/x-python\r\n\r\n")
+        buf.writeString("print('hello')\n")
+        buf.writeString("\r\n")
+        buf.writeString("--\(boundary)--\r\n")
+        return buf
+    }
+
     func testSubmissionPageRendersWarnings() async throws {
         let cookie = try await loginAsStudent()
         let user = try await studentUser()
@@ -415,6 +430,44 @@ final class WebRoutesTests: XCTestCase {
         }, afterResponse: { res in
             XCTAssertEqual(res.status, .notFound)
         })
+    }
+
+    func testSubmitPostRejectsOverdueAssignmentsAndPersistsClosure() async throws {
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enrollUser(user)
+        _ = try await insertSetup(id: "setup_submit_overdue")
+        let assignment = try await insertAssignment(
+            testSetupID: "setup_submit_overdue",
+            title: "Late Lab",
+            isOpen: true,
+            dueAt: Date().addingTimeInterval(-60)
+        )
+
+        let (csrf, sessionCookie) = try await csrfFields(
+            for: "/testsetups/setup_submit_overdue/submit",
+            cookie: cookie,
+            on: app
+        )
+        let boundary = "late-submit-boundary"
+
+        try await app.asyncTest(.POST, "/testsetups/setup_submit_overdue/submit", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart",
+                subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: submitMultipartBody(boundary: boundary, csrfToken: csrf))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .forbidden)
+            XCTAssertTrue(res.body.string.contains("closed"))
+        })
+
+        let refreshedOptional = try await APIAssignment.find(assignment.id, on: app.db)
+        XCTAssertNotNil(refreshedOptional)
+        let refreshed = refreshedOptional!
+        XCTAssertFalse(refreshed.isOpen)
     }
 
     // MARK: - GET /testsetups/:id/history


### PR DESCRIPTION
## Summary
- add a backend deadline monitor that auto-closes overdue open assignments
- block late student submissions on web upload and browser submission endpoints
- support instructor reopen-after-deadline via a persisted override flag

## Testing
- `swift test --filter APITests.AssignmentRoutesTests`
- `swift test --filter APITests.BrowserRunnerRoutesTests`