### PR TITLE
Add stale runner cleanup and offline indicators

### DIFF
--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -6,7 +6,7 @@ Runner #(runner.workerID)
 <section class="admin-section">
     <div data-runner-id="#(runner.workerID)" style="display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;flex-wrap:wrap;margin-bottom:1rem">
         <div>
-            <h2 style="margin:0"><code>#(runner.workerID)</code></h2>
+            <h2 style="margin:0"><code>#(runner.workerID)</code> <span id="runner-offline-badge" style="display:none;font-size:.7rem;font-weight:600;padding:.1rem .4rem;border-radius:999px;background:var(--gray-200);color:var(--gray-600);vertical-align:middle;letter-spacing:.03em;text-transform:uppercase">Offline</span></h2>
             <p style="margin:.4rem 0 0;color:var(--muted)">
                 <span id="runner-hostname">#if(runner.hostname != ""):#(runner.hostname)#else:Unknown host#endif</span>
                 ·
@@ -198,6 +198,8 @@ th.sort-desc .sort-header::after {
         return relativeFormatter.format(years, 'year');
     }
 
+    var offlineBadge = document.getElementById('runner-offline-badge');
+
     function applyRelativeTimes() {
         document.querySelectorAll('.js-relative-time[data-iso]').forEach(function (el) {
             var iso = el.getAttribute('data-iso');
@@ -207,6 +209,14 @@ th.sort-desc .sort-header::after {
             el.textContent = formatRelative(iso);
             el.title = date.toLocaleString();
         });
+        // Show/hide the offline badge based on how recently the runner checked in.
+        if (offlineBadge) {
+            var laEl = document.getElementById('runner-last-active');
+            var laIso = laEl ? laEl.getAttribute('data-iso') : null;
+            var laMs = laIso ? new Date(laIso).getTime() : 0;
+            var isOffline = laMs > 0 && (Date.now() - laMs) > 5 * 60 * 1000;
+            offlineBadge.style.display = isOffline ? '' : 'none';
+        }
     }
     applyRelativeTimes();
 

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -290,6 +290,22 @@ Admin
 #courses-table th[data-sort-key].sort-desc::after {
     content: "  ↓";
 }
