### PR TITLE
Fix Docker :latest stuck at 0.4.59 — apply OS security patches in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #
 # For additional R packages:
 #   RUN Rscript -e "install.packages(c('tidyverse', ...), repos='https://cloud.r-project.org')"
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         file \


### PR DESCRIPTION
$(cat <<'EOF'
## Problem

`docker compose pull` was returning the 0.4.59 image even after v0.4.60 and v0.4.61 were released and tagged on GitHub.

## Root cause

`docker-build.yml` runs a Trivy vulnerability scan with `exit-code: 1` / `severity: CRITICAL` **before** the push step. The Dockerfile runtime stage (`ubuntu:22.04`) was missing `apt-get upgrade`, so critical CVEs in base packages accumulated over time. Once a new critical CVE appeared after the 0.4.59 build, every subsequent Docker CI run failed at the Trivy step and never reached the push step — leaving `:latest` on GHCR frozen at 0.4.59.

## Fix

Added `apt-get upgrade -y` to the runtime stage `RUN` command so OS-level security patches are applied on every Docker build, clearing the CVEs that were blocking Trivy.

```diff
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
```

## Test plan

- [ ] Docker CI (`Build and Push Docker Image`) passes — specifically the Trivy scan step
- [ ] `:latest` on GHCR updates to 0.4.61 after merge + tag
- [ ] `docker compose pull && docker compose up -d` shows runner reporting version 0.4.61

https://claude.ai/code/session_01UX4gTR64ReSegusiCwZeY8
EOF
)