### PR TITLE
Fix four small concurrency / efficiency bugs

### DIFF
--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -304,16 +304,20 @@ extension AdminRoutes {
             throw Abort(.notFound)
         }
 
-        let enrollmentCounts = try await enrollmentCountsByCourse(on: req.db)
-        let assignmentCounts = try await assignmentCountsByCourse(on: req.db)
+        async let enrollmentCountFetch = APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseID)
+            .count()
+        async let assignmentCountFetch = APIAssignment.query(on: req.db)
+            .filter(\.$courseID == courseID)
+            .count()
         let courseRow = AdminCourseRow(
             id:              idString,
             code:            course.code,
             name:            course.name,
             isArchived:      course.isArchived,
             enrollmentMode:  course.enrollmentMode.rawValue,
-            enrollmentCount: enrollmentCounts[courseID] ?? 0,
-            assignmentCount: assignmentCounts[courseID] ?? 0,
+            enrollmentCount: try await enrollmentCountFetch,
+            assignmentCount: try await assignmentCountFetch,
             createdAt:       course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—"
         )
 

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -162,31 +162,29 @@ struct AuthRoutes: RouteCollection {
 
         let oidcConfig = req.application.oidcConfig
 
-        // Revoke any issued OAuth tokens at the IdP (fire-and-forget; never blocks logout).
+        // Revoke any issued OAuth tokens at the IdP. Runs concurrently and is
+        // bounded by a deadline so a slow/hung IdP can't keep the task alive
+        // indefinitely; the user-facing redirect still happens immediately.
         if let endpoint = oidcConfig?.discovery.revocationEndpoint,
            let config = oidcConfig
         {
             let app = req.application
             let logger = req.logger
-            Task {
-                let tokensToRevoke: [(token: String, hint: String)] = [
-                    accessToken.map { ($0, "access_token") },
-                    refreshToken.map { ($0, "refresh_token") },
-                ].compactMap { $0 }
+            let tokensToRevoke: [(token: String, hint: String)] = [
+                accessToken.map { ($0, "access_token") },
+                refreshToken.map { ($0, "refresh_token") },
+            ].compactMap { $0 }
 
-                for entry in tokensToRevoke {
-                    do {
-                        try await revokeToken(
-                            token: entry.token,
-                            tokenTypeHint: entry.hint,
-                            endpoint: endpoint,
-                            config: config,
-                            app: app,
-                            logger: logger
-                        )
-                    } catch {
-                        logger.warning("Token revocation failed (non-fatal): \(error)")
-                    }
+            if !tokensToRevoke.isEmpty {
+                Task { [tokensToRevoke] in
+                    await revokeTokensInParallel(
+                        tokens: tokensToRevoke,
+                        endpoint: endpoint,
+                        config: config,
+                        app: app,
+                        logger: logger,
+                        deadlineSeconds: 5
+                    )
                 }
             }
         }
@@ -216,7 +214,52 @@ struct AuthRoutes: RouteCollection {
     }
 }
 
-// MARK: - Token revocation helper
+// MARK: - Token revocation helpers
+
+/// Revokes all supplied tokens concurrently, bounded by `deadlineSeconds`.
+/// Per-token failures and the overall deadline are logged; the function
+/// always returns normally so callers can fire-and-forget without a leak.
+private func revokeTokensInParallel(
+    tokens: [(token: String, hint: String)],
+    endpoint: String,
+    config: OIDCConfiguration,
+    app: Application,
+    logger: Logger,
+    deadlineSeconds: Int
+) async {
+    await withTaskGroup(of: Bool.self) { group in
+        // Outer race: all revocations vs. a deadline timer.
+        group.addTask {
+            await withTaskGroup(of: Void.self) { revocations in
+                for entry in tokens {
+                    revocations.addTask {
+                        do {
+                            try await revokeToken(
+                                token: entry.token,
+                                tokenTypeHint: entry.hint,
+                                endpoint: endpoint,
+                                config: config,
+                                app: app,
+                                logger: logger
+                            )
+                        } catch {
+                            logger.warning("Token revocation failed (non-fatal): \(error)")
+                        }
+                    }
+                }
+            }
+            return true
+        }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: UInt64(deadlineSeconds) * 1_000_000_000)
+            return false
+        }
+        if let completedNormally = await group.next(), !completedNormally {
+            logger.warning("Token revocation deadline (\(deadlineSeconds)s) reached; cancelling remaining work")
+        }
+        group.cancelAll()
+    }
+}
 
 /// Calls the IdP's RFC 7009 revocation endpoint for the given token.
 /// Failures are non-fatal — the caller is responsible for logging them.

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -518,9 +518,7 @@ actor WorkerDaemon {
                     at: dest.deletingLastPathComponent(),
                     withIntermediateDirectories: true
                 )
