### PR TITLE
security: audit_log retention reaper

### DIFF
--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -19,6 +19,11 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
     app.lifecycle.use(AssignmentDeadlineLifecycleHandler())
     app.lifecycle.use(StuckSubmissionReaperLifecycleHandler())
     app.lifecycle.use(SessionReaperLifecycleHandler())
+    app.lifecycle.use(
+        AuditLogReaperLifecycleHandler(
+            maxAge: TimeInterval(appConfig.diagnostics.auditLogRetentionDays) * 86_400
+        )
+    )
     app.lifecycle.use(ServerHealthAlertLifecycleHandler())
 
     // BrightSpace grade sync (only registered when env vars are present).

--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -174,7 +174,8 @@ extension AppConfig {
                 runnerSnapshotRetentionDays: 14,
                 activeRunnerWindowSeconds: 120,
                 recentMetricsWindowHours: 24,
-                pruneIntervalHours: 24
+                pruneIntervalHours: 24,
+                auditLogRetentionDays: 90
             ),
             alerts: .default
         )

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
@@ -49,6 +49,13 @@ struct DiagnosticsConfiguration: Sendable {
     let activeRunnerWindowSeconds: TimeInterval
     let recentMetricsWindowHours: Int
     let pruneIntervalHours: Int
+    /// How many days of `audit_log` rows to keep before the audit-log
+    /// reaper deletes them.  Zero disables the reaper entirely so
+    /// operators piping audit_log to an external sink can manage
+    /// retention there.  Default 90 — long enough for last-term
+    /// debugging, short enough to satisfy FIPPA / PIPEDA's "dispose
+    /// once the operational need ends" principle.
+    let auditLogRetentionDays: Int
 
     static func fromEnvironment() -> Self {
         Self(
@@ -58,7 +65,8 @@ struct DiagnosticsConfiguration: Sendable {
             runnerSnapshotRetentionDays: environmentInt("RUNNER_SNAPSHOT_RETENTION_DAYS") ?? 14,
             activeRunnerWindowSeconds: TimeInterval(environmentInt("RUNNER_ACTIVE_WINDOW_SECONDS") ?? 120),
             recentMetricsWindowHours: environmentInt("METRICS_RECENT_WINDOW_HOURS") ?? 24,
-            pruneIntervalHours: environmentInt("OBSERVABILITY_PRUNE_INTERVAL_HOURS") ?? 24
+            pruneIntervalHours: environmentInt("OBSERVABILITY_PRUNE_INTERVAL_HOURS") ?? 24,
+            auditLogRetentionDays: environmentInt("AUDIT_LOG_RETENTION_DAYS") ?? 90
         )
     }
 }

--- a/Sources/APIServer/Services/AuditLogReaperService.swift
+++ b/Sources/APIServer/Services/AuditLogReaperService.swift
@@ -13,11 +13,13 @@
 // pipe audit_log to an external sink and want to manage retention there).
 //
 // Pattern mirrors `SessionReaperService` and `StuckSubmissionReaperService`
-// for consistency.
+// for consistency.  Uses Fluent's typed query instead of raw SQL so the
+// `Date < timestamptz` comparison works on both SQLite and Postgres (raw
+// SQL would need a `::timestamptz` cast on Postgres for Fluent's
+// `.datetime` columns).
 
 import Fluent
 import Foundation
-import SQLKit
 import Vapor
 
 /// Default audit-log retention.  90 days covers the usual "what happened
@@ -36,16 +38,11 @@ func reapStaleAuditLogEntries(
     now: Date = Date()
 ) async throws {
     guard maxAge > 0 else { return }
-    guard let sql = db as? SQLDatabase else { return }
     let cutoff = now.addingTimeInterval(-maxAge)
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let cutoffString = formatter.string(from: cutoff)
-
-    try await sql.raw(
-        "DELETE FROM audit_log WHERE created_at < \(bind: cutoffString)"
-    ).run()
-    logger.debug("Audit-log reaper sweep complete (cutoff=\(cutoffString))")
+    try await APIAuditLogEntry.query(on: db)
+        .filter(\.$createdAt < cutoff)
+        .delete()
+    logger.debug("Audit-log reaper sweep complete (cutoff=\(cutoff))")
 }
 
 final class AuditLogReaperMonitor: @unchecked Sendable {

--- a/Sources/APIServer/Services/AuditLogReaperService.swift
+++ b/Sources/APIServer/Services/AuditLogReaperService.swift
@@ -1,0 +1,138 @@
+// APIServer/Services/AuditLogReaperService.swift
+//
+// Periodic cleanup of stale `audit_log` rows.  Rows accumulate forever
+// without this — every authenticated action, login attempt, role change,
+// retest, and admin operation lands one — and the table carries actor
+// names, IPs, user-agents, and action metadata.  Under FIPPA / PIPEDA,
+// indefinite retention of personally-identifying audit trails is not a
+// defensible posture; periodic disposal once the operational need ends
+// is the standard mitigation.
+//
+// Default retention: 90 days, overridable via `AUDIT_LOG_RETENTION_DAYS`.
+// Setting it to 0 disables the reaper (kept around for installs that
+// pipe audit_log to an external sink and want to manage retention there).
+//
+// Pattern mirrors `SessionReaperService` and `StuckSubmissionReaperService`
+// for consistency.
+
+import Fluent
+import Foundation
+import SQLKit
+import Vapor
+
+/// Default audit-log retention.  90 days covers the usual "what happened
+/// last term" debugging window without amassing years of identifying
+/// metadata.
+let auditLogDefaultMaxAge: TimeInterval = 90 * 24 * 60 * 60
+
+/// Deletes audit_log rows older than `maxAge`.  A `maxAge` of zero (or
+/// negative) is a no-op so operators can disable the reaper cleanly via
+/// env var without removing the lifecycle handler.  `created_at` is
+/// NOT NULL in the schema, so no null-guard is needed.
+func reapStaleAuditLogEntries(
+    on db: Database,
+    logger: Logger,
+    maxAge: TimeInterval = auditLogDefaultMaxAge,
+    now: Date = Date()
+) async throws {
+    guard maxAge > 0 else { return }
+    guard let sql = db as? SQLDatabase else { return }
+    let cutoff = now.addingTimeInterval(-maxAge)
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    let cutoffString = formatter.string(from: cutoff)
+
+    try await sql.raw(
+        "DELETE FROM audit_log WHERE created_at < \(bind: cutoffString)"
+    ).run()
+    logger.debug("Audit-log reaper sweep complete (cutoff=\(cutoffString))")
+}
+
+final class AuditLogReaperMonitor: @unchecked Sendable {
+    private var task: Task<Void, Never>?
+    private let intervalNanoseconds: UInt64
+    private let maxAge: TimeInterval
+
+    init(interval: TimeInterval = 3600, maxAge: TimeInterval = auditLogDefaultMaxAge) {
+        intervalNanoseconds = UInt64(max(interval, 60) * 1_000_000_000)
+        self.maxAge = maxAge
+    }
+
+    func start(application: Application) {
+        guard task == nil else { return }
+        task = Task { [maxAge, intervalNanoseconds] in
+            while !Task.isCancelled {
+                do {
+                    try await reapStaleAuditLogEntries(
+                        on: application.db,
+                        logger: application.logger,
+                        maxAge: maxAge
+                    )
+                } catch {
+                    application.logger.error(
+                        "Audit-log reaper sweep failed: \(error.localizedDescription)"
+                    )
+                }
+                do {
+                    try await Task.sleep(nanoseconds: intervalNanoseconds)
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+}
+
+struct AuditLogReaperMonitorKey: StorageKey {
+    typealias Value = AuditLogReaperMonitor
+}
+
+struct AuditLogReaperLifecycleHandler: LifecycleHandler {
+    let maxAge: TimeInterval
+
+    init(maxAge: TimeInterval = auditLogDefaultMaxAge) {
+        self.maxAge = maxAge
+    }
+
+    func didBoot(_ application: Application) throws {
+        // Best-effort first sweep at boot so a restart after a long quiet
+        // period doesn't have to wait an hour to reclaim space.
+        let maxAgeCapture = maxAge
+        Task {
+            do {
+                try await reapStaleAuditLogEntries(
+                    on: application.db,
+                    logger: application.logger,
+                    maxAge: maxAgeCapture
+                )
+            } catch {
+                application.logger.error(
+                    "Initial audit-log reaper sweep failed: \(error.localizedDescription)"
+                )
+            }
+        }
+        application.auditLogReaperMonitor(maxAge: maxAge).start(application: application)
+    }
+
+    func shutdown(_ application: Application) {
+        application.storage[AuditLogReaperMonitorKey.self]?.stop()
+    }
+}
+
+extension Application {
+    /// Returns the singleton monitor, creating it with the supplied
+    /// `maxAge` on first access.  Subsequent calls ignore the parameter —
+    /// the caller (lifecycle handler) is the one source of truth for
+    /// retention configuration.
+    func auditLogReaperMonitor(maxAge: TimeInterval = auditLogDefaultMaxAge) -> AuditLogReaperMonitor {
+        if let existing = storage[AuditLogReaperMonitorKey.self] { return existing }
+        let created = AuditLogReaperMonitor(maxAge: maxAge)
+        storage[AuditLogReaperMonitorKey.self] = created
+        return created
+    }
+}

--- a/Tests/APITests/AuditLogReaperServiceTests.swift
+++ b/Tests/APITests/AuditLogReaperServiceTests.swift
@@ -1,0 +1,91 @@
+// Tests/APITests/AuditLogReaperServiceTests.swift
+//
+// Coverage for the audit_log retention reaper added in issue #555.
+
+import Fluent
+import Foundation
+import SQLKit
+import XCTVapor
+import XCTest
+
+@testable import chickadee_server
+
+final class AuditLogReaperServiceTests: XCTestCase {
+
+    private var app: Application!
+
+    override func setUp() async throws {
+        app = try await makeTestApp(prefix: "chickadee-auditreaper")
+    }
+
+    override func tearDown() async throws {
+        try await app.tearDownTestApp()
+    }
+
+    /// Inserts an audit_log row and back-dates its `created_at` to `daysOld`
+    /// days ago.  Fluent's @Timestamp(.create) populates created_at to "now"
+    /// on save, so we explicitly UPDATE afterwards.
+    @discardableResult
+    private func seedEntry(action: String, daysOld: Int) async throws -> UUID {
+        let entry = APIAuditLogEntry(action: action)
+        try await entry.save(on: app.db)
+        let id = try XCTUnwrap(entry.id)
+
+        let cutoff = Date().addingTimeInterval(-Double(daysOld) * 86_400)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let backdated = formatter.string(from: cutoff)
+        guard let sql = app.db as? SQLDatabase else {
+            XCTFail("Expected SQLDatabase")
+            return id
+        }
+        try await sql.raw(
+            "UPDATE audit_log SET created_at = \(bind: backdated) WHERE id = \(bind: id.uuidString)"
+        ).run()
+        return id
+    }
+
+    private func entryExists(_ id: UUID) async throws -> Bool {
+        try await APIAuditLogEntry.find(id, on: app.db) != nil
+    }
+
+    // MARK: - Reaper behaviour
+
+    func testReaper_deletesEntriesOlderThanMaxAge() async throws {
+        let stale = try await seedEntry(action: "test.stale", daysOld: 120)
+        let fresh = try await seedEntry(action: "test.fresh", daysOld: 5)
+
+        try await reapStaleAuditLogEntries(
+            on: app.db,
+            logger: app.logger,
+            maxAge: 90 * 86_400
+        )
+
+        let staleStillThere = try await entryExists(stale)
+        let freshStillThere = try await entryExists(fresh)
+        XCTAssertFalse(staleStillThere, "Entry older than maxAge should be deleted")
+        XCTAssertTrue(freshStillThere, "Entry inside the retention window must be preserved")
+    }
+
+    func testReaper_zeroMaxAgeIsNoOp() async throws {
+        // Operators piping to external sinks disable the reaper with
+        // AUDIT_LOG_RETENTION_DAYS=0; verify the helper short-circuits.
+        let recent = try await seedEntry(action: "test.recent", daysOld: 200)
+        try await reapStaleAuditLogEntries(
+            on: app.db,
+            logger: app.logger,
+            maxAge: 0
+        )
+        let stillThere = try await entryExists(recent)
+        XCTAssertTrue(stillThere, "maxAge == 0 must be a no-op")
+    }
+
+    func testReaper_handlesEmptyTableCleanly() async throws {
+        // No rows + no error — nothing to do, no throw.
+        try await reapStaleAuditLogEntries(
+            on: app.db,
+            logger: app.logger,
+            maxAge: 1
+        )
+    }
+}

--- a/Tests/APITests/AuditLogReaperServiceTests.swift
+++ b/Tests/APITests/AuditLogReaperServiceTests.swift
@@ -4,7 +4,6 @@
 
 import Fluent
 import Foundation
-import SQLKit
 import XCTVapor
 import XCTest
 
@@ -23,25 +22,17 @@ final class AuditLogReaperServiceTests: XCTestCase {
     }
 
     /// Inserts an audit_log row and back-dates its `created_at` to `daysOld`
-    /// days ago.  Fluent's @Timestamp(.create) populates created_at to "now"
-    /// on save, so we explicitly UPDATE afterwards.
+    /// days ago.  `@Timestamp(on: .create)` only fires on first insert, so a
+    /// second save with an explicit `createdAt` preserves the override —
+    /// portable across SQLite and Postgres (a raw SQL UPDATE binding the
+    /// timestamp as text trips Postgres's strict timestamptz typing).
     @discardableResult
     private func seedEntry(action: String, daysOld: Int) async throws -> UUID {
         let entry = APIAuditLogEntry(action: action)
         try await entry.save(on: app.db)
         let id = try XCTUnwrap(entry.id)
-
-        let cutoff = Date().addingTimeInterval(-Double(daysOld) * 86_400)
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime]
-        let backdated = formatter.string(from: cutoff)
-        guard let sql = app.db as? SQLDatabase else {
-            XCTFail("Expected SQLDatabase")
-            return id
-        }
-        try await sql.raw(
-            "UPDATE audit_log SET created_at = \(bind: backdated) WHERE id = \(bind: id.uuidString)"
-        ).run()
+        entry.createdAt = Date().addingTimeInterval(-Double(daysOld) * 86_400)
+        try await entry.save(on: app.db)
         return id
     }
 


### PR DESCRIPTION
## Summary

First of the two high-priority privacy items flagged in the security & privacy audit (issue #555).

The `audit_log` table grew forever — every authenticated action, login attempt, role change, retest, and admin operation lands a row, and rows carry actor names, IPs, user-agents, and action metadata. Under FIPPA / PIPEDA, indefinite retention of personally-identifying audit trails isn't defensible.

`AuditLogReaperService` mirrors the existing `SessionReaperService` / `StuckSubmissionReaperService` pattern exactly:

- One-shot startup sweep + hourly periodic sweep.
- Default 90-day retention, overridable via `AUDIT_LOG_RETENTION_DAYS`.
- Setting retention to `0` disables the reaper cleanly (for operators piping `audit_log` to an external sink that manages retention there).

Config plumbed via `DiagnosticsConfiguration.auditLogRetentionDays` ([OperationalDiagnostics.swift](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift)), sitting alongside the existing `jobMetricRetentionDays` / `runnerSnapshotRetentionDays` fields — audit retention is observability-adjacent, this avoids carving out a new top-level `AuditConfig` for a single field. Lifecycle handler registered in [AppServices.swift](../blob/claude/brainstorm-missing-features-8yIEh/Sources/APIServer/Bootstrap/AppServices.swift).

## Test plan

- [x] `swift build` clean against latest `main`
- [x] 3 new `AuditLogReaperServiceTests`: stale-row deletion respects cutoff; fresh rows preserved; `maxAge=0` is a no-op; empty-table case handled cleanly
- [x] Full test suite green (946 XCTest + 290 Swift Testing, exit 0)
- [x] `swift-format lint --strict` clean

The audit's "NULL created_at safety net" callout was dropped on inspection — `audit_log.created_at` is `NOT NULL` in the schema, so the guard would have been dead code.

## Closes

Closes #555.

## Next

#560 (self-host Pyodide + CodeMirror) is the other high-priority privacy item; queued for the next PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EVndTyaMvd2NC8FhDTwqRx)_