### PR TITLE
Constrain assignment runner requirements

### DIFF
--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -1003,7 +1003,7 @@ func detectRequirementSuggestions(
     }
 
     if let assignmentNotebookData { scanNotebook(assignmentNotebookData) }
-    if let solutionNotebookData { scanNotebook(solutionNotebookData) }
+    _ = solutionNotebookData
 
     for entry in listZipEntries(zipPath: setup.zipPath) {
         guard let data = extractZipEntry(zipPath: setup.zipPath, entryName: entry) else { continue }
@@ -1544,6 +1544,66 @@ func ensureValidationRunnerAvailability(req: Request) async {
 
     await req.application.localRunnerManager.ensureRunning(app: req.application, logger: req.logger)
     try? await Task.sleep(nanoseconds: 1_000_000_000)
+}
+
+func hasCompatibleValidationRunner(
+    req: Request,
+    requirements: AssignmentRequirementSpec?,
+    activeWindowSeconds: TimeInterval = 20
+) async throws -> Bool {
+    try await req.application.runnerProfiles.refreshActiveFlags(
+        activeWindowSeconds: activeWindowSeconds,
+        on: req.db
+    )
+
+    let profiles = try await RunnerProfile.query(on: req.db)
+        .filter(\.$isActive == true)
+        .all()
+    let matcher = CompatibilityMatcher()
+
+    return profiles.contains { profile in
+        matcher.evaluate(
+            runnerProfile: profile.capabilityProfile,
+            requirements: requirements
+        ).isCompatible
+    }
+}
+
+func ensureCompatibleValidationRunnerAvailability(
+    req: Request,
+    requirements: AssignmentRequirementSpec?,
+    activeWindowSeconds: TimeInterval = 20,
+    attempts: Int = 3
+) async throws -> Bool {
+    if try await hasCompatibleValidationRunner(
+        req: req,
+        requirements: requirements,
+        activeWindowSeconds: activeWindowSeconds
+    ) {
+        return true
+    }
+
+    let enabled = await req.application.localRunnerAutoStartStore.isEnabled()
+    guard enabled else { return false }
+
+    await req.application.localRunnerManager.ensureRunning(app: req.application, logger: req.logger)
+
+    for attempt in 0..<attempts {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        if try await hasCompatibleValidationRunner(
+            req: req,
+            requirements: requirements,
+            activeWindowSeconds: activeWindowSeconds
+        ) {
+            return true
+        }
+
+        if attempt + 1 < attempts {
+            await req.application.localRunnerManager.ensureRunning(app: req.application, logger: req.logger)
+        }
+    }
+
+    return false
 }
 
 func removeMaterializedNotebookFiles(req: Request, setupID: String) {

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -932,6 +932,13 @@ struct AssignmentRoutes: RouteCollection {
             return req.redirect(to: "/instructor/new?\(q)")
         }
 
+        let requirementSpec = assignmentRequirementSpec(
+            platform: requiredPlatform,
+            architecture: requiredArchitecture,
+            languagesCSV: requiredLanguagesCSV,
+            capabilitiesCSV: requiredCapabilitiesCSV
+        )
+
         let assignmentNotebook = normalizeNotebookForJupyterLite(assignmentNotebookRaw)
         let setupID = draftSetup?.id ?? "setup_\(UUID().uuidString.lowercased().prefix(8))"
         let setupsDir = req.application.testSetupsDirectory
@@ -1017,6 +1024,24 @@ struct AssignmentRoutes: RouteCollection {
         )
 
         let shouldQueueValidation = !setupPackage.testSuites.isEmpty
+        if shouldQueueValidation {
+            let hasEligibleRunner = try await ensureCompatibleValidationRunnerAvailability(
+                req: req,
+                requirements: requirementSpec
+            )
+            guard hasEligibleRunner else {
+                return redirectToNewAssignmentDraft(
+                    req: req,
+                    draftID: draftID,
+                    assignmentName: title,
+                    dueAt: dueAtRaw ?? "",
+                    sectionID: sectionIDRaw ?? "",
+                    notice: nil,
+                    error: "No compatible active runner is available to validate this assignment."
+                )
+            }
+        }
+
         let assignment = try await createAssignmentWithUniquePublicID(
             req: req,
             testSetupID: setupID,
@@ -1029,6 +1054,13 @@ struct AssignmentRoutes: RouteCollection {
             sectionID: resolvedSectionID,
             courseID: courseID
         )
+        if let requirements = requirementSpec {
+            let requirement = AssignmentRequirement(
+                assignmentID: try assignment.requireID(),
+                specification: requirements
+            )
+            try await requirement.save(on: req.db)
+        }
 
         if shouldQueueValidation {
             let validationSubmissionID = try await enqueueRunnerValidationSubmission(
@@ -1042,18 +1074,6 @@ struct AssignmentRoutes: RouteCollection {
             assignment.validationSubmissionID = validationSubmissionID
             try await assignment.save(on: req.db)
             await ensureValidationRunnerAvailability(req: req)
-        }
-        if let requirements = assignmentRequirementSpec(
-            platform: requiredPlatform,
-            architecture: requiredArchitecture,
-            languagesCSV: requiredLanguagesCSV,
-            capabilitiesCSV: requiredCapabilitiesCSV
-        ) {
-            let requirement = AssignmentRequirement(
-                assignmentID: try assignment.requireID(),
-                specification: requirements
-            )
-            try await requirement.save(on: req.db)
         }
         if !draftID.isEmpty {
             clearDraftFormState(req: req, draftID: draftID)

--- a/Tests/APITests/AssignmentHelpersTests.swift
+++ b/Tests/APITests/AssignmentHelpersTests.swift
@@ -44,6 +44,31 @@ final class AssignmentHelpersTests: XCTestCase {
         XCTAssertEqual(process.terminationStatus, 0, "zip should succeed")
     }
 
+    private func notebookData(language: String = "python", source: String) -> Data {
+        let json = """
+        {
+          "cells": [
+            {
+              "cell_type": "code",
+              "source": \(String(data: try! JSONEncoder().encode([source]), encoding: .utf8)!)
+            }
+          ],
+          "metadata": {
+            "kernelspec": {
+              "name": "\(language)",
+              "language": "\(language)"
+            },
+            "language_info": {
+              "name": "\(language)"
+            }
+          },
+          "nbformat": 4,
+          "nbformat_minor": 5
+        }
+        """
+        return Data(json.utf8)
+    }
+
     func testSanitizedAssignmentReturnPathAcceptsOnlyInstructorScopedPaths() {
         XCTAssertEqual(
             sanitizedAssignmentReturnPath(
@@ -206,6 +231,32 @@ final class AssignmentHelpersTests: XCTestCase {
         let props = try JSONDecoder().decode(TestProperties.self, from: Data(updated.utf8))
         XCTAssertEqual(props.testSuites.map(\.script), ["02_release.py"])
         XCTAssertEqual(props.testSuites.first?.dependsOn, [])
+    }
+
+    func testDetectRequirementSuggestionsIgnoresSolutionNotebookImports() throws {
+        let zipPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detect-requirements-\(UUID().uuidString).zip")
+            .path
+        try makeZip(at: zipPath, entries: [
+            (name: "tests/run.sh", content: "#!/bin/bash\necho ok\n")
+        ])
+
+        let setup = APITestSetup(
+            id: "setup_detect_requirements",
+            manifest: "{}",
+            zipPath: zipPath,
+            notebookPath: "/tmp/assignment.ipynb",
+            courseID: UUID()
+        )
+
+        let suggestions = detectRequirementSuggestions(
+            assignmentNotebookData: notebookData(source: "import pandas\n"),
+            solutionNotebookData: notebookData(source: "import scipy\nimport matplotlib\n"),
+            setup: setup
+        )
+
+        XCTAssertEqual(suggestions.languages, ["python"])
+        XCTAssertEqual(suggestions.capabilities, ["pandas", "shell-bash"])
     }
 
     func testMakeWorkerManifestJSONTopologicallySortsSuitesAndOmitsDefaults() throws {

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -500,6 +500,9 @@ final class AssignmentRoutesTests: XCTestCase {
 
     func testSaveNewAssignmentPreservesMultipleUploadedSuiteFiles() async throws {
         _ = try await makeTestCourseID()
+        app.migrations.add(CreateRunnerProfiles())
+        app.migrations.add(CreateAssignmentRequirements())
+        try await app.autoMigrate()
         let cookie = try await loginAsInstructor()
         let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
         let boundary = "Boundary-New-MultiSuites"

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -503,6 +503,19 @@ final class AssignmentRoutesTests: XCTestCase {
         app.migrations.add(CreateRunnerProfiles())
         app.migrations.add(CreateAssignmentRequirements())
         try await app.autoMigrate()
+        let now = Date()
+        let runnerProfile = RunnerProfile()
+        runnerProfile.runnerID = "runner-multi-suite"
+        runnerProfile.displayName = "Runner Multi Suite"
+        runnerProfile.platform = "linux"
+        runnerProfile.architecture = "x86_64"
+        runnerProfile.languageVersionsJSON = "[]"
+        runnerProfile.capabilitiesJSON = "[]"
+        runnerProfile.profileHash = nil
+        runnerProfile.lastRegisteredAt = now
+        runnerProfile.lastSeenAt = now
+        runnerProfile.isActive = true
+        try await runnerProfile.save(on: app.db)
         let cookie = try await loginAsInstructor()
         let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
         let boundary = "Boundary-New-MultiSuites"

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -821,6 +821,84 @@ final class AssignmentRoutesTests: XCTestCase {
         XCTAssertEqual(requirement?.requirementSpec.requiredCapabilities.map(\.name), ["numpy", "pandas"])
     }
 
+    func testSaveNewAssignmentRequiresCompatibleRunnerForValidation() async throws {
+        let courseID = try await makeTestCourseID()
+        app.migrations.add(CreateRunnerProfiles())
+        app.migrations.add(CreateAssignmentRequirements())
+        try await app.autoMigrate()
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
+
+        let setupID = "setup_validation_runner_gate"
+        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        var suiteBuffer = ByteBufferAllocator().buffer(capacity: 16)
+        suiteBuffer.writeString("print('ok')\n")
+        _ = try createRunnerSetupZip(
+            suiteFiles: [File(data: suiteBuffer, filename: "test_public.py")],
+            suiteConfigJSON: nil,
+            zipPath: zipPath
+        )
+        let manifest = try makeWorkerManifestJSON(
+            testSuites: [
+                ConfiguredSuiteEntry(
+                    script: "test_public.py",
+                    tier: "public",
+                    order: 1,
+                    dependsOn: [],
+                    points: 1,
+                    displayName: nil
+                )
+            ],
+            includeMakefile: false,
+            gradingMode: "worker"
+        )
+        let notebookDir = tmpDir + "testsetups/notebooks/\(setupID)/"
+        try FileManager.default.createDirectory(atPath: notebookDir, withIntermediateDirectories: true)
+        let assignmentPath = notebookDir + "assignment.ipynb"
+        try defaultNotebookData(title: "Runner Gate").write(to: URL(fileURLWithPath: assignmentPath))
+        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: tmpDir + "testsetups/", setupID: setupID)
+        try defaultNotebookData(title: "Runner Gate Solution").write(to: URL(fileURLWithPath: solutionPath))
+
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: manifest,
+            zipPath: zipPath,
+            notebookPath: assignmentPath,
+            courseID: courseID
+        )
+        try await setup.save(on: app.db)
+
+        let boundary = "Boundary-New-Runner-Gate"
+        try await app.asyncTest(.POST, "/instructor/new/save", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart",
+                subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: self.multipartBody(
+                boundary: boundary,
+                fields: [
+                    ("_csrf", csrf),
+                    ("draftID", setupID),
+                    ("assignmentName", "Needs Matplotlib"),
+                    ("requiredLanguagesCSV", "python"),
+                    ("requiredCapabilitiesCSV", "matplotlib")
+                ]
+            ))
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            let location = res.headers.first(name: .location) ?? ""
+            XCTAssertTrue(location.contains("/instructor/new?"))
+            XCTAssertTrue(location.contains("No%20compatible%20active%20runner%20is%20available%20to%20validate%20this%20assignment."))
+        })
+
+        let assignment = try await APIAssignment.query(on: app.db)
+            .filter(\.$title == "Needs Matplotlib")
+            .first()
+        XCTAssertNil(assignment)
+    }
+
     // MARK: - POST /instructor/:id/open
 
     func testOpenAssignmentSetsIsOpenTrue() async throws {


### PR DESCRIPTION
## Summary
- make auto-detected assignment requirements more conservative by ignoring solution-only notebook imports
- refuse `Create & Validate` when no compatible active runner is available
- persist assignment requirements before validation queueing and cover the new behavior with regression tests

## Testing
- swift test --filter AssignmentHelpersTests/testDetectRequirementSuggestionsIgnoresSolutionNotebookImports
- swift test --filter AssignmentRoutesTests/testSaveNewAssignmentRequiresCompatibleRunnerForValidation
- swift test --filter AssignmentRoutesTests/testSaveNewAssignmentFinalizesDraftAndPersistsRequirements