### PR TITLE
Fix :latest Docker tag not updated on version tag pushes

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           images: ${{ env.IMAGE }}
           tags: |
-            # :latest on every push to main
-            type=raw,value=latest,enable={{is_default_branch}}
+            # :latest on pushes to main AND on version tags
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
             # :sha-<short-commit> on every push (immutable, good for rollback)
             type=sha,prefix=sha-
             # :v0.4.1 etc. on version tags


### PR DESCRIPTION
## Summary

- `:latest` was only pushed when the workflow ran on the `main` branch. Version tag pushes (e.g. `v0.4.57`) produced `:0.4.57` and `:sha-...` but left `:latest` pointing at the previous build.
- Production servers running `docker compose pull` would pull `:latest` and see no change, silently staying on the old version.
- Fix: `:latest` is now also pushed when the trigger is a `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)