### PR TITLE
fix: hide action buttons on closed assignments in student dashboard

### DIFF
--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -93,27 +93,19 @@
             </td>
             <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    #if(setup.isOpen):
                     #if(setup.gradingMode == "browser"):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
-                       title="#if(setup.isOpen):Edit#else:View#endif" aria-label="#if(setup.isOpen):Edit#else:View#endif" style="padding:.3rem .45rem">
-                        #if(setup.isOpen):
+                       title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        #else:
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                        #endif
                     </a>
                     #else:
                     #if(setup.hasNotebook):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
-                       title="#if(setup.isOpen):Edit#else:View#endif" aria-label="#if(setup.isOpen):Edit#else:View#endif" style="padding:.3rem .45rem">
-                        #if(setup.isOpen):
+                       title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        #else:
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                        #endif
                     </a>
                     #endif
-                    #if(setup.isOpen):
                     <a class="btn action-btn" href="#(setup.submitURL)"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
@@ -200,27 +192,19 @@
             </td>
             <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    #if(setup.isOpen):
                     #if(setup.gradingMode == "browser"):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
-                       title="#if(setup.isOpen):Edit#else:View#endif" aria-label="#if(setup.isOpen):Edit#else:View#endif" style="padding:.3rem .45rem">
-                        #if(setup.isOpen):
+                       title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        #else:
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                        #endif
                     </a>
                     #else:
                     #if(setup.hasNotebook):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
-                       title="#if(setup.isOpen):Edit#else:View#endif" aria-label="#if(setup.isOpen):Edit#else:View#endif" style="padding:.3rem .45rem">
-                        #if(setup.isOpen):
+                       title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        #else:
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                        #endif
                     </a>
                     #endif
-                    #if(setup.isOpen):
                     <a class="btn action-btn" href="#(setup.submitURL)"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
@@ -307,27 +291,19 @@
             </td>
             <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                    #if(setup.isOpen):
                     #if(setup.gradingMode == "browser"):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
-                       title="#if(setup.isOpen):Edit#else:View#endif" aria-label="#if(setup.isOpen):Edit#else:View#endif" style="padding:.3rem .45rem">
-                        #if(setup.isOpen):
+                       title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        #else:
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                        #endif
                     </a>
                     #else:
                     #if(setup.hasNotebook):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
-                       title="#if(setup.isOpen):Edit#else:View#endif" aria-label="#if(setup.isOpen):Edit#else:View#endif" style="padding:.3rem .45rem">
-                        #if(setup.isOpen):
+                       title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
-                        #else:
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                        #endif
                     </a>
                     #endif
-                    #if(setup.isOpen):
                     <a class="btn action-btn" href="#(setup.submitURL)"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>


### PR DESCRIPTION
## Summary

- v0.4.166 (#486) intended to let closed assignments load read-only in the *instructor* editor. As part of that change, the student-dashboard action button in [Resources/Views/index.leaf](Resources/Views/index.leaf) had its outer `#if(setup.isOpen)` wrapper removed and replaced with an inner switch that flips the icon (pencil → eye) and label (Edit → View) when `setup.isOpen` is false — leaving a clickable "View" link on closed rows.
- The intent on the student dashboard is that closed assignments show **no** action button. This PR restores that pre-v0.4.166 behavior by wrapping the whole Actions cell (notebook link + upload link) in a single `#if(setup.isOpen)` and dropping the now-dead pencil/eye icon switch.
- Three call sites updated: per-section table, ungrouped trailing table, and the no-sections flat-layout fallback.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter Web` — 52 + 2 tests pass
- [ ] Browser smoke-check at https://chickadee.uwaterloo.ca/ after merge: closed assignment rows render an empty Actions cell; open rows still show pencil (Edit) + upload icons; unpublished rows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)