### PR TITLE
v0.5.0/v0.6.0 prep: migration consolidation (#502) + DEPRECATED runway (#501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed (groundwork for v0.5.0 / v0.6.0)
+
+- **#502 step 1+2 — migration consolidation prep.**  All 13 historical
+  `Add*` migrations except `AddSessionsCreatedAt` (which targets
+  Fluent's own `_fluent_sessions` table) have been folded into the
+  corresponding canonical `Create*` files.  Each `Add*` struct is
+  preserved in its file and in `registerMigrations(...)` so existing
+  production deploys, which already have these migrations marked
+  applied in `_fluent_migrations`, see no change at runtime — the
+  no-op bodies never run on those databases.  Fresh deploys produce
+  the same final schema in roughly one migration step per table
+  instead of 33 sequential steps.  The actual deletion of the no-op
+  `Add*` files is deferred to v0.5.0 once we've confirmed Fluent
+  tolerates name-disappearance gracefully.
+- **#501 prep — runway for the v0.6.0 DEPRECATED cleanup.**  Extracted
+  the inline 8-line enrollment-mode fallback at
+  `CourseBundleRoutes.swift:395` into a `bundledCourseEnrollmentMode(_:)`
+  helper in Core, so v0.6.0 has a single function to update when
+  dropping the `openEnrollment` back-compat field.  Added four Core
+  tests pinning the resolver branches (explicit mode wins, legacy
+  `openEnrollment: false → .closed`, legacy `openEnrollment: true →
+  .open`, both-missing defaults to `.open`) and two tests pinning the
+  `NotebookFunctionInfo.isShadowed` decode fallback (legacy JSON
+  without the field → false; modern JSON honours explicit true).
+  DEPRECATED-marker audit confirms only the two known sites; no
+  orphans.
+
 ## [0.4.170] - 2026-05-15
 
 ### Changed

--- a/Sources/APIServer/Migrations/AddAssignmentDeadlineOverrideActive.swift
+++ b/Sources/APIServer/Migrations/AddAssignmentDeadlineOverrideActive.swift
@@ -1,15 +1,18 @@
+// APIServer/Migrations/AddAssignmentDeadlineOverrideActive.swift
+//
+// CONSOLIDATED.  `deadline_override_active` is folded into
+// CreateAssignments as of v0.4.171.  Struct name preserved so existing
+// prod's `_fluent_migrations` tracking is undisturbed; no-op on fresh
+// deploys.
+
 import Fluent
 
 struct AddAssignmentDeadlineOverrideActive: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("assignments")
-            .field("deadline_override_active", .bool)
-            .update()
+        // No-op: see CreateAssignments.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("assignments")
-            .deleteField("deadline_override_active")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddAssignmentSlugs.swift
+++ b/Sources/APIServer/Migrations/AddAssignmentSlugs.swift
@@ -1,66 +1,21 @@
+// APIServer/Migrations/AddAssignmentSlugs.swift
+//
+// CONSOLIDATED.  The `slug` column, the (course_id, slug) unique index,
+// and the original backfill loop are folded into CreateAssignments as of
+// v0.4.171.  This migration's struct name remains in `app.migrations`
+// (see DatabaseConfiguration.registerMigrations) so existing production
+// deploys, which already have it marked applied in `_fluent_migrations`,
+// see no change.  On a fresh deploy the no-op runs and does nothing
+// because CreateAssignments already produced the column and index.
+
 import Fluent
-import Foundation
-import SQLKit
-
-private final class AssignmentSlugBackfillRow: Model, @unchecked Sendable {
-    static let schema = "assignments"
-
-    @ID(key: .id)
-    var id: UUID?
-
-    @Field(key: "title")
-    var title: String
-
-    @OptionalField(key: "slug")
-    var slug: String?
-
-    @Field(key: "course_id")
-    var courseID: UUID
-
-    @Timestamp(key: "created_at", on: .create)
-    var createdAt: Date?
-
-    init() {}
-}
 
 struct AddAssignmentSlugs: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("assignments")
-            .field("slug", .string)
-            .update()
-
-        let assignments = try await AssignmentSlugBackfillRow.query(on: database).all()
-        var usedByCourse: [UUID: Set<String>] = [:]
-        let sorted = assignments.sorted {
-            ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast)
-        }
-
-        for assignment in sorted {
-            let slug = try await uniqueAssignmentSlug(
-                title: assignment.title,
-                courseID: assignment.courseID,
-                excludingAssignmentID: try? assignment.requireID(),
-                db: database,
-                reserved: usedByCourse[assignment.courseID] ?? []
-            )
-            assignment.slug = slug
-            usedByCourse[assignment.courseID, default: []].insert(slug)
-            try await assignment.save(on: database)
-        }
-
-        if let sql = database as? SQLDatabase {
-            try await sql.raw(
-                "CREATE UNIQUE INDEX idx_assignments_course_slug ON assignments (course_id, slug)"
-            ).run()
-        }
+        // No-op: see CreateAssignments.swift for the canonical schema.
     }
 
     func revert(on database: Database) async throws {
-        if let sql = database as? SQLDatabase {
-            try await sql.raw("DROP INDEX IF EXISTS idx_assignments_course_slug").run()
-        }
-        try await database.schema("assignments")
-            .deleteField("slug")
-            .update()
+        // No-op.  CreateAssignments' revert tears down the column.
     }
 }

