### PR TITLE
feat: per-student grouped submissions + deadline extensions

### DIFF
--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -13,45 +13,220 @@
     <a class="btn action-btn" href="#(backURL)">Back to Instructor Dashboard</a>
 </div>
 
-#if(rows.isEmpty):
-<p class="empty">No submissions yet for this student in the active course.</p>
+#if(!hasSections && !hasUngrouped):
+<p class="empty">No published assignments in this course yet.</p>
 #else:
-<table class="results-table">
+
+#if(hasSections):
+#for(section in sections):
+#if(!section.rows.isEmpty):
+<h2 style="font-size:1.05rem;font-weight:600;margin-top:1.5rem;margin-bottom:.4rem">#(section.name)</h2>
+<table class="results-table" style="margin-bottom:.5rem">
     <thead>
         <tr>
-            <th>Assignment</th>
-            <th>Attempt</th>
-            <th>Submitted</th>
+            <th>Name</th>
             <th>Status</th>
+            <th class="due-col">Due</th>
             <th>Grade</th>
+            <th>History</th>
             <th>Actions</th>
         </tr>
     </thead>
     <tbody>
-    #for(row in rows):
+    #for(row in section.rows):
         <tr>
             <td>
-                #if(row.assignmentSubmissionsURL):
-                <strong><a href="#(row.assignmentSubmissionsURL)">#(row.assignmentTitle)</a></strong>
+                <div class="assignment-title-cell">
+                    <strong>#(row.title)</strong>
+                    #if(!row.badges.isEmpty):
+                    <span class="achievement-badges achievement-badges-compact">
+                        #for(badge in row.badges):
+                        <span class="achievement-badge achievement-badge-compact" title="#(badge.tooltip)">#(badge.label)</span>
+                        #endfor
+                    </span>
+                    #endif
+                </div>
+            </td>
+            <td>
+                <span class="tier
+                    #if(row.status == "open"):tier-open
+                    #elseif(row.status == "closed"):tier-closed
+                    #endif">#(row.status)</span>
+            </td>
+            <td class="due-col">
+                #if(row.effectiveDueAtText):
+                    <span title="Assignment-wide due date: #if(row.dueAtText):#(row.dueAtText)#else:none#endif">#(row.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">+ extension</span></span>
+                #elseif(row.dueAtText):
+                    #(row.dueAtText)
                 #else:
-                <strong>#(row.assignmentTitle)</strong>
+                    —
                 #endif
             </td>
-            <td>#(row.attemptNumber)</td>
-            <td>#(row.submittedAt)</td>
-            <td><span class="tier">#(row.status)</span></td>
-            <td><strong>#(row.gradeText)</strong></td>
-            <td style="white-space:nowrap">
-                <a class="btn action-btn" href="/submissions/#(row.submissionID)">View results</a>
-                <a class="btn action-btn" href="/api/v1/submissions/#(row.submissionID)/download">Download</a>
-                #if(row.canOpenInNotebook):
-                <a class="btn action-btn" href="#(row.openInNotebookURL)">Open</a>
+            <td>
+                #if(row.bestGradeText):
+                    <strong>#(row.bestGradeText)</strong>
+                #else:
+                    <span class="empty">—</span>
                 #endif
+            </td>
+            <td>
+                #if(row.submissionCount > 0):
+                    <div style="display:flex;flex-direction:column;gap:.2rem">
+                        #if(row.hasLatestSubmission):
+                            <a href="/submissions/#(row.latestSubmissionID)" style="font-size:.82rem">#(row.latestSubmittedAtText)</a>
+                        #endif
+                        #if(row.additionalSubmissionCount > 0):
+                            <a href="#(row.historyURL)" style="font-size:.78rem;color:var(--gray-600)">+#(row.additionalSubmissionCount) more</a>
+                        #endif
+                    </div>
+                #else:
+                    <span class="empty">No submissions yet</span>
+                #endif
+            </td>
+            <td>
+                <div style="display:flex;gap:.4rem;flex-wrap:wrap;align-items:center">
+                    #if(row.submissionCount > 0):
+                    <form method="post" action="#(row.retestPath)" onsubmit="return confirm('Re-test all of this student’s submissions on this assignment?')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn" type="submit" title="Re-test every submission this student has on this assignment">Retest</button>
+                    </form>
+                    #endif
+                    <details style="margin:0">
+                        <summary class="btn action-btn" style="cursor:pointer">
+                            #if(row.hasExtension):Edit extension#else:Grant extension#endif
+                        </summary>
+                        <form method="post" action="#(row.extensionSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                            #csrfFormField()
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                New deadline for this student
+                                <input type="datetime-local" name="extendedDueAt" value="#(row.extensionFormInput)" required style="width:100%;margin-top:.2rem">
+                            </label>
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Note (optional)
+                                <input type="text" name="note" placeholder="Reason for extension" style="width:100%;margin-top:.2rem">
+                            </label>
+                            <div style="display:flex;gap:.3rem">
+                                <button class="btn action-btn" type="submit">Save</button>
+                                #if(row.hasExtension):
+                                <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate onclick="return confirm('Remove this student’s extension on this assignment?')">Remove</button>
+                                #endif
+                            </div>
+                        </form>
+                    </details>
+                </div>
             </td>
         </tr>
     #endfor
     </tbody>
 </table>
+#endif
+#endfor
+#endif
+
+#if(hasUngrouped):
+#if(hasSections):
+<h2 style="font-size:1.05rem;font-weight:600;margin-top:1.5rem;margin-bottom:.4rem">Ungrouped</h2>
+#endif
+<table class="results-table" style="margin-bottom:.5rem">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th class="due-col">Due</th>
+            <th>Grade</th>
+            <th>History</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(row in ungroupedRows):
+        <tr>
+            <td>
+                <div class="assignment-title-cell">
+                    <strong>#(row.title)</strong>
+                    #if(!row.badges.isEmpty):
+                    <span class="achievement-badges achievement-badges-compact">
+                        #for(badge in row.badges):
+                        <span class="achievement-badge achievement-badge-compact" title="#(badge.tooltip)">#(badge.label)</span>
+                        #endfor
+                    </span>
+                    #endif
+                </div>
+            </td>
+            <td>
+                <span class="tier
+                    #if(row.status == "open"):tier-open
+                    #elseif(row.status == "closed"):tier-closed
+                    #endif">#(row.status)</span>
+            </td>
+            <td class="due-col">
+                #if(row.effectiveDueAtText):
+                    <span title="Assignment-wide due date: #if(row.dueAtText):#(row.dueAtText)#else:none#endif">#(row.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">+ extension</span></span>
+                #elseif(row.dueAtText):
+                    #(row.dueAtText)
+                #else:
+                    —
+                #endif
+            </td>
+            <td>
+                #if(row.bestGradeText):
+                    <strong>#(row.bestGradeText)</strong>
+                #else:
+                    <span class="empty">—</span>
+                #endif
+            </td>
+            <td>
+                #if(row.submissionCount > 0):
+                    <div style="display:flex;flex-direction:column;gap:.2rem">
+                        #if(row.hasLatestSubmission):
+                            <a href="/submissions/#(row.latestSubmissionID)" style="font-size:.82rem">#(row.latestSubmittedAtText)</a>
+                        #endif
+                        #if(row.additionalSubmissionCount > 0):
+                            <a href="#(row.historyURL)" style="font-size:.78rem;color:var(--gray-600)">+#(row.additionalSubmissionCount) more</a>
+                        #endif
+                    </div>
+                #else:
+                    <span class="empty">No submissions yet</span>
+                #endif
+            </td>
+            <td>
+                <div style="display:flex;gap:.4rem;flex-wrap:wrap;align-items:center">
+                    #if(row.submissionCount > 0):
+                    <form method="post" action="#(row.retestPath)" onsubmit="return confirm('Re-test all of this student’s submissions on this assignment?')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn" type="submit" title="Re-test every submission this student has on this assignment">Retest</button>
+                    </form>
+                    #endif
+                    <details style="margin:0">
+                        <summary class="btn action-btn" style="cursor:pointer">
+                            #if(row.hasExtension):Edit extension#else:Grant extension#endif
+                        </summary>
+                        <form method="post" action="#(row.extensionSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                            #csrfFormField()
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                New deadline for this student
+                                <input type="datetime-local" name="extendedDueAt" value="#(row.extensionFormInput)" required style="width:100%;margin-top:.2rem">
+                            </label>
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Note (optional)
+                                <input type="text" name="note" placeholder="Reason for extension" style="width:100%;margin-top:.2rem">
+                            </label>
+                            <div style="display:flex;gap:.3rem">
+                                <button class="btn action-btn" type="submit">Save</button>
+                                #if(row.hasExtension):
+                                <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate onclick="return confirm('Remove this student’s extension on this assignment?')">Remove</button>
+                                #endif
+                            </div>
+                        </form>
+                    </details>
+                </div>
+            </td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+#endif
+
 #endif
 #endexport
 #endextend

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -61,7 +61,15 @@
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
             </td>
-            <td class="due-col">#if(setup.dueAt):#(setup.dueAt)#else:—#endif</td>
+            <td class="due-col">
+                #if(setup.hasActiveExtension):
+                    <span title="Personal deadline extension granted by your instructor.">#(setup.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">(extension)</span></span>
+                #elseif(setup.dueAt):
+                    #(setup.dueAt)
+                #else:
+                    —
+                #endif
+            </td>
             <td>
                 #if(setup.bestGradeText):
                     <strong>#(setup.bestGradeText)</strong>
