### PR TITLE
Fix notebook upload CSRF; remove back button; use icon buttons on edi…

### DIFF
--- a/Resources/Views/admin-user.leaf
+++ b/Resources/Views/admin-user.leaf
@@ -4,7 +4,6 @@ Courses — #if(displayName):#(displayName)#else:#(username)#endif
 #endexport
 #export("content"):
 <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
-    <a href="/admin" class="btn">← Admin</a>
     <h1 style="margin:0">
         #if(displayName):#(displayName)#else:#(username)#endif — Courses
     </h1>

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -141,8 +141,14 @@
                 <td><input type="number" class="form-input suite-points" min="1" max="100" value="#(row.points)" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>
                 <td class="time">
                     <div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">
-                        <button class="btn action-btn suite-edit-btn" type="button" data-filename="#(row.name)">Edit</button>
-                        <button class="btn action-btn action-danger suite-delete-btn" type="button">Delete</button>
+                        <button class="btn action-btn suite-edit-btn" type="button" data-filename="#(row.name)"
+                                title="Edit script" aria-label="Edit script" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+                        </button>
+                        <button class="btn action-btn action-danger suite-delete-btn" type="button"
+                                title="Delete script" aria-label="Delete script" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                        </button>
                     </div>
                 </td>
             </tr>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -600,7 +600,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             inp.value = draftActionValue;
             form.appendChild(inp);
             form.action = '/instructor/new/draft';
-            form.submit();
+            form.requestSubmit();
         });
     }
     wireNotebookUpload('upload-assignment-notebook-btn', 'assignment-notebook-file-input', 'upload-assignment-notebook');


### PR DESCRIPTION
…t page (#352)

- Fix 403 on notebook upload: form.submit() skips the submit event so base.leaf's multipart→fetch interceptor never fires; use requestSubmit()
- Remove redundant "← Admin" button from admin user detail page
- Replace Edit/Delete text buttons with pencil/trash icons on assignment edit page to match the instructor assignments list