--- a/Sources/APIServer/Migrations/AddBrightSpaceSyncFields.swift
+++ b/Sources/APIServer/Migrations/AddBrightSpaceSyncFields.swift
@@ -1,69 +1,27 @@
 // APIServer/Migrations/AddBrightSpaceSyncFields.swift
 //
-// Adds BrightSpace grade-sync fields to courses, assignments, users, and results.
+// CONSOLIDATED.  The BrightSpace fields are folded into the appropriate
+// Create* files as of v0.4.171:
 //
-//   courses.brightspace_org_unit_id  — D2L org unit ID for this course
-//   assignments.brightspace_grade_object_id — D2L grade item ID for this assignment
-//   users.brightspace_user_id        — D2L internal user ID (cached after first lookup)
-//   results.brightspace_sync_pending — flag: grade push is waiting for debounce
-//   results.brightspace_pending_since — when the pending flag was set (debounce anchor)
-//   results.brightspace_synced_at    — when the grade was successfully pushed
-//   results.brightspace_sync_error   — last error message if push failed
+//   - courses.brightspace_org_unit_id           → CreateCourses
+//   - assignments.brightspace_grade_object_id   → CreateAssignments
+//   - users.brightspace_user_id                 → CreateUsers
+//   - results.brightspace_sync_pending          → CreateResults
+//   - results.brightspace_pending_since         → CreateResults
+//   - results.brightspace_synced_at             → CreateResults
+//   - results.brightspace_sync_error            → CreateResults
+//
+// Struct name preserved so existing prod's `_fluent_migrations` tracking
+// is undisturbed; no-op on fresh deploys.
 
 import Fluent
 
 struct AddBrightSpaceSyncFields: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("courses")
-            .field("brightspace_org_unit_id", .string)
-            .update()
-
-        try await database.schema("assignments")
-            .field("brightspace_grade_object_id", .string)
-            .update()
-
-        try await database.schema("users")
-            .field("brightspace_user_id", .string)
-            .update()
-
-        try await database.schema("results")
-            .field("brightspace_sync_pending", .bool)
-            .update()
-        try await database.schema("results")
-            .field("brightspace_pending_since", .datetime)
-            .update()
-        try await database.schema("results")
-            .field("brightspace_synced_at", .datetime)
-            .update()
-        try await database.schema("results")
-            .field("brightspace_sync_error", .string)
-            .update()
+        // No-op: see the Create* files listed above.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("courses")
-            .deleteField("brightspace_org_unit_id")
-            .update()
-
-        try await database.schema("assignments")
-            .deleteField("brightspace_grade_object_id")
-            .update()
-
-        try await database.schema("users")
-            .deleteField("brightspace_user_id")
-            .update()
-
-        try await database.schema("results")
-            .deleteField("brightspace_sync_pending")
-            .update()
-        try await database.schema("results")
-            .deleteField("brightspace_pending_since")
-            .update()
-        try await database.schema("results")
-            .deleteField("brightspace_synced_at")
-            .update()
-        try await database.schema("results")
-            .deleteField("brightspace_sync_error")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddCourseEnrollmentMode.swift
+++ b/Sources/APIServer/Migrations/AddCourseEnrollmentMode.swift
@@ -1,52 +1,22 @@
 // APIServer/Migrations/AddCourseEnrollmentMode.swift
 //
-// Replaces the boolean open_enrollment column with a three-state enrollment_mode
-// string column ('open' | 'auto' | 'closed').
-//
-// Data migration: courses that had open_enrollment = 0 become 'closed'.
-// All others (open_enrollment = 1, the default) become 'open'.
-// No existing courses become 'auto'; that mode must be set explicitly.
+// CONSOLIDATED.  The `enrollment_mode` column is folded into
+// CreateCourses as of v0.4.171.  The historical data migration (mapping
+// the legacy `open_enrollment = FALSE` rows to `'closed'`) ran once on
+// existing prod and is already reflected in their data.  Fresh deploys
+// start with `enrollment_mode` defaulted to `'open'` directly, and never
+// have an `open_enrollment` column to migrate from.  Struct name
+// preserved so existing prod's `_fluent_migrations` tracking is
+// undisturbed.
 
 import Fluent
-import SQLKit
 
 struct AddCourseEnrollmentMode: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("courses")
-            .field("enrollment_mode", .string, .required, .custom("DEFAULT 'open'"))
-            .update()
-
-        // Data migration: courses that were closed get the 'closed' mode.
-        let sql = database as! SQLDatabase
-        let closedPredicate =
-            sql.dialect.name == "postgresql"
-            ? "open_enrollment = FALSE"
-            : "open_enrollment = 0"
-        try await sql
-            .raw("UPDATE courses SET enrollment_mode = 'closed' WHERE \(unsafeRaw: closedPredicate)")
-            .run()
-
-        try await database.schema("courses")
-            .deleteField("open_enrollment")
-            .update()
+        // No-op: see CreateCourses.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("courses")
-            .field("open_enrollment", .bool, .required, .custom("DEFAULT TRUE"))
-            .update()
-
-        let sql = database as! SQLDatabase
-        let falseLiteral = sql.dialect.name == "postgresql" ? "FALSE" : "0"
-        let trueLiteral = sql.dialect.name == "postgresql" ? "TRUE" : "1"
-        try await sql
-            .raw(
-                "UPDATE courses SET open_enrollment = CASE WHEN enrollment_mode = 'closed' THEN \(unsafeRaw: falseLiteral) ELSE \(unsafeRaw: trueLiteral) END"
-            )
-            .run()
-
-        try await database.schema("courses")
-            .deleteField("enrollment_mode")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddCourseOpenEnrollment.swift
+++ b/Sources/APIServer/Migrations/AddCourseOpenEnrollment.swift
@@ -1,17 +1,20 @@
 // APIServer/Migrations/AddCourseOpenEnrollment.swift
