### PR TITLE
build: treat all compiler warnings as errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,8 @@
 // swift-tools-version:6.3
 import PackageDescription
 
+let strictWarnings: [SwiftSetting] = [.treatAllWarnings(as: .error)]
+
 let package = Package(
     name: "Chickadee",
     platforms: [
@@ -25,7 +27,8 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto")
             ],
             path: "Sources/Core",
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictWarnings
         ),
 
         // MARK: - API Server executable
@@ -42,7 +45,8 @@ let package = Package(
                 .product(name: "CSRF", package: "CSRF"),
             ],
             path: "Sources/APIServer",
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictWarnings
         ),
 
         // MARK: - Worker executable
@@ -54,7 +58,8 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources/Worker",
-            exclude: ["README.md"]
+            exclude: ["README.md"],
+            swiftSettings: strictWarnings
         ),
 
         // MARK: - Tests
@@ -63,7 +68,8 @@ let package = Package(
             dependencies: [
                 .target(name: "Core")
             ],
-            path: "Tests/CoreTests"
+            path: "Tests/CoreTests",
+            swiftSettings: strictWarnings
         ),
         .testTarget(
             name: "APITests",
@@ -75,14 +81,16 @@ let package = Package(
                 .product(name: "CSRF", package: "CSRF"),
                 .product(name: "Leaf", package: "leaf"),
             ],
-            path: "Tests/APITests"
+            path: "Tests/APITests",
+            swiftSettings: strictWarnings
         ),
         .testTarget(
             name: "WorkerTests",
             dependencies: [
                 .target(name: "chickadee-runner")
             ],
-            path: "Tests/WorkerTests"
+            path: "Tests/WorkerTests",
+            swiftSettings: strictWarnings
         ),
     ]
 )

--- a/Sources/Core/ManifestCodec.swift
+++ b/Sources/Core/ManifestCodec.swift
@@ -16,13 +16,12 @@ import Foundation
 /// encoding (`PatternFamilyRenderer`, `NotebookCheckRenderer`) need
 /// `outputFormatting = [.sortedKeys]` and also stay on a local encoder.
 ///
-/// `nonisolated(unsafe)`: `JSONDecoder` and `JSONEncoder` are not
-/// `Sendable` in current Swift Foundation, but their thread-safety
-/// contract permits concurrent `decode` / `encode` calls as long as the
-/// instance is not reconfigured.  These two are configured once at
-/// startup with default settings and never mutated, so concurrent use
-/// from request handlers is safe.
+/// `JSONDecoder` and `JSONEncoder` are `Sendable` in current Foundation,
+/// so sharing these instances across request handlers is safe as long
+/// as they are not reconfigured after initialization (we never do).
+/// The shared instances exist for allocation reuse on hot paths, not
+/// for concurrency-safety reasons.
 public enum ManifestCodec {
-    nonisolated(unsafe) public static let decoder: JSONDecoder = JSONDecoder()
-    nonisolated(unsafe) public static let encoder: JSONEncoder = JSONEncoder()
+    public static let decoder: JSONDecoder = JSONDecoder()
+    public static let encoder: JSONEncoder = JSONEncoder()
 }

--- a/Tests/APITests/AppConfigTests.swift
+++ b/Tests/APITests/AppConfigTests.swift
@@ -73,8 +73,8 @@ import Vapor
 
     /// Legacy `WORKER_SHARED_SECRET` wins only when `RUNNER_SHARED_SECRET` is
     /// unset, and the loader flags this so `logSummary` can warn.
