### PR TITLE
ci: bump worker-tests budget to 20m and enable --parallel

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -142,7 +142,7 @@ jobs:
 
   worker-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     container:
       image: swift:6.3-jammy
       options: --privileged
@@ -165,4 +165,4 @@ jobs:
         run: apt-get update -qq && apt-get install -y --no-install-recommends file
 
       - name: Run WorkerTests
-        run: swift test --filter WorkerTests
+        run: swift test --parallel --filter WorkerTests


### PR DESCRIPTION
## Summary

- `worker-tests` was the only Swift test job stuck at `timeout-minutes: 15` while every sibling (`core-tests`, `api-tests`, `api-tests-postgres`) runs at 20. PR #520 timed it out at exactly 15:03 — not a real failure, just compile-from-scratch + serial test execution leaving no headroom on a contended runner.
- Two minimal changes:
  - `timeout-minutes: 15 → 20`, matching siblings.
  - `swift test --filter WorkerTests` → `swift test --parallel --filter WorkerTests`. Every other test job already uses `--parallel`; WorkerTests targets use UUID-scoped tmp dirs, so parallel XCTestCase execution is safe.
- Bigger win (build artifact caching) deferred to follow-up issue.

## Test plan

- [ ] Push triggers CI; confirm worker-tests completes well under 20m
- [ ] Confirm no test isolation regressions from `--parallel` (tmp-dir conflicts, port races, etc.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2WxCgkyZsWuNFQGZA6gg2)_