+//
+// CONSOLIDATED.  The original `open_enrollment` column was already
+// dropped by AddCourseEnrollmentMode (which replaced it with the
+// three-state `enrollment_mode` string).  As of v0.4.171,
+// `enrollment_mode` is in CreateCourses directly, so this migration's
+// historical work is captured upstream.  Struct name preserved so
+// existing prod's `_fluent_migrations` tracking is undisturbed.
 
 import Fluent
 
 struct AddCourseOpenEnrollment: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("courses")
-            .field("open_enrollment", .bool, .required, .custom("DEFAULT TRUE"))
-            .update()
+        // No-op: see CreateCourses.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("courses")
-            .deleteField("open_enrollment")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddCourseSections.swift
+++ b/Sources/APIServer/Migrations/AddCourseSections.swift
@@ -1,39 +1,20 @@
 // APIServer/Migrations/AddCourseSections.swift
 //
-// Adds the course_sections table and a nullable section_id column to assignments.
-// Existing assignments have section_id = NULL (ungrouped) — no data loss.
+// CONSOLIDATED.  The `course_sections` table is folded into
+// CreateCourses; the `section_id` FK on assignments is folded into
+// CreateAssignments as of v0.4.171.  Struct name preserved so existing
+// prod's `_fluent_migrations` tracking is undisturbed; the body is a
+// no-op for fresh deploys since CreateCourses/CreateAssignments produce
+// both pieces.
 
 import Fluent
 
 struct AddCourseSections: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("course_sections")
-            .id()
-            .field("name", .string, .required)
-            .field("default_grading_mode", .string, .required)
-            .field("sort_order", .int, .required)
-            .field(
-                "course_id",
-                .uuid,
-                .required,
-                .references("courses", "id", onDelete: .cascade)
-            )
-            .field("created_at", .datetime)
-            .create()
-
-        try await database.schema("assignments")
-            .field(
-                "section_id",
-                .uuid,
-                .references("course_sections", "id", onDelete: .setNull)
-            )
-            .update()
+        // No-op: see CreateCourses.swift and CreateAssignments.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("assignments")
-            .deleteField("section_id")
-            .update()
-        try await database.schema("course_sections").delete()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddJobDiskUsageMetrics.swift
+++ b/Sources/APIServer/Migrations/AddJobDiskUsageMetrics.swift
@@ -1,41 +1,20 @@
+// APIServer/Migrations/AddJobDiskUsageMetrics.swift
+//
+// CONSOLIDATED.  The disk-usage columns (free_disk_mb_at_start,
+// free_disk_mb_at_end, workdir_peak_bytes) are folded into both
+// CreateJobExecutionMetrics and CreateSubmissionDiagnostics as of
+// v0.4.171.  Struct name preserved so existing prod's
+// `_fluent_migrations` tracking is undisturbed; no-op on fresh deploys.
+
 import Fluent
 