-                if FileManager.default.fileExists(atPath: dest.path) {
-                    try FileManager.default.removeItem(at: dest)
-                }
+                try? FileManager.default.removeItem(at: dest)
                 try FileManager.default.copyItem(at: submissionZip, to: dest)
             } else {
                 try unzip(submissionZip, to: submissionDir)
@@ -864,9 +862,7 @@ actor WorkerDaemon {
                     body: "<download body unavailable>"
                 )
             }
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
+            try? FileManager.default.removeItem(at: destination)
             try FileManager.default.moveItem(at: tmpURL, to: destination)
             await self.recordConnectionRestoredIfNeeded(stage: stage)
         }
@@ -1006,9 +1002,7 @@ actor WorkerDaemon {
 
     private func writeStudentModuleHint(in directory: URL, preferredFilename: String?) throws {
         let hintURL = directory.appendingPathComponent(".chickadee_student_module")
-        if FileManager.default.fileExists(atPath: hintURL.path) {
-            try FileManager.default.removeItem(at: hintURL)
-        }
+        try? FileManager.default.removeItem(at: hintURL)
 
         guard let preferredFilename, !preferredFilename.isEmpty else { return }
         try preferredFilename.write(to: hintURL, atomically: true, encoding: .utf8)
@@ -1033,9 +1027,7 @@ private func mergeDirectoryContents(from sourceDirectory: URL, into destinationD
             at: destinationURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        if FileManager.default.fileExists(atPath: destinationURL.path) {
-            try FileManager.default.removeItem(at: destinationURL)
-        }
+        try? FileManager.default.removeItem(at: destinationURL)
         try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
     }
 }

--- a/Sources/Worker/ScriptRunner.swift
+++ b/Sources/Worker/ScriptRunner.swift
@@ -88,7 +88,7 @@ func executeScriptProcess(
             try? await Task.sleep(nanoseconds: UInt64(timeLimitSeconds) * 1_000_000_000)
             guard !Task.isCancelled, proc.isRunning else { return }
             timedOut.withLock { $0 = true }
-            terminateScriptProcess(proc, usesSeparateProcessGroup: usesSeparateProcessGroup)
+            await terminateScriptProcess(proc, usesSeparateProcessGroup: usesSeparateProcessGroup)
         }
     }
 
@@ -131,14 +131,14 @@ private func finishPipeCapture(for pipe: Pipe, buffer: CapturedPipeBuffer) -> Da
     return buffer.snapshot()
 }
 
