### PR TITLE
Postgres test parallelization + TestSetupCache hit-rate telemetry

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -124,7 +124,7 @@ jobs:
           done
 
       - name: Run APITests against PostgreSQL
-        run: swift test --filter APITests
+        run: swift test --parallel --filter APITests
 
   browser-runner-tests:
     runs-on: ubuntu-latest

--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -29,6 +29,7 @@ Runner #(runner.workerID)
             <div><strong>Avg wait:</strong> #if(summary.avgQueueWaitFormatted):#(summary.avgQueueWaitFormatted)#else:—#endif</div>
             <div><strong>Avg setup/other:</strong> #if(summary.avgOverheadFormatted):#(summary.avgOverheadFormatted)#else:—#endif</div>
             <div><strong>Avg cache acquire:</strong> #if(summary.avgCacheAcquireFormatted):#(summary.avgCacheAcquireFormatted)#else:—#endif</div>
+            <div><strong>Cache hit rate:</strong> #if(summary.cacheHitRateFormatted):#(summary.cacheHitRateFormatted)#else:—#endif</div>
             <div><strong>Avg download:</strong> #if(summary.avgDownloadFormatted):#(summary.avgDownloadFormatted)#else:—#endif</div>
             <div><strong>Avg prep:</strong> #if(summary.avgPrepFormatted):#(summary.avgPrepFormatted)#else:—#endif</div>
         </div>

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
@@ -298,6 +298,7 @@ extension OperationalDiagnosticsService {
                 metric.makeStepMs = nil
                 metric.runtimeHelperSetupMs = nil
                 metric.testExecutionMs = nil
+                metric.testSetupCacheHit = nil
                 metric.freeDiskMBAtStart = nil
                 metric.freeDiskMBAtEnd = nil
                 metric.workdirPeakBytes = nil

--- a/Sources/APIServer/Diagnostics/StageTimingAggregator.swift
+++ b/Sources/APIServer/Diagnostics/StageTimingAggregator.swift
@@ -18,6 +18,7 @@ struct StageTimingAggregator: Sendable, Equatable {
     let makeStepMs: Int?
     let runtimeHelperSetupMs: Int?
     let testExecutionMs: Int?
+    let testSetupCacheHit: Bool?
 
     init(from timings: WorkerExecutionStageTimings?) {
         self.workdirSetupMs = timings?.workdirSetupMs
@@ -30,6 +31,7 @@ struct StageTimingAggregator: Sendable, Equatable {
         self.makeStepMs = timings?.makeStepMs
         self.runtimeHelperSetupMs = timings?.runtimeHelperSetupMs
         self.testExecutionMs = timings?.testExecutionMs
+        self.testSetupCacheHit = timings?.testSetupCacheHit
     }
 
     func apply(to metric: JobExecutionMetric) {
@@ -43,6 +45,7 @@ struct StageTimingAggregator: Sendable, Equatable {
         metric.makeStepMs = makeStepMs
         metric.runtimeHelperSetupMs = runtimeHelperSetupMs
         metric.testExecutionMs = testExecutionMs
+        metric.testSetupCacheHit = testSetupCacheHit
     }
 
     /// Sum of every populated stage timing. `nil` when every stage is `nil`.

--- a/Sources/APIServer/Migrations/AddJobExecutionCacheHit.swift
+++ b/Sources/APIServer/Migrations/AddJobExecutionCacheHit.swift
@@ -1,0 +1,20 @@
+import Fluent
+
+/// Adds `test_setup_cache_hit` to `job_execution_metrics` so the admin
+/// runner detail page can report each runner's TestSetupCache hit rate
+/// per the audit follow-up in #492.  Nullable boolean; existing rows
+/// stay nil, and older runners that don't yet send `testSetupCacheHit`
+/// continue to record nil.
+struct AddJobExecutionCacheHit: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(JobExecutionMetric.schema)
+            .field("test_setup_cache_hit", .bool)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(JobExecutionMetric.schema)
+            .deleteField("test_setup_cache_hit")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/JobExecutionMetric.swift
+++ b/Sources/APIServer/Models/JobExecutionMetric.swift
@@ -85,6 +85,12 @@ final class JobExecutionMetric: Model, Content, @unchecked Sendable {
     @OptionalField(key: "test_execution_ms")
     var testExecutionMs: Int?
 
+    /// Whether the runner-side TestSetupCache hit (true) for this job's
+    /// test setup, or had to populate from a fresh download (false).
+    /// Nil for jobs reported by runners that predate this field.
+    @OptionalField(key: "test_setup_cache_hit")
+    var testSetupCacheHit: Bool?
+
     @OptionalField(key: "final_status")
     var finalStatus: String?
 

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -54,6 +54,12 @@ struct AdminRunnerSummary: Encodable {
     let avgCacheAcquireFormatted: String?
     let avgDownloadFormatted: String?
     let avgPrepFormatted: String?
+    /// "<pct>% (<hits>/<total>)" over recent jobs with a recorded cache flag.
+    /// `nil` when no recent job reported a `testSetupCacheHit` (e.g. runner is
+    /// pre-v0.4.169 or only ran validation submissions).  When non-nil, this
+    /// is the only direct signal that the LRU cache is actually paying off
+    /// — compare hit-rate against `avgCacheAcquireFormatted` to confirm.
+    let cacheHitRateFormatted: String?
     let passedCount: Int
     let failedCount: Int
     let errorCount: Int

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -241,6 +241,13 @@ struct AdminRoutes: RouteCollection {
 
         let overheadSamples = recentJobs.compactMap { overheadMs(for: $0) }
         let stageBreakdowns = recentJobs.map(stageBreakdown(for:))
+        let cacheFlagged = recentJobs.compactMap { $0.testSetupCacheHit }
+        let cacheHitRateFormatted: String? = {
+            guard !cacheFlagged.isEmpty else { return nil }
+            let hits = cacheFlagged.filter { $0 }.count
+            let pct = Int((Double(hits) / Double(cacheFlagged.count) * 100).rounded())
+            return "\(pct)% (\(hits)/\(cacheFlagged.count))"
+        }()
         let jobRows = recentJobs.map {
             AdminRunnerJobRow(
                 submissionID: $0.submissionID,
@@ -269,6 +276,7 @@ struct AdminRoutes: RouteCollection {
             avgCacheAcquireFormatted: average(stageBreakdowns.compactMap { $0?.cacheAcquireMs }).map(formatMs),
             avgDownloadFormatted: average(stageBreakdowns.compactMap { $0?.downloadMs }).map(formatMs),
             avgPrepFormatted: average(stageBreakdowns.compactMap { $0?.prepMs }).map(formatMs),
+            cacheHitRateFormatted: cacheHitRateFormatted,
             passedCount: statusCounts["passed", default: 0],
             failedCount: statusCounts["failed", default: 0],
             errorCount: statusCounts["error", default: 0],

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -19,6 +19,7 @@ struct DatabaseSettings: Sendable {
     let postgresDatabase: String?
     let postgresUsername: String?
     let postgresPassword: String?
+    let postgresSearchPath: [String]?
 
     static func fromEnvironment(defaultSQLitePath: String) throws -> Self {
         let backend: DatabaseBackend
@@ -86,7 +87,8 @@ struct DatabaseSettings: Sendable {
             postgresPort: nil,
             postgresDatabase: nil,
             postgresUsername: nil,
-            postgresPassword: nil
+            postgresPassword: nil,
+            postgresSearchPath: nil
         )
     }
 
@@ -99,7 +101,8 @@ struct DatabaseSettings: Sendable {
             postgresPort: nil,
             postgresDatabase: nil,
             postgresUsername: nil,
-            postgresPassword: nil
+            postgresPassword: nil,
+            postgresSearchPath: nil
         )
     }
 
@@ -108,7 +111,8 @@ struct DatabaseSettings: Sendable {
         port: Int,
         database: String,
         username: String,
-        password: String
+        password: String,
+        searchPath: [String]? = nil
     ) -> Self {
         .init(
             backend: .postgres,
@@ -118,7 +122,8 @@ struct DatabaseSettings: Sendable {
             postgresPort: port,
             postgresDatabase: database,
             postgresUsername: username,
-            postgresPassword: password
+            postgresPassword: password,
+            postgresSearchPath: searchPath
         )
     }
 }
@@ -163,7 +168,7 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
             )
         }
 
-        let configuration = SQLPostgresConfiguration(
+        var configuration = SQLPostgresConfiguration(
             hostname: host,
             port: port,
             username: username,
@@ -171,6 +176,14 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
             database: database,
             tls: .disable
         )
+        // Per-connection `SET search_path TO ...` so tests can isolate themselves
+        // by schema and run in parallel against a single shared Postgres
+        // database.  Postgres tolerates a non-existent name in search_path until
+        // an unqualified reference resolves to it, so the bootstrap path can
+        // configure first, then `CREATE SCHEMA`, then run migrations.
+        if let searchPath = settings.postgresSearchPath, !searchPath.isEmpty {
+            configuration.searchPath = searchPath
+        }
         app.databases.use(
             .postgres(configuration: configuration),
             as: .chickadee,

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -226,4 +226,5 @@ func registerMigrations(on app: Application) {
     app.migrations.add(AddJobDiskUsageMetrics())
     app.migrations.add(AddSessionsCreatedAt())
     app.migrations.add(CreateAuditLog())
+    app.migrations.add(AddJobExecutionCacheHit())
 }

--- a/Sources/Core/Models/WorkerExecutionReport.swift
+++ b/Sources/Core/Models/WorkerExecutionReport.swift
@@ -11,6 +11,10 @@ public struct WorkerExecutionStageTimings: Codable, Sendable, Equatable {
     public let makeStepMs: Int?
     public let runtimeHelperSetupMs: Int?
     public let testExecutionMs: Int?
+    /// Whether the runner-side `TestSetupCache` hit (true) or had to populate
+    /// from a fresh download (false) when staging this job's test setup.
+    /// Nil when older runners that predate this field report results.
+    public let testSetupCacheHit: Bool?
 
     public init(
         workdirSetupMs: Int? = nil,
@@ -22,7 +26,8 @@ public struct WorkerExecutionStageTimings: Codable, Sendable, Equatable {
         submissionPrepareMs: Int? = nil,
         makeStepMs: Int? = nil,
         runtimeHelperSetupMs: Int? = nil,
-        testExecutionMs: Int? = nil
+        testExecutionMs: Int? = nil,
+        testSetupCacheHit: Bool? = nil
     ) {
         self.workdirSetupMs = workdirSetupMs
         self.submissionDirSetupMs = submissionDirSetupMs
@@ -34,6 +39,7 @@ public struct WorkerExecutionStageTimings: Codable, Sendable, Equatable {
         self.makeStepMs = makeStepMs
         self.runtimeHelperSetupMs = runtimeHelperSetupMs
         self.testExecutionMs = testExecutionMs
+        self.testSetupCacheHit = testSetupCacheHit
     }
 }
 

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -156,7 +156,7 @@ extension WorkerDaemon {
 
         let testSetupAcquireStartedAt = Date()
         let testSetupCacheKey = testSetupCacheKey(for: job)
-        let testSetupDir = try await testSetupCache.acquire(testSetupID: testSetupCacheKey) {
+        let acquireResult = try await testSetupCache.acquire(testSetupID: testSetupCacheKey) {
             let stagingZip = workDir.appendingPathComponent("testsetup.zip")
             let stagingDir = workDir.appendingPathComponent("testsetup_staging", isDirectory: true)
             try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
@@ -164,8 +164,10 @@ extension WorkerDaemon {
             try self.unzip(stagingZip, to: stagingDir)
             return stagingDir
         }
+        let testSetupDir = acquireResult.directory
         stageTimings.record(
             "test_setup_acquire", milliseconds: Int(Date().timeIntervalSince(testSetupAcquireStartedAt) * 1000))
+        stageTimings.testSetupCacheHit = acquireResult.didHit
         defer { try? FileManager.default.removeItem(at: testSetupDir) }
 
         try await submissionDownload

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -17,6 +17,7 @@ enum RunnerJobStatus: String {
 
 struct JobStageTimings {
     private var values: [String: Int] = [:]
+    var testSetupCacheHit: Bool?
 
     mutating func measureSync<T>(_ stage: String, operation: () throws -> T) rethrows -> T {
         let start = Date()
@@ -33,6 +34,9 @@ struct JobStageTimings {
         var result: [String: Any] = [:]
         for (key, value) in values {
             result["\(key)_ms"] = value
+        }
+        if let testSetupCacheHit {
+            result["test_setup_cache_hit"] = testSetupCacheHit
         }
         return result
     }
@@ -52,7 +56,8 @@ struct JobStageTimings {
             submissionPrepareMs: value(for: "submission_prepare"),
             makeStepMs: value(for: "make_step"),
             runtimeHelperSetupMs: value(for: "runtime_helper_setup"),
-            testExecutionMs: value(for: "test_execution")
+            testExecutionMs: value(for: "test_execution"),
+            testSetupCacheHit: testSetupCacheHit
         )
     }
 

--- a/Sources/Worker/TestSetupCache.swift
+++ b/Sources/Worker/TestSetupCache.swift
@@ -50,10 +50,20 @@ actor TestSetupCache {
     ///               into a staging directory and returns that directory URL.
     ///               Called at most once per key; concurrent callers await the
     ///               same in-flight task.
+    /// Result of an `acquire` call.  `directory` is the per-job scratch copy
+    /// the caller owns; `didHit` distinguishes a fresh-from-disk hit (true)
+    /// from a miss that triggered a populate or an await-in-progress (false),
+    /// so the worker can persist the cache effectiveness alongside the
+    /// existing `testSetupAcquireMs` stage timing.
+    struct AcquireResult: Sendable {
+        let directory: URL
+        let didHit: Bool
+    }
+
     func acquire(
         testSetupID: String,
         populate: @escaping @Sendable () async throws -> URL
-    ) async throws -> URL {
+    ) async throws -> AcquireResult {
 
         let preparedDir = entryPreparedDir(for: testSetupID)
 
@@ -65,7 +75,8 @@ actor TestSetupCache {
                 fields: [
                     "test_setup_id": testSetupID
                 ])
-            return try copyToScratch(source: preparedDir, label: testSetupID)
+            let scratch = try copyToScratch(source: preparedDir, label: testSetupID)
+            return AcquireResult(directory: scratch, didHit: true)
         }
 
         // ── Already populating — await in-flight task ─────────────────────
@@ -79,7 +90,10 @@ actor TestSetupCache {
             // Another caller may have already registered this key in lruKeys;
             // touchLRU is idempotent and safe to call from any code path.
             touchLRU(key: testSetupID)
-            return try copyToScratch(source: populated, label: testSetupID)
+            let scratch = try copyToScratch(source: populated, label: testSetupID)
+            // Awaiting an in-flight populate is a miss from the caller's
+            // perspective — work was still being done on their behalf.
+            return AcquireResult(directory: scratch, didHit: false)
         }
 
         // ── Cache miss — start population ────────────────────────────────────
@@ -109,7 +123,8 @@ actor TestSetupCache {
                 fields: [
                     "test_setup_id": testSetupID
                 ])
-            return try copyToScratch(source: populated, label: testSetupID)
+            let scratch = try copyToScratch(source: populated, label: testSetupID)
+            return AcquireResult(directory: scratch, didHit: false)
         } catch {
             inProgress.removeValue(forKey: testSetupID)
             cleanupPartialEntry(testSetupID: testSetupID)

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -17,11 +17,30 @@ import XCTest
 @testable import chickadee_server
 
 func configureTestDatabase(_ app: Application) async throws {
-    let settings = try testDatabaseSettingsFromEnvironment()
+    var settings = try testDatabaseSettingsFromEnvironment()
+
+    // Per-test isolated schema for Postgres so `swift test --parallel` can
+    // run XCTestCase subclasses concurrently against one shared database.
+    // Each `Application` gets its own schema + `search_path`, so migrations
+    // and queries on one app can't trample another.  Replaces the old
+    // `DROP SCHEMA public CASCADE; CREATE SCHEMA public` reset.
+    if settings.backend == .postgres {
+        let schemaName = "test_\(UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "").prefix(12))"
+        settings = .postgres(
+            host: settings.postgresHost!,
+            port: settings.postgresPort!,
+            database: settings.postgresDatabase!,
+            username: settings.postgresUsername!,
+            password: settings.postgresPassword!,
+            searchPath: [schemaName]
+        )
+        app.storage[TestPostgresSchemaKey.self] = schemaName
+    }
+
     try configureDatabase(app, settings: settings)
 
-    if settings.backend == .postgres {
-        try await resetPostgresTestSchema(app)
+    if let schemaName = app.storage[TestPostgresSchemaKey.self] {
+        try await createPostgresTestSchema(app, schemaName: schemaName)
     }
 
     registerMigrations(on: app)
@@ -29,11 +48,31 @@ func configureTestDatabase(_ app: Application) async throws {
     try await app.autoMigrate()
 }
 
-private func resetPostgresTestSchema(_ app: Application) async throws {
-    guard let sql = app.db as? SQLDatabase else { return }
+struct TestPostgresSchemaKey: StorageKey {
+    typealias Value = String
+}
 
-    try await sql.raw("DROP SCHEMA IF EXISTS public CASCADE").run()
-    try await sql.raw("CREATE SCHEMA public").run()
+/// Quotes an identifier for safe interpolation into raw SQL.  Test schema
+/// names are generated from a UUID so they shouldn't contain `"` themselves,
+/// but escape anyway — defense in depth, no perf cost.
+private func quotedIdentifier(_ raw: String) -> String {
+    "\"" + raw.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+}
+
+private func createPostgresTestSchema(_ app: Application, schemaName: String) async throws {
+    guard let sql = app.db as? SQLDatabase else { return }
+    // CREATE SCHEMA is global and doesn't depend on search_path, so this
+    // runs cleanly even though the freshly-configured connection has its
+    // search_path pointing at the not-yet-existent schema.
+    let quoted = quotedIdentifier(schemaName)
+    try await sql.raw("CREATE SCHEMA \(unsafeRaw: quoted)").run()
+}
+
+func dropPostgresTestSchema(_ app: Application) async throws {
+    guard let schemaName = app.storage[TestPostgresSchemaKey.self] else { return }
+    guard let sql = app.db as? SQLDatabase else { return }
+    let quoted = quotedIdentifier(schemaName)
+    try await sql.raw("DROP SCHEMA IF EXISTS \(unsafeRaw: quoted) CASCADE").run()
 }
 
 func testDatabaseSettingsFromEnvironment() throws -> DatabaseSettings {
@@ -151,6 +190,7 @@ extension Application {
     /// `makeTestApp`.
     func tearDownTestApp() async throws {
         let dir = storage[TestDataDirectoryKey.self]
+        try? await dropPostgresTestSchema(self)
         try await asyncShutdown()
         if let dir {
             try? FileManager.default.removeItem(atPath: dir)

--- a/Tests/WorkerTests/TestSetupCacheTests.swift
+++ b/Tests/WorkerTests/TestSetupCacheTests.swift
@@ -43,13 +43,14 @@ final class TestSetupCacheTests: XCTestCase {
             populateCalled.increment()
             return try makeTestStagingDir()
         }
-        defer { try? FileManager.default.removeItem(at: result) }
+        defer { try? FileManager.default.removeItem(at: result.directory) }
 
         XCTAssertEqual(populateCalled.value, 1)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: result.path))
+        XCTAssertFalse(result.didHit, "first acquire must report a miss")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.directory.path))
         XCTAssertTrue(
             FileManager.default.fileExists(
-                atPath: result.appendingPathComponent("test_script.sh").path
+                atPath: result.directory.appendingPathComponent("test_script.sh").path
             )
         )
     }
@@ -64,18 +65,20 @@ final class TestSetupCacheTests: XCTestCase {
             populateCalled.increment()
             return try makeTestStagingDir()
         }
-        defer { try? FileManager.default.removeItem(at: first) }
+        defer { try? FileManager.default.removeItem(at: first.directory) }
 
         let second = try await cache.acquire(testSetupID: "setup-2") {
             populateCalled.increment()  // must NOT be called on a hit
             return try makeTestStagingDir()
         }
-        defer { try? FileManager.default.removeItem(at: second) }
+        defer { try? FileManager.default.removeItem(at: second.directory) }
 
         XCTAssertEqual(
             populateCalled.value, 1,
             "populate must be called exactly once; second call should be a cache hit"
         )
+        XCTAssertFalse(first.didHit, "first acquire is a miss")
+        XCTAssertTrue(second.didHit, "second acquire on the same key is a hit")
     }
 
     // MARK: - Jobs receive isolated copies
@@ -86,38 +89,38 @@ final class TestSetupCacheTests: XCTestCase {
         let first = try await cache.acquire(testSetupID: "setup-3") {
             return try makeTestStagingDir(name: "sentinel.sh")
         }
-        defer { try? FileManager.default.removeItem(at: first) }
+        defer { try? FileManager.default.removeItem(at: first.directory) }
 
         let second = try await cache.acquire(testSetupID: "setup-3") {
             XCTFail("populate must not be called on cache hit")
             return try makeTestStagingDir()
         }
-        defer { try? FileManager.default.removeItem(at: second) }
+        defer { try? FileManager.default.removeItem(at: second.directory) }
 
         // Both copies contain the sentinel file.
         XCTAssertTrue(
             FileManager.default.fileExists(
-                atPath: first.appendingPathComponent("sentinel.sh").path
+                atPath: first.directory.appendingPathComponent("sentinel.sh").path
             )
         )
         XCTAssertTrue(
             FileManager.default.fileExists(
-                atPath: second.appendingPathComponent("sentinel.sh").path
+                atPath: second.directory.appendingPathComponent("sentinel.sh").path
             )
         )
 
         // The two scratch directories are distinct paths.
-        XCTAssertNotEqual(first.path, second.path)
+        XCTAssertNotEqual(first.directory.path, second.directory.path)
 
         // Mutating one copy does not affect the other.
         try "mutated".write(
-            to: first.appendingPathComponent("mutation.txt"),
+            to: first.directory.appendingPathComponent("mutation.txt"),
             atomically: true,
             encoding: .utf8
         )
         XCTAssertFalse(
             FileManager.default.fileExists(
-                atPath: second.appendingPathComponent("mutation.txt").path
+                atPath: second.directory.appendingPathComponent("mutation.txt").path
             )
         )
     }
@@ -136,7 +139,7 @@ final class TestSetupCacheTests: XCTestCase {
                         // Small delay to let other tasks pile up.
                         try await Task.sleep(for: .milliseconds(20))
                         return try makeTestStagingDir()
-                    }
+                    }.directory
                 }
             }
             var urls: [URL] = []
@@ -194,7 +197,7 @@ final class TestSetupCacheTests: XCTestCase {
             retryCount.increment()
             return try makeTestStagingDir()
         }
-        defer { try? FileManager.default.removeItem(at: result) }
+        defer { try? FileManager.default.removeItem(at: result.directory) }
         XCTAssertEqual(retryCount.value, 1, "after a failed population the next acquire must re-populate")
     }
 
@@ -208,7 +211,7 @@ final class TestSetupCacheTests: XCTestCase {
             let result = try await cache.acquire(testSetupID: "setup-evict-\(i)") {
                 try makeTestStagingDir(name: "script-\(i).sh")
             }
-            try? FileManager.default.removeItem(at: result)
+            try? FileManager.default.removeItem(at: result.directory)
         }
 
         // Count immediate subdirectory entries under cacheRoot.
@@ -237,20 +240,20 @@ final class TestSetupCacheTests: XCTestCase {
 
         // Insert A then B (cache full; A is LRU).
         let a1 = try await cache.acquire(testSetupID: "A") { try makeTestStagingDir(name: "a.sh") }
-        defer { try? FileManager.default.removeItem(at: a1) }
+        defer { try? FileManager.default.removeItem(at: a1.directory) }
 
         let b1 = try await cache.acquire(testSetupID: "B") { try makeTestStagingDir(name: "b.sh") }
-        defer { try? FileManager.default.removeItem(at: b1) }
+        defer { try? FileManager.default.removeItem(at: b1.directory) }
 
         // Re-access A so LRU order becomes [B, A] (B is now LRU).
         let a2 = try await cache.acquire(testSetupID: "A") {
             XCTFail("A should still be cached"); return try makeTestStagingDir()
         }
-        defer { try? FileManager.default.removeItem(at: a2) }
+        defer { try? FileManager.default.removeItem(at: a2.directory) }
 
         // Insert C — B (LRU) must be evicted.
         let c1 = try await cache.acquire(testSetupID: "C") { try makeTestStagingDir(name: "c.sh") }
-        defer { try? FileManager.default.removeItem(at: c1) }
+        defer { try? FileManager.default.removeItem(at: c1.directory) }
 
         XCTAssertTrue(
             FileManager.default.fileExists(


### PR DESCRIPTION
## Summary

Follow-on to #492.  Two independent items from the original audit, behaviour-preserving on both sides.

### Postgres parallelization (`661cf4f`)
The `api-tests-postgres` CI job ran sequentially because every test class did `DROP SCHEMA public CASCADE; CREATE SCHEMA public` in setUp — fine alone, fatal under `--parallel`.

Switch each test class to its own per-app schema:
1. Generate a `test_<12-hex>` schema name, stash on `app.storage`.
2. Configure Postgres with `searchPath: [schemaName]` via `SQLPostgresConfiguration` (PostgresKit applies it on every pool connection).  Postgres tolerates non-existent names in `search_path` until something unqualified resolves.
3. `CREATE SCHEMA "test_<...>"` via raw SQL (schema creation is global, not subject to search_path).
4. Run migrations — tables land in the new schema.
5. `tearDownTestApp()` drops the schema before `asyncShutdown()`.

CI: add `--parallel` to the postgres job to match the SQLite job.  The sequential job was the largest CI slot at ~14m 34s, so wall-clock savings should be meaningful — measured on the post-merge main run.

### TestSetupCache hit-rate telemetry (`2c3b1ce`)
The runner-side LRU cache (v0.4.41) logged structured hit/miss events but exposed nothing aggregateable — no DB column, no UI, no answer to "is this cache actually paying off?"

- `TestSetupCache.acquire(...)` returns a small `AcquireResult` struct (`directory: URL, didHit: Bool`); the eight test call sites updated.
- `WorkerExecutionStageTimings` (Core) gains optional `testSetupCacheHit: Bool` — older runners report nil and the server treats them as unknown (forward-compatible).
- `JobStageTimings` (runner-internal) carries the flag alongside the existing per-stage ms dict.
- New migration `AddJobExecutionCacheHit` adds `test_setup_cache_hit BOOLEAN` to `job_execution_metrics`; `StageTimingAggregator.apply(to:)` writes it during `recordWorkerExecutionReport`.
- New `cacheHitRateFormatted: String?` on `AdminRunnerSummary` — `"<pct>% (<hits>/<total>)"` over recent jobs, nil when no recent job reported the flag.
- New "Cache hit rate" row on the admin runner detail page next to the existing "Avg cache acquire".

Operators can now see both whether the LRU is doing useful work *and* how big the savings are when it does hit.

## Test plan

- [x] `swift build` clean
- [x] `swift test --parallel --filter APITests` → 739 tests, exit 0
- [x] `swift test --parallel --filter CoreTests|WorkerTests` → 112 + 10 tests, exit 0
- [x] `swift test --filter WorkerTests.TestSetupCacheTests` → 7 tests including a new hit/miss assertion
- [x] `scripts/lint.sh` clean on both commits
- [ ] CI green on this PR
- [ ] Postgres CI job runs `--parallel` cleanly (cannot validate locally — no docker in the sandbox)

https://claude.ai/code/session_01B65jS6gd64sk6waChCAFnp

---
_Generated by [Claude Code](https://claude.ai/code/session_01B65jS6gd64sk6waChCAFnp)_