### PR TITLE
Add delete user action to admin user page

### DIFF
--- a/Resources/Views/admin-user.leaf
+++ b/Resources/Views/admin-user.leaf
@@ -8,44 +8,15 @@ Courses — #if(displayName):#(displayName)#else:#(username)#endif
     <h1 style="margin:0">
         #if(displayName):#(displayName)#else:#(username)#endif — Courses
     </h1>
+    <form method="post" action="/admin/users/#(targetUserID)/delete" style="margin-left:auto">
+        #csrfFormField()
+        <button class="btn action-btn action-danger" type="submit"
+                onclick="return confirm('Delete this user? Their enrollments will be removed. They can log in again to restore their account.')">Delete User</button>
+    </form>
 </div>
 <p style="color:var(--gray-600);margin-top:-.75rem;margin-bottom:1.5rem">
     @#(username) · #(role)
 </p>
-
-<section class="admin-section">
-    <h2>Identity</h2>
-    #if(authProvider):
-    <p class="card-meta" style="margin-bottom:.75rem">Auth provider: <code>#(authProvider)</code></p>
-    #endif
-    <form method="post" action="/admin/users/#(targetUserID)/identity" style="max-width:540px">
-        #csrfFormField()
-        <div style="display:grid;gap:.75rem">
-            <label style="display:flex;flex-direction:column;gap:.25rem;font-size:.875rem">
-                SSO Subject
-                <input class="form-input" type="text" name="externalSubject"
-                       value="#(externalSubject)" placeholder="— not set —"
-                       style="font-family:monospace;font-size:.85rem">
-            </label>
-            <label style="display:flex;flex-direction:column;gap:.25rem;font-size:.875rem">
-                User ID
-                <input class="form-input" type="text" name="userIdentifier"
-                       value="#(userIdentifier)" placeholder="— not set —">
-            </label>
-            <label style="display:flex;flex-direction:column;gap:.25rem;font-size:.875rem">
-                Student ID
-                <input class="form-input" type="text" name="studentID"
-                       value="#(studentID)" placeholder="— not set —">
-            </label>
-            <label style="display:flex;flex-direction:column;gap:.25rem;font-size:.875rem">
-                Email
-                <input class="form-input" type="email" name="email"
-                       value="#(email)" placeholder="— not set —">
-            </label>
-        </div>
-        <button class="btn btn-primary" type="submit" style="margin-top:.75rem">Save</button>
-    </form>
-</section>
 
 <section class="admin-section">
     <h2>Enrolled courses</h2>

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -99,11 +99,6 @@ struct AdminUserDetailContext: Encodable {
     let displayName: String?
     let username: String
     let role: String
-    let authProvider: String
-    let externalSubject: String
-    let userIdentifier: String
-    let studentID: String
-    let email: String
     let enrolledCourses: [AdminUserCourseRow]
     let availableCourses: [AdminUserCourseRow]
 }

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -36,7 +36,7 @@ struct AdminRoutes: RouteCollection {
         admin.post("courses", ":courseID", "enroll-csv", use: adminBulkEnrollCSV)
         admin.post("courses", ":courseID", "unenroll", ":userID", use: unenrollUserFromCourse)
         admin.get("users", ":userID", use: userDetail)
-        admin.post("users", ":userID", "identity", use: updateUserIdentity)
+        admin.post("users", ":userID", "delete", use: deleteUser)
         admin.post("users", ":userID", "enroll", use: adminEnrollUser)
         admin.post("users", ":userID", "unenroll", ":courseID", use: adminUnenrollUser)
     }
@@ -395,27 +395,15 @@ struct AdminRoutes: RouteCollection {
             displayName:      user.displayName,
             username:         user.username,
             role:             user.role,
-            authProvider:     user.authProvider    ?? "",
-            externalSubject:  user.externalSubject ?? "",
-            userIdentifier:   user.userIdentifier  ?? "",
-            studentID:        user.studentID       ?? "",
-            email:            user.email           ?? "",
             enrolledCourses:  enrolledRows,
             availableCourses: availableRows
         ))
     }
 
-    // MARK: - POST /admin/users/:userID/identity
+    // MARK: - POST /admin/users/:userID/delete
 
     @Sendable
-    func updateUserIdentity(req: Request) async throws -> Response {
-        struct IdentityBody: Content {
-            var externalSubject: String?
-            var userIdentifier: String?
-            var studentID: String?
-            var email: String?
-        }
-
+    func deleteUser(req: Request) async throws -> Response {
         guard
             let idString = req.parameters.get("userID"),
             let uuid     = UUID(uuidString: idString),
@@ -424,22 +412,11 @@ struct AdminRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        let body = try req.content.decode(IdentityBody.self)
-
-        let sub = (body.externalSubject ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        user.externalSubject = sub.isEmpty ? nil : sub
-
-        let uid = (body.userIdentifier ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        user.userIdentifier = uid.isEmpty ? nil : uid
-
-        let sid = (body.studentID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        user.studentID = sid.isEmpty ? nil : sid
-
-        let em = (body.email ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        user.email = em.isEmpty ? nil : em
-
-        try await user.save(on: req.db)
-        return req.redirect(to: "/admin/users/\(idString)")
+        try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$userID == uuid)
+            .delete()
+        try await user.delete(on: req.db)
+        return req.redirect(to: "/admin")
     }
 
 }


### PR DESCRIPTION
Replaces the unwanted identity-edit form (PR #350) with a **Delete User** button on `/admin/users/:id`.

- `POST /admin/users/:userID/delete` removes the user's course enrollments and their record, then redirects to `/admin`
- Includes a `confirm()` prompt: *"Delete this user? Their enrollments will be removed. They can log in again to restore their account."*
- Intended for cleaning up corrupted SSO identity records — the account is automatically recreated on next SSO login

https://claude.ai/code/session_011AYiziVN1FhZEAQ1GT6Ecz