### PR TITLE
fix(alerts): queue-backup rule no longer fires on instructor retests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- **Queue-backup health alert no longer false-fires after a retest sweep.**
+  Two independent bugs were combining to produce bogus alerts like
+  `Queue backed up: 218 pending (>= 25); oldest pending 468679s old
+  (>= 600s)` immediately after an instructor retested an assignment
+  whose submissions drained within minutes.  (1) The "oldest pending
+  age" was measured from `submittedAt`, but a retest flips a
+  submission back to `pending` without resetting that column, so a
+  retest of a week-old submission looked week-old to the alert.  The
+  age now uses the effective enqueue time (`retestedAt ?? submittedAt`),
+  matching the `queueWaitMs` baseline established in v0.4.45.
+  (2) The rule fired on `depthBreached || ageBreached`, but a depth
+  spike with fresh items is normal load (instructor retest, exam
+  rush) — not a stuck queue.  The depth threshold is now an
+  *aggravating* signal that's only included in the summary when age
+  is *also* breached; age-breach is the sole trigger.  Both changes
+  live in `Sources/APIServer/Services/ServerHealthAlertService.swift`.
+  New regression tests cover both scenarios.
 - **Admin runner page no longer shows `Total < Queue Wait`.** v0.4.164's
   retest-clear fix closed one cause (stale per-attempt fields on the
   `JobExecutionMetric` row across a retest), but the underlying math

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -51,7 +51,7 @@ func evaluateHealthRules(
 
 // MARK: - Per-rule evaluators
 
-private struct PendingQueueState: Sendable {
+struct PendingQueueState: Sendable {
     let pendingCount: Int
     let oldestPendingAge: TimeInterval?
     static let empty = PendingQueueState(pendingCount: 0, oldestPendingAge: nil)
@@ -62,8 +62,11 @@ private func loadPendingQueueState(on application: Application, now: Date) async
         .filter(\.$status == "pending")
         .all()
     let pendingCount = pending.count
-    let oldestSubmittedAt = pending.compactMap(\.submittedAt).min()
-    let oldestAge = oldestSubmittedAt.map { now.timeIntervalSince($0) }
+    // Use the effective enqueue time (retestedAt ?? submittedAt) so a fresh
+    // retest of an old submission doesn't look like it's been queued for days.
+    // Matches the queueWaitMs baseline established in v0.4.45.
+    let oldestEnqueuedAt = pending.compactMap { $0.retestedAt ?? $0.submittedAt }.min()
+    let oldestAge = oldestEnqueuedAt.map { now.timeIntervalSince($0) }
     return PendingQueueState(pendingCount: pendingCount, oldestPendingAge: oldestAge)
 }
 
@@ -90,19 +93,24 @@ private func evaluateRunnerOffline(
     )
 }
 
-private func evaluateQueueBackedUp(
+func evaluateQueueBackedUp(
     pending: PendingQueueState,
     depthThreshold: Int,
     oldestPendingSeconds: TimeInterval
 ) -> RuleEvaluation {
-    let depthBreached = pending.pendingCount >= depthThreshold
+    // A backup means "items are sitting around" — depth alone isn't a signal,
+    // since an instructor retesting an assignment can legitimately enqueue
+    // hundreds of submissions that drain in minutes.  Only fire when the
+    // oldest pending item has exceeded the age threshold; depth is included
+    // in the summary as extra context when it's also high.
     let ageBreached = (pending.oldestPendingAge ?? 0) >= oldestPendingSeconds
-    guard depthBreached || ageBreached else { return .ok }
+    guard ageBreached, let age = pending.oldestPendingAge else { return .ok }
 
-    var reasons: [String] = []
-    if depthBreached { reasons.append("\(pending.pendingCount) pending (>= \(depthThreshold))") }
-    if ageBreached, let age = pending.oldestPendingAge {
-        reasons.append("oldest pending \(Int(age))s old (>= \(Int(oldestPendingSeconds))s)")
+    var reasons: [String] = [
+        "oldest pending \(Int(age))s old (>= \(Int(oldestPendingSeconds))s)"
+    ]
+    if pending.pendingCount >= depthThreshold {
+        reasons.append("\(pending.pendingCount) pending (>= \(depthThreshold))")
     }
 
     return RuleEvaluation(
@@ -111,7 +119,7 @@ private func evaluateQueueBackedUp(
         details: [
             "pending_count": String(pending.pendingCount),
             "queue_depth_threshold": String(depthThreshold),
-            "oldest_pending_age_seconds": pending.oldestPendingAge.map { String(Int($0)) } ?? "n/a",
+            "oldest_pending_age_seconds": String(Int(age)),
             "oldest_pending_threshold_seconds": String(Int(oldestPendingSeconds)),
         ]
     )

--- a/Tests/APITests/ServerHealthAlertTests.swift
+++ b/Tests/APITests/ServerHealthAlertTests.swift
@@ -250,4 +250,59 @@ final class ServerHealthAlertTests: XCTestCase {
                 testsTimedOut: nil
             ))
     }
+
+    // MARK: - evaluateQueueBackedUp
+
+    func testQueueBackedUp_freshRetestBurstDoesNotFire() {
+        // Instructor-triggered retest enqueues 250 submissions; oldest is 5s old.
+        // Depth exceeds the 25 default but nothing is stuck, so the rule must stay quiet.
+        let pending = PendingQueueState(pendingCount: 250, oldestPendingAge: 5)
+        let evaluation = evaluateQueueBackedUp(
+            pending: pending,
+            depthThreshold: 25,
+            oldestPendingSeconds: 600
+        )
+        XCTAssertFalse(evaluation.isFiring)
+    }
+
+    func testQueueBackedUp_oneStuckSubmissionFiresEvenAtLowDepth() {
+        // A single submission has been pending for 20 minutes — the queue is stuck
+        // even though depth (1) is far below the threshold.
+        let pending = PendingQueueState(pendingCount: 1, oldestPendingAge: 1200)
+        let evaluation = evaluateQueueBackedUp(
+            pending: pending,
+            depthThreshold: 25,
+            oldestPendingSeconds: 600
+        )
+        XCTAssertTrue(evaluation.isFiring)
+        XCTAssertTrue(
+            evaluation.summary.contains("oldest pending"),
+            "summary should describe the age breach, got: \(evaluation.summary)")
+        XCTAssertFalse(
+            evaluation.summary.contains("pending (>= "),
+            "depth context should be omitted when depth is below threshold")
+    }
+
+    func testQueueBackedUp_largeAndStuckMentionsBothInSummary() {
+        // Large pile AND oldest item exceeds the age threshold — fire and include
+        // the depth context for the on-call responder.
+        let pending = PendingQueueState(pendingCount: 218, oldestPendingAge: 1500)
+        let evaluation = evaluateQueueBackedUp(
+            pending: pending,
+            depthThreshold: 25,
+            oldestPendingSeconds: 600
+        )
+        XCTAssertTrue(evaluation.isFiring)
+        XCTAssertTrue(evaluation.summary.contains("oldest pending 1500s"))
+        XCTAssertTrue(evaluation.summary.contains("218 pending (>= 25)"))
+    }
+
+    func testQueueBackedUp_emptyQueueDoesNotFire() {
+        let evaluation = evaluateQueueBackedUp(
+            pending: .empty,
+            depthThreshold: 25,
+            oldestPendingSeconds: 600
+        )
+        XCTAssertFalse(evaluation.isFiring)
+    }
 }


### PR DESCRIPTION
## Summary

Two independent bugs combined to produce bogus alerts like

```
[Chickadee] Queue backed up: 218 pending (>= 25); oldest pending 468679s old (>= 600s)
```

immediately after an instructor retested an assignment whose ~250 submissions actually drained within a minute or two.

### Bug 1 — age was measured from `submittedAt`, not effective enqueue time

`loadPendingQueueState` did `pending.compactMap(\.submittedAt).min()`. A retest flips a submission back to `pending` but doesn't reset `submittedAt`, so retesting a week-old submission made the alert think it had been queued for a week. `468679s ≈ 5.4 days` — exactly the kind of number this would produce.

The codebase already established `retestedAt ?? submittedAt` as the effective enqueue time when measuring `queueWaitMs` (v0.4.45) and recording `JobExecutionMetric.enqueuedAt` (`OperationalDiagnostics+Recording.swift:272`, `OperationalDiagnostics+Queries.swift:60`). The alert now uses the same convention.

### Bug 2 — depth alone shouldn't trigger an alert

`evaluateQueueBackedUp` fired on `depthBreached || ageBreached`. With the default depth threshold at 25, an instructor retesting an assignment (250 submissions enqueued, drained in 2 min) trivially crosses depth even with everything brand-new. That's normal load, not a stuck queue.

Depth is now an **aggravating** signal: only mentioned in the summary when age is also breached. **Age-breach is the sole firing trigger.** A queue is "backed up" only when items are actually sitting around.

## Behaviour matrix

| Scenario | Depth | Oldest age | Old rule | New rule |
|---|---|---|---|---|
| Quiet | 0 | n/a | ok | ok |
| Retest burst (250 fresh submissions) | 250 | 5s | **FIRES** ❌ | ok ✅ |
| Single stuck job | 1 | 20 min | fires | fires |
| Large & stuck pile | 218 | 25 min | fires | fires (depth in summary) |
| Old submission retested today (pre-fix) | 218 | "5.4 days" (bogus) | **FIRES** ❌ | ok ✅ |

## Files

- `Sources/APIServer/Services/ServerHealthAlertService.swift` — both fixes; `PendingQueueState` + `evaluateQueueBackedUp` bumped to internal so tests can call them directly.
- `Tests/APITests/ServerHealthAlertTests.swift` — four new tests: fresh-retest-burst, single-stuck-item, large-and-stuck, empty-queue.
- `CHANGELOG.md` — Unreleased entry.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter ServerHealthAlertTests` — all 19 tests pass (15 existing + 4 new)
- [x] `scripts/lint.sh` clean
- [ ] Trigger another retest on production after deploy; confirm no spurious alert
- [ ] Confirm a real stuck submission (one item old enough to exceed `ALERT_OLDEST_PENDING_SECONDS`) still alerts

https://claude.ai/code/session_018k6L8UYZ21U9fL8PhuaZG4

---
_Generated by [Claude Code](https://claude.ai/code/session_018k6L8UYZ21U9fL8PhuaZG4)_