### PR TITLE
security: 404 unenrolled students on vanity URLs (#561)

### DIFF
--- a/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
+++ b/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
@@ -51,6 +51,8 @@ struct VanityURLRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
+        let user = try req.auth.require(APIUser.self)
+
         let courseCodeLower = courseCode.lowercased()
         let activeCourses = try await APICourse.query(on: req.db)
             .filter(\.$isArchived == false)
@@ -60,6 +62,26 @@ struct VanityURLRoutes: RouteCollection {
         }
 
         let courseID = try course.requireID()
+
+        // Enrollment check happens BEFORE the slug lookup so an unenrolled
+        // student receives the same 404 regardless of whether the slug
+        // exists. Without this gate, the route returned 303 → access-denied
+        // for valid slugs and 404 for typos, letting an authenticated
+        // attacker enumerate every assignment in every course they could
+        // identify by code (slugs are per-course unique by design).
+        //
+        // Instructors and admins (anyone whose role satisfies isInstructor)
+        // bypass the check so cross-course test/preview flows still work.
+        if !user.isInstructor {
+            guard let userID = user.id else { throw Abort(.notFound) }
+            let enrolled =
+                try await APICourseEnrollment.query(on: req.db)
+                .filter(\.$userID == userID)
+                .filter(\.$course.$id == courseID)
+                .count() > 0
+            guard enrolled else { throw Abort(.notFound) }
+        }
+
         let assignments = try await APIAssignment.query(on: req.db)
             .filter(\.$courseID == courseID)
             .all()

--- a/Tests/APITests/VanityURLRoutesTests.swift
+++ b/Tests/APITests/VanityURLRoutesTests.swift
@@ -51,6 +51,30 @@ final class VanityURLRoutesTests: XCTestCase {
         return course
     }
 
+    /// Enrolls `username` (creating the row only if the user already exists)
+    /// in `course`. Most vanity-URL tests use student accounts, which need
+    /// course enrollment to clear the resolver's enrollment gate; previously
+    /// the resolver was missing this check and an unenrolled student saw the
+    /// same 303 redirect as an enrolled one, which leaked the course/slug
+    /// catalogue (issue #561).
+    private func enrollStudent(username: String, in course: APICourse) async throws {
+        guard
+            let user = try await APIUser.query(on: app.db).filter(\.$username == username).first()
+        else {
+            XCTFail("user \(username) not found; call loginUser first")
+            return
+        }
+        let userID = try user.requireID()
+        let courseID = try course.requireID()
+        let exists =
+            try await APICourseEnrollment.query(on: app.db)
+            .filter(\.$userID == userID)
+            .filter(\.$course.$id == courseID)
+            .count() > 0
+        if exists { return }
+        try await APICourseEnrollment(userID: userID, courseID: courseID).save(on: app.db)
+    }
+
     @discardableResult
     private func seedSetupAndAssignment(
         courseID: UUID,
@@ -96,6 +120,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student1", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student1", in: course)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1",
             beforeRequest: { req in
@@ -116,6 +141,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student2", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student2", in: course)
         try await app.asyncTest(
             .GET, "/cs246/assignment-2",
             beforeRequest: { req in
@@ -136,6 +162,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student3", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student3", in: course)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1-intro",
             beforeRequest: { req in
@@ -187,6 +214,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student6", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student6", in: course)
         try await app.asyncTest(
             .GET, "/hlth230/lab99",
             beforeRequest: { req in
@@ -210,6 +238,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student7", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student7", in: active)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1",
             beforeRequest: { req in
@@ -231,6 +260,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student8", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student8", in: course)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1",
             beforeRequest: { req in
@@ -268,6 +298,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student9", password: "pw",
             role: "student", on: app)
+        try await enrollStudent(username: "vanity_student9", in: course)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1/submit",
             beforeRequest: { req in
@@ -286,6 +317,77 @@ final class VanityURLRoutesTests: XCTestCase {
             afterResponse: { res in
                 XCTAssertEqual(res.status, .seeOther)
                 XCTAssertEqual(res.headers.first(name: .location), "/testsetups/setup_van11/history")
+            })
+    }
+
+    // MARK: - Enrollment gate (issue #561)
+
+    func testVanityURL_unenrolledStudent_returns404() async throws {
+        // Regression: an unenrolled student receives the SAME 404 as a typo
+        // so they cannot distinguish "course/slug doesn't exist" from
+        // "course/slug exists but I'm not in that class." This closes the
+        // catalogue-enumeration vector documented in issue #561.
+        let course = try await seedCourse(code: "HLTH230")
+        let courseID = try course.requireID()
+        try await seedSetupAndAssignment(courseID: courseID, title: "Lab 1", setupID: "setup_van12")
+
+        let cookie = try await loginUser(
+            username: "vanity_outsider1", password: "pw",
+            role: "student", on: app)
+        // Deliberately NOT calling enrollStudent here.
+        try await app.asyncTest(
+            .GET, "/hlth230/lab-1",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .notFound)
+            })
+    }
+
+    func testVanityURL_unenrolledStudent_unknownSlug_alsoReturns404() async throws {
+        // Companion to the prior test: confirms the enrollment gate fires
+        // BEFORE the slug lookup, so an unenrolled student with a typo slug
+        // gets the same 404 as with a valid slug. Otherwise the timing /
+        // response difference between "valid slug, 404" and "invalid slug,
+        // 404" would still leak slug existence.
+        let course = try await seedCourse(code: "HLTH230")
+        let courseID = try course.requireID()
+        try await seedSetupAndAssignment(courseID: courseID, title: "Lab 1", setupID: "setup_van13")
+
+        let cookie = try await loginUser(
+            username: "vanity_outsider2", password: "pw",
+            role: "student", on: app)
+        try await app.asyncTest(
+            .GET, "/hlth230/no-such-slug",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .notFound)
+            })
+    }
+
+    func testVanityURL_instructor_bypassesEnrollmentCheck() async throws {
+        // Instructors and admins can preview / test any course's vanity URL
+        // without being enrolled — required by the "test my own assignment"
+        // and cross-course audit flows.
+        let course = try await seedCourse(code: "HLTH230")
+        let courseID = try course.requireID()
+        try await seedSetupAndAssignment(courseID: courseID, title: "Lab 1", setupID: "setup_van14")
+
+        let cookie = try await loginUser(
+            username: "vanity_instructor1", password: "pw",
+            role: "instructor", on: app)
+        // Deliberately NOT enrolling — instructors bypass the check.
+        try await app.asyncTest(
+            .GET, "/hlth230/lab-1",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+                XCTAssertEqual(res.headers.first(name: .location), "/testsetups/setup_van14/notebook")
             })
     }
 }


