### PR TITLE
[codex] Sync assignment suite script lists

### DIFF
--- a/Public/suite-list.js
+++ b/Public/suite-list.js
@@ -1,0 +1,123 @@
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.ChickadeeSuiteList = factory();
+    }
+})(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    var SCRIPT_EXTS = ['sh','bash','zsh','py','r','rb','pl','js','php'];
+    var BINARY_EXTS = ['exe','dll','so','dylib','class','jar','zip','tar','gz',
+                       'png','jpg','jpeg','gif','bmp','svg','pdf','doc','docx',
+                       'xls','xlsx','ppt','pptx','mp3','mp4','mov','avi'];
+
+    function extensionOf(name) {
+        var base = String(name || '').split('/').pop();
+        var dot = base.lastIndexOf('.');
+        return dot > 0 ? base.slice(dot + 1).toLowerCase() : '';
+    }
+
+    function isLikelyScriptName(name) {
+        var ext = extensionOf(name);
+        return SCRIPT_EXTS.indexOf(ext) >= 0;
+    }
+
+    function hasRecognizedShellShebang(text) {
+        var firstLine = String(text || '').split(/\r?\n/, 1)[0].trim().toLowerCase();
+        if (firstLine.indexOf('#!') !== 0) return false;
+        return /(^#!\s*\/.*\/(ba|z)?sh\b)|(^#!\s*\/usr\/bin\/env\s+(ba|z)?sh\b)/.test(firstLine);
+    }
+
+    function classify(name, content, size) {
+        var ext = extensionOf(name);
+        var hasExt = ext.length > 0;
+        var binary = BINARY_EXTS.indexOf(ext) >= 0;
+        var shellShebang = !hasExt && hasRecognizedShellShebang(content || '');
+        var isScript = isLikelyScriptName(name) || shellShebang;
+        var errs = [];
+        if (binary) errs.push('Binary file — unlikely to work as a test script');
+        if (!hasExt && !shellShebang) {
+            errs.push('No extension or shell shebang; this file will be included as support unless marked as a test');
+        }
+        if (size === 0) errs.push('Empty file');
+        return {
+            isScript: isScript,
+            tier: isScript ? 'public' : 'support',
+            errors: errs
+        };
+    }
+
+    function classifyFile(file) {
+        if (!file) return Promise.resolve(classify('', '', 0));
+        var ext = extensionOf(file.name);
+        if (ext) return Promise.resolve(classify(file.name, '', file.size));
+        var reader = typeof file.text === 'function'
+            ? file.text()
+            : Promise.resolve('');
+        return reader
+            .then(function (text) { return classify(file.name, text, file.size); })
+            .catch(function () { return classify(file.name, '', file.size); });
+    }
+
+    function mergeFiles(existingFiles, selectedFiles) {
+        var byName = {};
+        var merged = [];
+        function addOrReplace(file) {
+            if (!file || !file.name) return;
+            var idx = byName[file.name];
+            if (idx === undefined) {
+                byName[file.name] = merged.length;
+                merged.push(file);
+            } else {
+                merged[idx] = file;
+            }
+        }
+        (existingFiles || []).forEach(addOrReplace);
+        (selectedFiles || []).forEach(addOrReplace);
+        return merged;
+    }
+
+    function upsertUploadItems(items, files, classifications) {
+        var nonUploads = (items || []).filter(function (it) { return it.source !== 'upload'; });
+        var blocked = {};
+        nonUploads.forEach(function (it) { blocked[it.name] = true; });
+
+        var previousUploads = {};
+        (items || []).forEach(function (it) {
+            if (it.source === 'upload') previousUploads[it.name] = it;
+        });
+
+        var next = nonUploads.slice();
+        (files || []).forEach(function (file, idx) {
+            if (!file || !file.name || blocked[file.name]) return;
+            var cls = (classifications && classifications[idx]) || (old ? {
+                isScript: old.isTest,
+                tier: old.tier,
+                errors: old.errors || []
+            } : classify(file.name, '', file.size));
+            var old = previousUploads[file.name];
+            next.push({
+                name:        file.name,
+                displayName: old ? old.displayName : '',
+                source:      'upload',
+                index:       idx,
+                isTest:      old ? old.isTest : cls.isScript,
+                tier:        old ? old.tier : cls.tier,
+                dependsOn:   old ? old.dependsOn : [],
+                points:      old ? old.points : 1,
+                errors:      cls.errors
+            });
+        });
+        return next;
+    }
+
+    return {
+        classify: classify,
+        classifyFile: classifyFile,
+        hasRecognizedShellShebang: hasRecognizedShellShebang,
+        isLikelyScriptName: isLikelyScriptName,
+        mergeFiles: mergeFiles,
+        upsertUploadItems: upsertUploadItems
+    };
+});

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -249,6 +249,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 .suite-file-hint a { color: inherit; }
 #suite-config-table td { vertical-align: top; }
 </style>
