### PR TITLE
security: emit COOP and CORP same-origin on every response

### DIFF
--- a/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
+++ b/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
@@ -30,6 +30,25 @@
 //     Nothing in Chickadee uses camera, microphone, or geolocation —
 //     explicitly deny them so a future XSS can't escalate to media capture.
 //
+//   Cross-Origin-Opener-Policy: same-origin
+//     Severs the `window.opener` reference when our pages are opened from a
+//     third-party origin, mitigating tab-nabbing attacks and isolating our
+//     browsing-context group.  Chickadee's auth flows are redirects, not
+//     popups, so cutting the opener reference does not break anything.
+//
+//   Cross-Origin-Resource-Policy: same-origin
+//     Stops third-party origins from embedding our resources (scripts,
+//     stylesheets, images) via `<script src=...>` / `<img src=...>` etc.
+//     Chickadee assets are only consumed by Chickadee pages, so this is
+//     pure defence-in-depth.
+//
+//   Cross-Origin-Embedder-Policy is intentionally NOT set here.
+//     `require-corp` blocks the JupyterLite iframe (its service worker
+//     synthesises responses without CORP headers) and breaks Pyodide /
+//     CodeMirror CDN imports.  `COEPMiddleware` opts the narrow set of
+//     pages that genuinely need cross-origin isolation (currently just
+//     `/validate`) into the strict policy.
+//
 //   Strict-Transport-Security
 //     Set only when HTTPS enforcement is enabled.  Pinning HSTS during
 //     local-http development would break dev workflows; the gate via
@@ -122,6 +141,16 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
         "gyroscope=()",
     ].joined(separator: ", ")
 
+    /// Cross-Origin-Opener-Policy default. `same-origin` is the strictest
+    /// value supported by every modern browser and is safe whenever the app
+    /// does not need to talk to popups it opens. Chickadee's OIDC + logout
+    /// flows are redirects, not popups, so this is universally applicable.
+    static let defaultCrossOriginOpenerPolicy: String = "same-origin"
+
+    /// Cross-Origin-Resource-Policy default. `same-origin` prevents third
+    /// parties from embedding our scripts, stylesheets, images, etc.
+    static let defaultCrossOriginResourcePolicy: String = "same-origin"
+
     /// Two-year HSTS with subdomain coverage. Preload is intentionally NOT
     /// asserted — operators must explicitly opt in to preload separately,
     /// since it's near-impossible to undo.
@@ -129,15 +158,21 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
 
     let cspBaseDirectives: [String]
     let permissionsPolicy: String
+    let crossOriginOpenerPolicy: String
+    let crossOriginResourcePolicy: String
     let strictTransportSecurity: String?
 
     init(
         cspBaseDirectives: [String] = Self.defaultContentSecurityPolicyBase,
         permissionsPolicy: String = Self.defaultPermissionsPolicy,
+        crossOriginOpenerPolicy: String = Self.defaultCrossOriginOpenerPolicy,
+        crossOriginResourcePolicy: String = Self.defaultCrossOriginResourcePolicy,
         strictTransportSecurity: String? = nil
     ) {
         self.cspBaseDirectives = cspBaseDirectives
         self.permissionsPolicy = permissionsPolicy
+        self.crossOriginOpenerPolicy = crossOriginOpenerPolicy
+        self.crossOriginResourcePolicy = crossOriginResourcePolicy
         self.strictTransportSecurity = strictTransportSecurity
     }
 
@@ -155,6 +190,11 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
         response.headers.replaceOrAdd(name: "Referrer-Policy", value: "strict-origin-when-cross-origin")
         response.headers.replaceOrAdd(name: "Content-Security-Policy", value: csp)
         response.headers.replaceOrAdd(name: "Permissions-Policy", value: permissionsPolicy)
+        // COOP is set unconditionally; COEPMiddleware may override it for the
+        // narrow set of pages that need cross-origin isolation, but its value
+        // is `same-origin` too so the replaceOrAdd is a no-op there.
+        response.headers.replaceOrAdd(name: "Cross-Origin-Opener-Policy", value: crossOriginOpenerPolicy)
+        response.headers.replaceOrAdd(name: "Cross-Origin-Resource-Policy", value: crossOriginResourcePolicy)
         if let hsts = strictTransportSecurity {
             response.headers.replaceOrAdd(name: "Strict-Transport-Security", value: hsts)
         }

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -121,6 +121,8 @@ final class SecurityAndHealthTests: XCTestCase {
                 XCTAssertEqual(res.headers.first(name: "X-Content-Type-Options"), "nosniff")
                 XCTAssertEqual(res.headers.first(name: "X-Frame-Options"), "SAMEORIGIN")
                 XCTAssertEqual(res.headers.first(name: "Referrer-Policy"), "strict-origin-when-cross-origin")
+                XCTAssertEqual(res.headers.first(name: "Cross-Origin-Opener-Policy"), "same-origin")
+                XCTAssertEqual(res.headers.first(name: "Cross-Origin-Resource-Policy"), "same-origin")
             }
         }
     }


### PR DESCRIPTION
## Summary

Second wave of fixes from the ZAP baseline (issue [#565](https://github.com/JimWallace/Chickadee/issues/565)). Closes the remaining ZAP \`90004\` findings:

- **Cross-Origin-Opener-Policy Header Missing or Invalid** — \`/\`, \`/login\`, \`/register\`, \`/register?error=password_short\` (4 URLs)
- **Cross-Origin-Resource-Policy Header Missing or Invalid** — \`/\`, \`/app.js\`, \`/login\`, \`/register\`, \`/styles.css\` (5 URLs)

Both headers are set to \`same-origin\` by [\`SecurityHeadersMiddleware\`](Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift) (the outermost middleware as of [#566](https://github.com/JimWallace/Chickadee/pull/566)) so they land on every response: HTML pages, static assets, error pages, HTTPS redirects.

### Why these two are safe globally, but COEP is not

- **COOP \`same-origin\`** severs \`window.opener\` for third-party openers — mitigates tab-nabbing. Chickadee's auth flows are all redirects (OIDC Authorization Code + PKCE, RFC 7009 SSO logout, local session login) rather than popups, so this is a no-cost hardening.
- **CORP \`same-origin\`** prevents third parties from cross-origin-embedding our resources. Chickadee assets are only consumed by Chickadee pages.
- **COEP \`require-corp\` is deliberately not added.** It would block the JupyterLite iframe (its service worker produces responses without CORP headers) and break Pyodide / CodeMirror CDN imports. [\`COEPMiddleware\`](Sources/APIServer/Middleware/COEPMiddleware.swift) continues to opt only \`/validate\` into the strict COEP policy — unchanged here.

### Test coverage

- \`testSecurityHeadersMiddlewareAddsExpectedHeaders\` now asserts both new headers.
- \`COEPMiddlewareTests\` are unchanged — they construct a test app with \`COEPMiddleware\` in isolation, so they continue to verify the narrow opt-in behavior for \`/validate\`.

## Test plan
- [x] \`scripts/lint.sh\` passes.
- [ ] Existing Swift tests, format-lint, CodeQL JS/TS pass.
- [ ] After merge: \`workflow_dispatch\` the ZAP workflow on main and verify rule 90004 drops out of issue [#565](https://github.com/JimWallace/Chickadee/issues/565).
- [ ] Manual smoke after deploy: open the in-browser notebook editor + instructor validate flow to confirm Pyodide / JupyterLite still work (the COEP exclusion is the only thing keeping them functional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)