### PR TITLE
[codex] Add admin user delete action

### DIFF
--- a/Resources/Views/admin-user.leaf
+++ b/Resources/Views/admin-user.leaf
@@ -7,11 +7,6 @@ Courses — #if(displayName):#(displayName)#else:#(username)#endif
     <h1 style="margin:0">
         #if(displayName):#(displayName)#else:#(username)#endif — Courses
     </h1>
-    <form method="post" action="/admin/users/#(targetUserID)/delete" style="margin-left:auto">
-        #csrfFormField()
-        <button class="btn action-btn action-danger" type="submit"
-                onclick="return confirm('Delete this user? Their enrollments will be removed. They can log in again to restore their account.')">Delete User</button>
-    </form>
 </div>
 <p style="color:var(--gray-600);margin-top:-.75rem;margin-bottom:1.5rem">
     @#(username) · #(role)

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -208,7 +208,7 @@ Admin
                 <th data-sort-key="role" data-sort-type="text" tabindex="0" aria-sort="none">Role</th>
                 <th class="time" data-sort-key="last-login" data-sort-type="date" tabindex="0" aria-sort="none">Last Login</th>
                 <th class="time" data-sort-key="joined" data-sort-type="date" tabindex="0" aria-sort="none">Joined</th>
-                <th>Courses</th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -244,10 +244,20 @@ Admin
                 </td>
                 <td class="time js-relative-time" data-iso="#(user.createdAt)">#(user.createdAt)</td>
                 <td>
-                    <a href="/admin/users/#(user.id)"
-                       class="btn action-btn" title="Manage user" aria-label="Manage user" style="padding:.3rem .45rem">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                    </a>
+                    <div style="display:flex;align-items:center;gap:.35rem">
+                        <a href="/admin/users/#(user.id)"
+                           class="btn action-btn" title="Manage user" aria-label="Manage user" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
+                        </a>
+                        <form method="post" action="/admin/users/#(user.id)/delete" style="display:inline">
+                            #csrfFormField()
+                            <button class="btn action-btn action-danger" type="submit"
+                                    title="Delete user" aria-label="Delete user" style="padding:.3rem .45rem"
+                                    onclick="return confirm('Delete this user? Their enrollments will be removed. They can log in again to restore their account.')">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                            </button>
+                        </form>
+                    </div>
                 </td>
             </tr>
         #endfor

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -273,6 +273,32 @@ final class AdminRoutesTests: XCTestCase {
         })
     }
 
+    func testAdminUserActionsRenderDeleteInUsersTableOnly() async throws {
+        let cookie = try await loginAsAdmin()
+        let managedUser = try await makeUser(username: "managed_for_actions", role: "student")
+        let userID = try managedUser.requireID()
+
+        try await app.asyncTest(.GET, "/admin", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = String(buffer: res.body)
+            XCTAssertTrue(body.contains("<th>Actions</th>"))
+            XCTAssertFalse(body.contains("<th>Courses</th>"))
+            XCTAssertTrue(body.contains("/admin/users/\(userID.uuidString)/delete"))
+            XCTAssertTrue(body.contains("aria-label=\"Delete user\""))
+        })
+
+        try await app.asyncTest(.GET, "/admin/users/\(userID.uuidString)", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let body = String(buffer: res.body)
+            XCTAssertFalse(body.contains(">Delete User<"))
+            XCTAssertFalse(body.contains("/admin/users/\(userID.uuidString)/delete"))
+        })
+    }
+
     func testEditCourseUpdatesFields() async throws {
         let cookie = try await loginAsAdmin()
         let course = try await makeCourse(code: "EDIT101", name: "Original Name")


### PR DESCRIPTION
## Summary
- rename the admin users table’s rightmost column from `Courses` to `Actions`
- add an inline trashcan delete action for each user in the admin users table
- remove the redundant `Delete User` button from the admin user detail page and cover the UI change in `AdminRoutesTests`

## Why
Deleting a user was only available after drilling into the user detail page, and the admin list header no longer matched the actual intent of the rightmost column.

## Validation
- `swift test --filter APITests` (currently running locally in the background)
- added focused admin UI assertions in `Tests/APITests/AdminRoutesTests.swift`
