### PR TITLE
[codex] Move instructor CSV enrolment to a dedicated page

### DIFF
--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -405,7 +405,7 @@
 
 <!-- ── Enrolled students ──────────────────────────────────────────────── -->
 <div style="margin-top:2.5rem">
-    <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;margin-bottom:.75rem">
+    <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:.75rem">
         <h2 style="font-size:1.05rem;font-weight:600;margin:0">Enrolled students (#(enrolledStudentCount))</h2>
         #if(currentUser.activeCourse):
         #if(!courseIsArchived):
@@ -421,19 +421,12 @@
                 </select>
             </label>
         </form>
-        <form method="post" action="/courses/#(currentUser.activeCourse.id)/enroll-csv"
-              enctype="multipart/form-data" style="margin:0;margin-left:auto">
-            #csrfFormField()
-            <label class="visually-hidden" for="enroll-csv-file">CSV file</label>
-            <input id="enroll-csv-file" type="file" name="file" accept=".csv,.txt" required
-                   style="font-size:.8rem;max-width:12rem">
-            <button class="btn btn-primary" type="submit" style="margin:0">Enrol</button>
-        </form>
+        <a class="btn btn-primary" href="/instructor/enroll-csv">Enrol</a>
         #endif
         #endif
         <input id="enrolled-filter" class="form-input" type="search" autocomplete="off"
                placeholder="Filter by name or username…"
-               style="width:220px;margin-left:auto" aria-label="Filter enrolled students"
+               style="width:220px;flex:1 1 220px;min-width:220px" aria-label="Filter enrolled students"
                readonly onfocus="this.removeAttribute('readonly')">
     </div>
     #if(hasEnrolledStudents):

--- a/Resources/Views/instructor-enroll-csv.leaf
+++ b/Resources/Views/instructor-enroll-csv.leaf
@@ -1,0 +1,38 @@
+#extend("base"):
+#export("title"):
+Enrol from CSV — #(courseCode)
+#endexport
+#export("content"):
+<div style="display:flex;align-items:center;gap:.75rem;margin-bottom:1.5rem;flex-wrap:wrap">
+    <h1 style="margin:0">Enrol from CSV</h1>
+    <span style="color:var(--text-secondary)">#(courseCode) — #(courseName)</span>
+</div>
+
+#if(error):
+<div class="form-error" style="margin-bottom:1rem">#(error)</div>
+#endif
+
+<section class="admin-section">
+    <h2>Upload enrollment list</h2>
+    <p style="margin-bottom:1rem;color:var(--text-secondary);font-size:.9rem">
+        Upload a CSV or text file containing one username per line. The first column is used, and a header row like
+        <code>username</code> is ignored automatically.
+    </p>
+    <form method="post"
+          action="/courses/#(courseID)/enroll-csv"
+          enctype="multipart/form-data"
+          style="display:flex;flex-direction:column;gap:1rem;max-width:480px">
+        #csrfFormField()
+        <label class="form-label">
+            Enrollment CSV
+            <input class="form-input" type="file" name="file" accept=".csv,.txt" required
+                   style="display:block;margin-top:.25rem">
+        </label>
+        <div style="display:flex;gap:.75rem">
+            <button class="btn btn-primary" type="submit">Enrol</button>
+            <a href="/instructor" class="btn">Cancel</a>
+        </div>
+    </form>
+</section>
+#endexport
+#endextend

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Enrollment.swift
@@ -8,6 +8,38 @@ import Fluent
 import Core
 
 extension AssignmentRoutes {
+    // MARK: - GET /instructor/enroll-csv
+
+    @Sendable
+    func enrollCSVForm(req: Request) async throws -> View {
+        let caller = try req.auth.require(APIUser.self)
+        guard caller.isInstructor else { throw Abort(.forbidden) }
+
+        let courseState = try await req.resolveActiveCourse(for: caller)
+        guard let courseContext = courseState.active,
+              let courseID = courseState.activeCourseUUID,
+              let course = try await APICourse.find(courseID, on: req.db),
+              !course.isArchived
+        else {
+            throw Abort(.badRequest, reason: "No active course selected.")
+        }
+
+        struct EnrollCSVFormContext: Encodable {
+            let currentUser: CurrentUserContext?
+            let courseID: String
+            let courseCode: String
+            let courseName: String
+            let error: String?
+        }
+
+        return try await req.view.render("instructor-enroll-csv", EnrollCSVFormContext(
+            currentUser: req.currentUserContext,
+            courseID: courseID.uuidString,
+            courseCode: courseContext.code,
+            courseName: courseContext.name,
+            error: req.query[String.self, at: "error"]
+        ))
+    }
 
     // MARK: - POST /courses/:courseID/enrollment-mode
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -35,6 +35,7 @@ struct AssignmentRoutes: RouteCollection {
         let r = routes.grouped("instructor")
         r.get(use: list)
         r.get("grades.csv", use: exportGradesCSV)
+        r.get("enroll-csv", use: enrollCSVForm)
         r.get("students", ":studentID", "submissions", use: courseStudentSubmissionsPage)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
         r.get(":assignmentID", "students", ":studentID", "history", use: studentSubmissionHistoryPage)

--- a/Tests/APITests/AssignmentEnrollmentTests.swift
+++ b/Tests/APITests/AssignmentEnrollmentTests.swift
@@ -2,6 +2,7 @@
 //
 // Integration tests for AssignmentRoutes+Enrollment:
 //   POST /courses/:courseID/enrollment-mode  — set enrollment mode
+//   GET  /instructor/enroll-csv              — bulk-enrol upload form
 //   POST /courses/:courseID/enroll-csv       — bulk-enrol from CSV upload
 
 import XCTest
@@ -56,6 +57,11 @@ final class AssignmentEnrollmentTests: XCTestCase {
         let user = APIUser(username: username, passwordHash: hash, role: "student")
         try await user.save(on: app.db)
         return user
+    }
+
+    private func enroll(user: APIUser, in course: APICourse) async throws {
+        let enrollment = APICourseEnrollment(userID: try user.requireID(), courseID: try course.requireID())
+        try await enrollment.save(on: app.db)
     }
 
     // MARK: - POST /courses/:courseID/enrollment-mode
@@ -126,6 +132,29 @@ final class AssignmentEnrollmentTests: XCTestCase {
     }
 
     // MARK: - POST /courses/:courseID/enroll-csv
+
+    func testEnrollCSVFormShowsDedicatedUploadPage() async throws {
+        let course = try await makeCourse(code: "CSV_FORM1")
+        let cookie = try await loginUser(username: "csv_instructor_form", password: "pw",
+                                         role: "instructor", on: app)
+        let instructorQueryResult = try await APIUser.query(on: app.db)
+            .filter(\.$username == "csv_instructor_form")
+            .first()
+        let instructor = try XCTUnwrap(instructorQueryResult)
+        try await enroll(user: instructor, in: course)
+        let courseID = try course.requireID().uuidString
+
+        try await app.asyncTest(.GET, "/instructor/enroll-csv", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("Enrol from CSV"))
+            XCTAssertTrue(html.contains("/courses/\(courseID)/enroll-csv"))
+            XCTAssertTrue(html.contains("type=\"file\""))
+            XCTAssertTrue(html.contains("Cancel"))
+        })
+    }
 
     func testBulkEnrollCSV_enrollsMatchedUsers() async throws {
         let course = try await makeCourse(code: "CSV_ENROLL1")

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -374,6 +374,20 @@ final class AssignmentRoutesTests: XCTestCase {
         })
     }
 
+    func testAssignmentsPageUsesDedicatedEnrollCSVPageLink() async throws {
+        _ = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+
+        try await app.asyncTest(.GET, "/instructor", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("href=\"/instructor/enroll-csv\""))
+            XCTAssertFalse(html.contains("id=\"enroll-csv-file\""))
+        })
+    }
+
     // MARK: - POST /instructor (publish → creates draft)
 
     func testPublishCreatesDraftAssignment() async throws {


### PR DESCRIPTION
## Summary

- move instructor CSV enrollment to a dedicated upload page instead of the inline file picker
- place the `Enrol` button beside the enrollment-mode selector in the enrolled-students header
- keep the roster header inline with the search field and add regression coverage for the new flow

## Testing

- `swift test --filter AssignmentEnrollmentTests/testEnrollCSVFormShowsDedicatedUploadPage`
- `swift test --filter AssignmentRoutesTests/testAssignmentsPageUsesDedicatedEnrollCSVPageLink`