### PR TITLE
build: add SwiftLint via SwiftPM plugin (infra only, CI not yet enforced)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,94 @@
+# SwiftLint configuration for Chickadee.
+#
+# Style/formatting is owned by swift-format (.swift-format at repo root).
+# SwiftLint covers the quality / correctness layer that swift-format does not:
+# force unwraps, dead bindings, .isEmpty vs count == 0, first(where:), unused
+# imports, function complexity, etc.
+#
+# Run locally:  scripts/swiftlint.sh
+# Run formatter: scripts/format.sh   (swift-format, separate concern)
+
+disabled_rules:
+  # Rules below are owned by swift-format. Disabled here to keep one source of
+  # truth for formatting; SwiftLint would otherwise either duplicate or fight
+  # with swift-format.
+  - trailing_whitespace
+  - trailing_newline
+  - leading_whitespace
+  - vertical_whitespace
+  - opening_brace
+  - statement_position
+  - colon
+  - comma
+  - operator_whitespace
+  - return_arrow_whitespace
+  - line_length        # swift-format owns the 120-char limit
+  - todo               # repo has legitimate TODO/FIXME comments we keep
+  - file_length        # sub-rules below cap function/type size, which is what matters
+  - trailing_comma     # project convention uses multi-line trailing commas; formatting concern
+
+opt_in_rules:
+  - force_unwrapping
+  - explicit_init
+  - first_where
+  - last_where
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - empty_count
+  - empty_string
+  - empty_collection_literal
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - toggle_bool
+  - unused_import
+  - joined_default_parameter
+  - sorted_first_last
+  - static_operator
+  - yoda_condition
+  - prefer_zero_over_explicit_init
+  - override_in_extension
+  - prohibited_super_call
+  - discouraged_optional_boolean
+  - discouraged_optional_collection
+
+excluded:
+  - .build
+  - .swiftpm
+  - Packages
+  - Public          # generated JupyterLite assets
+  - reference       # original Java code, kept for behavioural reference
+  - Tools           # JupyterLite build config
+
+force_unwrapping:
+  excluded:
+    - Tests         # CLAUDE.md exempts test code from the no-force-unwrap rule
+
+identifier_name:
+  # Single-letter locals/closure params are common in this codebase
+  # (e.g. `s` for substring, `e` for element, `c` for character). Keeping
+  # min_length at 1 avoids ~390 violations on idiomatic short closures while
+  # still flagging unnamed-looking identifiers like empty strings.
+  min_length: 1
+  max_length:
+    warning: 50
+    error: 60
+
+type_name:
+  min_length: 3
+
+cyclomatic_complexity:
+  warning: 12
+  error: 20
+
+function_body_length:
+  warning: 80
+  error: 150
+
+type_body_length:
+  warning: 400
+  error: 600
+
+nesting:
+  type_level: 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,6 +357,15 @@ updating kernel versions or config.
 - Formatting is enforced by `swift-format` in CI (`.swift-format` at repo root).
   Run `scripts/format.sh` before committing, or `scripts/lint.sh` to check
   without modifying.
+- Quality rules (force unwraps, `.filter{}.first` antipatterns, oversized
+  functions, etc.) are enforced by SwiftLint (`.swiftlint.yml` at repo root,
+  delivered via the `SwiftLintPlugins` SwiftPM dependency — no separate
+  install). Run `scripts/swiftlint.sh` to check. The two tools are
+  complementary: swift-format owns formatting, SwiftLint owns correctness;
+  overlapping rules are disabled in `.swiftlint.yml`. CI enforcement of
+  SwiftLint is staged — adoption PR adds the config, follow-up PRs clear
+  the violation backlog, then the `Run SwiftLint` step is wired into the
+  `format-lint` job.
 
 ---
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "18691a2fccb883ede277101416a5604f2dc3a10fc45ed18ecbffcb45918807d5",
+  "originHash" : "5783f9c953dcdfb81312113e039d817d6056ce296249e22bd055458983a3de08",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -377,6 +377,15 @@
       "state" : {
         "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
         "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
+        "version" : "0.63.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,11 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.15.1"),
         .package(url: "https://github.com/vapor-community/CSRF.git", from: "3.1.1"),
