### PR TITLE
Improve instructor assignment submissions view UX

### DIFF
--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -3,15 +3,8 @@
 #(assignmentTitle) — Submissions
 #endexport
 #export("content"):
-<div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:.75rem;margin-bottom:1rem">
+<div style="margin-bottom:1rem">
     <h1 style="margin:0">#(assignmentTitle)</h1>
-    <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
-        <input id="submissions-filter" class="form-input" type="search" autocomplete="off"
-               placeholder="Filter by name or ID…"
-               style="width:220px" aria-label="Filter students"
-               readonly onfocus="this.removeAttribute('readonly')">
-        <a class="btn action-btn" href="/instructor">Back to Instructor</a>
-    </div>
 </div>
 
 <section class="assignment-diagnostics">
@@ -28,25 +21,31 @@
 #if(rows.isEmpty):
 <p class="empty">No student users found.</p>
 #else:
+<div style="margin-bottom:.5rem">
+    <input id="submissions-filter" class="form-input" type="search" autocomplete="off"
+           placeholder="Filter by name or ID…"
+           style="width:220px" aria-label="Filter students"
+           readonly onfocus="this.removeAttribute('readonly')">
+</div>
 <table class="results-table" id="assignment-submissions-table">
     <thead>
         <tr>
-            <th data-sort-key="student_id" data-sort-type="text" tabindex="0" aria-sort="none">Student ID</th>
             <th data-sort-key="surname" data-sort-type="text" tabindex="0" aria-sort="none">Surname</th>
             <th data-sort-key="given_names" data-sort-type="text" tabindex="0" aria-sort="none">Given Names</th>
+            <th data-sort-key="student_id" data-sort-type="text" tabindex="0" aria-sort="none">Student ID</th>
             <th data-sort-key="grade" data-sort-type="number" tabindex="0" aria-sort="none">Grade</th>
-            <th data-sort-key="history" data-sort-type="text" tabindex="0" aria-sort="none">History</th>
+            <th data-sort-key="history" data-sort-type="datetime" tabindex="0" aria-sort="none">History</th>
             <th>Action</th>
         </tr>
     </thead>
     <tbody>
     #for(row in rows):
         <tr>
-            <td><strong>#(row.studentID)</strong></td>
             <td>#(row.surname)</td>
             <td>#(row.givenNames)</td>
+            <td><strong>#(row.studentID)</strong></td>
             <td>#(row.gradeText)</td>
-            <td>
+            <td data-ts="#(row.latestSubmittedAtEpoch)">
                 #if(row.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(row.hasLatestSubmission):
@@ -138,7 +137,11 @@
 
     function readCellValue(row, index, type) {
         var cell = row.children[index];
-        if (!cell) return '';
+        if (!cell) return type === 'number' || type === 'datetime' ? Number.NEGATIVE_INFINITY : '';
+        if (type === 'datetime') {
+            var ts = parseInt(cell.getAttribute('data-ts') || '0', 10);
+            return isNaN(ts) ? 0 : ts;
+        }
         var text = (cell.textContent || '').trim();
         if (type === 'number') {
             return normalizeNumber(text);
@@ -162,15 +165,21 @@
             var lv = readCellValue(lhs, index, type);
             var rv = readCellValue(rhs, index, type);
             var result = 0;
-            if (type === 'number') {
+            if (type === 'number' || type === 'datetime') {
                 result = lv - rv;
             } else {
                 result = collator.compare(String(lv), String(rv));
             }
             if (result === 0) {
-                var lhsID = (lhs.children[0] && lhs.children[0].textContent || '').trim();
-                var rhsID = (rhs.children[0] && rhs.children[0].textContent || '').trim();
-                result = collator.compare(lhsID, rhsID);
+                // tie-break: surname (col 0), then given names (col 1)
+                var ls = (lhs.children[0] && lhs.children[0].textContent || '').trim();
+                var rs = (rhs.children[0] && rhs.children[0].textContent || '').trim();
+                result = collator.compare(ls, rs);
+                if (result === 0) {
+                    var lg = (lhs.children[1] && lhs.children[1].textContent || '').trim();
+                    var rg = (rhs.children[1] && rhs.children[1].textContent || '').trim();
+                    result = collator.compare(lg, rg);
+                }
             }
             return direction === 'asc' ? result : -result;
         });
@@ -195,7 +204,11 @@
         });
     });
 