-private func terminateScriptProcess(_ proc: Process, usesSeparateProcessGroup: Bool) {
+private func terminateScriptProcess(_ proc: Process, usesSeparateProcessGroup: Bool) async {
     if usesSeparateProcessGroup {
         _ = kill(-proc.processIdentifier, SIGTERM)
     } else {
         proc.terminate()
     }
 
-    Thread.sleep(forTimeInterval: 0.5)
+    try? await Task.sleep(nanoseconds: 500_000_000)
 
     guard proc.isRunning else { return }
     let signalTarget = usesSeparateProcessGroup ? -proc.processIdentifier : proc.processIdentifier

--- a/Sources/Worker/SubmissionNormalizer.swift
+++ b/Sources/Worker/SubmissionNormalizer.swift
@@ -75,9 +75,7 @@ struct SubmissionNormalizer {
                     at: destinationURL.deletingLastPathComponent(),
                     withIntermediateDirectories: true
                 )
-                if FileManager.default.fileExists(atPath: destinationURL.path) {
-                    try FileManager.default.removeItem(at: destinationURL)
-                }
+                try? FileManager.default.removeItem(at: destinationURL)
                 try FileManager.default.copyItem(at: fileURL, to: destinationURL)
                 producedPythonFiles.append(destinationURL)
                 preferredStudentModule = preferredStudentModule ?? preferredModuleIfRootLevel(fileRelativePath)
@@ -169,9 +167,7 @@ struct SubmissionNormalizer {
                 at: compatibilityURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
-            if FileManager.default.fileExists(atPath: compatibilityURL.path) {
-                try FileManager.default.removeItem(at: compatibilityURL)
-            }
+            try? FileManager.default.removeItem(at: compatibilityURL)
             try FileManager.default.copyItem(at: sourceURL, to: compatibilityURL)
             producedPythonFiles.append(compatibilityURL)
             if preferredStudentModule == nil {


### PR DESCRIPTION
## Summary

Surfaced during an architectural review pass on the codebase. These are the four narrow bugs from that review; the larger refactor opportunities are tracked in #442–#450.

- **`ScriptRunner`**: replace blocking `Thread.sleep(0.5)` with `await Task.sleep` in the SIGTERM→SIGKILL grace window so the timeout task no longer parks a thread per timed-out job. `terminateScriptProcess` is now `async`.
- **`AuthRoutes` (logout)**: wrap OIDC token revocation in a `TaskGroup` with a 5 s deadline. Revocations run in parallel with a bounded lifetime instead of an unstructured fire-and-forget `Task` that could outlive the request.
- **`AdminRoutes+Courses.courseDetail`**: stop calling the global `enrollmentCountsByCourse` / `assignmentCountsByCourse` helpers (which load entire tables) when only one course's count is needed. Replaced with scoped `.count()` queries running concurrently via `async let`.
- **`RunnerDaemon` + `SubmissionNormalizer`**: collapse the `fileExists → removeItem → copyItem` pattern (4 sites) to `try? removeItem` followed by copy/move. Same intent, no TOCTOU window, one fewer syscall per call.

## Test plan

- [ ] CI: `swift build` (no local toolchain in dev sandbox)
- [ ] CI: `swift test` — all targets, especially `WorkerTests` (ScriptRunner timeout path) and `AdminRoutesTests` (course detail page)
- [ ] Manual: trigger a script timeout, confirm SIGTERM→SIGKILL still works and exit code is `-1` with `timedOut: true`
- [ ] Manual: log in via SSO, log out, confirm redirect happens promptly even if revocation endpoint is slow
- [ ] Manual: open `/admin/courses/<id>` and confirm enrollment + assignment counts render correctly

## Follow-ups

Items 5–13 from the review pass are tracked separately:

- #442 split `AssignmentHelpers.swift` (2312 lines)
- #443 decompose oversized handlers in `AssignmentRoutes.swift`
- #444 untangle `OperationalDiagnostics.swift`
- #445 move SHA-256 manifest hashing to `Core`
- #446 reuse static `JSONDecoder` for `TestProperties`
- #447 memoize `ManifestValidation` (runs twice per save)
- #448 typed errors in Web routes
- #449 collapse single-impl protocols (`AlertNotifier`, `AuthProvider`)
- #450 `RunnerDaemonConfig` struct (env vars scattered)

https://claude.ai/code/session_01XHqUrkj5nyCMJG3MR6mZEP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHqUrkj5nyCMJG3MR6mZEP)_