### PR TITLE
Default dashboard user tables to recent logins

### DIFF
--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -684,7 +684,10 @@ Admin
                 });
             });
 
-            sortUsersByHeader(userHeaders[0], 'asc');
+            var defaultUserHeader = userHeaders.find(function (header) {
+                return header.getAttribute('data-sort-key') === 'last-login';
+            }) || userHeaders[0];
+            sortUsersByHeader(defaultUserHeader, 'desc');
         }
     }
 

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -881,8 +881,8 @@ tr.assignment-draggable td {
     // ── Enrolled students table sort ──────────────────────────────────────────
     var enrolledTable = document.getElementById('enrolled-students-table');
     if (enrolledTable) {
-        var sortCol = -1;
-        var sortAsc = true;
+        var sortCol = 3;
+        var sortAsc = false;
         enrolledTable.querySelectorAll('tbody tr.student-row-link').forEach(function (row) {
             row.addEventListener('click', function (event) {
                 var target = event.target;
@@ -929,6 +929,27 @@ tr.assignment-draggable td {
                 rows.forEach(function (row) { tbody.appendChild(row); });
             });
         });
+
+        var defaultEnrolledSortHeader = enrolledTable.querySelector('th.sortable[data-col="3"]');
+        if (defaultEnrolledSortHeader) {
+            defaultEnrolledSortHeader.querySelector('.sort-icon').textContent = '↓';
+            var defaultEnrolledBody = enrolledTable.querySelector('tbody');
+            var defaultEnrolledRows = Array.from(defaultEnrolledBody.querySelectorAll('tr'));
+            defaultEnrolledRows.sort(function (a, b) {
+                var aISO = a.cells[3] ? a.cells[3].getAttribute('data-iso') : '';
+                var bISO = b.cells[3] ? b.cells[3].getAttribute('data-iso') : '';
+                var aDate = aISO ? new Date(aISO).getTime() : 0;
+                var bDate = bISO ? new Date(bISO).getTime() : 0;
+                var result = aDate - bDate;
+                if (result === 0) {
+                    var aUsername = (a.cells[1] ? a.cells[1].textContent : '').trim().toLowerCase();
+                    var bUsername = (b.cells[1] ? b.cells[1].textContent : '').trim().toLowerCase();
+                    result = aUsername.localeCompare(bUsername);
+                }
+                return sortAsc ? result : -result;
+            });
+            defaultEnrolledRows.forEach(function (row) { defaultEnrolledBody.appendChild(row); });
+        }
 
         var enrolledFilter = document.getElementById('enrolled-filter');
         if (enrolledFilter) {

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -45,8 +45,27 @@ struct AdminRoutes: RouteCollection {
     @Sendable
     func dashboard(req: Request) async throws -> View {
         let users = try await APIUser.query(on: req.db)
-            .sort(\.$createdAt)
             .all()
+            .sorted { lhs, rhs in
+                switch (lhs.lastLoginAt, rhs.lastLoginAt) {
+                case let (l?, r?):
+                    if l != r { return l > r }
+                case (.some, nil):
+                    return true
+                case (nil, .some):
+                    return false
+                case (nil, nil):
+                    break
+                }
+
+                if lhs.username != rhs.username {
+                    return lhs.username.localizedStandardCompare(rhs.username) == .orderedAscending
+                }
+
+                let lhsCreated = lhs.createdAt ?? .distantPast
+                let rhsCreated = rhs.createdAt ?? .distantPast
+                return lhsCreated < rhsCreated
+            }
 
         let userRows = users.map { u in
             AdminUserRow(

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -144,8 +144,20 @@ struct AssignmentRoutes: RouteCollection {
             } else {
                 enrolledUsers = try await APIUser.query(on: req.db)
                     .filter(\.$id ~~ enrolledUserIDs)
-                    .sort(\.$username)
                     .all()
+                    .sorted { lhs, rhs in
+                        switch (lhs.lastLoginAt, rhs.lastLoginAt) {
+                        case let (l?, r?):
+                            if l != r { return l > r }
+                        case (.some, nil):
+                            return true
+                        case (nil, .some):
+                            return false
+                        case (nil, nil):
+                            break
+                        }
+                        return lhs.username.localizedStandardCompare(rhs.username) == .orderedAscending
+                    }
                 enrolledStudents = enrolledUsers.compactMap { u in
                     guard let id = u.id else { return nil }
                     return EnrolledStudentRow(

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -247,6 +247,32 @@ final class AdminRoutesTests: XCTestCase {
         })
     }
 
+    func testAdminDashboardDefaultsUsersToMostRecentLastLoginFirst() async throws {
+        let cookie = try await loginAsAdmin()
+        let now = Date()
+        _ = try await makeUser(username: "never_logged_in")
+        let older = try await makeUser(username: "older_login", role: "student")
+        older.lastLoginAt = now.addingTimeInterval(-3600)
+        try await older.save(on: app.db)
+        let recent = try await makeUser(username: "recent_login", role: "student")
+        recent.lastLoginAt = now
+        try await recent.save(on: app.db)
+
+        try await app.asyncTest(.GET, "/admin", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = String(buffer: res.body)
+            XCTAssertTrue(body.contains("data-sort-key=\"last-login\""))
+            XCTAssertTrue(body.contains("sortUsersByHeader(defaultUserHeader, 'desc');"))
+            let recentIndex = try XCTUnwrap(body.range(of: "recent_login")?.lowerBound)
+            let olderIndex = try XCTUnwrap(body.range(of: "older_login")?.lowerBound)
+            let neverIndex = try XCTUnwrap(body.range(of: "never_logged_in")?.lowerBound)
+            XCTAssertLessThan(recentIndex, olderIndex)
+            XCTAssertLessThan(olderIndex, neverIndex)
+        })
+    }
+
     func testEditCourseUpdatesFields() async throws {
         let cookie = try await loginAsAdmin()
         let course = try await makeCourse(code: "EDIT101", name: "Original Name")

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -388,6 +388,40 @@ final class AssignmentRoutesTests: XCTestCase {
         })
     }
 
+    func testAssignmentsPageDefaultsEnrolledStudentsToMostRecentLastLoginFirst() async throws {
+        _ = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+        let now = Date()
+
+        let never = try await insertStudent(username: "never_login_student", displayName: "Never Login")
+        try await enrollStudentInTestCourse(never)
+
+        let older = try await insertStudent(username: "older_login_student", displayName: "Older Login")
+        older.lastLoginAt = now.addingTimeInterval(-3600)
+        try await older.save(on: app.db)
+        try await enrollStudentInTestCourse(older)
+
+        let recent = try await insertStudent(username: "recent_login_student", displayName: "Recent Login")
+        recent.lastLoginAt = now
+        try await recent.save(on: app.db)
+        try await enrollStudentInTestCourse(recent)
+
+        try await app.asyncTest(.GET, "/instructor", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("id=\"enrolled-students-table\""))
+            XCTAssertTrue(html.contains("var sortCol = 3;"))
+            XCTAssertTrue(html.contains("var sortAsc = false;"))
+            let recentIndex = try XCTUnwrap(html.range(of: "recent_login_student")?.lowerBound)
+            let olderIndex = try XCTUnwrap(html.range(of: "older_login_student")?.lowerBound)
+            let neverIndex = try XCTUnwrap(html.range(of: "never_login_student")?.lowerBound)
+            XCTAssertLessThan(recentIndex, olderIndex)
+            XCTAssertLessThan(olderIndex, neverIndex)
+        })
+    }
+
     // MARK: - POST /instructor (publish → creates draft)
 
     func testPublishCreatesDraftAssignment() async throws {


### PR DESCRIPTION
## Summary
- default the instructor enrolled-students table to last login descending
- default the admin users table to last login descending
- add focused regression coverage for both dashboard tables

## Testing
- swift test --filter AssignmentRoutesTests/testAssignmentsPageDefaultsEnrolledStudentsToMostRecentLastLoginFirst
- swift test --filter AdminRoutesTests/testAdminDashboardDefaultsUsersToMostRecentLastLoginFirst