### PR TITLE
tests: makeTestApp() helper + drift fix + Swift session hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Installs the Swift toolchain into the Claude Code on the web sandbox so
+# `swift build` / `swift test` work during the session.  Local Claude Code
+# sessions skip this (the user manages their own toolchain on the laptop).
+#
+# Version pin must match Dockerfile (Stage 1 FROM swift:X.Y-jammy) and
+# Package.swift (swift-tools-version).  Update all three together.
+
+set -euo pipefail
+
+# Skip on local Claude Code sessions — the developer's toolchain is on disk.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+SWIFT_VERSION="6.3"
+SWIFT_PLATFORM="ubuntu24.04"
+SWIFT_RELEASE="swift-${SWIFT_VERSION}-RELEASE"
+SWIFT_DIR="${HOME}/swift/${SWIFT_RELEASE}-${SWIFT_PLATFORM}"
+SWIFT_BIN="${SWIFT_DIR}/usr/bin"
+
+if [ ! -x "${SWIFT_BIN}/swift" ]; then
+    echo "Installing Swift ${SWIFT_VERSION} for ${SWIFT_PLATFORM}..."
+    mkdir -p "${HOME}/swift"
+    TARBALL_URL="https://download.swift.org/swift-${SWIFT_VERSION}-release/${SWIFT_PLATFORM/./}/${SWIFT_RELEASE}/${SWIFT_RELEASE}-${SWIFT_PLATFORM}.tar.gz"
+    TMP_TARBALL="$(mktemp -t swift-XXXXXX.tar.gz)"
+    trap 'rm -f "${TMP_TARBALL}"' EXIT
+    curl -fL --retry 3 --retry-delay 5 -o "${TMP_TARBALL}" "${TARBALL_URL}"
+    tar -xzf "${TMP_TARBALL}" -C "${HOME}/swift"
+    rm -f "${TMP_TARBALL}"
+    trap - EXIT
+    echo "Swift installed at ${SWIFT_DIR}"
+fi
+
+"${SWIFT_BIN}/swift" --version
+
+# Persist PATH for the session so subsequent shells see swift.
+echo "export PATH=\"${SWIFT_BIN}:\$PATH\"" >> "${CLAUDE_ENV_FILE}"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 .swiftpm/xcode/package.xcworkspace/xcuserdata/
 
 # Local tooling environments
-.claude/
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
 .venv-jlite/
 .jupyterlite.doit.db
 Tools/jupyterlite/.jupyterlite.doit.db

--- a/Tests/APITests/AccountRoutesTests.swift
+++ b/Tests/APITests/AccountRoutesTests.swift
@@ -20,32 +20,12 @@ import Crypto
 final class AccountRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-acct-\(UUID().uuidString)/")
-            .path
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-acct")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers
@@ -191,7 +171,7 @@ final class AccountRoutesTests: XCTestCase {
 
         // Create a minimal test setup and submission record.
         let setupID = UUID().uuidString
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         try Data("PK".utf8).write(to: URL(fileURLWithPath: zipPath))
         let manifest = """
             {"schemaVersion":1,"testSuites":[{"tier":"public","script":"t.sh"}],"timeLimitSeconds":5}
@@ -201,7 +181,7 @@ final class AccountRoutesTests: XCTestCase {
         try await setup.save(on: app.db)
 
         let subID = UUID().uuidString
-        let subZip = tmpDir + "submissions/\(subID).zip"
+        let subZip = app.submissionsDirectory + "\(subID).zip"
         try Data("PK".utf8).write(to: URL(fileURLWithPath: subZip))
         let sub = APISubmission(id: subID, testSetupID: setupID, zipPath: subZip,
                                 attemptNumber: 1, status: "complete",

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -8,37 +8,15 @@ import Core
 final class AdminRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-admin-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory = dirs[0]
-        app.testSetupsDirectory = dirs[1]
-        app.submissionsDirectory = dirs[2]
-        app.workerSecretFilePath = tmpDir + ".worker-secret"
-        app.localRunnerAutoStartFilePath = tmpDir + ".local-runner-autostart"
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-admin")
+        app.workerSecretFilePath = app.testDataDirectory! + ".worker-secret"
+        app.localRunnerAutoStartFilePath = app.testDataDirectory! + ".local-runner-autostart"
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     private func loginAsAdmin() async throws -> String {

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -30,7 +30,7 @@ final class AdminRoutesTests: XCTestCase {
         app.sessions.use(.memory)
         app.middleware.use(app.sessions.middleware)
 
-        try await configureTestDatabase(app, options: .observability)
+        try await configureTestDatabase(app)
 
         configureLeaf(app)
         try routes(app)

--- a/Tests/APITests/AssignmentEnrollmentTests.swift
+++ b/Tests/APITests/AssignmentEnrollmentTests.swift
@@ -15,32 +15,12 @@ import Core
 final class AssignmentEnrollmentTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-enroll-\(UUID().uuidString)/")
-            .path
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-enroll")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers

--- a/Tests/APITests/AssignmentRoutesTests.swift
+++ b/Tests/APITests/AssignmentRoutesTests.swift
@@ -19,35 +19,12 @@ import Core
 final class AssignmentRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-art-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-art")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -77,7 +54,7 @@ final class AssignmentRoutesTests: XCTestCase {
         {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,"makefile":null}
         """
         let courseID = try await makeTestCourseID()
-        let setup = APITestSetup(id: id, manifest: manifest, zipPath: tmpDir + "testsetups/\(id).zip", courseID: courseID)
+        let setup = APITestSetup(id: id, manifest: manifest, zipPath: app.testSetupsDirectory + "\(id).zip", courseID: courseID)
         try await setup.save(on: app.db)
         return setup
     }
@@ -149,7 +126,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: id,
             testSetupID: testSetupID,
-            zipPath: tmpDir + "submissions/\(id).zip",
+            zipPath: app.submissionsDirectory + "\(id).zip",
             attemptNumber: attemptNumber,
             status: status,
             userID: userID,
