### PR TITLE
security: enforce enrollment on submit, 0600 worker secret, equalize login timing

### DIFF
--- a/Sources/APIServer/APIServerApp+Stores.swift
+++ b/Sources/APIServer/APIServerApp+Stores.swift
@@ -373,6 +373,9 @@ func readWorkerSecretFromDisk(workerSecretFilePath: String) -> String? {
     else {
         return nil
     }
+    // Harden permissions on files written by older builds that ran before
+    // writeWorkerSecretToDisk set the mode explicitly.
+    restrictWorkerSecretFilePermissions(at: workerSecretFilePath)
     return text
 }
 
@@ -381,6 +384,17 @@ func writeWorkerSecretToDisk(secret: String, workerSecretFilePath: String) {
     guard !value.isEmpty else { return }
     let url = URL(fileURLWithPath: workerSecretFilePath)
     try? value.write(to: url, atomically: true, encoding: .utf8)
+    // The runner shared secret is the HMAC signing key for every worker
+    // request.  Default umask (typically 0644 on Linux) lets any local user
+    // read it and forge worker traffic; restrict to owner read/write only.
+    restrictWorkerSecretFilePermissions(at: workerSecretFilePath)
+}
+
+private func restrictWorkerSecretFilePermissions(at path: String) {
+    try? FileManager.default.setAttributes(
+        [.posixPermissions: NSNumber(value: 0o600)],
+        ofItemAtPath: path
+    )
 }
 
 func randomWorkerPassphrase(workerSecretWordlistPath: String) -> String {

--- a/Sources/APIServer/Auth/AuthProvider.swift
+++ b/Sources/APIServer/Auth/AuthProvider.swift
@@ -26,17 +26,41 @@ protocol AuthProvider: Sendable {
 /// BCrypt-backed credential verification against the local user table.
 struct LocalAuthProvider: AuthProvider {
     func authenticate(username: String, password: String, on req: Request) async throws -> APIUser? {
-        guard
-            let user = try await APIUser.query(on: req.db)
-                .filter(\.$username == username)
-                .first()
-        else {
-            return nil
+        let user = try await APIUser.query(on: req.db)
+            .filter(\.$username == username)
+            .first()
+        // Always run a bcrypt verify — even on user-not-found, against a
+        // cached dummy hash — so the wall-clock time of "no such user" and
+        // "user found, password wrong" are indistinguishable to a remote
+        // observer.  Skipping the verify on miss is a textbook account-
+        // enumeration timing leak (~150ms bcrypt cost is easily measured).
+        let hash: String
+        if let user {
+            hash = user.passwordHash
+        } else {
+            hash = try await timingEqualizerHashCache.hash(using: req.password.async)
         }
-        let verified = try await req.password.async.verify(password, created: user.passwordHash)
+        let verified = try await req.password.async.verify(password, created: hash)
         return verified ? user : nil
     }
 }
+
+/// One-shot cache of a bcrypt hash used to equalize verify timing on the
+/// user-not-found path.  Computed lazily on the first miss via the same
+/// `AsyncPasswordHasher` the real verify uses, so the cost factor (and
+/// therefore verify time) is identical to a real account.
+private actor TimingEqualizerHashCache {
+    private var cached: String?
+
+    func hash(using hasher: AsyncPasswordHasher) async throws -> String {
+        if let cached { return cached }
+        let value = try await hasher.hash("chickadee-login-timing-equalizer-not-a-real-password")
+        cached = value
+        return value
+    }
+}
+
+private let timingEqualizerHashCache = TimingEqualizerHashCache()
 
 // MARK: - Application storage
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -69,12 +69,17 @@ extension WebRoutes {
 
     @Sendable
     func submitForm(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
         guard
             let setupID = req.parameters.get("testSetupID"),
             let setup = try await APITestSetup.find(setupID, on: req.db)
         else {
             throw Abort(.notFound)
         }
+        // Block cross-tenant info disclosure: an authenticated student
+        // shouldn't be able to learn that a setupID exists in a course
+        // they aren't enrolled in, nor see its assignment title.
+        try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
         // Browser-graded assignments are submitted from the notebook page, not this form.
         let manifestData = Data(setup.manifest.utf8)
         if let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData),

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -136,6 +136,14 @@ func requireOpenStudentAssignment(
         return nil
     }
 
+    // Enforce course enrollment before any open/closed check.  Without this,
+    // a student in course A who learns a testSetupID belonging to course B
+    // (UUIDs are exposed in submission URLs, shared instructor pages, and
+    // vanity-URL resolutions) can submit to that assignment and pollute
+    // foreign instructors' queues.  Instructors and admins bypass via
+    // `requireCourseEnrollment`'s own short-circuit.
+    try await requireCourseEnrollment(caller: user, courseID: assignment.courseID, db: req.db)
+
     _ = try await closeAssignmentIfExpired(assignment, on: req.db, logger: req.logger, now: now)
     let open = try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db, now: now)
     guard open else {

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -182,6 +182,38 @@ final class AdminRoutesTests: XCTestCase {
         )
     }
 
+    func testWriteWorkerSecretToDiskSetsOwnerOnlyPermissions() throws {
+        // The worker secret is the HMAC signing key for runner↔server
+        // requests; default umask leaves it world-readable on Linux, so
+        // writeWorkerSecretToDisk must enforce 0o600.
+        let path = app.workerSecretFilePath
+        writeWorkerSecretToDisk(secret: "mode-check-secret", workerSecretFilePath: path)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        XCTAssertEqual(
+            perms & 0o777, 0o600,
+            "Expected .worker-secret to be 0600; got \(String(perms, radix: 8))")
+    }
+
+    func testReadWorkerSecretFromDiskTightensExistingPermissions() throws {
+        // Files written by older builds may be world-readable; read-time
+        // hardening ensures upgraded installs converge on 0o600.
+        let path = app.workerSecretFilePath
+        try "legacy-secret".write(
+            toFile: path, atomically: true, encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o644)], ofItemAtPath: path
+        )
+
+        _ = readWorkerSecretFromDisk(workerSecretFilePath: path)
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        XCTAssertEqual(perms & 0o777, 0o600)
+    }
+
     func testUpdateWorkerSecretBlankRestoresPersistedValue() async throws {
         let cookie = try await loginAsAdmin()
         writeWorkerSecretToDisk(secret: "persisted-secret", workerSecretFilePath: app.workerSecretFilePath)

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -157,6 +157,45 @@ final class AuthRoutesTests: XCTestCase {
             })
     }
 
