### PR TITLE
swiftlint: clear mechanical violations + scope tests/discouraged_optional/etc.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -41,7 +41,12 @@ opt_in_rules:
   - last_where
   - contains_over_filter_count
   - contains_over_filter_is_empty
-  - contains_over_first_not_nil
+  # contains_over_first_not_nil disabled for the same reason as
+  # first_where above: structural matching can't distinguish Fluent's
+  # `QueryBuilder.first()` (issues SQL LIMIT 1) from
+  # `Sequence.first(where:)`.  All three violations were Fluent calls
+  # like `try await X.query(on:).filter(...).first() != nil` — the
+  # rule's suggested `.contains(where:)` doesn't exist on QueryBuilder.
   - contains_over_range_nil_comparison
   - empty_count
   - empty_string

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,8 +57,18 @@ opt_in_rules:
   - prefer_zero_over_explicit_init
   - override_in_extension
   - prohibited_super_call
-  - discouraged_optional_boolean
-  - discouraged_optional_collection
+  # NOTE: discouraged_optional_boolean and discouraged_optional_collection
+  # are intentionally NOT enabled.  They conflict with two well-established
+  # patterns in this codebase:
+  #   1. Codable JSON models where `nil` (key absent) is semantically
+  #      distinct from `false` / `[]` (key present, explicitly false /
+  #      explicitly empty).  NotebookCheck, CourseBundleManifest, and
+  #      most Fluent models rely on this distinction at decode time.
+  #   2. Functions / env parsers that return `Bool?` or `[T]?` where
+  #      `nil` means "input absent or unparseable" — a meaning that
+  #      collapses to false / [] if the rule's advice were followed.
+  # Re-enable only after auditing every Codable schema for absence-vs-
+  # default-value semantics.
 
 excluded:
   - .build

