### PR TITLE
security: zip-bomb upload guard, vanity URL 404 unification, OIDC URL validation

### DIFF
--- a/Sources/APIServer/Auth/OIDCConfiguration.swift
+++ b/Sources/APIServer/Auth/OIDCConfiguration.swift
@@ -137,6 +137,15 @@ struct OIDCConfiguration: Sendable {
             }
             return "https://sso-4ccc589b.sso.duosecurity.com/oidc/\(clientID)/.well-known/openid-configuration"
         }()
+
+        // Defense in depth against a fat-fingered OIDC_AUTH_SERVER pointing
+        // at an internal service or going out over plain HTTP.  Operator-
+        // settable, so not strictly a remote-attacker SSRF, but the failure
+        // mode without this check (server happily fetches from
+        // http://localhost:6379) is bad enough that failing loud at
+        // startup beats a confusing runtime error.
+        try validateOIDCDiscoveryURL(discoveryURL, allowInsecure: env.allowInsecure)
+
         app.logger.info("Fetching OIDC discovery document: \(discoveryURL)")
         let discoveryResponse = try await app.client.get(URI(string: discoveryURL))
         guard discoveryResponse.status == .ok else {
@@ -176,6 +185,74 @@ struct OIDCConfiguration: Sendable {
             claimConfig: claimConfig
         )
     }
+}
+
+// MARK: - Discovery URL validation
+
+enum OIDCDiscoveryURLError: Error, CustomStringConvertible {
+    case malformed(url: String)
+    case insecureScheme(url: String)
+    case privateHost(host: String)
+
+    var description: String {
+        switch self {
+        case .malformed(let url):
+            return "OIDC_AUTH_SERVER is not a valid URL: \(url)"
+        case .insecureScheme(let url):
+            return
+                "OIDC_AUTH_SERVER must use https:// (got \(url)); set OIDC_ALLOW_INSECURE=true to override (development only)"
+        case .privateHost(let host):
+            return
+                "OIDC_AUTH_SERVER host \(host) resolves into a loopback / private IP range; set OIDC_ALLOW_INSECURE=true to override (development only)"
+        }
+    }
+}
+
+/// Throws if `urlString` would have the discovery fetch land on plaintext or
+/// at a loopback / private-range host without an explicit `allowInsecure`
+/// override.  Intentionally string-based: we don't resolve DNS here, only
+/// reject hosts that are syntactically private — operators with a private
+/// IdP behind a domain name continue to work as long as the hostname isn't
+/// itself a private literal.
+func validateOIDCDiscoveryURL(_ urlString: String, allowInsecure: Bool) throws {
+    guard let url = URL(string: urlString), let scheme = url.scheme?.lowercased(),
+        let host = url.host?.lowercased()
+    else {
+        throw OIDCDiscoveryURLError.malformed(url: urlString)
+    }
+    if !allowInsecure {
+        guard scheme == "https" else {
+            throw OIDCDiscoveryURLError.insecureScheme(url: urlString)
+        }
+        if isPrivateOrLoopbackHost(host) {
+            throw OIDCDiscoveryURLError.privateHost(host: host)
+        }
+    }
+}
+
+private func isPrivateOrLoopbackHost(_ host: String) -> Bool {
+    if host == "localhost" || host.hasSuffix(".localhost") { return true }
+    if host == "0.0.0.0" { return true }
+    // IPv6 loopback.
+    if host == "::1" || host == "[::1]" { return true }
+    // IPv4 ranges: 10/8, 127/8, 172.16/12, 192.168/16.
+    let parts = host.split(separator: ".").map(String.init)
+    if parts.count == 4, let a = Int(parts[0]), let b = Int(parts[1]),
+        Int(parts[2]) != nil, Int(parts[3]) != nil
+    {
+        if a == 10 || a == 127 { return true }
+        if a == 192, b == 168 { return true }
+        if a == 172, (16...31).contains(b) { return true }
+        if a == 169, b == 254 { return true }  // link-local
+    }
+    // IPv6 unique-local fc00::/7 (literal form, post-bracket-strip).
+    let trimmedHost = host.trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+    if trimmedHost.hasPrefix("fc") || trimmedHost.hasPrefix("fd") {
+        // Conservative: any host starting with fc/fd that contains a colon
+        // looks like an IPv6 unique-local literal.
+        if trimmedHost.contains(":") { return true }
+    }
+    return false
 }
 
 // MARK: - Application Storage