-/// Adds disk-usage telemetry columns to both `submission_diagnostics`
-/// (the 1:1 legacy mirror) and `job_execution_metrics` (the canonical
-/// v0.4.46 table). `workdir_peak_bytes` is a bigint because workspace
-/// sizes can exceed Int32 on larger assignments; the MB columns stay
-/// `int` since 2 GB is well past any realistic free-disk reading.
 struct AddJobDiskUsageMetrics: AsyncMigration {
-    private static let intFields: [String] = [
-        "free_disk_mb_at_start",
-        "free_disk_mb_at_end",
-    ]
-    private static let bigIntFields: [String] = [
-        "workdir_peak_bytes"
-    ]
-
     func prepare(on database: Database) async throws {
-        for schemaName in [JobExecutionMetric.schema, APISubmissionDiagnostics.schema] {
-            for field in Self.intFields {
-                try await database.schema(schemaName)
-                    .field(FieldKey(stringLiteral: field), .int)
-                    .update()
-            }
-            for field in Self.bigIntFields {
-                try await database.schema(schemaName)
-                    .field(FieldKey(stringLiteral: field), .int64)
-                    .update()
-            }
-        }
+        // No-op: see CreateJobExecutionMetrics.swift and
+        // CreateSubmissionDiagnostics.swift.
     }
 
     func revert(on database: Database) async throws {
-        for schemaName in [JobExecutionMetric.schema, APISubmissionDiagnostics.schema] {
-            for field in Self.intFields + Self.bigIntFields {
-                try await database.schema(schemaName)
-                    .deleteField(FieldKey(stringLiteral: field))
-                    .update()
-            }
-        }
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddJobExecutionCacheHit.swift
+++ b/Sources/APIServer/Migrations/AddJobExecutionCacheHit.swift
@@ -1,20 +1,18 @@
+// APIServer/Migrations/AddJobExecutionCacheHit.swift
+//
+// CONSOLIDATED.  `test_setup_cache_hit` is folded into
+// CreateJobExecutionMetrics as of v0.4.171.  Struct name preserved so
+// existing prod's `_fluent_migrations` tracking is undisturbed; no-op
+// on fresh deploys.
+
 import Fluent
 
-/// Adds `test_setup_cache_hit` to `job_execution_metrics` so the admin
-/// runner detail page can report each runner's TestSetupCache hit rate
-/// per the audit follow-up in #492.  Nullable boolean; existing rows
-/// stay nil, and older runners that don't yet send `testSetupCacheHit`
-/// continue to record nil.
 struct AddJobExecutionCacheHit: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema(JobExecutionMetric.schema)
-            .field("test_setup_cache_hit", .bool)
-            .update()
+        // No-op: see CreateJobExecutionMetrics.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema(JobExecutionMetric.schema)
-            .deleteField("test_setup_cache_hit")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddJobExecutionStageTimings.swift
+++ b/Sources/APIServer/Migrations/AddJobExecutionStageTimings.swift
@@ -1,34 +1,18 @@
+// APIServer/Migrations/AddJobExecutionStageTimings.swift
+//
+// CONSOLIDATED.  The 10 stage-timing columns are folded into
+// CreateJobExecutionMetrics as of v0.4.171.  Struct name preserved so
+// existing prod's `_fluent_migrations` tracking is undisturbed; no-op
+// on fresh deploys.
+
 import Fluent
 
 struct AddJobExecutionStageTimings: AsyncMigration {
     func prepare(on database: Database) async throws {
-        for field in fields {
-            try await database.schema(JobExecutionMetric.schema)
-                .field(FieldKey(stringLiteral: field), .int)
-                .update()
-        }
+        // No-op: see CreateJobExecutionMetrics.swift.
     }
 
     func revert(on database: Database) async throws {
-        for field in fields {
-            try await database.schema(JobExecutionMetric.schema)
-                .deleteField(FieldKey(stringLiteral: field))
-                .update()
-        }
-    }
-
-    private var fields: [String] {
-        [
-            "workdir_setup_ms",
-            "submission_dir_setup_ms",
-            "submission_download_ms",
-            "test_setup_acquire_ms",
-            "submission_unpack_ms",
-            "starter_cleanup_ms",
-            "submission_prepare_ms",
-            "make_step_ms",
-            "runtime_helper_setup_ms",
-            "test_execution_ms",
-        ]
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddSubmissionRetestedAt.swift
+++ b/Sources/APIServer/Migrations/AddSubmissionRetestedAt.swift
@@ -1,21 +1,17 @@
 // APIServer/Migrations/AddSubmissionRetestedAt.swift
+//
+// CONSOLIDATED.  `retested_at` is folded into CreateSubmissions as of
+// v0.4.171.  Struct name preserved so existing prod's
+// `_fluent_migrations` tracking is undisturbed; no-op on fresh deploys.
 
 import Fluent
 
-/// Adds `retested_at` to the submissions table.
-/// Set to the timestamp when an instructor triggers a re-test, so wait-time
-/// and turnaround statistics can be measured from the re-test request rather
-/// than the original submission time.
 struct AddSubmissionRetestedAt: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("submissions")
-            .field("retested_at", .datetime)
-            .update()
+        // No-op: see CreateSubmissions.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("submissions")
-            .deleteField("retested_at")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddSubmissionRetestedByUserID.swift
+++ b/Sources/APIServer/Migrations/AddSubmissionRetestedByUserID.swift
@@ -1,23 +1,17 @@
 // APIServer/Migrations/AddSubmissionRetestedByUserID.swift
+//
+// CONSOLIDATED.  `retested_by_user_id` is folded into CreateSubmissions
+// as of v0.4.171.  Struct name preserved so existing prod's
+// `_fluent_migrations` tracking is undisturbed; no-op on fresh deploys.
 
 import Fluent
 
-/// Adds `retested_by_user_id` to the submissions table.
-///
-/// Records which instructor triggered the most recent retest — used by the
-/// per-submission / per-assignment retest audit trail added in v0.4.93.
-/// Nullable so existing rows (and original student submissions) stay valid;
-/// a non-nil value indicates "this submission was retested by user X".
 struct AddSubmissionRetestedByUserID: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("submissions")
-            .field("retested_by_user_id", .uuid)
-            .update()
+        // No-op: see CreateSubmissions.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("submissions")
-            .deleteField("retested_by_user_id")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddTestSetupLastRetestedManifestHash.swift
+++ b/Sources/APIServer/Migrations/AddTestSetupLastRetestedManifestHash.swift
@@ -1,24 +1,18 @@
 // APIServer/Migrations/AddTestSetupLastRetestedManifestHash.swift
+//
+// CONSOLIDATED.  `last_retested_manifest_hash` is folded into
+// CreateTestSetups as of v0.4.171.  Struct name preserved so existing
+// prod's `_fluent_migrations` tracking is undisturbed; no-op on fresh
+// deploys.
 
 import Fluent
 
-/// Adds `last_retested_manifest_hash` to the test_setups table.
-///
-/// Records the SHA-256 hex of the `manifest` bytes at the time of the most
-/// recent "retest every submission" fan-out.  The auto-retest trigger on
-/// assignment save uses this to skip work when the save was a
-/// metadata-only edit (name, due date, notebook upload) that doesn't
-/// affect grading.  Added in v0.4.93.
 struct AddTestSetupLastRetestedManifestHash: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("test_setups")
-            .field("last_retested_manifest_hash", .string)
-            .update()
+        // No-op: see CreateTestSetups.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("test_setups")
-            .deleteField("last_retested_manifest_hash")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/AddUserLastSeenAt.swift
+++ b/Sources/APIServer/Migrations/AddUserLastSeenAt.swift
@@ -1,21 +1,17 @@
 // APIServer/Migrations/AddUserLastSeenAt.swift
+//
+// CONSOLIDATED.  `last_seen_at` is folded into CreateUsers as of
+// v0.4.171.  Struct name preserved so existing prod's
+// `_fluent_migrations` tracking is undisturbed; no-op on fresh deploys.
 
 import Fluent
 
-/// Adds `last_seen_at` to the users table.
-/// Refreshed on every authenticated request (debounced) so the instructor
-/// and admin dashboards show real activity, not a stale `last_login_at`
-/// frozen at the moment the cookie session was first established.
 struct AddUserLastSeenAt: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("users")
-            .field("last_seen_at", .datetime)
-            .update()
+        // No-op: see CreateUsers.swift.
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("users")
-            .deleteField("last_seen_at")
-            .update()
+        // No-op.
     }
 }

--- a/Sources/APIServer/Migrations/CreateAssignments.swift
+++ b/Sources/APIServer/Migrations/CreateAssignments.swift
@@ -2,8 +2,20 @@
 //
 // An "assignment" is a test setup that an instructor has published to students.
 // Students only see test setups that have a corresponding open assignment.
+//
+// Canonical schema for net-new deploys.  Historically built up by:
+//   - CreateAssignments (this file)            — base columns + unique indexes
+//   - AddAssignmentSlugs                       — `slug` + unique (course_id, slug)
+//   - AddCourseSections                        — `section_id` FK to course_sections
+//   - AddAssignmentDeadlineOverrideActive      — `deadline_override_active`
+//   - AddBrightSpaceSyncFields                 — `brightspace_grade_object_id`
+//
+// The historical Add* migrations remain registered and become no-ops on
+// fresh deploys; existing prod has them already marked applied so the
+// body changes are invisible to production.
 
 import Fluent
+import SQLKit
 
 struct CreateAssignments: AsyncMigration {
     func prepare(on database: Database) async throws {
@@ -32,13 +44,41 @@ struct CreateAssignments: AsyncMigration {
                 .required,
                 .references("courses", "id", onDelete: .cascade)
             )
+            // Folded from AddAssignmentSlugs.  Unique index (course_id, slug)
+            // created below after the table.
+            .field("slug", .string)
+            // Folded from AddCourseSections.  Nullable for ungrouped assignments;
+            // ON DELETE SET NULL so removing a section leaves orphaned
+            // assignments in the trailing Ungrouped bucket.
+            .field(
+                "section_id",
+                .uuid,
+                .references("course_sections", "id", onDelete: .setNull)
+            )
+            // Folded from AddAssignmentDeadlineOverrideActive.
+            .field("deadline_override_active", .bool)
+            // Folded from AddBrightSpaceSyncFields.
+            .field("brightspace_grade_object_id", .string)
             .field("created_at", .datetime)
             .unique(on: "public_id")
             .unique(on: "test_setup_id")
             .create()
+
+        // Folded from AddAssignmentSlugs.  The historical migration ran a
+        // backfill loop over existing rows before creating the index; on a
+        // fresh deploy there are no rows yet, so the index can be created
+        // immediately.
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "CREATE UNIQUE INDEX idx_assignments_course_slug ON assignments (course_id, slug)"
+            ).run()
+        }
     }
 
     func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_assignments_course_slug").run()
+        }
         try await database.schema("assignments").delete()
     }
 }