+        // SwiftLint via SimplyDanny's plugin distribution: ships a pre-built
+        // binary so CI / fresh checkouts don't pay a SwiftLint-from-source build.
+        // Invoked on demand via `scripts/swiftlint.sh`; no `plugins:` entry on
+        // any target, so `swift build` / `swift test` are unaffected.
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.63.0"),
     ],
     targets: [
         // MARK: - Core library

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# swift-format: applies the formatting rules in .swift-format in place.
+# Companion: scripts/swiftlint.sh runs the SwiftLint quality-rule layer.
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 

--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runs SwiftLint against the repo. swift-format owns formatting (see
+# scripts/lint.sh and .swift-format); this script enforces the quality /
+# correctness layer configured in .swiftlint.yml.
+#
+# SwiftLint is delivered via the SwiftLintPlugins SwiftPM package (see
+# Package.swift). The plugin ships a pre-built binary, so the first
+# invocation on a fresh checkout downloads + caches it; subsequent runs are
+# fast. `--strict` upgrades warnings to errors so any violation fails CI.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+exec swift package --allow-writing-to-package-directory swiftlint lint --strict


### PR DESCRIPTION
## Summary

- Adds SwiftLint as the quality/correctness layer alongside `swift-format`, delivered via the [`SimplyDanny/SwiftLintPlugins`](https://github.com/SimplyDanny/SwiftLintPlugins) SwiftPM dependency — no separate install on dev machines or CI.
- Invoked on demand via the new `scripts/swiftlint.sh`. No `plugins:` entry on any target, so `swift build` and `swift test` are unaffected.
- CI enforcement is **deliberately not** wired in this PR. `.github/workflows/swift-tests.yml` is untouched.

## Why staged

A cold run flags **636 violations across 319 files** — overwhelmingly real cleanup work (266 `force_unwrapping`, 98 `first_where` antipatterns, 39 oversized functions, etc.). Splitting infra-add from CI-enforce lets reviewers see the violation list before committing to fixes, and lets the cleanup parallelize across area-scoped follow-up PRs (Core / APIServer / Worker / Tests). The `Run SwiftLint` CI step is added in the final cleanup PR.

## Config notes

`.swiftlint.yml` is tuned to avoid overlap with `swift-format`:

- Formatting rules (`trailing_whitespace`, `opening_brace`, `colon`, `comma`, `line_length`, etc.) disabled — `swift-format` owns them.
- `trailing_comma` disabled — the codebase uses multi-line trailing commas everywhere (317 false positives, formatting concern anyway).
- `identifier_name.min_length: 1` — single-letter closure params are idiomatic here (~390 false positives suppressed).
- Opt-in quality rules covering the real gaps: `force_unwrapping`, `first_where`, `contains_over_*`, `redundant_*`, `discouraged_optional_*`, plus size/complexity caps (`function_body_length: 80/150`, `type_body_length: 400/600`, `cyclomatic_complexity: 12/20`).
- `force_unwrapping` excluded for `Tests/` (CLAUDE.md exempts test code).
- Existing `// swiftlint:disable:next force_try` directive in [Sources/APIServer/Services/NotebookSubstitution.swift](Sources/APIServer/Services/NotebookSubstitution.swift) is respected under the new config.

## Test plan

- [x] `scripts/lint.sh` (swift-format) — clean
- [x] `scripts/swiftlint.sh` — runs, reports 636 violations (the cleanup backlog)
- [x] Existing `swiftlint:disable:next` directive honored
- [x] CI step deliberately omitted — `format-lint` job will not run SwiftLint
- [ ] Local `time swift build` / `time swift test` flat vs main (command plugin only runs on explicit invocation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)