-    @Test func legacyWorkerSecretAliasIsHonouredButFlagged() throws {
-        try withEnvironment(
+    @Test func legacyWorkerSecretAliasIsHonouredButFlagged() {
+        withEnvironment(
             set: ["WORKER_SHARED_SECRET": "legacy-value"],
             unset: ["RUNNER_SHARED_SECRET"]
         ) {
@@ -83,7 +83,7 @@ import Vapor
             #expect(workers.usedLegacyAlias == true)
         }
 
-        try withEnvironment(set: [
+        withEnvironment(set: [
             "RUNNER_SHARED_SECRET": "primary",
             "WORKER_SHARED_SECRET": "legacy",
         ]) {
@@ -94,8 +94,8 @@ import Vapor
     }
 
     /// SSO mode is forced when non-SSO modes are not explicitly enabled.
-    @Test func authModeDowngradesToSSOWhenNonSSODisabled() throws {
-        try withEnvironment(set: [
+    @Test func authModeDowngradesToSSOWhenNonSSODisabled() {
+        withEnvironment(set: [
             "AUTH_MODE": "local",
             "ENABLE_NON_SSO_AUTH_MODES": "false",
         ]) {
@@ -247,15 +247,7 @@ private struct ClosureLogHandler: LogHandler {
         set { metadata[key] = newValue }
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
-        onLog("\(level) \(message)")
+    func log(event: LogEvent) {
+        onLog("\(event.level) \(event.message)")
     }
 }

--- a/Tests/APITests/DraftNotebookChecksRoutesTests.swift
+++ b/Tests/APITests/DraftNotebookChecksRoutesTests.swift
@@ -36,7 +36,7 @@ final class DraftNotebookChecksRoutesTests: XCTestCase {
 
         let setupID = "dnct_\(UUID().uuidString.prefix(8))"
         let zipPath = app.testSetupsDirectory + setupID + ".zip"
-        FileManager.default.createFile(atPath: zipPath, contents: Data())
+        _ = FileManager.default.createFile(atPath: zipPath, contents: Data())
         // Seed the zip with a placeholder entry so the apply path's
         // zip-rewrite step has something to read; an empty stub file
         // would fail with ScriptZipError.zipFailed on the first PUT.

--- a/Tests/APITests/DraftSuiteSectionRoutesTests.swift
+++ b/Tests/APITests/DraftSuiteSectionRoutesTests.swift
@@ -46,7 +46,7 @@ final class DraftSuiteSectionRoutesTests: XCTestCase {
 
         let setupID = "dssrt_\(UUID().uuidString.prefix(8))"
         let zipPath = app.testSetupsDirectory + setupID + ".zip"
-        FileManager.default.createFile(atPath: zipPath, contents: Data())
+        _ = FileManager.default.createFile(atPath: zipPath, contents: Data())
 
         var manifestDict: [String: Any] = [
             "schemaVersion": 1,

--- a/Tests/APITests/DraftSupportFilesTests.swift
+++ b/Tests/APITests/DraftSupportFilesTests.swift
@@ -39,7 +39,7 @@ final class DraftSupportFilesTests: XCTestCase {
         let setupID = "dsft_\(UUID().uuidString.prefix(8))"
         let zipPath = app.testSetupsDirectory + setupID + ".zip"
         // Empty zip first; updateScriptInZip handles the create-from-empty case.
-        FileManager.default.createFile(atPath: zipPath, contents: Data())
+        _ = FileManager.default.createFile(atPath: zipPath, contents: Data())
 
         if let f = withSupportFile {
             try updateScriptInZip(zipPath: zipPath, filename: f.name, content: f.contents)

--- a/Tests/APITests/SuiteSectionRoutesTests.swift
+++ b/Tests/APITests/SuiteSectionRoutesTests.swift
@@ -48,7 +48,7 @@ final class SuiteSectionRoutesTests: XCTestCase {
 
         let setupID = "ssrt_\(UUID().uuidString.prefix(8))"
         let zipPath = app.testSetupsDirectory + setupID + ".zip"
-        FileManager.default.createFile(atPath: zipPath, contents: Data())
+        _ = FileManager.default.createFile(atPath: zipPath, contents: Data())
 
         var manifestDict: [String: Any] = [
             "schemaVersion": 1,

--- a/Tests/APITests/VanityURLRoutesTests.swift
+++ b/Tests/APITests/VanityURLRoutesTests.swift
@@ -51,6 +51,7 @@ final class VanityURLRoutesTests: XCTestCase {
         return course
     }
 
+    @discardableResult
     private func seedSetupAndAssignment(
         courseID: UUID,
         title: String,


### PR DESCRIPTION
## Summary

- Linux Docker builds (`swift:6.3-jammy`) were silently emitting `'nonisolated(unsafe)' is unnecessary for a constant with 'Sendable' type` warnings against `Sources/Core/ManifestCodec.swift` because corelibs Foundation marks `JSONDecoder`/`JSONEncoder` `Sendable`. Nothing in the pipeline failed on warnings, so they accumulated unnoticed.
- `Package.swift` now sets `swiftSettings: [.treatAllWarnings(as: .error)]` on every target (Core, chickadee-server, chickadee-runner, CoreTests, APITests, WorkerTests). One switch covers `swift build`, `swift test`, the Dockerfile, and developer laptops.
- Drops the redundant `nonisolated(unsafe)` from `ManifestCodec.swift` and refreshes the doc comment.
- The strict gate immediately surfaced 13 additional pre-existing warnings in the test target; fixed in the same change:
  - `Tests/APITests/VanityURLRoutesTests.swift`: `@discardableResult` on `seedSetupAndAssignment` (9 unused-result warnings).
  - `Tests/APITests/AppConfigTests.swift`: bogus `try` removed from three `withEnvironment` calls; deprecated `LogHandler.log(level:...)` override replaced with `log(event:)`.

## Test plan

- [x] `swift build` (debug) — passes, 0 warnings.
- [x] `swift build -c release` — passes, 0 warnings.
- [x] Synthetic `#warning` injected into Core — `swift build` exits 1 as expected; reverted.
- [x] `swift test --parallel --filter CoreTests` — 108 tests pass.
- [x] `swift test --parallel --filter APITests` — 154 swift-testing tests pass, 0 XCTest failures.
- [x] `swift test --filter WorkerTests` (serial, matching CI) — 169 tests, 4 skipped, 0 failures.
- [x] `scripts/lint.sh` (swift-format) — clean.
- [ ] CI: `.github/workflows/swift-tests.yml` on `swift:6.3-jammy` — this is the canonical Linux check; should now reject any remaining Linux-specific warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)