### PR TITLE
Fix assignment creation workflow: script visibility, file upload, and templates

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -397,7 +397,10 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             + '</select></td>'
             + '<td><input type="number" class="form-input suite-points" min="1" max="100" value="' + pts + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
             + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
-            +   (isNew ? '' : '<button class="btn action-btn suite-edit-btn" type="button" data-filename="' + escAttr(item.name) + '" title="Edit script" aria-label="Edit script" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>')
+            +   (isNew
+                    ? '<button class="btn action-btn suite-edit-upload-btn" type="button" data-name="' + escAttr(item.name) + '" title="View/Edit script" aria-label="View/Edit script" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>'
+                    : '<button class="btn action-btn suite-edit-btn" type="button" data-filename="' + escAttr(item.name) + '" title="Edit script" aria-label="Edit script" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>'
+                )
             +   '<button class="btn action-btn action-danger suite-delete-btn" type="button" title="Delete script" aria-label="Delete script" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>'
             + '</div></td>'
             + '</tr>';
@@ -710,6 +713,7 @@ const csrfToken = (document.querySelector('meta[name="csrf-token"]') || {}).cont
 let view = null;
 let currentFilename = null;  // null when creating a new file
 let isCreating = false;
+let isEditingUpload = false;  // true when editing a not-yet-saved upload item
 
 function initView(content, filename) {
     if (view) { view.destroy(); view = null; }
@@ -747,6 +751,24 @@ function openCreator() {
 function closeEditor() {
     overlay.style.display = 'none';
     if (view) { view.destroy(); view = null; }
+    isEditingUpload = false;
+    if (newNameInput) newNameInput.disabled = false;
+}
+
+// Open editor pre-loaded with the content of an upload-sourced (not yet saved) file.
+const editPageFilesInput = document.getElementById('suite-files-input');
+function openEditorForUpload(name, content) {
+    currentFilename = name;
+    isCreating = false;
+    isEditingUpload = true;
+    titleEl.textContent = 'Edit: ' + name;
+    newControls.style.display = '';
+    newNameInput.value = name;
+    newNameInput.disabled = true;
+    statusEl.textContent = '';
+    overlay.style.display = 'flex';
+    initView(content, name);
+    if (view) view.focus();
 }
 
 // ── Edit buttons on existing rows ─────────────────────────────────────────
@@ -766,6 +788,20 @@ document.addEventListener('click', function(e) {
         .catch(err => { statusEl.textContent = 'Error: ' + err; console.error('getScript error:', err); });
 });
 
+// ── Edit buttons on upload-sourced (not-yet-saved) rows ───────────────────
+
+document.addEventListener('click', function(e) {
+    const btn = e.target.closest && e.target.closest('.suite-edit-upload-btn');
+    if (!btn) return;
+    const name = btn.getAttribute('data-name');
+    if (!name) return;
+    const files = Array.from(editPageFilesInput ? editPageFilesInput.files : []);
+    const file  = files.find(f => f.name === name);
+    if (!file) { statusEl.textContent = 'File not found in upload queue.'; return; }
+    file.text().then(content => openEditorForUpload(name, content))
+              .catch(err    => { statusEl.textContent = 'Could not read file: ' + err; });
+});
+
 // ── New Script button ──────────────────────────────────────────────────────
 
 if (newScriptBtn) newScriptBtn.addEventListener('click', openCreator);
@@ -777,22 +813,9 @@ let templateCache = null;
 
 function fetchTemplates() {
     if (templateCache) return Promise.resolve(templateCache);
-    // Fetch generic templates (no function-specific personalisation) by scanning an empty notebook.
-    return fetch('/instructor/scan-notebook', {
-        method: 'POST',
-        body: JSON.stringify({ cells: [], metadata: {}, nbformat: 4, nbformat_minor: 5 }),
-        headers: {
-            'Content-Type': 'application/json',
-            'x-csrf-token': csrfToken
-        }
-    })
-    .then(r => r.ok ? r.json() : [])
-    .then(functions => {
-        // If the notebook has no functions the endpoint returns [].
-        // Fall back to server-generated generic templates via the template-info endpoint.
-        templateCache = null;
-        return null;
-    });
+    return fetch('/instructor/script-templates', { headers: { 'x-csrf-token': csrfToken } })
+        .then(r => r.ok ? r.json() : Promise.reject(r.status))
+        .then(data => { templateCache = data; return data; });
 }
 
 // Inline template content matching server templates (avoids a round-trip for the
@@ -823,24 +846,27 @@ templateSel.addEventListener('change', function() {
 });
 
 applyTplBtn.addEventListener('click', function() {
-    const tpl = INLINE_TEMPLATES[templateSel.value];
-    if (tpl === undefined) return;
+    const tplKey = templateSel ? templateSel.value : 'blank';
     // Auto-fill filename if empty.
-    if (!newNameInput.value.trim()) {
-        const [lang] = (templateSel.value || '').split(':');
-        const ext = lang === 'py' ? 'py' : lang === 'sh' ? 'sh' : 'py';
-        newNameInput.value = 'test_new.' + ext;
+    function doApply(content) {
+        if (!newNameInput.value.trim()) {
+            const [lang] = (tplKey || '').split(':');
+            const ext = lang === 'py' ? 'py' : lang === 'sh' ? 'sh' : 'py';
+            newNameInput.value = 'test_new.' + ext;
+        }
+        if (view) {
+            view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: content } });
+            view.dispatch({ effects: langComp.reconfigure(langExtensionFor(newNameInput.value)) });
+            view.focus();
+        }
     }
-    if (view) {
-        view.dispatch({
-            changes: { from: 0, to: view.state.doc.length, insert: tpl }
-        });
-        // Re-apply language for new filename.
-        view.dispatch({
-            effects: langComp.reconfigure(langExtensionFor(newNameInput.value))
-        });
-        view.focus();
-    }
+    if (tplKey === 'blank') { doApply(''); return; }
+    // Try inline cache first, then fetch from server.
+    const inline = INLINE_TEMPLATES[tplKey];
+    if (inline !== undefined) { doApply(inline); return; }
+    fetchTemplates()
+        .then(templates => { doApply(templates[tplKey] || ''); })
+        .catch(err => { if (statusEl) statusEl.textContent = 'Could not load template: ' + err; });
 });
 
 // ── Save ───────────────────────────────────────────────────────────────────
