### PR TITLE
Fix CI fallout from deadline submission gating

### DIFF
--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -3,13 +3,10 @@ import Vapor
 import Foundation
 
 enum AssignmentSubmissionGateError: AbortError {
-    case unavailable
     case closed
 
     var status: HTTPResponseStatus {
         switch self {
-        case .unavailable:
-            return .forbidden
         case .closed:
             return .forbidden
         }
@@ -17,8 +14,6 @@ enum AssignmentSubmissionGateError: AbortError {
 
     var reason: String {
         switch self {
-        case .unavailable:
-            return "This assignment is not available for student submissions."
         case .closed:
             return "This assignment is closed and no longer accepts submissions."
         }
@@ -85,11 +80,11 @@ func requireOpenStudentAssignment(
     for testSetupID: String,
     on req: Request,
     now: Date = Date()
-) async throws -> APIAssignment {
+) async throws -> APIAssignment? {
     guard let assignment = try await APIAssignment.query(on: req.db)
         .filter(\.$testSetupID == testSetupID)
         .first() else {
-        throw AssignmentSubmissionGateError.unavailable
+        return nil
     }
 
     _ = try await closeAssignmentIfExpired(assignment, on: req.db, logger: req.logger, now: now)

--- a/Tests/APITests/DatabaseConfigurationTests.swift
+++ b/Tests/APITests/DatabaseConfigurationTests.swift
@@ -173,4 +173,30 @@ struct DatabaseConfigurationTests {
             #expect(app.databases.configuration(for: .chickadee) != nil)
         }
     }
+
+    @Test func observabilityTestDatabaseIncludesRunnerProfiles() async throws {
+        let env = EnvironmentScope()
+        env.set("TEST_DATABASE_BACKEND", nil)
+
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app, options: .observability)
+
+            let profile = RunnerProfile(
+                runnerID: "runner-observability",
+                displayName: "Runner Observability",
+                profile: nil,
+                profileHash: nil,
+                lastRegisteredAt: nil,
+                lastSeenAt: Date(),
+                isActive: true
+            )
+            try await profile.save(on: app.db)
+
+            let saved = try await RunnerProfile.query(on: app.db)
+                .filter(\.$runnerID == "runner-observability")
+                .first()
+            #expect(saved != nil)
+        }
+    }
 }

--- a/Tests/APITests/DatabaseConfigurationTests.swift
+++ b/Tests/APITests/DatabaseConfigurationTests.swift
@@ -182,22 +182,18 @@ struct DatabaseConfigurationTests {
         try await withApp(app) { app in
             try await configureTestDatabase(app, options: .observability)
 
-            let capabilityProfile = RunnerCapabilityProfile(
-                platform: "macOS",
-                architecture: "arm64",
-                languageVersions: [],
-                capabilities: []
-            )
             let now = Date()
-            let profile = RunnerProfile(
-                runnerID: "runner-observability",
-                displayName: "Runner Observability",
-                profile: capabilityProfile,
-                profileHash: nil,
-                lastRegisteredAt: now,
-                lastSeenAt: now,
-                isActive: true
-            )
+            let profile = RunnerProfile()
+            profile.runnerID = "runner-observability"
+            profile.displayName = "Runner Observability"
+            profile.platform = "macOS"
+            profile.architecture = "arm64"
+            profile.languageVersionsJSON = "[]"
+            profile.capabilitiesJSON = "[]"
+            profile.profileHash = nil
+            profile.lastRegisteredAt = now
+            profile.lastSeenAt = now
+            profile.isActive = true
             try await profile.save(on: app.db)
 
             let saved = try await RunnerProfile.query(on: app.db)

--- a/Tests/APITests/DatabaseConfigurationTests.swift
+++ b/Tests/APITests/DatabaseConfigurationTests.swift
@@ -182,13 +182,20 @@ struct DatabaseConfigurationTests {
         try await withApp(app) { app in
             try await configureTestDatabase(app, options: .observability)
 
+            let capabilityProfile = RunnerCapabilityProfile(
+                platform: "macOS",
+                architecture: "arm64",
+                languageVersions: [],
+                capabilities: []
+            )
+            let now = Date()
             let profile = RunnerProfile(
                 runnerID: "runner-observability",
                 displayName: "Runner Observability",
-                profile: nil,
+                profile: capabilityProfile,
                 profileHash: nil,
-                lastRegisteredAt: nil,
-                lastSeenAt: Date(),
+                lastRegisteredAt: now,
+                lastSeenAt: now,
                 isActive: true
             )
             try await profile.save(on: app.db)

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -132,10 +132,10 @@ private func registerObservabilityTestMigrations(on app: Application) {
     app.migrations.add(CreateJobExecutionMetrics())
     app.migrations.add(AddJobExecutionStageTimings())
     app.migrations.add(CreateRunnerSnapshots())
+    app.migrations.add(CreateRunnerProfiles())
 }
 
 private func registerRunnerCompatibilityTestMigrations(on app: Application) {
-    app.migrations.add(CreateRunnerProfiles())
     app.migrations.add(CreateAssignmentRequirements())
 }
 


### PR DESCRIPTION
## Summary
- only enforce deadline auto-close when a real assignment exists for the setup
- register runner profile migrations in observability test bootstrapping
- add a regression test covering observability bootstrap for runner profiles

## Notes
- this fixes the runner_profiles missing-table failure in PostgreSQL CI
- this also restores standalone setup submission flows that were returning 403 in APITests
