### PR TITLE
[codex] Fix student submit actions and browser first-open flow

### DIFF
--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -87,7 +87,7 @@
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
                     #if(setup.isOpen):
                     #if(setup.gradingMode == "browser"):
-                    <a class="btn btn-primary action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
@@ -98,9 +98,9 @@
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
                     #endif
-                    <a class="btn btn-primary action-btn" href="/testsetups/#(setup.id)/submit"
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/submit"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
                     </a>
                     #endif
                     #endif
@@ -178,7 +178,7 @@
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
                     #if(setup.isOpen):
                     #if(setup.gradingMode == "browser"):
-                    <a class="btn btn-primary action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
@@ -189,9 +189,9 @@
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
                     #endif
-                    <a class="btn btn-primary action-btn" href="/testsetups/#(setup.id)/submit"
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/submit"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
                     </a>
                     #endif
                     #endif
@@ -269,7 +269,7 @@
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
                     #if(setup.isOpen):
                     #if(setup.gradingMode == "browser"):
-                    <a class="btn btn-primary action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/notebook?title=#(setup.title)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
@@ -280,9 +280,9 @@
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
                     #endif
-                    <a class="btn btn-primary action-btn" href="/testsetups/#(setup.id)/submit"
+                    <a class="btn action-btn" href="/testsetups/#(setup.id)/submit"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
                     </a>
                     #endif
                     #endif

--- a/Resources/Views/submit.leaf
+++ b/Resources/Views/submit.leaf
@@ -3,7 +3,7 @@
 Submit Code
 #endexport
 #export("content"):
-<h1>Submit to <code>#(testSetupID)</code></h1>
+<h1>Submit to #(assignmentTitle)</h1>
 <form class="form" id="submit-form" method="post"
     action="/testsetups/#(testSetupID)/submit" enctype="multipart/form-data">
     #csrfFormField()
@@ -17,8 +17,5 @@ Submit Code
         <a class="btn" href="/">Cancel</a>
     </div>
 </form>
-<p class="alt-submit">
-    Or <a href="/testsetups/#(testSetupID)/notebook">write and run in the browser →</a>
-</p>
 #endexport
 #endextend

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -56,6 +56,7 @@ struct IndexContext: Encodable {
 
 struct SubmitContext: Encodable {
     let testSetupID: String
+    let assignmentTitle: String
     let currentUser: CurrentUserContext?
 }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -26,8 +26,16 @@ extension WebRoutes {
            manifest.gradingMode == .browser {
             return req.redirect(to: "/testsetups/\(setupID)/notebook")
         }
+        let assignment = try await APIAssignment.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .first()
         return try await req.view.render("submit",
-            SubmitContext(testSetupID: setupID, currentUser: req.currentUserContext)).encodeResponse(for: req)
+            SubmitContext(
+                testSetupID: setupID,
+                assignmentTitle: assignment?.title ?? setupID,
+                currentUser: req.currentUserContext
+            )
+        ).encodeResponse(for: req)
     }
 
     // MARK: - POST /testsetups/:id/submit

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -287,6 +287,46 @@ final class WebRoutesTests: XCTestCase {
         })
     }
 
+    func testIndexShowsBrowserEditActionBeforeStudentHasAnyNotebookWork() async throws {
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enrollUser(user)
+
+        let setupID = "setup_browser_first_open"
+        let course = try await makeCourse()
+        let courseID = try course.requireID()
+        let notebookPath = tmpDir + "testsetups/\(setupID).ipynb"
+        let notebookJSON = """
+        {"cells":[{"cell_type":"markdown","metadata":{},"source":["Browser starter"]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"name":"python"}},"nbformat":4,"nbformat_minor":5}
+        """
+        try notebookJSON.data(using: .utf8)!.write(to: URL(fileURLWithPath: notebookPath))
+
+        let manifest = """
+        {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_browser.py"}],"timeLimitSeconds":10}
+        """
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: manifest,
+            zipPath: tmpDir + "testsetups/\(setupID).zip",
+            notebookPath: notebookPath,
+            courseID: courseID
+        )
+        try await setup.save(on: app.db)
+        try await insertAssignment(testSetupID: setupID, title: "Browser Lab", isOpen: true)
+
+        try await app.asyncTest(.GET, "/", beforeRequest: { req in
+            req.headers.add(name: .cookie, value: cookie)
+        }, afterResponse: { res in
+            XCTAssertEqual(res.status, .ok)
+            let html = res.body.string
+            XCTAssertTrue(html.contains("Browser Lab"))
+            XCTAssertTrue(
+                html.contains("/testsetups/\(setupID)/notebook?title=Browser Lab"),
+                "Browser-graded assignments should expose the notebook action even before any student edits"
+            )
+        })
+    }
+
     func testIndexHidesUnpublishedSetupsFromStudent() async throws {
         let cookie = try await loginAsStudent()
         let user = try await studentUser()


### PR DESCRIPTION
## Summary
- remove the browser-run helper copy from the submit page and show the assignment title there
- make student dashboard upload actions use the same neutral styling as edit
- swap the upload icon to a clearer upward upload glyph
- restore the browser notebook entry point on the student dashboard so first-open browser assignments still seed a working copy
- add a regression test for the browser first-open dashboard path

## Validation
- `swift test --filter WebRoutesTests/testIndexShowsBrowserEditActionBeforeStudentHasAnyNotebookWork`
- `swift test --filter NotebookWebRoutesTests/testNotebookPageSeedsWorkingCopyAndRendersEditorFrame`