@@ -848,6 +874,23 @@ applyTplBtn.addEventListener('click', function() {
 saveBtn.addEventListener('click', function() {
     if (!view) { statusEl.textContent = 'Editor not ready — try closing and reopening.'; return; }
     const content = view.state.doc.toString();
+
+    // Editing an upload-sourced file (not yet saved to the server): update filesInput.
+    if (isEditingUpload) {
+        const name = currentFilename;
+        if (!name) return;
+        const updated = new File([content], name, { type: 'text/plain' });
+        const dt = new DataTransfer();
+        Array.from(editPageFilesInput ? editPageFilesInput.files : []).forEach(f => {
+            dt.items.add(f.name === name ? updated : f);
+        });
+        if (editPageFilesInput) {
+            editPageFilesInput.files = dt.files;
+            editPageFilesInput.dispatchEvent(new Event('change'));
+        }
+        closeEditor();
+        return;
+    }
 
     if (isCreating) {
         const filename = (newNameInput.value || '').trim();

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -415,6 +415,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
             + '</select></td>'
             + '<td><input type="number" class="form-input suite-points" min="1" max="100" value="' + pts + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
             + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
+            +   '<button class="btn action-btn suite-edit-upload-btn" type="button" data-name="' + escAttr(item.name) + '" title="View/Edit script" aria-label="View/Edit script" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>'
             +   '<button class="btn action-btn action-danger suite-delete-btn" type="button" title="Delete script" aria-label="Delete script" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>'
             + '</div></td>'
             + '</tr>';
@@ -620,7 +621,49 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 
     var form = document.getElementById('new-assignment-form');
     if (form) {
-        form.addEventListener('submit', function () { syncConfig(); });
+        // Override the generic base.leaf multipart submit so we can explicitly
+        // append files from filesInput.  Some browsers do not include
+        // programmatically-set input.files (via DataTransfer) in new FormData(form),
+        // which would silently drop auto-generated test scripts.
+        form.addEventListener('submit', function (e) {
+            syncConfig();
+
+            // Let draft-action submissions (wireNotebookUpload) fall through to the
+            // base.leaf handler — they set form.action themselves and don't need
+            // explicit file injection.  Only intercept the main save submission.
+            var targetURL = form.action;
+            if (e.submitter && e.submitter.getAttribute('formaction')) {
+                // A hidden draft-action button fired the submit — let base.leaf handle it.
+                return;
+            }
+
+            // Prevent base.leaf's generic handler from running.
+            e.preventDefault();
+
+            var fd = new FormData(form);
+            // Explicitly (re-)append suite files so DataTransfer-set files are always
+            // included, even in browsers that don't propagate them through FormData.
+            if (filesInput) {
+                Array.from(filesInput.files).forEach(function (file) {
+                    fd.append('suiteFiles[]', file, file.name);
+                });
+            }
+
+            var meta   = document.querySelector('meta[name="csrf-token"]');
+            var token  = meta ? meta.getAttribute('content') : '';
+            var submitBtn = e.submitter || form.querySelector('.btn-primary[type="submit"]');
+            if (submitBtn) submitBtn.disabled = true;
+
+            fetch(targetURL, {
+                method: 'POST',
+                headers: { 'x-csrf-token': token },
+                body: fd
+            }).then(function (res) {
+                window.location.href = res.url || window.location.href;
+            }).catch(function () {
+                if (submitBtn) submitBtn.disabled = false;
+            });
+        });
         form.addEventListener('chickadee:before-multipart-submit', function () { syncConfig(); });
     }
 
@@ -844,6 +887,41 @@ function openCreator() {
 function closeEditor() {
     overlay.style.display = 'none';
     if (view) { view.destroy(); view = null; }
+    // Re-enable filename input in case it was locked for editing
+    if (newNameInput) newNameInput.disabled = false;
+}
+
+// Open editor pre-loaded with the content of an existing upload-sourced file.
+function openEditorForUpload(name, content) {
+    if (titleEl)  titleEl.textContent  = 'Edit: ' + name;
+    if (statusEl) statusEl.textContent = '';
+    if (newControls) newControls.style.display = '';
+    if (newNameInput) { newNameInput.value = name; newNameInput.disabled = true; }
+    overlay.style.display = 'flex';
+    initView(content, name);
+    if (view) view.focus();
+}
+
+// Delegated click handler for the View/Edit button on upload-sourced rows.
+const suiteTableBody = document.getElementById('suite-config-body');
+if (suiteTableBody) {
+    suiteTableBody.addEventListener('click', function (e) {
+        const btn = e.target.closest('.suite-edit-upload-btn');
+        if (!btn) return;
+        const name = btn.getAttribute('data-name');
+        if (!name) return;
+        const files = Array.from(filesInput ? filesInput.files : []);
+        const file  = files.find(function (f) { return f.name === name; });
+        if (!file) {
+            if (statusEl) statusEl.textContent = 'File not found in queue.';
+            return;
+        }
+        file.text().then(function (content) {
+            openEditorForUpload(name, content);
+        }).catch(function (err) {
+            if (statusEl) statusEl.textContent = 'Could not read file: ' + err;
+        });
+    });
 }
 
 if (newScriptBtn) newScriptBtn.addEventListener('click', openCreator);

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -76,9 +76,11 @@
         form.dispatchEvent(new CustomEvent('chickadee:before-multipart-submit', { bubbles: false }));
         var meta = document.querySelector('meta[name="csrf-token"]');
         var csrfToken = meta ? meta.getAttribute('content') : '';
-        var btn = form.querySelector('[type="submit"]');
+        var btn = e.submitter || form.querySelector('[type="submit"]');
         if (btn) btn.disabled = true;
-        fetch(form.action, {
+        // Respect formaction on the activating submit button (e.g. hidden draft-action buttons).
+        var actionURL = (e.submitter && e.submitter.getAttribute('formaction')) || form.action;
+        fetch(actionURL, {
             method: form.method.toUpperCase() || 'POST',
             headers: { 'x-csrf-token': csrfToken },
             body: new FormData(form)

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -1159,4 +1159,180 @@ final class AssignmentRoutesTests: XCTestCase {
             XCTAssertTrue(body.contains(expectedClock), "Expected clock '\(expectedClock)' in body: \(body)")
         })
     }
+
+    // MARK: - Regression tests: assignment creation bug fixes
+
+    /// Bug #2 regression: browser posts suiteFiles with "suiteFiles[]" field name and includes extra
+    /// JSON fields in suiteConfig (source, isIncluded, dependsOn: [], displayName: null) that the
+    /// server must ignore. Files must land in the zip, the manifest must list them correctly, and
+    /// a validation job must be queued when at least one test suite entry is present.
+    func testSaveNewAssignmentWithBrowserFormatSuiteFilesAndFieldName() async throws {
+        _ = try await makeTestCourseID()
+        app.migrations.add(CreateRunnerProfiles())
+        app.migrations.add(CreateAssignmentRequirements())
+        try await app.autoMigrate()
+
+        // Register an active runner so the validation-runner gate passes.
+        let now = Date()
+        let runnerProfile = RunnerProfile()
+        runnerProfile.runnerID = "runner-browser-fmt"
+        runnerProfile.displayName = "Runner Browser Format"
+        runnerProfile.platform = "linux"
+        runnerProfile.architecture = "x86_64"
+        runnerProfile.languageVersionsJSON = "[]"
+        runnerProfile.capabilitiesJSON = "[]"
+        runnerProfile.profileHash = nil
+        runnerProfile.lastRegisteredAt = now
+        runnerProfile.lastSeenAt = now
+        runnerProfile.isActive = true
+        try await runnerProfile.save(on: app.db)
+
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
+        let boundary = "Boundary-BrowserFmt"
+        let notebook = #"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#
+
+        // Exact JSON that syncConfig() produces in assignment-new.leaf:
+        // extra fields (source, isIncluded) must be silently ignored by SuiteConfigRow.
+        let suiteConfig = """
+        [
+          {"source":"upload","isIncluded":true,"isTest":true,"tier":"public","order":1,"dependsOn":[],"points":1,"displayName":null,"index":0},
+          {"source":"upload","isIncluded":true,"isTest":false,"tier":"support","order":2,"dependsOn":[],"points":1,"displayName":null,"index":1}
+        ]
+        """
+
+        var body = ByteBufferAllocator().buffer(capacity: 4096)
+        func field(_ name: String, _ value: String) {
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+            body.writeString(value + "\r\n")
+        }
+        func file(_ name: String, filename: String, contentType: String, content: String) {
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+            body.writeString("Content-Type: \(contentType)\r\n\r\n")
+            body.writeString(content + "\r\n")
+        }
+        field("_csrf", csrf)
+        field("assignmentName", "Browser Format Lab")
+        file("assignmentNotebookFile", filename: "assignment.ipynb", contentType: "application/json", content: notebook)
+        file("solutionNotebookFile",   filename: "solution.ipynb",   contentType: "application/json", content: notebook)
+        // "suiteFiles[]" with brackets — exact field name sent by the browser's FormData API.
+        file("suiteFiles[]", filename: "test_bmi.py", contentType: "text/plain", content: "print('test bmi')")
+        file("suiteFiles[]", filename: "helpers.py",  contentType: "text/plain", content: "# helpers")
+        field("suiteConfig", suiteConfig)
+        body.writeString("--\(boundary)--\r\n")
+
+        try await app.asyncTest(.POST, "/instructor/new/save", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart", subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: body)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertEqual(res.headers.first(name: .location), "/instructor")
+        })
+
+        let assignment = try await APIAssignment.query(on: app.db)
+            .filter(\.$title == "Browser Format Lab")
+            .first()
+        let setupID = try XCTUnwrap(assignment?.testSetupID)
+        let setup   = try await APITestSetup.find(setupID, on: app.db)
+
+        // Manifest: test_bmi.py (isTest:true, tier:public) → 1 suite entry; helpers.py → support, not listed.
+        let props = try JSONDecoder().decode(
+            TestProperties.self,
+            from: try XCTUnwrap(setup?.manifest.data(using: .utf8))
+        )
+        XCTAssertEqual(props.testSuites.map(\.script), ["test_bmi.py"],
+                       "test_bmi.py must be the only test suite entry in manifest")
+
+        // Both files must be present in the zip (support files are stored even if not in manifest).
+        let zipEntries = Set(listZipEntries(zipPath: try XCTUnwrap(setup?.zipPath)))
+        XCTAssertTrue(zipEntries.contains("test_bmi.py"), "test_bmi.py missing from zip; entries: \(zipEntries)")
+        XCTAssertTrue(zipEntries.contains("helpers.py"),  "helpers.py missing from zip; entries: \(zipEntries)")
+
+        // Validation job must have been queued (Bug #2: was never queued when DataTransfer files
+        // were absent from FormData, causing testSuites to be empty and shouldQueueValidation=false).
+        XCTAssertEqual(assignment?.validationStatus, "pending")
+        XCTAssertNotNil(assignment?.validationSubmissionID,
+                        "validationSubmissionID must be set when suite files are present")
+    }
+
+    /// Bug #1 regression: the new assignment page must include JavaScript for the edit button
+    /// on uploaded suite file rows so instructors can view/edit script content before saving.
+    func testNewAssignmentPageContainsEditButtonForUploadedSuiteItems() async throws {
+        _ = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+
+        try await app.asyncTest(.GET, "/instructor/new", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            // The rowHTML JS function must contain the edit-button class that opens the CodeMirror editor.
+            XCTAssertTrue(html.contains("suite-edit-upload-btn"),
+                          "New assignment page must contain suite-edit-upload-btn in rowHTML JS")
+        })
+    }
+
+    /// Bug #1 regression: the edit assignment page must include JavaScript for the edit button
+    /// on newly uploaded (not-yet-saved) suite file rows.
+    func testEditAssignmentPageContainsEditButtonForUploadedSuiteItems() async throws {
+        let courseID = try await makeTestCourseID()
+        let cookie   = try await loginAsInstructor()
+        let setupID  = "setup_edit_upload_btn_reg"
+        let zipPath  = tmpDir + "testsetups/\(setupID).zip"
+        try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
+        """
+        let setup = APITestSetup(
+            id: setupID, manifest: manifest, zipPath: zipPath,
+            notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb",
+            courseID: courseID
+        )
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(
+            publicID: "RGRN01", testSetupID: setupID, title: "Edit Btn Regression",
+            dueAt: nil, isOpen: false, courseID: courseID
+        )
+        try await assignment.save(on: app.db)
+
+        try await app.asyncTest(.GET, "/instructor/RGRN01/edit", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            // The rowHTML JS function for new (uploaded) items must contain the edit-button class.
+            XCTAssertTrue(html.contains("suite-edit-upload-btn"),
+                          "Edit assignment page must contain suite-edit-upload-btn for newly uploaded suite items")
+        })
+    }
+
+    /// Bug #3 regression: GET /instructor/script-templates must return a non-empty JSON dict
+    /// with keys for both Python and shell template types. The edit page's fetchTemplates()
+    /// now calls this endpoint (was previously broken, returning null).
+    func testScriptTemplatesEndpointReturnsTemplatesForAllTypes() async throws {
+        _ = try await makeTestCourseID()
+        let cookie = try await loginAsInstructor()
+
+        try await app.asyncTest(.GET, "/instructor/script-templates", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let json = try JSONDecoder().decode([String: String].self, from: Data(res.body.readableBytesView))
+            // Must include at least one Python template and one shell template.
+            XCTAssertTrue(json.keys.contains(where: { $0.hasPrefix("py:") }),
+                          "Expected at least one py: key in script templates, got: \(json.keys.sorted())")
+            XCTAssertTrue(json.keys.contains(where: { $0.hasPrefix("sh:") }),
+                          "Expected at least one sh: key in script templates, got: \(json.keys.sorted())")
+            // Values must be non-empty script content.
+            for (key, content) in json {
+                XCTAssertFalse(content.isEmpty, "Template '\(key)' must have non-empty content")
+            }
+        })
+    }
 }


### PR DESCRIPTION
## Summary

- **Bug #1 (script visibility):** Add edit/view button to uploaded suite file rows on both create and edit pages. Previously only existing (saved) files had an edit button; newly-added files had no way to inspect or modify content before saving.
- **Bug #2 (files lost on save):** The create page now explicitly re-appends DataTransfer-backed suite files when POSTing. Browsers don't reliably include programmatically-set `input.files` in `new FormData()`, so scan-notebook generated files were silently dropped — leaving `testSuites` empty and no validation job queued.
- **Bug #3 (empty templates):** `fetchTemplates()` on the edit page was broken (scanned an empty notebook, always returned null). Fixed to call `/instructor/script-templates` directly, matching the create page behaviour.
- **base.leaf:** Respect `formaction` on the activating submit button so hidden draft-action buttons (Create Blank, Clear) POST to the correct URL instead of the form's default action.

## Regression tests

Four new `AssignmentRoutesTests` cases:
- `testSaveNewAssignmentWithBrowserFormatSuiteFilesAndFieldName` — posts `suiteFiles[]` (exact browser field name) with full browser-format suiteConfig JSON; verifies files in zip, manifest entries, and validation job queued
- `testNewAssignmentPageContainsEditButtonForUploadedSuiteItems` — asserts create page HTML contains `suite-edit-upload-btn`
- `testEditAssignmentPageContainsEditButtonForUploadedSuiteItems` — same for edit page
- `testScriptTemplatesEndpointReturnsTemplatesForAllTypes` — asserts `GET /instructor/script-templates` returns non-empty content for `py:` and `sh:` keys

## Test plan

- [ ] All 211 tests pass (`swift test`)
- [ ] Create a new assignment with scan-notebook: verify generated scripts appear with edit buttons and survive save & validate
- [ ] Confirm a validation job appears in the runner queue after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)