### PR TITLE
refactor(routes): extract updateNewAssignmentDraft body parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Extract `updateNewAssignmentDraft` request-body parsing into
+  `parseNewAssignmentDraftPayload(req:)`.**  The handler's first
+  ~90 lines were Multi/Single Vapor `Content` decoding + multipart
+  fallback chains for 13 fields — exactly the pattern
+  `parseSaveEditedAssignmentForm` follows further down the same
+  file.  The body parsing moves into a `fileprivate` helper and a
+  named `NewAssignmentDraftPayload` struct; the handler keeps its
+  inline `switch action` over the 9 draft verbs (per the author's
+  documented preference at lines 95-104 — the per-case branches
+  share enough state that splitting them through helpers would
+  be a regression, but the parsing is a clean cut).  Handler
+  shrinks from ~370 LOC to ~280 LOC; the payload struct is
+  testable on its own and forms the foundation for a future
+  `NewAssignmentDraftService` per-action extraction if that
+  direction is chosen.  No behaviour changes — `swift test
+  --filter AssignmentRoutesPublishTests` is unchanged
+  (18 tests, 0 failures).
+
 - **Add `RunnerNetworkResilienceTests` to plug the coverage gap on the
   worker's retry classifier + backoff helpers.**  Prior coverage was
   indirect — `Reporter`/`JobPoller` tests drive the helpers through

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
@@ -102,6 +102,11 @@ extension AssignmentRoutes {
     // splitting them into per-action helpers would require passing the
     // same five locals through each helper.  Inline switch reads more
     // straightforwardly than the threaded-helper version.
+    //
+    // What IS extracted: the body-parsing boilerplate above the switch
+    // (Multi/Single Content + multipart fallback chain).  See
+    // `parseNewAssignmentDraftPayload(req:)` below.  Mirrors the
+    // `parseSaveEditedAssignmentForm` pattern further down this file.
     @Sendable
     // swiftlint:disable:next function_body_length cyclomatic_complexity
     func updateNewAssignmentDraft(req: Request) async throws -> Response {
@@ -114,117 +119,38 @@ extension AssignmentRoutes {
             throw WebAssignmentError.noActiveCourse(action: "creating an assignment")
         }
 
-        struct DraftBodyMany: Content {
-            var assignmentName: String?
-            var dueAt: String?
-            var sectionID: String?
-            var draftID: String?
-            var draftAction: String?
-            var assignmentNotebookFile: File?
-            var solutionNotebookFile: File?
-            var suiteFiles: [File]?
-            var suiteConfig: String?
-            var requiredPlatform: String?
-            var requiredArchitecture: String?
-            var requiredLanguagesCSV: String?
-            var requiredCapabilitiesCSV: String?
-        }
-        struct DraftBodySingle: Content {
-            var assignmentName: String?
-            var dueAt: String?
-            var sectionID: String?
-            var draftID: String?
-            var draftAction: String?
-            var assignmentNotebookFile: File?
-            var solutionNotebookFile: File?
-            var suiteFiles: File?
-            var suiteConfig: String?
-            var requiredPlatform: String?
-            var requiredArchitecture: String?
-            var requiredLanguagesCSV: String?
-            var requiredCapabilitiesCSV: String?
-        }
-
-        let bodyMany = try? req.content.decode(DraftBodyMany.self)
-        let bodySingle = bodyMany == nil ? (try? req.content.decode(DraftBodySingle.self)) : nil
-        guard bodyMany != nil || bodySingle != nil else {
-            throw WebAssignmentError.invalidParameter(name: "request body", reason: "Invalid assignment draft payload")
-        }
-
-        let assignmentName =
-            try multipartTextField(named: ["assignmentName"], from: req)
-            ?? bodyMany?.assignmentName
-            ?? bodySingle?.assignmentName
-            ?? ""
-        let dueAt =
-            try multipartTextField(named: ["dueAt"], from: req)
-            ?? bodyMany?.dueAt
-            ?? bodySingle?.dueAt
-            ?? ""
-        let sectionIDRaw =
-            try multipartTextField(named: ["sectionID"], from: req)
-            ?? bodyMany?.sectionID
-            ?? bodySingle?.sectionID
-            ?? ""
-        let draftIDRaw =
-            try multipartTextField(named: ["draftID"], from: req)
-            ?? bodyMany?.draftID
-            ?? bodySingle?.draftID
-        let action =
-            (try multipartTextField(named: ["draftAction"], from: req)
-            ?? bodyMany?.draftAction
-            ?? bodySingle?.draftAction
-            ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
-        let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
-        let suiteFiles =
-            (try multipartFiles(named: ["suiteFiles[]", "suiteFiles"], from: req)
-            ?? bodyMany?.suiteFiles
-            ?? (bodySingle?.suiteFiles.map { [$0] } ?? []))
-            .filter { $0.data.readableBytes > 0 }
-        let suiteConfigRaw =
-            try multipartTextField(named: ["suiteConfig"], from: req)
-            ?? bodyMany?.suiteConfig
-            ?? bodySingle?.suiteConfig
-        let requiredPlatform =
-            try multipartTextField(named: ["requiredPlatform"], from: req)
-            ?? bodyMany?.requiredPlatform
-            ?? bodySingle?.requiredPlatform
-            ?? ""
-        let requiredArchitecture =
-            try multipartTextField(named: ["requiredArchitecture"], from: req)
-            ?? bodyMany?.requiredArchitecture
-            ?? bodySingle?.requiredArchitecture
-            ?? ""
-        let requiredLanguagesCSV =
-            try multipartTextField(named: ["requiredLanguagesCSV"], from: req)
-            ?? bodyMany?.requiredLanguagesCSV
-            ?? bodySingle?.requiredLanguagesCSV
-            ?? ""
-        let requiredCapabilitiesCSV =
-            try multipartTextField(named: ["requiredCapabilitiesCSV"], from: req)
-            ?? bodyMany?.requiredCapabilitiesCSV
-            ?? bodySingle?.requiredCapabilitiesCSV
-            ?? ""
+        let payload = try parseNewAssignmentDraftPayload(req: req)
 
         let setup = try await resolveOrCreateNewAssignmentDraft(
             req: req,
             courseID: courseID,
-            draftID: draftIDRaw,
-            sectionIDRaw: sectionIDRaw
+            draftID: payload.draftIDRaw,
+            sectionIDRaw: payload.sectionIDRaw
         )
         guard let setupID = setup.id else {
             throw WebAssignmentError.internalFailure(reason: "Draft test setup persisted without an id")
         }
 
         var formState = loadDraftFormState(req: req, draftID: setupID)
-        formState.assignmentName = assignmentName
-        formState.dueAt = dueAt
-        formState.sectionID = sectionIDRaw
-        formState.requiredPlatform = requiredPlatform
-        formState.requiredArchitecture = requiredArchitecture
-        formState.requiredLanguagesCSV = requiredLanguagesCSV
-        formState.requiredCapabilitiesCSV = requiredCapabilitiesCSV
+        formState.assignmentName = payload.assignmentName
+        formState.dueAt = payload.dueAt
+        formState.sectionID = payload.sectionIDRaw
+        formState.requiredPlatform = payload.requiredPlatform
+        formState.requiredArchitecture = payload.requiredArchitecture
+        formState.requiredLanguagesCSV = payload.requiredLanguagesCSV
+        formState.requiredCapabilitiesCSV = payload.requiredCapabilitiesCSV
+
+        // Locals the per-action branches below depend on.  Spelt out here
+        // so each case reads like a small recipe rather than chasing
+        // payload-field unpacks inline.
+        let assignmentName = payload.assignmentName
+        let dueAt = payload.dueAt
+        let sectionIDRaw = payload.sectionIDRaw
+        let action = payload.action
+        let assignmentNotebookFile = payload.assignmentNotebookFile
+        let solutionNotebookFile = payload.solutionNotebookFile
+        let suiteFiles = payload.suiteFiles
+        let suiteConfigRaw = payload.suiteConfigRaw
 
         let actionTitle = assignmentName.trimmingCharacters(in: .whitespacesAndNewlines)
         let notebookTitle = actionTitle.isEmpty ? "New Assignment" : actionTitle
@@ -475,6 +401,142 @@ extension AssignmentRoutes {
             sectionID: sectionIDRaw,
             notice: nil,
             error: nil
+        )
+    }
+
+    // MARK: - updateNewAssignmentDraft helpers
+
+    /// Parsed payload for `POST /instructor/new/draft`.  Resolves the
+    /// array-typed (`suiteFiles[]`) and single-typed (`suiteFiles`)
+    /// Vapor decode paths into one shape, and reads each text field
+    /// through `multipartTextField` first (so urlencoded-form clients
+    /// and multipart-form clients see the same final values).  Mirrors
+    /// the `SaveEditedAssignmentForm` / `parseSaveEditedAssignmentForm`
+    /// pattern used by `saveEditedAssignment` further down the file.
+    fileprivate struct NewAssignmentDraftPayload {
+        let assignmentName: String
+        let dueAt: String
+        let sectionIDRaw: String
+        let draftIDRaw: String?
+        let action: String
+        let assignmentNotebookFile: File?
+        let solutionNotebookFile: File?
+        let suiteFiles: [File]
+        let suiteConfigRaw: String?
+        let requiredPlatform: String
+        let requiredArchitecture: String
+        let requiredLanguagesCSV: String
+        let requiredCapabilitiesCSV: String
+    }
+
+    fileprivate func parseNewAssignmentDraftPayload(req: Request) throws -> NewAssignmentDraftPayload {
+        struct DraftBodyMany: Content {
+            var assignmentName: String?
+            var dueAt: String?
+            var sectionID: String?
+            var draftID: String?
+            var draftAction: String?
+            var assignmentNotebookFile: File?
+            var solutionNotebookFile: File?
+            var suiteFiles: [File]?
+            var suiteConfig: String?
+            var requiredPlatform: String?
+            var requiredArchitecture: String?
+            var requiredLanguagesCSV: String?
+            var requiredCapabilitiesCSV: String?
+        }
+        struct DraftBodySingle: Content {
+            var assignmentName: String?
+            var dueAt: String?
+            var sectionID: String?
+            var draftID: String?
+            var draftAction: String?
+            var assignmentNotebookFile: File?
+            var solutionNotebookFile: File?
+            var suiteFiles: File?
+            var suiteConfig: String?
+            var requiredPlatform: String?
+            var requiredArchitecture: String?
+            var requiredLanguagesCSV: String?
+            var requiredCapabilitiesCSV: String?
+        }
+
+        let bodyMany = try? req.content.decode(DraftBodyMany.self)
+        let bodySingle = bodyMany == nil ? (try? req.content.decode(DraftBodySingle.self)) : nil
+        guard bodyMany != nil || bodySingle != nil else {
+            throw WebAssignmentError.invalidParameter(name: "request body", reason: "Invalid assignment draft payload")
+        }
+
+        let assignmentName =
+            try multipartTextField(named: ["assignmentName"], from: req)
+            ?? bodyMany?.assignmentName
+            ?? bodySingle?.assignmentName
+            ?? ""
+        let dueAt =
+            try multipartTextField(named: ["dueAt"], from: req)
+            ?? bodyMany?.dueAt
+            ?? bodySingle?.dueAt
+            ?? ""
+        let sectionIDRaw =
+            try multipartTextField(named: ["sectionID"], from: req)
+            ?? bodyMany?.sectionID
+            ?? bodySingle?.sectionID
+            ?? ""
+        let draftIDRaw =
+            try multipartTextField(named: ["draftID"], from: req)
+            ?? bodyMany?.draftID
+            ?? bodySingle?.draftID
+        let action =
+            (try multipartTextField(named: ["draftAction"], from: req)
+            ?? bodyMany?.draftAction
+            ?? bodySingle?.draftAction
+            ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let assignmentNotebookFile = bodyMany?.assignmentNotebookFile ?? bodySingle?.assignmentNotebookFile
+        let solutionNotebookFile = bodyMany?.solutionNotebookFile ?? bodySingle?.solutionNotebookFile
+        let suiteFiles =
+            (try multipartFiles(named: ["suiteFiles[]", "suiteFiles"], from: req)
+            ?? bodyMany?.suiteFiles
+            ?? (bodySingle?.suiteFiles.map { [$0] } ?? []))
+            .filter { $0.data.readableBytes > 0 }
+        let suiteConfigRaw =
+            try multipartTextField(named: ["suiteConfig"], from: req)
+            ?? bodyMany?.suiteConfig
+            ?? bodySingle?.suiteConfig
+        let requiredPlatform =
+            try multipartTextField(named: ["requiredPlatform"], from: req)
+            ?? bodyMany?.requiredPlatform
+            ?? bodySingle?.requiredPlatform
+            ?? ""
+        let requiredArchitecture =
+            try multipartTextField(named: ["requiredArchitecture"], from: req)
+            ?? bodyMany?.requiredArchitecture
+            ?? bodySingle?.requiredArchitecture
+            ?? ""
+        let requiredLanguagesCSV =
+            try multipartTextField(named: ["requiredLanguagesCSV"], from: req)
+            ?? bodyMany?.requiredLanguagesCSV
+            ?? bodySingle?.requiredLanguagesCSV
+            ?? ""
+        let requiredCapabilitiesCSV =
+            try multipartTextField(named: ["requiredCapabilitiesCSV"], from: req)
+            ?? bodyMany?.requiredCapabilitiesCSV
+            ?? bodySingle?.requiredCapabilitiesCSV
+            ?? ""
+
+        return NewAssignmentDraftPayload(
+            assignmentName: assignmentName,
+            dueAt: dueAt,
+            sectionIDRaw: sectionIDRaw,
+            draftIDRaw: draftIDRaw,
+            action: action,
+            assignmentNotebookFile: assignmentNotebookFile,
+            solutionNotebookFile: solutionNotebookFile,
+            suiteFiles: suiteFiles,
+            suiteConfigRaw: suiteConfigRaw,
+            requiredPlatform: requiredPlatform,
+            requiredArchitecture: requiredArchitecture,
+            requiredLanguagesCSV: requiredLanguagesCSV,
+            requiredCapabilitiesCSV: requiredCapabilitiesCSV
         )
     }
 


### PR DESCRIPTION
## Summary

Architecture-review follow-up #7 — first slice of the **service-layer extraction** item from the review.

This PR takes the **conservative cut**: extracts only the request-body parsing block at the top of `updateNewAssignmentDraft` into a named helper + payload struct, matching the existing `parseSaveEditedAssignmentForm` pattern used by `saveEditedAssignment` further down the same file.

## What changed

| Before | After |
|---|---|
| 90 LOC of inline Multi/Single `Content` decoding + multipart fallback for 13 fields, declared inside the handler | `fileprivate struct NewAssignmentDraftPayload` + `fileprivate func parseNewAssignmentDraftPayload(req:) throws -> NewAssignmentDraftPayload` below the handler |
| Handler ~370 LOC | Handler ~280 LOC |

The per-action `switch action` over the 9 draft verbs is **deliberately left inline**, per the author's documented preference at lines 95-104 of the original file:

> The per-case branches share enough local state (setup, formState, userID, paths) that splitting them into per-action helpers would require passing the same five locals through each helper. Inline switch reads more straightforwardly than the threaded-helper version.

That comment is rebutted by a service-type extraction (locals become instance properties), but that's a larger refactor than this PR. This PR is the minimum-viable shape change — it pulls out the only block that doesn't share locals with the switch.

## Why this slice

The architecture review flagged `updateNewAssignmentDraft` (lines 232-450 in pre-PR-numbering) as the worst layering offender in the codebase. The full service extraction is ~5x the diff of this PR and warrants a strategic decision (see the chat discussion attached). This slice:

- Lands an immediate ~25% reduction in handler size
- Adds a named, testable input type (`NewAssignmentDraftPayload`)
- Follows the existing in-codebase pattern (`parseSaveEditedAssignmentForm`) — zero new architectural concepts
- Forms the foundation for a future `NewAssignmentDraftService` per-action extraction if that's the direction chosen

## Diff size

```
2 files changed, 181 insertions(+), 101 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build --target chickadee-server` — clean
- [x] `swift test --filter "AssignmentRoutesPublishTests"` — 18 tests, 0 failures (the suite that exercises `updateNewAssignmentDraft` end-to-end)
- [ ] Full CI

## Conflict note

`CHANGELOG.md` may conflict trivially with other in-flight PRs on the `[Unreleased]` section.

## Long-term direction

See the chat discussion attached to this session. Short version: the right long-term shape is a service layer per route file (`AssignmentDraftService`, `TestSetupManager`, `NotebookManager`, ...) with thin route handlers (~20-50 LOC) that just parse and delegate. This PR is the smallest step in that direction. The bigger extraction is a separate PR that I'm holding for an explicit decision on whether to commit to the service-layer pattern (and whether to wait for the Vapor 5 unknown).

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_