--- a/Sources/APIServer/Migrations/CreateCourses.swift
+++ b/Sources/APIServer/Migrations/CreateCourses.swift
@@ -3,6 +3,21 @@
 import Fluent
 import SQLKit
 
+/// Canonical `courses` schema for net-new deploys.
+///
+/// Historically the schema was built up by:
+///   - CreateCourses (this file)         — base columns + active-code partial unique index
+///   - AddCourseOpenEnrollment           — `open_enrollment` Bool (later dropped)
+///   - AddCourseEnrollmentMode           — drops `open_enrollment`, adds `enrollment_mode`
+///   - AddCourseSections                 — creates the `course_sections` child table
+///   - AddBrightSpaceSyncFields          — adds `brightspace_org_unit_id`
+///
+/// The consolidated form below produces the same final schema in a single
+/// Create step.  Existing deploys have CreateCourses already marked
+/// applied in `_fluent_migrations` and never re-run it, so the body
+/// change is invisible to production.  The historical Add* migrations
+/// remain registered and become no-ops on fresh deploys (they "run" but
+/// the columns they would add already exist via this Create).
 struct CreateCourses: AsyncMigration {
     func prepare(on database: Database) async throws {
         try await database.schema("courses")
@@ -10,6 +25,11 @@ struct CreateCourses: AsyncMigration {
             .field("code", .string, .required)
             .field("name", .string, .required)
             .field("is_archived", .bool, .required)
+            // Folded from AddCourseEnrollmentMode (which itself replaced the
+            // boolean `open_enrollment` added by AddCourseOpenEnrollment).
+            .field("enrollment_mode", .string, .required, .custom("DEFAULT 'open'"))
+            // Folded from AddBrightSpaceSyncFields.
+            .field("brightspace_org_unit_id", .string)
             .field("created_at", .datetime)
             .create()
         // Partial unique index: only one active course per code.
@@ -27,9 +47,28 @@ struct CreateCourses: AsyncMigration {
                 """
             ).run()
         }
+
+        // Folded from AddCourseSections.  Created in the same Create* as its
+        // parent table so the schema is coherent for fresh deploys; the
+        // assignments table FK-references this via `section_id` (see
+        // CreateAssignments).
+        try await database.schema("course_sections")
+            .id()
+            .field("name", .string, .required)
+            .field("default_grading_mode", .string, .required)
+            .field("sort_order", .int, .required)
+            .field(
+                "course_id",
+                .uuid,
+                .required,
+                .references("courses", "id", onDelete: .cascade)
+            )
+            .field("created_at", .datetime)
+            .create()
     }
 
     func revert(on database: Database) async throws {
+        try await database.schema("course_sections").delete()
         if let sql = database as? SQLDatabase {
             try await sql.raw("DROP INDEX IF EXISTS idx_courses_code_active").run()
         }

--- a/Sources/APIServer/Migrations/CreateJobExecutionMetrics.swift
+++ b/Sources/APIServer/Migrations/CreateJobExecutionMetrics.swift
@@ -36,6 +36,24 @@ struct CreateJobExecutionMetrics: AsyncMigration {
             .field("tests_errored", .int)
             .field("tests_timed_out", .int)
             .field("skipped_count", .int)
+            // Folded from AddJobExecutionStageTimings — per-stage breakdown
+            // of the worker's job runtime, in milliseconds.
+            .field("workdir_setup_ms", .int)
+            .field("submission_dir_setup_ms", .int)
+            .field("submission_download_ms", .int)
+            .field("test_setup_acquire_ms", .int)
+            .field("submission_unpack_ms", .int)
+            .field("starter_cleanup_ms", .int)
+            .field("submission_prepare_ms", .int)
+            .field("make_step_ms", .int)
+            .field("runtime_helper_setup_ms", .int)
+            .field("test_execution_ms", .int)
+            // Folded from AddJobDiskUsageMetrics.
+            .field("free_disk_mb_at_start", .int)
+            .field("free_disk_mb_at_end", .int)
+            .field("workdir_peak_bytes", .int64)
+            // Folded from AddJobExecutionCacheHit.
+            .field("test_setup_cache_hit", .bool)
             .field("created_at", .datetime)
             .field("updated_at", .datetime)
             .unique(on: "submission_id")

--- a/Sources/APIServer/Migrations/CreateResults.swift
+++ b/Sources/APIServer/Migrations/CreateResults.swift
@@ -15,6 +15,13 @@ struct CreateResults: AsyncMigration {
             .field("collection_json", .string, .required)
             .field("source", .string, .required)
             .field("received_at", .datetime)
+            // Folded from AddBrightSpaceSyncFields.  Sync state per-result so
+            // a regrade can re-flag a previously-synced result as pending
+            // without losing the original sync timestamp.
+            .field("brightspace_sync_pending", .bool)
+            .field("brightspace_pending_since", .datetime)
+            .field("brightspace_synced_at", .datetime)
+            .field("brightspace_sync_error", .string)
             .create()
     }
 

--- a/Sources/APIServer/Migrations/CreateSubmissionDiagnostics.swift
+++ b/Sources/APIServer/Migrations/CreateSubmissionDiagnostics.swift
@@ -35,6 +35,12 @@ struct CreateSubmissionDiagnostics: AsyncMigration {
             .field("child_process_count", .int)
             .field("stdout_bytes", .int)
             .field("stderr_bytes", .int)
+            // Folded from AddJobDiskUsageMetrics.  Mirrors the same disk-usage
+            // fields on job_execution_metrics; submission_diagnostics is the
+            // 1:1 legacy mirror kept for cross-runner debugging.
+            .field("free_disk_mb_at_start", .int)
+            .field("free_disk_mb_at_end", .int)
+            .field("workdir_peak_bytes", .int64)
             .field("created_at", .datetime)
             .field("updated_at", .datetime)
             .create()

--- a/Sources/APIServer/Migrations/CreateSubmissions.swift
+++ b/Sources/APIServer/Migrations/CreateSubmissions.swift
@@ -25,6 +25,10 @@ struct CreateSubmissions: AsyncMigration {
             )
             .field("submitted_at", .datetime)
             .field("assigned_at", .datetime)
+            // Folded from AddSubmissionRetestedAt.
+            .field("retested_at", .datetime)
+            // Folded from AddSubmissionRetestedByUserID.
+            .field("retested_by_user_id", .uuid)
             .create()
     }
 

--- a/Sources/APIServer/Migrations/CreateTestSetups.swift
+++ b/Sources/APIServer/Migrations/CreateTestSetups.swift
@@ -15,6 +15,8 @@ struct CreateTestSetups: AsyncMigration {
                 .required,
                 .references("courses", "id", onDelete: .cascade)
             )
+            // Folded from AddTestSetupLastRetestedManifestHash.
+            .field("last_retested_manifest_hash", .string)
             .field("created_at", .datetime)
             .create()
     }

--- a/Sources/APIServer/Migrations/CreateUsers.swift
+++ b/Sources/APIServer/Migrations/CreateUsers.swift
@@ -21,6 +21,10 @@ struct CreateUsers: AsyncMigration {
             .field("email", .string)
             .field("display_name", .string)
             .field("last_login_at", .datetime)
+            // Folded from AddUserLastSeenAt.
+            .field("last_seen_at", .datetime)
+            // Folded from AddBrightSpaceSyncFields.
+            .field("brightspace_user_id", .string)
             .field("created_at", .datetime)
             .create()
 

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -388,15 +388,7 @@ struct CourseBundleRoutes: RouteCollection {
             )
 
             // 6b. Create course
-            // Resolve enrollment mode: prefer the new field; fall back to the legacy bool.
-            let importedMode: CourseEnrollmentMode
-            if let mode = manifest.course.enrollmentMode {
-                importedMode = mode
-            } else if manifest.course.openEnrollment == false {
-                importedMode = .closed
-            } else {
-                importedMode = .open
-            }
+            let importedMode = bundledCourseEnrollmentMode(manifest.course)
             let newCourse = APICourse(
                 code: manifest.course.code, name: manifest.course.name,
                 enrollmentMode: importedMode)

--- a/Sources/Core/CourseBundleManifest.swift
+++ b/Sources/Core/CourseBundleManifest.swift
@@ -76,7 +76,7 @@ public struct BundledCourse: Codable, Sendable {
     // DEPRECATED: remove in v0.6.0 — see CHANGELOG.
     // Present only in `.chickadee` bundles exported before `enrollmentMode` was added.
     // Ignored when `enrollmentMode` is non-nil. Once v0.6.0 is cut, drop the field
-    // and stop honouring it in `bundledCourseEnrollmentMode(...)`.
+    // and the `openEnrollment` branch inside `bundledCourseEnrollmentMode(_:)`.
     public let openEnrollment: Bool?
 
     public init(
@@ -89,6 +89,21 @@ public struct BundledCourse: Codable, Sendable {
         self.enrollmentMode = enrollmentMode
         self.openEnrollment = openEnrollment
     }
+}
+
+/// Resolves the effective `CourseEnrollmentMode` for an imported bundle.
+///
+/// Prefers `enrollmentMode` (the canonical field).  Falls back to the
+/// pre-v0.3.x `openEnrollment` boolean for older bundles: `false → closed`,
+/// any other value → `open`.  Both paths default to `.open` when neither
+/// field is present so import never fails on a missing-field error.
+///
+/// v0.6.0 cleanup site: drop the `openEnrollment` branch and inline the
+/// `enrollmentMode ?? .open` form at the call site.
+public func bundledCourseEnrollmentMode(_ course: BundledCourse) -> CourseEnrollmentMode {
+    if let mode = course.enrollmentMode { return mode }
+    if course.openEnrollment == false { return .closed }
+    return .open
 }
 
 public struct BundledUser: Codable, Sendable {

--- a/Tests/CoreTests/CourseBundleManifestTests.swift
+++ b/Tests/CoreTests/CourseBundleManifestTests.swift
@@ -130,6 +130,44 @@ struct CourseBundleManifestTests {
         #expect(course.openEnrollment == nil)
     }
 
+    // MARK: - bundledCourseEnrollmentMode resolver
+    //
+    // Pin the resolver so v0.6.0 can drop the `openEnrollment` branch with
+    // confidence — when the deprecation lands, only the legacy-bundle cases
+    // below need updating (or deleting).
+
+    @Test func enrollmentModeResolver_prefersExplicitMode() {
+        let course = BundledCourse(
+            code: "CS101", name: "Intro CS",
+            enrollmentMode: .auto, openEnrollment: false
+        )
+        #expect(bundledCourseEnrollmentMode(course) == .auto)
+    }
+
+    @Test func enrollmentModeResolver_legacyOpenEnrollmentFalseMapsToClosed() {
+        let course = BundledCourse(
+            code: "CS101", name: "Intro CS",
+            enrollmentMode: nil, openEnrollment: false
+        )
+        #expect(bundledCourseEnrollmentMode(course) == .closed)
+    }
+
+    @Test func enrollmentModeResolver_legacyOpenEnrollmentTrueMapsToOpen() {
+        let course = BundledCourse(
+            code: "CS101", name: "Intro CS",
+            enrollmentMode: nil, openEnrollment: true
+        )
+        #expect(bundledCourseEnrollmentMode(course) == .open)
+    }
+
+    @Test func enrollmentModeResolver_bothFieldsMissingDefaultsToOpen() {
+        let course = BundledCourse(
+            code: "CS101", name: "Intro CS",
+            enrollmentMode: nil, openEnrollment: nil
+        )
+        #expect(bundledCourseEnrollmentMode(course) == .open)
+    }
+
     // MARK: - CourseEnrollmentMode raw values
 
     @Test(

--- a/Tests/CoreTests/NotebookFunctionScannerTests.swift
+++ b/Tests/CoreTests/NotebookFunctionScannerTests.swift
@@ -166,6 +166,38 @@ struct NotebookFunctionScannerTests {
         #expect(fns[0].name == "public_fn")
     }
 
+    // Pre-v0.4.94 browser clients didn't send `isShadowed`. The custom
+    // decoder defaults the missing key to false. Pin both branches so the
+    // v0.6.0 cleanup that removes the fallback only has to delete the
+    // `decodeIfPresent ?? false` line — these tests will fail loudly if
+    // anyone changes the contract.
+    @Test func isShadowedDecodeFallback_legacyJSONWithoutFieldDefaultsToFalse() throws {
+        let json = """
+            {
+              "name": "tax",
+              "paramNames": ["price"],
+              "hasTypeHints": true,
+              "hasDocstring": false
+            }
+            """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
+        #expect(decoded.isShadowed == false)
+    }
+
+    @Test func isShadowedDecodeFallback_modernJSONHonoursExplicitTrue() throws {
+        let json = """
+            {
+              "name": "tax",
+              "paramNames": ["price"],
+              "hasTypeHints": true,
+              "hasDocstring": false,
+              "isShadowed": true
+            }
+            """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
+        #expect(decoded.isShadowed == true)
+    }
+
     @Test func shadowedFunctionMarked() {
         // Pedagogical notebooks often redefine a function to extend it.  Only
         // the LAST definition is callable at runtime; the scanner must mark


### PR DESCRIPTION
## Summary

Forward-thinking groundwork that lands safely under 0.4.x without breaking production. Two commits, scannable independently.

### Precondition for safe merge

This PR is safe to merge **iff every deployment is already at ≥ v0.4.169** (i.e. has the `AddBrightSpaceSyncFields`, `AddJobDiskUsageMetrics`, and `AddJobExecutionCacheHit` migrations recorded in `_fluent_migrations`).

A database that lags behind v0.4.169 has those three `Add*` migrations *unapplied*. After this PR, those migrations run for the first time but with no-op bodies — so the columns they were supposed to add (BrightSpace fields, disk-usage metrics, cache-hit flag) never get added. The server would crash on first query touching them.

For Jim's single-server deployment (currently at v0.4.169) this PR is safe. For anyone running multiple environments, audit every DB's `_fluent_migrations` table before merging.

### #501 prep — runway for the v0.6.0 cleanup ([a7ceb6c](../commit/a7ceb6c))

We can't yet **remove** the DEPRECATED shims (doing so on 0.4.x would break old `.chickadee` bundles and pre-v0.4.94 browser clients) but we can solidify the rails so v0.6.0 lands as a one-shot:

- Audit confirms only two DEPRECATED markers, no orphans:
  - `Sources/Core/CourseBundleManifest.swift:76` (`BundledCourse.openEnrollment`)
  - `Sources/Core/NotebookFunctionScanner.swift:80` (`isShadowed` decode fallback)
- Extracted the inline 8-line enrollment-mode resolution at `CourseBundleRoutes.swift:395` into a `bundledCourseEnrollmentMode(_:)` helper in Core. The DEPRECATED comment already named this function as the v0.6.0 cleanup site — now there's an actual function for v0.6.0 to delete one branch from.
- Six pinning tests added (four for the enrollment-mode resolver, two for the `isShadowed` decode fallback). When v0.6.0 drops the back-compat, three of these tests fail loudly so the deprecation can't be forgotten.

### #502 step 1+2 — migration consolidation ([2d22208](../commit/2d22208))

Folded 13 of 14 historical `Add*` migrations into the appropriate canonical `Create*` files. `AddSessionsCreatedAt` stays as a real migration because Fluent owns `_fluent_sessions`.

| Create* | Absorbs |
| --- | --- |
| `CreateCourses` | `AddCourseOpenEnrollment`, `AddCourseEnrollmentMode`, `AddCourseSections` (the table itself), `AddBrightSpaceSyncFields` (org-unit id) |
| `CreateAssignments` | `AddAssignmentSlugs` (column + unique index), `AddCourseSections` (section_id FK), `AddAssignmentDeadlineOverrideActive`, `AddBrightSpaceSyncFields` (grade-object id) |
| `CreateUsers` | `AddUserLastSeenAt`, `AddBrightSpaceSyncFields` (user id) |
| `CreateSubmissions` | `AddSubmissionRetestedAt`, `AddSubmissionRetestedByUserID` |
| `CreateTestSetups` | `AddTestSetupLastRetestedManifestHash` |
| `CreateResults` | `AddBrightSpaceSyncFields` (4 sync-state columns) |
| `CreateJobExecutionMetrics` | `AddJobExecutionStageTimings` (10 cols), `AddJobDiskUsageMetrics` (3 cols), `AddJobExecutionCacheHit` (1 col) |
| `CreateSubmissionDiagnostics` | `AddJobDiskUsageMetrics` (3 cols) |

### Why this is safe under 0.4.x (subject to the precondition above)

Fluent matches migrations by struct name. Every consolidated `Add*` keeps the same struct name and stays registered in `registerMigrations(...)`:

- **Existing production deploys (at v0.4.169)** have these migrations already marked applied in `_fluent_migrations`. Fluent never re-runs an applied migration even if its body changes, so the (now-empty) `prepare` body has zero effect.
- **Fresh deploys** see the `Create*` produce the full final schema in one step; the registered no-op `Add*` migrations run sequentially after but do nothing because their columns already exist via the `Create*`.

The end state is identical for both. The actual deletion of the no-op `Add*` files is deferred to v0.5.0 once we've confirmed Fluent tolerates a name disappearing from the migration list.

### Future hardening (out of scope for this PR)

To remove the precondition above and make this safe for lagging DBs too, each `Add*` body would need to be **idempotent** — check whether its target column exists, add only if missing. Cross-dialect (Postgres `information_schema` + SQLite `pragma_table_info`) introspection helper. Filed as a follow-up if needed.

### Why #498 / #500 stay deferred

This PR does NOT touch:

- **#498** (role string-compare → enum) — the five DB-stored literal sites are stable; the compiler-safety argument doesn't earn its keep.
- **#500** (Leaf template partials) — blocked by a known LeafKit 1.14.1 cycle-detection false positive; needs upstream or a Vapor 5 / LeafKit 2.x upgrade.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 908 tests, 4 skipped, 0 failures. Every test that builds a fresh DB through `configureTestDatabase` exercises the consolidated `Create*` + no-op `Add*` path; any missing column would surface as a Postgres/SQLite error at setUp time.
- [x] `scripts/format.sh` no diff
- [x] Lagging-DB sanity check via `_fluent_migrations` audit (see precondition above)
- [ ] Manual smoke: `swift run chickadee-server` against production-equivalent DB; confirm no migration errors at startup.

## Versioning

Targets the next 0.4.x release (whatever that becomes after PR #503 merges) under `[Unreleased]`. No VERSION bump in this PR so it doesn't conflict with #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)