### PR DESCRIPTION
Closes [#561](https://github.com/JimWallace/Chickadee/issues/561).

## Summary

\`GET /:courseCode/:assignmentSlug\` previously returned 303 to \`/testsetups/<id>/notebook\` (which then 303'd to an enrollment / access-denied page) for unenrolled students hitting a valid course/slug pair, but returned 404 for a typo. Combined with the per-course unique-slug invariant from v0.4.71, this let any authenticated student enumerate the entire course + assignment catalogue institution-wide by walking slug guesses and watching for non-404 responses.

## Fix

\`resolveAssignment\` in [VanityURLRoutes.swift](Sources/APIServer/Routes/Web/VanityURLRoutes.swift) now performs an enrollment check **between** the course lookup and the slug lookup:

- Instructors / admins (\`user.isInstructor == true\`) bypass — matches the existing \`requireCourseEnrollment\` policy and keeps cross-course test / audit flows working.
- Students must be in \`APICourseEnrollment\` for the course; otherwise the resolver throws \`Abort(.notFound)\` — the **same** 404 the resolver returns for a missing course code or a missing slug.

Putting the gate **before** the slug query is deliberate: it makes the "valid slug, unenrolled" path indistinguishable from the "invalid slug, unenrolled" path. Exact wall-clock timing-equality is still out of scope per the issue body (rate-limiting brute-force enumeration is the right mitigation for that, tracked separately).

## Test coverage

- **New**: unenrolled student → 404 for a valid slug.
- **New**: unenrolled student → 404 for an unknown slug (same status, same path through LeafErrorMiddleware).
- **New**: instructor not enrolled → 303 redirect (bypass verified).
- **Updated**: all pre-existing happy-path tests (\`testVanityURL_redirectsToNotebook\`, etc.) now call a new \`enrollStudent\` helper before hitting the route. Previously they relied on the missing enforcement to redirect even for unenrolled students; with this PR they would have started failing as 404s, so the helper restores the original test intent (verifying redirect mechanics for an enrolled student).

## Test plan
- [x] \`scripts/lint.sh\` passes.
- [ ] Existing Swift tests + format-lint pass on CI.
- [ ] After merge: the next ZAP run continues to show no vanity-URL findings (this hardening is invisible to ZAP, which crawls unauthenticated).
- [ ] Manual smoke after deploy: a student in course A hitting a course B vanity URL gets the same 404 they'd see for a typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)