### PR TITLE
fix: admin runner page Total < Queue Wait under runner clock skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Admin runner page no longer shows `Total < Queue Wait`.** v0.4.164's
+  retest-clear fix closed one cause (stale per-attempt fields on the
+  `JobExecutionMetric` row across a retest), but the underlying math
+  for `totalProcessingMs` still straddled two clocks:
+  `millisecondsBetween(server enqueuedAt, runner finishedAt)`. Any
+  runner clock skew let totals slip below queue wait — for example
+  Queue Wait 210ms / Execution 101ms / Total 112ms on a runner whose
+  clock was ~200ms behind the server. Now
+  `totalProcessingMs = queueWaitMs + executionMs` (and the parallel
+  `APISubmissionDiagnostics.turnaroundMs` is computed the same way) in
+  both `recordWorkerExecutionReport` and `recordJobFailure`. Each
+  component already lives on a single clock, so the sum is skew-safe.
+  New `sumComponentMs` helper sits next to `millisecondsBetween`. New
+  regression test `testTotalProcessingMsIsResilientToRunnerClockSkew`
+  models the production failure mode. Existing rows in the DB carry
+  their old values until reprocessed (no backfill).
+
 ## [0.4.172] - 2026-05-15
 
 ### Fixed

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
@@ -374,7 +374,10 @@ extension OperationalDiagnosticsService {
             diagnostics.executionMs =
                 workerDiagnostics?.wallClockMs
                 ?? millisecondsBetween(startedAt, completedAt)
-            diagnostics.turnaroundMs = millisecondsBetween(effectiveEnqueuedAt, completedAt)
+            // Sum the two single-clock components instead of straddling
+            // server `enqueuedAt` and runner `completedAt`: runner clock
+            // skew otherwise lets `turnaroundMs < queueWaitMs` slip through.
+            diagnostics.turnaroundMs = sumComponentMs(diagnostics.queueWaitMs, diagnostics.executionMs)
             diagnostics.finalStatus = finalStatus
             diagnostics.timedOut = finalStatus == JobFinalStatus.timeout.rawValue
             diagnostics.exitCode = workerDiagnostics?.exitCode
@@ -402,7 +405,7 @@ extension OperationalDiagnosticsService {
             metric.completedAt = completedAt
             metric.queueWaitMs = millisecondsBetween(metric.enqueuedAt, metric.assignedAt)
             metric.executionMs = workerDiagnostics?.wallClockMs ?? millisecondsBetween(startedAt, completedAt)
-            metric.totalProcessingMs = millisecondsBetween(metric.enqueuedAt, completedAt)
+            metric.totalProcessingMs = sumComponentMs(metric.queueWaitMs, metric.executionMs)
             StageTimingAggregator(from: workerDiagnostics?.stageTimings).apply(to: metric)
             metric.finalStatus = finalStatus
             metric.testsPassed = collection.passCount
@@ -545,7 +548,7 @@ extension OperationalDiagnosticsService {
             diagnostics.finishedAt = finishedAt ?? diagnostics.finishedAt
             diagnostics.queueWaitMs = millisecondsBetween(diagnostics.submittedAt, submission.assignedAt)
             diagnostics.executionMs = millisecondsBetween(diagnostics.startedAt, diagnostics.finishedAt)
-            diagnostics.turnaroundMs = millisecondsBetween(diagnostics.submittedAt, diagnostics.finishedAt)
+            diagnostics.turnaroundMs = sumComponentMs(diagnostics.queueWaitMs, diagnostics.executionMs)
             diagnostics.finalStatus =
                 terminationReason == "job_timeout"
                 ? JobFinalStatus.timeout.rawValue
@@ -564,7 +567,7 @@ extension OperationalDiagnosticsService {
             metric.completedAt = finishedAt ?? metric.completedAt
             metric.queueWaitMs = millisecondsBetween(metric.enqueuedAt, submission.assignedAt)
             metric.executionMs = millisecondsBetween(metric.startedAt, metric.completedAt)
-            metric.totalProcessingMs = millisecondsBetween(metric.enqueuedAt, metric.completedAt)
+            metric.totalProcessingMs = sumComponentMs(metric.queueWaitMs, metric.executionMs)
             metric.finalStatus =
                 terminationReason == "job_timeout"
                 ? JobFinalStatus.timeout.rawValue

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
@@ -227,6 +227,15 @@ func millisecondsBetween(_ start: Date?, _ end: Date?) -> Int? {
     return Int((end.timeIntervalSince(start) * 1000).rounded())
 }
 
+/// Sum two single-clock millisecond components into a wall-clock total.
+/// Preferred over `millisecondsBetween(enqueuedAt, completedAt)` when the
+/// two endpoints live on different clocks (server vs. runner) — runner
+/// clock skew otherwise produces `total < queueWait` on the admin page.
+func sumComponentMs(_ a: Int?, _ b: Int?) -> Int? {
+    guard let a, let b else { return nil }
+    return a + b
+}
+
 func iso8601Metadata(_ date: Date) -> Logger.MetadataValue {
     .string(ISO8601DateFormatter().string(from: date))
 }

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -98,7 +98,11 @@ final class ObservabilityTests: XCTestCase {
             .filter(\.$submissionID == "sub_exec_metric")
             .first()
         XCTAssertEqual(metric?.executionMs, 3250)
-        XCTAssertEqual(metric?.totalProcessingMs, 6250)
+        // totalProcessingMs is the sum of queueWaitMs (2000) and executionMs
+        // (3250), not `completedAt − enqueuedAt`. Summing avoids mixing
+        // server `enqueuedAt` with runner `completedAt`, which under any
+        // runner clock skew would let `total < queueWait` slip through.
+        XCTAssertEqual(metric?.totalProcessingMs, 5250)
         XCTAssertEqual(metric?.finalStatus, JobFinalStatus.error.rawValue)
     }
 
@@ -362,6 +366,80 @@ final class ObservabilityTests: XCTestCase {
             })
     }
 
+    /// Regression test for the admin runner page showing `Total < Queue
+    /// Wait`. Models the production failure mode: the runner's wall clock
+    /// is offset relative to the server, so the runner-reported
+    /// `finishedAt` lands "before" the server-recorded `assignedAt` in
+    /// absolute time. The old formula
+    /// (`completedAt − enqueuedAt`) straddled the two clocks and produced
+    /// totals smaller than the queue wait. `totalProcessingMs` must now
+    /// be `queueWaitMs + executionMs`, which never inverts.
+    func testTotalProcessingMsIsResilientToRunnerClockSkew() async throws {
+        let (_, submission) = try await makeSubmission(submissionID: "sub_clock_skew")
+
+        // Server clock: submitted at T+0, assigned 210 ms later.
+        let enqueuedAt = Date(timeIntervalSince1970: 10_000.000)
+        let assignedAt = Date(timeIntervalSince1970: 10_000.210)
+
+        submission.submittedAt = enqueuedAt
+        submission.workerID = "runner-skewed"
+        submission.assignedAt = assignedAt
+        submission.status = "assigned"
+        try await submission.update(on: app.db)
+
+        await app.diagnostics.recordSubmissionCreated(submission: submission, on: app.db, logger: app.logger)
+        await app.diagnostics.recordJobAssigned(submission: submission, on: app.db, logger: app.logger)
+
+        // Runner clock runs ~200ms behind the server, so its reported
+        // start/finish timestamps land "before" assignedAt in absolute
+        // time. wallClockMs (a duration on the runner's clock) is correct.
+        let runnerStartedAt = Date(timeIntervalSince1970: 10_000.010)
+        let runnerFinishedAt = Date(timeIntervalSince1970: 10_000.111)
+
+        let collection = TestOutcomeCollection(
+            submissionID: try submission.requireID(),
+            testSetupID: submission.testSetupID,
+            attemptNumber: submission.attemptNumber ?? 1,
+            buildStatus: .passed,
+            compilerOutput: nil,
+            outcomes: [],
+            totalTests: 0,
+            passCount: 0, failCount: 0, errorCount: 0, timeoutCount: 0,
+            executionTimeMs: 101,
+            jobStartedAt: runnerStartedAt,
+            runnerVersion: "runner-test/1.0",
+            timestamp: runnerFinishedAt
+        )
+        await app.diagnostics.recordWorkerResult(
+            collection: collection,
+            submission: submission,
+            on: app.db,
+            logger: app.logger
+        )
+
+        let metric = try await JobExecutionMetric.query(on: app.db)
+            .filter(\.$submissionID == "sub_clock_skew")
+            .first()
+        XCTAssertEqual(metric?.queueWaitMs, 210)
+        XCTAssertEqual(metric?.executionMs, 101)
+        // The invariant: total >= queueWait. The old formula yielded 111ms
+        // (a clock-skewed completedAt − enqueuedAt), inverting against
+        // the 210ms queueWait. The summed formula yields 311ms.
+        XCTAssertEqual(metric?.totalProcessingMs, 311)
+        if let total = metric?.totalProcessingMs, let queue = metric?.queueWaitMs {
+            XCTAssertGreaterThanOrEqual(total, queue)
+        } else {
+            XCTFail("expected queueWaitMs and totalProcessingMs to be populated")
+        }
+
+        // Same invariant on APISubmissionDiagnostics.turnaroundMs.
+        let diag = try await APISubmissionDiagnostics.find("sub_clock_skew", on: app.db)
+        XCTAssertEqual(diag?.turnaroundMs, 311)
+        if let turnaround = diag?.turnaroundMs, let queue = diag?.queueWaitMs {
+            XCTAssertGreaterThanOrEqual(turnaround, queue)
+        }
+    }
+
     /// Retests reuse the same `JobExecutionMetric` row. Two things must be
     /// true after the new assignment is recorded:
     /// 1. `enqueuedAt` is re-baselined to `retestedAt`, so `queueWaitMs`
@@ -414,7 +492,7 @@ final class ObservabilityTests: XCTestCase {
         let postFirstRun = try await JobExecutionMetric.query(on: app.db)
             .filter(\.$submissionID == "sub_retest")
             .first()
-        XCTAssertEqual(postFirstRun?.totalProcessingMs, 10_000)  // 1_010 − 1_000
+        XCTAssertEqual(postFirstRun?.totalProcessingMs, 9_000)  // queueWait 2_000 + execution 7_000
         XCTAssertEqual(postFirstRun?.queueWaitMs, 2_000)  //  1_002 − 1_000
         XCTAssertNotNil(postFirstRun?.completedAt)
 


### PR DESCRIPTION
## Summary

- Fixes the `Total < Queue Wait` weirdness reported on `/admin/runners/:id` — the math straddled the server and runner clocks, so any runner clock skew let totals slip below the queue wait.
- v0.4.164 closed one variant of this (retest race) but left the underlying mixed-clock arithmetic in place. This is the follow-up.
- Symptom seen in production: `Queue Wait 210ms / Execution 101ms / Total 112ms` on Sparrow (~200ms behind server).

## Approach

`totalProcessingMs` (and the parallel `APISubmissionDiagnostics.turnaroundMs`) is now `queueWaitMs + executionMs`. Each component already lives on a single clock, so the sum is skew-safe. New `sumComponentMs` helper sits next to `millisecondsBetween`. Four call sites updated in `OperationalDiagnostics+Recording.swift` (`recordWorkerExecutionReport` + `recordJobFailure`, each touching both the metric row and the diagnostics row).

Existing wrong rows in the DB carry their old values until reprocessed — no backfill.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter ObservabilityTests` — all 8 pass, including new `testTotalProcessingMsIsResilientToRunnerClockSkew` (models 200ms runner-behind-server skew; asserts `total >= queueWait`).
- [x] `swift test --filter AdminRoutesTests` — all 13 pass.
- [ ] Watch `/admin/runners/Sparrow` after deploy: new rows should always have `Total >= Queue Wait`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)