### PR TITLE
Remove platform and architecture fields from assignment create form

### DIFF
--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -134,14 +134,6 @@ Create Assignment
                 Capabilities
                 <input class="form-input" type="text" name="requiredCapabilitiesCSV" value="#(requiredCapabilitiesCSV)" placeholder="numpy, pandas, shell-bash">
             </label>
-            <label class="form-label">
-                Platform (advanced)
-                <input class="form-input" type="text" name="requiredPlatform" value="#(requiredPlatform)" placeholder="linux">
-            </label>
-            <label class="form-label">
-                Architecture (advanced)
-                <input class="form-input" type="text" name="requiredArchitecture" value="#(requiredArchitecture)" placeholder="arm64">
-            </label>
         </div>
     </section>
 


### PR DESCRIPTION
Removes the "Platform (advanced)" and "Architecture (advanced)" text inputs from the instructor assignment create page. These runner-matching fields add unnecessary complexity and are not needed in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)