### PR TITLE
refactor(routes): drop redundant role guards + wire SwiftLint into CI

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -8,15 +8,29 @@ on:
 jobs:
   format-lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     container:
       image: swift:6.3-jammy
 
     steps:
       - uses: actions/checkout@v6
 
+      - name: Compute SPM cache key
+        id: spm-cache-key
+        run: echo "value=$(sha256sum Package.resolved | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache SPM checkouts
+        uses: actions/cache@v5
+        with:
+          path: .build/checkouts
+          key: ${{ runner.os }}-spm-${{ steps.spm-cache-key.outputs.value }}
+          restore-keys: ${{ runner.os }}-spm-
+
       - name: Check formatting
         run: scripts/lint.sh
+
+      - name: Run SwiftLint
+        run: scripts/swiftlint.sh
 
   core-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -9,8 +9,14 @@ jobs:
   format-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # noble (Ubuntu 24.04) rather than jammy (22.04) because SwiftLintBinary
+    # 0.63.2 — shipped by the SwiftLintPlugins package and downloaded on
+    # demand — is linked against GLIBC 2.38, which jammy's glibc 2.35 cannot
+    # satisfy.  The test/build jobs below stay on jammy because they don't
+    # invoke the swiftlint plugin.  Re-unify when SwiftLintBinary publishes
+    # a jammy-compatible release or when the project moves all jobs to noble.
     container:
-      image: swift:6.3-jammy
+      image: swift:6.3-noble
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Internal
+
+- **Drop redundant in-handler role guards on AssignmentRoutes.**  The
+  `AssignmentRoutes` collection (and every `+Extension`) is already
+  registered behind `RoleMiddleware(required: .instructor)` in
+  `routes.swift`, so the ~40 in-handler `guard user.isInstructor`
+  checks (15 inline `WebAssignmentError.forbidden(action:)` sites in
+  `+Editor` / `+Enrollment` / `editPage`; 25 `try requireInstructor(req)`
+  sites in `+Suite` / `+Checks` / `+Families` / `+GlobalVariables` /
+  `+SuiteSections` / `+DraftSections` / `+Draft`) were dead code — the
+  middleware throws `Abort(.forbidden)` before any handler runs.  The
+  `requireInstructor(_:)` helper in `SuiteEditHelpers.swift` is
+  removed too.  Net: 11 files, 5 +, 104 −.  Two combined
+  `guard user.isInstructor, let userID = user.id else { … }` sites in
+  `+Editor` are simplified to a plain `let userID = user.id` extract
+  (still required because `APIUser.id` is `UUID?` for Fluent reasons);
+  their throw site changes from `.forbidden` to `.internalFailure`
+  since the only reachable branch is a server-side data inconsistency,
+  not an authorization failure.  Tests assert on HTTP status
+  (`.forbidden`), not on `WebAssignmentError` cases, so existing
+  rejection coverage in `AssignmentRoutesDashboardTests`,
+  `AssignmentEnrollmentTests`, `SuiteRouteTests` continues to assert
+  the right thing — `Abort(.forbidden)` from the middleware also
+  yields a 403.  `TestSetupRoutes`, `WebRoutes(+Submission)`,
+  `SubmissionRoutes`, and `VanityURLRoutes` are unchanged because
+  their inline checks are legitimate per-resource authorization
+  (the collections themselves are in the `.authenticated` group,
+  not the `.instructor` group).
+
 ## [0.4.173] - 2026-05-17
 
 Security & privacy pass.  Closes the security findings raised by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Wire SwiftLint into the `format-lint` CI job.**  `.swiftlint.yml` and
+  `scripts/swiftlint.sh` have been on disk since the adoption PR, but the
+  workflow only ran `scripts/lint.sh` (swift-format).  The violation
+  backlog is now empty (`Found 0 violations, 0 serious in 329 files`),
+  so the staged rollout described in `CLAUDE.md` advances to its final
+  state: the `Run SwiftLint` step runs after `Check formatting` in the
+  same job.  The script still skips `--strict`, so warning-severity
+  rules report without blocking while error-severity outliers (function
+  body > 300 lines, type body > 800 lines, cyclomatic complexity > 40,
+  etc.) fail the job.  Added an SPM checkout cache to keep the
+  swiftlint plugin warm across runs, and bumped the job timeout from
+  5 min to 10 min to absorb the first cold build.
+
 - **Drop redundant in-handler role guards on AssignmentRoutes.**  The
   `AssignmentRoutes` collection (and every `+Extension`) is already
   registered behind `RoleMiddleware(required: .instructor)` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,10 +391,11 @@ same bytes without a build-time network fetch.
   delivered via the `SwiftLintPlugins` SwiftPM dependency — no separate
   install). Run `scripts/swiftlint.sh` to check. The two tools are
   complementary: swift-format owns formatting, SwiftLint owns correctness;
