### PR TITLE
security: replace :username with opaque :urlToken in per-student URLs (#556)

### DIFF
--- a/Sources/APIServer/Migrations/AddUrlTokenToUsers.swift
+++ b/Sources/APIServer/Migrations/AddUrlTokenToUsers.swift
@@ -1,0 +1,78 @@
+// APIServer/Migrations/AddUrlTokenToUsers.swift
+//
+// Adds the per-user `url_token` column used by instructor-facing
+// per-student URLs (#556).  Replaces the previous `:username` URL
+// segments with an opaque 8-character lowercase alphanumeric token so
+// usernames stop leaking into nginx access logs, browser history, and
+// Referer headers.
+//
+// Migration shape:
+//   1. Add `url_token` as a nullable column (Fluent / SQLite can't add
+//      NOT NULL post-hoc cleanly, and a nullable column is enough — the
+//      model invariant is that every row carries a token, enforced by
+//      the init default plus this migration's backfill).
+//   2. Backfill: every existing user gets a unique token.  Collision
+//      retries cover the (vanishingly unlikely) case where two rows
+//      hash to the same 8-char token.
+//   3. Create a unique index so future writes can't violate the
+//      invariant.
+
+import Fluent
+import SQLKit
+import Vapor
+
+struct AddUrlTokenToUsers: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("users")
+            .field("url_token", .string)
+            .update()
+
+        // Backfill existing users.
+        let users = try await APIUser.query(on: database).all()
+        for user in users where user.urlToken == nil {
+            user.urlToken = try await uniqueURLToken(on: database)
+            try await user.save(on: database)
+        }
+
+        // Enforce uniqueness from here on.  Partial index so the
+        // (transient) NULLs above don't violate uniqueness; once every
+        // row is backfilled the partial clause matches everything.
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_users_url_token
+                ON users(url_token)
+                WHERE url_token IS NOT NULL
+                """
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_users_url_token").run()
+        }
+        try await database.schema("users")
+            .deleteField("url_token")
+            .update()
+    }
+
+    /// Generates a candidate token and retries until one is unused.  At
+    /// 36^8 ≈ 2.8 × 10^12 combinations the expected number of retries
+    /// stays at 0 for any realistic user count, but the loop is here so
+    /// a future shrink to a shorter token (or a partial backfill that
+    /// races with new sign-ups) stays safe.
+    private func uniqueURLToken(on database: Database) async throws -> String {
+        for _ in 0..<16 {
+            let candidate = APIUser.generateURLToken()
+            let collision =
+                try await APIUser.query(on: database)
+                .filter(\.$urlToken == candidate)
+                .count() > 0
+            if !collision {
+                return candidate
+            }
+        }
+        throw Abort(.internalServerError, reason: "Could not generate a unique url_token after 16 attempts")
+    }
+}

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -44,6 +44,17 @@ final class APIUser: Model, Content, @unchecked Sendable {
     @OptionalField(key: "display_name")
     var displayName: String?
 
+    /// Opaque 8-character token used in instructor-facing per-student
+    /// URL paths (e.g. `/:courseCode/students/:urlToken/submissions`)
+    /// so usernames stop leaking into request logs and Referer headers
+    /// (#556).  Declared optional only because Fluent + SQLite can't
+    /// add a NOT NULL column post-hoc; in practice every row carries a
+    /// token — fresh users get one from `init` below, and the
+    /// `AddUrlTokenToUsers` migration backfills pre-existing rows.
+    /// Uniqueness is enforced by `idx_users_url_token`.
+    @OptionalField(key: "url_token")
+    var urlToken: String?
+
     @OptionalField(key: "last_login_at")
     var lastLoginAt: Date?
 
@@ -79,6 +90,7 @@ final class APIUser: Model, Content, @unchecked Sendable {
         userIdentifier: String? = nil,
         studentID: String? = nil,
         displayName: String? = nil,
+        urlToken: String? = nil,
         lastLoginAt: Date? = nil,
         lastSeenAt: Date? = nil
     ) {
@@ -92,9 +104,22 @@ final class APIUser: Model, Content, @unchecked Sendable {
         self.userIdentifier = userIdentifier
         self.studentID = studentID
         self.displayName = displayName
+        self.urlToken = urlToken ?? APIUser.generateURLToken()
         self.lastLoginAt = lastLoginAt
         self.lastSeenAt = lastSeenAt
         self.role = role
+    }
+
+    /// Generates a fresh 8-character lowercase alphanumeric URL token.
+    /// 36^8 ≈ 2.8 × 10^12 combinations leaves a comfortable margin even
+    /// at institution-scale enrollment.  Uniqueness is enforced at the
+    /// DB layer via `idx_users_url_token`; callers that need a
+    /// guaranteed-unused token (e.g. the `AddUrlTokenToUsers` migration)
+    /// retry on collision.
+    static func generateURLToken(length: Int = 8) -> String {
+        let alphabet = Array("abcdefghijklmnopqrstuvwxyz0123456789")
+        var rng = SystemRandomNumberGenerator()
+        return String((0..<length).compactMap { _ in alphabet.randomElement(using: &rng) })
     }
 }
 
@@ -103,6 +128,26 @@ final class APIUser: Model, Content, @unchecked Sendable {
 extension APIUser {
     var isAdmin: Bool { role == "admin" }
     var isInstructor: Bool { role == "instructor" || role == "admin" }
+}
+
+// MARK: - URL token
+
+extension APIUser {
+    /// Non-optional accessor for `urlToken`.  The column is technically
+    /// nullable so the `AddUrlTokenToUsers` migration could add it as a
+    /// post-hoc field on SQLite (which can't add NOT NULL to an existing
+    /// column), but every row is expected to carry a token — fresh users
+    /// get one from `init` and the migration backfills the rest.  Throw
+    /// rather than silently emit a broken URL if the invariant breaks.
+    func requireURLToken() throws -> String {
+        guard let token = urlToken, !token.isEmpty else {
+            throw Abort(
+                .internalServerError,
+                reason: "APIUser \(id?.uuidString ?? "?") is missing urlToken"
+            )
+        }
+        return token
+    }
 }
 
 // MARK: - Vapor session authentication

--- a/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentContextTypes.swift
@@ -362,7 +362,7 @@ struct AssignmentSubmissionHistoryRow: Encodable {
 }
 
 /// View context for the per-student, grouped-by-assignment view at
-/// `/:courseCode/students/:username/submissions`.  Each `StudentAssignmentRow`
+/// `/:courseCode/students/:urlToken/submissions`.  Each `StudentAssignmentRow`
 /// mirrors `TestSetupRow` from the student dashboard so the same per-row
 /// chrome (status / due / grade / latest submission / badges) renders the
 /// same way, with an extra Actions column carrying instructor-only

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+List.swift
@@ -179,6 +179,11 @@ extension AssignmentRoutes {
     ) -> [EnrolledStudentRow] {
         enrolledUsers.compactMap { u in
             guard let id = u.id else { return nil }
+            // Skip rows that somehow lack a urlToken instead of failing
+            // the whole roster render — the invariant says every user has
+            // one (init default + AddUrlTokenToUsers backfill), so this
+            // branch is unreachable in practice but kept for safety.
+            guard let token = u.urlToken, !token.isEmpty else { return nil }
             return EnrolledStudentRow(
                 id: id.uuidString,
                 username: u.username,
@@ -188,7 +193,7 @@ extension AssignmentRoutes {
                 lastSeenAtISO: u.lastSeenAt.map { isoFormatter.string(from: $0) },
                 submissionsURL: studentSubmissionsURL(
                     courseCode: activeCourseCode,
-                    username: u.username
+                    urlToken: token
                 ),
                 unenrollURL: "/courses/\(activeCourseUUID.uuidString)/unenroll/\(id.uuidString)",
                 isPending: false

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
@@ -513,7 +513,7 @@ extension AssignmentRoutes {
             .filter(\.$userID == student.id ?? UUID())
             .count() > 0
         guard isEnrolled else {
-            throw WebAssignmentError.notFound(resource: "Enrolled student '\(usernameRaw)'")
+            throw WebAssignmentError.notFound(resource: "Enrolled student")
         }
         return (course, student)
     }

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
@@ -1,7 +1,7 @@
 // APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
 //
 // Instructor-facing per-student, per-course views, scoped by the URL
-// segments `/:courseCode/students/:username/...`.
+// segments `/:courseCode/students/:urlToken/...`.
 //
 // Mirrors the student dashboard shape (one row per published assignment,
 // section grouping, latest submission + best grade + badges) and adds two
@@ -16,7 +16,7 @@ import Vapor
 
 extension AssignmentRoutes {
 
-    // MARK: - GET /:courseCode/students/:username/submissions
+    // MARK: - GET /:courseCode/students/:urlToken/submissions
 
     @Sendable
     func courseStudentSubmissionsPage(req: Request) async throws -> View {
@@ -56,7 +56,7 @@ extension AssignmentRoutes {
 
         let rowContext = StudentAssignmentRowContext(
             courseCode: course.code,
-            username: student.username,
+            urlToken: try student.requireURLToken(),
             preferredResultBySubmissionID: preferredResultBySubmissionID,
             student: student,
             fmt: fmt
@@ -220,7 +220,7 @@ extension AssignmentRoutes {
         return (sectionContexts, ungroupedRows)
     }
 
-    // MARK: - GET /:courseCode/students/:username/assignments/:assignmentID/history
+    // MARK: - GET /:courseCode/students/:urlToken/assignments/:assignmentID/history
 
     @Sendable
     func studentAssignmentHistoryPage(req: Request) async throws -> View {
@@ -272,13 +272,14 @@ extension AssignmentRoutes {
             )
         }
 
+        let studentToken = try student.requireURLToken()
         let backURL = StudentCoursePaths.submissions(
             courseCode: course.code,
-            username: student.username
+            urlToken: studentToken
         )
         let historyPath = StudentCoursePaths.assignmentHistory(
             courseCode: course.code,
-            username: student.username,
+            urlToken: studentToken,
             assignmentID: assignmentIDRaw
         )
 
@@ -298,7 +299,7 @@ extension AssignmentRoutes {
         )
     }
 
-    // MARK: - POST /:courseCode/students/:username/assignments/:assignmentID/retest
+    // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/retest
 
     @Sendable
     func retestStudentAssignment(req: Request) async throws -> Response {
@@ -342,12 +343,12 @@ extension AssignmentRoutes {
         return req.redirect(
             to: StudentCoursePaths.submissions(
                 courseCode: course.code,
-                username: student.username
+                urlToken: try student.requireURLToken()
             )
         )
     }
 
-    // MARK: - POST /:courseCode/students/:username/assignments/:assignmentID/extension
+    // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/extension
 
     @Sendable
     func saveStudentAssignmentExtension(req: Request) async throws -> Response {
@@ -420,12 +421,12 @@ extension AssignmentRoutes {
         return req.redirect(
             to: StudentCoursePaths.submissions(
                 courseCode: course.code,
-                username: student.username
+                urlToken: try student.requireURLToken()
             )
         )
     }
 
-    // MARK: - POST /:courseCode/students/:username/assignments/:assignmentID/extension/delete
+    // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/extension/delete
 
     @Sendable
     func deleteStudentAssignmentExtension(req: Request) async throws -> Response {
@@ -465,7 +466,7 @@ extension AssignmentRoutes {
         return req.redirect(
             to: StudentCoursePaths.submissions(
                 courseCode: course.code,
-                username: student.username
+                urlToken: try student.requireURLToken()
             )
         )
     }
@@ -474,15 +475,19 @@ extension AssignmentRoutes {
 // MARK: - Private helpers
 
 extension AssignmentRoutes {
-    /// Resolves `(course, student)` from `:courseCode` + `:username`.
+    /// Resolves `(course, student)` from `:courseCode` + `:urlToken`.
     /// Throws `WebAssignmentError.notFound` if either side is missing OR if
     /// the student is not currently enrolled in the course (matches the
     /// instructor dashboard's clickability rule).  Enrollment, not role,
     /// gates this — an instructor enrolled for testing should be reachable
-    /// via the same path the dashboard exposes for them.
+    /// via the same path the dashboard exposes for them.  The url token
+    /// is opaque (8-char lowercase alphanumeric) so usernames don't leak
+    /// into request logs (#556); on miss the response body is the same
+    /// generic "student not found" page either way, so brute-force token
+    /// enumeration learns nothing.
     fileprivate func resolveCourseAndStudent(req: Request) async throws -> (APICourse, APIUser) {
         guard let courseCodeRaw = req.parameters.get("courseCode"),
-            let usernameRaw = req.parameters.get("username")
+            let urlTokenRaw = req.parameters.get("urlToken")
         else {
             throw WebAssignmentError.notFound(resource: "Course or student")
         }
@@ -497,10 +502,10 @@ extension AssignmentRoutes {
         }
         guard
             let student = try await APIUser.query(on: req.db)
-                .filter(\.$username == usernameRaw)
+                .filter(\.$urlToken == urlTokenRaw)
                 .first()
         else {
-            throw WebAssignmentError.notFound(resource: "Student '\(usernameRaw)'")
+            throw WebAssignmentError.notFound(resource: "Student")
         }
         let isEnrolled =
             try await APICourseEnrollment.query(on: req.db)
@@ -515,10 +520,12 @@ extension AssignmentRoutes {
 
     /// Bundles the per-table inputs that don't vary across rows.  Lets
     /// `buildStudentAssignmentRow` stay at 5 parameters even with 9
-    /// logical inputs.
+    /// logical inputs.  `urlToken` is the student's opaque URL token
+    /// (#556) — used to build per-student action URLs without leaking
+    /// the username into request logs.
     fileprivate struct StudentAssignmentRowContext {
         let courseCode: String
-        let username: String
+        let urlToken: String
         let preferredResultBySubmissionID: [String: APIResult]
         let student: APIUser
         let fmt: DateFormatter
@@ -532,7 +539,7 @@ extension AssignmentRoutes {
         context: StudentAssignmentRowContext
     ) -> StudentAssignmentRow {
         let courseCode = context.courseCode
-        let username = context.username
+        let urlToken = context.urlToken
         let preferredResultBySubmissionID = context.preferredResultBySubmissionID
         let student = context.student
         let fmt = context.fmt
@@ -602,22 +609,22 @@ extension AssignmentRoutes {
             extensionFormInput: formInput,
             extensionSavePath: StudentCoursePaths.extensionSave(
                 courseCode: courseCode,
-                username: username,
+                urlToken: urlToken,
                 assignmentID: assignment.publicID
             ),
             extensionDeletePath: StudentCoursePaths.extensionDelete(
                 courseCode: courseCode,
-                username: username,
+                urlToken: urlToken,
                 assignmentID: assignment.publicID
             ),
             retestPath: StudentCoursePaths.retest(
                 courseCode: courseCode,
-                username: username,
+                urlToken: urlToken,
                 assignmentID: assignment.publicID
             ),
             historyURL: StudentCoursePaths.assignmentHistory(
                 courseCode: courseCode,
-                username: username,
+                urlToken: urlToken,
                 assignmentID: assignment.publicID
             ),
             submissionCount: history.count,

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes.swift
@@ -38,21 +38,21 @@ struct AssignmentRoutes: RouteCollection {
         // Lives outside the `/instructor` prefix so the URL carries the
         // course code; the literal `students` second segment routes ahead
         // of the vanity catch-all `/:courseCode/:assignmentSlug`.
-        routes.get(":courseCode", "students", ":username", "submissions", use: courseStudentSubmissionsPage)
+        routes.get(":courseCode", "students", ":urlToken", "submissions", use: courseStudentSubmissionsPage)
         routes.get(
-            ":courseCode", "students", ":username", "assignments", ":assignmentID", "history",
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "history",
             use: studentAssignmentHistoryPage
         )
         routes.post(
-            ":courseCode", "students", ":username", "assignments", ":assignmentID", "retest",
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "retest",
             use: retestStudentAssignment
         )
         routes.post(
-            ":courseCode", "students", ":username", "assignments", ":assignmentID", "extension",
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "extension",
             use: saveStudentAssignmentExtension
         )
         routes.post(
-            ":courseCode", "students", ":username", "assignments", ":assignmentID", "extension",
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "extension",
             "delete",
             use: deleteStudentAssignmentExtension
         )

--- a/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
+++ b/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
@@ -1,40 +1,48 @@
 // APIServer/Routes/Web/StudentCoursePaths.swift
 //
-// One-stop builder for the `/:courseCode/students/:username/...` URL family
-// introduced for the instructor "per-student grouped submissions" view.
-// Centralising the formatting keeps the route registration, the inbound
-// links (instructor dashboard roster), and the redirects after POSTs in
-// agreement.  All paths are URL-encoded so course codes / usernames with
-// unusual characters don't break the links.
+// One-stop builder for the `/:courseCode/students/:urlToken/...` URL
+// family used by the instructor "per-student grouped submissions" view
+// and the per-student-per-assignment drilldown.  Centralising the
+// formatting keeps the route registration, the dashboard's inbound
+// links, and the redirects after POSTs in agreement.
+//
+// `:urlToken` is the opaque 8-character `APIUser.urlToken` rather than
+// the username (#556) so usernames don't leak into nginx access logs,
+// browser history, or Referer headers.  Token values are URL-safe
+// lowercase alphanumeric and do not need percent-encoding, but encoding
+// is still applied so the helper works correctly if a future format
+// change introduces characters that do.
 
 import Foundation
 
 enum StudentCoursePaths {
-    /// Grouped submissions page — `/:courseCode/students/:username/submissions`.
-    static func submissions(courseCode: String, username: String) -> String {
-        "/\(encode(courseCode))/students/\(encode(username))/submissions"
+    /// Grouped submissions page — `/:courseCode/students/:urlToken/submissions`.
+    static func submissions(courseCode: String, urlToken: String) -> String {
+        "/\(encode(courseCode))/students/\(encode(urlToken))/submissions"
     }
 
     /// Per-assignment history drilldown for one student.
     static func assignmentHistory(
         courseCode: String,
-        username: String,
+        urlToken: String,
         assignmentID: String
     ) -> String {
-        "\(submissions(courseCode: courseCode, username: username))"
-            .replacingOccurrences(of: "/submissions", with: "")
-            + "/assignments/\(encode(assignmentID))/history"
+        baseAssignmentPath(
+            courseCode: courseCode,
+            urlToken: urlToken,
+            assignmentID: assignmentID
+        ) + "/history"
     }
 
     /// POST target — retest every submission the student has on one assignment.
     static func retest(
         courseCode: String,
-        username: String,
+        urlToken: String,
         assignmentID: String
     ) -> String {
         baseAssignmentPath(
             courseCode: courseCode,
-            username: username,
+            urlToken: urlToken,
             assignmentID: assignmentID
         ) + "/retest"
     }
@@ -42,12 +50,12 @@ enum StudentCoursePaths {
     /// POST target — upsert an extension for one student × one assignment.
     static func extensionSave(
         courseCode: String,
-        username: String,
+        urlToken: String,
         assignmentID: String
     ) -> String {
         baseAssignmentPath(
             courseCode: courseCode,
-            username: username,
+            urlToken: urlToken,
             assignmentID: assignmentID
         ) + "/extension"
     }
@@ -55,19 +63,19 @@ enum StudentCoursePaths {
     /// POST target — remove an existing extension.
     static func extensionDelete(
         courseCode: String,
-        username: String,
+        urlToken: String,
         assignmentID: String
     ) -> String {
-        extensionSave(courseCode: courseCode, username: username, assignmentID: assignmentID)
+        extensionSave(courseCode: courseCode, urlToken: urlToken, assignmentID: assignmentID)
             + "/delete"
     }
 
     private static func baseAssignmentPath(
         courseCode: String,
-        username: String,
+        urlToken: String,
         assignmentID: String
     ) -> String {
-        "/\(encode(courseCode))/students/\(encode(username))/assignments/\(encode(assignmentID))"
+        "/\(encode(courseCode))/students/\(encode(urlToken))/assignments/\(encode(assignmentID))"
     }
 
     private static func encode(_ component: String) -> String {
@@ -77,6 +85,6 @@ enum StudentCoursePaths {
 
 /// Shorthand wrapper kept lowercase to match call sites that reach for a
 /// "build the URL" helper without remembering the type name.
-func studentSubmissionsURL(courseCode: String, username: String) -> String {
-    StudentCoursePaths.submissions(courseCode: courseCode, username: username)
+func studentSubmissionsURL(courseCode: String, urlToken: String) -> String {
+    StudentCoursePaths.submissions(courseCode: courseCode, urlToken: urlToken)
 }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -214,4 +214,5 @@ func registerMigrations(on app: Application) {
     app.migrations.add(AddSessionsCreatedAt())
     app.migrations.add(CreateAuditLog())
     app.migrations.add(CreateAssignmentExtensions())
+    app.migrations.add(AddUrlTokenToUsers())
 }

--- a/Tests/APITests/AssignmentExtensionsTests.swift
+++ b/Tests/APITests/AssignmentExtensionsTests.swift
@@ -1,7 +1,7 @@
 // Tests/APITests/AssignmentExtensionsTests.swift
 //
 // Coverage for the per-student deadline extension feature introduced
-// alongside the grouped /:courseCode/students/:username/submissions page.
+// alongside the grouped /:courseCode/students/:urlToken/submissions page.
 //
 //  * Extension upsert (POST extension)            → row exists with new date.
 //  * Extension upsert (overwrite)                 → row updated, no duplicate.
@@ -47,7 +47,7 @@ final class AssignmentExtensionsTests: AssignmentRoutesTestCase {
 
         try await app.asyncTest(
             .POST,
-            "/TEST101/students/ext_student/assignments/\(assignment.publicID)/extension",
+            "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/extension",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: sessionCookie)
                 try req.content.encode(
@@ -76,7 +76,7 @@ final class AssignmentExtensionsTests: AssignmentRoutesTestCase {
         let furtherInput = fmt.string(from: further)
         try await app.asyncTest(
             .POST,
-            "/TEST101/students/ext_student/assignments/\(assignment.publicID)/extension",
+            "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/extension",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: sessionCookie)
                 try req.content.encode(
@@ -118,7 +118,7 @@ final class AssignmentExtensionsTests: AssignmentRoutesTestCase {
 
         try await app.asyncTest(
             .POST,
-            "/TEST101/students/ext_delete_student/assignments/\(assignment.publicID)/extension/delete",
+            "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/extension/delete",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: sessionCookie)
                 try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
@@ -221,7 +221,7 @@ final class AssignmentExtensionsTests: AssignmentRoutesTestCase {
 
         try await app.asyncTest(
             .POST,
-            "/TEST101/students/scoped_target/assignments/\(assignment.publicID)/retest",
+            "/TEST101/students/\(try targetStudent.requireURLToken())/assignments/\(assignment.publicID)/retest",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: sessionCookie)
                 try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
@@ -269,7 +269,7 @@ final class AssignmentExtensionsTests: AssignmentRoutesTestCase {
         )
 
         try await app.asyncTest(
-            .GET, "/TEST101/students/grp_student/submissions",
+            .GET, "/TEST101/students/\(try student.requireURLToken())/submissions",
             beforeRequest: { req in
                 req.headers.add(name: .cookie, value: cookie)
             },

--- a/Tests/APITests/AssignmentRoutesNotebookTests.swift
+++ b/Tests/APITests/AssignmentRoutesNotebookTests.swift
@@ -178,7 +178,7 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
             }
         )
     }
-    // MARK: - GET /:courseCode/students/:username/submissions
+    // MARK: - GET /:courseCode/students/:urlToken/submissions
 
     /// The dashboard roster lists every enrolled user (students, plus
     /// instructors/admins enrolled for testing).  Clicking any of them used
@@ -213,7 +213,7 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
             userID: try otherInstructor.requireID()
         )
 
-        let url = "/TEST101/students/other_instructor/submissions"
+        let url = "/TEST101/students/\(try otherInstructor.requireURLToken())/submissions"
         try await app.asyncTest(
             .GET, url,
             beforeRequest: { req in
@@ -232,19 +232,46 @@ final class AssignmentRoutesNotebookTests: AssignmentRoutesTestCase {
             })
     }
 
+    /// #556: the old `/students/<username>/...` URL shape no longer routes
+    /// after the switch to opaque `urlToken`s.  Bookmarks against the
+    /// legacy URL must 404 cleanly instead of resolving by username — that
+    /// would defeat the privacy goal (usernames in logs / Referer headers).
+    func testCourseStudentSubmissionsPage404sForLegacyUsernameURL() async throws {
+        _ = try await app.testCourseID(enrollmentMode: .auto)
+        let cookie = try await loginAsInstructor()
+
+        let student = try await insertStudent(username: "legacy_url_student")
+        try await enrollStudentInTestCourse(student)
+
+        // The username happens to be alphanumeric-only so it satisfies the
+        // urlToken character set.  The route should still 404 because the
+        // resolver looks up by `urlToken`, not by `username`.
+        let url = "/TEST101/students/legacy_url_student/submissions"
+        try await app.asyncTest(
+            .GET, url,
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(
+                    res.status, .notFound,
+                    "Legacy `/students/<username>` URL must 404 — only the urlToken shape is valid")
+            })
+    }
+
     /// Non-enrolled users (in any role) still 404 — the page is course-scoped
     /// and must not leak submissions for users outside the active course.
     func testCourseStudentSubmissionsPage404sForNonEnrolledUser() async throws {
         _ = try await app.testCourseID(enrollmentMode: .auto)
         let cookie = try await loginAsInstructor()
 
-        _ = try await insertUser(
+        let stranger = try await insertUser(
             username: "stranger_user",
             role: "student",
             displayName: "Stranger"
         )
 
-        let url = "/TEST101/students/stranger_user/submissions"
+        let url = "/TEST101/students/\(try stranger.requireURLToken())/submissions"
         try await app.asyncTest(
             .GET, url,
             beforeRequest: { req in


### PR DESCRIPTION
Closes [#556](https://github.com/JimWallace/Chickadee/issues/556).

## Summary

Instructor-facing per-student URLs (`/:courseCode/students/:username/...`) used to embed plaintext usernames in the path, which then leaked to nginx access logs, browser history, the Referer header sent to every third-party origin the page loads, and error aggregators that capture request URLs. FIPPA / PIPEDA flags leaking student identifiers to systems outside the agreed processing chain.

Switching to an opaque per-user URL token closes the leak without touching how usernames are stored or displayed.

## Token shape

`APIUser.urlToken` — 8 lowercase alphanumeric characters (`abcdefghijklmnopqrstuvwxyz0123456789`), generated from `SystemRandomNumberGenerator`. 36^8 ≈ 2.8 × 10^12 combinations leaves ample margin even at institution scale. Uniqueness is enforced by a partial unique index (`idx_users_url_token`).

The column is nullable in the schema because Fluent + SQLite cannot cleanly add NOT NULL post-hoc, but the model invariant is "every row has a token": `init` generates one, the `AddUrlTokenToUsers` migration backfills pre-existing rows, and `requireURLToken()` throws if the invariant is ever violated.

## Migration

`AddUrlTokenToUsers` adds the column nullable, backfills every row with a unique token (retry-on-collision loop, capped at 16 attempts), then creates the unique partial index. Reverse drops the index and column.

## Route changes

All five routes under `/:courseCode/students/:username/...` now use `:urlToken`:

- `GET /:courseCode/students/:urlToken/submissions`
- `GET /:courseCode/students/:urlToken/assignments/:assignmentID/history`
- `POST /:courseCode/students/:urlToken/assignments/:assignmentID/retest`
- `POST /:courseCode/students/:urlToken/assignments/:assignmentID/extension`
- `POST /:courseCode/students/:urlToken/assignments/:assignmentID/extension/delete`

`resolveCourseAndStudent` now looks up by `urlToken`, not `username`. The resource string in the not-found path was also generalised to "Student" so a bad token doesn't echo the value back into the error page (further reduces enumeration signal).

Old `/students/<username>/...` URLs cleanly 404 — no redirect bridge. These are instructor-only URLs reached via the dashboard, so external bookmarks are unlikely.

## Tests

- 6 existing per-student URL strings in `AssignmentExtensionsTests.swift` and `AssignmentRoutesNotebookTests.swift` now use `try student.requireURLToken()` instead of the literal username.
- New `testCourseStudentSubmissionsPage404sForLegacyUsernameURL` asserts the clean-break: a route that happens to have a urlToken-shaped username still 404s when accessed via the legacy URL shape.

## Out of scope
- Hiding submission UUIDs in URLs — separate concern; covered by the cross-tenant fix in #567.
- Course codes in URLs — those aren't PII.
- Logged usernames in `audit_log` and middleware metadata — separate data-handling concern from URL paths.

## Test plan
- [x] `scripts/lint.sh` passes.
- [ ] CI: format-lint, all Swift tests, CodeQL JS/TS.
- [ ] Post-deploy smoke: instructor dashboard roster shows student rows; clicking a row navigates to `/:courseCode/students/<token>/submissions`; that page renders correctly; old `/students/<username>/...` URLs return 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)