### PR TITLE
Surface import traceback to students on submission load failure

### DIFF
--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -206,10 +206,8 @@ def require_function(name: str):
         errors = student_module_errors()
         if errors:
             first_name = next(iter(errors.keys()))
-            errored(
-                "Could not load any student Python module from submission. "
-                f"First load failure came from '{first_name}'."
-            )
+            print(errors[first_name], end="")
+            errored("SyntaxError in submission")
         errored("Could not load a student Python module from submission.")
 
     errored(f"Required function '{name}' was not found or is not callable in loaded student modules.")

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -196,10 +196,8 @@ def require_function(name: str):
         errors = student_module_errors()
         if errors:
             first_name = next(iter(errors.keys()))
-            errored(
-                "Could not load any student Python module from submission. "
-                f"First load failure came from '{first_name}'."
-            )
+            print(errors[first_name], end="")
+            errored("SyntaxError in submission")
         errored("Could not load a student Python module from submission.")
 
     errored(f"Required function '{name}' was not found or is not callable in loaded student modules.")


### PR DESCRIPTION
## Summary

- When a student's `submission.py` has a syntax or indentation error, the module import fails and the stored traceback is now printed to stdout before the `errored()` call
- This puts the file path, line number, and error type in `longResult` for both the native runner (via `strippedStdout`) and the browser runner (via `extractTracebackText`)
- `shortResult` is changed from the internal harness message to `"SyntaxError in submission"`

## Test plan

- [ ] Submit a notebook with an `IndentationError` — confirm `longResult` contains the traceback and `shortResult` is `"SyntaxError in submission"`
- [ ] Submit a notebook with a `SyntaxError` (e.g. `return dict_name{...}`) — same check
- [ ] Submit a valid notebook — confirm no change to passing/failing/error feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)