### PR TITLE
zap: suppress two accepted-by-design warnings (CSP unsafe-eval, COEP)

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -8,10 +8,18 @@
 # with fewer than three tab-separated tokens). Use `.*` to apply the
 # threshold to every URL.
 #
-# Suppressions below are rules ZAP fires that are either informational
-# (it noticed a feature) or describe browser-side request headers the
-# server doesn't control. Real findings (CSP, header coverage, etc.)
-# are still surfaced.
+# Suppressions below fall into two buckets:
+#   1. Noise / informational rules: ZAP observations ("we noticed a login
+#      form") or browser-side request headers the server can't control.
+#   2. Accepted-by-design warnings: real ZAP findings whose only "fix"
+#      would break the JupyterLite + Pyodide runtime, so we accept them
+#      with an explanation. Each entry in this bucket carries a pointer
+#      to the design doc / middleware comment that owns the rationale,
+#      so reviewers in the future can revisit the trade-off.
+#
+# Anything outside these two buckets continues to fire normally, so a
+# regression that introduces a new header gap or a new CSP allowance
+# will still produce a WARN-NEW.
 
 # Information Disclosure - Suspicious Comments
 # Flags TODO/FIXME strings in JS bundles; not actionable as a recurring CI rule.
@@ -36,3 +44,32 @@
 # Sec-Fetch-* Headers Missing
 # Those are request headers the browser sends; the server cannot set them.
 90005	IGNORE	.*
+
+# ---------------------------------------------------------------------------
+# Accepted-by-design warnings.
+# ---------------------------------------------------------------------------
+
+# CSP: script-src unsafe-eval
+# Pyodide's WASM bootstrap requires `unsafe-eval` to run Python in the
+# browser. Removing it would break the student notebook page, the
+# instructor validate flow, the browser-runner grading path, and every
+# JupyterLite-embedded view. The CSP base directives in
+# Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift document
+# this; the same file also explains why `unsafe-inline` is kept (Leaf
+# templates use inline event handlers and style attributes — tightening
+# to per-response nonces is tracked as a separate follow-up).
+10055	IGNORE	.*
+
+# Cross-Origin-Embedder-Policy Header Missing or Invalid
+# COEP `require-corp` would block the JupyterLite iframe: its service
+# worker synthesises responses (virtual filesystem, contents API) that
+# don't carry Cross-Origin-Resource-Policy headers, so a COEP-enabled
+# parent page sees them as ERR_BLOCKED_BY_RESPONSE and JupyterLite fails
+# to initialise. Sources/APIServer/Bootstrap/AppMiddleware.swift and
+# Sources/APIServer/Middleware/COEPMiddleware.swift document the
+# constraint. The narrow `/validate` path opts into the strict policy
+# because nothing on that page is cross-origin; the rest of the site
+# leaves COEP unset by design. Modern Pyodide (0.27+) does not require
+# SharedArrayBuffer for the iframe document, so cross-origin isolation
+# is not a functional requirement on the main pages.
+90004	IGNORE	.*


### PR DESCRIPTION
(Re-opening from #584, which was closed because it accidentally carried an unrelated commit. Same content as before.)

## Summary

After [#566](https://github.com/JimWallace/Chickadee/pull/566), [#568](https://github.com/JimWallace/Chickadee/pull/568), and [#572](https://github.com/JimWallace/Chickadee/pull/572), the weekly ZAP baseline reports two recurring `WARN-NEW` findings whose only "fix" would break the JupyterLite + Pyodide runtime:

- **10055** CSP `script-src 'unsafe-eval'` × 11 — required by Pyodide's WASM bootstrap.
- **90004** Cross-Origin-Embedder-Policy missing/invalid × 5 — `require-corp` blocks the JupyterLite iframe (service worker synthesises responses without CORP).

Both already have a paragraph of rationale in the middleware:

- [SecurityHeadersMiddleware.swift](Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift)
- [AppMiddleware.swift](Sources/APIServer/Bootstrap/AppMiddleware.swift) and [COEPMiddleware.swift](Sources/APIServer/Middleware/COEPMiddleware.swift)

This PR adds both to `.zap/rules.tsv` with comments pointing at the design docs so any future reviewer who wants to revisit the trade-off (CSP nonces; Pyodide changes) has a one-hop path to the reasoning.

## Result

Before:
```
FAIL-NEW: 0   WARN-NEW: 2   IGNORE: 6   PASS: 62
```

After:
```
FAIL-NEW: 0   WARN-NEW: 0   IGNORE: 8   PASS: 62
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)