### PR TITLE
fix(compose): drop empty environment: key on runner service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,6 @@ services:
       # Docker already provides container-level process isolation.
       # To enable OS-level sandboxing (Linux unshare namespaces),
       # add "--sandbox" here and "cap_add: [SYS_ADMIN]" to this service.
-    environment:
     networks:
       - chickadee
     depends_on:


### PR DESCRIPTION
## Summary

`docker-compose.yml` had a bare `environment:` key with no value on the `runner` service. Newer docker compose versions reject this with:

\`\`\`
validating docker-compose.yml: services.runner.environment must be a mapping
\`\`\`

This surfaced when the new ZAP baseline workflow (added in #525) tried to run \`docker compose up\` in CI — the first place in CI that exercises \`docker compose up\` against this file. The existing \`docker-build.yml\` only does \`docker build\`, which doesn't validate compose schema.

The runner doesn't need any env vars passed via compose — \`RUNNER_WORKER_ID\` and \`RUNNER_MAX_JOBS\` are referenced in the \`command:\` block and substituted from the shell at parse time. Removing the empty key is the simplest correct fix.

## Test plan
- [x] YAML parses cleanly.
- [ ] CI's existing docker-related checks pass.
- [ ] Manually trigger ZAP workflow after merge to confirm \`docker compose up\` succeeds in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)