+    func testLoginWithUnknownUserStillRunsBcryptVerify() async throws {
+        // Regression for issue #559 (account-enumeration timing).  The
+        // user-not-found path must run a bcrypt verify against a dummy
+        // hash so its wall-clock time matches the user-found-wrong-
+        // password path.  bcrypt cost 12 takes ≥100 ms on any reasonable
+        // host; without the equalizer the miss returns in <10 ms.
+        //
+        // Warm-up POST primes the timing-equalizer hash cache so we
+        // measure verify time, not the one-shot hash+verify cost of the
+        // first-ever miss.
+        let warmupCSRF = try await csrfFields(for: "/login", on: app)
+        try await app.asyncTest(
+            .POST, "/login",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: warmupCSRF.1)
+                try req.content.encode(
+                    ["username": "warmup_user", "password": "x", "_csrf": warmupCSRF.0],
+                    as: .urlEncodedForm)
+            }, afterResponse: { _ in })
+
+        let (token, cookie) = try await csrfFields(for: "/login", on: app)
+        let start = Date()
+        try await app.asyncTest(
+            .POST, "/login",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                try req.content.encode(
+                    ["username": "still_no_such_user", "password": "x", "_csrf": token],
+                    as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+            })
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertGreaterThan(
+            elapsed, 0.05,
+            "User-not-found login completed in \(elapsed)s; bcrypt verify likely skipped (cost 12 is ≥100 ms).")
+    }
+
     // MARK: - Access control
 
     func testUnauthenticatedHomeRedirectsToLogin() async throws {

--- a/Tests/APITests/CSRFTests.swift
+++ b/Tests/APITests/CSRFTests.swift
@@ -179,6 +179,17 @@ final class CSRFTests: XCTestCase {
         let cookie = try await loginUser(
             username: "student_ok_tok", password: "pass1234",
             role: "student", on: app)
+        // Enroll the student in the seeded course so the cross-tenant
+        // enrollment gate (issue #551) doesn't 403 the GET below — the
+        // intent of this test is to exercise CSRF middleware, not the
+        // enrollment check.
+        let user = try await APIUser.query(on: app.db)
+            .filter(\.$username == "student_ok_tok").first()!
+        let courseID = try await APICourse.query(on: app.db)
+            .filter(\.$code == "CS203").first()!.requireID()
+        try await APICourseEnrollment(
+            userID: try user.requireID(), courseID: courseID
+        ).save(on: app.db)
 
         // GET the submit page to obtain a session-bound CSRF token.
         let (token, _) = try await csrfFields(

--- a/Tests/APITests/WebRoutesSubmissionPageTests.swift
+++ b/Tests/APITests/WebRoutesSubmissionPageTests.swift
@@ -13,6 +13,95 @@ import XCTest
 
 final class WebRoutesSubmissionPageTests: WebRoutesTestCase {
 
+    // MARK: - Cross-tenant submission gate (issue #551)
+
+    func testStudentCannotSubmitToAssignmentInForeignCourse() async throws {
+        // requireOpenStudentAssignment must reject submissions to a setup
+        // whose course the caller isn't enrolled in.  Without the check, a
+        // student in CS101 who learns a testSetupID for a different course
+        // can submit there and pollute the foreign instructor's queue.
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enrollUser(user)  // Enrolls in CS101 only.
+
+        let foreignCourse = APICourse(code: "OTHER101", name: "Other Course")
+        try await foreignCourse.save(on: app.db)
+        let foreignCourseID = try foreignCourse.requireID()
+
+        let foreignSetup = APITestSetup(
+            id: "setup_foreign",
+            manifest: """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+                """,
+            zipPath: app.testSetupsDirectory + "setup_foreign.zip",
+            courseID: foreignCourseID
+        )
+        try await foreignSetup.save(on: app.db)
+        let foreignAssignment = APIAssignment(
+            testSetupID: "setup_foreign",
+            title: "Foreign Assignment",
+            dueAt: nil,
+            isOpen: true,
+            courseID: foreignCourseID
+        )
+        try await foreignAssignment.save(on: app.db)
+
+        // GET should already fail (added to submitForm in the same fix), so
+        // pull CSRF from a page the student CAN see.
+        let (csrf, sessionCookie) = try await csrfFields(
+            for: "/", cookie: cookie, on: app
+        )
+        let boundary = "xtenant-boundary"
+        try await app.asyncTest(
+            .POST, "/testsetups/setup_foreign/submit",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                req.headers.contentType = HTTPMediaType(
+                    type: "multipart", subType: "form-data",
+                    parameters: ["boundary": boundary]
+                )
+                req.body = .init(
+                    buffer: self.submitMultipartBody(boundary: boundary, csrfToken: csrf)
+                )
+            },
+            afterResponse: { res in
+                XCTAssertEqual(
+                    res.status, .forbidden,
+                    "Student not enrolled in foreign course must get 403; got \(res.status)")
+            })
+    }
+
+    func testStudentCannotGetSubmitPageForForeignCourse() async throws {
+        // GET /testsetups/:id/submit leaked the assignment title and the
+        // existence of the setup to any authenticated user.  Same fix as
+        // the POST: require course enrollment.
+        let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enrollUser(user)
+
+        let foreignCourse = APICourse(code: "OTHER202", name: "Other Course 2")
+        try await foreignCourse.save(on: app.db)
+        let foreignCourseID = try foreignCourse.requireID()
+        let foreignSetup = APITestSetup(
+            id: "setup_foreign_get",
+            manifest: """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+                """,
+            zipPath: app.testSetupsDirectory + "setup_foreign_get.zip",
+            courseID: foreignCourseID
+        )
+        try await foreignSetup.save(on: app.db)
+
+        try await app.asyncTest(
+            .GET, "/testsetups/setup_foreign_get/submit",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .forbidden)
+            })
+    }
+
     func testSubmissionPageRendersWarnings() async throws {
         let cookie = try await loginAsStudent()
         let user = try await studentUser()

--- a/Tests/APITests/WebRoutesSubmitHistoryTests.swift
+++ b/Tests/APITests/WebRoutesSubmitHistoryTests.swift
@@ -17,6 +17,8 @@ final class WebRoutesSubmitHistoryTests: WebRoutesTestCase {
 
     func testSubmitFormRendersForStudent() async throws {
         let cookie = try await loginAsStudent()
+        let user = try await studentUser()
+        try await enrollUser(user)
         try await insertSetup(id: "setup_sub")
 
         try await app.asyncTest(


### PR DESCRIPTION
## Summary

Three small, surgical security fixes from the recent security & privacy audit.  Each closes one issue; together they share little surface area and ship cleanly as a single PR.

- **#551 — Cross-tenant submission** (HIGH).  `requireOpenStudentAssignment` ([Sources/APIServer/Services/AssignmentDeadlineService.swift:125](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Services/AssignmentDeadlineService.swift#L125)) checked only that an assignment was open — never that the caller was enrolled in the owning course.  A student in course A who learned a `testSetupID` for course B (UUIDs are exposed in submission URLs and vanity-URL resolutions) could submit there and pollute the foreign instructor's queue.  Fix: inject `requireCourseEnrollment` inside the helper so all three callers (`POST /testsetups/:id/submit`, browser submit, browser finalize) inherit the gate.  Also closed the GET-side info leak in `submitForm` (the assignment title was leaking across tenants).
- **#552 — Worker secret world-readable**.  `writeWorkerSecretToDisk` ([Sources/APIServer/APIServerApp+Stores.swift:379](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/APIServerApp+Stores.swift#L379)) used the process umask.  On most Linux deploys that's 0644 — any local user could read `.worker-secret` and forge HMAC-signed worker requests.  Now 0600 on write; `readWorkerSecretFromDisk` also tightens permissions on files written by older builds so upgraded installs converge.
- **#559 — Account-enumeration timing on login**.  `LocalAuthProvider.authenticate` ([Sources/APIServer/Auth/AuthProvider.swift:28](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Auth/AuthProvider.swift#L28)) skipped bcrypt verify when the username didn't exist, leaking account existence via response time (~150 ms vs ~0 ms).  Now always runs verify against a cached dummy hash computed lazily via the same `AsyncPasswordHasher`, so cost factor matches a real account.

## Test plan

- [x] `swift build` clean
- [x] 5 new tests cover all three fixes: cross-tenant POST + GET, worker-secret write mode, worker-secret read-time chmod, login-timing >50 ms
- [x] Full test suite green (920 XCTest + ~290 Swift Testing, exit 0)
- [x] `swift-format lint --strict` clean on every touched file
- [x] Pre-existing tests that relied on the missing enrollment check (`WebRoutesSubmitHistoryTests.testSubmitFormRendersForStudent`, `CSRFTests.testMultipartSubmitWithValidCSRFTokenPassesCSRFMiddleware`) updated to enroll their student — the behaviour change is the intended fix.

Closes #551, #552, #559.

Other issues from the audit (#553, #554, #555, #556, #557, #558, #560, #561, #562, #563) remain open — left for separate, focused PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVndTyaMvd2NC8FhDTwqRx)_