### PR TITLE
test(worker): cover RunnerNetworkResilience helpers + ExponentialBackoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Add `RunnerNetworkResilienceTests` to plug the coverage gap on the
+  worker's retry classifier + backoff helpers.**  Prior coverage was
+  indirect — `Reporter`/`JobPoller` tests drive the helpers through
+  the HTTP stack and the two-case sanity check in `WorkerTests`
+  (`testClassifyHTTPRetry*`) covered 4 of 9 status codes the classifier
+  handles.  New file adds 16 pure-function tests with no daemon spin-up
+  or wall-clock dependency:
+    * `classifyHTTPRetry` — full grid of retryable codes (408, 425,
+      429, 500, 502, 503, 504), terminal auth codes (401, 403), the
+      duplicate-worker-ID 409 terminal case, and the
+      "unknown-4xx ⇒ terminal" default.
+    * `classifyPollHTTPRetry` — pins the poll-path-specific upgrade
+      of 401/403 to retryable (so long-lived runners recover from
+      transient auth-reconfiguration windows) and confirms non-auth
+      codes fall through to the base classifier.
+    * `withRunnerRetry` — succeeds without retry on first hit, retries
+      until success, short-circuits on terminal disposition, respects
+      `maxAttempts` and rethrows, honours `policy.enabled=false`,
+      invokes `onRetry` exactly between attempts (N–1 calls for N
+      attempts) with correct stage/attempt/message.
+    * `ExponentialBackoff` — stays within the cap, never returns zero
+      (regression-pin for the early bug fixed in v0.4.22), and `reset()`
+      returns the next draw to within `2× initial`.
+
 - **Add `AssignmentRoutesEditorTests` to plug the coverage gap on
   `AssignmentRoutes+Editor.swift` (881 LOC).**  The script CRUD
   endpoints (`getScript` / `updateScript` / `createScript` /

--- a/Tests/WorkerTests/RunnerNetworkResilienceTests.swift
+++ b/Tests/WorkerTests/RunnerNetworkResilienceTests.swift
@@ -1,0 +1,311 @@
+// Tests/WorkerTests/RunnerNetworkResilienceTests.swift
+//
+// Unit tests for the retry-classification + backoff helpers in
+// `Sources/Worker/RunnerNetworkResilience.swift`.  Coverage prior to
+// this file was indirect — the Reporter and JobPoller suites exercise
+// the helpers through the full HTTP stack, but the classifier itself
+// (the heart of the runner's retry policy) only had two sanity cases
+// in WorkerTests.  This file closes that gap with pure-function unit
+// tests so individual status-code behaviours don't have to be inferred
+// from end-to-end HTTP stubs.
+
+import XCTest
+
+@testable import chickadee_runner
+
+final class RunnerNetworkResilienceTests: XCTestCase {
+
+    // MARK: - classifyHTTPRetry
+
+    func testClassifyHTTPRetryMarksGatewayErrorsRetryable() {
+        for code in [500, 502, 503, 504] {
+            XCTAssertEqual(
+                classifyHTTPRetry(statusCode: code, body: "x"),
+                .retryable("HTTP \(code): x"),
+                "expected \(code) to be retryable")
+        }
+    }
+
+    func testClassifyHTTPRetryMarksRateLimitAndTimeoutCodesRetryable() {
+        for code in [408, 425, 429] {
+            XCTAssertEqual(
+                classifyHTTPRetry(statusCode: code, body: "rl"),
+                .retryable("HTTP \(code): rl"),
+                "expected \(code) to be retryable")
+        }
+    }
+
+    func testClassifyHTTPRetryTerminatesOnAuthFailures() {
+        XCTAssertEqual(
+            classifyHTTPRetry(statusCode: 401, body: "unauth"),
+            .terminal("HTTP 401: unauth"))
+        XCTAssertEqual(
+            classifyHTTPRetry(statusCode: 403, body: "forbidden"),
+            .terminal("HTTP 403: forbidden"))
+    }
+
+    func testClassifyHTTPRetryTerminatesOnConflict() {
+        // 409 — duplicate worker ID claim — is terminal so the worker
+        // can re-roll its ID rather than spin.
+        XCTAssertEqual(
+            classifyHTTPRetry(statusCode: 409, body: "duplicate worker"),
+            .terminal("HTTP 409: duplicate worker"))
+    }
+
+    func testClassifyHTTPRetryTerminatesOnUnknownClientErrors() {
+        // 400-range responses other than the explicitly retryable codes
+        // are treated as client bugs — no point retrying.
+        for code in [400, 404, 422] {
+            XCTAssertEqual(
+                classifyHTTPRetry(statusCode: code, body: "bad"),
+                .terminal("HTTP \(code): bad"),
+                "expected \(code) to be terminal")
+        }
+    }
+
+    // MARK: - classifyPollHTTPRetry
+
+    func testClassifyPollHTTPRetryUpgrades401And403ToRetryable() {
+        // Poll-path-specific: long-lived runners should recover through
+        // server-side auth reconfiguration windows rather than terminating.
+        XCTAssertEqual(
+            classifyPollHTTPRetry(statusCode: 401, body: "rotating-secret"),
+            .retryable("HTTP 401: rotating-secret"))
+        XCTAssertEqual(
+            classifyPollHTTPRetry(statusCode: 403, body: "tmp"),
+            .retryable("HTTP 403: tmp"))
+    }
+
+    func testClassifyPollHTTPRetryDelegatesNonAuthCodesToBaseClassifier() {
+        // Everything except 401/403 falls through to the standard
+        // classifier — confirm by spot-checking a retryable and a terminal.
+        XCTAssertEqual(
+            classifyPollHTTPRetry(statusCode: 503, body: "down"),
+            .retryable("HTTP 503: down"))
+        XCTAssertEqual(
+            classifyPollHTTPRetry(statusCode: 409, body: "dup"),
+            .terminal("HTTP 409: dup"))
+    }
+
+    // MARK: - withRunnerRetry
+
+    /// Fast policy with no real wall-clock sleeping: 1 ms base, 2 ms cap.
+    /// Tests using this policy still cost a few ms per retry, which is
+    /// acceptable for ≤ 4 retries.
+    private func fastPolicy(maxAttempts: Int = 3, enabled: Bool = true) -> RunnerRetryPolicy {
+        RunnerRetryPolicy(
+            enabled: enabled,
+            maxAttempts: maxAttempts,
+            baseDelayMs: 1,
+            maxDelayMs: 2
+        )
+    }
+
+    private struct StubError: Error {}
+
+    func testWithRunnerRetryReturnsImmediatelyOnSuccess() async throws {
+        actor Counter { var n = 0; func incr() { n += 1 } }
+        let calls = Counter()
+
+        let result: Int = try await withRunnerRetry(
+            stage: .heartbeat,
+            policy: fastPolicy(),
+            shouldRetry: { _ in .retryable("never reached") },
+            operation: {
+                await calls.incr()
+                return 42
+            }
+        )
+
+        XCTAssertEqual(result, 42)
+        let n = await calls.n
+        XCTAssertEqual(n, 1, "operation should run exactly once on success")
+    }
+
+    func testWithRunnerRetryRetriesUntilSuccess() async throws {
+        actor Counter { var n = 0; func incr() { n += 1 }; func value() -> Int { n } }
+        let calls = Counter()
+
+        let result: Int = try await withRunnerRetry(
+            stage: .heartbeat,
+            policy: fastPolicy(maxAttempts: 5),
+            shouldRetry: { _ in .retryable("transient") },
+            operation: {
+                await calls.incr()
+                if await calls.value() < 3 { throw StubError() }
+                return 7
+            }
+        )
+
+        XCTAssertEqual(result, 7)
+        let n = await calls.n
+        XCTAssertEqual(n, 3, "operation should run until the 3rd attempt succeeds")
+    }
+
+    func testWithRunnerRetryShortCircuitsOnTerminalDisposition() async {
+        actor Counter { var n = 0; func incr() { n += 1 } }
+        let calls = Counter()
+
+        do {
+            let _: Int = try await withRunnerRetry(
+                stage: .heartbeat,
+                policy: fastPolicy(maxAttempts: 5),
+                shouldRetry: { _ in .terminal("never retry") },
+                operation: {
+                    await calls.incr()
+                    throw StubError()
+                }
+            )
+            XCTFail("expected StubError to be thrown")
+        } catch is StubError {
+            // expected
+        } catch {
+            XCTFail("expected StubError, got \(error)")
+        }
+
+        let n = await calls.n
+        XCTAssertEqual(n, 1, "terminal disposition must not trigger a retry")
+    }
+
+    func testWithRunnerRetryRespectsMaxAttemptsAndRethrows() async {
+        actor Counter { var n = 0; func incr() { n += 1 } }
+        let calls = Counter()
+
+        do {
+            let _: Int = try await withRunnerRetry(
+                stage: .heartbeat,
+                policy: fastPolicy(maxAttempts: 3),
+                shouldRetry: { _ in .retryable("forever") },
+                operation: {
+                    await calls.incr()
+                    throw StubError()
+                }
+            )
+            XCTFail("expected the operation to exhaust its retries")
+        } catch is StubError {
+            // expected
+        } catch {
+            XCTFail("expected StubError, got \(error)")
+        }
+
+        let n = await calls.n
+        XCTAssertEqual(n, 3, "operation should run exactly maxAttempts times")
+    }
+
+    func testWithRunnerRetryThrowsImmediatelyWhenPolicyDisabled() async {
+        actor Counter { var n = 0; func incr() { n += 1 } }
+        let calls = Counter()
+
+        do {
+            let _: Int = try await withRunnerRetry(
+                stage: .heartbeat,
+                policy: fastPolicy(maxAttempts: 5, enabled: false),
+                shouldRetry: { _ in .retryable("transient") },
+                operation: {
+                    await calls.incr()
+                    throw StubError()
+                }
+            )
+            XCTFail("expected throw")
+        } catch is StubError {
+            // expected
+        } catch {
+            XCTFail("expected StubError, got \(error)")
+        }
+
+        let n = await calls.n
+        XCTAssertEqual(n, 1, "policy.enabled=false should disable retry entirely")
+    }
+
+    func testWithRunnerRetryInvokesOnRetryForEachRetryButNotForFinalThrow() async {
+        actor RetryLog {
+            var contexts: [RunnerRetryContext] = []
+            func append(_ c: RunnerRetryContext) { contexts.append(c) }
+            func snapshot() -> [RunnerRetryContext] { contexts }
+        }
+        let log = RetryLog()
+
+        do {
+            let _: Int = try await withRunnerRetry(
+                stage: .resultUpload,
+                policy: fastPolicy(maxAttempts: 3),
+                shouldRetry: { _ in .retryable("try again") },
+                onRetry: { ctx in await log.append(ctx) },
+                operation: { throw StubError() }
+            )
+            XCTFail("expected throw")
+        } catch is StubError {
+            // expected
+        } catch {
+            XCTFail("expected StubError, got \(error)")
+        }
+
+        let recorded = await log.snapshot()
+        // 3 attempts total → 2 retries scheduled before the final throw.
+        XCTAssertEqual(recorded.count, 2)
+        XCTAssertEqual(recorded.map(\.attempt), [1, 2])
+        XCTAssertEqual(recorded.map(\.stage), [.resultUpload, .resultUpload])
+        XCTAssertEqual(recorded.map(\.message), ["try again", "try again"])
+        XCTAssertTrue(recorded.allSatisfy(\.retryable))
+    }
+
+    // MARK: - ExponentialBackoff
+
+    // Note: there is no "monotonic non-decreasing" test for ExponentialBackoff.
+    // `next()` returns a value in `[initial, currentCappedDoubled]` — the
+    // *upper bound* grows on each call (until it hits the cap), but the
+    // jittered return value can be smaller than the previous draw.  The
+    // tests below pin what callers actually rely on: bounded delay,
+    // never-zero so the loop doesn't spin, and a working reset.
+
+    func testExponentialBackoffStaysWithinCap() {
+        var backoff = ExponentialBackoff(
+            initial: .milliseconds(10),
+            max: .milliseconds(50)
+        )
+        // Burn enough iterations that any unbounded doubling would blow past
+        // the cap.
+        for _ in 0..<20 {
+            let next = backoff.next()
+            XCTAssertLessThanOrEqual(
+                seconds(next), 0.050 + 0.001,
+                "next must respect the cap")
+        }
+    }
+
+    func testExponentialBackoffNeverReturnsZero() {
+        // Regression: an early version returned a zero-duration delay when
+        // jitter bottomed out, defeating the purpose of backing off.
+        var backoff = ExponentialBackoff(
+            initial: .milliseconds(5),
+            max: .milliseconds(50)
+        )
+        for _ in 0..<10 {
+            let next = backoff.next()
+            XCTAssertGreaterThan(seconds(next), 0, "next must never return zero")
+        }
+    }
+
+    func testExponentialBackoffResetReturnsToInitial() {
+        var backoff = ExponentialBackoff(
+            initial: .milliseconds(10),
+            max: .milliseconds(1000)
+        )
+        // Climb a few steps.
+        for _ in 0..<5 { _ = backoff.next() }
+        backoff.reset()
+        // After reset, the next draw should be in roughly the initial
+        // band (jitter spans [initial, doubled-from-initial]).
+        let first = backoff.next()
+        XCTAssertLessThanOrEqual(
+            seconds(first), 0.020 + 0.001,
+            "first draw after reset should be within 2× initial")
+    }
+
+    // MARK: - Helpers
+
+    private func seconds(_ d: Duration) -> Double {
+        Double(d.components.seconds)
+            + Double(d.components.attoseconds) / 1_000_000_000_000_000_000
+    }
+}


### PR DESCRIPTION
## Summary

Architecture-review follow-up #6 — first slice of the **`RunnerDaemon` test-coverage gap** flagged by the architecture review.

The original review summary called for tests covering "job-claiming concurrency, retry backoff logic, and state-transition errors."  This PR takes the **retry-classifier and backoff** part — pure-function unit tests with no daemon spin-up, no mock HTTP server, no wall-clock dependency — so each status-code behaviour is pinned in isolation.  The concurrency / state-transition slice is a follow-up that needs more fixture work.

## Why this slice first

The retry classifier is the heart of the runner's resilience contract.  Prior coverage was **indirect**: `ReporterTests` and `JobPollerTests` drive the helpers through the full HTTP stack, and `WorkerTests` had a two-case sanity check (`testClassifyHTTPRetry*`) covering **4 of the 9 status codes** the classifier handles.  Concretely: if someone changed `classifyHTTPRetry` to treat 429 as terminal tomorrow, no test would fail until a real 429 happened in production.

## Tests added (16 cases in one new file)

`Tests/WorkerTests/RunnerNetworkResilienceTests.swift` (335 LOC, no setUp/tearDown — pure functions only).

### `classifyHTTPRetry`
| Test | Pinned status codes |
|---|---|
| `testClassifyHTTPRetryMarksGatewayErrorsRetryable` | 500, 502, 503, 504 |
| `testClassifyHTTPRetryMarksRateLimitAndTimeoutCodesRetryable` | 408, 425, 429 |
| `testClassifyHTTPRetryTerminatesOnAuthFailures` | 401, 403 |
| `testClassifyHTTPRetryTerminatesOnConflict` | 409 (duplicate worker ID) |
| `testClassifyHTTPRetryTerminatesOnUnknownClientErrors` | 400, 404, 422 |

### `classifyPollHTTPRetry`
| Test | Behaviour |
|---|---|
| `testClassifyPollHTTPRetryUpgrades401And403ToRetryable` | Poll-path upgrade so long-lived runners recover from transient auth-reconfiguration windows |
| `testClassifyPollHTTPRetryDelegatesNonAuthCodesToBaseClassifier` | Non-auth codes fall through to the standard classifier |

### `withRunnerRetry`
| Test | Asserts |
|---|---|
| `testWithRunnerRetryReturnsImmediatelyOnSuccess` | First-call success → no retry |
| `testWithRunnerRetryRetriesUntilSuccess` | 3rd attempt succeeds → 3 invocations |
| `testWithRunnerRetryShortCircuitsOnTerminalDisposition` | Terminal disposition → 1 invocation, rethrow |
| `testWithRunnerRetryRespectsMaxAttemptsAndRethrows` | maxAttempts=3 → exactly 3 invocations, rethrow |
| `testWithRunnerRetryThrowsImmediatelyWhenPolicyDisabled` | policy.enabled=false → 1 invocation |
| `testWithRunnerRetryInvokesOnRetryForEachRetryButNotForFinalThrow` | onRetry called exactly N-1 times for N attempts; correct stage/attempt/message |

### `ExponentialBackoff`
| Test | Asserts |
|---|---|
| `testExponentialBackoffStaysWithinCap` | 20 iterations all ≤ cap |
| `testExponentialBackoffNeverReturnsZero` | Regression-pin for the v0.4.22 bug where jitter could bottom out at zero |
| `testExponentialBackoffResetReturnsToInitial` | After reset(), next draw ≤ 2× initial |

### Explicitly NOT tested

A "monotonic non-decreasing" property is **deliberately omitted** with a clarifying note in the file.  `next()` jitters in `[initial, currentCappedDoubled]`, so successive draws can be smaller than each other — the cap grows monotonically, but the return value doesn't.  Pinning false invariants would either flake or constrain future jitter changes.

## What this does NOT cover (and is queued as a follow-up)

- **Job-claim concurrency.**  Multiple `maxConcurrentJobs` loops claiming jobs in parallel against a shared mock server.  Doable but needs the in-process mock-server fixture from `WorkerDaemonTests` and significant additional plumbing.
- **State-transition error paths.**  The job-processing pipeline's failure modes (download fails → fall-through to reportProcessingFailure, partial script run, etc.).  Some are covered by the existing `WorkerDaemonTests` (`testWorkerDaemonContinuesToNextJobAfterProcessingFailure`); a focused audit + gap-fill is its own PR.

## Diff size

```
2 files changed, 335 insertions(+)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift test --filter "RunnerNetworkResilienceTests"` — 16 tests, 0 failures
- [x] `swift test --filter "WorkerTests"` — 187 tests across all worker suites, 4 skipped, 0 failures (regression sweep)
- [ ] Full CI

## Conflict note

If #581 (editor-coverage tests) merges before this PR, `CHANGELOG.md` will have a tiny conflict at the top of `[Unreleased]` — both PRs add a sibling entry.  Trivial to resolve at rebase time.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_