### PR TITLE
swiftlint: clear all production force_unwrapping violations (89 → 0)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -61,10 +61,6 @@ excluded:
   - reference       # original Java code, kept for behavioural reference
   - Tools           # JupyterLite build config
 
-force_unwrapping:
-  excluded:
-    - Tests         # CLAUDE.md exempts test code from the no-force-unwrap rule
-
 identifier_name:
   # Single-letter locals/closure params are common in this codebase
   # (e.g. `s` for substring, `e` for element, `c` for character). Keeping

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
@@ -157,7 +157,9 @@ extension OperationalDiagnosticsService {
             guard isWorkerEligible, let submittedAt = submission.submittedAt else { continue }
 
             let assignedAt = submission.assignedAt
-            if submittedAt < windowStart && (assignedAt == nil || assignedAt! > windowStart) {
+            // Pending at windowStart: submitted before the window opened AND
+            // either never assigned, or assigned after the window opened.
+            if submittedAt < windowStart, (assignedAt ?? .distantFuture) > windowStart {
                 queueDepth += 1
             }
             if submittedAt >= windowStart && submittedAt <= now {

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -81,7 +81,7 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
     static func generatePublicID(length: Int = APIAssignment.publicIDLength) -> String {
         let alphabet = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
         var rng = SystemRandomNumberGenerator()
-        return String((0..<length).map { _ in alphabet.randomElement(using: &rng)! })
+        return String((0..<length).compactMap { _ in alphabet.randomElement(using: &rng) })
     }
 
     init(

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -72,7 +72,7 @@ struct BrowserResultRoutes: RouteCollection {
 
         // Count prior submissions to derive the attempt number.
         let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == setup.id!)
+            .filter(\.$testSetupID == body.testSetupID)
             .filter(\.$userID == caller.id)
             .filter(\.$kind == APISubmission.Kind.student)
             .count()
@@ -82,7 +82,7 @@ struct BrowserResultRoutes: RouteCollection {
         // results are authoritative and no native worker re-run is queued.
         let submission = APISubmission(
             id: subID,
-            testSetupID: setup.id!,
+            testSetupID: body.testSetupID,
             zipPath: nbPath,
             attemptNumber: attemptNumber,
             status: "complete",
@@ -117,7 +117,7 @@ struct BrowserResultRoutes: RouteCollection {
         if let userID = caller.id {
             _ = try? await ensureUserNotebookWorkingCopy(
                 req: req,
-                setupID: setup.id!,
+                setupID: body.testSetupID,
                 userID: userID,
                 fallbackSetup: setup,
                 overwriteWith: body.notebook
@@ -166,7 +166,7 @@ struct BrowserResultRoutes: RouteCollection {
         try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
 
         let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == setup.id!)
+            .filter(\.$testSetupID == body.testSetupID)
             .filter(\.$userID == caller.id)
             .filter(\.$kind == APISubmission.Kind.student)
             .count()
@@ -174,7 +174,7 @@ struct BrowserResultRoutes: RouteCollection {
         let submittedFilename = normalizedNotebookFilename(body.filename)
         let submission = APISubmission(
             id: subID,
-            testSetupID: setup.id!,
+            testSetupID: body.testSetupID,
             zipPath: nbPath,
             attemptNumber: priorCount + 1,
             status: "pending",

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -65,13 +65,14 @@ struct ResultRoutes: RouteCollection {
                 let status = passed ? "passed" : "failed"
 
                 if let assignment = try await APIAssignment.query(on: req.db)
-                    .filter(\.$validationSubmissionID == submission.id!)
+                    .filter(\.$validationSubmissionID == collection.submissionID)
                     .first()
                 {
                     assignment.validationStatus = status
                     try await assignment.save(on: req.db)
                     req.logger.info(
-                        "Validation \(status) for assignment '\(assignment.title)' (submission \(submission.id!))")
+                        "Validation \(status) for assignment '\(assignment.title)' (submission \(collection.submissionID))"
+                    )
                 }
             }
 

--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -22,7 +22,7 @@ struct SubmissionRoutes: RouteCollection {
     func createSubmission(req: Request) async throws -> SubmissionCreatedResponse {
         let body = try req.content.decode(CreateSubmissionBody.self)
 
-        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
+        guard try await APITestSetup.find(body.testSetupID, on: req.db) != nil else {
             throw Abort(.badRequest, reason: "Invalid testSetupID")
         }
 
@@ -39,13 +39,13 @@ struct SubmissionRoutes: RouteCollection {
 
         // Count prior submissions for this test setup to determine attempt number.
         let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == setup.id!)
+            .filter(\.$testSetupID == body.testSetupID)
             .filter(\.$kind == APISubmission.Kind.student)
             .count()
 
         let submission = APISubmission(
             id: subID,
-            testSetupID: setup.id!,
+            testSetupID: body.testSetupID,
             zipPath: zipPath,
             attemptNumber: priorCount + 1,
             kind: APISubmission.Kind.student
@@ -71,7 +71,7 @@ struct SubmissionRoutes: RouteCollection {
             fallback: "submission.bin"
         )
 
-        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
+        guard try await APITestSetup.find(body.testSetupID, on: req.db) != nil else {
             throw Abort(.badRequest, reason: "Invalid testSetupID")
         }
 
@@ -96,13 +96,13 @@ struct SubmissionRoutes: RouteCollection {
         try fileData.write(to: URL(fileURLWithPath: filePath))
 
         let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == setup.id!)
+            .filter(\.$testSetupID == body.testSetupID)
             .filter(\.$kind == APISubmission.Kind.student)
             .count()
 
         let submission = APISubmission(
             id: subID,
-            testSetupID: setup.id!,
+            testSetupID: body.testSetupID,
             zipPath: filePath,
             attemptNumber: priorCount + 1,
             filename: submittedFilename,

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
@@ -234,9 +234,9 @@ extension AssignmentRoutes {
         }
         if resolvedSolutionNotebookRaw.isEmpty, let userID = user.id,
             let draftData = draftNotebookData(
-                req: req, setupID: setup.id!, userID: userID, fileKind: .solution,
+                req: req, setupID: assignment.testSetupID, userID: userID, fileKind: .solution,
                 fallbackPath: draftSolutionNotebookPath(
-                    testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!))
+                    testSetupsDirectory: req.application.testSetupsDirectory, setupID: assignment.testSetupID))
         {
             resolvedSolutionNotebookRaw = draftData
         }
@@ -273,11 +273,11 @@ extension AssignmentRoutes {
                     ?? "assignment.ipynb"
                 let uploadedName = assignmentNotebookFile?.filename
                 let filename = notebookFilenameForStorage(uploadedName: uploadedName, fallback: fallbackName)
-                let dir = req.application.testSetupsDirectory + "notebooks/\(setup.id!)/"
+                let dir = req.application.testSetupsDirectory + "notebooks/\(assignment.testSetupID)/"
                 try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
                 return dir + filename
             }
-            return setup.notebookPath ?? (req.application.testSetupsDirectory + "\(setup.id!).ipynb")
+            return setup.notebookPath ?? (req.application.testSetupsDirectory + "\(assignment.testSetupID).ipynb")
         }()
         try assignmentNotebook.write(to: URL(fileURLWithPath: notebookPath))
 
@@ -292,7 +292,7 @@ extension AssignmentRoutes {
         }()
         extractSupportFilesToSharedDirectory(
             zipPath: setup.zipPath,
-            setupID: setup.id!,
+            setupID: assignment.testSetupID,
             testSuiteScripts: activeTestSuiteScripts,
             testSetupsDirectory: req.application.testSetupsDirectory
         )
@@ -335,7 +335,7 @@ extension AssignmentRoutes {
             : resolvedSolutionNotebookRaw
         let validationSubmissionID = try await enqueueRunnerValidationSubmission(
             req: req,
-            setupID: setup.id!,
+            setupID: assignment.testSetupID,
             solutionNotebookData: solutionDataToSubmit,
             filename: solutionFilename
         )
@@ -516,7 +516,7 @@ extension AssignmentRoutes {
             }()
             extractSupportFilesToSharedDirectory(
                 zipPath: setup.zipPath,
-                setupID: setup.id!,
+                setupID: assignment.testSetupID,
                 testSuiteScripts: activeTestSuiteScripts,
                 testSetupsDirectory: req.application.testSetupsDirectory
             )
@@ -601,7 +601,7 @@ extension AssignmentRoutes {
         }()
         extractSupportFilesToSharedDirectory(
             zipPath: setup.zipPath,
-            setupID: setup.id!,
+            setupID: assignment.testSetupID,
             testSuiteScripts: activeTestSuiteScripts,
             testSetupsDirectory: req.application.testSetupsDirectory
         )
@@ -622,14 +622,16 @@ extension AssignmentRoutes {
 
         guard let draftID = try? req.query.get(String.self, at: "draftID"),
             !draftID.isEmpty,
-            let setup = try await APITestSetup.find(draftID, on: req.db)
+            try await APITestSetup.find(draftID, on: req.db) != nil
         else { throw WebAssignmentError.notFound(resource: "Draft assignment") }
 
+        // setup.id equals draftID (lookup key); use the query parameter
+        // directly so we don't have to force-unwrap setup.id.
         let fallbackPath = draftSolutionNotebookPath(
-            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: draftID)
         guard
             let data = draftNotebookData(
-                req: req, setupID: setup.id!, userID: userID,
+                req: req, setupID: draftID, userID: userID,
                 fileKind: .solution, fallbackPath: fallbackPath)
         else { throw WebAssignmentError.notFound(resource: "Draft solution notebook") }
 
@@ -753,19 +755,19 @@ extension AssignmentRoutes {
         let normalized = normalizeNotebookForJupyterLite(sourceData)
 
         let draftPath = draftSolutionNotebookPath(
-            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: assignment.testSetupID)
         _ = try ensureDraftNotebookDirectory(
-            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: assignment.testSetupID)
         try normalized.write(to: URL(fileURLWithPath: draftPath))
 
         _ = try await ensureUserNotebookWorkingCopy(
-            req: req, setupID: setup.id!, userID: userID, fallbackSetup: setup,
+            req: req, setupID: assignment.testSetupID, userID: userID, fallbackSetup: setup,
             relativePath: userNotebookWorkingCopyRelativePath(
-                setupID: setup.id!, userID: userID, fileKind: .solution),
+                setupID: assignment.testSetupID, userID: userID, fileKind: .solution),
             overwriteWith: normalized)
 
         return req.redirect(
-            to: "/testsetups/\(setup.id!)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))")
+            to: "/testsetups/\(assignment.testSetupID)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))")
     }
 }
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+GlobalVariables.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+GlobalVariables.swift
@@ -175,7 +175,7 @@ extension AssignmentRoutes {
                     seedHex: seedHex,
                     staticVariables: staticVars,
                     expressions: expressions,
-                    supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setup.id!)/"
+                    supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(assignment.testSetupID)/"
                 )
             } catch let PersonalizationEvaluatorError.nonZeroExit(_, stderr) {
                 let tail = stderr.split(separator: "\n").suffix(3).joined(separator: " ")

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
@@ -202,8 +202,11 @@ extension AssignmentRoutes {
             draftID: draftIDRaw,
             sectionIDRaw: sectionIDRaw
         )
+        guard let setupID = setup.id else {
+            throw WebAssignmentError.internalFailure(reason: "Draft test setup persisted without an id")
+        }
 
-        var formState = loadDraftFormState(req: req, draftID: setup.id!)
+        var formState = loadDraftFormState(req: req, draftID: setupID)
         formState.assignmentName = assignmentName
         formState.dueAt = dueAt
         formState.sectionID = sectionIDRaw
@@ -219,14 +222,14 @@ extension AssignmentRoutes {
         case "create-assignment-notebook":
             let data = defaultNotebookData(title: notebookTitle)
             let dir = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             let path = dir + "assignment.ipynb"
             try data.write(to: URL(fileURLWithPath: path))
             setup.notebookPath = path
             try await setup.save(on: req.db)
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fallbackSetup: setup,
                 overwriteWith: data
@@ -236,7 +239,7 @@ extension AssignmentRoutes {
             guard let assignmentNotebookFile, assignmentNotebookFile.data.readableBytes > 0 else {
                 return redirectToNewAssignmentDraft(
                     req: req,
-                    draftID: setup.id!,
+                    draftID: setupID,
                     assignmentName: assignmentName,
                     dueAt: dueAt,
                     sectionID: sectionIDRaw,
@@ -248,7 +251,7 @@ extension AssignmentRoutes {
             guard (try? JSONSerialization.jsonObject(with: raw)) != nil else {
                 return redirectToNewAssignmentDraft(
                     req: req,
-                    draftID: setup.id!,
+                    draftID: setupID,
                     assignmentName: assignmentName,
                     dueAt: dueAt,
                     sectionID: sectionIDRaw,
@@ -258,7 +261,7 @@ extension AssignmentRoutes {
             }
             let normalized = normalizeNotebookForJupyterLite(raw)
             let dir = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             let filename = notebookFilenameForStorage(
                 uploadedName: assignmentNotebookFile.filename, fallback: "assignment.ipynb")
             let path = dir + filename
@@ -267,7 +270,7 @@ extension AssignmentRoutes {
             try await setup.save(on: req.db)
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fallbackSetup: setup,
                 overwriteWith: normalized
@@ -276,7 +279,7 @@ extension AssignmentRoutes {
         case "clear-assignment-notebook":
             removeDraftNotebookFiles(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fileKind: .assignment,
                 persistedPath: setup.notebookPath
@@ -287,17 +290,17 @@ extension AssignmentRoutes {
         case "create-solution-notebook":
             let data = defaultNotebookData(title: "\(notebookTitle) Solution")
             let path = draftSolutionNotebookPath(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             _ = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             try data.write(to: URL(fileURLWithPath: path))
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fallbackSetup: setup,
                 relativePath: userNotebookWorkingCopyRelativePath(
-                    setupID: setup.id!, userID: userID, fileKind: .solution),
+                    setupID: setupID, userID: userID, fileKind: .solution),
                 overwriteWith: data
             )
             formState.solutionNotebookName = "solution.ipynb"
@@ -321,17 +324,17 @@ extension AssignmentRoutes {
             }()
             let normalized = normalizeNotebookForJupyterLite(sourceData)
             let path = draftSolutionNotebookPath(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             _ = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             try normalized.write(to: URL(fileURLWithPath: path))
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fallbackSetup: setup,
                 relativePath: userNotebookWorkingCopyRelativePath(
-                    setupID: setup.id!, userID: userID, fileKind: .solution),
+                    setupID: setupID, userID: userID, fileKind: .solution),
                 overwriteWith: normalized
             )
             formState.solutionNotebookName = "solution.ipynb"
@@ -339,7 +342,7 @@ extension AssignmentRoutes {
             guard let solutionNotebookFile, solutionNotebookFile.data.readableBytes > 0 else {
                 return redirectToNewAssignmentDraft(
                     req: req,
-                    draftID: setup.id!,
+                    draftID: setupID,
                     assignmentName: assignmentName,
                     dueAt: dueAt,
                     sectionID: sectionIDRaw,
@@ -351,7 +354,7 @@ extension AssignmentRoutes {
             guard (try? JSONSerialization.jsonObject(with: raw)) != nil else {
                 return redirectToNewAssignmentDraft(
                     req: req,
-                    draftID: setup.id!,
+                    draftID: setupID,
                     assignmentName: assignmentName,
                     dueAt: dueAt,
                     sectionID: sectionIDRaw,
@@ -361,17 +364,17 @@ extension AssignmentRoutes {
             }
             let normalized = normalizeNotebookForJupyterLite(raw)
             let path = draftSolutionNotebookPath(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             _ = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             try normalized.write(to: URL(fileURLWithPath: path))
             _ = try await ensureUserNotebookWorkingCopy(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fallbackSetup: setup,
                 relativePath: userNotebookWorkingCopyRelativePath(
-                    setupID: setup.id!, userID: userID, fileKind: .solution),
+                    setupID: setupID, userID: userID, fileKind: .solution),
                 overwriteWith: normalized
             )
             formState.solutionNotebookName = notebookFilenameForStorage(
@@ -402,11 +405,11 @@ extension AssignmentRoutes {
         case "clear-solution-notebook":
             removeDraftNotebookFiles(
                 req: req,
-                setupID: setup.id!,
+                setupID: setupID,
                 userID: userID,
                 fileKind: .solution,
                 persistedPath: draftSolutionNotebookPath(
-                    testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+                    testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
             )
             formState.solutionNotebookName = nil
         case "replace-suite-files":
@@ -431,7 +434,7 @@ extension AssignmentRoutes {
             try await setup.save(on: req.db)
             extractSupportFilesToSharedDirectory(
                 zipPath: setup.zipPath,
-                setupID: setup.id!,
+                setupID: setupID,
                 testSuiteScripts: Set(setupPackage.testSuites.map { $0.script }),
                 testSetupsDirectory: req.application.testSetupsDirectory
             )
@@ -451,11 +454,11 @@ extension AssignmentRoutes {
             break
         }
 
-        saveDraftFormState(req: req, draftID: setup.id!, state: formState)
+        saveDraftFormState(req: req, draftID: setupID, state: formState)
 
         return redirectToNewAssignmentDraft(
             req: req,
-            draftID: setup.id!,
+            draftID: setupID,
             assignmentName: assignmentName,
             dueAt: dueAt,
             sectionID: sectionIDRaw,

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+NewPage.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+NewPage.swift
@@ -23,14 +23,14 @@ extension AssignmentRoutes {
         setup: APITestSetup?,
         storedState: NewAssignmentDraftFormState
     ) -> NewAssignmentNotebookContext? {
-        guard let setup, let notebookPath = setup.notebookPath else { return nil }
+        guard let setup, let setupID = setup.id, let notebookPath = setup.notebookPath else { return nil }
         let name =
             storedState.assignmentNotebookName
             ?? URL(fileURLWithPath: notebookPath).lastPathComponent
         let titleParam = storedState.assignmentName.isEmpty ? "Assignment Notebook" : storedState.assignmentName
         return NewAssignmentNotebookContext(
             name: name,
-            editURL: "/testsetups/\(setup.id!)/notebook?title=\(urlEncode(titleParam))"
+            editURL: "/testsetups/\(setupID)/notebook?title=\(urlEncode(titleParam))"
         )
     }
 
@@ -43,14 +43,14 @@ extension AssignmentRoutes {
         setup: APITestSetup?,
         storedState: NewAssignmentDraftFormState
     ) -> NewAssignmentNotebookContext? {
-        guard let setup else { return nil }
+        guard let setup, let setupID = setup.id else { return nil }
         let draftPath = draftSolutionNotebookPath(
             testSetupsDirectory: req.application.testSetupsDirectory,
-            setupID: setup.id!
+            setupID: setupID
         )
         let fallbackData = draftNotebookData(
             req: req,
-            setupID: setup.id!,
+            setupID: setupID,
             userID: userID,
             fileKind: .solution,
             fallbackPath: draftPath
@@ -61,7 +61,7 @@ extension AssignmentRoutes {
             ?? URL(fileURLWithPath: draftPath).lastPathComponent
         return NewAssignmentNotebookContext(
             name: name,
-            editURL: "/testsetups/\(setup.id!)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))"
+            editURL: "/testsetups/\(setupID)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))"
         )
     }
 
@@ -101,24 +101,24 @@ extension AssignmentRoutes {
         userID: UUID,
         setup: APITestSetup?
     ) -> DraftRequirementSuggestions {
-        guard let setup else {
+        guard let setup, let setupID = setup.id else {
             return DraftRequirementSuggestions(languages: [], capabilities: [])
         }
         let assignmentData = draftNotebookData(
             req: req,
-            setupID: setup.id!,
+            setupID: setupID,
             userID: userID,
             fileKind: .assignment,
             fallbackPath: setup.notebookPath
         )
         let solutionData = draftNotebookData(
             req: req,
-            setupID: setup.id!,
+            setupID: setupID,
             userID: userID,
             fileKind: .solution,
             fallbackPath: draftSolutionNotebookPath(
                 testSetupsDirectory: req.application.testSetupsDirectory,
-                setupID: setup.id!
+                setupID: setupID
             )
         )
         return detectRequirementSuggestions(

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+SaveValidation.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+SaveValidation.swift
@@ -194,10 +194,10 @@ extension AssignmentRoutes {
             if let f = form.assignmentNotebookFile, f.data.readableBytes > 0 {
                 return Data(f.data.readableBytesView)
             }
-            guard let draftSetup, let saveUserID else { return Data() }
+            guard let draftSetup, let draftSetupID = draftSetup.id, let saveUserID else { return Data() }
             return draftNotebookData(
                 req: req,
-                setupID: draftSetup.id!,
+                setupID: draftSetupID,
                 userID: saveUserID,
                 fileKind: .assignment,
                 fallbackPath: draftSetup.notebookPath
@@ -215,15 +215,15 @@ extension AssignmentRoutes {
             if let f = form.solutionNotebookFile, f.data.readableBytes > 0 {
                 return Data(f.data.readableBytesView)
             }
-            guard let draftSetup, let saveUserID else { return Data() }
+            guard let draftSetup, let draftSetupID = draftSetup.id, let saveUserID else { return Data() }
             return draftNotebookData(
                 req: req,
-                setupID: draftSetup.id!,
+                setupID: draftSetupID,
                 userID: saveUserID,
                 fileKind: .solution,
                 fallbackPath: draftSolutionNotebookPath(
                     testSetupsDirectory: req.application.testSetupsDirectory,
-                    setupID: draftSetup.id!
+                    setupID: draftSetupID
                 )
             ) ?? Data()
         }()

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
@@ -425,7 +425,7 @@ extension AssignmentRoutes {
         }
 
         let count = try await retestAllSubmissionsForSetup(
-            setupID: setup.id!,
+            setupID: assignment.testSetupID,
             triggeredBy: user.id,
             on: req.db,
             force: true

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+SuiteSections.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+SuiteSections.swift
@@ -229,7 +229,7 @@ extension AssignmentRoutes {
                     seedHex: seedHex,
                     staticVariables: staticVars,
                     expressions: expressions,
-                    supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setup.id!)/"
+                    supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(assignment.testSetupID)/"
                 )
             } catch let PersonalizationEvaluatorError.nonZeroExit(_, stderr) {
                 let tail = stderr.split(separator: "\n").suffix(3).joined(separator: " ")

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -532,7 +532,7 @@ struct AssignmentRoutes: RouteCollection {
         }
         let q = try? req.query.decode(EditQuery.self)
         let draftSolutionPath = draftSolutionNotebookPath(
-            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setup.id!)
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: assignment.testSetupID)
         let existingSolutionName = try await existingSolutionFilename(req: req, assignment: assignment)
         let hasDraftSolution = FileManager.default.fileExists(atPath: draftSolutionPath)
         let fallbackSolutionFilename =
@@ -566,16 +566,17 @@ struct AssignmentRoutes: RouteCollection {
         let ctx = EditAssignmentContext(
             currentUser: req.currentUserContext,
             assignmentID: idStr,
-            testSetupID: setup.id!,
+            testSetupID: assignment.testSetupID,
             assignmentName: (q?.assignmentName ?? assignment.title).trimmingCharacters(in: .whitespacesAndNewlines),
             dueAt: q?.dueAt ?? currentDueAt,
             currentAssignmentFile: currentFiles.assignmentFile.name,
             currentAssignmentURL: currentFiles.assignmentFile.url,
-            assignmentNotebookEditURL: "/testsetups/\(setup.id!)/notebook?title=\(urlEncode(assignment.title))",
+            assignmentNotebookEditURL:
+                "/testsetups/\(assignment.testSetupID)/notebook?title=\(urlEncode(assignment.title))",
             currentSolutionFile: currentFiles.solutionFile?.name,
             currentSolutionURL: currentFiles.solutionFile?.url,
             solutionNotebookEditURL: currentFiles.solutionFile != nil
-                ? "/testsetups/\(setup.id!)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))"
+                ? "/testsetups/\(assignment.testSetupID)/notebook?file=solution&title=\(urlEncode("Solution Notebook"))"
                 : nil,
             existingSuiteRows: currentFiles.existingSuiteRows.filter { $0.tier != "support" },
             supportFileRows: currentFiles.existingSuiteRows.filter { $0.tier == "support" },

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -86,7 +86,9 @@ struct CourseBundleRoutes: RouteCollection {
                 .all()
         }
         let allUsers = (enrolledUsers + additionalUsers)
-            .reduce(into: [UUID: APIUser]()) { $0[$1.id!] = $1 }
+            .reduce(into: [UUID: APIUser]()) { dict, user in
+                if let id = user.id { dict[id] = user }
+            }
             .values
             .sorted { ($0.username) < ($1.username) }
 
@@ -393,7 +395,10 @@ struct CourseBundleRoutes: RouteCollection {
                 code: manifest.course.code, name: manifest.course.name,
                 enrollmentMode: importedMode)
             try await newCourse.save(on: db)
-            t.courseID = newCourse.id!
+            guard let newCourseID = newCourse.id else {
+                throw Abort(.internalServerError, reason: "Created course missing id after save")
+            }
+            t.courseID = newCourseID
             t.courseCode = newCourse.code
             t.courseName = newCourse.name
 
@@ -404,7 +409,10 @@ struct CourseBundleRoutes: RouteCollection {
                     .filter(\.$username == bundledUser.username)
                     .first()
                 {
-                    userIDMap[bundledUser.bundleID] = existing.id!
+                    guard let existingID = existing.id else {
+                        throw Abort(.internalServerError, reason: "User '\(bundledUser.username)' missing id")
+                    }
+                    userIDMap[bundledUser.bundleID] = existingID
                     t.usersMatched += 1
                 } else {
                     // Create placeholder — inert until password reset or SSO login.
@@ -417,7 +425,10 @@ struct CourseBundleRoutes: RouteCollection {
                         displayName: bundledUser.displayName
                     )
                     try await newUser.save(on: db)
-                    userIDMap[bundledUser.bundleID] = newUser.id!
+                    guard let newUserID = newUser.id else {
+                        throw Abort(.internalServerError, reason: "Created user missing id after save")
+                    }
+                    userIDMap[bundledUser.bundleID] = newUserID
                     t.usersCreated += 1
                 }
             }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -410,13 +410,17 @@ private func applyNotebookSubstitutionsIfNeeded(
     }
     if !allExpressions.isEmpty {
         do {
+            guard let setupID = setup.id else {
+                logger.warning("Setup has no id; skipping expression eval.")
+                return try applySubstitutions(seedData, substitutions: substitutions, setup: setup, logger: logger)
+            }
             guard
                 let assignment = try await APIAssignment.query(on: db)
-                    .filter(\.$testSetupID == setup.id!)
+                    .filter(\.$testSetupID == setupID)
                     .first(),
                 let assignmentID = assignment.id
             else {
-                logger.warning("No assignment found for setup \(setup.id ?? "<nil>"); skipping expression eval.")
+                logger.warning("No assignment found for setup \(setupID); skipping expression eval.")
                 return try applySubstitutions(seedData, substitutions: substitutions, setup: setup, logger: logger)
             }
             let seedHex = try await AssignmentSeedStore.ensureSeed(

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -247,14 +247,23 @@ struct WorkerJobRoutes: RouteCollection {
             }
         }
 
-        let setupDownloadVersion = testSetupDownloadVersion(for: setup)
+        guard let submissionID = submission.id, let setupID = setup.id else {
+            throw WorkerJobError.internalInconsistency(reason: "Claimed submission or test setup missing id")
+        }
+        guard
+            let submissionURL = URL(string: "\(base)/api/v1/worker/submissions/\(submissionID)/download"),
+            let testSetupURL = URL(
+                string: "\(base)/api/v1/worker/testsetups/\(setupID)/download?v=\(testSetupDownloadVersion(for: setup))"
+            )
+        else {
+            throw WorkerJobError.internalInconsistency(reason: "Failed to build worker download URLs from base=\(base)")
+        }
         let job = Job(
-            submissionID: submission.id!,
-            testSetupID: setup.id!,
+            submissionID: submissionID,
+            testSetupID: setupID,
             attemptNumber: submission.attemptNumber ?? 1,
-            submissionURL: URL(string: "\(base)/api/v1/worker/submissions/\(submission.id!)/download")!,
-            testSetupURL: URL(
-                string: "\(base)/api/v1/worker/testsetups/\(setup.id!)/download?v=\(setupDownloadVersion)")!,
+            submissionURL: submissionURL,
+            testSetupURL: testSetupURL,
             manifest: manifest.runnerSanitized(),
             submissionFilename: submission.filename,
             assignmentSeed: assignmentSeed

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -51,18 +51,18 @@ struct DatabaseSettings: Sendable {
             if password == nil { missing.append("DATABASE_PASSWORD") }
             if port == nil { missing.append("DATABASE_PORT") }
 
-            guard missing.isEmpty else {
+            guard let host, let database, let username, let password, let port else {
                 throw DatabaseConfigurationError.invalidSettings(
                     "DATABASE_BACKEND=postgres requires: \(missing.joined(separator: ", "))"
                 )
             }
 
             return .postgres(
-                host: host!,
-                port: port!,
-                database: database!,
-                username: username!,
-                password: password!
+                host: host,
+                port: port,
+                database: database,
+                username: username,
+                password: password
             )
         }
     }

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,12 @@
+# Child SwiftLint config for Tests/. Inherits the repo-root .swiftlint.yml
+# and only overrides what differs for test code.
+#
+# CLAUDE.md exempts test code from the no-force-unwrap rule: `XCTUnwrap`
+# is the idiomatic alternative but plenty of existing test code uses `!`
+# on values known to be present in fixtures. Disabling the rule here
+# avoids a sweeping rewrite of test code that adds no real safety.
+
+parent_config: ../.swiftlint.yml
+
+disabled_rules:
+  - force_unwrapping


### PR DESCRIPTION
## Summary

Clears every `force_unwrapping` violation in `Sources/` flagged by SwiftLint. Stacks on top of [#514](https://github.com/JimWallace/Chickadee/pull/514) (now merged). No behaviour changes — every site was either rebinding an id that was logically guaranteed non-nil at that point, or substituting the lookup key (which is already non-optional) for the looked-up model's optional id.

- **Commit 1** (`e71dad1`) — two heaviest files (`AssignmentRoutes+NewAssignment.swift` @ 27, `AssignmentRoutes+Editor.swift` @ 15) + fixes the `Tests/` exclusion that was silently a no-op. Replaces it with a child `Tests/.swiftlint.yml` (standard SwiftLint pattern for per-path rule overrides).
- **Commit 2** (`4c1ee85`) — remaining 46 production sites across 15 files.

## Per-pattern approach

Two recurring fix recipes covered ~90% of sites:

1. **`assignment.testSetupID` / `body.testSetupID` / `collection.submissionID`** — when a model is looked up by a key already in scope, the model's optional `id` is logically identical to that key. Substituting the key avoids the unwrap with no semantic change. Used in `AssignmentRoutes*.swift`, `BrowserResultRoutes.swift`, `SubmissionRoutes.swift`, `ResultRoutes.swift`.
2. **`guard let setupID = setup.id`** — bind once at the function entry (or inside the existing `guard let setup` clause), then use `setupID` throughout. Used in `AssignmentRoutes+NewAssignment.swift`, `AssignmentRoutes+NewPage.swift`, `AssignmentRoutes+SaveValidation.swift`, `WorkerJobRoutes.swift`.

The remaining edge cases:

| File | Pattern | Fix |
|---|---|---|
| `DatabaseConfiguration.swift` | 5x check-then-unwrap of env vars | Single `guard let` covering all 5; the pre-collected `missing` array still drives the error message |
| `CourseBundleRoutes.swift` | user-dict reduce + 3 newly-saved-model ids | `if let id = …` inside closure; `guard let … else { throw Abort(.internalServerError) }` after `save(on:)` |
| `WorkerJobRoutes.swift` | 2x `URL(string: "literal")!` | `guard let … else { throw WorkerJobError.internalInconsistency }` — covers the (impossible-but-cheap-to-check) malformed-base-URL case |
| `APIAssignment.swift` | `alphabet.randomElement(using: &rng)!` on a static non-empty `Array` | `compactMap` instead of `map`+`!` |
| `OperationalDiagnostics+Queries.swift` | `assignedAt!` after nil check | `(assignedAt ?? .distantFuture) > windowStart` |
| `WebRoutes+Notebook.swift` | `setup.id!` in query filter where no lookup key is in scope | early-return guard on `setup.id` |

Two SubmissionRoutes guard bindings became `guard try await find(...) != nil` after their force-unwrap was eliminated, to avoid an unused-binding error under `treatAllWarnings(as: .error)`.

## Verification

- `swift build` — clean
- `scripts/lint.sh` (swift-format) — clean (auto-fix run on 2 lines that went over 120 chars after longer identifiers replaced `setup.id!`)
- `scripts/swiftlint.sh force_unwrapping` count — **0** (was 89 pre-PR, 266 before the `Tests/` child config landed)
- `swift test --filter "APITests.AssignmentRoutes* | ScriptEditRoutes | SubmissionRoutes | CourseBundle | WorkerRoutes | SuiteRoute* | GlobalVariables | SuiteSection | NotebookWebRoutes"` — 123 tests, 0 failures (114 s)

## What this does NOT do

- Does not wire the `Run SwiftLint` CI step yet — that's the final PR in the rollout, after the rest of the SwiftLint backlog (`first_where` 98, `function_body_length` 39, `cyclomatic_complexity` 27, etc.) is cleared.
- Does not touch test code — `Tests/` continues to use force-unwraps where idiomatic; CLAUDE.md exempts tests.

## Test plan

- [x] Build clean
- [x] swift-format clean
- [x] SwiftLint `force_unwrapping` count = 0 in `Sources/`
- [x] 123 focused tests pass locally
- [ ] CI: `format-lint`, `core-tests`, `api-tests`, `api-tests-postgres`, `worker-tests`, `browser-runner-tests`, `build-and-verify`, `build-and-push` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)