### PR TITLE
chore(core): drop the two DEPRECATED back-compat shims (v0.6.0 cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **v0.6.0 cleanup: drop the two DEPRECATED back-compat shims.**
+  CLAUDE.md flagged both for removal once their compatibility window
+  closed.  (1) `NotebookFunctionScanner`: the
+  `isShadowed = decodeIfPresent(...) ?? false` fallback in the custom
+  `init(from:)` is now a plain `decode(...)` — browser clients on
+  v0.4.94+ have shipped `isShadowed` unconditionally and the
+  fallback no longer carries weight.  (2) `CourseBundleManifest`:
+  the `openEnrollment: Bool?` field on `BundledCourse` (and its
+  init parameter) is gone, and `bundledCourseEnrollmentMode(_:)`
+  collapses to `course.enrollmentMode ?? .open`.  `.chickadee`
+  bundle exports have only emitted `enrollmentMode` (never
+  `openEnrollment`) since the helper extraction in #501, so old
+  imports were already going through the `?? .open` default branch.
+  Five tests that pinned the legacy contract
+  (`isShadowedDecodeFallback_legacyJSONWithoutFieldDefaultsToFalse`,
+  `bundledCourseBackwardCompatEnrollmentModeAbsent`, and the three
+  `enrollmentModeResolver_legacy*` cases) are rewritten to assert
+  the new contract: missing `isShadowed` now throws `DecodingError`,
+  `bundledCourseEnrollmentMode` only consults `enrollmentMode`.
+
 - **v0.5.0 cleanup: delete the 13 no-op `Add*` migration stubs.**
   PR #502 (v0.4.171) folded these into the corresponding `Create*`
   files, but left the structs in place as empty-bodied `AsyncMigration`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,19 +716,18 @@ model quickly.
   Fresh deploys produce the same final schema from the `Create*`
   files alone.  Separately (#501), the inline enrollment-mode
   fallback in `CourseBundleRoutes.swift` was extracted to a Core
-  helper `bundledCourseEnrollmentMode(_:)` to give **v0.6.0** a
-  single resolver to update when dropping the `openEnrollment`
-  back-compat field.  The two remaining DEPRECATED back-compat sites
-  ([Sources/Core/NotebookFunctionScanner.swift:80](Sources/Core/NotebookFunctionScanner.swift:80)
-  and [Sources/Core/CourseBundleManifest.swift:76](Sources/Core/CourseBundleManifest.swift:76))
-  are slated for removal in v0.6.0.
+  helper `bundledCourseEnrollmentMode(_:)` so the v0.6.0 cleanup
+  had a single resolver to update.  The two DEPRECATED back-compat
+  sites — `NotebookFunctionScanner.isShadowed` decode fallback and
+  `CourseBundleManifest.openEnrollment` — have now been removed
+  (v0.6.0 cleanup).  Browser clients on v0.4.94+ already send
+  `isShadowed` unconditionally; `.chickadee` bundle exports have
+  only emitted `enrollmentMode` (never `openEnrollment`) since the
+  helper extraction in #501.
 
 **Near-term roadmap:**
 
-- **v0.6.0** — Drop the two DEPRECATED back-compat shims
-  (`NotebookFunctionScanner` `isShadowed` decode fallback,
-  `CourseBundleManifest` `openEnrollment` field).  Likely
-  Vapor 5 / LeafKit 2.x investigation window — the LeafKit 1.14.1
+- **Vapor 5 / LeafKit 2.x investigation window** — the LeafKit 1.14.1
   cycle-detection false positive blocking `assignment-{new,edit}.leaf`
   decomposition is upstream and only fixed in the LeafKit 2 line.
 - **Feature backlog:** continued personalization / notebook-check

--- a/Sources/Core/CourseBundleManifest.swift
+++ b/Sources/Core/CourseBundleManifest.swift
@@ -70,40 +70,23 @@ public struct CourseBundleManifest: Codable, Sendable {
 public struct BundledCourse: Codable, Sendable {
     public let code: String
     public let name: String
-    /// Enrollment mode; nil in bundles exported before this field was added.
-    /// When nil, fall back to `openEnrollment` for backward compatibility.
+    /// Enrollment mode; nil defaults to `.open` at resolution time.
     public let enrollmentMode: CourseEnrollmentMode?
-    // DEPRECATED: remove in v0.6.0 — see CHANGELOG.
-    // Present only in `.chickadee` bundles exported before `enrollmentMode` was added.
-    // Ignored when `enrollmentMode` is non-nil. Once v0.6.0 is cut, drop the field
-    // and the `openEnrollment` branch inside `bundledCourseEnrollmentMode(_:)`.
-    public let openEnrollment: Bool?
 
     public init(
         code: String, name: String,
-        enrollmentMode: CourseEnrollmentMode? = nil,
-        openEnrollment: Bool? = nil
+        enrollmentMode: CourseEnrollmentMode? = nil
     ) {
         self.code = code
         self.name = name
         self.enrollmentMode = enrollmentMode
-        self.openEnrollment = openEnrollment
     }
 }
 
 /// Resolves the effective `CourseEnrollmentMode` for an imported bundle.
-///
-/// Prefers `enrollmentMode` (the canonical field).  Falls back to the
-/// pre-v0.3.x `openEnrollment` boolean for older bundles: `false → closed`,
-/// any other value → `open`.  Both paths default to `.open` when neither
-/// field is present so import never fails on a missing-field error.
-///
-/// v0.6.0 cleanup site: drop the `openEnrollment` branch and inline the
-/// `enrollmentMode ?? .open` form at the call site.
+/// Defaults to `.open` when the bundle omitted the field.
 public func bundledCourseEnrollmentMode(_ course: BundledCourse) -> CourseEnrollmentMode {
-    if let mode = course.enrollmentMode { return mode }
-    if course.openEnrollment == false { return .closed }
-    return .open
+    course.enrollmentMode ?? .open
 }
 
 public struct BundledUser: Codable, Sendable {

--- a/Sources/Core/NotebookFunctionScanner.swift
+++ b/Sources/Core/NotebookFunctionScanner.swift
@@ -77,9 +77,7 @@ public struct NotebookFunctionInfo: Codable, Sendable {
         paramNames = try c.decode([String].self, forKey: .paramNames)
         hasTypeHints = try c.decode(Bool.self, forKey: .hasTypeHints)
         hasDocstring = try c.decode(Bool.self, forKey: .hasDocstring)
-        // DEPRECATED: remove `decodeIfPresent ?? false` fallback in v0.6.0 —
-        // by then every browser client will have shipped the v0.4.94+ scanner.
-        isShadowed = try c.decodeIfPresent(Bool.self, forKey: .isShadowed) ?? false
+        isShadowed = try c.decode(Bool.self, forKey: .isShadowed)
         let decodedParamTypes = try c.decodeIfPresent([String?].self, forKey: .paramTypes) ?? []
         paramTypes =
             decodedParamTypes.count == paramNames.count

--- a/Tests/CoreTests/CourseBundleManifestTests.swift
+++ b/Tests/CoreTests/CourseBundleManifestTests.swift
@@ -107,18 +107,7 @@ struct CourseBundleManifestTests {
         #expect(decoded.results[0].source == "worker")
     }
 
-    // MARK: - Backward compatibility: enrollmentMode nil → openEnrollment
-
-    @Test func bundledCourseBackwardCompatEnrollmentModeAbsent() throws {
-        // Old bundle JSON without enrollmentMode — only openEnrollment present.
-        let json = """
-            { "code": "CS101", "name": "Intro CS", "openEnrollment": true }
-            """.data(using: .utf8)!
-
-        let course = try decoder.decode(BundledCourse.self, from: json)
-        #expect(course.enrollmentMode == nil)
-        #expect(course.openEnrollment == true)
-    }
+    // MARK: - bundledCourseEnrollmentMode resolver
 
     @Test func bundledCourseEnrollmentModePresent() throws {
         let json = """
@@ -127,43 +116,18 @@ struct CourseBundleManifestTests {
 
         let course = try decoder.decode(BundledCourse.self, from: json)
         #expect(course.enrollmentMode == .auto)
-        #expect(course.openEnrollment == nil)
     }
 
-    // MARK: - bundledCourseEnrollmentMode resolver
-    //
-    // Pin the resolver so v0.6.0 can drop the `openEnrollment` branch with
-    // confidence — when the deprecation lands, only the legacy-bundle cases
-    // below need updating (or deleting).
-
-    @Test func enrollmentModeResolver_prefersExplicitMode() {
+    @Test func enrollmentModeResolver_returnsExplicitMode() {
         let course = BundledCourse(
-            code: "CS101", name: "Intro CS",
-            enrollmentMode: .auto, openEnrollment: false
+            code: "CS101", name: "Intro CS", enrollmentMode: .auto
         )
         #expect(bundledCourseEnrollmentMode(course) == .auto)
     }
 
-    @Test func enrollmentModeResolver_legacyOpenEnrollmentFalseMapsToClosed() {
+    @Test func enrollmentModeResolver_nilDefaultsToOpen() {
         let course = BundledCourse(
-            code: "CS101", name: "Intro CS",
-            enrollmentMode: nil, openEnrollment: false
-        )
-        #expect(bundledCourseEnrollmentMode(course) == .closed)
-    }
-
-    @Test func enrollmentModeResolver_legacyOpenEnrollmentTrueMapsToOpen() {
-        let course = BundledCourse(
-            code: "CS101", name: "Intro CS",
-            enrollmentMode: nil, openEnrollment: true
-        )
-        #expect(bundledCourseEnrollmentMode(course) == .open)
-    }
-
-    @Test func enrollmentModeResolver_bothFieldsMissingDefaultsToOpen() {
-        let course = BundledCourse(
-            code: "CS101", name: "Intro CS",
-            enrollmentMode: nil, openEnrollment: nil
+            code: "CS101", name: "Intro CS", enrollmentMode: nil
         )
         #expect(bundledCourseEnrollmentMode(course) == .open)
     }

--- a/Tests/CoreTests/NotebookFunctionScannerTests.swift
+++ b/Tests/CoreTests/NotebookFunctionScannerTests.swift
@@ -166,25 +166,7 @@ struct NotebookFunctionScannerTests {
         #expect(fns[0].name == "public_fn")
     }
 
-    // Pre-v0.4.94 browser clients didn't send `isShadowed`. The custom
-    // decoder defaults the missing key to false. Pin both branches so the
-    // v0.6.0 cleanup that removes the fallback only has to delete the
-    // `decodeIfPresent ?? false` line — these tests will fail loudly if
-    // anyone changes the contract.
-    @Test func isShadowedDecodeFallback_legacyJSONWithoutFieldDefaultsToFalse() throws {
-        let json = """
-            {
-              "name": "tax",
-              "paramNames": ["price"],
-              "hasTypeHints": true,
-              "hasDocstring": false
-            }
-            """.data(using: .utf8)!
-        let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
-        #expect(decoded.isShadowed == false)
-    }
-
-    @Test func isShadowedDecodeFallback_modernJSONHonoursExplicitTrue() throws {
+    @Test func isShadowedDecodes() throws {
         let json = """
             {
               "name": "tax",
@@ -196,6 +178,22 @@ struct NotebookFunctionScannerTests {
             """.data(using: .utf8)!
         let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
         #expect(decoded.isShadowed == true)
+    }
+
+    @Test func isShadowedDecodeRequiresField() {
+        // v0.6.0 removed the `decodeIfPresent ?? false` fallback; missing
+        // `isShadowed` is now a decode error rather than silently false.
+        let json = """
+            {
+              "name": "tax",
+              "paramNames": ["price"],
+              "hasTypeHints": true,
+              "hasDocstring": false
+            }
+            """.data(using: .utf8)!
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
+        }
     }
 
     @Test func shadowedFunctionMarked() {


### PR DESCRIPTION
## Summary

Architecture-review follow-up #3: ticks the **v0.6.0 cleanup** item from `CLAUDE.md`'s Near-term roadmap.

Both shims were left in place when their respective consolidations landed, with explicit `DEPRECATED — remove in v0.6.0` markers in the source.  Both compatibility windows have closed; this PR drops the shims and tightens the contracts.

## What changed

### (1) `NotebookFunctionScanner.isShadowed` decode fallback

```swift
// before
isShadowed = try c.decodeIfPresent(Bool.self, forKey: .isShadowed) ?? false
// after
isShadowed = try c.decode(Bool.self, forKey: .isShadowed)
```

Browser clients on v0.4.94+ ship `isShadowed` unconditionally on every payload the scan endpoint emits.  Older clients can't reach this code path post-deploy; the fallback was protecting nothing.

### (2) `BundledCourse.openEnrollment` field + resolver branch

```swift
// before
public struct BundledCourse: Codable, Sendable {
    public let code: String
    public let name: String
    public let enrollmentMode: CourseEnrollmentMode?
    public let openEnrollment: Bool?        // DEPRECATED
    public init(code:, name:, enrollmentMode:, openEnrollment:)
}

public func bundledCourseEnrollmentMode(_ course: BundledCourse) -> CourseEnrollmentMode {
    if let mode = course.enrollmentMode { return mode }
    if course.openEnrollment == false { return .closed }
    return .open
}

// after
public struct BundledCourse: Codable, Sendable {
    public let code: String
    public let name: String
    public let enrollmentMode: CourseEnrollmentMode?
    public init(code:, name:, enrollmentMode:)
}

public func bundledCourseEnrollmentMode(_ course: BundledCourse) -> CourseEnrollmentMode {
    course.enrollmentMode ?? .open
}
```

`.chickadee` bundle exports have only emitted `enrollmentMode` (never `openEnrollment`) since the helper extraction in #501.  Old `.chickadee` bundles without `enrollmentMode` were already going through the `?? .open` default branch — the `openEnrollment == false → .closed` branch hasn't been reachable for any post-#501 export.

The resolver wrapper stays (instead of inlining at the single call site in `CourseBundleRoutes.swift:475`) because the function still serves to document "missing → open" as the import policy.

## Tests

Five tests that pinned the legacy contract:

| Removed / replaced | New |
|---|---|
| `isShadowedDecodeFallback_legacyJSONWithoutFieldDefaultsToFalse` | `isShadowedDecodeRequiresField` — asserts `DecodingError` is thrown when the key is absent |
| `isShadowedDecodeFallback_modernJSONHonoursExplicitTrue` | `isShadowedDecodes` — same shape, renamed |
| `bundledCourseBackwardCompatEnrollmentModeAbsent` | _removed_ — JSON without `enrollmentMode` no longer carries `openEnrollment` to read |
| `enrollmentModeResolver_legacyOpenEnrollmentFalseMapsToClosed` | _removed_ |
| `enrollmentModeResolver_legacyOpenEnrollmentTrueMapsToOpen` | _removed_ |
| `enrollmentModeResolver_bothFieldsMissingDefaultsToOpen` | `enrollmentModeResolver_nilDefaultsToOpen` |
| `enrollmentModeResolver_prefersExplicitMode` | `enrollmentModeResolver_returnsExplicitMode` (no longer "prefers" — only field) |

## Docs

- `CLAUDE.md` v0.5.0/v0.6.0 runway paragraph updated: the "two remaining DEPRECATED back-compat sites … slated for removal in v0.6.0" sentence becomes "have now been removed (v0.6.0 cleanup)."
- "Near-term roadmap → v0.6.0" bullet deleted; the Vapor 5 / LeafKit 2.x investigation note that lived under it is preserved as its own bullet.
- `CHANGELOG.md` entry added to `[Unreleased]`.

## Diff size

```
6 files changed, 50 insertions(+), 88 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build` — clean
- [x] `swift test --filter "CoreTests"` — 105 tests, 0 failures (the touched modules are Core-only)
- [ ] Full CI

This PR does **not** bump `VERSION` — leaving that decision to whichever release cycle picks up `[Unreleased]`.  It is technically a breaking change to the `Core` decoder contract, so a v0.6.0 (or later) release tag is appropriate.

## Conflict note

If #577 (v0.5.0 migration cleanup) merges before this PR, `CHANGELOG.md` and `CLAUDE.md` will each have a small text conflict in regions both PRs touch.  Trivial to resolve: keep both `[Unreleased]` entries, and the CLAUDE.md "v0.5.0/v0.6.0 runway" paragraph is rewritten by both PRs but to compatible end-states.  Will rebase if needed.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_