### PR TITLE
security: tighten security-header coverage + ZAP baseline polish

### DIFF
--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -38,10 +38,11 @@ jobs:
           exit 1
 
       - name: Run ZAP baseline scan
-        uses: zaproxy/action-baseline@v0.12.0
+        uses: zaproxy/action-baseline@v0.15.0
         with:
           target: 'http://localhost:8080'
           cmd_options: '-a'
+          rules_file_name: '.zap/rules.tsv'
           fail_action: false
           allow_issue_writing: true
 

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,35 @@
+# ZAP baseline rule configuration for the Chickadee weekly scan.
+#
+# Format (tab-separated):
+#   RULE_ID    THRESHOLD    [URL_REGEX]
+#
+# THRESHOLD values: IGNORE | INFO | WARN | FAIL
+#
+# Suppressions below are rules ZAP fires that are either informational
+# (it noticed a feature) or describe browser-side request headers the
+# server doesn't control.  Real findings (CSP, header coverage, etc.)
+# are still surfaced.
+
+# Information Disclosure - Suspicious Comments
+# Flags TODO/FIXME strings in JS bundles; not actionable as a recurring CI rule.
+10027	IGNORE
+
+# Non-Storable / Storable Content
+# Informational caching observation, not a vulnerability.
+10049	IGNORE
+
+# Base64 Disclosure
+# Flags session cookies and asset-versioning hashes that look base64.
+10094	IGNORE
+
+# Authentication Request Identified
+# ZAP noting a login form exists; not a finding.
+10111	IGNORE
+
+# Session Management Response Identified
+# ZAP noting session cookies exist; not a finding.
+10112	IGNORE
+
+# Sec-Fetch-* Headers Missing
+# Those are request headers the browser sends; the server cannot set them.
+90005	IGNORE

--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -3,21 +3,24 @@
 // Order-sensitive middleware registration plus view/static-file setup.
 // The order here is load-bearing:
 //
-//   LeafErrorMiddleware     — outermost so it catches every downstream error
+//   SecurityHeadersMiddleware — outermost so it adds CSP / nosniff /
+//                               Permissions-Policy to EVERY response,
+//                               including 404s rendered by
+//                               LeafErrorMiddleware, static assets served
+//                               by FileMiddleware, and 301s from
+//                               HTTPSRedirectMiddleware
+//   LeafErrorMiddleware     — catches every downstream error
 //   HTTPSRedirectMiddleware — only when enforceHTTPS, before sessions
 //   sessions.middleware
 //   UserSessionAuthenticator
 //   UserActivityMiddleware
 //   UserFileNamespaceMiddleware
 //   ScanModeMiddleware      — gates destructive POSTs in scan windows
-//   FileMiddleware          — short-circuits the chain for static files,
-//                             so all *prior* middleware run only for
-//                             dynamic Leaf-rendered pages
+//   FileMiddleware          — short-circuits the chain for static files
 //   COEPMiddleware          — sets Cross-Origin-Embedder-Policy headers
 //                             on dynamic pages (NOT on JupyterLite static
 //                             assets, since the service worker produces
 //                             synthetic responses without CORP headers)
-//   SecurityHeadersMiddleware
 //
 // Storage seeding for auth/security configs happens here too because
 // the middleware chain reads them via app.storage.
@@ -61,8 +64,22 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
 
     // MARK: - Middleware (order matters)
 
-    // Error page middleware must be outermost so it catches errors from all
-    // subsequent middleware and route handlers.
+    // Security headers run *outermost* so that CSP, X-Content-Type-Options,
+    // Permissions-Policy, etc. land on every response — including 404s
+    // produced by LeafErrorMiddleware, static-asset responses served by
+    // FileMiddleware, and 301s issued by HTTPSRedirectMiddleware.  Each of
+    // those middlewares either short-circuits the chain or builds its own
+    // response, so middleware registered *after* them never sees the
+    // response on the way back.  HSTS is still gated on enforceHTTPS via
+    // the strictTransportSecurity argument below.
+    let hstsValue: String? =
+        securityConfiguration.enforceHTTPS
+        ? SecurityHeadersMiddleware.defaultStrictTransportSecurity
+        : nil
+    app.middleware.use(SecurityHeadersMiddleware(strictTransportSecurity: hstsValue))
+
+    // Error page middleware sits beneath SecurityHeadersMiddleware so it
+    // catches errors from all subsequent middleware and route handlers.
     app.middleware.use(LeafErrorMiddleware())
     if securityConfiguration.enforceHTTPS {
         app.middleware.use(HTTPSRedirectMiddleware(configuration: securityConfiguration))
@@ -103,12 +120,4 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // fallback — so cross-origin isolation on the iframe document is unnecessary.
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(COEPMiddleware())
-    // HSTS is set only when HTTPS enforcement is active. Pinning Strict-
-    // Transport-Security against a dev http://localhost server would brick
-    // local browsers; the enforceHTTPS gate matches HTTPSRedirectMiddleware.
-    let hstsValue: String? =
-        securityConfiguration.enforceHTTPS
-        ? SecurityHeadersMiddleware.defaultStrictTransportSecurity
-        : nil
-    app.middleware.use(SecurityHeadersMiddleware(strictTransportSecurity: hstsValue))
 }