--- a/Sources/APIServer/Configuration/OIDCEnvConfig.swift
+++ b/Sources/APIServer/Configuration/OIDCEnvConfig.swift
@@ -19,6 +19,11 @@ struct OIDCEnvConfig: Sendable {
     let usernameClaim: String
     /// JWT claim used as the email address (default `email`).
     let emailClaim: String
+    /// When true, `OIDC_AUTH_SERVER` accepts `http://` and private-range
+    /// hosts.  Required for local-Docker IdP fixtures; off in production
+    /// so a fat-fingered env var can't redirect the discovery fetch to an
+    /// internal service.
+    let allowInsecure: Bool
 
     static let `default` = OIDCEnvConfig(
         clientID: nil,
@@ -26,7 +31,8 @@ struct OIDCEnvConfig: Sendable {
         authServerOverride: nil,
         callbackPath: "/auth/sso/callback",
         usernameClaim: "preferred_username",
-        emailClaim: "email"
+        emailClaim: "email",
+        allowInsecure: false
     )
 
     static func fromEnvironment() -> OIDCEnvConfig {
@@ -36,7 +42,10 @@ struct OIDCEnvConfig: Sendable {
             authServerOverride: trimmedEnv("OIDC_AUTH_SERVER"),
             callbackPath: normalizedCallbackPath(trimmedEnv("OIDC_CALLBACK")),
             usernameClaim: trimmedEnv("OIDC_USERNAME_CLAIM") ?? "preferred_username",
-            emailClaim: trimmedEnv("OIDC_EMAIL_CLAIM") ?? "email"
+            emailClaim: trimmedEnv("OIDC_EMAIL_CLAIM") ?? "email",
+            allowInsecure: (trimmedEnv("OIDC_ALLOW_INSECURE")?.lowercased()).map {
+                ["1", "true", "yes"].contains($0)
+            } ?? false
         )
     }
 

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -284,6 +284,17 @@ struct TestSetupRoutes: RouteCollection {
         let zipBytes = upload.files
         try zipBytes.write(to: URL(fileURLWithPath: zipPath))
 
+        // Reject zip bombs before any DB row references this file.  The
+        // upload sits in setupsDir until validation passes; on failure we
+        // delete it so a malicious upload doesn't leave stale bytes on
+        // disk indefinitely.
+        do {
+            try validateZipUploadSize(zipPath: zipPath)
+        } catch let error as ZipUploadValidationError {
+            try? FileManager.default.removeItem(atPath: zipPath)
+            throw Abort(.unprocessableEntity, reason: String(describing: error))
+        }
+
         // Store metadata in DB.
         let storedManifest =
             String(data: try ManifestCodec.encoder.encode(manifest), encoding: .utf8) ?? upload.manifest

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -16,6 +16,97 @@ enum ScriptZipError: Error {
     case zipFailed
 }
 
+// MARK: - Zip upload size guard
+
+/// Upper bounds applied to a freshly-uploaded test-setup zip before it is
+/// persisted.  Defaults are deliberately generous for legitimate course
+/// material while small enough that a single malicious upload can't
+/// exhaust the host's disk.  Per-entry plus total cover the two common
+/// zip-bomb shapes: many small entries summing into a giant whole, or
+/// one entry that expands wildly.
+struct ZipUploadLimits {
+    let maxTotalUncompressedBytes: Int
+    let maxEntryUncompressedBytes: Int
+
+    static let `default` = ZipUploadLimits(
+        maxTotalUncompressedBytes: 256 * 1024 * 1024,
+        maxEntryUncompressedBytes: 64 * 1024 * 1024
+    )
+}
+
+enum ZipUploadValidationError: Error, CustomStringConvertible {
+    case inspectionFailed
+    case totalSizeExceeded(actualBytes: Int, limitBytes: Int)
+    case entrySizeExceeded(name: String, actualBytes: Int, limitBytes: Int)
+
+    var description: String {
+        switch self {
+        case .inspectionFailed:
+            return "Could not read uploaded zip (corrupt or unsupported format)"
+        case .totalSizeExceeded(let actual, let limit):
+            return "Uploaded zip decompresses to \(actual) bytes; total limit is \(limit) bytes"
+        case .entrySizeExceeded(let name, let actual, let limit):
+            return "Zip entry '\(name)' decompresses to \(actual) bytes; per-entry limit is \(limit) bytes"
+        }
+    }
+}
+
+/// Inspects the supplied zip's declared uncompressed sizes via `unzip -v`
+/// and throws if any entry — or the total — exceeds `limits`.  Runs
+/// before extraction so a zip bomb can't waste disk on its way to being
+/// rejected.  `unzip -v` parses table-of-entries delimited by a pair of
+/// dashed separator lines; each entry has seven space-separated columns
+/// (Length, Method, Size, Cmpr, Date, Time, CRC-32) before the name.
+func validateZipUploadSize(zipPath: String, limits: ZipUploadLimits = .default) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/unzip")
+    process.arguments = ["-v", zipPath]
+    let out = Pipe()
+    process.standardOutput = out
+    process.standardError = Pipe()
+    do {
+        try process.run()
+    } catch {
+        throw ZipUploadValidationError.inspectionFailed
+    }
+    let data = out.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0,
+        let text = String(data: data, encoding: .utf8)
+    else {
+        throw ZipUploadValidationError.inspectionFailed
+    }
+
+    var inEntries = false
+    var total = 0
+    for line in text.split(separator: "\n").map(String.init) {
+        if line.hasPrefix("--------") {
+            inEntries.toggle()
+            continue
+        }
+        guard inEntries else { continue }
+        let parts =
+            line.trimmingCharacters(in: .whitespaces)
+            .split(separator: " ", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard parts.count >= 8, let length = Int(parts[0]) else { continue }
+        let name = parts.dropFirst(7).joined(separator: " ")
+        if length > limits.maxEntryUncompressedBytes {
+            throw ZipUploadValidationError.entrySizeExceeded(
+                name: name, actualBytes: length,
+                limitBytes: limits.maxEntryUncompressedBytes
+            )
+        }
+        total += length
+        if total > limits.maxTotalUncompressedBytes {
+            throw ZipUploadValidationError.totalSizeExceeded(
+                actualBytes: total,
+                limitBytes: limits.maxTotalUncompressedBytes
+            )
+        }
+    }
+}
+
 struct RunnerSetupPackage {
     let testSuites: [ConfiguredSuiteEntry]
     let hasMakefile: Bool

--- a/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
+++ b/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
@@ -44,6 +44,7 @@ struct VanityURLRoutes: RouteCollection {
     }
 
     private func resolveAssignment(req: Request) async throws -> APIAssignment {
+        let user = try req.auth.require(APIUser.self)
         guard
             let courseCode = req.parameters.get("courseCode"),
             let slug = req.parameters.get("assignmentSlug")
@@ -60,6 +61,24 @@ struct VanityURLRoutes: RouteCollection {
         }
 
         let courseID = try course.requireID()
+
+        // Treat unenrolled access as 404 (matching the no-such-course /
+        // no-such-assignment cases) so vanity URLs aren't a course /
+        // assignment enumeration vector for students browsing the
+        // institutional catalogue.  Instructors and admins bypass via
+        // the usual `isInstructor` short-circuit.
+        if !user.isInstructor {
+            let userID = try user.requireID()
+            let enrolled =
+                try await APICourseEnrollment.query(on: req.db)
+                .filter(\.$userID == userID)
+                .filter(\.$course.$id == courseID)
+                .count() > 0
+            guard enrolled else {
+                throw Abort(.notFound)
+            }
+        }
+
         let assignments = try await APIAssignment.query(on: req.db)
             .filter(\.$courseID == courseID)
             .all()

--- a/Tests/APITests/AppConfigTests.swift
+++ b/Tests/APITests/AppConfigTests.swift
@@ -122,7 +122,8 @@ import Vapor
                 authServerOverride: nil,
                 callbackPath: "/x",
                 usernameClaim: "u",
-                emailClaim: "e"
+                emailClaim: "e",
+                allowInsecure: false
             ),
             security: seed.security,
             scanMode: seed.scanMode,
@@ -150,7 +151,8 @@ import Vapor
                 authServerOverride: nil,
                 callbackPath: "/cb",
                 usernameClaim: "u",
-                emailClaim: "e"
+                emailClaim: "e",
+                allowInsecure: false
             ),
             security: .default,
             scanMode: .default,

--- a/Tests/APITests/OIDCDiscoveryURLValidationTests.swift
+++ b/Tests/APITests/OIDCDiscoveryURLValidationTests.swift
@@ -1,0 +1,166 @@
+// Tests/APITests/OIDCDiscoveryURLValidationTests.swift
+//
+// Coverage for the OIDC_AUTH_SERVER URL validator added in issue #563.
+// Pure function tests — no network, no env munging.
+
+import XCTest
+
+@testable import chickadee_server
+
+final class OIDCDiscoveryURLValidationTests: XCTestCase {
+
+    // MARK: - Happy path
+
+    func testAccepts_httpsPublicHost() {
+        XCTAssertNoThrow(
+            try validateOIDCDiscoveryURL(
+                "https://sso.example.com/oidc/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        )
+    }
+
+    func testAccepts_httpsPublicIPv4() {
+        // A genuine public IPv4 (8.8.8.8) should pass — we only block the
+        // private / loopback / link-local ranges.
+        XCTAssertNoThrow(
+            try validateOIDCDiscoveryURL(
+                "https://8.8.8.8/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        )
+    }
+
+    // MARK: - Insecure scheme
+
+    func testRejects_httpScheme() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "http://sso.example.com/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        ) { err in
+            guard case OIDCDiscoveryURLError.insecureScheme = err else {
+                XCTFail("Expected insecureScheme, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testAllowsInsecureOverride_httpScheme() {
+        XCTAssertNoThrow(
+            try validateOIDCDiscoveryURL(
+                "http://localhost:8080/.well-known/openid-configuration",
+                allowInsecure: true
+            )
+        )
+    }
+
+    // MARK: - Private / loopback hosts
+
+    func testRejects_localhost() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "https://localhost/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        ) { err in
+            guard case OIDCDiscoveryURLError.privateHost = err else {
+                XCTFail("Expected privateHost, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testRejects_loopbackIPv4() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "https://127.0.0.1/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        ) { err in
+            guard case OIDCDiscoveryURLError.privateHost = err else {
+                XCTFail("Expected privateHost, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testRejects_class10Range() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "https://10.1.2.3/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        ) { err in
+            guard case OIDCDiscoveryURLError.privateHost = err else {
+                XCTFail("Expected privateHost, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testRejects_class192_168Range() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "https://192.168.1.1/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        ) { err in
+            guard case OIDCDiscoveryURLError.privateHost = err else {
+                XCTFail("Expected privateHost, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testRejects_class172_16to31Range() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "https://172.20.0.5/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        )
+    }
+
+    func testAccepts_class172_outsidePrivateRange() {
+        // 172.32 is outside the 172.16/12 private range — must pass.
+        XCTAssertNoThrow(
+            try validateOIDCDiscoveryURL(
+                "https://172.32.0.1/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        )
+    }
+
+    func testRejects_linkLocal() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL(
+                "https://169.254.0.1/.well-known/openid-configuration",
+                allowInsecure: false
+            )
+        )
+    }
+
+    func testAllowsInsecureOverride_loopbackIPv4() {
+        XCTAssertNoThrow(
+            try validateOIDCDiscoveryURL(
+                "https://127.0.0.1/.well-known/openid-configuration",
+                allowInsecure: true
+            )
+        )
+    }
+
+    // MARK: - Malformed input
+
+    func testRejects_malformedURL() {
+        XCTAssertThrowsError(
+            try validateOIDCDiscoveryURL("not a url at all", allowInsecure: false)
+        ) { err in
+            guard case OIDCDiscoveryURLError.malformed = err else {
+                XCTFail("Expected malformed, got \(err)")
+                return
+            }
+        }
+    }
+}

--- a/Tests/APITests/OIDCTests.swift
+++ b/Tests/APITests/OIDCTests.swift
@@ -129,6 +129,9 @@ final class OIDCTests: XCTestCase {
                 "OIDC_CLIENT_SECRET": "super-secret",
                 "OIDC_AUTH_SERVER": "http://127.0.0.1:\(provider.port)/oidc/test-client/",
                 "OIDC_CALLBACK": "oidc/callback",
+                // Mock IdP runs on http://127.0.0.1; allow loopback for test fixtures
+                // (issue #563 hardens the validator against production misconfig).
+                "OIDC_ALLOW_INSECURE": "true",
             ]) {
                 try await withApp(try await makeOIDCApp(publicBaseURL: "https://courses.example.edu/")) { app in
                     let config = try await OIDCConfiguration.load(from: app)
@@ -152,6 +155,7 @@ final class OIDCTests: XCTestCase {
                 "OIDC_CLIENT_SECRET": "super-secret",
                 "OIDC_AUTH_SERVER": "http://127.0.0.1:\(provider.port)/custom/.well-known/openid-configuration",
                 "OIDC_CALLBACK": "",
+                "OIDC_ALLOW_INSECURE": "true",
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
                     let config = try await OIDCConfiguration.load(from: app)
@@ -203,6 +207,7 @@ final class OIDCTests: XCTestCase {
                 "OIDC_CLIENT_ID": "test-client",
                 "OIDC_CLIENT_SECRET": "super-secret",
                 "OIDC_AUTH_SERVER": "http://127.0.0.1:\(provider.port)/oidc/test-client",
+                "OIDC_ALLOW_INSECURE": "true",
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
                     await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app)) { error in
@@ -224,6 +229,7 @@ final class OIDCTests: XCTestCase {
                 "OIDC_CLIENT_ID": "test-client",
                 "OIDC_CLIENT_SECRET": "super-secret",
                 "OIDC_AUTH_SERVER": "http://127.0.0.1:\(provider.port)/oidc/test-client",
+                "OIDC_ALLOW_INSECURE": "true",
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
                     await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app)) { error in

--- a/Tests/APITests/VanityURLRoutesTests.swift
+++ b/Tests/APITests/VanityURLRoutesTests.swift
@@ -73,6 +73,24 @@ final class VanityURLRoutesTests: XCTestCase {
         return assignment
     }
 
+    /// Enrolls the named user in `courseID`.  Required to exercise the
+    /// happy path after the v0.4.171 enrollment gate landed on
+    /// `resolveAssignment` (issue #561) — unenrolled users now get 404
+    /// from every vanity URL so the routes can't be used to enumerate
+    /// the catalogue.
+    private func enroll(username: String, courseID: UUID) async throws {
+        guard
+            let user = try await APIUser.query(on: app.db)
+                .filter(\.$username == username).first()
+        else {
+            XCTFail("Expected user \(username) to exist")
+            return
+        }
+        try await APICourseEnrollment(
+            userID: try user.requireID(), courseID: courseID
+        ).save(on: app.db)
+    }
+
     // MARK: - Unauthenticated
 
     func testVanityURL_unauthenticated_redirectsToLogin() async throws {
@@ -96,6 +114,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student1", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student1", courseID: courseID)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1",
             beforeRequest: { req in
@@ -116,6 +135,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student2", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student2", courseID: courseID)
         try await app.asyncTest(
             .GET, "/cs246/assignment-2",
             beforeRequest: { req in
@@ -136,6 +156,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student3", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student3", courseID: courseID)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1-intro",
             beforeRequest: { req in
@@ -187,6 +208,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student6", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student6", courseID: courseID)
         try await app.asyncTest(
             .GET, "/hlth230/lab99",
             beforeRequest: { req in
@@ -210,6 +232,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student7", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student7", courseID: activeID)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1",
             beforeRequest: { req in
@@ -231,6 +254,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student8", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student8", courseID: courseID)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1",
             beforeRequest: { req in
@@ -260,6 +284,53 @@ final class VanityURLRoutesTests: XCTestCase {
         XCTAssertEqual(slug, "lab-1-2")
     }
 
+    // MARK: - Enrollment gate (issue #561)
+
+    func testVanityURL_unenrolledStudent_returns404() async throws {
+        // Regression for issue #561: vanity URLs leaked the existence of
+        // a (courseCode, assignmentSlug) pair to any authenticated user
+        // by redirecting unenrolled students into the access-denied page
+        // instead of 404'ing.
+        let course = try await seedCourse(code: "HLTH230")
+        let courseID = try course.requireID()
+        try await seedSetupAndAssignment(courseID: courseID, title: "Lab 1", setupID: "setup_van_enr01")
+
+        let cookie = try await loginUser(
+            username: "vanity_outsider", password: "pw",
+            role: "student", on: app)
+        try await app.asyncTest(
+            .GET, "/hlth230/lab-1",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(
+                    res.status, .notFound,
+                    "Unenrolled student must see 404 (matching no-such-course response), got \(res.status)")
+            })
+    }
+
+    func testVanityURL_instructor_bypassesEnrollment() async throws {
+        // Instructors and admins skip the enrollment check so they can
+        // QA assignments in courses they aren't formally enrolled in.
+        let course = try await seedCourse(code: "HLTH230")
+        let courseID = try course.requireID()
+        try await seedSetupAndAssignment(courseID: courseID, title: "Lab 1", setupID: "setup_van_enr02")
+
+        let cookie = try await loginUser(
+            username: "vanity_instructor", password: "pw",
+            role: "instructor", on: app)
+        try await app.asyncTest(
+            .GET, "/hlth230/lab-1",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+                XCTAssertEqual(res.headers.first(name: .location), "/testsetups/setup_van_enr02/notebook")
+            })
+    }
+
     func testVanityURL_submitAndHistoryRoutesRedirectToCanonicalStudentRoutes() async throws {
         let course = try await seedCourse(code: "HLTH230")
         let courseID = try course.requireID()
@@ -268,6 +339,7 @@ final class VanityURLRoutesTests: XCTestCase {
         let cookie = try await loginUser(
             username: "vanity_student9", password: "pw",
             role: "student", on: app)
+        try await enroll(username: "vanity_student9", courseID: courseID)
         try await app.asyncTest(
             .GET, "/hlth230/lab-1/submit",
             beforeRequest: { req in

--- a/Tests/APITests/ZipUploadValidationTests.swift
+++ b/Tests/APITests/ZipUploadValidationTests.swift
@@ -1,0 +1,121 @@
+// Tests/APITests/ZipUploadValidationTests.swift
+//
+// Coverage for the zip-bomb guard added in issue #554.  Pure helper-level
+// tests against real zips on disk — no HTTP plumbing needed.
+
+import Foundation
+import XCTVapor
+import XCTest
+
+@testable import chickadee_server
+
+final class ZipUploadValidationTests: XCTestCase {
+
+    private var tmpDir: URL!
+
+    override func setUp() async throws {
+        tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-zipguard-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+    }
+
+    /// Builds a zip on disk with the given entries (name → content bytes).
+    private func makeZip(named: String, entries: [(String, Data)]) throws -> String {
+        let workDir = tmpDir.appendingPathComponent("work-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        for (name, data) in entries {
+            let fileURL = workDir.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL)
+        }
+        let zipPath = tmpDir.appendingPathComponent(named).path
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = workDir
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        try zip.run()
+        zip.waitUntilExit()
+        XCTAssertEqual(zip.terminationStatus, 0, "zip command must succeed")
+        try FileManager.default.removeItem(at: workDir)
+        return zipPath
+    }
+
+    // MARK: - Happy path
+
+    func testValidateZipUploadSize_acceptsNormalZip() throws {
+        let zipPath = try makeZip(
+            named: "ok.zip",
+            entries: [
+                ("readme.txt", Data("hello world".utf8)),
+                ("nested/a.py", Data("print('a')".utf8)),
+            ])
+        XCTAssertNoThrow(try validateZipUploadSize(zipPath: zipPath))
+    }
+
+    // MARK: - Per-entry limit
+
+    func testValidateZipUploadSize_rejectsOversizedEntry() throws {
+        // Tight per-entry limit; total stays well under.
+        let limits = ZipUploadLimits(
+            maxTotalUncompressedBytes: 10 * 1024 * 1024,
+            maxEntryUncompressedBytes: 1024
+        )
+        let big = Data(repeating: 0x41, count: 5_000)
+        let zipPath = try makeZip(named: "big-entry.zip", entries: [("big.bin", big)])
+
+        XCTAssertThrowsError(try validateZipUploadSize(zipPath: zipPath, limits: limits)) { err in
+            guard case ZipUploadValidationError.entrySizeExceeded(let name, _, _) = err else {
+                XCTFail("Expected entrySizeExceeded, got \(err)")
+                return
+            }
+            XCTAssertTrue(name.contains("big.bin"), "Reported name should identify the offending entry")
+        }
+    }
+
+    // MARK: - Total limit
+
+    func testValidateZipUploadSize_rejectsOversizedTotal() throws {
+        // Per-entry generous; total tiny — every entry is under per-entry
+        // but they sum past the total cap.
+        let limits = ZipUploadLimits(
+            maxTotalUncompressedBytes: 4_000,
+            maxEntryUncompressedBytes: 10 * 1024 * 1024
+        )
+        let chunk = Data(repeating: 0x41, count: 2_000)
+        let zipPath = try makeZip(
+            named: "many.zip",
+            entries: [
+                ("a.bin", chunk),
+                ("b.bin", chunk),
+                ("c.bin", chunk),
+            ])
+
+        XCTAssertThrowsError(try validateZipUploadSize(zipPath: zipPath, limits: limits)) { err in
+            guard case ZipUploadValidationError.totalSizeExceeded = err else {
+                XCTFail("Expected totalSizeExceeded, got \(err)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Inspection failure
+
+    func testValidateZipUploadSize_failsCleanlyOnCorruptZip() throws {
+        let badPath = tmpDir.appendingPathComponent("not-a-zip.zip").path
+        try Data("definitely not a zip".utf8).write(to: URL(fileURLWithPath: badPath))
+
+        XCTAssertThrowsError(try validateZipUploadSize(zipPath: badPath)) { err in
+            guard case ZipUploadValidationError.inspectionFailed = err else {
+                XCTFail("Expected inspectionFailed for a corrupt zip, got \(err)")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second small-surgical batch from the security & privacy audit, same shape as PR #567.

- **#554 — Zip-bomb test-setup uploads**.  `validateZipUploadSize` ([TestSetupZipHelpers.swift](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift)) inspects `unzip -v` metadata and enforces per-entry (64 MB) and total (256 MB) uncompressed caps before any DB row references the file.  Called from `uploadTestSetup`; on failure the offending bytes are deleted from disk.  Limited blast radius (instructor-only upload path) but a compromised instructor account shouldn't be able to take down the host with a 1 MB upload.
- **#561 — Vanity URL enumeration**.  `resolveAssignment` ([VanityURLRoutes.swift](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Routes/Web/VanityURLRoutes.swift)) now requires course enrollment.  Unenrolled access produces the same 404 as no-such-course / no-such-assignment, so the routes can't be used to enumerate the institutional catalogue.  Instructors and admins bypass via the standard `isInstructor` short-circuit.
- **#563 — OIDC_AUTH_SERVER validation**.  New `validateOIDCDiscoveryURL` ([OIDCConfiguration.swift](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Auth/OIDCConfiguration.swift)) rejects `http://` and loopback / private-range hosts at startup unless `OIDC_ALLOW_INSECURE=true` is set.  Defense in depth against a fat-fingered env var pointing the discovery fetch at an internal service.

#553 was found to be already implemented by `validatePatternFamilies` ([ManifestValidation.swift:288](../blob/main/Sources/APIServer/Utilities/ManifestValidation.swift#L288)) — closed with a comment.

## Test plan

- [x] `swift build` clean against latest `main`
- [x] 4 new ZipUploadValidationTests (happy path, per-entry limit, total limit, corrupt zip)
- [x] 12 new OIDCDiscoveryURLValidationTests (https public, http rejection, private/loopback ranges, override behaviour, malformed input)
- [x] 2 new VanityURLRoutesTests (unenrolled → 404, instructor bypass) plus 6 existing tests updated to enroll the student
- [x] Existing OIDCTests updated to pass `OIDC_ALLOW_INSECURE=true` for their loopback IdP fixtures
- [x] Full test suite green (939 XCTest + 290 Swift Testing, exit 0)
- [x] `swift-format lint --strict` clean

## Closes

Closes #554, #561, #563. (#553 closed separately as already-implemented.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVndTyaMvd2NC8FhDTwqRx)_