+tr.runner-row-offline {
+    opacity: .5;
+}
+.runner-badge-offline {
+    display: inline-block;
+    font-size: .7rem;
+    font-weight: 600;
+    padding: .1rem .4rem;
+    border-radius: 999px;
+    background: var(--gray-200);
+    color: var(--gray-600);
+    vertical-align: middle;
+    margin-left: .3rem;
+    letter-spacing: .03em;
+    text-transform: uppercase;
+}
 </style>
 <script>
 (function () {
@@ -430,7 +446,12 @@ Admin
             var lastActive = escapeHtml(worker.lastActive || '');
             var detailURL = '/admin/runners/' + encodeURIComponent(worker.workerID || '');
 
+            // Runners not seen in the last 5 minutes are considered offline.
+            var lastActiveMs = lastActive ? new Date(lastActive).getTime() : 0;
+            var isOffline = lastActiveMs > 0 && (Date.now() - lastActiveMs) > 5 * 60 * 1000;
+
             var idCell = '<a href="' + detailURL + '"><code>' + id + '</code></a>'
+                + (isOffline ? ' <span class="runner-badge-offline">Offline</span>' : '')
                 + (hostname ? '<br><span style="font-size:.8em;color:var(--muted)">' + hostname + '</span>' : '');
             var loadCell = maxJobs > 0
                 ? (assignedJobs + '&thinsp;/&thinsp;' + maxJobs)
@@ -438,6 +459,7 @@ Admin
             var loadStyle = assignedJobs > 0 ? ' style="font-weight:600"' : '';
 
             return '<tr'
+                + (isOffline ? ' class="runner-row-offline"' : '')
                 + ' data-runner="' + id + '"'
                 + ' data-version="' + version + '"'
                 + ' data-load="' + assignedJobs + '"'
@@ -588,6 +610,7 @@ Admin
 
     applyRelativeTimes(document);
     recomputeLoadSummaryFromTable();
+    refreshWorkers();
     refreshDiagnostics();
 
     if (workersTable && workersBody && workerHeaders.length) {

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -426,8 +426,14 @@ actor WorkerActivityStore {
         return withinTTL && !entry.hostname.isEmpty && entry.hostname != hostname
     }
 
-    func snapshotsSortedByRecent() -> [WorkerActivitySnapshot] {
-        entries
+    /// Returns snapshots for runners seen within `cutoff` seconds, pruning
+    /// stale entries from the in-memory store at the same time.  Runners that
+    /// have not contacted the server for more than an hour are dropped so they
+    /// don't accumulate forever after a rename or permanent shutdown.
+    func snapshotsSortedByRecent(cutoff: TimeInterval = 3600, now: Date = Date()) -> [WorkerActivitySnapshot] {
+        // Prune any entry that hasn't been seen within the cutoff window.
+        entries = entries.filter { now.timeIntervalSince($0.value.lastSeen) <= cutoff }
+        return entries
             .map { WorkerActivitySnapshot(
                 workerID: $0.key,
                 lastActive: $0.value.lastSeen,

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -137,8 +137,42 @@ struct AdminRoutes: RouteCollection {
         }
 
         let workerRows = try await makeWorkerRows(req: req)
-        guard let worker = workerRows.first(where: { $0.workerID == runnerID }) else {
-            throw Abort(.notFound)
+        let worker: AdminWorkerRow
+        if let found = workerRows.first(where: { $0.workerID == runnerID }) {
+            worker = found
+        } else {
+            // Runner was pruned from the in-memory store (offline >60 min).
+            // Reconstruct a minimal row from the most recent DB snapshot so
+            // the detail page can still render historical data instead of 404.
+            guard let latestSnapshot = try await RunnerSnapshot.query(on: req.db)
+                .filter(\.$runnerID == runnerID)
+                .sort(\.$recordedAt, .descending)
+                .first()
+            else {
+                throw Abort(.notFound)
+            }
+            let iso = ISO8601DateFormatter()
+            let processedCount = try await APISubmission.query(on: req.db)
+                .filter(\.$workerID == runnerID)
+                .filter(\.$status ~~ ["complete", "failed"])
+                .count()
+            let avgData = try? await req.application.diagnostics.rollingAverages(
+                for: [runnerID], sampleSize: 50, on: req.db
+            )
+            let avg = avgData?[runnerID]
+            worker = AdminWorkerRow(
+                workerID: runnerID,
+                hostname: latestSnapshot.hostname ?? "",
+                runnerVersion: latestSnapshot.runnerVersion ?? "",
+                maxConcurrentJobs: latestSnapshot.maxJobs,
+                lastActive: iso.string(from: latestSnapshot.recordedAt),
+                assignedJobs: 0,
+                jobsProcessed: processedCount,
+                avgExecutionMs: avg?.avgExecutionMs,
+                avgQueueWaitMs: avg?.avgQueueWaitMs,
+                avgExecutionFormatted: avg?.avgExecutionMs.map(formatMs),
+                avgQueueWaitFormatted: avg?.avgQueueWaitMs.map(formatMs)
+            )
         }
         let runnerProfile = try? await req.application.runnerProfiles.profile(for: runnerID, on: req.db)
 


### PR DESCRIPTION
## Summary

- **Auto-prune stale runners**: `WorkerActivityStore.snapshotsSortedByRecent()` now drops entries older than 60 minutes from its in-memory dictionary on every read. Runners that were renamed, crashed, or permanently shut down disappear from the admin list automatically without requiring a server restart.
- **Offline badge on admin dashboard**: `renderWorkers()` in `admin.leaf` now computes whether each runner's last contact is >5 minutes ago and, if so, dims the row and shows an "Offline" badge next to the runner ID. The initial `refreshWorkers()` call now runs immediately on page load (previously only in the 5-second interval).
- **Offline badge on runner detail page**: `admin-runner.leaf`'s JS refresh loop now also shows/hides an inline "Offline" badge in the page header based on last-active age.
- **Graceful fallback for pruned runners**: `runnerDetail()` no longer 404s when a runner has aged out of the in-memory store. It reconstructs a minimal `AdminWorkerRow` from the most-recent `RunnerSnapshot` DB record so the historical jobs and snapshot tables remain browseable.

## Thresholds

| Threshold | Meaning |
|-----------|---------|
| >5 min without contact | Row dimmed + "Offline" badge (admin dashboard and detail page) |
| >60 min without contact | Entry pruned from in-memory store; detail page falls back to DB-only view |

## Test plan
- [ ] Open `/admin`, stop the runner container, wait 5 minutes → row dims and shows "Offline"
- [ ] Wait 60+ minutes (or set `cutoff: 5` in dev) → runner disappears from the list
- [ ] Navigate directly to `/admin/runners/<stale-runner-id>` → page renders with historical snapshots/jobs instead of 404
- [ ] Restart the runner → it reappears in the list within 5 seconds and badge disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)