-  overlapping rules are disabled in `.swiftlint.yml`. CI enforcement of
-  SwiftLint is staged — adoption PR adds the config, follow-up PRs clear
-  the violation backlog, then the `Run SwiftLint` step is wired into the
-  `format-lint` job.
+  overlapping rules are disabled in `.swiftlint.yml`. CI enforces SwiftLint
+  as a step in the `format-lint` job (alongside `scripts/lint.sh`); the
+  script does not pass `--strict` so warning-severity rules still report
+  for visibility without blocking, while error-severity rules (outsized
+  functions/types, real outliers) fail the job.
 
 ---
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Checks.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Checks.swift
@@ -21,7 +21,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func getNotebookChecks(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
 
         let checks: [NotebookCheck] = {
@@ -46,7 +45,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func putNotebookChecks(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (assignment, setup) = try await loadAssignmentAndSetup(req)
 
         let checks: [NotebookCheck]

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Draft.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Draft.swift
@@ -33,7 +33,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func getDraftSuite(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         let payload = buildSuitePayload(fromManifest: setup.manifest)
         return try await payload.encodeResponse(for: req)
@@ -47,7 +46,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func putDraftSuite(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
 
         let body: SuitePayload
@@ -67,7 +65,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func putDraftPatternFamilies(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
 
         let families: [PatternFamily]
@@ -94,7 +91,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func putDraftNotebookChecks(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
 
         let checks: [NotebookCheck]
@@ -115,7 +111,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func createDraftScript(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
 
         struct CreateBody: Content {
@@ -189,7 +184,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func deleteDraftScript(req: Request) async throws -> HTTPStatus {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         let filename = try safeScriptFilename(from: req)
 
@@ -234,7 +228,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func downloadDraftSetupItem(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
 
         struct FileQuery: Content { let name: String }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+DraftSections.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+DraftSections.swift
@@ -35,7 +35,6 @@ extension AssignmentRoutes {
     func createDraftSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         let body = try req.content.decode(Body.self)
         let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -61,7 +60,6 @@ extension AssignmentRoutes {
     func renameDraftSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
@@ -90,7 +88,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func deleteDraftSuiteSection(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
@@ -129,7 +126,6 @@ extension AssignmentRoutes {
     func updateDraftSuiteSectionVariables(req: Request) async throws -> Response {
         struct Body: Content { var variables: [FamilyVariable] }
 
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
@@ -179,7 +175,6 @@ extension AssignmentRoutes {
     func reorderDraftSuiteSections(req: Request) async throws -> HTTPStatus {
         struct Body: Content { var sectionIDs: [String] }
 
-        try requireInstructor(req)
         let setup = try await loadDraftSetup(req)
         let body = try req.content.decode(Body.self)
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Editor.swift
@@ -13,11 +13,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func downloadCurrentNotebookFile(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "download assignment files")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         guard
             let assignment = try await assignmentByPublicID(idStr, on: req.db),
@@ -39,11 +34,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func downloadCurrentSetupItem(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "download assignment files")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         guard
             let assignment = try await assignmentByPublicID(idStr, on: req.db),
@@ -71,11 +61,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func downloadCurrentSolutionFile(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "download assignment files")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         guard
             let assignment = try await assignmentByPublicID(idStr, on: req.db),
@@ -122,9 +107,6 @@ extension AssignmentRoutes {
     @Sendable
     func saveEditedAssignment(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "edit assignments")
-        }
 
         let idStr = try assignmentPublicIDParameter(from: req)
         guard
@@ -442,11 +424,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func getScript(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "edit assignment scripts")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         let filename = try safeScriptFilename(from: req)
 
@@ -470,11 +447,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func updateScript(req: Request) async throws -> HTTPStatus {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "edit assignment scripts")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         let filename = try safeScriptFilename(from: req)
 
@@ -529,11 +501,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func createScript(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "create assignment scripts")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
 
         struct CreateBody: Content {
@@ -638,11 +605,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func deleteScript(req: Request) async throws -> HTTPStatus {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "delete assignment scripts")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         let filename = try safeScriptFilename(from: req)
 
@@ -708,8 +670,8 @@ extension AssignmentRoutes {
     @Sendable
     func draftSolutionNotebook(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor, let userID = user.id else {
-            throw WebAssignmentError.forbidden(action: "view draft solution notebooks")
+        guard let userID = user.id else {
+            throw WebAssignmentError.internalFailure(reason: "Authenticated user has no ID")
         }
 
         guard let draftID = try? req.query.get(String.self, at: "draftID"),
@@ -760,11 +722,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func scanNotebook(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "scan notebooks")
-        }
-
         guard let buffer = req.body.data else {
             throw WebAssignmentError.invalidParameter(name: "request body", reason: "Request body is empty")
         }
@@ -831,8 +788,8 @@ extension AssignmentRoutes {
     @Sendable
     func createSolutionFromAssignment(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor, let userID = user.id else {
-            throw WebAssignmentError.forbidden(action: "create a solution notebook")
+        guard let userID = user.id else {
+            throw WebAssignmentError.internalFailure(reason: "Authenticated user has no ID")
         }
 
         let idStr = try assignmentPublicIDParameter(from: req)

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Enrollment.swift
@@ -13,10 +13,6 @@ extension AssignmentRoutes {
     @Sendable
     func enrollCSVForm(req: Request) async throws -> View {
         let caller = try req.auth.require(APIUser.self)
-        guard caller.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "manage enrollments")
-        }
-
         let courseState = try await req.resolveActiveCourse(for: caller)
         guard let courseContext = courseState.active,
             let courseID = courseState.activeCourseUUID,
@@ -105,11 +101,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func instructorUnenrollUser(req: Request) async throws -> Response {
-        let caller = try req.auth.require(APIUser.self)
-        guard caller.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "manage enrollments")
-        }
-
         guard
             let courseIDString = req.parameters.get("courseID"),
             let courseID = UUID(uuidString: courseIDString),
@@ -138,11 +129,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func instructorCancelPreEnrollment(req: Request) async throws -> Response {
-        let caller = try req.auth.require(APIUser.self)
-        guard caller.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "manage enrollments")
-        }
-
         guard
             let courseIDString = req.parameters.get("courseID"),
             let courseID = UUID(uuidString: courseIDString),

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Families.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Families.swift
@@ -21,7 +21,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func getPatternFamilies(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
 
         let families: [PatternFamily] = {
@@ -48,7 +47,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func putPatternFamilies(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (assignment, setup) = try await loadAssignmentAndSetup(req)
 
         let families: [PatternFamily]

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+GlobalVariables.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+GlobalVariables.swift
@@ -56,7 +56,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func getGlobalVariables(req: Request) async throws -> GlobalVariablesResponse {
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
 
         let manifest = try decodeManifest(setup: setup)
@@ -71,7 +70,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func putGlobalVariables(req: Request) async throws -> GlobalVariablesResponse {
-        try requireInstructor(req)
         let (assignment, setup) = try await loadAssignmentAndSetup(req)
         let body = try req.content.decode(GlobalVariablesBody.self)
         let expressions = body.expressions ?? []

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Suite.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Suite.swift
@@ -82,7 +82,6 @@ extension AssignmentRoutes {
     /// runner-facing expanded form.
     @Sendable
     func getSuite(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
         let payload = buildSuitePayload(fromManifest: setup.manifest)
         return try await payload.encodeResponse(for: req)
@@ -96,7 +95,6 @@ extension AssignmentRoutes {
     /// view without a second round-trip.
     @Sendable
     func putSuite(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (assignment, setup) = try await loadAssignmentAndSetup(req)
 
         let body: SuitePayload

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+SuiteSections.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+SuiteSections.swift
@@ -34,7 +34,6 @@ extension AssignmentRoutes {
     func createSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
         let body = try req.content.decode(Body.self)
         let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -60,7 +59,6 @@ extension AssignmentRoutes {
     func renameSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
@@ -89,7 +87,6 @@ extension AssignmentRoutes {
 
     @Sendable
     func deleteSuiteSection(req: Request) async throws -> Response {
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
@@ -134,7 +131,6 @@ extension AssignmentRoutes {
             var expressions: [PersonalizationExpression]?
         }
 
-        try requireInstructor(req)
         let (assignment, setup) = try await loadAssignmentAndSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
@@ -346,7 +342,6 @@ extension AssignmentRoutes {
     func reorderSuiteSections(req: Request) async throws -> HTTPStatus {
         struct Body: Content { var sectionIDs: [String] }
 
-        try requireInstructor(req)
         let (_, setup) = try await loadAssignmentAndSetup(req)
         let body = try req.content.decode(Body.self)
 

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -510,11 +510,6 @@ struct AssignmentRoutes: RouteCollection {
 
     @Sendable
     func editPage(req: Request) async throws -> View {
-        let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "edit assignments")
-        }
-
         let idStr = try assignmentPublicIDParameter(from: req)
         guard
             let assignment = try await assignmentByPublicID(idStr, on: req.db),

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -31,19 +31,7 @@ import Fluent
 import Foundation
 import Vapor
 
-// MARK: - Auth + setup resolution
-
-/// Authenticates the request as an instructor.  Throws .unauthorized
-/// if no user, .forbidden if the user isn't at least an instructor.
-/// Returns the user for callers that need it (e.g. for retest stamping).
-@discardableResult
-func requireInstructor(_ req: Request) throws -> APIUser {
-    let user = try req.auth.require(APIUser.self)
-    guard user.isInstructor else {
-        throw WebAssignmentError.forbidden(action: "edit assignments")
-    }
-    return user
-}
+// MARK: - Setup resolution
 
 /// Loads the (assignment, setup) pair from a `:assignmentID` path
 /// parameter.  Throws `.notFound` if either the assignment or its


### PR DESCRIPTION
Two architecture-review follow-ups, both small and independent.

## 1. Drop redundant role guards on AssignmentRoutes

The `AssignmentRoutes` collection (and every `+Extension` file) is already gated behind `RoleMiddleware(required: .instructor)` in `routes.swift:51` — so the ~40 in-handler `guard user.isInstructor` checks scattered across 11 files were dead code: the middleware throws `Abort(.forbidden)` before any handler runs.

- **15 inline `guard user.isInstructor else { throw WebAssignmentError.forbidden(action: …) }` blocks** removed from `+Editor`, `+Enrollment`, `editPage`.
- **25 `try requireInstructor(req)` calls** removed from `+Suite`, `+Checks`, `+Families`, `+GlobalVariables`, `+SuiteSections`, `+DraftSections`, `+Draft`.
- **`requireInstructor(_:)` helper** in `SuiteEditHelpers.swift` deleted (no remaining callers).
- Two combined `guard user.isInstructor, let userID = user.id else { throw .forbidden }` sites in `+Editor` reduced to plain `let userID = user.id` extracts.  Throw site moves from `.forbidden` to `.internalFailure` — the only reachable branch is server-side data inconsistency, not auth failure.

`TestSetupRoutes`, `WebRoutes(+Submission)`, `SubmissionRoutes`, and `VanityURLRoutes` are left alone: their inline checks are legitimate per-resource authorization (those collections sit in the `.authenticated` route group, not the `.instructor` group).

## 2. Wire SwiftLint into the `format-lint` CI job

`.swiftlint.yml` and `scripts/swiftlint.sh` have been on disk since the SwiftLint adoption PR, but the workflow only ran `scripts/lint.sh` (swift-format).  Per `CLAUDE.md:386–397` the rollout was staged "until the violation backlog is cleared."

That backlog is now empty:

```
Found 0 violations, 0 serious in 329 files.
```

So the `Run SwiftLint` step is wired into the `format-lint` job, alongside `Check formatting`.  The script still skips `--strict`, so warning-severity rules report for visibility without blocking; error-severity outliers (function body > 300 lines, type body > 800, cyclomatic complexity > 40, etc.) fail the job.

Added an SPM checkout cache (`actions/cache@v5`) to keep the SwiftLint plugin warm across runs.  Bumped the job timeout from 5 min to 10 min to absorb the first cold build.

`CLAUDE.md` updated; "staged" prose removed.

## Diff size

```
14 files changed, 39 insertions(+), 109 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `scripts/swiftlint.sh` — 0 violations, 0 serious in 329 files
- [x] `swift build` — clean
- [x] `swift test --filter "AssignmentRoutesLifecycleTests|SuiteRouteTests|AssignmentEnrollmentTests|AssignmentRoutesDashboardTests|AssignmentRoutesRetestTests|AssignmentRoutesPublishTests|SuiteSectionRoutesTests|DraftSuiteSectionRoutesTests"` — 78 tests, 0 failures
- [ ] CI runs full APITests / WorkerTests / format-lint (with the new SwiftLint step)

## Follow-ups still pending from the architecture review

- Error-handling consistency (typed `WebAssignmentError` vs bare `Abort` vs query-param redirects)
- v0.5.0 / v0.6.0 cleanup items already flagged in `CLAUDE.md` (no-op `Add*` migrations, the two DEPRECATED back-compat shims)
- Optional: service-layer extraction in the largest route handlers

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM