### PR TITLE
fix: SSO logout button silently fails under CSP form-action 'self'

### DIFF
--- a/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
+++ b/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
@@ -54,7 +54,14 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
     ///   - https://esm.sh is whitelisted because the new-assignment editor
     ///     imports CodeMirror modules from there.
     /// Tighten with per-response nonces in a follow-up.
-    static let defaultContentSecurityPolicy: String = [
+    ///
+    /// `form-action` is rendered per-request so the IdP origin from
+    /// `app.oidcConfig?.discovery.endSessionEndpoint` can be appended when
+    /// SSO is configured.  Without that, Chrome (and recent Firefox) enforce
+    /// form-action across the redirect chain and block the POST /logout →
+    /// 303 → end_session_endpoint navigation, breaking the SSO "Log out"
+    /// button.
+    static let defaultContentSecurityPolicyBase: [String] = [
         "default-src 'self'",
         "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://cdn.jsdelivr.net https://esm.sh",
         "style-src 'self' 'unsafe-inline'",
@@ -64,10 +71,44 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
         "child-src 'self' blob:",
         "connect-src 'self' https://cdn.jsdelivr.net https://esm.sh",
         "frame-ancestors 'self'",
-        "form-action 'self'",
         "base-uri 'self'",
         "object-src 'none'",
-    ].joined(separator: "; ")
+    ]
+
+    /// CSP used when no extra form-action origins apply (e.g. local-only mode
+    /// or pre-OIDC-load).  Kept around for tests that pin the literal header.
+    static let defaultContentSecurityPolicy: String = renderCSP(
+        base: defaultContentSecurityPolicyBase,
+        formActionOrigins: []
+    )
+
+    /// Builds the CSP string from the base directives plus a `form-action`
+    /// directive whose allow-list always includes `'self'` and any extra
+    /// origins passed in.
+    static func renderCSP(base: [String], formActionOrigins: [String]) -> String {
+        var sources = ["'self'"]
+        for origin in formActionOrigins where !sources.contains(origin) {
+            sources.append(origin)
+        }
+        var directives = base
+        directives.append("form-action " + sources.joined(separator: " "))
+        return directives.joined(separator: "; ")
+    }
+
+    /// Extracts the scheme://host[:port] origin from a URL string, suitable
+    /// for use as a CSP source expression.  Returns nil for malformed input
+    /// or schemes without a host (e.g. `data:`, `mailto:`).
+    static func cspOrigin(of urlString: String) -> String? {
+        guard
+            let components = URLComponents(string: urlString),
+            let scheme = components.scheme,
+            let host = components.host, !host.isEmpty
+        else { return nil }
+        if let port = components.port {
+            return "\(scheme)://\(host):\(port)"
+        }
+        return "\(scheme)://\(host)"
+    }
 
     /// Permissions-Policy denying browser features Chickadee never uses.
     static let defaultPermissionsPolicy: String = [
@@ -86,16 +127,16 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
     /// since it's near-impossible to undo.
     static let defaultStrictTransportSecurity: String = "max-age=63072000; includeSubDomains"
 
-    let contentSecurityPolicy: String
+    let cspBaseDirectives: [String]
     let permissionsPolicy: String
     let strictTransportSecurity: String?
 
     init(
-        contentSecurityPolicy: String = Self.defaultContentSecurityPolicy,
+        cspBaseDirectives: [String] = Self.defaultContentSecurityPolicyBase,
         permissionsPolicy: String = Self.defaultPermissionsPolicy,
         strictTransportSecurity: String? = nil
     ) {
-        self.contentSecurityPolicy = contentSecurityPolicy
+        self.cspBaseDirectives = cspBaseDirectives
         self.permissionsPolicy = permissionsPolicy
         self.strictTransportSecurity = strictTransportSecurity
     }
@@ -105,14 +146,29 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
         chainingTo next: any AsyncResponder
     ) async throws -> Response {
         let response = try await next.respond(to: request)
+        let csp = Self.renderCSP(
+            base: cspBaseDirectives,
+            formActionOrigins: formActionExtras(for: request)
+        )
         response.headers.replaceOrAdd(name: "X-Content-Type-Options", value: "nosniff")
         response.headers.replaceOrAdd(name: "X-Frame-Options", value: "SAMEORIGIN")
         response.headers.replaceOrAdd(name: "Referrer-Policy", value: "strict-origin-when-cross-origin")
-        response.headers.replaceOrAdd(name: "Content-Security-Policy", value: contentSecurityPolicy)
+        response.headers.replaceOrAdd(name: "Content-Security-Policy", value: csp)
         response.headers.replaceOrAdd(name: "Permissions-Policy", value: permissionsPolicy)
         if let hsts = strictTransportSecurity {
             response.headers.replaceOrAdd(name: "Strict-Transport-Security", value: hsts)
         }
         return response
+    }
+
+    /// The SSO `end_session_endpoint` is an external origin the browser is
+    /// redirected to after POST /logout.  Without it in form-action, the
+    /// redirect chain is blocked and "Log out" silently does nothing.
+    private func formActionExtras(for request: Request) -> [String] {
+        guard
+            let endpoint = request.application.oidcConfig?.discovery.endSessionEndpoint,
+            let origin = Self.cspOrigin(of: endpoint)
+        else { return [] }
+        return [origin]
     }
 }

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -125,6 +125,62 @@ final class SecurityAndHealthTests: XCTestCase {
         }
     }
 
+    func testCSPFormActionDefaultsToSelfOnly() async throws {
+        try await withApp(try await makeSecurityHeadersApp()) { app in
+            try await app.asyncTest(.GET, "/headers") { res in
+                let csp = res.headers.first(name: "Content-Security-Policy") ?? ""
+                XCTAssertTrue(
+                    csp.contains("form-action 'self'"),
+                    "expected form-action 'self' in CSP, got: \(csp)"
+                )
+            }
+        }
+    }
+
+    func testCSPFormActionIncludesIdPOriginWhenSSOConfigured() async throws {
+        // Regression: CSP form-action 'self' alone blocks the SSO logout
+        // redirect chain (POST /logout → 303 → end_session_endpoint), which
+        // Chrome and recent Firefox enforce across redirects.  Loading an
+        // OIDC config with an end_session_endpoint must extend form-action
+        // with that IdP origin so the "Log out" button actually navigates.
+        try await withApp(try await makeSecurityHeadersApp()) { app in
+            app.oidcConfig = OIDCConfiguration(
+                clientID: "id",
+                clientSecret: "secret",
+                redirectURI: "http://localhost:8080/auth/sso/callback",
+                discovery: OIDCDiscovery(
+                    issuer: "https://idp.example.com",
+                    authorizationEndpoint: "https://idp.example.com/oauth/authorize",
+                    tokenEndpoint: "https://idp.example.com/oauth/token",
+                    jwksURI: "https://idp.example.com/oauth/jwks",
+                    revocationEndpoint: nil,
+                    endSessionEndpoint: "https://idp.example.com/oauth/logout"
+                ),
+                claimConfig: OIDCClaimConfig()
+            )
+            try await app.asyncTest(.GET, "/headers") { res in
+                let csp = res.headers.first(name: "Content-Security-Policy") ?? ""
+                XCTAssertTrue(
+                    csp.contains("form-action 'self' https://idp.example.com"),
+                    "expected end_session_endpoint origin in form-action, got: \(csp)"
+                )
+            }
+        }
+    }
+
+    func testCSPOriginExtractionHandlesSchemeHostPort() {
+        XCTAssertEqual(
+            SecurityHeadersMiddleware.cspOrigin(of: "https://idp.example.com/oauth/logout"),
+            "https://idp.example.com"
+        )
+        XCTAssertEqual(
+            SecurityHeadersMiddleware.cspOrigin(of: "http://127.0.0.1:9001/logout?foo=bar"),
+            "http://127.0.0.1:9001"
+        )
+        XCTAssertNil(SecurityHeadersMiddleware.cspOrigin(of: "not a url"))
+        XCTAssertNil(SecurityHeadersMiddleware.cspOrigin(of: "mailto:nobody@example.com"))
+    }
+
     func testLeafErrorMiddlewareReturnsJSONForAPIRoutes() async throws {
         try await withApp(try await makeLeafErrorApp(configureViews: false)) { app in
             try await app.asyncTest(.GET, "/api/boom") { res in


### PR DESCRIPTION
## Summary

- `SecurityHeadersMiddleware` (v0.4.167) ships CSP `form-action 'self'`, which Chrome and recent Firefox enforce **across the entire redirect chain** — not just the form's immediate target. SSO logout goes POST `/logout` → 303 to `end_session_endpoint` (external IdP), and the browser refuses the redirect; the "Log out" button silently produces nothing.
- Local-mode logout was unaffected because its redirect target is `/login` (same origin), so this regressed quietly when SSO sites picked up v0.4.167.
- Middleware now renders CSP per request and appends the IdP `end_session_endpoint` origin to `form-action` whenever `app.oidcConfig` is loaded. The endpoint URL only becomes known after `OIDCConfiguration.load(_:)` finishes its discovery fetch at startup (after middleware is registered), so the lookup has to be deferred to response time.

## Files
- `Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift` — split CSP into base directives + per-request `form-action`; new `renderCSP` + `cspOrigin` helpers.
- `Tests/APITests/SecurityAndHealthTests.swift` — three new tests:
  - `testCSPFormActionDefaultsToSelfOnly` (no regression for local mode)
  - `testCSPFormActionIncludesIdPOriginWhenSSOConfigured` (regression pin)
  - `testCSPOriginExtractionHandlesSchemeHostPort` (helper coverage)

## Test plan
- [x] `swift test --filter "AuthRoutesTests|CSRFTests|SSOAuthFlowTests|SecurityAndHealthTests"` — 44/44 pass
- [x] `scripts/lint.sh` — clean
- [ ] Manual: SSO deployment, click "Log out", confirm browser follows redirect to IdP `end_session_endpoint` instead of silently dropping it
- [ ] Manual: local-mode deployment, confirm "Log out" still redirects to `/login` (regression check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2WxCgkyZsWuNFQGZA6gg2)_