--- a/Sources/APIServer/Helpers/ClassAchievements.swift
+++ b/Sources/APIServer/Helpers/ClassAchievements.swift
@@ -26,18 +26,18 @@ func awardClassBadgesFor100Percent(
         user.role == "student"
     else { return }
 
-    async let _trail = awardImmutableBadge(
+    async let trail: Void = awardImmutableBadge(
         achievementID: "trailblazer",
         testSetupID: testSetupID, userID: userID, submissionID: submissionID, on: db)
-    async let _speed = updateRecordBadge(
+    async let speed: Void = updateRecordBadge(
         achievementID: "speed_champion",
         testSetupID: testSetupID, userID: userID, submissionID: submissionID,
         newValue: Double(executionTimeMs), on: db)
-    async let _mini = updateRecordBadge(
+    async let mini: Void = updateRecordBadge(
         achievementID: "minimalist",
         testSetupID: testSetupID, userID: userID, submissionID: submissionID,
         newValue: Double(attemptNumber), on: db)
-    _ = try await (_trail, _speed, _mini)
+    _ = try await (trail, speed, mini)
 }
 
 /// Inserts the badge record only if no holder exists yet (first-to wins).

--- a/Sources/APIServer/Helpers/SubmissionOutputFormatting.swift
+++ b/Sources/APIServer/Helpers/SubmissionOutputFormatting.swift
@@ -172,15 +172,11 @@ private func bestDetailedSection(stderr: String?, stdout: String?) -> String? {
         .filter { !$0.isEmpty }
     guard !candidates.isEmpty else { return nil }
 
-    for candidate in candidates {
-        if extractStructuredErrorText(from: candidate) != nil {
-            return candidate
-        }
+    for candidate in candidates where extractStructuredErrorText(from: candidate) != nil {
+        return candidate
     }
-    for candidate in candidates {
-        if extractTraceback(in: candidate) != nil {
-            return candidate
-        }
+    for candidate in candidates where extractTraceback(in: candidate) != nil {
+        return candidate
     }
     return stderr ?? stdout
 }

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -392,7 +392,7 @@ extension AdminRoutes {
         guard
             let idString = req.parameters.get("userID"),
             let userID = UUID(uuidString: idString),
-            let _ = try await APIUser.find(userID, on: req.db)
+            try await APIUser.find(userID, on: req.db) != nil
         else {
             throw Abort(.notFound)
         }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+DraftSections.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+DraftSections.swift
@@ -106,10 +106,8 @@ extension AssignmentRoutes {
             // into the trailing Ungrouped block — same semantics as the
             // assignment-scoped variant.
             if var testSuites = dict["testSuites"] as? [[String: Any]] {
-                for i in testSuites.indices {
-                    if (testSuites[i]["sectionID"] as? String) == sectionID {
-                        testSuites[i].removeValue(forKey: "sectionID")
-                    }
+                for i in testSuites.indices where (testSuites[i]["sectionID"] as? String) == sectionID {
+                    testSuites[i].removeValue(forKey: "sectionID")
                 }
                 dict["testSuites"] = testSuites
             }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
@@ -793,7 +793,7 @@ extension AssignmentRoutes {
         let courseState = try await req.resolveActiveCourse(for: publishUser)
         let body = try req.content.decode(PublishBody.self)
 
-        guard let _ = try await APITestSetup.find(body.testSetupID, on: req.db) else {
+        guard try await APITestSetup.find(body.testSetupID, on: req.db) != nil else {
             throw WebAssignmentError.invalidParameter(
                 name: "testSetupID",
                 reason: "unknown test setup '\(body.testSetupID)'"

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+SuiteSections.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+SuiteSections.swift
@@ -105,10 +105,8 @@ extension AssignmentRoutes {
             // into the trailing Ungrouped block — same semantics as the
             // dashboard's onDelete: .setNull on course_sections.
             if var testSuites = dict["testSuites"] as? [[String: Any]] {
-                for i in testSuites.indices {
-                    if (testSuites[i]["sectionID"] as? String) == sectionID {
-                        testSuites[i].removeValue(forKey: "sectionID")
-                    }
+                for i in testSuites.indices where (testSuites[i]["sectionID"] as? String) == sectionID {
+                    testSuites[i].removeValue(forKey: "sectionID")
                 }
                 dict["testSuites"] = testSuites
             }

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -158,16 +158,15 @@ func retestAllSubmissionsForSetup(
 
     let now = Date()
     var touched = 0
-    for submission in submissions {
-        if try await flipSubmissionToPending(
-            submission,
-            triggeredBy: userID,
-            on: db,
-            force: force,
-            now: now
-        ) {
-            touched += 1
-        }
+    for submission in submissions
+    where try await flipSubmissionToPending(
+        submission,
+        triggeredBy: userID,
+        on: db,
+        force: force,
+        now: now
+    ) {
+        touched += 1
     }
     return touched
 }
@@ -195,16 +194,15 @@ func retestStudentSubmissionsForSetup(
 
     let now = Date()
     var touched = 0
-    for submission in submissions {
-        if try await flipSubmissionToPending(
-            submission,
-            triggeredBy: userID,
-            on: db,
-            force: force,
-            now: now
-        ) {
-            touched += 1
-        }
+    for submission in submissions
+    where try await flipSubmissionToPending(
+        submission,
+        triggeredBy: userID,
+        on: db,
+        force: force,
+        now: now
+    ) {
+        touched += 1
     }
     return touched
 }

--- a/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
@@ -654,7 +654,8 @@ func isLikelyTestSuiteFile(_ file: File, storedName: String) -> Bool {
 }
 
 func hasRecognizedScriptShebang(_ file: File) -> Bool {
-    let prefix = String(decoding: Data(file.data.readableBytesView.prefix(256)), as: UTF8.self)
+    let head = Data(file.data.readableBytesView.prefix(256))
+    guard let prefix = String(bytes: head, encoding: .utf8) else { return false }
     let firstLine = prefix.split(whereSeparator: \.isNewline).first.map(String.init) ?? prefix
     let normalized = firstLine.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     guard normalized.hasPrefix("#!") else { return false }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -194,7 +194,7 @@ extension WebRoutes {
         guard let userID = user.id else { throw Abort(.unauthorized) }
         guard
             let setupID = req.parameters.get("testSetupID"),
-            let _ = try await APITestSetup.find(setupID, on: req.db)
+            try await APITestSetup.find(setupID, on: req.db) != nil
         else {
             throw Abort(.notFound)
         }

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -115,10 +115,9 @@ func closeExpiredAssignments(
         .all()
 
     var closedCount = 0
-    for assignment in assignments {
-        if try await closeAssignmentIfExpired(assignment, on: db, logger: logger, now: now) {
-            closedCount += 1
-        }
+    for assignment in assignments
+    where try await closeAssignmentIfExpired(assignment, on: db, logger: logger, now: now) {
+        closedCount += 1
     }
     return closedCount
 }

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -130,10 +130,14 @@ actor BrightSpaceAPIClient {
         let url = signed(url: rawURL, method: "PUT")
 
         struct NumericGradeValue: Content {
-            let GradeObjectType: Int
-            let PointsNumerator: Double
+            let gradeObjectType: Int
+            let pointsNumerator: Double
+            enum CodingKeys: String, CodingKey {
+                case gradeObjectType = "GradeObjectType"
+                case pointsNumerator = "PointsNumerator"
+            }
         }
-        let body = NumericGradeValue(GradeObjectType: 1, PointsNumerator: earnedPoints)
+        let body = NumericGradeValue(gradeObjectType: 1, pointsNumerator: earnedPoints)
 
         let response = try await application.client.put(URI(string: url)) { req in
             req.headers.contentType = .json
@@ -171,13 +175,15 @@ actor BrightSpaceAPIClient {
         // D2L returns { "Items": [{ "UserId": 12345, ... }], "PagingInfo": {...} }
         struct UserListResponse: Decodable {
             struct UserItem: Decodable {
-                let UserId: Int
+                let userId: Int
+                enum CodingKeys: String, CodingKey { case userId = "UserId" }
             }
-            let Items: [UserItem]
+            let items: [UserItem]
+            enum CodingKeys: String, CodingKey { case items = "Items" }
         }
         let decoded = try response.content.decode(UserListResponse.self)
-        guard let first = decoded.Items.first else { return nil }
-        return String(first.UserId)
+        guard let first = decoded.items.first else { return nil }
+        return String(first.userId)
     }
 }
 

--- a/Sources/APIServer/Utilities/ManifestValidation.swift
+++ b/Sources/APIServer/Utilities/ManifestValidation.swift
@@ -349,14 +349,12 @@ func validatePatternFamilies(
     //    generator set (mirrors `TestSuiteEntry.isGenerated`).
     let rawScripts = Set(testSuites.filter { !$0.isGenerated }.map(\.script))
     for family in families {
-        for filename in patternFamilyAllGeneratedFilenames(family) {
-            if rawScripts.contains(filename) {
-                throw Abort(
-                    .unprocessableEntity,
-                    reason:
-                        "Pattern family '\(family.id)' would generate '\(filename)', but a hand-written script with that name already exists. Rename the raw script or change the family id/case key."
-                )
-            }
+        for filename in patternFamilyAllGeneratedFilenames(family) where rawScripts.contains(filename) {
+            throw Abort(
+                .unprocessableEntity,
+                reason:
+                    "Pattern family '\(family.id)' would generate '\(filename)', but a hand-written script with that name already exists. Rename the raw script or change the family id/case key."
+            )
         }
     }
 }

--- a/Sources/Worker/NotebookExtractor.swift
+++ b/Sources/Worker/NotebookExtractor.swift
@@ -187,8 +187,9 @@ struct NotebookExtractor {
 /// than executing side-effectful or control-flow code.
 private func isSafeTopLevelStatement(_ trimmed: String) -> Bool {
     // Definitions and structural annotations are always safe.
-    for prefix in ["def ", "async def ", "class ", "import ", "from ", "@", "#"] {
-        if trimmed.hasPrefix(prefix) { return true }
+    for prefix in ["def ", "async def ", "class ", "import ", "from ", "@", "#"]
+    where trimmed.hasPrefix(prefix) {
+        return true
     }
 
     // Bare string literals are module-level docstrings — safe.

--- a/Sources/Worker/Reporter.swift
+++ b/Sources/Worker/Reporter.swift
@@ -114,16 +114,17 @@ struct Reporter: Sendable {
                             "retryable": context.retryable,
                             "error_message_summary": context.message,
                         ])
+                },
+                operation: {
+                    let result = await Self.attemptReport(session: session, request: request, expectedStatus: 200)
+                    switch result {
+                    case .success:
+                        return ()
+                    case .failure(let error):
+                        throw error
+                    }
                 }
-            ) {
-                let result = await Self.attemptReport(session: session, request: request, expectedStatus: 200)
-                switch result {
-                case .success:
-                    return ()
-                case .failure(let error):
-                    throw error
-                }
-            }
+            )
         } catch let reporterError as ReporterError {
             throw reporterError
         } catch {

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -517,26 +517,27 @@ actor WorkerDaemon {
                         "retryable": context.retryable,
                         "error_message_summary": context.message,
                     ])
+            },
+            operation: {
+                var request = URLRequest(url: url)
+                request.httpMethod = "GET"
+                request.timeoutInterval = 5
+                self.signer.sign(&request)
+                let (tmpURL, response) = try await Self.downloadSession.download(for: request)
+                guard let http = response as? HTTPURLResponse else {
+                    throw WorkerDaemonError.downloadFailed(url)
+                }
+                guard http.statusCode == 200 else {
+                    throw WorkerDaemonError.httpDownloadFailure(
+                        statusCode: http.statusCode,
+                        body: "<download body unavailable>"
+                    )
+                }
+                try? FileManager.default.removeItem(at: destination)
+                try FileManager.default.moveItem(at: tmpURL, to: destination)
+                await self.recordConnectionRestoredIfNeeded(stage: stage)
             }
-        ) {
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
-            request.timeoutInterval = 5
-            self.signer.sign(&request)
-            let (tmpURL, response) = try await Self.downloadSession.download(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                throw WorkerDaemonError.downloadFailed(url)
-            }
-            guard http.statusCode == 200 else {
-                throw WorkerDaemonError.httpDownloadFailure(
-                    statusCode: http.statusCode,
-                    body: "<download body unavailable>"
-                )
-            }
-            try? FileManager.default.removeItem(at: destination)
-            try FileManager.default.moveItem(at: tmpURL, to: destination)
-            await self.recordConnectionRestoredIfNeeded(stage: stage)
-        }
+        )
     }
 
     nonisolated func unzip(_ zipFile: URL, to directory: URL) throws {

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -10,6 +10,13 @@ parent_config: ../.swiftlint.yml
 
 disabled_rules:
   - force_unwrapping
+  # force_try and force_cast follow the same rationale as
+  # force_unwrapping: tests operate on controlled inputs (literal JSON,
+  # known-shape fixture data, etc.) where `try!` and `as!` are the
+  # idiomatic shorthand for "this cannot fail given the setup; if it
+  # does, the test failure is the right signal."
+  - force_try
+  - force_cast
   # `non_optional_string_data_conversion` flags
   # `<string>.data(using: .utf8)` and suggests `Data(<string>.utf8)`.
   # All 29 violations are in test fixtures with controlled multi-line

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -10,3 +10,11 @@ parent_config: ../.swiftlint.yml
 
 disabled_rules:
   - force_unwrapping
+  # `non_optional_string_data_conversion` flags
+  # `<string>.data(using: .utf8)` and suggests `Data(<string>.utf8)`.
+  # All 29 violations are in test fixtures with controlled multi-line
+  # `"""…"""` literals where `.data(using: .utf8)!` is the standard
+  # idiom.  The transformation would require wrapping every fixture in
+  # `Data(... .utf8)` for negligible benefit.  The companion
+  # force_unwrapping exemption above covers the same reasoning.
+  - non_optional_string_data_conversion

--- a/Tests/APITests/EnrollCSVHelperTests.swift
+++ b/Tests/APITests/EnrollCSVHelperTests.swift
@@ -120,7 +120,7 @@ import Testing
             #174667.teststudent2,#174667.teststudent2,#
             #174667.alice,#174667.alice,#
             """
-        #expect(parseUsernamesFromCSV(Data(csv.utf8)) == [])
+        #expect(parseUsernamesFromCSV(Data(csv.utf8)).isEmpty)
     }
 
     @Test func brightspacePrefersUsernameColumnWhenDifferent() {
@@ -141,7 +141,7 @@ import Testing
         // Same test-account filter applies even without a header, for
         // instructors who paste a column of dotted-form values.
         let csv = "#174667.alice\n#174667.bob\n"
-        #expect(parseUsernamesFromCSV(Data(csv.utf8)) == [])
+        #expect(parseUsernamesFromCSV(Data(csv.utf8)).isEmpty)
     }
 
     @Test func stripsBareHashPrefix() {

--- a/Tests/APITests/MarmosetImportParserTests.swift
+++ b/Tests/APITests/MarmosetImportParserTests.swift
@@ -96,7 +96,7 @@ import Testing
     @Test func parseEmptyValue() {
         let input = "key1=\nkey2=value\n"
         let result = parseJavaProperties(Data(input.utf8))
-        #expect(result["key1"] == "")
+        #expect(result["key1"]?.isEmpty == true)
         #expect(result["key2"] == "value")
     }
 

--- a/Tests/APITests/PatternFamilyApplyTests.swift
+++ b/Tests/APITests/PatternFamilyApplyTests.swift
@@ -180,7 +180,7 @@ final class PatternFamilyApplyTests: PatternFamilyTestCase {
 
         let props = try decodeManifest(fixture.setup.manifest)
         XCTAssertEqual(props.patternFamilies, [])
-        XCTAssertTrue(props.testSuites.filter { $0.generatedBy != nil }.isEmpty)
+        XCTAssertFalse(props.testSuites.contains { $0.generatedBy != nil })
     }
 
     func testApply_preservesHandWrittenScripts() async throws {

--- a/Tests/CoreTests/CoreCodableTests.swift
+++ b/Tests/CoreTests/CoreCodableTests.swift
@@ -125,7 +125,7 @@ struct CoreCodableTests {
         let col = try decoder.decode(TestOutcomeCollection.self, from: json)
         #expect(col.totalPoints == 5)  // falls back to totalTests
         #expect(col.earnedPoints == 3)  // falls back to passCount
-        #expect(col.warnings == [])  // defaults to empty
+        #expect(col.warnings.isEmpty)  // defaults to empty
         #expect(col.jobStartedAt == nil)  // optional, absent
     }
 

--- a/Tests/CoreTests/CoreModelTests.swift
+++ b/Tests/CoreTests/CoreModelTests.swift
@@ -152,7 +152,7 @@ struct CoreModelTests {
     @Test func testSuiteEntryDefaultsEmptyDependsOn() throws {
         let json = #"{ "tier": "public", "script": "test_foo.sh" }"#.data(using: .utf8)!
         let entry = try decoder.decode(TestSuiteEntry.self, from: json)
-        #expect(entry.dependsOn == [])
+        #expect(entry.dependsOn.isEmpty)
     }
 
     @Test func testSuiteEntryWithDependsOnRoundTrip() throws {
@@ -183,7 +183,7 @@ struct CoreModelTests {
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
         #expect(manifest.testSuites.count == 3)
-        #expect(manifest.testSuites[0].dependsOn == [])
+        #expect(manifest.testSuites[0].dependsOn.isEmpty)
         #expect(manifest.testSuites[1].dependsOn == ["test_build.sh"])
         #expect(manifest.testSuites[2].dependsOn == ["test_build.sh"])
 

--- a/Tests/CoreTests/NotebookFunctionScannerTests.swift
+++ b/Tests/CoreTests/NotebookFunctionScannerTests.swift
@@ -140,7 +140,7 @@ struct NotebookFunctionScannerTests {
     @Test func paramHasDefaultEmptyWhenNoParams() {
         let nb = notebook(code: "def nothing():\n    return 1\n")
         let fns = scanNotebookForFunctions(nb)
-        #expect(fns[0].paramHasDefault == [])
+        #expect(fns[0].paramHasDefault.isEmpty)
     }
 
     @Test func functionWithoutAnyAnnotations() {
@@ -229,7 +229,7 @@ struct NotebookFunctionScannerTests {
         let nb = notebook(code: "def get_count():\n    return 0\n")
         let fns = scanNotebookForFunctions(nb)
         #expect(fns.count == 1)
-        #expect(fns[0].paramNames == [])
+        #expect(fns[0].paramNames.isEmpty)
     }
 
     @Test func varargsExcluded() {

--- a/Tests/WorkerTests/Support/MockURLProtocol.swift
+++ b/Tests/WorkerTests/Support/MockURLProtocol.swift
@@ -82,7 +82,12 @@ final class MockURLProtocol: URLProtocol {
 
     // MARK: URLProtocol
 
+    // Must remain `class func` (not `static`) to override URLProtocol's
+    // base-class `class func` declarations.  `static` would not satisfy
+    // the override contract.
+    // swiftlint:disable:next static_over_final_class
     override class func canInit(with request: URLRequest) -> Bool { true }
+    // swiftlint:disable:next static_over_final_class
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -582,7 +582,7 @@ final class WorkerTests: XCTestCase {
         XCTAssertTrue(content.contains("x = 1"))
         // The file should not have multiple blank-line groups from empty cells.
         let codeLines = content.split(separator: "\n", omittingEmptySubsequences: false)
-            .filter { $0.trimmingCharacters(in: .whitespaces) == "" }
+            .filter { $0.trimmingCharacters(in: .whitespaces).isEmpty }
         // Allow at most a few blank lines (one between cells + header gap).
         XCTAssertLessThan(codeLines.count, 5, "Excess blank lines from empty cells")
     }


### PR DESCRIPTION
## Summary

Stacks on top of [#516](https://github.com/JimWallace/Chickadee/pull/516) (now merged). Clears 133 of the 258 SwiftLint violations remaining after #516 — every mechanical fix or false-positive disable, leaving only the **structural-rule backlog** (function/type/complexity caps, large tuples, function parameter counts).

| | Before this PR | After |
|---|---|---|
| Total SwiftLint violations | 258 | **125** |
| Mechanical rules cleared | — | `for_where`, `identifier_name`, `unused_optional_binding`, `multiple_closures_with_trailing_closure`, `optional_data_string_conversion`, `empty_collection_literal`, `empty_string`, `contains_over_filter_is_empty`, `static_over_final_class` |
| Rules disabled with rationale | — | `non_optional_string_data_conversion` (tests), `discouraged_optional_boolean`, `discouraged_optional_collection`, `contains_over_first_not_nil`, `force_try` (tests), `force_cast` (tests) |

Three commits, each independently meaningful:

### 1. Exempt `Tests/` from `non_optional_string_data_conversion` ([3a9d1fe](https://github.com/JimWallace/Chickadee/commit/3a9d1fe))

All 29 violations were test fixtures with `""" … """.data(using: .utf8)!` for known-valid JSON / Python strings. The rule's suggested `Data(""" … """.utf8)` wrap costs more than it gains in test code with controlled inputs. The companion `force_unwrapping` exemption already in the child config covers the same reasoning. Zero violations in `Sources/`, so the rule stays on for production code.

### 2. Disable `discouraged_optional_boolean` + `discouraged_optional_collection` ([695d313](https://github.com/JimWallace/Chickadee/commit/695d313))

57 violations spread across Codable JSON models (`NotebookCheck`'s `checkDtype: Bool?`, `expectedColumns: [String]?` etc., `CourseBundleManifest.openEnrollment: Bool?` — already slated for v0.6.0 removal, Fluent models, env parsers).

The fundamental problem: for Codable / Fluent / env-driven inputs, `nil` (key absent / file missing / unparseable) is semantically distinct from `false` / `[]` (key present, explicitly false / explicitly empty). The rule's suggested rewrite would collapse those two cases. Re-enable only after auditing every Codable schema for absence-vs-default-value semantics.

### 3. Clear mechanical violations across 18 files ([4c44bda](https://github.com/JimWallace/Chickadee/commit/4c44bda))

**Source changes (no behaviour change):**
- `for_where` (9 → 0): `for x in xs { if cond { … } }` → `for x in xs where cond { … }`.
- `identifier_name` (7 → 0): `async let _trail/_speed/_mini` → bare names in `ClassAchievements`; PascalCase D2L API struct fields converted to lowercase with explicit `CodingKeys` (wire format preserved).
- `unused_optional_binding` (3 → 0): `guard let _ = …` → `guard … != nil`.
- `multiple_closures_with_trailing_closure` (2 → 0): name the trailing `operation:` closure explicitly at `RunnerDaemon.download` and `Reporter.report`.
- `optional_data_string_conversion` (1 → 0): `String(decoding:as:)` → failable `String(bytes:encoding:)` in `hasRecognizedScriptShebang` — non-UTF-8 binaries now correctly return false instead of returning a replacement-char string that might coincidentally start with `#!`.

**Config changes:**
- `.swiftlint.yml`: disable `contains_over_first_not_nil` for the same Fluent QueryBuilder false-positive reason as `first_where` (all 3 sites were `.first() != nil` on QueryBuilder, not Sequence).
- `Tests/.swiftlint.yml`: add `force_try` + `force_cast` to the child-config disabled list.

**Test mechanical fixes:**
- `empty_collection_literal` (7 → 0): `x == []` → `x.isEmpty`.
- `empty_string` (2 → 0): `x == ""` → `x.isEmpty`.
- `contains_over_filter_is_empty` (1 → 0): `.filter { … }.isEmpty` → `!contains { … }`.
- `static_over_final_class` (2 → 0): inline `// swiftlint:disable:next` directives at the two `MockURLProtocol` overrides of `URLProtocol`'s `class func canInit` / `canonicalRequest`, since `static func` would not satisfy the override contract.

## What's left at 125

All structural rules requiring real refactor work:

| Rule | Count |
|---|---|
| `function_body_length` | 41 |
| `cyclomatic_complexity` | 28 |
| `type_body_length` | 25 |
| `large_tuple` | 17 |
| `function_parameter_count` | 13 |
| `nesting` | 1 |

These should be tackled per-file in follow-up PRs — they're refactors, not substitutions.

## Verification

- `swift build` — clean
- `scripts/lint.sh` (swift-format) — clean
- `swift test --filter "APITests|CoreTests|WorkerTests"` — **914 tests, 0 failures** (4 skipped as expected, ~490 s)
- `scripts/swiftlint.sh` reports 125 / 125 serious; all in the structural-rule categories above

## Test plan

- [x] Build clean
- [x] swift-format clean
- [x] 914 tests pass locally
- [x] No remaining mechanical or false-positive violations
- [ ] CI: `format-lint`, `core-tests`, `api-tests`, `api-tests-postgres`, `worker-tests`, `browser-runner-tests`, `build-and-verify`, `build-and-push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)