### PR TITLE
cleanup: refresh CLAUDE.md, bump deps, doc freshness pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,7 +362,7 @@ updating kernel versions or config.
 
 ## Versioning
 
-Follows Semantic Versioning in the `0.y.z` phase. Current version: **0.4.112**
+Follows Semantic Versioning in the `0.y.z` phase. Current version: **0.4.170**
 (`VERSION` file + `ChickadeeVersion.current` in Core).
 
 Release checklist:
@@ -596,10 +596,109 @@ Post-8 work also complete:
   block (hidden when empty).  Legacy manifests with no `sections` key
   decode with `decodeIfPresent` defaults so older runners stay compatible.
 
-**Next work:** Gamification expansion (leaderboards, more badges beyond
-First-Try Perfect); multi-provider SSO testing beyond UWaterloo DUO; pattern
-kinds beyond `.boundaryEquality` / `.approximateEquality` / `.variableEquality`
-(e.g. exception-expected, type-check); refresh token handling.
+### v0.4.97 – v0.4.170 highlights (themed digest)
+
+The per-version log above stops at v0.4.96.  For the ~70 versions that
+followed, the full per-release detail lives in `CHANGELOG.md`; what
+follows is grouped by subsystem so a fresh session can build a mental
+model quickly.
+
+- **Notebook checks (v0.4.149–v0.4.155).**  In-browser editor preflight
+  + watchdog, `JupyterLite 0.7.6` upgrade, browser-error dashboard,
+  kernel-probe inversion to fire on failure evidence only, Safari
+  phase-1 timeout hotfix, JupyterLite SW manager disabled to fix
+  "Kernel Unknown".  IndexedDB cache-bust no longer wipes in-progress
+  work on first post-deploy visit (v0.4.154).  Instructor reset-notebook
+  action on the submissions page (v0.4.153).  `variableExists` check
+  type (defined, optional type) (v0.4.155).
+
+- **Personalization & generalized inputs (issue #461 slices, v0.4.156–v0.4.162).**
+  Per-student assignment seed plumbing (v0.4.156); generalized inputs
+  with a Global panel, raw-script inlining, and notebook substitution
+  (v0.4.157); per-student expressions on Global Inputs (v0.4.158);
+  suite-editor drag-and-drop fix for notebook-check rows (v0.4.159);
+  unified "enrolled students" count and tidied Global Inputs UI plus
+  section variables carrying `=` expressions (v0.4.160); retest queue
+  priority and 404 fix for non-student submission view (v0.4.162a);
+  personalization expressions can import support files, with auto-
+  extracted `solution.py` (v0.4.162b — issue #461 Slice 5).  See
+  [docs/inputs.md](docs/inputs.md) and
+  [docs/personalization-phase1.md](docs/personalization-phase1.md).
+
+- **BrightSpace grade sync (v0.4.145–v0.4.146).**  Debounced per-
+  submission grade push via the D2L REST API, then auth switched to
+  D2L Valence key signing (App+User key model, not OAuth2).  Currently
+  waiting on UWaterloo IST for credentials before enabling in prod.
+
+- **Worker / runner ops (v0.4.147, v0.4.164).**  Health-alert "error
+  rate spike" excludes student-code errors (v0.4.147).  Worker test
+  coverage expanded, disk-usage telemetry added, retest-metric fixes
+  (v0.4.164).  Tests run against real Postgres in parallel with
+  `TestSetupCache` hit-rate telemetry surfacing in CI (v0.4.165-ish,
+  commit `b615235`).
+
+- **Closed-assignment behaviour (v0.4.166).**  Closed assignments now
+  load read-only in the instructor editor instead of editable.
+
+- **AppScan / security hardening (v0.4.167–v0.4.168).**  `SCAN_MODE`
+  env flag, rate-limit middleware, session reaper, CSP, audit log;
+  v0.4.168 hotfix loosened CSP to allow `cdn.jsdelivr.net` (Pyodide)
+  and `esm.sh` (CodeMirror).
+
+- **Test/format/CI tooling.**  `makeTestApp()` helper plus drift fix
+  and Swift session hook (commit `8b88585`).  `swift-format` strict CI
+  gate + bulk format pass (commit `2bbebf9`).  WorkerTests restored to
+  the per-PR gate and the 3-job split collapsed to one (commit
+  `a5a6f61`).
+
+- **AppConfig centralization (v0.4.169).**  Every server env var now
+  flows through a single `AppConfig` struct read once at startup —
+  already documented in detail at lines 92–100 above.
+
+- **v0.4.170 maintenance pass (#495, #496, #497, #499).**  Shared
+  `escapeForPythonStringLiteral` / `tierFilenamePrefix` helpers
+  (`Sources/APIServer/Utilities/PythonScriptHelpers.swift`); submission
+  output-formatting helpers split into
+  `Sources/APIServer/Helpers/SubmissionOutputFormatting.swift`;
+  `APIServerApp.configure(_:)` decomposed into
+  `Sources/APIServer/Bootstrap/AppDirectories.swift`,
+  `AppMiddleware.swift`, and `AppServices.swift`; `makeTestApp()`
+  now seeds the worker secret + autostart paths inside the per-test
+  temp dir.  No behaviour changes; generated test-script bytes
+  unchanged so `spec_hash` / `TestSetupCache` keys stay stable.
+
+- **v0.5.0 / v0.6.0 runway (PR #505).**  Migration consolidation (#502):
+  the 13 historical `Add*` migrations except `AddSessionsCreatedAt`
+  have been folded into the corresponding `Create*` files.  The
+  `Add*` structs and their `registerMigrations(...)` calls are kept
+  as no-ops so existing production DBs (with these migrations already
+  marked applied) see no change at runtime; fresh deploys produce the
+  same final schema in fewer steps.  Actual deletion of the no-op
+  files is deferred to **v0.5.0**.  Separately (#501), the inline
+  enrollment-mode fallback in `CourseBundleRoutes.swift` was extracted
+  to a Core helper `bundledCourseEnrollmentMode(_:)` to give **v0.6.0**
+  a single resolver to update when dropping the `openEnrollment`
+  back-compat field.  The two remaining DEPRECATED back-compat sites
+  ([Sources/Core/NotebookFunctionScanner.swift:80](Sources/Core/NotebookFunctionScanner.swift:80)
+  and [Sources/Core/CourseBundleManifest.swift:76](Sources/Core/CourseBundleManifest.swift:76))
+  are slated for removal in v0.6.0.
+
+**Near-term roadmap:**
+
+- **v0.5.0** — Delete the no-op `Add*` migration files folded in #502
+  once production has been observed tolerant of the consolidation.
+- **v0.6.0** — Drop the two DEPRECATED back-compat shims
+  (`NotebookFunctionScanner` `isShadowed` decode fallback,
+  `CourseBundleManifest` `openEnrollment` field).  Likely
+  Vapor 5 / LeafKit 2.x investigation window — the LeafKit 1.14.1
+  cycle-detection false positive blocking `assignment-{new,edit}.leaf`
+  decomposition is upstream and only fixed in the LeafKit 2 line.
+- **Feature backlog:** continued personalization / notebook-check
+  expansion; pattern kinds beyond
+  `.boundaryEquality` / `.approximateEquality` / `.variableEquality`
+  (e.g. exception-expected, type-check); multi-provider SSO testing
+  beyond UWaterloo DUO; refresh-token handling; gamification
+  expansion (leaderboards, more badges beyond First-Try Perfect).
 
 ---
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "445f13d1a47a62fbc6d9b2d57d7a8ec0b4ffdfcc399fc6306e1607ad8b030328",
+  "originHash" : "18691a2fccb883ede277101416a5604f2dc3a10fc45ed18ecbffcb45918807d5",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "60235983163d040f343a489f7e2e77c1918a8bd9",
-        "version" : "1.26.1"
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "6f3615ccf2ac3c2ae0c8087d527546e9544a43dd",
-        "version" : "1.21.0"
+        "revision" : "6bbb83cbf9d886623a967a965c8fb1b73e6566f9",
+        "version" : "1.22.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
-        "version" : "4.15.2"
+        "revision" : "32ad16dfc7677b927b225595ed18f3debb32f577",
+        "version" : "4.16.0"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/leaf-kit.git",
       "state" : {
-        "revision" : "e84a3d17afa7f9dd2168af51a81fabf62196989e",
-        "version" : "1.14.1"
+        "revision" : "6044b844caa858a0c5f2505ac166f5a057c990dc",
+        "version" : "1.14.2"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/postgres-nio.git",
       "state" : {
-        "revision" : "26b1d6825e7101ec4118fc208aa4574442319792",
-        "version" : "1.32.2"
+        "revision" : "f2188e05ba3546a76e61a5193c071b82c4d69a45",
+        "version" : "1.33.0"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/routing-kit.git",
       "state" : {
-        "revision" : "8c9a227476555c55837e569be71944e02a056b72",
-        "version" : "4.9.1"
+        "revision" : "1a10ccea61e4248effd23b6e814999ce7bdf0ee0",
+        "version" : "4.9.3"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "46d1a644846c6c42890a06988eb85cd975c3afc6",
-        "version" : "3.35.0"
+        "revision" : "3779cedb44b1f374f2cca261c6d28f206024a582",
+        "version" : "3.36.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sqlite-nio.git",
       "state" : {
-        "revision" : "2adc895b738210bbbb3b9cd982c86a634542e87f",
-        "version" : "1.11.2"
+        "revision" : "95595bbf0e044ee549fbb64aeaeec8d7f7059a16",
+        "version" : "1.12.8"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a54383ada6cecde007d374f58f864e29370ba5c3",
-        "version" : "1.3.2"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
       }
     },
     {
@@ -231,8 +231,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "c11818f3cae0780656baa430b49e7f163f08dffd",
-        "version" : "1.1.6"
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
       }
     },
     {
@@ -240,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "d79c573e1b400d670ed12c0cb29d33f2c0f5ab70",
-        "version" : "3.12.5"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {
@@ -249,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-distributed-tracing.git",
       "state" : {
-        "revision" : "baa932c1336f7894145cbaafcd34ce2dd0b77c97",
-        "version" : "1.3.1"
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
       }
     },
     {
@@ -258,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "f280fc7676b9940ff2c6598642751ea333c6544f",
-        "version" : "1.2.2"
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
@@ -276,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
-        "version" : "1.11.0"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -285,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "0743a9364382629da3bf5677b46a2c4b1ce5d2a6",
-        "version" : "2.7.1"
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -294,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
-        "version" : "2.97.1"
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
       }
     },
     {
@@ -303,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "f1f6f772198bee35d99dd145f1513d8581a54f2c",
-        "version" : "1.26.0"
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
       }
     },
     {
@@ -312,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "4281466512f63d1bd530e33f4aa6993ee7864be0",
-        "version" : "1.36.0"
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
       }
     },
     {
@@ -321,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
-        "version" : "2.36.1"
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
       }
     },
     {
@@ -330,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "cd1e89816d345d2523b11c55654570acd5cd4c56",
-        "version" : "1.24.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
@@ -348,8 +357,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-service-context.git",
       "state" : {
-        "revision" : "1983448fefc717a2bc2ebde5490fe99873c5b8a6",
-        "version" : "1.2.1"
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
       }
     },
     {
@@ -375,8 +384,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "a8db2dbda8b3cdc8a61bd35128590bd296e85563",
-        "version" : "4.121.3"
+        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
+        "version" : "4.121.4"
       }
     },
     {
@@ -384,8 +393,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "4232d34efa49f633ba61afde365d3896fc7f8740",
-        "version" : "2.15.0"
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/leaf.git", from: "4.5.1"),
         .package(url: "https://github.com/vapor/jwt.git", from: "5.1.2"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.15.1"),
         .package(url: "https://github.com/vapor-community/CSRF.git", from: "3.1.1"),
     ],
     targets: [

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -345,7 +345,12 @@ additive (new columns or tables); no migration drops data. Migration names
 follow the pattern `Create<ModelName>` for canonical baseline tables and
 `Add<Feature>` for subsequent additions.
 
-Current migration count: 17 (as of v0.4.36).
+For the current set, see `Sources/APIServer/Migrations/`. Note that PR #502
+(v0.5.0 prep) folded all historical `Add*` migrations except
+`AddSessionsCreatedAt` into their corresponding `Create*` files; the `Add*`
+files remain as registered no-ops for compatibility with production DBs that
+already have them marked applied, and will be deleted in v0.5.0 once that
+behaviour has been observed tolerant in practice.
 
 ---
 

--- a/docs/ci-followups.md
+++ b/docs/ci-followups.md
@@ -1,5 +1,10 @@
 # CI Follow-Ups
 
+> **Historical.** This note documents the CI containment work done for the
+> `v0.4.6` release push. The 3-job `Swift Tests` split was collapsed back
+> to a single job and `WorkerTests` returned to the per-PR gate as part of
+> the 2026 cleanup (commit `a5a6f61`). Kept here for archaeology.
+
 This note captures the CI changes made during the `0.4.6` release push, why
 they were made, and the cleanup work that should happen next.
 


### PR DESCRIPTION
## Summary

No behaviour changes — between-release housekeeping while v0.4.170 lands. Three small tracks bundled into one PR since they share the "no logic touched" property.

- **CLAUDE.md.** Bump current version `0.4.112` → `0.4.170`. Add a themed v0.4.97–v0.4.170 digest (notebook checks, personalization/inputs, BrightSpace, AppScan hardening, swift-format, AppConfig, v0.4.170 maintenance pass, v0.5.0/v0.6.0 runway). Replace the stale "Next work" line with a near-term roadmap pointing at v0.5.0 (delete no-op `Add*` migrations) and v0.6.0 (drop the two DEPRECATED back-compat shims).
- **Dependencies.** `swift package update` lifts direct deps: Vapor 4.121.3 → 4.121.4, leaf-kit 1.14.1 → 1.14.2, async-kit 1.21.0 → 1.22.0, console-kit 4.15.2 → 4.16.0, postgres-nio 1.32.2 → 1.33.0, plus transitive bumps. Bumped `swift-crypto` floor `3.0.0` → `3.15.1` — the only direct dep with a substantial gap between floor and resolved. **Did not** touch the LeafKit major; the LeafKit 1.14.1 cycle-detection false positive blocking `assignment-{new,edit}.leaf` decomposition is fixed only in LeafKit 2.x (Vapor 5), which belongs in its own release cycle.
- **Docs.** `docs/architecture.md` — replace stale "Current migration count: 17 (as of v0.4.36)" with a pointer to `Sources/APIServer/Migrations/` and a note on the #502 consolidation. `docs/ci-followups.md` — add a "Historical" header citing commit `a5a6f61` (the 2026 cleanup that restored WorkerTests to the per-PR gate and collapsed the 3-job split).

`git diff` touches only `CLAUDE.md`, `Package.swift`, `Package.resolved`, and the two `docs/` files — nothing under `Sources/`.

## Test plan

- [x] `swift test` exits 0 locally
- [ ] CI green (per-PR gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)