### PR TITLE
Fix trivy-action version tag (0.30.0 → v0.35.0)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: table


### PR DESCRIPTION
The `aquasecurity/trivy-action@0.30.0` tag doesn't exist — all trivy-action releases now require the `v` prefix. Update to the current release (`v0.35.0`, Trivy 0.69.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)