### PR TITLE
Add "Create solution" button to assignment edit page

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -91,7 +91,11 @@
                         #if(solutionNotebookEditURL):
                         <a class="btn action-btn" id="solution-notebook-edit-btn" href="#(solutionNotebookEditURL)">Edit</a>
                         #else:
-                        <span class="card-meta">—</span>
+                        <form method="post" action="/instructor/#(assignmentID)/create-solution" style="margin:0">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    title="Copy the assignment notebook as a starting point for the solution">Create solution</button>
+                        </form>
                         #endif
                     </td>
                 </tr>

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
@@ -211,6 +211,13 @@ extension AssignmentRoutes {
             resolvedSolutionNotebookRaw = existingSolution.data
             solutionFilename = existingSolution.filename
         }
+        if resolvedSolutionNotebookRaw.isEmpty, let userID = user.id,
+           let draftData = draftNotebookData(
+               req: req, setupID: setup.id!, userID: userID, fileKind: .solution,
+               fallbackPath: draftSolutionNotebookPath(
+                   testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)) {
+            resolvedSolutionNotebookRaw = draftData
+        }
         guard !resolvedSolutionNotebookRaw.isEmpty else {
             let q = "assignmentName=\(urlEncode(title))&dueAt=\(urlEncode(dueAtRaw ?? ""))&error=Solution%20notebook%20(.ipynb)%20is%20required%20for%20validation"
             return req.redirect(to: "/instructor/\(idStr)/edit?\(q)")
@@ -529,6 +536,38 @@ extension AssignmentRoutes {
         }
 
         return try await results.encodeResponse(for: req)
+    }
+
+    // MARK: - POST /instructor/:assignmentID/create-solution
+
+    @Sendable
+    func createSolutionFromAssignment(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard user.isInstructor, let userID = user.id else { throw Abort(.forbidden) }
+
+        let idStr = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(idStr, on: req.db),
+            let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
+        else { throw Abort(.notFound) }
+
+        let sourceData = (try? notebookData(for: setup))
+            ?? defaultNotebookData(title: "\(assignment.title) Solution")
+        let normalized = normalizeNotebookForJupyterLite(sourceData)
+
+        let draftPath = draftSolutionNotebookPath(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+        _ = try ensureDraftNotebookDirectory(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+        try normalized.write(to: URL(fileURLWithPath: draftPath))
+
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req, setupID: setup.id!, userID: userID, fallbackSetup: setup,
+            relativePath: userNotebookWorkingCopyRelativePath(
+                setupID: setup.id!, userID: userID, fileKind: .solution),
+            overwriteWith: normalized)
+
+        return req.redirect(to: "/testsetups/\(setup.id!)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))")
     }
 }
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -61,6 +61,7 @@ struct AssignmentRoutes: RouteCollection {
         r.post(":assignmentID", "open",    use: openAssignment)
         r.post(":assignmentID", "close",   use: closeAssignment)
         r.post(":assignmentID", "delete",  use: deleteAssignment)
+        r.post(":assignmentID", "create-solution", use: createSolutionFromAssignment)
 
         // Script editor — inline CRUD for individual test/support files in the setup zip.
         r.post("scan-notebook", use: scanNotebook)
@@ -1422,8 +1423,11 @@ struct AssignmentRoutes: RouteCollection {
             var notice: String?
         }
         let q = try? req.query.decode(EditQuery.self)
+        let draftSolutionPath = draftSolutionNotebookPath(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
         let hasKnownSolution = assignment.validationStatus == "passed"
             || assignment.validationSubmissionID != nil
+            || FileManager.default.fileExists(atPath: draftSolutionPath)
         let currentFiles = currentSetupFiles(
             for: setup,
             assignmentID: idStr,


### PR DESCRIPTION
## Summary

- Replaces the blank "—" in the Solution Notebook action column with a **Create solution** button when no solution exists
- Clicking the button (`POST /instructor/:id/create-solution`) copies the current assignment notebook to a draft solution and opens it in the JupyterLite editor
- `editPage` now detects a draft solution on disk so the "Edit" button appears immediately on return from the editor
- `saveEditedAssignment` gains a `draftNotebookData()` fallback so the draft is picked up on the next Save without requiring a manual file upload

## Test plan

- [ ] Open an assignment edit page with no solution — confirm "Create solution" button appears
- [ ] Click "Create solution" — JupyterLite opens with a copy of the assignment notebook
- [ ] Edit a cell, navigate back to edit page — confirm "Edit" button now shows for Solution Notebook
- [ ] Click "Save" — validation succeeds without uploading a file manually
- [ ] Open an assignment that already has a solution — confirm "Edit" button still shows (no regression)
- [ ] Confirm `POST /instructor/:id/create-solution` returns 403 for non-instructors

https://claude.ai/code/session_01TTCTL5C6LhZ5FX5rKuNaPC