@@ -160,7 +168,15 @@
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
             </td>
-            <td class="due-col">#if(setup.dueAt):#(setup.dueAt)#else:—#endif</td>
+            <td class="due-col">
+                #if(setup.hasActiveExtension):
+                    <span title="Personal deadline extension granted by your instructor.">#(setup.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">(extension)</span></span>
+                #elseif(setup.dueAt):
+                    #(setup.dueAt)
+                #else:
+                    —
+                #endif
+            </td>
             <td>
                 #if(setup.bestGradeText):
                     <strong>#(setup.bestGradeText)</strong>
@@ -259,7 +275,15 @@
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
             </td>
-            <td class="due-col">#if(setup.dueAt):#(setup.dueAt)#else:—#endif</td>
+            <td class="due-col">
+                #if(setup.hasActiveExtension):
+                    <span title="Personal deadline extension granted by your instructor.">#(setup.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">(extension)</span></span>
+                #elseif(setup.dueAt):
+                    #(setup.dueAt)
+                #else:
+                    —
+                #endif
+            </td>
             <td>
                 #if(setup.bestGradeText):
                     <strong>#(setup.bestGradeText)</strong>

--- a/Resources/Views/student-assignment-history.leaf
+++ b/Resources/Views/student-assignment-history.leaf
@@ -1,0 +1,51 @@
+#extend("base"):
+#export("title"):
+#(studentName) — #(assignmentTitle)
+#endexport
+#export("content"):
+<div style="display:flex;justify-content:space-between;align-items:baseline;flex-wrap:wrap;gap:.75rem;margin-bottom:1rem">
+    <div>
+        <h1 style="margin:0">#(assignmentTitle)</h1>
+        <p style="margin:.35rem 0 0;color:var(--gray-700)">
+            <strong>#(studentName)</strong> (#(studentUsername))
+        </p>
+    </div>
+    <a class="btn action-btn" href="#(backURL)">Back to student</a>
+</div>
+
+#if(rows.isEmpty):
+<p class="empty">No submissions yet for this student on this assignment.</p>
+#else:
+<table class="results-table">
+    <thead>
+        <tr>
+            <th>Attempt</th>
+            <th>Status</th>
+            <th>Submitted</th>
+            <th>Grade</th>
+            <th>Details</th>
+            <th>Action</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(row in rows):
+        <tr>
+            <td>#(row.attemptNumber)</td>
+            <td><span class="tier">#(row.status)</span></td>
+            <td>#(row.submittedAt)</td>
+            <td><strong>#(row.gradeText)</strong></td>
+            <td><a href="/submissions/#(row.submissionID)">Open</a></td>
+            <td>
+                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
+                    #csrfFormField()
+                    <input type="hidden" name="returnTo" value="#(historyPath)">
+                    <button class="btn action-btn" type="submit">Re-test</button>
+                </form>
+            </td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+#endif
+#endexport
+#endextend

