### PR TITLE
fix(zap): use three-column tab format in .zap/rules.tsv

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,35 +1,38 @@
 # ZAP baseline rule configuration for the Chickadee weekly scan.
 #
-# Format (tab-separated):
-#   RULE_ID    THRESHOLD    [URL_REGEX]
+# Format (tab-separated, exactly three columns):
+#   RULE_ID<TAB>THRESHOLD<TAB>URL_REGEX
 #
 # THRESHOLD values: IGNORE | INFO | WARN | FAIL
+# URL_REGEX is required by the parser (zap-baseline.py refuses any line
+# with fewer than three tab-separated tokens). Use `.*` to apply the
+# threshold to every URL.
 #
 # Suppressions below are rules ZAP fires that are either informational
 # (it noticed a feature) or describe browser-side request headers the
-# server doesn't control.  Real findings (CSP, header coverage, etc.)
+# server doesn't control. Real findings (CSP, header coverage, etc.)
 # are still surfaced.
 
 # Information Disclosure - Suspicious Comments
 # Flags TODO/FIXME strings in JS bundles; not actionable as a recurring CI rule.
-10027	IGNORE
+10027	IGNORE	.*
 
 # Non-Storable / Storable Content
 # Informational caching observation, not a vulnerability.
-10049	IGNORE
+10049	IGNORE	.*
 
 # Base64 Disclosure
 # Flags session cookies and asset-versioning hashes that look base64.
-10094	IGNORE
+10094	IGNORE	.*
 
 # Authentication Request Identified
 # ZAP noting a login form exists; not a finding.
-10111	IGNORE
+10111	IGNORE	.*
 
 # Session Management Response Identified
 # ZAP noting session cookies exist; not a finding.
-10112	IGNORE
+10112	IGNORE	.*
 
 # Sec-Fetch-* Headers Missing
 # Those are request headers the browser sends; the server cannot set them.
-90005	IGNORE
+90005	IGNORE	.*


### PR DESCRIPTION
## Summary

The ZAP baseline scanner refuses any rules line with fewer than three tab-separated tokens — the URL_REGEX column is required even for "match every URL." My initial file from [#566](https://github.com/JimWallace/Chickadee/pull/566) had only two columns (RULE_ID, THRESHOLD), so ZAP bailed at parse time:

\`\`\`
Failed to load config file /zap/wrk/.zap/rules.tsv
Unexpected number of tokens on line - there should be at least 3,
tab separated: 10027    IGNORE
\`\`\`

…and the scan exited with \`docker exit 3\`, marking the workflow as failed even though the scan would have otherwise run with the default ruleset (this is why the verification run after [#568](https://github.com/JimWallace/Chickadee/pull/568) merge still showed failure).

## Fix

Add \`.*\` as the URL_REGEX on every rule so the threshold applies to all URLs (matches the intent of the previous two-column format). Updated the header comment to document the requirement so the next reader doesn't re-introduce the bug.

## Verification
- [x] Hand-counted columns: all 6 data lines now have exactly 3 tab-separated tokens.
- [ ] After merge: rerun \`gh workflow run zap-baseline.yml --ref main\`. Expect the scan to complete and the workflow run to be green (or failing only on real new findings, which \`fail_action: false\` should still allow to pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)