### PR TITLE
suite editor: fix spurious "not contiguous" alert when moving tests across sections

### DIFF
--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -319,9 +319,32 @@
 
         // ── Persistence (items only; sections go through dedicated endpoints) ──
 
+        /// Linearize items[] into one contiguous run per sectionID, in the
+        /// DOM section-block order.  The server enforces that items with
+        /// the same sectionID form a contiguous block; mutation paths
+        /// (root-drop, addExistingScript, syncFamilies) can otherwise
+        /// leave items[] non-contiguous while the rendered tables still
+        /// look correct (each <tbody> filters items[] by sectionID).
+        function itemsGroupedBySection() {
+            var blocks = container.querySelectorAll('.section-block[data-section-id]');
+            var seen = new Set();
+            var out = [];
+            blocks.forEach(function (b) {
+                var sid = b.getAttribute('data-section-id') || null;
+                items.forEach(function (item) {
+                    if ((item.sectionID || null) === (sid || null)) {
+                        out.push(item);
+                        seen.add(item);
+                    }
+                });
+            });
+            items.forEach(function (item) { if (!seen.has(item)) out.push(item); });
+            return out;
+        }
+
         function buildPayload() {
             return {
-                items: items.map(function (item) {
+                items: itemsGroupedBySection().map(function (item) {
                     if (item.kind === 'family') {
                         var family = Object.assign({}, item.family);
                         family.dependsOn = item.dependsOn ? item.dependsOn.slice() : [];


### PR DESCRIPTION
## Summary

When an instructor drags tests around the suite editor, they sometimes see a pop-up "Items with sectionID '…' are not contiguous" — but dismissing the alert leaves a visually-correct table, and subsequent moves usually succeed. This PR removes the spurious alert.

## Root cause

`Public/suite-table.js` keeps a flat `items[]` array. Each section's `<tbody>` is rendered by *filtering* that array on `sectionID`, so a section can look correct on screen even when its items aren't contiguous in `items[]`.

Several mutation paths leave `items[]` non-contiguous:
- **Root-drop zone** (`drop` handler, lines 546–553): flips `dragItem.sectionID` to the target section without repositioning the item in `items[]`.
- **`addExistingScript` / `syncFamilies`**: push new items to the end of `items[]` even when targeted at a section whose existing items are mid-array.

When `buildPayload()` walked `items[]` linearly, any non-contiguity went straight into the PUT, which the server correctly rejects (`PatternFamilyApplication.swift:266-294`). Dismissing the alert leaves local state intact, and the next drop frequently happens to land contiguously — which is why "everything is fine" after dismissing.

## Fix

`buildPayload()` now routes through a new `itemsGroupedBySection()` helper that emits items in DOM section-block order, one contiguous run per `sectionID`. Every PUT is contiguity-valid by construction, regardless of which mutation path produced the local state. The server response then re-syncs `items[]` into the canonical order via `normaliseItems`.

Pure client-side change — no server, schema, or test contract changes.

## Test plan

- [ ] Open an assignment with two or more sections each containing multiple tests.
- [ ] Drag a test from section B onto the "Drop here to remove dependency" zone of section A — confirm save succeeds with no alert.
- [ ] Drag a test from a mid-list section into a section earlier in the list — confirm save succeeds.
- [ ] Add a new script via the per-section "+ Add Script" button on a section that already has items — confirm save succeeds.
- [ ] Reload the page and confirm the persisted order matches what was on screen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEdrGLoqrrsMjqFMRtZEa7)_