--- a/Sources/APIServer/Migrations/CreateAssignmentExtensions.swift
+++ b/Sources/APIServer/Migrations/CreateAssignmentExtensions.swift
@@ -1,0 +1,51 @@
+// APIServer/Migrations/CreateAssignmentExtensions.swift
+//
+// Per-student deadline extension table.  One row per (assignment, user)
+// enforced by the composite UNIQUE constraint; the `extended_due_at`
+// timestamp is the new deadline for that specific student.
+
+import Fluent
+import SQLKit
+
+struct CreateAssignmentExtensions: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignment_extensions")
+            .id()
+            .field(
+                "assignment_id",
+                .uuid,
+                .required,
+                .references("assignments", "id", onDelete: .cascade)
+            )
+            .field(
+                "user_id",
+                .uuid,
+                .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field("extended_due_at", .datetime, .required)
+            .field("note", .string)
+            .field(
+                "granted_by_user_id",
+                .uuid,
+                .references("users", "id", onDelete: .setNull)
+            )
+            .field("granted_at", .datetime)
+            .field("updated_at", .datetime)
+            .unique(on: "assignment_id", "user_id")
+            .create()
+
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "CREATE INDEX IF NOT EXISTS idx_assignment_extensions_user ON assignment_extensions(user_id)"
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_assignment_extensions_user").run()
+        }
+        try await database.schema("assignment_extensions").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignmentExtension.swift
+++ b/Sources/APIServer/Models/APIAssignmentExtension.swift
@@ -1,0 +1,60 @@
+// APIServer/Models/APIAssignmentExtension.swift
+//
+// Per-student deadline extension on an assignment.  An extension lets one
+// student keep submitting past the assignment-wide deadline; the assignment
+// itself remains closed for every other student.  See
+// `AssignmentDeadlineService.requireOpenStudentAssignment(for:user:on:)` for
+// the gate that consults this row.
+//
+// One row per (assignment, user) — enforced by the composite UNIQUE index in
+// CreateAssignmentExtensions.
+
+import Fluent
+import Vapor
+
+final class APIAssignmentExtension: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context.
+    static let schema = "assignment_extensions"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "assignment_id")
+    var assignmentID: UUID
+
+    @Field(key: "user_id")
+    var userID: UUID
+
+    @Field(key: "extended_due_at")
+    var extendedDueAt: Date
+
+    @OptionalField(key: "note")
+    var note: String?
+
+    @OptionalField(key: "granted_by_user_id")
+    var grantedByUserID: UUID?
+
+    @Timestamp(key: "granted_at", on: .create)
+    var grantedAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        assignmentID: UUID,
+        userID: UUID,
+        extendedDueAt: Date,
+        note: String? = nil,
+        grantedByUserID: UUID? = nil
+    ) {
+        self.id = id
+        self.assignmentID = assignmentID
+        self.userID = userID
+        self.extendedDueAt = extendedDueAt
+        self.note = note
+        self.grantedByUserID = grantedByUserID
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -89,6 +89,9 @@ enum AuditAction: String, Sendable {
     case runnerSecretRotated = "runner.secret_rotated"
     case runnerAutostartChanged = "runner.autostart_changed"
     case submissionRetestAll = "submission.retest_all"
+    case submissionRetestForStudent = "submission.retest_for_student"
+    case extensionGranted = "extension.granted"
+    case extensionRevoked = "extension.revoked"
     case loginSuccess = "auth.login_success"
     case loginFailure = "auth.login_failure"
     case loginLocked = "auth.login_locked"
@@ -99,4 +102,5 @@ enum AuditTargetType: String, Sendable {
     case runner
     case testSetup = "test_setup"
     case auth
+    case assignment
 }

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -36,7 +36,7 @@ struct BrowserResultRoutes: RouteCollection {
         }
 
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
-        _ = try await requireOpenStudentAssignment(for: body.testSetupID, on: req)
+        _ = try await requireOpenStudentAssignment(for: body.testSetupID, user: caller, on: req)
 
         // Decode the TestOutcomeCollection the browser sent.
         let decoder = JSONDecoder()
@@ -139,7 +139,7 @@ struct BrowserResultRoutes: RouteCollection {
         }
 
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
-        _ = try await requireOpenStudentAssignment(for: body.testSetupID, on: req)
+        _ = try await requireOpenStudentAssignment(for: body.testSetupID, user: caller, on: req)
 
         let manifestData = Data(setup.manifest.utf8)
         if let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData),

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -361,24 +361,62 @@ struct AssignmentSubmissionHistoryRow: Encodable {
     let gradeText: String
 }
 
+/// View context for the per-student, grouped-by-assignment view at
+/// `/:courseCode/students/:username/submissions`.  Each `StudentAssignmentRow`
+/// mirrors `TestSetupRow` from the student dashboard so the same per-row
+/// chrome (status / due / grade / latest submission / badges) renders the
+/// same way, with an extra Actions column carrying instructor-only
+/// affordances (Retest, inline extension form).
 struct CourseStudentSubmissionsContext: Encodable {
     let currentUser: CurrentUserContext?
     let studentName: String
     let studentUsername: String
+    let courseCode: String
     let courseName: String
     let backURL: String
-    let rows: [CourseStudentSubmissionRow]
+    let sections: [StudentAssignmentSectionContext]
+    let ungroupedRows: [StudentAssignmentRow]
+    let hasSections: Bool
+    let hasUngrouped: Bool
 }
 
-struct CourseStudentSubmissionRow: Encodable {
+struct StudentAssignmentSectionContext: Encodable {
+    let sectionID: String
+    let name: String
+    let rows: [StudentAssignmentRow]
+}
+
+struct StudentAssignmentRow: Encodable {
+    let assignmentID: String
+    let title: String
+    let status: String  // "open" | "closed"
+    let isOpen: Bool
+    let dueAtText: String?
+    let effectiveDueAtText: String?  // shown when an extension is active
+    let hasExtension: Bool
+    let extensionFormInput: String  // datetime-local prefill (extension or dueAt)
+    let extensionSavePath: String
+    let extensionDeletePath: String
+    let retestPath: String
+    let historyURL: String
+    let submissionCount: Int
+    let hasLatestSubmission: Bool
+    let latestSubmissionID: String
+    let latestSubmittedAtText: String
+    let additionalSubmissionCount: Int
+    let bestGradeText: String?
+    let badges: [AchievementBadge]
+}
+
+/// Per-student, per-assignment full submission history page.
+struct StudentAssignmentHistoryContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let studentName: String
+    let studentUsername: String
+    let courseCode: String
+    let assignmentID: String
     let assignmentTitle: String
-    let assignmentSubmissionsURL: String?
-    let submissionID: String
-    let attemptNumber: Int
-    let status: String
-    let submittedAt: String
-    let gradeText: String
-    let submissionFilename: String?
-    let canOpenInNotebook: Bool
-    let openInNotebookURL: String?
+    let backURL: String
+    let historyPath: String
+    let rows: [AssignmentSubmissionHistoryRow]
 }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+List.swift
@@ -87,6 +87,7 @@ extension AssignmentRoutes {
     func buildCourseRoster(
         req: Request,
         activeCourseUUID: UUID,
+        activeCourseCode: String,
         allSetupIDs: [String],
         fmt: DateFormatter,
         isoFormatter: ISO8601DateFormatter
@@ -127,7 +128,10 @@ extension AssignmentRoutes {
                     role: u.role,
                     lastSeenAtText: u.lastSeenAt.map { fmt.string(from: $0) } ?? "—",
                     lastSeenAtISO: u.lastSeenAt.map { isoFormatter.string(from: $0) },
-                    submissionsURL: "/instructor/students/\(id.uuidString)/submissions",
+                    submissionsURL: studentSubmissionsURL(
+                        courseCode: activeCourseCode,
+                        username: u.username
+                    ),
                     unenrollURL: "/courses/\(activeCourseUUID.uuidString)/unenroll/\(id.uuidString)",
                     isPending: false
                 )

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
@@ -1,0 +1,592 @@
+// APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
+//
+// Instructor-facing per-student, per-course views, scoped by the URL
+// segments `/:courseCode/students/:username/...`.
+//
+// Mirrors the student dashboard shape (one row per published assignment,
+// section grouping, latest submission + best grade + badges) and adds two
+// instructor actions per row: per-student retest, and an inline form to
+// grant / edit / revoke a deadline extension that lets that one student
+// keep submitting after the assignment-wide deadline.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension AssignmentRoutes {
+
+    // MARK: - GET /:courseCode/students/:username/submissions
+
+    @Sendable
+    func courseStudentSubmissionsPage(req: Request) async throws -> View {
+        let viewer = try req.auth.require(APIUser.self)
+        guard viewer.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "view student submissions")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        guard let courseID = course.id else {
+            throw WebAssignmentError.notFound(resource: "Course")
+        }
+
+        // Published assignments — i.e. those that have an APIAssignment row.
+        // Setups without an assignment are draft/unpublished and never appear
+        // in the student-facing dashboard, so they don't appear here either.
+        let assignments = try await APIAssignment.query(on: req.db)
+            .filter(\.$courseID == courseID)
+            .all()
+
+        let setupIDs = assignments.map(\.testSetupID)
+        let setupsByID: [String: APITestSetup]
+        if setupIDs.isEmpty {
+            setupsByID = [:]
+        } else {
+            let setups = try await APITestSetup.query(on: req.db)
+                .filter(\.$id ~~ Set(setupIDs))
+                .all()
+            setupsByID = Dictionary(
+                setups.compactMap { setup in setup.id.map { ($0, setup) } },
+                uniquingKeysWith: { first, _ in first }
+            )
+        }
+
+        // Submissions for this student across all published setups.
+        let submissions: [APISubmission]
+        if let studentUUID = student.id, !setupIDs.isEmpty {
+            submissions = try await APISubmission.query(on: req.db)
+                .filter(\.$userID == studentUUID)
+                .filter(\.$kind == APISubmission.Kind.student)
+                .filter(\.$testSetupID ~~ Set(setupIDs))
+                .sort(\.$submittedAt, .descending)
+                .all()
+        } else {
+            submissions = []
+        }
+        var submissionsBySetupID: [String: [APISubmission]] = [:]
+        for submission in submissions {
+            submissionsBySetupID[submission.testSetupID, default: []].append(submission)
+        }
+
+        let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
+            for: submissions.compactMap(\.id),
+            on: req.db
+        )
+
+        // Active extensions for this student in this course.
+        var extensionByAssignmentID: [UUID: APIAssignmentExtension] = [:]
+        if let studentUUID = student.id, !assignments.isEmpty {
+            let assignmentUUIDs = assignments.compactMap(\.id)
+            let extensions = try await APIAssignmentExtension.query(on: req.db)
+                .filter(\.$assignmentID ~~ Set(assignmentUUIDs))
+                .filter(\.$userID == studentUUID)
+                .all()
+            for row in extensions {
+                extensionByAssignmentID[row.assignmentID] = row
+            }
+        }
+
+        // Class-wide achievements held by this student across the course's setups.
+        var classBadgesBySetupID: [String: [AchievementBadge]] = [:]
+        if let studentUUID = student.id, !setupIDs.isEmpty {
+            let classAchievements = try await APIClassAchievement.query(on: req.db)
+                .filter(\.$userID == studentUUID)
+                .filter(\.$testSetupID ~~ Set(setupIDs))
+                .all()
+            for achievement in classAchievements {
+                if let badge = AchievementBadge.forClassAchievement(achievement.achievementID) {
+                    classBadgesBySetupID[achievement.testSetupID, default: []].append(badge)
+                }
+            }
+        }
+
+        let fmt = waterlooDateTimeFormatter()
+
+        // Sort comparator matches the student dashboard (`WebRoutes.swift`):
+        // sortOrder → createdAt → id.
+        let sortedAssignments = assignments.sorted { lhs, rhs in
+            let lhsOrder = lhs.sortOrder
+            let rhsOrder = rhs.sortOrder
+            if let l = lhsOrder, let r = rhsOrder, l != r { return l < r }
+            let lhsCreated = setupsByID[lhs.testSetupID]?.createdAt ?? .distantPast
+            let rhsCreated = setupsByID[rhs.testSetupID]?.createdAt ?? .distantPast
+            if lhsCreated != rhsCreated { return lhsCreated > rhsCreated }
+            return lhs.testSetupID < rhs.testSetupID
+        }
+
+        let rows = sortedAssignments.map { assignment in
+            buildStudentAssignmentRow(
+                assignment: assignment,
+                courseCode: course.code,
+                username: student.username,
+                history: submissionsBySetupID[assignment.testSetupID] ?? [],
+                preferredResultBySubmissionID: preferredResultBySubmissionID,
+                classBadges: classBadgesBySetupID[assignment.testSetupID] ?? [],
+                activeExtension: assignment.id.flatMap { extensionByAssignmentID[$0] },
+                student: student,
+                fmt: fmt
+            )
+        }
+
+        // Group by course section, just like the student dashboard.
+        let allSections = try await APICourseSection.query(on: req.db)
+            .filter(\.$courseID == courseID)
+            .sort(\.$sortOrder, .ascending)
+            .all()
+        let sectionByAssignmentID: [String: UUID] = Dictionary(
+            assignments.compactMap { a -> (String, UUID)? in
+                guard let sid = a.sectionID else { return nil }
+                return (a.publicID, sid)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var rowsBySectionID: [UUID: [StudentAssignmentRow]] = [:]
+        var ungroupedRows: [StudentAssignmentRow] = []
+        for row in rows {
+            if let sID = sectionByAssignmentID[row.assignmentID] {
+                rowsBySectionID[sID, default: []].append(row)
+            } else {
+                ungroupedRows.append(row)
+            }
+        }
+        let sectionContexts: [StudentAssignmentSectionContext] = allSections.compactMap { section in
+            guard let sID = section.id else { return nil }
+            let sectionRows = rowsBySectionID[sID] ?? []
+            guard !sectionRows.isEmpty else { return nil }
+            return StudentAssignmentSectionContext(
+                sectionID: sID.uuidString,
+                name: section.name,
+                rows: sectionRows
+            )
+        }
+
+        return try await req.view.render(
+            "course-student-submissions",
+            CourseStudentSubmissionsContext(
+                currentUser: req.currentUserContext,
+                studentName: student.displayName ?? student.username,
+                studentUsername: student.username,
+                courseCode: course.code,
+                courseName: "\(course.code) — \(course.name)",
+                backURL: "/instructor",
+                sections: sectionContexts,
+                ungroupedRows: ungroupedRows,
+                hasSections: !allSections.isEmpty,
+                hasUngrouped: !ungroupedRows.isEmpty
+            )
+        )
+    }
+
+    // MARK: - GET /:courseCode/students/:username/assignments/:assignmentID/history
+
+    @Sendable
+    func studentAssignmentHistoryPage(req: Request) async throws -> View {
+        let viewer = try req.auth.require(APIUser.self)
+        guard viewer.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "view student submission history")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+
+        let submissions: [APISubmission]
+        if let studentUUID = student.id {
+            submissions = try await APISubmission.query(on: req.db)
+                .filter(\.$testSetupID == assignment.testSetupID)
+                .filter(\.$userID == studentUUID)
+                .filter(\.$kind == APISubmission.Kind.student)
+                .sort(\.$submittedAt, .descending)
+                .all()
+        } else {
+            submissions = []
+        }
+        let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
+            for: submissions.compactMap(\.id),
+            on: req.db
+        )
+
+        let fmt = waterlooDateTimeFormatter()
+        let rows = submissions.map { submission -> AssignmentSubmissionHistoryRow in
+            let subID = submission.id ?? ""
+            let gradeText: String
+            if let result = preferredResultBySubmissionID[subID],
+                let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+            {
+                gradeText = "\(pct)%"
+            } else {
+                gradeText = "—"
+            }
+            return AssignmentSubmissionHistoryRow(
+                submissionID: subID,
+                attemptNumber: submission.attemptNumber ?? 1,
+                status: submission.status,
+                submittedAt: submission.submittedAt.map { fmt.string(from: $0) } ?? "—",
+                gradeText: gradeText
+            )
+        }
+
+        let backURL = StudentCoursePaths.submissions(
+            courseCode: course.code,
+            username: student.username
+        )
+        let historyPath = StudentCoursePaths.assignmentHistory(
+            courseCode: course.code,
+            username: student.username,
+            assignmentID: assignmentIDRaw
+        )
+
+        return try await req.view.render(
+            "student-assignment-history",
+            StudentAssignmentHistoryContext(
+                currentUser: req.currentUserContext,
+                studentName: student.displayName ?? student.username,
+                studentUsername: student.username,
+                courseCode: course.code,
+                assignmentID: assignmentIDRaw,
+                assignmentTitle: assignment.title,
+                backURL: backURL,
+                historyPath: historyPath,
+                rows: rows
+            )
+        )
+    }
+
+    // MARK: - POST /:courseCode/students/:username/assignments/:assignmentID/retest
+
+    @Sendable
+    func retestStudentAssignment(req: Request) async throws -> Response {
+        let actor = try req.auth.require(APIUser.self)
+        guard actor.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "retest student submissions")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id,
+            let studentID = student.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+
+        let count = try await retestStudentSubmissionsForSetup(
+            setupID: assignment.testSetupID,
+            studentUserID: studentID,
+            triggeredBy: actor.id,
+            on: req.db,
+            force: true
+        )
+
+        req.logger.info(
+            "retest_student_triggered assignment=\(assignmentIDRaw) student=\(student.username) count=\(count) by=\(actor.id?.uuidString ?? "nil")"
+        )
+        await AuditLogger.record(
+            action: .submissionRetestForStudent,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: [
+                "assignment": assignmentIDRaw,
+                "student_username": student.username,
+                "submission_count": String(count),
+            ],
+            on: req
+        )
+
+        return req.redirect(
+            to: StudentCoursePaths.submissions(
+                courseCode: course.code,
+                username: student.username
+            )
+        )
+    }
+
+    // MARK: - POST /:courseCode/students/:username/assignments/:assignmentID/extension
+
+    @Sendable
+    func saveStudentAssignmentExtension(req: Request) async throws -> Response {
+        struct ExtensionBody: Content {
+            var extendedDueAt: String?
+            var note: String?
+        }
+
+        let actor = try req.auth.require(APIUser.self)
+        guard actor.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "grant deadline extensions")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id,
+            let assignmentUUID = assignment.id,
+            let studentUUID = student.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+
+        let body = try req.content.decode(ExtensionBody.self)
+        let rawDate = (body.extendedDueAt ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawDate.isEmpty,
+            let newDueAt = parseLocalInputDate(rawDate)
+        else {
+            throw WebAssignmentError.invalidParameter(
+                name: "extendedDueAt",
+                reason: "Provide a valid date and time in the form's input."
+            )
+        }
+        let trimmedNote = body.note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let note = (trimmedNote?.isEmpty == false) ? trimmedNote : nil
+
+        let existing = try await APIAssignmentExtension.query(on: req.db)
+            .filter(\.$assignmentID == assignmentUUID)
+            .filter(\.$userID == studentUUID)
+            .first()
+
+        if let existing {
+            existing.extendedDueAt = newDueAt
+            existing.note = note
+            existing.grantedByUserID = actor.id
+            try await existing.save(on: req.db)
+        } else {
+            let row = APIAssignmentExtension(
+                assignmentID: assignmentUUID,
+                userID: studentUUID,
+                extendedDueAt: newDueAt,
+                note: note,
+                grantedByUserID: actor.id
+            )
+            try await row.save(on: req.db)
+        }
+
+        await AuditLogger.record(
+            action: .extensionGranted,
+            targetType: .assignment,
+            targetID: assignmentUUID.uuidString,
+            metadata: [
+                "assignment": assignmentIDRaw,
+                "student_username": student.username,
+                "extended_due_at": ISO8601DateFormatter().string(from: newDueAt),
+            ],
+            on: req
+        )
+
+        return req.redirect(
+            to: StudentCoursePaths.submissions(
+                courseCode: course.code,
+                username: student.username
+            )
+        )
+    }
+
+    // MARK: - POST /:courseCode/students/:username/assignments/:assignmentID/extension/delete
+
+    @Sendable
+    func deleteStudentAssignmentExtension(req: Request) async throws -> Response {
+        let actor = try req.auth.require(APIUser.self)
+        guard actor.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "revoke deadline extensions")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id,
+            let assignmentUUID = assignment.id,
+            let studentUUID = student.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+
+        let existing = try await APIAssignmentExtension.query(on: req.db)
+            .filter(\.$assignmentID == assignmentUUID)
+            .filter(\.$userID == studentUUID)
+            .first()
+        if let existing {
+            try await existing.delete(on: req.db)
+            await AuditLogger.record(
+                action: .extensionRevoked,
+                targetType: .assignment,
+                targetID: assignmentUUID.uuidString,
+                metadata: [
+                    "assignment": assignmentIDRaw,
+                    "student_username": student.username,
+                ],
+                on: req
+            )
+        }
+
+        return req.redirect(
+            to: StudentCoursePaths.submissions(
+                courseCode: course.code,
+                username: student.username
+            )
+        )
+    }
+}
+
+// MARK: - Private helpers
+
+extension AssignmentRoutes {
+    /// Resolves `(course, student)` from `:courseCode` + `:username`.
+    /// Throws `WebAssignmentError.notFound` if either side is missing OR if
+    /// the student is not currently enrolled in the course (matches the
+    /// instructor dashboard's clickability rule).  Enrollment, not role,
+    /// gates this — an instructor enrolled for testing should be reachable
+    /// via the same path the dashboard exposes for them.
+    fileprivate func resolveCourseAndStudent(req: Request) async throws -> (APICourse, APIUser) {
+        guard let courseCodeRaw = req.parameters.get("courseCode"),
+            let usernameRaw = req.parameters.get("username")
+        else {
+            throw WebAssignmentError.notFound(resource: "Course or student")
+        }
+        let courseCode = courseCodeRaw.lowercased()
+        let course =
+            try await APICourse.query(on: req.db)
+            .filter(\.$isArchived == false)
+            .all()
+            .first(where: { $0.code.lowercased() == courseCode })
+        guard let course, let courseUUID = course.id else {
+            throw WebAssignmentError.notFound(resource: "Course '\(courseCodeRaw)'")
+        }
+        guard
+            let student = try await APIUser.query(on: req.db)
+                .filter(\.$username == usernameRaw)
+                .first()
+        else {
+            throw WebAssignmentError.notFound(resource: "Student '\(usernameRaw)'")
+        }
+        let isEnrolled =
+            try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseUUID)
+            .filter(\.$userID == student.id ?? UUID())
+            .count() > 0
+        guard isEnrolled else {
+            throw WebAssignmentError.notFound(resource: "Enrolled student '\(usernameRaw)'")
+        }
+        return (course, student)
+    }
+
+    fileprivate func buildStudentAssignmentRow(
+        assignment: APIAssignment,
+        courseCode: String,
+        username: String,
+        history: [APISubmission],
+        preferredResultBySubmissionID: [String: APIResult],
+        classBadges: [AchievementBadge],
+        activeExtension: APIAssignmentExtension?,
+        student: APIUser,
+        fmt: DateFormatter
+    ) -> StudentAssignmentRow {
+        let latest = history.first
+        let bestGradePercent: Int? = {
+            var best = -1
+            for submission in history {
+                guard let subID = submission.id,
+                    let result = preferredResultBySubmissionID[subID],
+                    let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+                else {
+                    continue
+                }
+                if pct > best { best = pct }
+            }
+            return best >= 0 ? best : nil
+        }()
+
+        var badges: [AchievementBadge] = []
+        if let latestSubmission = latest,
+            let latestSubID = latestSubmission.id,
+            let result = preferredResultBySubmissionID[latestSubID],
+            let collection = visibleCollection(
+                from: result.collectionJSON,
+                for: student,
+                assignment: assignment
+            ),
+            let gradePct = gradePercent(from: collection)
+        {
+            let latestAttempt = latestSubmission.attemptNumber ?? 1
+            let priorSub = history.first(where: { $0.attemptNumber == latestAttempt - 1 })
+            let priorPct: Int? = priorSub.flatMap { ps in
+                guard let psID = ps.id, let pr = preferredResultBySubmissionID[psID] else {
+                    return nil
+                }
+                return gradePercentFromCollectionJSON(pr.collectionJSON)
+            }
+            badges.append(
+                contentsOf: AchievementBadge.forSubmission(
+                    BadgeContext(
+                        attemptNumber: latestAttempt,
+                        gradePercent: gradePct,
+                        executionTimeMs: collection.executionTimeMs,
+                        priorGradePercent: priorPct
+                    )
+                )
+            )
+        }
+        badges.append(contentsOf: classBadges)
+
+        let dueAtText = assignment.dueAt.map { fmt.string(from: $0) }
+        let extensionDueAt = activeExtension?.extendedDueAt
+        let effectiveDueAtText: String? = {
+            guard let extDate = extensionDueAt else { return nil }
+            return fmt.string(from: extDate)
+        }()
+        let formInput = dueAtLocalInputString(extensionDueAt ?? assignment.dueAt)
+
+        return StudentAssignmentRow(
+            assignmentID: assignment.publicID,
+            title: assignment.title,
+            status: assignment.isOpen ? "open" : "closed",
+            isOpen: assignment.isOpen,
+            dueAtText: dueAtText,
+            effectiveDueAtText: effectiveDueAtText,
+            hasExtension: activeExtension != nil,
+            extensionFormInput: formInput,
+            extensionSavePath: StudentCoursePaths.extensionSave(
+                courseCode: courseCode,
+                username: username,
+                assignmentID: assignment.publicID
+            ),
+            extensionDeletePath: StudentCoursePaths.extensionDelete(
+                courseCode: courseCode,
+                username: username,
+                assignmentID: assignment.publicID
+            ),
+            retestPath: StudentCoursePaths.retest(
+                courseCode: courseCode,
+                username: username,
+                assignmentID: assignment.publicID
+            ),
+            historyURL: StudentCoursePaths.assignmentHistory(
+                courseCode: courseCode,
+                username: username,
+                assignmentID: assignment.publicID
+            ),
+            submissionCount: history.count,
+            hasLatestSubmission: latest != nil,
+            latestSubmissionID: latest?.id ?? "",
+            latestSubmittedAtText: latest?.submittedAt.map { fmt.string(from: $0) } ?? "—",
+            additionalSubmissionCount: max(history.count - 1, 0),
+            bestGradeText: bestGradePercent.map { "\($0)%" },
+            badges: badges
+        )
+    }
+}
+
+/// Parses an HTML5 `datetime-local` input value (e.g. `"2026-05-20T23:59"`)
+/// into a `Date`.  Both with and without seconds are accepted; the value is
+/// interpreted in the Waterloo timezone, matching the rest of the UI.
+func parseLocalInputDate(_ input: String) -> Date? {
+    let tz = TimeZone(identifier: "America/Toronto") ?? .current
+    let candidates = ["yyyy-MM-dd'T'HH:mm", "yyyy-MM-dd'T'HH:mm:ss"]
+    for fmt in candidates {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = tz
+        df.dateFormat = fmt
+        if let d = df.date(from: input) { return d }
+    }
+    return nil
+}

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
@@ -156,111 +156,6 @@ extension AssignmentRoutes {
     // MARK: - GET /instructor/:assignmentID/submissions
 
     @Sendable
-    func courseStudentSubmissionsPage(req: Request) async throws -> View {
-        let user = try req.auth.require(APIUser.self)
-        let courseState = try await req.resolveActiveCourse(for: user)
-        guard
-            let activeCourse = courseState.active,
-            let activeCourseUUID = courseState.activeCourseUUID,
-            let studentIDRaw = req.parameters.get("studentID"),
-            let studentID = UUID(uuidString: studentIDRaw)
-        else {
-            throw WebAssignmentError.noActiveCourse(action: "viewing student submissions")
-        }
-
-        // Any enrolled user (student, instructor enrolled for testing, admin)
-        // can have submissions in the course; gate only on enrollment, not on
-        // role. The dashboard roster table lists all enrolled users, so this
-        // mirrors what's clickable there.
-        let isEnrolled =
-            try await APICourseEnrollment.query(on: req.db)
-            .filter(\.$course.$id == activeCourseUUID)
-            .filter(\.$userID == studentID)
-            .count() > 0
-        guard
-            isEnrolled,
-            let student = try await APIUser.find(studentID, on: req.db)
-        else {
-            throw WebAssignmentError.notFound(resource: "Student")
-        }
-
-        let setups = try await APITestSetup.query(on: req.db)
-            .filter(\.$courseID == activeCourseUUID)
-            .all()
-        let setupIDs = Set(setups.compactMap(\.id))
-        let assignments =
-            setupIDs.isEmpty
-            ? []
-            : try await APIAssignment.query(on: req.db)
-                .filter(\.$testSetupID ~~ setupIDs)
-                .all()
-        let assignmentBySetupID = Dictionary(
-            assignments.map { ($0.testSetupID, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
-
-        let submissions =
-            setupIDs.isEmpty
-            ? []
-            : try await APISubmission.query(on: req.db)
-                .filter(\.$userID == studentID)
-                .filter(\.$kind == APISubmission.Kind.student)
-                .filter(\.$testSetupID ~~ setupIDs)
-                .sort(\.$submittedAt, .descending)
-                .all()
-        let submissionIDs = submissions.compactMap(\.id)
-        let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
-            for: submissionIDs,
-            on: req.db
-        )
-
-        let fmt = waterlooDateTimeFormatter()
-        let rows = submissions.map { submission -> CourseStudentSubmissionRow in
-            let submissionID = submission.id ?? ""
-            let assignment = assignmentBySetupID[submission.testSetupID]
-            let gradeText: String
-            if let result = preferredResultBySubmissionID[submissionID],
-                let pct = gradePercentFromCollectionJSON(result.collectionJSON)
-            {
-                gradeText = "\(pct)%"
-            } else {
-                gradeText = "—"
-            }
-            let pathExt = URL(fileURLWithPath: submission.zipPath).pathExtension.lowercased()
-            let nameExt = (submission.filename ?? "").lowercased()
-            let canOpenInNotebook = pathExt == "ipynb" || nameExt.hasSuffix(".ipynb")
-            let openInNotebookURL =
-                canOpenInNotebook
-                ? "/testsetups/\(submission.testSetupID)/notebook?submissionID=\(submissionID)"
-                : nil
-            return CourseStudentSubmissionRow(
-                assignmentTitle: assignment?.title ?? "Unpublished setup",
-                assignmentSubmissionsURL: assignment.map { "/instructor/\($0.publicID)/submissions" },
-                submissionID: submissionID,
-                attemptNumber: submission.attemptNumber ?? 1,
-                status: submission.status,
-                submittedAt: submission.submittedAt.map { fmt.string(from: $0) } ?? "—",
-                gradeText: gradeText,
-                submissionFilename: submission.filename,
-                canOpenInNotebook: canOpenInNotebook,
-                openInNotebookURL: openInNotebookURL
-            )
-        }
-
-        return try await req.view.render(
-            "course-student-submissions",
-            CourseStudentSubmissionsContext(
-                currentUser: req.currentUserContext,
-                studentName: student.displayName ?? student.username,
-                studentUsername: student.username,
-                courseName: "\(activeCourse.code) — \(activeCourse.name)",
-                backURL: "/instructor",
-                rows: rows
-            )
-        )
-    }
-
-    @Sendable
     func assignmentSubmissionsPage(req: Request) async throws -> View {
         let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
         guard let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db) else {
@@ -490,15 +385,11 @@ extension AssignmentRoutes {
                 name: "submissionID", reason: "Only student submissions can be re-tested.")
         }
 
-        // Prevent duplicate queue entries for in-flight jobs.
-        if submission.status != "pending" && submission.status != "assigned" {
-            submission.status = "pending"
-            submission.workerID = nil
-            submission.assignedAt = nil
-            submission.retestedAt = Date()
-            submission.retestedByUserID = user.id
-            try await submission.save(on: req.db)
-        }
+        _ = try await flipSubmissionToPending(
+            submission,
+            triggeredBy: user.id,
+            on: req.db
+        )
 
         let body = try? req.content.decode(RetestBody.self)
         let fallbackPath = "/instructor/\(assignmentIDRaw)/submissions"
@@ -647,7 +538,7 @@ extension AssignmentRoutes {
     }
 }
 
-private extension AssignmentRoutes {
+extension AssignmentRoutes {
     func preferredResultsBySubmissionID(
         for submissionIDs: [String],
         on db: Database

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -34,11 +34,33 @@ struct AssignmentRoutes: RouteCollection {
         routes.post("courses", ":courseID", "unenroll", ":userID", use: instructorUnenrollUser)
         routes.post("courses", ":courseID", "pre-unenroll", ":preEnrollmentID", use: instructorCancelPreEnrollment)
 
+        // Per-course, per-student grouped submissions view + drilldown.
+        // Lives outside the `/instructor` prefix so the URL carries the
+        // course code; the literal `students` second segment routes ahead
+        // of the vanity catch-all `/:courseCode/:assignmentSlug`.
+        routes.get(":courseCode", "students", ":username", "submissions", use: courseStudentSubmissionsPage)
+        routes.get(
+            ":courseCode", "students", ":username", "assignments", ":assignmentID", "history",
+            use: studentAssignmentHistoryPage
+        )
+        routes.post(
+            ":courseCode", "students", ":username", "assignments", ":assignmentID", "retest",
+            use: retestStudentAssignment
+        )
+        routes.post(
+            ":courseCode", "students", ":username", "assignments", ":assignmentID", "extension",
+            use: saveStudentAssignmentExtension
+        )
+        routes.post(
+            ":courseCode", "students", ":username", "assignments", ":assignmentID", "extension",
+            "delete",
+            use: deleteStudentAssignmentExtension
+        )
+
         let r = routes.grouped("instructor")
         r.get(use: list)
         r.get("grades.csv", use: exportGradesCSV)
         r.get("enroll-csv", use: enrollCSVForm)
-        r.get("students", ":studentID", "submissions", use: courseStudentSubmissionsPage)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
         r.get(":assignmentID", "students", ":studentID", "history", use: studentSubmissionHistoryPage)
         r.post(":assignmentID", "submissions", ":submissionID", "retest", use: retestSubmission)
@@ -190,6 +212,7 @@ struct AssignmentRoutes: RouteCollection {
             roster = try await buildCourseRoster(
                 req: req,
                 activeCourseUUID: activeCourseUUID,
+                activeCourseCode: courseState.active?.code ?? "",
                 allSetupIDs: allSetupIDs,
                 fmt: fmt,
                 isoFormatter: isoFormatter

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -159,18 +159,78 @@ func retestAllSubmissionsForSetup(
     let now = Date()
     var touched = 0
     for submission in submissions {
-        if !force && (submission.status == "pending" || submission.status == "assigned") {
-            continue
+        if try await flipSubmissionToPending(
+            submission,
+            triggeredBy: userID,
+            on: db,
+            force: force,
+            now: now
+        ) {
+            touched += 1
         }
-        submission.status = "pending"
-        submission.workerID = nil
-        submission.assignedAt = nil
-        submission.retestedAt = now
-        submission.retestedByUserID = userID
-        try await submission.save(on: db)
-        touched += 1
     }
     return touched
+}
+
+/// Retests every `kind == .student` submission on `setupID` for one user
+/// only (used by the per-student × per-assignment Retest button).  Skips
+/// `kind == .validation` and other students' submissions.  Honours the
+/// same "already in flight" skip rule as `retestAllSubmissionsForSetup`
+/// unless `force = true`.
+///
+/// Returns the number of submissions whose status was flipped to pending.
+@discardableResult
+func retestStudentSubmissionsForSetup(
+    setupID: String,
+    studentUserID: UUID,
+    triggeredBy userID: UUID?,
+    on db: Database,
+    force: Bool = false
+) async throws -> Int {
+    let submissions = try await APISubmission.query(on: db)
+        .filter(\.$testSetupID == setupID)
+        .filter(\.$userID == studentUserID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .all()
+
+    let now = Date()
+    var touched = 0
+    for submission in submissions {
+        if try await flipSubmissionToPending(
+            submission,
+            triggeredBy: userID,
+            on: db,
+            force: force,
+            now: now
+        ) {
+            touched += 1
+        }
+    }
+    return touched
+}
+
+/// Flips one submission back to `pending` for the worker queue.  Returns
+/// true when the row was actually mutated; false when `force == false`
+/// and the row was already in flight (`pending`/`assigned`).  Stamps
+/// `retested_at` and `retested_by_user_id` for traceability.
+@discardableResult
+func flipSubmissionToPending(
+    _ submission: APISubmission,
+    triggeredBy userID: UUID?,
+    on db: Database,
+    force: Bool = false,
+    now: Date = Date()
+) async throws -> Bool {
+    if !force && (submission.status == "pending" || submission.status == "assigned") {
+        return false
+    }
+    submission.status = "pending"
+    submission.workerID = nil
+    submission.assignedAt = nil
+    submission.retestedAt = now
+    submission.retestedByUserID = userID
+    try await submission.save(on: db)
+    return true
 }
 
 func waitForRunnerValidation(

--- a/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
+++ b/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
@@ -1,0 +1,82 @@
+// APIServer/Routes/Web/StudentCoursePaths.swift
+//
+// One-stop builder for the `/:courseCode/students/:username/...` URL family
+// introduced for the instructor "per-student grouped submissions" view.
+// Centralising the formatting keeps the route registration, the inbound
+// links (instructor dashboard roster), and the redirects after POSTs in
+// agreement.  All paths are URL-encoded so course codes / usernames with
+// unusual characters don't break the links.
+
+import Foundation
+
+enum StudentCoursePaths {
+    /// Grouped submissions page — `/:courseCode/students/:username/submissions`.
+    static func submissions(courseCode: String, username: String) -> String {
+        "/\(encode(courseCode))/students/\(encode(username))/submissions"
+    }
+
+    /// Per-assignment history drilldown for one student.
+    static func assignmentHistory(
+        courseCode: String,
+        username: String,
+        assignmentID: String
+    ) -> String {
+        "\(submissions(courseCode: courseCode, username: username))"
+            .replacingOccurrences(of: "/submissions", with: "")
+            + "/assignments/\(encode(assignmentID))/history"
+    }
+
+    /// POST target — retest every submission the student has on one assignment.
+    static func retest(
+        courseCode: String,
+        username: String,
+        assignmentID: String
+    ) -> String {
+        baseAssignmentPath(
+            courseCode: courseCode,
+            username: username,
+            assignmentID: assignmentID
+        ) + "/retest"
+    }
+
+    /// POST target — upsert an extension for one student × one assignment.
+    static func extensionSave(
+        courseCode: String,
+        username: String,
+        assignmentID: String
+    ) -> String {
+        baseAssignmentPath(
+            courseCode: courseCode,
+            username: username,
+            assignmentID: assignmentID
+        ) + "/extension"
+    }
+
+    /// POST target — remove an existing extension.
+    static func extensionDelete(
+        courseCode: String,
+        username: String,
+        assignmentID: String
+    ) -> String {
+        extensionSave(courseCode: courseCode, username: username, assignmentID: assignmentID)
+            + "/delete"
+    }
+
+    private static func baseAssignmentPath(
+        courseCode: String,
+        username: String,
+        assignmentID: String
+    ) -> String {
+        "/\(encode(courseCode))/students/\(encode(username))/assignments/\(encode(assignmentID))"
+    }
+
+    private static func encode(_ component: String) -> String {
+        component.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? component
+    }
+}
+
+/// Shorthand wrapper kept lowercase to match call sites that reach for a
+/// "build the URL" helper without remembering the type name.
+func studentSubmissionsURL(courseCode: String, username: String) -> String {
+    StudentCoursePaths.submissions(courseCode: courseCode, username: username)
+}

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -34,6 +34,15 @@ struct TestSetupRow: Encodable {
     let additionalSubmissionCount: Int
     let bestGradeText: String?
     let badges: [AchievementBadge]
+    /// True when this student has an active deadline extension on this
+    /// assignment.  Used by the template to show the Submit button and
+    /// surface the effective deadline even when the assignment-wide
+    /// deadline has passed.
+    let hasActiveExtension: Bool
+    /// Formatted deadline that actually applies to this user (assignment
+    /// `dueAt` or the extension's `extendedDueAt`, whichever is later).
+    /// nil when there's no deadline and no extension.
+    let effectiveDueAtText: String?
 }
 
 struct LatestSubmissionItem: Encodable {

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -116,7 +116,7 @@ extension WebRoutes {
             return req.redirect(to: "/testsetups/\(setupID)/notebook")
         }
 
-        _ = try await requireOpenStudentAssignment(for: setupID, on: req)
+        _ = try await requireOpenStudentAssignment(for: setupID, user: user, on: req)
 
         let body = try req.content.decode(SubmitFormBody.self)
         let subsDir = req.application.submissionsDirectory

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -110,6 +110,27 @@ struct WebRoutes: RouteCollection {
         var submissionCountBySetupID: [String: Int] = [:]
         var bestGradePercentBySetupID: [String: Int] = [:]
         var latestBadgesBySetupID: [String: [AchievementBadge]] = [:]
+        // Per-user active extensions for the current user, keyed by
+        // testSetupID (since the dashboard works in setup space; we look
+        // up the assignment for each row separately).
+        var extensionDueAtBySetupID: [String: Date] = [:]
+        if let userID = user.id, !allAssignments.isEmpty {
+            let assignmentIDs = allAssignments.compactMap(\.id)
+            let extensions = try await APIAssignmentExtension.query(on: req.db)
+                .filter(\.$assignmentID ~~ Set(assignmentIDs))
+                .filter(\.$userID == userID)
+                .all()
+            let setupIDByAssignmentID = Dictionary(
+                uniqueKeysWithValues: allAssignments.compactMap { a -> (UUID, String)? in
+                    guard let id = a.id else { return nil }
+                    return (id, a.testSetupID)
+                }
+            )
+            for row in extensions {
+                guard let setupID = setupIDByAssignmentID[row.assignmentID] else { continue }
+                extensionDueAtBySetupID[setupID] = row.extendedDueAt
+            }
+        }
         if let userID = user.id {
             let setupIDs = setups.compactMap(\.id)
             if !setupIDs.isEmpty {
@@ -267,6 +288,30 @@ struct WebRoutes: RouteCollection {
                 else { return nil }
                 return VanityURLRoutes.vanityPath(courseCode: courseCode, assignmentSlug: assignment.slug)
             }()
+            // Active extension for this student on this assignment.  Drives
+            // the Submit button and Due column when the assignment-wide
+            // deadline has passed but this user retains submit privileges.
+            let extensionDueAt = extensionDueAtBySetupID[setupID]
+            let baselineDueAt = assignment?.dueAt
+            let hasActiveExtension: Bool = {
+                guard let extDate = extensionDueAt else { return false }
+                if let baseline = baselineDueAt, extDate <= baseline { return false }
+                return Date() < extDate
+            }()
+            let isOpenForThisUser: Bool = {
+                guard let assignment else { return false }
+                if !assignment.isOpen { return false }
+                if let dueAt = assignment.dueAt, dueAt <= Date() {
+                    if assignment.deadlineOverrideActive == true { return true }
+                    return hasActiveExtension
+                }
+                return true
+            }()
+            let effectiveDueAt: Date? = {
+                guard let extDate = extensionDueAt else { return baselineDueAt }
+                guard let baseline = baselineDueAt else { return extDate }
+                return max(extDate, baseline)
+            }()
             return TestSetupRow(
                 id: setupID,
                 title: assignment?.title,
@@ -277,7 +322,7 @@ struct WebRoutes: RouteCollection {
                 createdAt: setup.createdAt.map { fmt.string(from: $0) } ?? "—",
                 dueAt: assignment?.dueAt.map { fmt.string(from: $0) },
                 status: status,
-                isOpen: assignment?.isOpen ?? false,
+                isOpen: isOpenForThisUser,
                 gradingMode: props?.gradingMode.rawValue ?? GradingMode.worker.rawValue,
                 hasNotebook: hasNotebook,
                 submissionCount: submissionCount,
@@ -286,7 +331,9 @@ struct WebRoutes: RouteCollection {
                 latestSubmittedAtText: latestSubmission?.submittedAtText ?? "—",
                 additionalSubmissionCount: max(submissionCount - 1, 0),
                 bestGradeText: bestGradePercentBySetupID[setupID].map { "\($0)%" },
-                badges: latestBadgesBySetupID[setupID] ?? []
+                badges: latestBadgesBySetupID[setupID] ?? [],
+                hasActiveExtension: hasActiveExtension,
+                effectiveDueAtText: effectiveDueAt.map { fmt.string(from: $0) }
             )
         }
 

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -35,6 +35,53 @@ func isAssignmentEffectivelyOpen(_ assignment: APIAssignment, now: Date = Date()
     return assignmentDeadlineOverrideIsActive(assignment)
 }
 
+/// Returns the deadline that actually applies to `user` for `assignment`,
+/// consulting per-student extension rows.  A user with no extension gets
+/// the assignment-wide `dueAt`; with an extension, the later of the two.
+/// Returns nil only when the assignment has no deadline at all.
+func effectiveDueAt(
+    for assignment: APIAssignment,
+    user: APIUser,
+    on db: Database
+) async throws -> Date? {
+    let baseline = assignment.dueAt
+    guard let assignmentID = assignment.id, let userID = user.id else {
+        return baseline
+    }
+    guard
+        let extensionRow = try await APIAssignmentExtension.query(on: db)
+            .filter(\.$assignmentID == assignmentID)
+            .filter(\.$userID == userID)
+            .first()
+    else {
+        return baseline
+    }
+    if let baseline {
+        return max(baseline, extensionRow.extendedDueAt)
+    }
+    return extensionRow.extendedDueAt
+}
+
+/// Per-user variant of `isAssignmentEffectivelyOpen`.  An active extension
+/// keeps submission open for one student even after the assignment-wide
+/// deadline has passed.  The assignment's `isOpen` flag is still respected
+/// — if an instructor manually closed an assignment, an extension does not
+/// reopen it.
+func isAssignmentEffectivelyOpen(
+    _ assignment: APIAssignment,
+    for user: APIUser,
+    on db: Database,
+    now: Date = Date()
+) async throws -> Bool {
+    guard assignment.isOpen else { return false }
+    if !assignmentDeadlineHasPassed(assignment, now: now) { return true }
+    if assignmentDeadlineOverrideIsActive(assignment) { return true }
+    guard let effective = try await effectiveDueAt(for: assignment, user: user, on: db) else {
+        return false
+    }
+    return now < effective
+}
+
 @discardableResult
 func closeAssignmentIfExpired(
     _ assignment: APIAssignment,
@@ -78,6 +125,7 @@ func closeExpiredAssignments(
 
 func requireOpenStudentAssignment(
     for testSetupID: String,
+    user: APIUser,
     on req: Request,
     now: Date = Date()
 ) async throws -> APIAssignment? {
@@ -90,7 +138,8 @@ func requireOpenStudentAssignment(
     }
 
     _ = try await closeAssignmentIfExpired(assignment, on: req.db, logger: req.logger, now: now)
-    guard isAssignmentEffectivelyOpen(assignment, now: now) else {
+    let open = try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db, now: now)
+    guard open else {
         throw AssignmentSubmissionGateError.closed
     }
     return assignment

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -216,4 +216,5 @@ func registerMigrations(on app: Application) {
     app.migrations.add(AddSessionsCreatedAt())
     app.migrations.add(CreateAuditLog())
     app.migrations.add(AddJobExecutionCacheHit())
+    app.migrations.add(CreateAssignmentExtensions())
 }

--- a/Tests/APITests/AssignmentExtensionsTests.swift
+++ b/Tests/APITests/AssignmentExtensionsTests.swift
@@ -1,0 +1,292 @@
+// Tests/APITests/AssignmentExtensionsTests.swift
+//
+// Coverage for the per-student deadline extension feature introduced
+// alongside the grouped /:courseCode/students/:username/submissions page.
+//
+//  * Extension upsert (POST extension)            → row exists with new date.
+//  * Extension upsert (overwrite)                 → row updated, no duplicate.
+//  * Extension delete                             → row gone.
+//  * isAssignmentEffectivelyOpen(for:on:) gate    → respects extension.
+//  * Scoped retest (one student × one assignment) → flips only that student.
+
+import Core
+import Fluent
+import Foundation
+import XCTVapor
+import XCTest
+
+@testable import chickadee_server
+
+final class AssignmentExtensionsTests: AssignmentRoutesTestCase {
+
+    // MARK: - Extension upsert
+
+    func testExtensionPostCreatesAndUpdatesRow() async throws {
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+        let student = try await insertStudent(username: "ext_student")
+        try await enrollStudentInTestCourse(student)
+
+        try await insertSetup(id: "ext_setup")
+        let pastDeadline = Date().addingTimeInterval(-3_600)  // 1h ago
+        let assignment = try await insertAssignment(
+            testSetupID: "ext_setup",
+            title: "Closed by deadline",
+            isOpen: true,
+            dueAt: pastDeadline
+        )
+
+        // Pick a date 1 day in the future, formatted for `datetime-local`.
+        let future = Date().addingTimeInterval(86_400)
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone(identifier: "America/Toronto")
+        fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
+        let futureInput = fmt.string(from: future)
+
+        try await app.asyncTest(
+            .POST,
+            "/TEST101/students/ext_student/assignments/\(assignment.publicID)/extension",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                try req.content.encode(
+                    [
+                        "_csrf": csrf,
+                        "extendedDueAt": futureInput,
+                        "note": "Conference travel",
+                    ],
+                    as: .urlEncodedForm
+                )
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+            }
+        )
+
+        let saved = try await APIAssignmentExtension.query(on: app.db)
+            .filter(\.$assignmentID == (try assignment.requireID()))
+            .filter(\.$userID == (try student.requireID()))
+            .all()
+        XCTAssertEqual(saved.count, 1, "Upsert must create exactly one row")
+        XCTAssertEqual(saved.first?.note, "Conference travel")
+
+        // Second POST updates in place.
+        let further = Date().addingTimeInterval(172_800)
+        let furtherInput = fmt.string(from: further)
+        try await app.asyncTest(
+            .POST,
+            "/TEST101/students/ext_student/assignments/\(assignment.publicID)/extension",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                try req.content.encode(
+                    ["_csrf": csrf, "extendedDueAt": furtherInput, "note": ""],
+                    as: .urlEncodedForm
+                )
+            },
+            afterResponse: { _ in }
+        )
+        let updated = try await APIAssignmentExtension.query(on: app.db)
+            .filter(\.$assignmentID == (try assignment.requireID()))
+            .filter(\.$userID == (try student.requireID()))
+            .all()
+        XCTAssertEqual(updated.count, 1, "Second POST must not create a duplicate")
+        XCTAssertNil(updated.first?.note, "Empty note must clear the note field")
+    }
+
+    // MARK: - Extension delete
+
+    func testExtensionDeleteRemovesRow() async throws {
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+        let student = try await insertStudent(username: "ext_delete_student")
+        try await enrollStudentInTestCourse(student)
+        try await insertSetup(id: "ext_delete_setup")
+        let assignment = try await insertAssignment(
+            testSetupID: "ext_delete_setup",
+            title: "Removable extension",
+            isOpen: true
+        )
+
+        let row = APIAssignmentExtension(
+            assignmentID: try assignment.requireID(),
+            userID: try student.requireID(),
+            extendedDueAt: Date().addingTimeInterval(86_400)
+        )
+        try await row.save(on: app.db)
+
+        try await app.asyncTest(
+            .POST,
+            "/TEST101/students/ext_delete_student/assignments/\(assignment.publicID)/extension/delete",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+            }
+        )
+
+        let remaining = try await APIAssignmentExtension.query(on: app.db)
+            .filter(\.$assignmentID == (try assignment.requireID()))
+            .count()
+        XCTAssertEqual(remaining, 0, "Delete must remove the row")
+    }
+
+    // MARK: - Deadline gate behaviour
+
+    func testEffectiveDueAtUsesExtensionWhenLater() async throws {
+        try await insertSetup(id: "effective_setup")
+        let baseline = Date().addingTimeInterval(-3_600)  // 1h ago
+        let assignment = try await insertAssignment(
+            testSetupID: "effective_setup",
+            title: "Past assignment",
+            isOpen: true,
+            dueAt: baseline
+        )
+        let student = try await insertStudent(username: "effective_student")
+        try await enrollStudentInTestCourse(student)
+
+        // No extension yet — effectiveDueAt == baseline.
+        let withoutExt = try await effectiveDueAt(for: assignment, user: student, on: app.db)
+        XCTAssertEqual(withoutExt, baseline)
+
+        // Add an extension into the future — that's what gets returned.
+        let future = Date().addingTimeInterval(86_400)
+        try await APIAssignmentExtension(
+            assignmentID: try assignment.requireID(),
+            userID: try student.requireID(),
+            extendedDueAt: future
+        ).save(on: app.db)
+        let withExt = try await effectiveDueAt(for: assignment, user: student, on: app.db)
+        XCTAssertNotNil(withExt)
+        XCTAssertEqual(withExt!.timeIntervalSinceReferenceDate, future.timeIntervalSinceReferenceDate, accuracy: 1)
+
+        // Sanity: the per-user gate now reports open.
+        let openForExtended = try await isAssignmentEffectivelyOpen(
+            assignment, for: student, on: app.db
+        )
+        XCTAssertTrue(
+            openForExtended,
+            "Student with an active extension must see the assignment as open")
+
+        // A peer without an extension still hits the closed gate.
+        let peer = try await insertStudent(username: "effective_peer")
+        try await enrollStudentInTestCourse(peer)
+        let openForPeer = try await isAssignmentEffectivelyOpen(
+            assignment, for: peer, on: app.db
+        )
+        XCTAssertFalse(openForPeer, "Other students must not benefit from someone else's extension")
+    }
+
+    // MARK: - Scoped retest
+
+    func testScopedRetestFlipsOnlyThisStudentsSubmissions() async throws {
+        let cookie = try await loginAsInstructor()
+        let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+        try await insertSetup(id: "scoped_retest_setup")
+        let assignment = try await insertAssignment(
+            testSetupID: "scoped_retest_setup",
+            title: "Scoped retest",
+            isOpen: true
+        )
+
+        let targetStudent = try await insertStudent(username: "scoped_target")
+        try await enrollStudentInTestCourse(targetStudent)
+        let otherStudent = try await insertStudent(username: "scoped_other")
+        try await enrollStudentInTestCourse(otherStudent)
+
+        let targetSubmission = APISubmission(
+            id: "sub_scoped_target",
+            testSetupID: "scoped_retest_setup",
+            zipPath: app.submissionsDirectory + "sub_scoped_target.zip",
+            attemptNumber: 1,
+            status: "complete",
+            userID: targetStudent.id
+        )
+        targetSubmission.workerID = "worker-x"
+        try await targetSubmission.save(on: app.db)
+
+        let otherSubmission = APISubmission(
+            id: "sub_scoped_other",
+            testSetupID: "scoped_retest_setup",
+            zipPath: app.submissionsDirectory + "sub_scoped_other.zip",
+            attemptNumber: 1,
+            status: "complete",
+            userID: otherStudent.id
+        )
+        try await otherSubmission.save(on: app.db)
+
+        try await app.asyncTest(
+            .POST,
+            "/TEST101/students/scoped_target/assignments/\(assignment.publicID)/retest",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+            }
+        )
+
+        let targetAfter = try await APISubmission.find("sub_scoped_target", on: app.db)
+        XCTAssertEqual(targetAfter?.status, "pending")
+        XCTAssertNil(targetAfter?.workerID)
+        XCTAssertNotNil(targetAfter?.retestedAt)
+
+        let otherAfter = try await APISubmission.find("sub_scoped_other", on: app.db)
+        XCTAssertEqual(
+            otherAfter?.status, "complete",
+            "Scoped retest must not touch other students' submissions")
+        XCTAssertNil(otherAfter?.retestedAt)
+    }
+
+    // MARK: - Grouped page rendering
+
+    func testGroupedPageShowsAllPublishedAssignmentsIncludingEmptyOnes() async throws {
+        let cookie = try await loginAsInstructor()
+
+        try await insertSetup(id: "grp_setup_1")
+        _ = try await insertAssignment(
+            testSetupID: "grp_setup_1", title: "First Lab", isOpen: true
+        )
+        try await insertSetup(id: "grp_setup_2")
+        _ = try await insertAssignment(
+            testSetupID: "grp_setup_2", title: "Second Lab", isOpen: true
+        )
+
+        let student = try await insertStudent(username: "grp_student")
+        try await enrollStudentInTestCourse(student)
+
+        // Submit on the first assignment only — the second must render as
+        // "No submissions yet" rather than be hidden.
+        _ = try await insertSubmission(
+            id: "sub_grp_1",
+            testSetupID: "grp_setup_1",
+            userID: try student.requireID()
+        )
+
+        try await app.asyncTest(
+            .GET, "/TEST101/students/grp_student/submissions",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .ok)
+                let body = res.body.string
+                XCTAssertTrue(body.contains("First Lab"), "Submitted assignment must appear")
+                XCTAssertTrue(body.contains("Second Lab"), "Empty assignment must also appear")
+                XCTAssertTrue(
+                    body.contains("No submissions yet"),
+                    "Empty row must surface the friendly placeholder"
+                )
+                XCTAssertTrue(
+                    body.contains("sub_grp_1"),
+                    "Latest submission link should reference the submission ID"
+                )
+            }
+        )
+    }
+}

--- a/Tests/APITests/AssignmentRoutesNotebookTests.swift
+++ b/Tests/APITests/AssignmentRoutesNotebookTests.swift
@@ -178,12 +178,13 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
             }
         )
     }
-    // MARK: - GET /instructor/students/:studentID/submissions
+    // MARK: - GET /:courseCode/students/:username/submissions
 
     /// The dashboard roster lists every enrolled user (students, plus
     /// instructors/admins enrolled for testing).  Clicking any of them used
     /// to 404 unless the target had role == "student".  Now any enrolled
-    /// user's course-scoped submissions are viewable.
+    /// user's course-scoped submissions are viewable, and the row appears
+    /// once-per-assignment with a link to the latest submission.
     func testCourseStudentSubmissionsPageWorksForEnrolledInstructor() async throws {
         _ = try await app.testCourseID(enrollmentMode: .auto)
         let cookie = try await loginAsInstructor()
@@ -212,7 +213,7 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
             userID: try otherInstructor.requireID()
         )
 
-        let url = "/instructor/students/\(try otherInstructor.requireID().uuidString)/submissions"
+        let url = "/TEST101/students/other_instructor/submissions"
         try await app.asyncTest(
             .GET, url,
             beforeRequest: { req in
@@ -223,8 +224,11 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
                     res.status, .ok,
                     "Course-scoped submissions page must render for an enrolled non-student")
                 XCTAssertTrue(
+                    res.body.string.contains("Visible Assignment"),
+                    "Grouped page must show the assignment title row for this student")
+                XCTAssertTrue(
                     res.body.string.contains("instr_view_sub"),
-                    "Submission row for the instructor user must appear on the page")
+                    "Latest-submission link should include the submission ID")
             })
     }
 
@@ -234,13 +238,13 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
         _ = try await app.testCourseID(enrollmentMode: .auto)
         let cookie = try await loginAsInstructor()
 
-        let stranger = try await insertUser(
+        _ = try await insertUser(
             username: "stranger_user",
             role: "student",
             displayName: "Stranger"
         )
 
-        let url = "/instructor/students/\(try stranger.requireID().uuidString)/submissions"
+        let url = "/TEST101/students/stranger_user/submissions"
         try await app.asyncTest(
             .GET, url,
             beforeRequest: { req in


### PR DESCRIPTION
## Summary
- Instructor view at `/:courseCode/students/:username/submissions` now mirrors the student dashboard — one row per published assignment with latest submission, attempt count, best grade, and badges, grouped by course section.
- New per-row Actions column: per-student **Retest** and an inline form to **grant / edit / revoke a deadline extension** that lets one student keep submitting past the assignment-wide deadline.
- URL cleanup: `/instructor/students/:UUID/submissions` → `/:courseCode/students/:username/submissions`; new drilldown at `/:courseCode/students/:username/assignments/:assignmentID/history`. Routes register before the vanity catch-all so `students` wins over `:assignmentSlug`.
- Student dashboard now surfaces an active extension (Submit button visible + effective due date in the Due column) when the assignment is globally closed.

## Plumbing
- New `assignment_extensions` table (FK to assignments + users, UNIQUE on the pair) + `APIAssignmentExtension` model + migration registered after `AddJobExecutionCacheHit`.
- `AssignmentDeadlineService` gains `effectiveDueAt(for:user:on:)` and an extension-aware `isAssignmentEffectivelyOpen` overload. `requireOpenStudentAssignment` now takes the current user; gate callers ([WebRoutes+Submission.swift](Sources/APIServer/Routes/Web/WebRoutes+Submission.swift) and [BrowserResultRoutes.swift](Sources/APIServer/Routes/BrowserResultRoutes.swift)) updated.
- Per-assignment `isOpen` flag and auto-close monitor are unchanged — extensions are an override on top of the closed state, not a per-user open flag.
- Refactor: extracted `flipSubmissionToPending` shared by single, all-for-setup, and new per-student retest paths.
- New `AuditAction`s: `submission.retest_for_student`, `extension.granted`, `extension.revoked`. New `assignment` target type.

## Test plan
- [x] `swift build` clean under `treatAllWarnings(as: .error)` from #511
- [x] 17 targeted XCTest cases pass (`AssignmentExtensionsTests`, updated `AssignmentRoutesNotebookTests`, `AssignmentRoutesRetestTests`)
- [x] `swift-format lint --strict` clean on changed files
- [ ] CI full test suite green
- [ ] Manual smoke: instructor → student row → grouped page → grant extension → sign in as student → Submit on closed assignment succeeds
- [ ] Manual smoke: retest button flips only that student's submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)