### PR TITLE
Drop top-level iso8601String helper from AlertNotifier

### DIFF
--- a/Sources/APIServer/Services/AlertNotifier.swift
+++ b/Sources/APIServer/Services/AlertNotifier.swift
@@ -83,7 +83,3 @@ enum WebhookNotifierError: Error, CustomStringConvertible {
         }
     }
 }
-
-func iso8601String(_ date: Date) -> String {
-    ISO8601DateFormatter().string(from: date)
-}

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -436,7 +436,7 @@ actor ServerHealthAlertMonitor {
         return AlertMessage(
             rule: rule.rawValue,
             severity: rule.severity,
-            firedAt: iso8601String(firedAt),
+            firedAt: formatAlertTimestamp(firedAt),
             resolved: resolved,
             summary: summary,
             details: details,
@@ -444,6 +444,10 @@ actor ServerHealthAlertMonitor {
             text: "[Chickadee] \(summary)"
         )
     }
+}
+
+private func formatAlertTimestamp(_ date: Date) -> String {
+    ISO8601DateFormatter().string(from: date)
 }
 
 // MARK: - Webhook URL persistence


### PR DESCRIPTION
## Summary

`AlertNotifier.swift` defined a top-level `iso8601String(_:)` at module-internal scope. `AdminRoutes.swift` already has a `private func iso8601String(_:)` with the same signature. Swift's file-private precedence resolves this safely, but it's noise — and the helper had a single caller (`ServerHealthAlertService.makeAlertMessage`).

This pushes the helper down as a private file-scope `formatAlertTimestamp` inside `ServerHealthAlertService.swift` and removes the top-level one. No behaviour change.

## Test plan

- [x] CI must remain green (Swift Tests, Docker build, JupyterLite, Test Coverage, Worker Tests)

https://claude.ai/code/session_015ite9LRMhow1872LL3UgMh

---
_Generated by [Claude Code](https://claude.ai/code/session_015ite9LRMhow1872LL3UgMh)_