### PR DESCRIPTION
## Summary

First wave of fixes from the ZAP baseline (issue [#565](https://github.com/JimWallace/Chickadee/issues/565)) plus the workflow-level breakage from \`zaproxy/action-baseline@v0.12.0\`.

### Server change: SecurityHeadersMiddleware is now outermost

Previously registered *after* \`FileMiddleware\` (which short-circuits for static files) and *after* \`LeafErrorMiddleware\` (which builds error responses outside the inner chain). As a result:

- Static assets (\`app.js\`, \`styles.css\`, icons) had no security headers.
- 404 pages had no security headers.
- \`/robots.txt\` and \`/sitemap.xml\` (both 404) had no CSP / Permissions-Policy.

Moving the middleware to the outermost position fixes four real ZAP findings in one move:

| Rule | Finding | URLs |
|---|---|---|
| 10021 | X-Content-Type-Options Header Missing | 5 static asset URLs |
| 10038 | CSP not set | \`/robots.txt\`, \`/sitemap.xml\` |
| 10063 | Permissions-Policy not set | \`/app.js\`, \`/robots.txt\`, \`/sitemap.xml\` |

\`COEPMiddleware\` is **deliberately left in its current position** (after \`FileMiddleware\`) so JupyterLite's static assets continue to not receive Cross-Origin-Embedder-Policy — that exclusion is intentional, and changing it would break the service-worker-served virtual filesystem responses.

HSTS gating on \`appConfig.security.enforceHTTPS\` is preserved.

### CI change: bump \`zaproxy/action-baseline\` v0.12.0 → v0.15.0

v0.12.0 (Apr 2024) bundled an old \`actions/upload-artifact\` that uses the deprecated artifact API. Every successful scan still exits 1 with \`"The artifact name zap_scan is not valid"\`, which makes the workflow appear failed even though findings are written to the issue. v0.15.0 (Oct 2025) is the current release and ships a working upload-artifact.

### CI change: add \`.zap/rules.tsv\` to suppress six noise rules

| Rule | Why suppressed |
|---|---|
| 10027 Suspicious Comments | Flags TODO/FIXME in JS — not actionable as a recurring CI rule |
| 10049 Storable / Non-Storable Content | Informational caching observation |
| 10094 Base64 Disclosure | Session cookies and asset versioning hashes |
| 10111 Authentication Request Identified | "We found a login form" |
| 10112 Session Management Response Identified | "We found session cookies" |
| 90005 Sec-Fetch-\* Headers Missing | These are request headers; the server cannot set them |

Real header-coverage findings (CSP, X-Content-Type-Options, Permissions-Policy, COOP/COEP/CORP) remain active.

### What this PR does NOT do

- **COOP/COEP/CORP (rule 90004) is not addressed.** That triplet must be set carefully per-route to coexist with JupyterLite's service worker. Deferred to its own PR.
- **CSP \`unsafe-eval\` / \`unsafe-inline\`** stays — Pyodide requires \`unsafe-eval\`, inline scripts/styles are used by Leaf templates. Already documented in [SecurityHeadersMiddleware.swift](Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift).

## Test plan
- [x] \`scripts/lint.sh\` passes.
- [ ] CI \`format-lint\`, Swift tests pass.
- [ ] CodeQL JS/TS clean.
- [ ] After merge: \`workflow_dispatch\` the ZAP workflow on main and verify (a) the workflow goes green, (b) the four addressed rules drop out of the findings, (c) the suppressed rules disappear from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)