-    sortByHeader(headers[0], 'asc');
+    // Default: most recent submissions at top (History column, descending)
+    var historyHeader = headers.find(function (h) { return h.getAttribute('data-sort-key') === 'history'; });
+    if (historyHeader) {
+        sortByHeader(historyHeader, 'desc');
+    }
 
     var filter = document.getElementById('submissions-filter');
     if (filter && tbody) {

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -77,6 +77,7 @@ struct AssignmentStudentRow: Encodable {
     let hasLatestSubmission: Bool
     let latestSubmissionID: String
     let latestSubmittedAtText: String
+    let latestSubmittedAtEpoch: Int   // Unix timestamp (0 if no submission) for chronological sort
     let additionalSubmissionCount: Int
     let fullHistoryURL: String
     let bestGradePercent: Int?

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
@@ -318,6 +318,7 @@ extension AssignmentRoutes {
                 hasLatestSubmission: latest != nil,
                 latestSubmissionID: latest?.id ?? "",
                 latestSubmittedAtText: latest?.submittedAt.map { fmt.string(from: $0) } ?? "—",
+                latestSubmittedAtEpoch: latest?.submittedAt.map { Int($0.timeIntervalSince1970) } ?? 0,
                 additionalSubmissionCount: max(history.count - 1, 0),
                 fullHistoryURL: "/instructor/\(assignmentIDRaw)/students/\(studentID.uuidString)/history",
                 bestGradePercent: bestGradePercent
@@ -325,7 +326,6 @@ extension AssignmentRoutes {
         }
 
         let submittedCount = rows.filter { $0.submissionCount > 0 }.count
-        let neverSubmittedCount = max(rows.count - submittedCount, 0)
         let submissions24h = submissions.filter { submission in
             guard let submittedAt = submission.submittedAt else { return false }
             return submittedAt >= windowStart
@@ -337,15 +337,30 @@ extension AssignmentRoutes {
             count += 1
         }
         let gradedRows = rows.compactMap(\.bestGradePercent)
-        let averageBestGrade = gradedRows.isEmpty
-            ? "—"
-            : "\(Int((Double(gradedRows.reduce(0, +)) / Double(gradedRows.count)).rounded()))%"
+        let medianBestGrade: String
+        if gradedRows.isEmpty {
+            medianBestGrade = "—"
+        } else {
+            let sorted = gradedRows.sorted()
+            let mid = sorted.count / 2
+            let median = sorted.count % 2 == 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+            medianBestGrade = "\(median)%"
+        }
+        let submittedRows = rows.filter { $0.submissionCount > 0 }
+        let avgAttempts: String
+        if submittedRows.isEmpty {
+            avgAttempts = "—"
+        } else {
+            let total = submittedRows.reduce(0) { $0 + $1.submissionCount }
+            let avg = Double(total) / Double(submittedRows.count)
+            avgAttempts = String(format: "%.1f", avg)
+        }
         let metrics = [
-            InstructorDashboardMetric(label: "Submitted At Least Once", value: "\(submittedCount)/\(rows.count)"),
-            InstructorDashboardMetric(label: "No Submission Yet", value: "\(neverSubmittedCount)"),
+            InstructorDashboardMetric(label: "Students Submitted", value: "\(submittedCount)/\(rows.count)"),
+            InstructorDashboardMetric(label: "Avg Attempts/Student", value: avgAttempts),
             InstructorDashboardMetric(label: "Submissions (24h)", value: "\(submissions24h)"),
-            InstructorDashboardMetric(label: "Pending Latest Attempts", value: "\(pendingLatestCount)"),
-            InstructorDashboardMetric(label: "Average Best Grade", value: averageBestGrade)
+            InstructorDashboardMetric(label: "Queued Jobs", value: "\(pendingLatestCount)"),
+            InstructorDashboardMetric(label: "Median Grade", value: medianBestGrade)
         ]
 
         return try await req.view.render(


### PR DESCRIPTION
- Sort by most recent submission descending on page load (was alphabetical by student ID)
- Reorder columns: Surname, Given Names, Student ID (names first)
- Move filter input to immediately above the table; remove Back to Instructor button
- Metrics: Students Submitted, Avg Attempts/Student, Submissions (24h), Queued Jobs, Median Grade (replaced "No Submission Yet" with avg attempts, average→median grade, label renames)