### PR TITLE
refactor(errors): unify rendering for bare Abort and typed WebAssignmentError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Unify error rendering for bare `Abort(...)` and typed
+  `WebAssignmentError` throws.**  Both have always funneled through
+  `LeafErrorMiddleware` and rendered the same Leaf `error` template,
+  but the *user-facing message* diverged: typed errors produced
+  contextual reasons ("Assignment 'foo' not found", "You do not have
+  permission to edit assignments."), while a bare `Abort(.notFound)`
+  with no `reason:` rendered the raw HTTP reason phrase
+  ("Not Found", "Forbidden", "Bad Request") — and the Leaf template
+  threw away typed-error context on 404 by hard-coding a canned
+  message.  `LeafErrorMiddleware` now passes every `Abort` reason
+  through a new `friendlyReason(status:reason:)` helper that
+  substitutes a humane default (`We couldn't find that page.`,
+  `You don't have permission to view this page.`, etc.) only when
+  the caller did not supply a contextual reason; explicit reasons —
+  including all `WebAssignmentError` messages — are returned
+  verbatim.  The `error.leaf` template drops its 404 special-case
+  branch since the middleware now always provides a meaningful
+  message.  The JSON error envelope for `/api/*` and `/worker/*`
+  paths gains a `"status": <code>` field for symmetry with the HTML
+  page.  No source-side migration required — the 127 bare `Abort`
+  call sites scattered across the non-AssignmentRoutes surface now
+  render as friendly defaults without touching the route handlers
+  themselves.
+
 - **v0.6.0 cleanup: drop the two DEPRECATED back-compat shims.**
   CLAUDE.md flagged both for removal once their compatibility window
   closed.  (1) `NotebookFunctionScanner`: the

--- a/Resources/Views/error.leaf
+++ b/Resources/Views/error.leaf
@@ -7,11 +7,7 @@
     <img class="error-bird" src="/images/chickadee-icon-alt.png" alt="">
     <div class="error-code">#(status)</div>
     <h1 class="error-title">#(title)</h1>
-    #if(isNotFound):
-    <p class="error-message">This page doesn't exist, or you don't have permission to view it.</p>
-    #else:
     <p class="error-message">#(message)</p>
-    #endif
     <a href="/" class="btn">Go home</a>
 </div>
 <style>

--- a/Sources/APIServer/Middleware/LeafErrorMiddleware.swift
+++ b/Sources/APIServer/Middleware/LeafErrorMiddleware.swift
@@ -4,6 +4,13 @@
 // renders a branded HTML error page for browser requests.  API and worker
 // endpoints (/api/…, /worker/…) still receive a plain JSON error response so
 // machine clients are not broken.
+//
+// Both typed errors (`WebAssignmentError`, etc.) and bare `Abort(...)` flow
+// through here via the `AbortError` protocol.  When a bare `Abort` provides
+// no `reason:`, the protocol default returns the HTTP reason phrase (e.g.,
+// "Not Found"), which renders as a terse, unfriendly page.  `friendlyReason`
+// below substitutes a more humane default in that case, so the user-facing
+// output is consistent regardless of which error style the handler used.
 
 import Vapor
 
@@ -18,10 +25,10 @@ struct LeafErrorMiddleware: AsyncMiddleware {
             switch error {
             case let abort as AbortError:
                 status = abort.status
-                reason = abort.reason
+                reason = friendlyReason(status: abort.status, reason: abort.reason)
             default:
                 status = .internalServerError
-                reason = "Something went wrong."
+                reason = friendlyReason(status: .internalServerError, reason: "")
                 request.logger.report(error: error)
             }
 
@@ -37,7 +44,9 @@ struct LeafErrorMiddleware: AsyncMiddleware {
                 return Response(
                     status: status,
                     headers: headers,
-                    body: .init(string: #"{"error":true,"reason":"\#(escaped)"}"#)
+                    body: .init(
+                        string: #"{"error":true,"status":\#(status.code),"reason":"\#(escaped)"}"#
+                    )
                 )
             }
 
@@ -46,8 +55,7 @@ struct LeafErrorMiddleware: AsyncMiddleware {
                 currentUser: request.currentUserContext,
                 status: Int(status.code),
                 title: status.reasonPhrase,
-                message: reason,
-                isNotFound: status == .notFound
+                message: reason
             )
 
             do {
@@ -63,6 +71,48 @@ struct LeafErrorMiddleware: AsyncMiddleware {
     }
 }
 
+/// Returns a humane user-facing message for an HTTP error.  When the caller
+/// supplied an explicit `reason:` (i.e., not the HTTP status reason phrase),
+/// the reason is returned verbatim — typed errors like
+/// `WebAssignmentError.forbidden(action:)` already produce friendly text and
+/// we don't want to clobber them.  When the reason is empty or matches the
+/// generic reason phrase (i.e., a bare `Abort(.notFound)` with no message),
+/// substitute a status-appropriate friendly default.
+func friendlyReason(status: HTTPStatus, reason: String) -> String {
+    let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty && trimmed != status.reasonPhrase {
+        return trimmed
+    }
+    switch status {
+    case .badRequest:
+        return "We couldn't understand that request."
+    case .unauthorized:
+        return "Please sign in to continue."
+    case .forbidden:
+        return "You don't have permission to view this page."
+    case .notFound:
+        return "We couldn't find that page."
+    case .methodNotAllowed:
+        return "That action isn't allowed here."
+    case .conflict:
+        return "That action conflicts with the current state of the resource."
+    case .gone:
+        return "That page is no longer available."
+    case .payloadTooLarge:
+        return "The upload was too large."
+    case .unprocessableEntity:
+        return "We couldn't process that request."
+    case .tooManyRequests:
+        return "Too many requests — please slow down and try again in a moment."
+    case .internalServerError:
+        return "Something went wrong on our end."
+    case .badGateway, .serviceUnavailable, .gatewayTimeout:
+        return "The service is temporarily unavailable — please try again shortly."
+    default:
+        return trimmed.isEmpty ? "Something went wrong." : trimmed
+    }
+}
+
 // MARK: - View context
 
 private struct ErrorPageContext: Encodable {
@@ -70,5 +120,4 @@ private struct ErrorPageContext: Encodable {
     let status: Int
     let title: String
     let message: String
-    let isNotFound: Bool
 }

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -57,6 +57,15 @@ final class SecurityAndHealthTests: XCTestCase {
         app.get("boom") { _ async throws -> Response in
             throw Abort(.notFound, reason: "page missing")
         }
+        // Bare `Abort` sites (no `reason:`) — used to verify the friendlyReason
+        // substitution that makes user-facing output consistent with the
+        // explicit-reason path.
+        app.get("bare-404") { _ async throws -> Response in throw Abort(.notFound) }
+        app.get("bare-403") { _ async throws -> Response in throw Abort(.forbidden) }
+        app.get("bare-400") { _ async throws -> Response in throw Abort(.badRequest) }
+        app.get("api", "bare-500") { _ async throws -> Response in
+            throw Abort(.internalServerError)
+        }
         return app
     }
 
@@ -189,6 +198,9 @@ final class SecurityAndHealthTests: XCTestCase {
                 XCTAssertEqual(res.status, .badRequest)
                 XCTAssertEqual(res.headers.contentType?.description, "application/json; charset=utf-8")
                 XCTAssertTrue(res.body.string.contains(#""reason":"api exploded""#))
+                // Status code is now included in the JSON envelope for symmetry
+                // with the HTML page (where the user sees the big "400" tile).
+                XCTAssertTrue(res.body.string.contains(#""status":400"#))
             }
         }
     }
@@ -198,9 +210,89 @@ final class SecurityAndHealthTests: XCTestCase {
             try await app.asyncTest(.GET, "/boom") { res in
                 XCTAssertEqual(res.status, .notFound)
                 XCTAssertEqual(res.headers.contentType, .html)
-                XCTAssertTrue(res.body.string.contains("This page doesn't exist"))
+                // Explicit reason from `Abort(.notFound, reason: "page missing")`
+                // is rendered verbatim — the old template hard-coded a canned
+                // 404 message that clobbered typed-error context.  The
+                // middleware's friendlyReason() only fills in when the reason
+                // is empty or matches the generic status reasonPhrase.
+                XCTAssertTrue(
+                    res.body.string.contains("page missing"),
+                    "Explicit Abort reason should render verbatim: \(res.body.string.prefix(400))"
+                )
             }
         }
+    }
+
+    func testLeafErrorMiddlewareSubstitutesFriendlyDefaultsForBareAborts() async throws {
+        // `#(message)` in the Leaf template HTML-escapes the apostrophe in
+        // "couldn't" / "don't" to `&#39;`, so the assertions look for the
+        // apostrophe-free portion of each canonical message.
+        try await withApp(try await makeLeafErrorApp(configureViews: true)) { app in
+            try await app.asyncTest(.GET, "/bare-404") { res in
+                XCTAssertEqual(res.status, .notFound)
+                XCTAssertTrue(
+                    res.body.string.contains("find that page"),
+                    "Bare 404 should get the friendly default; body did not contain expected substring."
+                )
+            }
+            try await app.asyncTest(.GET, "/bare-403") { res in
+                XCTAssertEqual(res.status, .forbidden)
+                XCTAssertTrue(
+                    res.body.string.contains("have permission to view this page"),
+                    "Bare 403 should get the friendly default; body did not contain expected substring."
+                )
+            }
+            try await app.asyncTest(.GET, "/bare-400") { res in
+                XCTAssertEqual(res.status, .badRequest)
+                XCTAssertTrue(
+                    res.body.string.contains("understand that request"),
+                    "Bare 400 should get the friendly default; body did not contain expected substring."
+                )
+            }
+        }
+    }
+
+    func testLeafErrorMiddlewareJSONEnvelopeIncludesFriendlyDefaultForBareAbort() async throws {
+        try await withApp(try await makeLeafErrorApp(configureViews: false)) { app in
+            try await app.asyncTest(.GET, "/api/bare-500") { res in
+                XCTAssertEqual(res.status, .internalServerError)
+                XCTAssertTrue(res.body.string.contains(#""status":500"#))
+                XCTAssertTrue(
+                    res.body.string.contains("Something went wrong on our end"),
+                    "Bare 500 JSON should get the friendly default: \(res.body.string)"
+                )
+            }
+        }
+    }
+
+    func testFriendlyReasonPreservesExplicitContextualReason() {
+        // Typed errors like `WebAssignmentError.notFound(resource: "Assignment 'foo'")`
+        // produce a contextual reason ("Assignment 'foo' not found").  The
+        // middleware must NOT replace those with the generic default.
+        XCTAssertEqual(
+            friendlyReason(status: .notFound, reason: "Assignment 'foo' not found"),
+            "Assignment 'foo' not found"
+        )
+        XCTAssertEqual(
+            friendlyReason(status: .forbidden, reason: "You do not have permission to edit assignments."),
+            "You do not have permission to edit assignments."
+        )
+        // But a reason that matches the HTTP reasonPhrase exactly (i.e., a
+        // bare `Abort(.notFound)`) gets the friendly substitution.
+        XCTAssertEqual(
+            friendlyReason(status: .notFound, reason: "Not Found"),
+            "We couldn't find that page."
+        )
+        // Empty reasons get the friendly substitution too.
+        XCTAssertEqual(
+            friendlyReason(status: .forbidden, reason: ""),
+            "You don't have permission to view this page."
+        )
+        // Whitespace-only reasons are treated as empty.
+        XCTAssertEqual(
+            friendlyReason(status: .badRequest, reason: "   "),
+            "We couldn't understand that request."
+        )
     }
 
     func testHealthRouteReturnsOKWhenDatabaseIsReachable() async throws {


### PR DESCRIPTION
## Summary

Architecture-review follow-up #4 — Option 1 of the error-handling consistency discussion.  Unifies the user-facing rendering for bare `Abort(...)` and typed `WebAssignmentError` throws *without* touching the 127 bare `Abort` call sites scattered across the non-assignment surface.

## The problem

Both error styles already funnel through `LeafErrorMiddleware` via Vapor's `AbortError` protocol and render the same Leaf `error` template.  But the message the user sees diverged:

| Throw site | Rendered message (before) |
|---|---|
| `throw WebAssignmentError.notFound(resource: "Assignment 'foo'")` | "Assignment 'foo' not found" |
| `throw WebAssignmentError.forbidden(action: "edit assignments")` | "You do not have permission to edit assignments." |
| `throw Abort(.notFound)` (bare) | "Not Found" |
| `throw Abort(.forbidden)` (bare) | "Forbidden" |
| `throw Abort(.badRequest)` (bare) | "Bad Request" |

…and the `error.leaf` template made it worse by hard-coding a canned 404 message ("This page doesn't exist, or you don't have permission to view it.") that clobbered typed-error 404 context entirely.

## The fix

`LeafErrorMiddleware` now passes every `AbortError`'s reason through a new `friendlyReason(status:reason:)` helper.  It:

- Returns the caller-supplied reason **verbatim** when one is provided (i.e., when the reason is non-empty and differs from `status.reasonPhrase`).  Every `WebAssignmentError` case produces a contextual reason, so these come through unchanged.
- Substitutes a **humane default** keyed by HTTP status when the reason is empty or matches the generic HTTP reason phrase (i.e., a bare `throw Abort(.notFound)` with no `reason:` argument).

Substitution table:

| Status | Friendly default |
|---|---|
| 400 Bad Request | "We couldn't understand that request." |
| 401 Unauthorized | "Please sign in to continue." |
| 403 Forbidden | "You don't have permission to view this page." |
| 404 Not Found | "We couldn't find that page." |
| 405 Method Not Allowed | "That action isn't allowed here." |
| 409 Conflict | "That action conflicts with the current state of the resource." |
| 410 Gone | "That page is no longer available." |
| 413 Payload Too Large | "The upload was too large." |
| 422 Unprocessable Entity | "We couldn't process that request." |
| 429 Too Many Requests | "Too many requests — please slow down and try again in a moment." |
| 500 Internal Server Error | "Something went wrong on our end." |
| 502 / 503 / 504 | "The service is temporarily unavailable — please try again shortly." |
| other | "Something went wrong." |

Also:

- `error.leaf` drops its `#if(isNotFound)` branch (now redundant — middleware always provides a meaningful message).
- The JSON error envelope for `/api/*` and `/worker/*` gains a `"status": <code>` field for symmetry with the HTML page (where the user sees the big `404` tile).
- `ErrorPageContext` drops the now-unused `isNotFound` field.

## What this does **not** do

No source-side migration.  The 127 bare `Abort` sites across `AccountRoutes`, `AdminRoutes`, `AuthRoutes`, `CourseBundleRoutes`, `EnrollmentRoutes`, `TestSetupRoutes`, `WebRoutes(+Notebook,+Submission)`, `Submission*Routes`, `BrowserResult/RunnerRoutes`, `VanityURLRoutes`, `HealthRoutes`, `JupyterLiteContentsRoutes`, `WorkerArtifactRoutes`, and `MarmosetImportRoutes` are unchanged.  They now produce a friendly user-facing page without any change to the handlers themselves.

The full migration to typed errors (Option 2 from the chat discussion) is still possible later — this PR doesn't preclude it, it just defers the cost.

## Tests

- `testLeafErrorMiddlewareReturnsJSONForAPIRoutes` — now also asserts the new `"status":<code>` JSON field.
- `testLeafErrorMiddlewareRendersHTMLForBrowserRoutes` — asserts the explicit `Abort(.notFound, reason: "page missing")` reason renders verbatim (the old test checked the now-removed canned 404 message).
- `testLeafErrorMiddlewareSubstitutesFriendlyDefaultsForBareAborts` (new) — exercises bare 404/403/400 on browser routes.
- `testLeafErrorMiddlewareJSONEnvelopeIncludesFriendlyDefaultForBareAbort` (new) — exercises bare 500 on `/api/*`.
- `testFriendlyReasonPreservesExplicitContextualReason` (new) — unit-pins `friendlyReason()` for both the explicit-reason path and the substitution path.

## Diff size

```
4 files changed, 172 insertions(+), 11 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build` — clean
- [x] `swift test --filter "WebAssignmentErrorTests|SecurityAndHealthTests|VanityURLRoutesTests|AssignmentRoutesLifecycleTests"` — 39 tests, 0 failures (the touched middleware affects routing-level error rendering across the board, so this sweep covers the assignment route, the vanity URL surface that's known to produce 404s, and the middleware unit tests)
- [ ] Full CI

## Behaviour change for tests of other packages

None expected.  The `error.leaf` template change drops the 404-only canned message; any test that relied on the literal string "This page doesn't exist" would fail.  A repo-wide grep found zero such tests.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_