+<script src="/suite-list.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -312,22 +313,13 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     // items: { name, source, index?, isTest, tier, dependsOn[], points, url? }
     var items = [];
     var dragName = null;
-    function isLikelyScript(name) {
-        var ext = (name || '').toLowerCase().split('.').pop();
-        return ['sh','bash','zsh','py','r','rb','pl','js','php'].indexOf(ext) >= 0;
-    }
+    var suiteUploadFiles = Array.from(filesInput.files || []);
 
-    var BINARY_EXTS = ['exe','dll','so','dylib','class','jar','zip','tar','gz',
-                       'png','jpg','jpeg','gif','bmp','svg','pdf','doc','docx',
-                       'xls','xlsx','ppt','pptx','mp3','mp4','mov','avi'];
-
-    function fileErrors(file) {
-        var errs = [];
-        var ext = (file.name || '').toLowerCase().split('.').pop();
-        if (BINARY_EXTS.indexOf(ext) >= 0) errs.push('Binary file — unlikely to work as a test script');
-        if (!file.name.includes('.'))       errs.push('No file extension');
-        if (file.size === 0)                errs.push('Empty file');
-        return errs;
+    function setQueuedUploadFiles(files) {
+        suiteUploadFiles = files || [];
+        var dt = new DataTransfer();
+        suiteUploadFiles.forEach(function (file) { dt.items.add(file); });
+        filesInput.files = dt.files;
     }
 
     function hasChildren(name) {
@@ -458,26 +450,24 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     }
 
     // Add newly uploaded files to the items list (appended as root items)
-    function addUploadedFiles() {
-        var files = Array.from(filesInput.files || []);
-        // Remove previously added upload items (re-add fresh)
-        items = items.filter(function (it) { return it.source !== 'upload'; });
-        files.forEach(function (file, idx) {
-            var name = file.name;
-            items.push({
-                name:        name,
-                displayName: '',
-                source:      'upload',
-                index:       idx,
-                isTest:      isLikelyScript(name),
-                tier:        isLikelyScript(name) ? 'public' : 'support',
-                dependsOn:   [],
-                points:      1,
-                errors:      fileErrors(file)
-            });
-        });
-        renderTree();
+    function refreshUploadItems(selectedFiles) {
         syncConfig();
+        var mergedFiles = ChickadeeSuiteList.mergeFiles(suiteUploadFiles, selectedFiles || []);
+        var existingNames = {};
+        items.forEach(function (it) { if (it.source !== 'upload') existingNames[it.name] = true; });
+        mergedFiles = mergedFiles.filter(function (file) { return !existingNames[file.name]; });
+        return Promise.all(mergedFiles.map(ChickadeeSuiteList.classifyFile)).then(function (classifications) {
+            setQueuedUploadFiles(mergedFiles);
+            items = ChickadeeSuiteList.upsertUploadItems(items, suiteUploadFiles, classifications);
+            renderTree();
+            syncConfig();
+        });
+    }
+
+    function addUploadedFiles() {
+        refreshUploadItems(Array.from(filesInput.files || [])).catch(function (err) {
+            console.error('suite upload refresh failed:', err);
+        });
     }
 
     // --- Drag & Drop ---
@@ -571,7 +561,12 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         var row = btn.closest('tr[data-name]');
         if (!row) return;
         var name = row.getAttribute('data-name');
+        var removed = items.find(function (it) { return it.name === name; });
         items = items.filter(function (it) { return it.name !== name; });
+        if (removed && removed.source === 'upload') {
+            setQueuedUploadFiles(suiteUploadFiles.filter(function (file) { return file.name !== name; }));
+            items = ChickadeeSuiteList.upsertUploadItems(items, suiteUploadFiles, []);
+        }
         // Clear any dependsOn references to the deleted item
         items.forEach(function (it) {
             it.dependsOn = it.dependsOn.filter(function (d) { return d !== name; });
@@ -606,6 +601,25 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     function escAttr(v) { return String(v).replaceAll('"','&quot;'); }
 
     initFromDOM();
+
+    window.chickadeeAddExistingSuiteScript = function (script) {
+        if (!script || !script.filename) return;
+        syncConfig();
+        items = items.filter(function (it) { return it.name !== script.filename; });
+        setQueuedUploadFiles(suiteUploadFiles.filter(function (file) { return file.name !== script.filename; }));
+        items.push({
+            name:        script.filename,
+            displayName: '',
+            source:      'existing',
+            isTest:      !!script.isTest,
+            tier:        script.tier || (script.isTest ? 'public' : 'support'),
+            dependsOn:   [],
+            points:      Math.max(1, parseInt(script.points) || 1),
+            url:         script.editURL || '#'
+        });
+        renderTree();
+        syncConfig();
+    };
 
     // Reload when restored from bfcache (browser back/forward) so the page
     // always reflects the server's current state rather than a cached snapshot.
@@ -909,8 +923,10 @@ saveBtn.addEventListener('click', function() {
         .then(data => {
             statusEl.textContent = 'Saved.';
             saveBtn.disabled = false;
-            // Reload the page so the new file appears in the table.
-            window.location.reload();
+            if (window.chickadeeAddExistingSuiteScript) {
+                window.chickadeeAddExistingSuiteScript(data);
+            }
+            closeEditor();
         })
         .catch(err => {
             statusEl.textContent = 'Error: ' + err;

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -322,6 +322,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
 .suite-upload-error { font-size: .78rem; color: var(--red,#c0392b); margin-top: .2rem; }
 #suite-config-table td { vertical-align: top; }
 </style>
+<script src="/suite-list.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -335,22 +336,13 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
     var items = [];
     var dragName = null;
 
-    function isLikelyScript(name) {
-        var ext = (name || '').toLowerCase().split('.').pop();
-        return ['sh','bash','zsh','py','r','rb','pl','js','php'].indexOf(ext) >= 0;
-    }
+    var suiteUploadFiles = Array.from(filesInput.files || []);
 
-    var BINARY_EXTS = ['exe','dll','so','dylib','class','jar','zip','tar','gz',
-                       'png','jpg','jpeg','gif','bmp','svg','pdf','doc','docx',
-                       'xls','xlsx','ppt','pptx','mp3','mp4','mov','avi'];
-
-    function fileErrors(file) {
-        var errs = [];
-        var ext = (file.name || '').toLowerCase().split('.').pop();
-        if (BINARY_EXTS.indexOf(ext) >= 0) errs.push('Binary file — unlikely to work as a test script');
-        if (!file.name.includes('.'))       errs.push('No file extension');
-        if (file.size === 0)                errs.push('Empty file');
-        return errs;
+    function setQueuedUploadFiles(files) {
+        suiteUploadFiles = files || [];
+        var dt = new DataTransfer();
+        suiteUploadFiles.forEach(function (file) { dt.items.add(file); });
+        filesInput.files = dt.files;
     }
 
     function stemOf(filename) {
@@ -468,27 +460,24 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         syncConfig();
     }
 
-    function addUploadedFiles() {
-        var files = Array.from(filesInput.files || []);
-        items = items.filter(function (it) { return it.source !== 'upload'; });
-        files.forEach(function (file, idx) {
-            var name = file.name;
-            // Don't add if a same-named item already exists from draft
-            if (items.some(function (it) { return it.name === name; })) return;
-            items.push({
-                name:        name,
-                displayName: '',
-                source:      'upload',
-                index:       idx,
-                isTest:      isLikelyScript(name),
-                tier:        isLikelyScript(name) ? 'public' : 'support',
-                dependsOn:   [],
-                points:      1,
-                errors:      fileErrors(file)
-            });
-        });
-        renderTree();
+    function refreshUploadItems(selectedFiles) {
         syncConfig();
+        var mergedFiles = ChickadeeSuiteList.mergeFiles(suiteUploadFiles, selectedFiles || []);
+        var existingNames = {};
+        items.forEach(function (it) { if (it.source !== 'upload') existingNames[it.name] = true; });
+        mergedFiles = mergedFiles.filter(function (file) { return !existingNames[file.name]; });
+        return Promise.all(mergedFiles.map(ChickadeeSuiteList.classifyFile)).then(function (classifications) {
+            setQueuedUploadFiles(mergedFiles);
+            items = ChickadeeSuiteList.upsertUploadItems(items, suiteUploadFiles, classifications);
+            renderTree();
+            syncConfig();
+        });
+    }
+
+    function addUploadedFiles() {
+        refreshUploadItems(Array.from(filesInput.files || [])).catch(function (err) {
+            console.error('suite upload refresh failed:', err);
+        });
     }
 
     // --- Drag & Drop ---
@@ -568,7 +557,12 @@ tr.drop-adopt  { outline: 2px solid var(--blue,#0070c9); outline-offset: -2px; }
         var row = btn.closest('tr[data-name]');
         if (!row) return;
         var name = row.getAttribute('data-name');
+        var removed = items.find(function (it) { return it.name === name; });
         items = items.filter(function (it) { return it.name !== name; });
+        if (removed && removed.source === 'upload') {
+            setQueuedUploadFiles(suiteUploadFiles.filter(function (file) { return file.name !== name; }));
+            items = ChickadeeSuiteList.upsertUploadItems(items, suiteUploadFiles, []);
+        }
         items.forEach(function (it) { it.dependsOn = it.dependsOn.filter(function (d) { return d !== name; }); });
         renderTree(); syncConfig();
     });

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -1423,12 +1423,10 @@ func buildSuiteEntries(
     }
 
     // Backward-compatible fallback when no suite config JSON is submitted.
-    let supportedExtensions: Set<String> = ["sh", "bash", "zsh", "py", "r", "rb", "pl", "js", "php"]
     var defaults: [ConfiguredSuiteEntry] = []
     for index in suiteFiles.indices {
         guard let script = storedNameByIndex[index], !script.isEmpty else { continue }
-        let ext = URL(fileURLWithPath: script).pathExtension.lowercased()
-        guard supportedExtensions.contains(ext) else { continue }
+        guard isLikelyTestSuiteFile(suiteFiles[index], storedName: script) else { continue }
         defaults.append(ConfiguredSuiteEntry(
             script: script,
             tier: "public",
@@ -1472,6 +1470,28 @@ func normalizeTier(_ raw: String?, isTest: Bool? = nil) -> String {
     default:
         return "public"
     }
+}
+
+func isLikelyTestSuiteFile(_ file: File, storedName: String) -> Bool {
+    let supportedExtensions: Set<String> = ["sh", "bash", "zsh", "py", "r", "rb", "pl", "js", "php"]
+    let ext = URL(fileURLWithPath: storedName).pathExtension.lowercased()
+    if supportedExtensions.contains(ext) { return true }
+    guard ext.isEmpty else { return false }
+    return hasRecognizedShellShebang(file)
+}
+
+func hasRecognizedShellShebang(_ file: File) -> Bool {
+    let prefix = String(decoding: Data(file.data.readableBytesView.prefix(256)), as: UTF8.self)
+    let firstLine = prefix.split(whereSeparator: \.isNewline).first.map(String.init) ?? prefix
+    let normalized = firstLine.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard normalized.hasPrefix("#!") else { return false }
+    if normalized.range(of: #"^#!\s*/.*/(ba|z)?sh\b"#, options: .regularExpression) != nil {
+        return true
+    }
+    if normalized.range(of: #"^#!\s*/usr/bin/env\s+(ba|z)?sh\b"#, options: .regularExpression) != nil {
+        return true
+    }
+    return false
 }
 
 func makeWorkerManifestJSON(

--- a/Tests/APITests/AssignmentHelpersTests.swift
+++ b/Tests/APITests/AssignmentHelpersTests.swift
@@ -376,6 +376,29 @@ final class AssignmentHelpersTests: XCTestCase {
         XCTAssertTrue(entries.allSatisfy { $0.tier == "public" })
     }
 
+    func testBuildSuiteEntriesFallsBackToExtensionlessShellShebangScripts() throws {
+        let suiteFiles = [
+            makeFile(named: "01_shell", contents: "#!/bin/sh\necho ok\n"),
+            makeFile(named: "02_bash", contents: "#!/usr/bin/env bash\necho ok\n"),
+            makeFile(named: "03_notes", contents: "echo support but no shebang\n"),
+            makeFile(named: "04_python.py", contents: "print('ok')\n")
+        ]
+
+        let entries = try buildSuiteEntries(
+            suiteFiles: suiteFiles,
+            storedNameByIndex: [
+                0: "01_shell",
+                1: "02_bash",
+                2: "03_notes",
+                3: "04_python.py"
+            ],
+            suiteConfigJSON: nil
+        )
+
+        XCTAssertEqual(entries.map(\.script), ["01_shell", "02_bash", "04_python.py"])
+        XCTAssertTrue(entries.allSatisfy { $0.tier == "public" })
+    }
+
     func testBuildSuiteEntriesTreatsAnyNonSupportTierAsATestWhenIsTestIsMissing() throws {
         let suiteFiles = [
             makeFile(named: "assignment.ipynb", contents: "{}"),

--- a/Tests/BrowserRunnerJSTests/suite-list.test.mjs
+++ b/Tests/BrowserRunnerJSTests/suite-list.test.mjs
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const SuiteList = require('../../Public/suite-list.js');
+
+function fakeFile(name, content) {
+  return {
+    name,
+    size: Buffer.byteLength(content),
+    text: () => Promise.resolve(content),
+  };
+}
+
+test('classifies extensionless shell shebang files as scripts', async () => {
+  const sh = await SuiteList.classifyFile(fakeFile('check_submission', '#!/bin/sh\necho ok\n'));
+  const bash = await SuiteList.classifyFile(fakeFile('run_public', '#!/usr/bin/env bash\necho ok\n'));
+
+  assert.equal(sh.isScript, true);
+  assert.equal(sh.tier, 'public');
+  assert.deepEqual(sh.errors, []);
+  assert.equal(bash.isScript, true);
+  assert.equal(bash.tier, 'public');
+  assert.deepEqual(bash.errors, []);
+});
+
+test('classifies extensionless files without shebang as support with a clear warning', async () => {
+  const result = await SuiteList.classifyFile(fakeFile('notes', 'echo not necessarily runnable\n'));
+
+  assert.equal(result.isScript, false);
+  assert.equal(result.tier, 'support');
+  assert.deepEqual(result.errors, [
+    'No extension or shell shebang; this file will be included as support unless marked as a test',
+  ]);
+});
+
+test('mergeFiles appends new files and replaces duplicates in place', () => {
+  const oldA = fakeFile('a.py', 'old');
+  const oldB = fakeFile('b.sh', 'old');
+  const newA = fakeFile('a.py', 'new');
+  const newC = fakeFile('c.sh', 'new');
+
+  const merged = SuiteList.mergeFiles([oldA, oldB], [newA, newC]);
+
+  assert.deepEqual(merged.map((file) => file.name), ['a.py', 'b.sh', 'c.sh']);
+  assert.equal(merged[0], newA);
+  assert.equal(merged[1], oldB);
+  assert.equal(merged[2], newC);
+});
+
+test('upsertUploadItems preserves settings for replaced upload files', () => {
+  const existingItems = [
+    { name: 'starter.py', source: 'existing', tier: 'support', dependsOn: [], points: 1 },
+    {
+      name: 'check',
+      source: 'upload',
+      index: 0,
+      isTest: true,
+      tier: 'secret',
+      dependsOn: ['starter.py'],
+      points: 7,
+      displayName: 'Private check',
+      errors: [],
+    },
+  ];
+  const files = [fakeFile('check', '#!/bin/sh\necho ok\n'), fakeFile('helper.txt', 'support\n')];
+  const classifications = [
+    { isScript: true, tier: 'public', errors: [] },
+    { isScript: false, tier: 'support', errors: [] },
+  ];
+
+  const items = SuiteList.upsertUploadItems(existingItems, files, classifications);
+  const check = items.find((item) => item.name === 'check');
+  const helper = items.find((item) => item.name === 'helper.txt');
+
+  assert.equal(check.tier, 'secret');
+  assert.equal(check.points, 7);
+  assert.equal(check.displayName, 'Private check');
+  assert.deepEqual(check.dependsOn, ['starter.py']);
+  assert.equal(check.index, 0);
+  assert.equal(helper.tier, 'support');
+  assert.equal(helper.index, 1);
+});
+
+test('upsertUploadItems does not create upload rows over existing files', () => {
+  const items = [{ name: 'already.py', source: 'existing', tier: 'public', dependsOn: [], points: 1 }];
+  const files = [fakeFile('already.py', 'print(1)\n'), fakeFile('new.py', 'print(2)\n')];
+  const classifications = [
+    { isScript: true, tier: 'public', errors: [] },
+    { isScript: true, tier: 'public', errors: [] },
+  ];
+
+  const next = SuiteList.upsertUploadItems(items, files, classifications);
+
+  assert.deepEqual(next.map((item) => item.name), ['already.py', 'new.py']);
+  assert.equal(next[0].source, 'existing');
+  assert.equal(next[1].source, 'upload');
+  assert.equal(next[1].index, 1);
+});


### PR DESCRIPTION
## Summary
- Keep assignment create/edit suite lists in sync when uploading files or creating scripts manually
- Add shared browser helper logic for upload merging, duplicate replacement, and script classification
- Treat extensionless files with recognized shell shebangs as runnable shell tests in both the UI and server fallback path

## Why
The create/edit pages were maintaining upload-backed rows separately from the hidden suite config. Re-selecting uploads could drop prior unsaved files from the visible list, and the edit page reloaded after manual script creation instead of updating the current list model.

## Validation
- `node --test Tests/BrowserRunnerJSTests/*.mjs`
- `swift test --filter AssignmentHelpersTests/testBuildSuiteEntriesFallsBackToExtensionlessShellShebangScripts`
- `swift test --filter 'AssignmentRoutesTests/test(EditPageSyncsSuiteConfigOnSubmit|NewAssignmentPageSyncsSuiteConfigBeforeMultipartSubmit)'`
- `git diff --check`