### PR TITLE
Fix conflict TTL never expiring when RUNNER_WORKER_ID is fixed

### DIFF
--- a/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
+++ b/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
@@ -69,14 +69,25 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
             throw Abort(.unauthorized, reason: "Invalid worker signature.")
         }
 
-        if let workerID, !workerID.isEmpty {
-            // Pass hostname: "" here — the middleware doesn't have access to the
-            // request body, so we preserve whatever hostname was set by the
-            // job-request body handler rather than clobbering it with empty string.
+        let response = try await next.respond(to: request)
+
+        // Update last-seen AFTER the handler responds so that a 409 conflict
+        // response does NOT refresh lastSeen.  If we updated before the handler,
+        // the conflict TTL would be reset on every poll attempt and would never
+        // expire, permanently locking out a runner whose container hostname
+        // changed on restart (e.g. docker compose down/up with a fixed
+        // RUNNER_WORKER_ID).  Skipping the touch on 409 lets lastSeen go stale
+        // naturally so the TTL expires and the runner can re-register with its
+        // new hostname and updated version.
+        //
+        // Pass hostname: "" — the middleware has no access to the request body,
+        // so we preserve whatever hostname the handler already wrote rather than
+        // clobbering it with an empty string.
+        if let workerID, !workerID.isEmpty, response.status != .conflict {
             await request.application.workerActivityStore.markActive(workerID: workerID, hostname: "")
         }
 
-        return try await next.respond(to: request)
+        return response
     }
 }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The HMAC middleware was calling `markActive(workerID, hostname: "")` **before** passing the request to the handler, which refreshed `lastSeen` to NOW on every poll attempt — including ones that were about to return 409 Conflict
- Because `isConflict` gates on whether `lastSeen` falls within the 90-second TTL, and the middleware always reset it to NOW first, the conflict **never expired** while the runner kept retrying
- The runner's `runnerVersion` was permanently frozen (handler's `markActive` — the only place that writes `runnerVersion` for idle runners — was never reached), while `lastSeen` stayed fresh so the dashboard showed the runner as "active"

## Fix

Move the middleware's `markActive` touch to after `next.respond`, and skip it on 409. The conflict TTL now counts down from when the old container last successfully polled, not from when the new container started retrying.

## Test plan

- [ ] `docker compose down && docker compose up -d` with `RUNNER_WORKER_ID` set to a fixed value — runner should go offline briefly, then come back online with updated version/hostname after the TTL window
- [ ] Confirm runner version updates in admin dashboard after restart
- [ ] Confirm downloads and result submissions still update last-seen (middleware touch still fires for non-409 responses)

https://claude.ai/code/session_01JqkGk3grd4qcgCKG1d1a2R
EOF
)