@@ -829,12 +806,12 @@ final class AssignmentRoutesTests: XCTestCase {
         let courseID = try await makeTestCourseID()
         let cookie = try await loginAsInstructor()
         let setupID = "setup_edit_display"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
         let manifest = """
         {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
         """
-        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: app.testSetupsDirectory + "notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
         try await setup.save(on: app.db)
         let assignment = APIAssignment(publicID: "ABC123", testSetupID: setupID, title: "Practice Lab", dueAt: nil, isOpen: false, courseID: courseID)
         try await assignment.save(on: app.db)
@@ -867,12 +844,12 @@ final class AssignmentRoutesTests: XCTestCase {
         let courseID = try await makeTestCourseID()
         let cookie = try await loginAsInstructor()
         let setupID = "setup_edit_display_reload"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
         let manifest = """
         {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
         """
-        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: app.testSetupsDirectory + "notebooks/\(setupID)/assignment.ipynb", courseID: courseID)
         try await setup.save(on: app.db)
         let assignment = APIAssignment(publicID: "GHI789", testSetupID: setupID, title: "Practice Lab", dueAt: nil, isOpen: false, courseID: courseID)
         try await assignment.save(on: app.db)
@@ -992,14 +969,14 @@ final class AssignmentRoutesTests: XCTestCase {
         let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
         let setupID = "setup_draft_finalize"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         _ = try createRunnerSetupZip(suiteFiles: [], suiteConfigJSON: nil, zipPath: zipPath)
         let manifest = try makeWorkerManifestJSON(testSuites: [], includeMakefile: false, gradingMode: "worker")
-        let notebookDir = tmpDir + "testsetups/notebooks/\(setupID)/"
+        let notebookDir = app.testSetupsDirectory + "notebooks/\(setupID)/"
         try FileManager.default.createDirectory(atPath: notebookDir, withIntermediateDirectories: true)
         let assignmentPath = notebookDir + "assignment.ipynb"
         try defaultNotebookData(title: "Draft Finalize").write(to: URL(fileURLWithPath: assignmentPath))
-        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: tmpDir + "testsetups/", setupID: setupID)
+        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: app.testSetupsDirectory + "", setupID: setupID)
         try defaultNotebookData(title: "Draft Finalize Solution").write(to: URL(fileURLWithPath: solutionPath))
 
         let setup = APITestSetup(
@@ -1071,14 +1048,14 @@ final class AssignmentRoutesTests: XCTestCase {
         let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
         let setupID = "setup_generated_suite_finalize"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         _ = try createRunnerSetupZip(suiteFiles: [], suiteConfigJSON: nil, zipPath: zipPath)
         let manifest = try makeWorkerManifestJSON(testSuites: [], includeMakefile: false, gradingMode: "worker")
-        let notebookDir = tmpDir + "testsetups/notebooks/\(setupID)/"
+        let notebookDir = app.testSetupsDirectory + "notebooks/\(setupID)/"
         try FileManager.default.createDirectory(atPath: notebookDir, withIntermediateDirectories: true)
         let assignmentPath = notebookDir + "assignment.ipynb"
         try defaultNotebookData(title: "Generated Suite").write(to: URL(fileURLWithPath: assignmentPath))
-        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: tmpDir + "testsetups/", setupID: setupID)
+        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: app.testSetupsDirectory + "", setupID: setupID)
         try defaultNotebookData(title: "Generated Suite Solution").write(to: URL(fileURLWithPath: solutionPath))
 
         let setup = APITestSetup(
@@ -1155,7 +1132,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
         let setupID = "setup_validation_runner_gate"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         var suiteBuffer = ByteBufferAllocator().buffer(capacity: 16)
         suiteBuffer.writeString("print('ok')\n")
         _ = try createRunnerSetupZip(
@@ -1177,11 +1154,11 @@ final class AssignmentRoutesTests: XCTestCase {
             includeMakefile: false,
             gradingMode: "worker"
         )
-        let notebookDir = tmpDir + "testsetups/notebooks/\(setupID)/"
+        let notebookDir = app.testSetupsDirectory + "notebooks/\(setupID)/"
         try FileManager.default.createDirectory(atPath: notebookDir, withIntermediateDirectories: true)
         let assignmentPath = notebookDir + "assignment.ipynb"
         try defaultNotebookData(title: "Runner Gate").write(to: URL(fileURLWithPath: assignmentPath))
-        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: tmpDir + "testsetups/", setupID: setupID)
+        let solutionPath = draftSolutionNotebookPath(testSetupsDirectory: app.testSetupsDirectory + "", setupID: setupID)
         try defaultNotebookData(title: "Runner Gate Solution").write(to: URL(fileURLWithPath: solutionPath))
 
         let setup = APITestSetup(
@@ -1326,7 +1303,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let submission = APISubmission(
             id: "sub_retest_1",
             testSetupID: "setup_retest",
-            zipPath: tmpDir + "submissions/sub_retest_1.zip",
+            zipPath: app.submissionsDirectory + "sub_retest_1.zip",
             attemptNumber: 1,
             status: "complete",
             userID: student.id
@@ -1364,7 +1341,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let submission = APISubmission(
             id: "sub_retest_mismatch",
             testSetupID: "setup_b",
-            zipPath: tmpDir + "submissions/sub_retest_mismatch.zip",
+            zipPath: app.submissionsDirectory + "sub_retest_mismatch.zip",
             attemptNumber: 1,
             status: "complete",
             userID: student.id
@@ -1403,7 +1380,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let subA = APISubmission(
             id: "sub_retest_all_a",
             testSetupID: "setup_retest_all",
-            zipPath: tmpDir + "submissions/sub_retest_all_a.zip",
+            zipPath: app.submissionsDirectory + "sub_retest_all_a.zip",
             attemptNumber: 1,
             status: "complete",
             userID: student.id
@@ -1415,7 +1392,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let subB = APISubmission(
             id: "sub_retest_all_b",
             testSetupID: "setup_retest_all",
-            zipPath: tmpDir + "submissions/sub_retest_all_b.zip",
+            zipPath: app.submissionsDirectory + "sub_retest_all_b.zip",
             attemptNumber: 2,
             status: "pending",
             userID: student.id
@@ -1426,7 +1403,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let validation = APISubmission(
             id: "sub_retest_all_validation",
             testSetupID: "setup_retest_all",
-            zipPath: tmpDir + "submissions/sub_retest_all_validation.zip",
+            zipPath: app.submissionsDirectory + "sub_retest_all_validation.zip",
             attemptNumber: 1,
             status: "complete",
             userID: nil,
@@ -1511,14 +1488,14 @@ final class AssignmentRoutesTests: XCTestCase {
         let cookie = try await loginAsInstructor()
 
         let setupID = "setup_no_runner"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
         let manifest = """
         {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
         """
         let setup = APITestSetup(
             id: setupID, manifest: manifest, zipPath: zipPath,
-            notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb",
+            notebookPath: app.testSetupsDirectory + "notebooks/\(setupID)/assignment.ipynb",
             courseID: courseID
         )
         try await setup.save(on: app.db)
@@ -1533,7 +1510,7 @@ final class AssignmentRoutesTests: XCTestCase {
         // `loadExistingSolution` returns data — otherwise
         // `scheduleValidationAfterSuiteEdit` returns early before
         // reaching the runner pre-check.
-        let solutionPath = tmpDir + "submissions/no_runner_solution.ipynb"
+        let solutionPath = app.submissionsDirectory + "no_runner_solution.ipynb"
         try defaultNotebookData(title: "Solution").write(to: URL(fileURLWithPath: solutionPath))
         let validation = APISubmission(
             id: "sub_no_runner_validation",
@@ -1638,7 +1615,7 @@ final class AssignmentRoutesTests: XCTestCase {
         let submission = APISubmission(
             id: "sub_display_name",
             testSetupID: "setup_submissions_display_name",
-            zipPath: tmpDir + "submissions/sub_display_name.zip",
+            zipPath: app.submissionsDirectory + "sub_display_name.zip",
             attemptNumber: 1,
             status: "complete",
             filename: "submission.ipynb",
@@ -1693,8 +1670,9 @@ final class AssignmentRoutesTests: XCTestCase {
         to setup: APITestSetup,
         bytes: Data
     ) async throws -> String {
-        try FileManager.default.createDirectory(atPath: tmpDir + "starters/", withIntermediateDirectories: true)
-        let starterPath = tmpDir + "starters/\(setup.id ?? "x").ipynb"
+        let startersDir = app.testDataDirectory! + "starters/"
+        try FileManager.default.createDirectory(atPath: startersDir, withIntermediateDirectories: true)
+        let starterPath = startersDir + "\(setup.id ?? "x").ipynb"
         try bytes.write(to: URL(fileURLWithPath: starterPath))
         setup.notebookPath = starterPath
         try await setup.save(on: app.db)
@@ -2110,14 +2088,14 @@ final class AssignmentRoutesTests: XCTestCase {
         let courseID = try await makeTestCourseID()
         let cookie   = try await loginAsInstructor()
         let setupID  = "setup_edit_upload_btn_reg"
-        let zipPath  = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath  = app.testSetupsDirectory + "\(setupID).zip"
         try makeZip(at: zipPath, entries: [("test_q1.py", "print('q1')")])
         let manifest = """
         {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_q1.py"}],"timeLimitSeconds":10,"makefile":null}
         """
         let setup = APITestSetup(
             id: setupID, manifest: manifest, zipPath: zipPath,
-            notebookPath: tmpDir + "testsetups/notebooks/\(setupID)/assignment.ipynb",
+            notebookPath: app.testSetupsDirectory + "notebooks/\(setupID)/assignment.ipynb",
             courseID: courseID
         )
         try await setup.save(on: app.db)

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -11,34 +11,13 @@ import Foundation
 final class AuthRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-auth-\(UUID().uuidString)", isDirectory: true)
-            .path + "/"
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs { try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true) }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        // Sessions required for auth routes.
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-auth")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Registration

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -20,35 +20,13 @@ import Foundation
 final class BrowserRunnerRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-br-\(UUID().uuidString)/")
-            .path
-
-        for subdir in ["results/", "testsetups/", "submissions/"] {
-            try FileManager.default.createDirectory(
-                atPath: tmpDir + subdir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-br")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers
@@ -60,7 +38,7 @@ final class BrowserRunnerRoutesTests: XCTestCase {
     /// Creates a test setup with a given manifest JSON and a small dummy zip.
     private func insertSetup(manifest: String) async throws -> String {
         let setupID = "setup_\(UUID().uuidString.lowercased().prefix(8))"
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         // Write a minimal valid ZIP (end-of-central-directory record only).
         let emptyZip = Data([0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18))
         try emptyZip.write(to: URL(fileURLWithPath: zipPath))

--- a/Tests/APITests/CSRFTests.swift
+++ b/Tests/APITests/CSRFTests.swift
@@ -12,35 +12,13 @@ import Foundation
 final class CSRFTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-csrf-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-csrf")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - URL-encoded form (login)
@@ -95,7 +73,7 @@ final class CSRFTests: XCTestCase {
         let course = APICourse(code: courseCode, name: "\(courseCode) Course")
         try await course.save(on: app.db)
 
-        let zipPath = tmpDir + "testsetups/\(setupID).zip"
+        let zipPath = app.testSetupsDirectory + "\(setupID).zip"
         let emptyZip = Data([0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18))
         try emptyZip.write(to: URL(fileURLWithPath: zipPath))
 

--- a/Tests/APITests/ClientDiagnosticsRoutesTests.swift
+++ b/Tests/APITests/ClientDiagnosticsRoutesTests.swift
@@ -16,19 +16,11 @@ final class ClientDiagnosticsRoutesTests: XCTestCase {
     private var app: Application!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-cdr")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers

--- a/Tests/APITests/CourseBundleTests.swift
+++ b/Tests/APITests/CourseBundleTests.swift
@@ -17,35 +17,12 @@ import Core
 final class CourseBundleTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-cbtest-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-cbtest")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -75,7 +52,7 @@ final class CourseBundleTests: XCTestCase {
         let manifest = """
         {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
         """
-        let zipPath = tmpDir + "testsetups/\(id).zip"
+        let zipPath = app.testSetupsDirectory + "\(id).zip"
         // Minimal valid ZIP end-of-central-directory record (22 bytes)
         try Data([0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18))
             .write(to: URL(fileURLWithPath: zipPath))

--- a/Tests/APITests/DatabaseConfigurationTests.swift
+++ b/Tests/APITests/DatabaseConfigurationTests.swift
@@ -183,13 +183,13 @@ struct DatabaseConfigurationTests {
         }
     }
 
-    @Test func observabilityTestDatabaseIncludesRunnerProfiles() async throws {
+    @Test func configureTestDatabaseIncludesRunnerProfiles() async throws {
         let env = EnvironmentScope()
         env.set("TEST_DATABASE_BACKEND", nil)
 
         let app = try await Application.make(.testing)
         try await withApp(app) { app in
-            try await configureTestDatabase(app, options: .observability)
+            try await configureTestDatabase(app)
 
             let now = Date()
             let profile = RunnerProfile()

--- a/Tests/APITests/DraftNotebookChecksRoutesTests.swift
+++ b/Tests/APITests/DraftNotebookChecksRoutesTests.swift
@@ -20,29 +20,12 @@ import Core
 final class DraftNotebookChecksRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-dnct-\(UUID().uuidString)/")
-            .path
-        for dir in ["results/", "testsetups/", "submissions/"].map({ tmpDir + $0 }) {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-dnct")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     private func makeDraft() async throws -> String {

--- a/Tests/APITests/DraftSuiteSectionRoutesTests.swift
+++ b/Tests/APITests/DraftSuiteSectionRoutesTests.swift
@@ -22,29 +22,12 @@ import Core
 final class DraftSuiteSectionRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-dssrt-\(UUID().uuidString)/")
-            .path
-        for dir in ["results/", "testsetups/", "submissions/"].map({ tmpDir + $0 }) {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-dssrt")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Fixture

--- a/Tests/APITests/DraftSupportFilesTests.swift
+++ b/Tests/APITests/DraftSupportFilesTests.swift
@@ -20,29 +20,12 @@ import Core
 final class DraftSupportFilesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-dsft-\(UUID().uuidString)/")
-            .path
-        for dir in ["results/", "testsetups/", "submissions/"].map({ tmpDir + $0 }) {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-dsft")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // Creates a course + draft test setup with a real zip file containing

--- a/Tests/APITests/EnrollmentRoutesTests.swift
+++ b/Tests/APITests/EnrollmentRoutesTests.swift
@@ -19,32 +19,12 @@ import Crypto
 final class EnrollmentRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-enr-\(UUID().uuidString)/")
-            .path
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-enr")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -16,8 +16,6 @@ import Foundation
 final class NotebookDownloadTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     // A notebook with 4 cells: public test, secret test, release test, solution.
     private let mixedNotebookJSON = """
     {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[
@@ -29,32 +27,11 @@ final class NotebookDownloadTests: XCTestCase {
     """
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-dl-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-dl")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -81,12 +58,12 @@ final class NotebookDownloadTests: XCTestCase {
     /// Saves a notebook JSON directly as a flat .ipynb file and returns the setup ID.
     private func insertSetupWithNotebook(notebookJSON: String) async throws -> String {
         let setupID      = "setup_test_\(UUID().uuidString.lowercased().prefix(6))"
-        let notebookPath = tmpDir + "testsetups/\(setupID).ipynb"
+        let notebookPath = app.testSetupsDirectory + "\(setupID).ipynb"
         let manifest = """
         {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
         """
         // Write a dummy zip (the flat .ipynb takes priority in getAssignment).
-        let dummyZipPath = tmpDir + "testsetups/\(setupID).zip"
+        let dummyZipPath = app.testSetupsDirectory + "\(setupID).zip"
         try Data().write(to: URL(fileURLWithPath: dummyZipPath))
         try notebookJSON.data(using: .utf8)!.write(to: URL(fileURLWithPath: notebookPath))
 

--- a/Tests/APITests/NotebookScanRoutesTests.swift
+++ b/Tests/APITests/NotebookScanRoutesTests.swift
@@ -12,35 +12,12 @@ import Foundation
 final class NotebookScanRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-nbscan-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-nbscan")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -15,7 +15,7 @@ final class ObservabilityTests: XCTestCase {
         app.middleware.use(app.sessions.middleware)
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
 
-        try await configureTestDatabase(app, options: .runnerCompatibility)
+        try await configureTestDatabase(app)
 
         configureLeaf(app)
         try routes(app)

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -10,19 +10,12 @@ final class ObservabilityTests: XCTestCase {
     private let workerSecret = "observability-secret"
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
+        app = try await makeTestApp(prefix: "chickadee-obs")
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     }
 
     func testQueueWaitMetricCalculationPersistsExpectedMilliseconds() async throws {

--- a/Tests/APITests/PatternFamilyRouteTests.swift
+++ b/Tests/APITests/PatternFamilyRouteTests.swift
@@ -14,33 +14,12 @@ import Core
 final class PatternFamilyRouteTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-pf-routes-\(UUID().uuidString)/")
-            .path
-
-        for dir in ["results/", "testsetups/", "submissions/"].map({ tmpDir + $0 }) {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-pf-routes")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Test fixture

--- a/Tests/APITests/ResultRoutesTests.swift
+++ b/Tests/APITests/ResultRoutesTests.swift
@@ -31,7 +31,7 @@ final class ResultRoutesTests: XCTestCase {
         app.middleware.use(app.sessions.middleware)
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
 
-        try await configureTestDatabase(app, options: .observability)
+        try await configureTestDatabase(app)
 
         try routes(app)
     }

--- a/Tests/APITests/ResultRoutesTests.swift
+++ b/Tests/APITests/ResultRoutesTests.swift
@@ -8,37 +8,16 @@ import Foundation
 final class ResultRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpResultsDir: String!
     private let workerSecret = "test-worker-secret"
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        // Use a temp directory so tests don't pollute the project directory
-        tmpResultsDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-test-results-\(UUID().uuidString)", isDirectory: true)
-            .path + "/"
-        try FileManager.default.createDirectory(
-            atPath: tmpResultsDir,
-            withIntermediateDirectories: true
-        )
-
-        app.resultsDirectory = tmpResultsDir
+        app = try await makeTestApp(prefix: "chickadee-test-results")
         app.routes.defaultMaxBodySize = "10mb"
-
-        // Sessions are required because routes.swift now registers UserSessionAuthenticator.
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
-
-        try await configureTestDatabase(app)
-
-        try routes(app)
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpResultsDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers
@@ -91,7 +70,7 @@ final class ResultRoutesTests: XCTestCase {
             let setup = APITestSetup(
                 id: testSetupID,
                 manifest: #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
-                zipPath: tmpResultsDir + "\(testSetupID).zip",
+                zipPath: app.resultsDirectory + "\(testSetupID).zip",
                 courseID: courseID
             )
             try setup.save(on: app.db).wait()
@@ -101,7 +80,7 @@ final class ResultRoutesTests: XCTestCase {
             let submission = APISubmission(
                 id: submissionID,
                 testSetupID: testSetupID,
-                zipPath: tmpResultsDir + "\(submissionID).zip",
+                zipPath: app.resultsDirectory + "\(submissionID).zip",
                 attemptNumber: 1,
                 status: "pending",
                 kind: APISubmission.Kind.student
@@ -143,7 +122,7 @@ final class ResultRoutesTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         })
 
-        let files = try FileManager.default.contentsOfDirectory(atPath: tmpResultsDir)
+        let files = try FileManager.default.contentsOfDirectory(atPath: app.resultsDirectory)
         let resultFile = files.first { $0.hasPrefix("sub_disktest") }
         XCTAssertNotNil(resultFile, "Expected a result file for sub_disktest to be written")
     }
@@ -185,7 +164,7 @@ final class ResultRoutesTests: XCTestCase {
             XCTAssertEqual(res.status, .ok)
         })
 
-        let files = try FileManager.default.contentsOfDirectory(atPath: tmpResultsDir)
+        let files = try FileManager.default.contentsOfDirectory(atPath: app.resultsDirectory)
         let resultFile = files.first { $0.hasPrefix(collection.submissionID) }
         XCTAssertNotNil(resultFile, "Expected a result file for wrapped reports to be written")
     }

--- a/Tests/APITests/RoleMiddlewareTests.swift
+++ b/Tests/APITests/RoleMiddlewareTests.swift
@@ -12,29 +12,9 @@ import Foundation
 final class RoleMiddlewareTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-role-\(UUID().uuidString)", isDirectory: true)
-            .path + "/"
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-role")
 
         // Register lightweight test-only routes with each protection level.
         // Browser-style paths (no /api/ prefix) → unauthenticated → 303 /login.
@@ -59,8 +39,7 @@ final class RoleMiddlewareTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Unauthenticated

--- a/Tests/APITests/RunnerCompatibilityTests.swift
+++ b/Tests/APITests/RunnerCompatibilityTests.swift
@@ -15,7 +15,7 @@ final class RunnerCompatibilityTests: XCTestCase {
         app.middleware.use(app.sessions.middleware)
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
 
-        try await configureTestDatabase(app, options: .runnerCompatibility)
+        try await configureTestDatabase(app)
 
         configureLeaf(app)
         try routes(app)

--- a/Tests/APITests/RunnerCompatibilityTests.swift
+++ b/Tests/APITests/RunnerCompatibilityTests.swift
@@ -10,19 +10,12 @@ final class RunnerCompatibilityTests: XCTestCase {
     private let workerSecret = "compatibility-secret"
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
+        app = try await makeTestApp(prefix: "chickadee-rct")
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
+        try await app.tearDownTestApp()
     }
 
     func testVersionComparatorSupportsMinimumAndExactMatches() {

--- a/Tests/APITests/ScriptEditRoutesTests.swift
+++ b/Tests/APITests/ScriptEditRoutesTests.swift
@@ -16,35 +16,12 @@ import Foundation
 final class ScriptEditRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-scripts-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-scripts")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -76,7 +53,7 @@ final class ScriptEditRoutesTests: XCTestCase {
         {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
         """
         let courseID = try await makeTestCourseID()
-        let zipPath = tmpDir + "testsetups/\(id).zip"
+        let zipPath = app.testSetupsDirectory + "\(id).zip"
         try makeZipAt(zipPath: zipPath, entries: entries)
         let setup = APITestSetup(id: id, manifest: manifest, zipPath: zipPath, courseID: courseID)
         try await setup.save(on: app.db)

--- a/Tests/APITests/SectionRoutesTests.swift
+++ b/Tests/APITests/SectionRoutesTests.swift
@@ -17,32 +17,12 @@ import Core
 final class SectionRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-sect-\(UUID().uuidString)/")
-            .path
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-sect")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers
@@ -73,7 +53,7 @@ final class SectionRoutesTests: XCTestCase {
         {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,"makefile":null,"gradingMode":"worker"}
         """
         let setup = APITestSetup(id: setupID, manifest: manifest,
-                                  zipPath: tmpDir + "testsetups/\(setupID).zip", courseID: courseID)
+                                  zipPath: app.testSetupsDirectory + "\(setupID).zip", courseID: courseID)
         try await setup.save(on: app.db)
         let assignment = APIAssignment(testSetupID: setupID, title: title,
                                         dueAt: nil, isOpen: true, courseID: courseID)
@@ -433,7 +413,7 @@ final class SectionRoutesTests: XCTestCase {
         """
         let setupID = "move_setup3"
         let setup = APITestSetup(id: setupID, manifest: manifest,
-                                  zipPath: tmpDir + "testsetups/\(setupID).zip", courseID: courseID)
+                                  zipPath: app.testSetupsDirectory + "\(setupID).zip", courseID: courseID)
         try await setup.save(on: app.db)
         let assignment = APIAssignment(testSetupID: setupID, title: "GradeModeTest",
                                         dueAt: nil, isOpen: true, courseID: courseID)

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -16,36 +16,13 @@ import Foundation
 final class SubmissionQueryRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-sqr-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        // Sessions are required because routes.swift now registers UserSessionAuthenticator.
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-sqr")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helper
@@ -75,7 +52,7 @@ final class SubmissionQueryRoutesTests: XCTestCase {
         let setup = APITestSetup(
             id: id,
             manifest: #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
-            zipPath: tmpDir + "testsetups/\(id).zip",
+            zipPath: app.testSetupsDirectory + "\(id).zip",
             courseID: courseID
         )
         try await setup.save(on: app.db)
@@ -95,7 +72,7 @@ final class SubmissionQueryRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: id,
             testSetupID: testSetupID,
-            zipPath: tmpDir + "submissions/\(id).zip",
+            zipPath: app.submissionsDirectory + "\(id).zip",
             attemptNumber: attemptNumber,
             status: status,
             userID: userID

--- a/Tests/APITests/SubmissionRoutesTests.swift
+++ b/Tests/APITests/SubmissionRoutesTests.swift
@@ -13,35 +13,13 @@ import Foundation
 final class SubmissionRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-subr-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-subr")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -80,7 +58,7 @@ final class SubmissionRoutesTests: XCTestCase {
         let setup = APITestSetup(
             id: id,
             manifest: #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
-            zipPath: tmpDir + "testsetups/\(id).zip",
+            zipPath: app.testSetupsDirectory + "\(id).zip",
             courseID: courseID
         )
         try await setup.save(on: app.db)
@@ -263,7 +241,7 @@ final class SubmissionRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: "sub_dl_own",
             testSetupID: "setup_dl",
-            zipPath: tmpDir + "submissions/sub_dl_own.zip",
+            zipPath: app.submissionsDirectory + "sub_dl_own.zip",
             attemptNumber: 1,
             userID: ownerID
         )
@@ -290,7 +268,7 @@ final class SubmissionRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: "sub_dl_instr",
             testSetupID: "setup_dl2",
-            zipPath: tmpDir + "submissions/sub_dl_instr.zip",
+            zipPath: app.submissionsDirectory + "sub_dl_instr.zip",
             attemptNumber: 1,
             userID: studentID
         )
@@ -314,7 +292,7 @@ final class SubmissionRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: "sub_dl_forbid",
             testSetupID: "setup_dl3",
-            zipPath: tmpDir + "submissions/sub_dl_forbid.zip",
+            zipPath: app.submissionsDirectory + "sub_dl_forbid.zip",
             attemptNumber: 1,
             userID: idA
         )
@@ -346,7 +324,7 @@ final class SubmissionRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: "sub_dl_fname",
             testSetupID: "setup_fname",
-            zipPath: tmpDir + "submissions/sub_dl_fname.ipynb",
+            zipPath: app.submissionsDirectory + "sub_dl_fname.ipynb",
             attemptNumber: 1,
             filename: "my_notebook.ipynb"
         )

--- a/Tests/APITests/SuiteRouteTests.swift
+++ b/Tests/APITests/SuiteRouteTests.swift
@@ -18,29 +18,12 @@ import Core
 final class SuiteRouteTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-suite-rt-\(UUID().uuidString)/")
-            .path
-        for dir in ["results/", "testsetups/", "submissions/"].map({ tmpDir + $0 }) {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-suite-rt")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Fixtures

--- a/Tests/APITests/SuiteSectionRoutesTests.swift
+++ b/Tests/APITests/SuiteSectionRoutesTests.swift
@@ -22,29 +22,12 @@ import Core
 final class SuiteSectionRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-ssrt-\(UUID().uuidString)/")
-            .path
-        for dir in ["results/", "testsetups/", "submissions/"].map({ tmpDir + $0 }) {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = tmpDir + "results/"
-        app.testSetupsDirectory  = tmpDir + "testsetups/"
-        app.submissionsDirectory = tmpDir + "submissions/"
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-ssrt")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Fixture

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -14,30 +14,7 @@ import FluentPostgresDriver
 import Foundation
 import SQLKit
 
-struct TestDatabaseOptions: Sendable {
-    let includeObservability: Bool
-    let includeRunnerCompatibility: Bool
-
-    static let `default` = TestDatabaseOptions(
-        includeObservability: false,
-        includeRunnerCompatibility: false
-    )
-
-    static let observability = TestDatabaseOptions(
-        includeObservability: true,
-        includeRunnerCompatibility: false
-    )
-
-    static let runnerCompatibility = TestDatabaseOptions(
-        includeObservability: true,
-        includeRunnerCompatibility: true
-    )
-}
-
-func configureTestDatabase(
-    _ app: Application,
-    options: TestDatabaseOptions = .default
-) async throws {
+func configureTestDatabase(_ app: Application) async throws {
     let settings = try testDatabaseSettingsFromEnvironment()
     try configureDatabase(app, settings: settings)
 
@@ -45,13 +22,7 @@ func configureTestDatabase(
         try await resetPostgresTestSchema(app)
     }
 
-    registerBaseTestMigrations(on: app)
-    if options.includeObservability {
-        registerObservabilityTestMigrations(on: app)
-    }
-    if options.includeRunnerCompatibility {
-        registerRunnerCompatibilityTestMigrations(on: app)
-    }
+    registerMigrations(on: app)
 
     try await app.autoMigrate()
 }
@@ -108,45 +79,6 @@ func testDatabaseSettingsFromEnvironment() throws -> DatabaseSettings {
             password: password
         )
     }
-}
-
-private func registerBaseTestMigrations(on app: Application) {
-    app.migrations.add(CreateUsers())
-    app.migrations.add(CreateCourses())
-    app.migrations.add(CreateCourseEnrollments())
-    app.migrations.add(CreateTestSetups())
-    app.migrations.add(CreateSubmissions())
-    app.migrations.add(CreateResults())
-    app.migrations.add(CreateAssignments())
-    app.migrations.add(AddAssignmentSlugs())
-    app.migrations.add(CreatePerformanceIndexes())
-    app.migrations.add(AddCourseSections())
-    app.migrations.add(AddCourseOpenEnrollment())
-    app.migrations.add(AddCourseEnrollmentMode())
-    app.migrations.add(AddSubmissionRetestedAt())
-    app.migrations.add(AddAssignmentDeadlineOverrideActive())
-    app.migrations.add(CreateClassAchievements())
-    app.migrations.add(AddSubmissionRetestedByUserID())
-    app.migrations.add(AddTestSetupLastRetestedManifestHash())
-    app.migrations.add(CreatePreEnrollments())
-    app.migrations.add(AddUserLastSeenAt())
-    app.migrations.add(AddBrightSpaceSyncFields())
-    app.migrations.add(CreateClientDiagnostics())
-    app.migrations.add(CreateAssignmentPersonalizationSeeds())
-}
-
-private func registerObservabilityTestMigrations(on app: Application) {
-    app.migrations.add(CreateSubmissionDiagnostics())
-    app.migrations.add(CreateRequestMetrics())
-    app.migrations.add(CreateJobExecutionMetrics())
-    app.migrations.add(AddJobExecutionStageTimings())
-    app.migrations.add(CreateRunnerSnapshots())
-    app.migrations.add(CreateRunnerProfiles())
-    app.migrations.add(AddJobDiskUsageMetrics())
-}
-
-private func registerRunnerCompatibilityTestMigrations(on app: Application) {
-    app.migrations.add(CreateAssignmentRequirements())
 }
 
 // MARK: - Async app lifecycle

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -94,6 +94,71 @@ func withApp(_ app: Application, _ body: (Application) async throws -> Void) asy
     }
 }
 
+// MARK: - Standard test app
+
+private struct TestDataDirectoryKey: StorageKey {
+    typealias Value = String
+}
+
+extension Application {
+    /// Filesystem directory created by `makeTestApp` for this app's
+    /// results/testsetups/submissions trees. Nil if the app wasn't built
+    /// via `makeTestApp`.
+    var testDataDirectory: String? {
+        storage[TestDataDirectoryKey.self]
+    }
+
+    /// Shuts the app down and removes the temp directory created by
+    /// `makeTestApp`. Use in tearDown for any app obtained from
+    /// `makeTestApp`.
+    func tearDownTestApp() async throws {
+        let dir = storage[TestDataDirectoryKey.self]
+        try await asyncShutdown()
+        if let dir {
+            try? FileManager.default.removeItem(atPath: dir)
+        }
+    }
+}
+
+/// Builds a `.testing` Vapor application with the standard test wiring:
+/// per-app temp directories for results/testsetups/submissions,
+/// in-memory sessions, the production migration list, Leaf views, and
+/// the full route tree mounted.
+///
+/// Caller owns the lifecycle — pair with `app.tearDownTestApp()` in
+/// tearDown.  For unit tests that need a bare app (single-middleware
+/// isolation, custom auth modes, custom database configuration), use
+/// `Application.make(.testing)` directly.
+func makeTestApp(
+    prefix: String = "chickadee-test",
+    authMode: AuthMode = .local
+) async throws -> Application {
+    let app = try await Application.make(.testing)
+    app.authMode = authMode
+
+    let tmpDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("\(prefix)-\(UUID().uuidString)/")
+        .path
+    let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
+    for dir in dirs {
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+    }
+    app.resultsDirectory     = dirs[0]
+    app.testSetupsDirectory  = dirs[1]
+    app.submissionsDirectory = dirs[2]
+    app.storage[TestDataDirectoryKey.self] = tmpDir
+
+    app.sessions.use(.memory)
+    app.middleware.use(app.sessions.middleware)
+
+    try await configureTestDatabase(app)
+
+    configureLeaf(app)
+    try routes(app)
+
+    return app
+}
+
 extension Application {
     @discardableResult
     func asyncTest(

--- a/Tests/APITests/TestSetupEditTests.swift
+++ b/Tests/APITests/TestSetupEditTests.swift
@@ -15,35 +15,12 @@ import Foundation
 final class TestSetupEditTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-edit-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-edit")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -77,7 +54,7 @@ final class TestSetupEditTests: XCTestCase {
         let setup = APITestSetup(
             id: id,
             manifest: manifest,
-            zipPath: tmpDir + "testsetups/\(id).zip",
+            zipPath: app.testSetupsDirectory + "\(id).zip",
             courseID: courseID
         )
         try await setup.save(on: app.db)
@@ -178,7 +155,7 @@ final class TestSetupEditTests: XCTestCase {
         )
 
         // File should be on disk.
-        let expectedPath = tmpDir + "testsetups/setup_put1.ipynb"
+        let expectedPath = app.testSetupsDirectory + "setup_put1.ipynb"
         XCTAssertTrue(FileManager.default.fileExists(atPath: expectedPath),
                       "Expected flat .ipynb file at \(expectedPath)")
     }
@@ -220,7 +197,7 @@ final class TestSetupEditTests: XCTestCase {
             }
         )
 
-        let expectedPath = tmpDir + "testsetups/setup_put_kernel.ipynb"
+        let expectedPath = app.testSetupsDirectory + "setup_put_kernel.ipynb"
         let savedData = try Data(contentsOf: URL(fileURLWithPath: expectedPath))
         let savedJSON = try JSONSerialization.jsonObject(with: savedData) as? [String: Any]
         let metadata = savedJSON?["metadata"] as? [String: Any]
@@ -234,7 +211,7 @@ final class TestSetupEditTests: XCTestCase {
         try await insertSetup(id: "setup_flat")
 
         // Write a flat notebook file directly.
-        let flatPath = tmpDir + "testsetups/setup_flat.ipynb"
+        let flatPath = app.testSetupsDirectory + "setup_flat.ipynb"
         let editedJSON = """
         {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[{"cell_type":"code","source":["# edited"],"metadata":{},"outputs":[]}]}
         """
@@ -262,7 +239,7 @@ final class TestSetupEditTests: XCTestCase {
         let cookie = try await loginAsInstructor()
         try await insertSetup(id: "setup_flat_kernel")
 
-        let flatPath = tmpDir + "testsetups/setup_flat_kernel.ipynb"
+        let flatPath = app.testSetupsDirectory + "setup_flat_kernel.ipynb"
         try python3NotebookJSON.write(toFile: flatPath, atomically: true, encoding: .utf8)
 
         let setup = try await APITestSetup.find("setup_flat_kernel", on: app.db)!
@@ -401,7 +378,7 @@ final class TestSetupEditTests: XCTestCase {
             }
         )
 
-        let expectedPath = tmpDir + "testsetups/setup_put_ir.ipynb"
+        let expectedPath = app.testSetupsDirectory + "setup_put_ir.ipynb"
         let savedData    = try Data(contentsOf: URL(fileURLWithPath: expectedPath))
         let savedJSON    = try JSONSerialization.jsonObject(with: savedData) as? [String: Any]
         let metadata     = savedJSON?["metadata"]  as? [String: Any]
@@ -414,7 +391,7 @@ final class TestSetupEditTests: XCTestCase {
         let cookie = try await loginAsInstructor()
         try await insertSetup(id: "setup_flat_ir")
 
-        let flatPath = tmpDir + "testsetups/setup_flat_ir.ipynb"
+        let flatPath = app.testSetupsDirectory + "setup_flat_ir.ipynb"
         try irNotebookJSON.write(toFile: flatPath, atomically: true, encoding: .utf8)
 
         let setup = try await APITestSetup.find("setup_flat_ir", on: app.db)!
@@ -453,7 +430,7 @@ final class TestSetupEditTests: XCTestCase {
             }
         )
 
-        let expectedPath = tmpDir + "testsetups/setup_put_py_check.ipynb"
+        let expectedPath = app.testSetupsDirectory + "setup_put_py_check.ipynb"
         let savedData    = try Data(contentsOf: URL(fileURLWithPath: expectedPath))
         let savedJSON    = try JSONSerialization.jsonObject(with: savedData) as? [String: Any]
         let metadata     = savedJSON?["metadata"]  as? [String: Any]

--- a/Tests/APITests/VanityURLRoutesTests.swift
+++ b/Tests/APITests/VanityURLRoutesTests.swift
@@ -11,32 +11,12 @@ import Foundation
 final class VanityURLRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-vanity-\(UUID().uuidString)/")
-            .path
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-vanity")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - slugify
@@ -81,7 +61,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let setup = APITestSetup(
             id: setupID,
             manifest: manifest,
-            zipPath: tmpDir + "testsetups/\(setupID).zip",
+            zipPath: app.testSetupsDirectory + "\(setupID).zip",
             courseID: courseID
         )
         try await setup.save(on: app.db)

--- a/Tests/APITests/WebRoutesTests.swift
+++ b/Tests/APITests/WebRoutesTests.swift
@@ -17,35 +17,12 @@ import Core
 final class WebRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: String!
-
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-wrt-\(UUID().uuidString)/")
-            .path
-
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
-        for dir in dirs {
-            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0]
-        app.testSetupsDirectory  = dirs[1]
-        app.submissionsDirectory = dirs[2]
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-
-        try await configureTestDatabase(app)
-
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-wrt")
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(atPath: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Auth helpers
@@ -93,7 +70,7 @@ final class WebRoutesTests: XCTestCase {
         """
         let course = try await makeCourse()
         let courseID = try course.requireID()
-        let setup = APITestSetup(id: id, manifest: manifest, zipPath: tmpDir + "testsetups/\(id).zip", courseID: courseID)
+        let setup = APITestSetup(id: id, manifest: manifest, zipPath: app.testSetupsDirectory + "\(id).zip", courseID: courseID)
         try await setup.save(on: app.db)
         return setup
     }
@@ -124,7 +101,7 @@ final class WebRoutesTests: XCTestCase {
         let sub = APISubmission(
             id: id,
             testSetupID: testSetupID,
-            zipPath: tmpDir + "submissions/\(id).py",
+            zipPath: app.submissionsDirectory + "\(id).py",
             attemptNumber: attemptNumber,
             status: status,
             filename: filename,
@@ -295,7 +272,7 @@ final class WebRoutesTests: XCTestCase {
         let setupID = "setup_browser_first_open"
         let course = try await makeCourse()
         let courseID = try course.requireID()
-        let notebookPath = tmpDir + "testsetups/\(setupID).ipynb"
+        let notebookPath = app.testSetupsDirectory + "\(setupID).ipynb"
         let notebookJSON = """
         {"cells":[{"cell_type":"markdown","metadata":{},"source":["Browser starter"]}],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"name":"python"}},"nbformat":4,"nbformat_minor":5}
         """
@@ -307,7 +284,7 @@ final class WebRoutesTests: XCTestCase {
         let setup = APITestSetup(
             id: setupID,
             manifest: manifest,
-            zipPath: tmpDir + "testsetups/\(setupID).zip",
+            zipPath: app.testSetupsDirectory + "\(setupID).zip",
             notebookPath: notebookPath,
             courseID: courseID
         )
@@ -637,7 +614,7 @@ final class WebRoutesTests: XCTestCase {
         let setup = APITestSetup(
             id: "setup_browser_names",
             manifest: manifest,
-            zipPath: tmpDir + "testsetups/setup_browser_names.zip",
+            zipPath: app.testSetupsDirectory + "setup_browser_names.zip",
             courseID: courseID
         )
         try await setup.save(on: app.db)

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -15,7 +15,6 @@ import Core
 final class WorkerRoutesTests: XCTestCase {
 
     private var app: Application!
-    private var tmpDir: URL!
     private let workerSecret = "test-worker-secret-abc123"
 
     // Minimal worker-mode manifest JSON (gradingMode defaults to .worker)
@@ -29,23 +28,7 @@ final class WorkerRoutesTests: XCTestCase {
     """
 
     override func setUp() async throws {
-        app = try await Application.make(.testing)
-
-        tmpDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("chickadee-worker-\(UUID().uuidString)")
-        let dirs = ["results", "testsetups", "submissions"].map { tmpDir.appendingPathComponent($0) }
-        for dir in dirs {
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        }
-        app.resultsDirectory     = dirs[0].path + "/"
-        app.testSetupsDirectory  = dirs[1].path + "/"
-        app.submissionsDirectory = dirs[2].path + "/"
-
-        app.sessions.use(.memory)
-        app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app)
-        configureLeaf(app)
-        try routes(app)
+        app = try await makeTestApp(prefix: "chickadee-worker")
 
         // Initialize the claim queue before requests start (mirrors configure() eager-init pattern).
         app.storage[WorkerClaimQueueKey.self] = WorkerClaimQueue()
@@ -54,8 +37,7 @@ final class WorkerRoutesTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        try await app.asyncShutdown()
-        try? FileManager.default.removeItem(at: tmpDir)
+        try await app.tearDownTestApp()
     }
 
     // MARK: - Helpers
@@ -92,7 +74,7 @@ final class WorkerRoutesTests: XCTestCase {
 
     private func makeTestSetup(id: String, manifest: String) async throws -> APITestSetup {
         let zipPath = try makeDummyZip(named: "\(id).zip",
-                                       in: tmpDir.appendingPathComponent("testsetups"))
+                                       in: URL(fileURLWithPath: app.testSetupsDirectory))
         // Each test setup needs a course (FK constraint); create a throw-away one.
         let course = APICourse(code: "WK_\(id)", name: "Worker Test Course", enrollmentMode: .closed)
         try await course.save(on: app.db)
@@ -105,7 +87,7 @@ final class WorkerRoutesTests: XCTestCase {
     private func makeSubmission(id: String, setupID: String, status: String = "pending",
                                  kind: String = APISubmission.Kind.student) async throws -> APISubmission {
         let zipPath = try makeDummyZip(named: "\(id).zip",
-                                       in: tmpDir.appendingPathComponent("submissions"))
+                                       in: URL(fileURLWithPath: app.submissionsDirectory))
         let sub = APISubmission(id: id, testSetupID: setupID, zipPath: zipPath,
                                 attemptNumber: 1, status: status,
                                 filename: "submission.zip", userID: nil, kind: kind)

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -43,7 +43,7 @@ final class WorkerRoutesTests: XCTestCase {
 
         app.sessions.use(.memory)
         app.middleware.use(app.sessions.middleware)
-        try await configureTestDatabase(app, options: .runnerCompatibility)
+        try await configureTestDatabase(app)
         configureLeaf(app)
         try routes(app)
 


### PR DESCRIPTION
## Summary

Three commits, each shippable independently:

1. **`tests: route configureTestDatabase through production registerMigrations(on:)`** — kills the migration-list drift between the test helper and `Sources/APIServer/Utilities/DatabaseConfiguration.swift`. Tests now call the same function as production, so a new migration only has to be registered once. `TestDatabaseOptions` and the three duplicated `register*TestMigrations` functions are gone.

2. **`chore: SessionStart hook to install Swift in Claude Code on the web sandbox`** — adds `.claude/hooks/session-start.sh` (installs Swift 6.3 on first use, idempotent thereafter) plus a narrow `.gitignore` exception so `.claude/hooks/` and `.claude/settings.json` ship while `.claude/settings.local.json` stays local. Skips entirely on local Claude Code sessions.

3. **`tests: introduce makeTestApp() helper and migrate 30 test files`** — `makeTestApp(prefix:)` builds a `.testing` Vapor app with the standard test wiring (per-app temp dirs, in-memory sessions, full migration list, Leaf, routes); tests pair with `app.tearDownTestApp()` in tearDown. Net: **−515 lines** across 30 files. Bare-app tests (SecurityAndHealth, HTTPS, COEP, WorkerHMAC, OIDC, SSO, AuthModeGating, DatabaseConfiguration, NotebookWebRoutes, AssignmentSeedStore, AssignmentHelpers, PatternFamily one-off) intentionally stay on direct `Application.make(.testing)` — they isolate a single middleware, test the helpers themselves, or need custom auth/database configuration.

## Test plan

- [x] `swift build --target APITests` — clean
- [x] `swift test --filter "APITests.(Observability|AdminRoutes|RunnerCompatibility|WorkerRoutes|SubmissionRoutes|ResultRoutes)"` — 68 tests pass after rebase onto latest main (resolved one conflict in `TestHelpers.swift` where v0.4.164 added `AddJobDiskUsageMetrics` to the now-deleted gated migration list; production's `registerMigrations` already includes it).
- [x] Full `swift test` — passed on pre-rebase tip (10m50s, exit 0)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WC53WzYexAQKQEnFu92Y7M)_