### PR TITLE
Fix notebook upload bypassing draft endpoint in some browsers

### DIFF
--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -586,19 +586,29 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     }
     filesInput.addEventListener('change', addUploadedFiles);
 
-    // Notebook upload buttons: open picker, auto-submit draft action on selection
-    function wireNotebookUpload(btnID, inputID, draftBtnID) {
+    // Notebook upload buttons: open picker, submit to draft endpoint on selection.
+    // Uses explicit form.action override instead of formaction on hidden buttons to
+    // avoid browser inconsistencies with programmatic clicks on hidden submit elements.
+    function wireNotebookUpload(btnID, inputID, draftActionValue) {
         var btn       = document.getElementById(btnID);
         var fileInput = document.getElementById(inputID);
-        var draftBtn  = document.getElementById(draftBtnID);
-        if (!btn || !fileInput || !draftBtn) return;
+        if (!btn || !fileInput) return;
         btn.addEventListener('click', function () { fileInput.value = ''; fileInput.click(); });
         fileInput.addEventListener('change', function () {
-            if (fileInput.files.length > 0) draftBtn.click();
+            if (fileInput.files.length === 0) return;
+            syncConfig();
+            var form = document.getElementById('new-assignment-form');
+            var inp = document.createElement('input');
+            inp.type = 'hidden';
+            inp.name = 'draftAction';
+            inp.value = draftActionValue;
+            form.appendChild(inp);
+            form.action = '/instructor/new/draft';
+            form.submit();
         });
     }
-    wireNotebookUpload('upload-assignment-notebook-btn', 'assignment-notebook-file-input', 'js-upload-assignment-notebook');
-    wireNotebookUpload('upload-solution-notebook-btn',   'solution-notebook-file-input',   'js-upload-solution-notebook');
+    wireNotebookUpload('upload-assignment-notebook-btn', 'assignment-notebook-file-input', 'upload-assignment-notebook');
+    wireNotebookUpload('upload-solution-notebook-btn',   'solution-notebook-file-input',   'upload-solution-notebook');
 
     // Solution file selection shows Generate Tests panel
     var solutionFileInput = document.getElementById('solution-notebook-file-input');


### PR DESCRIPTION
## Summary

- Notebook upload buttons were using `.click()` on hidden `type="submit"` buttons with `formaction` to route to `/instructor/new/draft`. Programmatic clicks on hidden submit elements with `formaction` are unreliable in some browsers (notably Safari), causing the form to fall through to the default `/instructor/new/save` action and trigger full validation (assignment name required, both notebooks required) on what should be a single-file draft save.
- Fix: replace the hidden-button-click pattern with an explicit `form.action = '/instructor/new/draft'` override, a dynamically-injected `draftAction` hidden input, and `form.submit()`. This bypasses `formaction` entirely and guarantees uploads always reach the draft endpoint.
- `syncConfig()` is called before submission to ensure suite config state is current.

## Test plan

- [ ] Upload an assignment notebook on a fresh create-assignment page (no draft, no name filled in) — should succeed and redirect back with a notice, not an "Assignment name is required" error
- [ ] Upload a solution notebook after uploading an assignment notebook — should succeed independently
- [ ] Click "Create & Validate" without filling in assignment name — should still show "Assignment name is required" (full validation still runs on save)
- [ ] Click "Create Blank" and "Clear" for both notebooks — should still work (those buttons still use the existing `formaction` hidden-button path, which is triggered by direct user clicks and is reliable)

https://claude.ai/code/session_011AYiziVN1FhZEAQ1GT6Ecz