### PR TITLE
refactor(routes): extract NewAssignmentDraftService — service-layer prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Extract `updateNewAssignmentDraft` per-action dispatch into a
+  new `NewAssignmentDraftService`.**  The 9 draft-action verbs
+  (create / upload / clear assignment & solution notebooks, replace
+  / clear suite files, etc.) had been an inline `switch action`
+  inside the route handler — preserved that way through the parser
+  extraction in PR #583 because the per-case branches shared five
+  locals (`setup`, `setupID`, `userID`, `courseID`, `formState`)
+  that threading through per-action free helpers would have made
+  worse, not better.
+
+  This PR moves the shared locals onto a `NewAssignmentDraftService`
+  struct in `Sources/APIServer/Services/` and turns each verb into
+  a `mutating` method on the service.  Each method reads/writes
+  `self.setup` / `self.formState` instead of a thread-through.
+  The handler shrinks from ~290 LOC to ~60 LOC: parse → resolve
+  setup → seed form state → `service.perform()` → write back →
+  redirect.  Outcome enum `NewAssignmentDraftActionOutcome`
+  (`.applied` / `.validationFailed(String)`) keeps the service
+  HTTP-agnostic — the handler builds the redirect from it.
+
+  Additional changes:
+    * `NewAssignmentDraftPayload` moved from a `fileprivate` struct
+      inside `+NewAssignment.swift` to a file-internal struct in
+      `Sources/APIServer/Routes/Web/NewAssignmentDraftPayload.swift`
+      so the service can construct one.
+    * `newAssignmentSectionGradingMode(...)` lifted from a `private`
+      method on the `AssignmentRoutes` extension to a file-scope
+      function so the service can call it.
+
+  New `NewAssignmentDraftServiceTests` adds 11 service-level unit
+  tests exercising each action in isolation (validation branches
+  for both upload variants, file-system + form-state assertions
+  for create/clear assignment notebook, no-op behaviour for
+  unknown/empty action verbs, `notebookTitle` derivation).  The 18
+  end-to-end tests in `AssignmentRoutesPublishTests` remain green
+  (behavior parity confirmed).  Service-level tests run ~5× faster
+  per case than the integration tests — adding a new action now
+  comes with a fast inner-loop test cost.
+
+  Sets the precedent for the service-layer pattern across the rest
+  of the routes layer; follow-ups can apply the same shape to
+  `saveEditedAssignment` and the helpers-as-services migration.
+
 - **Parallelise the 7 sequential DB queries on
   `courseStudentSubmissionsPage`.**  The
   `/:courseCode/students/:username/submissions` handler in

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift
@@ -93,22 +93,17 @@ extension AssignmentRoutes {
     }
 
     // updateNewAssignmentDraft is the dispatcher for the new-assignment
-    // form's "Save draft" partial actions — its body is one big
-    // `switch action` over ~10 distinct verbs (create / upload / clear
-    // assignment & solution notebooks, replace / clear suite files,
-    // etc.).  Each case touches file I/O, draft state, and zip
-    // rebuilding in slightly different ways; the per-case branches
-    // share enough local state (setup, formState, userID, paths) that
-    // splitting them into per-action helpers would require passing the
-    // same five locals through each helper.  Inline switch reads more
-    // straightforwardly than the threaded-helper version.
+    // form's "Save draft" partial-form actions (9 verbs: create / upload
+    // / clear assignment & solution notebooks, replace / clear suite
+    // files, etc.).  Each verb touches file I/O, draft state, and zip
+    // rebuilding in slightly different ways.
     //
-    // What IS extracted: the body-parsing boilerplate above the switch
-    // (Multi/Single Content + multipart fallback chain).  See
-    // `parseNewAssignmentDraftPayload(req:)` below.  Mirrors the
-    // `parseSaveEditedAssignmentForm` pattern further down this file.
+    // The handler stays thin: parse → resolve setup → seed form state
+    // → delegate to `NewAssignmentDraftService` → write back form
+    // state → redirect.  The per-verb logic lives on the service so
+    // each verb is independently navigable and unit-testable.  See
+    // `Sources/APIServer/Services/NewAssignmentDraftService.swift`.
     @Sendable
-    // swiftlint:disable:next function_body_length cyclomatic_complexity
     func updateNewAssignmentDraft(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
         guard let userID = user.id else {
@@ -140,294 +135,35 @@ extension AssignmentRoutes {
         formState.requiredLanguagesCSV = payload.requiredLanguagesCSV
         formState.requiredCapabilitiesCSV = payload.requiredCapabilitiesCSV
 
-        // Locals the per-action branches below depend on.  Spelt out here
-        // so each case reads like a small recipe rather than chasing
-        // payload-field unpacks inline.
-        let assignmentName = payload.assignmentName
-        let dueAt = payload.dueAt
-        let sectionIDRaw = payload.sectionIDRaw
-        let action = payload.action
-        let assignmentNotebookFile = payload.assignmentNotebookFile
-        let solutionNotebookFile = payload.solutionNotebookFile
-        let suiteFiles = payload.suiteFiles
-        let suiteConfigRaw = payload.suiteConfigRaw
+        var service = NewAssignmentDraftService(
+            req: req,
+            setup: setup,
+            setupID: setupID,
+            userID: userID,
+            courseID: courseID,
+            formState: formState,
+            payload: payload
+        )
+        let outcome = try await service.perform()
 
-        let actionTitle = assignmentName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let notebookTitle = actionTitle.isEmpty ? "New Assignment" : actionTitle
+        saveDraftFormState(req: req, draftID: setupID, state: service.formState)
 
-        switch action {
-        case "create-assignment-notebook":
-            let data = defaultNotebookData(title: notebookTitle)
-            let dir = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            let path = dir + "assignment.ipynb"
-            try data.write(to: URL(fileURLWithPath: path))
-            setup.notebookPath = path
-            try await setup.save(on: req.db)
-            _ = try await ensureUserNotebookWorkingCopy(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fallbackSetup: setup,
-                overwriteWith: data
-            )
-            formState.assignmentNotebookName = "assignment.ipynb"
-        case "upload-assignment-notebook":
-            guard let assignmentNotebookFile, assignmentNotebookFile.data.readableBytes > 0 else {
-                return redirectToNewAssignmentDraft(
-                    req: req,
-                    draftID: setupID,
-                    assignmentName: assignmentName,
-                    dueAt: dueAt,
-                    sectionID: sectionIDRaw,
-                    notice: nil,
-                    error: "Select an assignment notebook to upload"
-                )
-            }
-            let raw = Data(assignmentNotebookFile.data.readableBytesView)
-            guard (try? JSONSerialization.jsonObject(with: raw)) != nil else {
-                return redirectToNewAssignmentDraft(
-                    req: req,
-                    draftID: setupID,
-                    assignmentName: assignmentName,
-                    dueAt: dueAt,
-                    sectionID: sectionIDRaw,
-                    notice: nil,
-                    error: "Assignment notebook must be valid JSON (.ipynb)"
-                )
-            }
-            let normalized = normalizeNotebookForJupyterLite(raw)
-            let dir = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            let filename = notebookFilenameForStorage(
-                uploadedName: assignmentNotebookFile.filename, fallback: "assignment.ipynb")
-            let path = dir + filename
-            try normalized.write(to: URL(fileURLWithPath: path))
-            setup.notebookPath = path
-            try await setup.save(on: req.db)
-            _ = try await ensureUserNotebookWorkingCopy(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fallbackSetup: setup,
-                overwriteWith: normalized
-            )
-            formState.assignmentNotebookName = filename
-        case "clear-assignment-notebook":
-            removeDraftNotebookFiles(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fileKind: .assignment,
-                persistedPath: setup.notebookPath
-            )
-            setup.notebookPath = nil
-            try await setup.save(on: req.db)
-            formState.assignmentNotebookName = nil
-        case "create-solution-notebook":
-            let data = defaultNotebookData(title: "\(notebookTitle) Solution")
-            let path = draftSolutionNotebookPath(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            _ = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            try data.write(to: URL(fileURLWithPath: path))
-            _ = try await ensureUserNotebookWorkingCopy(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fallbackSetup: setup,
-                relativePath: userNotebookWorkingCopyRelativePath(
-                    setupID: setupID, userID: userID, fileKind: .solution),
-                overwriteWith: data
-            )
-            formState.solutionNotebookName = "solution.ipynb"
-        case "create-solution-from-assignment":
-            // Parity PR 4 of #433.  Mirrors the assignment-scoped
-            // `createSolutionFromAssignment` (POST /:id/create-solution):
-            // copy the assignment notebook bytes into the draft solution
-            // path so the instructor can author the answer key starting
-            // from the student-facing notebook.  Falls back to a blank
-            // notebook with the title suffix " Solution" when the
-            // assignment notebook isn't readable yet — same fallback
-            // the assignment-scoped variant uses.
-            let sourceData: Data = {
-                if let path = setup.notebookPath,
-                    let bytes = try? Data(contentsOf: URL(fileURLWithPath: path)),
-                    !bytes.isEmpty
-                {
-                    return bytes
-                }
-                return defaultNotebookData(title: "\(notebookTitle) Solution")
-            }()
-            let normalized = normalizeNotebookForJupyterLite(sourceData)
-            let path = draftSolutionNotebookPath(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            _ = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            try normalized.write(to: URL(fileURLWithPath: path))
-            _ = try await ensureUserNotebookWorkingCopy(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fallbackSetup: setup,
-                relativePath: userNotebookWorkingCopyRelativePath(
-                    setupID: setupID, userID: userID, fileKind: .solution),
-                overwriteWith: normalized
-            )
-            formState.solutionNotebookName = "solution.ipynb"
-        case "upload-solution-notebook":
-            guard let solutionNotebookFile, solutionNotebookFile.data.readableBytes > 0 else {
-                return redirectToNewAssignmentDraft(
-                    req: req,
-                    draftID: setupID,
-                    assignmentName: assignmentName,
-                    dueAt: dueAt,
-                    sectionID: sectionIDRaw,
-                    notice: nil,
-                    error: "Select a solution notebook to upload"
-                )
-            }
-            let raw = Data(solutionNotebookFile.data.readableBytesView)
-            guard (try? JSONSerialization.jsonObject(with: raw)) != nil else {
-                return redirectToNewAssignmentDraft(
-                    req: req,
-                    draftID: setupID,
-                    assignmentName: assignmentName,
-                    dueAt: dueAt,
-                    sectionID: sectionIDRaw,
-                    notice: nil,
-                    error: "Solution notebook must be valid JSON (.ipynb)"
-                )
-            }
-            let normalized = normalizeNotebookForJupyterLite(raw)
-            let path = draftSolutionNotebookPath(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            _ = try ensureDraftNotebookDirectory(
-                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            try normalized.write(to: URL(fileURLWithPath: path))
-            _ = try await ensureUserNotebookWorkingCopy(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fallbackSetup: setup,
-                relativePath: userNotebookWorkingCopyRelativePath(
-                    setupID: setupID, userID: userID, fileKind: .solution),
-                overwriteWith: normalized
-            )
-            formState.solutionNotebookName = notebookFilenameForStorage(
-                uploadedName: solutionNotebookFile.filename, fallback: "solution.ipynb")
-
-            // v0.4.100: auto-scan the solution for `##` sections and
-            // top-level function defs, then scaffold one `publictest_
-            // exists_<fn>.py` per detected function, placed in the
-            // section whose `##` header most recently preceded it.
-            // One-shot: silently skips if the manifest already has
-            // sections / test entries.  Errors are swallowed — this is
-            // a nice-to-have that must not block the upload.
-            do {
-                let result = try await autoScaffoldFromSolutionNotebook(
-                    setup: setup,
-                    notebookData: normalized,
-                    zipPath: setup.zipPath,
-                    on: req.db
-                )
-                if result.functions > 0 {
-                    req.logger.info(
-                        "auto_scaffold sections=\(result.sections) functions=\(result.functions) setup=\(setup.id ?? "?")"
-                    )
-                }
-            } catch {
-                req.logger.warning("auto_scaffold_failed setup=\(setup.id ?? "?") error=\(error)")
-            }
-        case "clear-solution-notebook":
-            removeDraftNotebookFiles(
-                req: req,
-                setupID: setupID,
-                userID: userID,
-                fileKind: .solution,
-                persistedPath: draftSolutionNotebookPath(
-                    testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
-            )
-            formState.solutionNotebookName = nil
-        case "replace-suite-files":
-            let setupPackage = try createRunnerSetupZip(
-                suiteFiles: suiteFiles,
-                suiteConfigJSON: suiteConfigRaw,
-                zipPath: setup.zipPath
-            )
-            let sectionGradingMode = try await newAssignmentSectionGradingMode(
-                req: req,
-                courseID: courseID,
-                sectionIDRaw: sectionIDRaw
-            )
-            let starterNotebook =
-                setup.notebookPath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "assignment.ipynb"
-            setup.manifest = try makeWorkerManifestJSON(
-                testSuites: setupPackage.testSuites,
-                includeMakefile: setupPackage.hasMakefile,
-                gradingMode: sectionGradingMode,
-                starterNotebook: starterNotebook
-            )
-            try await setup.save(on: req.db)
-            extractSupportFilesToSharedDirectory(
-                zipPath: setup.zipPath,
-                setupID: setupID,
-                testSuiteScripts: Set(setupPackage.testSuites.map { $0.script }),
-                testSetupsDirectory: req.application.testSetupsDirectory
-            )
-        case "clear-suite-files":
-            let starterNotebook =
-                setup.notebookPath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "assignment.ipynb"
-            _ = try createRunnerSetupZip(suiteFiles: [], suiteConfigJSON: nil, zipPath: setup.zipPath)
-            setup.manifest = try makeWorkerManifestJSON(
-                testSuites: [],
-                includeMakefile: false,
-                gradingMode: try await newAssignmentSectionGradingMode(
-                    req: req, courseID: courseID, sectionIDRaw: sectionIDRaw),
-                starterNotebook: starterNotebook
-            )
-            try await setup.save(on: req.db)
-        default:
-            break
-        }
-
-        saveDraftFormState(req: req, draftID: setupID, state: formState)
-
+        let errorMessage: String? = {
+            if case .validationFailed(let msg) = outcome { return msg }
+            return nil
+        }()
         return redirectToNewAssignmentDraft(
             req: req,
             draftID: setupID,
-            assignmentName: assignmentName,
-            dueAt: dueAt,
-            sectionID: sectionIDRaw,
+            assignmentName: payload.assignmentName,
+            dueAt: payload.dueAt,
+            sectionID: payload.sectionIDRaw,
             notice: nil,
-            error: nil
+            error: errorMessage
         )
     }
 
     // MARK: - updateNewAssignmentDraft helpers
-
-    /// Parsed payload for `POST /instructor/new/draft`.  Resolves the
-    /// array-typed (`suiteFiles[]`) and single-typed (`suiteFiles`)
-    /// Vapor decode paths into one shape, and reads each text field
-    /// through `multipartTextField` first (so urlencoded-form clients
-    /// and multipart-form clients see the same final values).  Mirrors
-    /// the `SaveEditedAssignmentForm` / `parseSaveEditedAssignmentForm`
-    /// pattern used by `saveEditedAssignment` further down the file.
-    fileprivate struct NewAssignmentDraftPayload {
-        let assignmentName: String
-        let dueAt: String
-        let sectionIDRaw: String
-        let draftIDRaw: String?
-        let action: String
-        let assignmentNotebookFile: File?
-        let solutionNotebookFile: File?
-        let suiteFiles: [File]
-        let suiteConfigRaw: String?
-        let requiredPlatform: String
-        let requiredArchitecture: String
-        let requiredLanguagesCSV: String
-        let requiredCapabilitiesCSV: String
-    }
 
     fileprivate func parseNewAssignmentDraftPayload(req: Request) throws -> NewAssignmentDraftPayload {
         struct DraftBodyMany: Content {
@@ -955,18 +691,9 @@ extension AssignmentRoutes {
         return setup
     }
 
-    private func newAssignmentSectionGradingMode(
-        req: Request,
-        courseID: UUID,
-        sectionIDRaw: String
-    ) async throws -> String {
-        guard let sid = try await resolveSectionID(sectionIDRaw, courseID: courseID, db: req.db),
-            let sec = try await APICourseSection.find(sid, on: req.db)
-        else {
-            return "worker"
-        }
-        return sec.defaultGradingMode
-    }
+    // newAssignmentSectionGradingMode moved to file scope (below the
+    // extension) so `NewAssignmentDraftService` can call it without
+    // needing visibility into the extension's privates.
 
     @Sendable
     func publish(req: Request) async throws -> Response {
@@ -1029,4 +756,26 @@ extension AssignmentRoutes {
         return req.redirect(to: "/instructor/\(assignment.publicID)/validate")
     }
 
+}
+
+// MARK: - File-scope helpers
+
+/// Resolves the default grading mode for the section identified by
+/// `sectionIDRaw` within `courseID`.  Falls back to `"worker"` when
+/// the section can't be resolved (e.g., the form's "Ungrouped"
+/// pseudo-section, or a missing section row).
+///
+/// File-scope so `NewAssignmentDraftService` (in `Services/`) can
+/// call it without needing to access the route extension's privates.
+func newAssignmentSectionGradingMode(
+    req: Request,
+    courseID: UUID,
+    sectionIDRaw: String
+) async throws -> String {
+    guard let sid = try await resolveSectionID(sectionIDRaw, courseID: courseID, db: req.db),
+        let sec = try await APICourseSection.find(sid, on: req.db)
+    else {
+        return "worker"
+    }
+    return sec.defaultGradingMode
 }

--- a/Sources/APIServer/Routes/Web/NewAssignmentDraftPayload.swift
+++ b/Sources/APIServer/Routes/Web/NewAssignmentDraftPayload.swift
@@ -1,0 +1,33 @@
+// APIServer/Routes/Web/NewAssignmentDraftPayload.swift
+//
+// Parsed payload for `POST /instructor/new/draft`.  Resolves the
+// array-typed (`suiteFiles[]`) and single-typed (`suiteFiles`) Vapor
+// decode paths into one shape, and reads each text field through
+// `multipartTextField` first (so urlencoded-form clients and
+// multipart-form clients see the same final values).  Mirrors the
+// `SaveEditedAssignmentForm` / `parseSaveEditedAssignmentForm` pattern
+// used by `saveEditedAssignment` in `AssignmentRoutes+Editor.swift`.
+//
+// Lives at file-internal visibility so `NewAssignmentDraftService`
+// (Sources/APIServer/Services/) can construct one without importing
+// fileprivate handler internals.  The parser itself
+// (`parseNewAssignmentDraftPayload(req:)`) stays inside the route
+// file because it's only called from one place.
+
+import Vapor
+
+struct NewAssignmentDraftPayload {
+    let assignmentName: String
+    let dueAt: String
+    let sectionIDRaw: String
+    let draftIDRaw: String?
+    let action: String
+    let assignmentNotebookFile: File?
+    let solutionNotebookFile: File?
+    let suiteFiles: [File]
+    let suiteConfigRaw: String?
+    let requiredPlatform: String
+    let requiredArchitecture: String
+    let requiredLanguagesCSV: String
+    let requiredCapabilitiesCSV: String
+}

--- a/Sources/APIServer/Services/NewAssignmentDraftService.swift
+++ b/Sources/APIServer/Services/NewAssignmentDraftService.swift
@@ -1,0 +1,336 @@
+// APIServer/Services/NewAssignmentDraftService.swift
+//
+// Per-action dispatch for the new-assignment "Save draft" partial-form
+// endpoint (`POST /instructor/new/draft`).  Each action verb the form
+// can send — create / upload / clear assignment & solution notebooks,
+// replace / clear suite files — has a dedicated method here, mutating
+// the service's instance state (setup, formState).
+//
+// Pre-this-PR the same logic lived as an inline `switch action` inside
+// the `updateNewAssignmentDraft` route handler.  The handler had a
+// documented preference for keeping it inline because the 9 cases
+// shared 5 locals (`setup`, `setupID`, `userID`, `courseID`,
+// `formState`) — threading them through per-action free helpers would
+// have been a regression.  Pulling those locals onto a service type
+// resolves that objection: each method just reads/writes `self`.
+//
+// Service shape:
+//
+//   - Plain struct (not actor or class).  A draft update is a single
+//     request-scoped object; there is no concurrent access between
+//     methods.  Struct + `mutating` keeps Sendable obligations simple
+//     and makes unit tests trivial — instantiate, call, assert on
+//     `service.setup` / `service.formState`.
+//   - `req: Request` is a dependency because the actions touch the
+//     filesystem (testSetupsDirectory), the database (setup.save), the
+//     logger, and the per-user JupyterLite working copy that lives
+//     under `req.application.directory.publicDirectory`.  A future
+//     refactor could replace `req` with a smaller interface.
+//   - Each method returns a `NewAssignmentDraftActionOutcome` so the
+//     handler can distinguish "applied → standard redirect" from
+//     "validation failed → redirect with error message in the query."
+//     Throwing for true errors (file I/O failure, DB save failure)
+//     stays on the throws channel.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// Result of dispatching a single draft action.
+///
+/// The HTTP-shape of the response (303 to which URL, query parameters)
+/// is the handler's responsibility — the service only signals what
+/// happened.
+enum NewAssignmentDraftActionOutcome: Sendable, Equatable {
+    /// Action applied successfully.  Handler should redirect to the
+    /// standard "draft updated" target with no error in the query.
+    case applied
+
+    /// Action validation failed (e.g., upload action with no file).
+    /// Handler should redirect to the draft page with this string as
+    /// the `error=` query parameter.
+    case validationFailed(String)
+}
+
+/// Per-request service that owns the state shared across the 9
+/// draft-action verbs.  Construct via the handler after parsing the
+/// payload + resolving the setup; call `perform()` to apply one
+/// action; read back `setup` and `formState` afterwards.
+struct NewAssignmentDraftService {
+    let req: Request
+    let setup: APITestSetup
+    let setupID: String
+    let userID: UUID
+    let courseID: UUID
+    var formState: NewAssignmentDraftFormState
+    let payload: NewAssignmentDraftPayload
+
+    /// Title used inside generated default notebooks.  Derived from
+    /// `payload.assignmentName`; falls back to a generic placeholder
+    /// when the instructor hasn't entered one yet.
+    var notebookTitle: String {
+        let trimmed = payload.assignmentName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "New Assignment" : trimmed
+    }
+
+    // MARK: - Dispatcher
+
+    /// Dispatches `payload.action` to the matching per-action method.
+    /// Unknown actions (including the empty string) are no-ops that
+    /// fall through to the standard redirect.
+    mutating func perform() async throws -> NewAssignmentDraftActionOutcome {
+        switch payload.action {
+        case "create-assignment-notebook":
+            try await createAssignmentNotebook()
+            return .applied
+        case "upload-assignment-notebook":
+            return try await uploadAssignmentNotebook()
+        case "clear-assignment-notebook":
+            try await clearAssignmentNotebook()
+            return .applied
+        case "create-solution-notebook":
+            try await createSolutionNotebook()
+            return .applied
+        case "create-solution-from-assignment":
+            try await createSolutionFromAssignment()
+            return .applied
+        case "upload-solution-notebook":
+            return try await uploadSolutionNotebook()
+        case "clear-solution-notebook":
+            try clearSolutionNotebook()
+            return .applied
+        case "replace-suite-files":
+            try await replaceSuiteFiles()
+            return .applied
+        case "clear-suite-files":
+            try await clearSuiteFiles()
+            return .applied
+        default:
+            return .applied
+        }
+    }
+
+    // MARK: - Notebook actions
+
+    mutating func createAssignmentNotebook() async throws {
+        let data = defaultNotebookData(title: notebookTitle)
+        let dir = try ensureDraftNotebookDirectory(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        let path = dir + "assignment.ipynb"
+        try data.write(to: URL(fileURLWithPath: path))
+        setup.notebookPath = path
+        try await setup.save(on: req.db)
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            overwriteWith: data
+        )
+        formState.assignmentNotebookName = "assignment.ipynb"
+    }
+
+    mutating func uploadAssignmentNotebook() async throws -> NewAssignmentDraftActionOutcome {
+        guard let file = payload.assignmentNotebookFile, file.data.readableBytes > 0 else {
+            return .validationFailed("Select an assignment notebook to upload")
+        }
+        let raw = Data(file.data.readableBytesView)
+        guard (try? JSONSerialization.jsonObject(with: raw)) != nil else {
+            return .validationFailed("Assignment notebook must be valid JSON (.ipynb)")
+        }
+        let normalized = normalizeNotebookForJupyterLite(raw)
+        let dir = try ensureDraftNotebookDirectory(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        let filename = notebookFilenameForStorage(
+            uploadedName: file.filename, fallback: "assignment.ipynb")
+        let path = dir + filename
+        try normalized.write(to: URL(fileURLWithPath: path))
+        setup.notebookPath = path
+        try await setup.save(on: req.db)
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            overwriteWith: normalized
+        )
+        formState.assignmentNotebookName = filename
+        return .applied
+    }
+
+    mutating func clearAssignmentNotebook() async throws {
+        removeDraftNotebookFiles(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fileKind: .assignment,
+            persistedPath: setup.notebookPath
+        )
+        setup.notebookPath = nil
+        try await setup.save(on: req.db)
+        formState.assignmentNotebookName = nil
+    }
+
+    mutating func createSolutionNotebook() async throws {
+        let data = defaultNotebookData(title: "\(notebookTitle) Solution")
+        let path = draftSolutionNotebookPath(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        _ = try ensureDraftNotebookDirectory(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        try data.write(to: URL(fileURLWithPath: path))
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            relativePath: userNotebookWorkingCopyRelativePath(
+                setupID: setupID, userID: userID, fileKind: .solution),
+            overwriteWith: data
+        )
+        formState.solutionNotebookName = "solution.ipynb"
+    }
+
+    /// Parity with `createSolutionFromAssignment` (POST /:id/create-solution):
+    /// copy the assignment notebook bytes into the draft solution path so
+    /// the instructor can author the answer key starting from the
+    /// student-facing notebook.  Falls back to a blank notebook with the
+    /// title suffix " Solution" when the assignment notebook isn't
+    /// readable yet — same fallback the assignment-scoped variant uses.
+    mutating func createSolutionFromAssignment() async throws {
+        let sourceData: Data = {
+            if let path = setup.notebookPath,
+                let bytes = try? Data(contentsOf: URL(fileURLWithPath: path)),
+                !bytes.isEmpty
+            {
+                return bytes
+            }
+            return defaultNotebookData(title: "\(notebookTitle) Solution")
+        }()
+        let normalized = normalizeNotebookForJupyterLite(sourceData)
+        let path = draftSolutionNotebookPath(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        _ = try ensureDraftNotebookDirectory(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        try normalized.write(to: URL(fileURLWithPath: path))
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            relativePath: userNotebookWorkingCopyRelativePath(
+                setupID: setupID, userID: userID, fileKind: .solution),
+            overwriteWith: normalized
+        )
+        formState.solutionNotebookName = "solution.ipynb"
+    }
+
+    mutating func uploadSolutionNotebook() async throws -> NewAssignmentDraftActionOutcome {
+        guard let file = payload.solutionNotebookFile, file.data.readableBytes > 0 else {
+            return .validationFailed("Select a solution notebook to upload")
+        }
+        let raw = Data(file.data.readableBytesView)
+        guard (try? JSONSerialization.jsonObject(with: raw)) != nil else {
+            return .validationFailed("Solution notebook must be valid JSON (.ipynb)")
+        }
+        let normalized = normalizeNotebookForJupyterLite(raw)
+        let path = draftSolutionNotebookPath(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        _ = try ensureDraftNotebookDirectory(
+            testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        try normalized.write(to: URL(fileURLWithPath: path))
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            relativePath: userNotebookWorkingCopyRelativePath(
+                setupID: setupID, userID: userID, fileKind: .solution),
+            overwriteWith: normalized
+        )
+        formState.solutionNotebookName = notebookFilenameForStorage(
+            uploadedName: file.filename, fallback: "solution.ipynb")
+
+        // v0.4.100: auto-scan the solution for `##` sections and top-level
+        // function defs, then scaffold one `publictest_exists_<fn>.py` per
+        // detected function, placed in the section whose `##` header most
+        // recently preceded it.  One-shot: silently skips if the manifest
+        // already has sections / test entries.  Errors are swallowed —
+        // this is a nice-to-have that must not block the upload.
+        do {
+            let result = try await autoScaffoldFromSolutionNotebook(
+                setup: setup,
+                notebookData: normalized,
+                zipPath: setup.zipPath,
+                on: req.db
+            )
+            if result.functions > 0 {
+                req.logger.info(
+                    "auto_scaffold sections=\(result.sections) functions=\(result.functions) setup=\(setup.id ?? "?")"
+                )
+            }
+        } catch {
+            req.logger.warning("auto_scaffold_failed setup=\(setup.id ?? "?") error=\(error)")
+        }
+
+        return .applied
+    }
+
+    mutating func clearSolutionNotebook() throws {
+        removeDraftNotebookFiles(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fileKind: .solution,
+            persistedPath: draftSolutionNotebookPath(
+                testSetupsDirectory: req.application.testSetupsDirectory, setupID: setupID)
+        )
+        formState.solutionNotebookName = nil
+    }
+
+    // MARK: - Suite-file actions
+
+    mutating func replaceSuiteFiles() async throws {
+        let setupPackage = try createRunnerSetupZip(
+            suiteFiles: payload.suiteFiles,
+            suiteConfigJSON: payload.suiteConfigRaw,
+            zipPath: setup.zipPath
+        )
+        let sectionGradingMode = try await newAssignmentSectionGradingMode(
+            req: req,
+            courseID: courseID,
+            sectionIDRaw: payload.sectionIDRaw
+        )
+        let starterNotebook =
+            setup.notebookPath.map { URL(fileURLWithPath: $0).lastPathComponent }
+            ?? "assignment.ipynb"
+        setup.manifest = try makeWorkerManifestJSON(
+            testSuites: setupPackage.testSuites,
+            includeMakefile: setupPackage.hasMakefile,
+            gradingMode: sectionGradingMode,
+            starterNotebook: starterNotebook
+        )
+        try await setup.save(on: req.db)
+        extractSupportFilesToSharedDirectory(
+            zipPath: setup.zipPath,
+            setupID: setupID,
+            testSuiteScripts: Set(setupPackage.testSuites.map(\.script)),
+            testSetupsDirectory: req.application.testSetupsDirectory
+        )
+    }
+
+    mutating func clearSuiteFiles() async throws {
+        let starterNotebook =
+            setup.notebookPath.map { URL(fileURLWithPath: $0).lastPathComponent }
+            ?? "assignment.ipynb"
+        _ = try createRunnerSetupZip(suiteFiles: [], suiteConfigJSON: nil, zipPath: setup.zipPath)
+        setup.manifest = try makeWorkerManifestJSON(
+            testSuites: [],
+            includeMakefile: false,
+            gradingMode: try await newAssignmentSectionGradingMode(
+                req: req, courseID: courseID, sectionIDRaw: payload.sectionIDRaw),
+            starterNotebook: starterNotebook
+        )
+        try await setup.save(on: req.db)
+    }
+}

--- a/Tests/APITests/NewAssignmentDraftServiceTests.swift
+++ b/Tests/APITests/NewAssignmentDraftServiceTests.swift
@@ -1,0 +1,302 @@
+// Tests/APITests/NewAssignmentDraftServiceTests.swift
+//
+// Unit tests for the per-action service that backs
+// `POST /instructor/new/draft`.  These tests construct the service
+// directly (no HTTP layer, no CSRF, no multipart body) and call each
+// action method individually, then assert on `setup` / `formState`.
+//
+// This is the win from moving the action dispatcher off the route
+// handler: each action becomes testable in isolation in
+// ~10-20 lines of fixture setup rather than a full multipart
+// integration test.  The end-to-end happy path is still exercised
+// by `AssignmentRoutesPublishTests`.
+//
+// The service still depends on `Request` (for filesystem + db +
+// logger), so these tests use a synthetic `Request` from a test
+// `Application`.  That's a heavier setUp than truly Vapor-free unit
+// tests, but a clean improvement on the previous "spin up the whole
+// HTTP stack to test one validation branch" pattern.
+
+import Fluent
+import Foundation
+import Vapor
+import XCTVapor
+import XCTest
+
+@testable import chickadee_server
+
+final class NewAssignmentDraftServiceTests: XCTestCase {
+
+    private var app: Application!
+
+    override func setUp() async throws {
+        app = try await makeTestApp(prefix: "chickadee-draft-svc")
+    }
+
+    override func tearDown() async throws {
+        try await app.tearDownTestApp()
+    }
+
+    // MARK: - Fixture helpers
+
+    private func makeSyntheticRequest() -> Request {
+        Request(application: app, on: app.eventLoopGroup.next())
+    }
+
+    private func sampleNotebookData(marker: String = "marker") -> Data {
+        let json = """
+            {
+              "cells": [
+                {"cell_type": "code", "source": ["# \(marker)\\n"], "metadata": {}, "outputs": [], "execution_count": null}
+              ],
+              "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"}, "language_info": {"name": "python"}},
+              "nbformat": 4,
+              "nbformat_minor": 5
+            }
+            """
+        return Data(json.utf8)
+    }
+
+    private func makeFile(named name: String, contents: Data) -> File {
+        var buffer = ByteBufferAllocator().buffer(capacity: contents.count)
+        buffer.writeBytes(contents)
+        return File(data: buffer, filename: name)
+    }
+
+    private func makePayload(
+        action: String,
+        assignmentNotebookFile: File? = nil,
+        solutionNotebookFile: File? = nil,
+        suiteFiles: [File] = []
+    ) -> NewAssignmentDraftPayload {
+        NewAssignmentDraftPayload(
+            assignmentName: "Test Assignment",
+            dueAt: "",
+            sectionIDRaw: "",
+            draftIDRaw: nil,
+            action: action,
+            assignmentNotebookFile: assignmentNotebookFile,
+            solutionNotebookFile: solutionNotebookFile,
+            suiteFiles: suiteFiles,
+            suiteConfigRaw: nil,
+            requiredPlatform: "",
+            requiredArchitecture: "",
+            requiredLanguagesCSV: "",
+            requiredCapabilitiesCSV: ""
+        )
+    }
+
+    @discardableResult
+    private func insertCourseAndDraftSetup(id: String) async throws -> (UUID, APITestSetup) {
+        let courseID = try await app.testCourseID(code: "DSVC101", name: "Draft Svc Course")
+        let manifest = """
+            {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
+            """
+        let zipPath = app.testSetupsDirectory + "\(id).zip"
+        // Ensure parent exists; an empty file is fine for actions that
+        // don't actually re-read the zip.
+        try FileManager.default.createDirectory(
+            atPath: app.testSetupsDirectory, withIntermediateDirectories: true)
+        try Data().write(to: URL(fileURLWithPath: zipPath))
+
+        let setup = APITestSetup(
+            id: id, manifest: manifest, zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+        return (courseID, setup)
+    }
+
+    private func makeService(
+        courseID: UUID,
+        setup: APITestSetup,
+        payload: NewAssignmentDraftPayload
+    ) -> NewAssignmentDraftService {
+        NewAssignmentDraftService(
+            req: makeSyntheticRequest(),
+            setup: setup,
+            setupID: setup.id ?? "",
+            userID: UUID(),
+            courseID: courseID,
+            formState: NewAssignmentDraftFormState.empty,
+            payload: payload
+        )
+    }
+
+    // MARK: - createAssignmentNotebook
+
+    func testCreateAssignmentNotebookWritesFileAndUpdatesFormState() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_create_an1")
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "create-assignment-notebook"))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(outcome, .applied)
+        XCTAssertEqual(service.formState.assignmentNotebookName, "assignment.ipynb")
+        XCTAssertNotNil(setup.notebookPath)
+        if let path = setup.notebookPath {
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: path),
+                "expected default notebook on disk at \(path)")
+        }
+    }
+
+    // MARK: - uploadAssignmentNotebook (validation branches)
+
+    func testUploadAssignmentNotebookReturnsValidationFailedWhenFileMissing() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_upload_an_missing")
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "upload-assignment-notebook"))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(outcome, .validationFailed("Select an assignment notebook to upload"))
+        XCTAssertNil(service.formState.assignmentNotebookName)
+        XCTAssertNil(setup.notebookPath)
+    }
+
+    func testUploadAssignmentNotebookReturnsValidationFailedWhenJSONInvalid() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_upload_an_badjson")
+        let badFile = makeFile(named: "garbage.ipynb", contents: Data("not json at all".utf8))
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "upload-assignment-notebook", assignmentNotebookFile: badFile))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(
+            outcome, .validationFailed("Assignment notebook must be valid JSON (.ipynb)"))
+        XCTAssertNil(setup.notebookPath)
+    }
+
+    func testUploadAssignmentNotebookPersistsValidNotebook() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_upload_an_ok")
+        let nb = sampleNotebookData(marker: "uploaded-marker")
+        let file = makeFile(named: "my-lab.ipynb", contents: nb)
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "upload-assignment-notebook", assignmentNotebookFile: file))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(outcome, .applied)
+        XCTAssertEqual(service.formState.assignmentNotebookName, "my-lab.ipynb")
+        XCTAssertNotNil(setup.notebookPath)
+        if let path = setup.notebookPath {
+            let onDisk = try Data(contentsOf: URL(fileURLWithPath: path))
+            XCTAssertTrue(
+                String(data: onDisk, encoding: .utf8)?.contains("uploaded-marker") == true,
+                "expected uploaded marker to survive normalization")
+        }
+    }
+
+    // MARK: - clearAssignmentNotebook
+
+    func testClearAssignmentNotebookResetsNotebookPath() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_clear_an")
+        // First create the notebook so there's something to clear.
+        let createPayload = makePayload(action: "create-assignment-notebook")
+        var createSvc = makeService(courseID: courseID, setup: setup, payload: createPayload)
+        _ = try await createSvc.perform()
+        XCTAssertNotNil(setup.notebookPath, "preconditions: notebook must exist before clear")
+
+        // Now clear.
+        var clearSvc = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "clear-assignment-notebook"))
+        let outcome = try await clearSvc.perform()
+
+        XCTAssertEqual(outcome, .applied)
+        XCTAssertNil(setup.notebookPath)
+        XCTAssertNil(clearSvc.formState.assignmentNotebookName)
+    }
+
+    // MARK: - uploadSolutionNotebook (validation branches)
+
+    func testUploadSolutionNotebookReturnsValidationFailedWhenFileMissing() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_upload_sn_missing")
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "upload-solution-notebook"))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(outcome, .validationFailed("Select a solution notebook to upload"))
+    }
+
+    func testUploadSolutionNotebookReturnsValidationFailedWhenJSONInvalid() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_upload_sn_badjson")
+        let badFile = makeFile(named: "junk.ipynb", contents: Data("nope".utf8))
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "upload-solution-notebook", solutionNotebookFile: badFile))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(
+            outcome, .validationFailed("Solution notebook must be valid JSON (.ipynb)"))
+    }
+
+    // MARK: - Unknown / empty action
+
+    func testUnknownActionIsNoOpReturningApplied() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_unknown")
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: "totally-not-a-real-action"))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(outcome, .applied)
+        XCTAssertNil(setup.notebookPath)
+        XCTAssertNil(service.formState.assignmentNotebookName)
+    }
+
+    func testEmptyActionIsNoOpReturningApplied() async throws {
+        let (courseID, setup) = try await insertCourseAndDraftSetup(id: "svc_empty")
+        var service = makeService(
+            courseID: courseID, setup: setup,
+            payload: makePayload(action: ""))
+
+        let outcome = try await service.perform()
+
+        XCTAssertEqual(outcome, .applied)
+    }
+
+    // MARK: - notebookTitle derivation
+
+    func testNotebookTitleFallsBackToPlaceholderWhenAssignmentNameEmpty() {
+        let payload = NewAssignmentDraftPayload(
+            assignmentName: "  ", dueAt: "", sectionIDRaw: "",
+            draftIDRaw: nil, action: "",
+            assignmentNotebookFile: nil, solutionNotebookFile: nil,
+            suiteFiles: [], suiteConfigRaw: nil,
+            requiredPlatform: "", requiredArchitecture: "",
+            requiredLanguagesCSV: "", requiredCapabilitiesCSV: "")
+        let service = NewAssignmentDraftService(
+            req: makeSyntheticRequest(),
+            setup: APITestSetup(id: "x", manifest: "{}", zipPath: "/tmp/x", courseID: UUID()),
+            setupID: "x", userID: UUID(), courseID: UUID(),
+            formState: NewAssignmentDraftFormState.empty, payload: payload)
+
+        XCTAssertEqual(service.notebookTitle, "New Assignment")
+    }
+
+    func testNotebookTitleUsesTrimmedAssignmentNameWhenSet() {
+        let payload = NewAssignmentDraftPayload(
+            assignmentName: "  Linked Lists  ", dueAt: "", sectionIDRaw: "",
+            draftIDRaw: nil, action: "",
+            assignmentNotebookFile: nil, solutionNotebookFile: nil,
+            suiteFiles: [], suiteConfigRaw: nil,
+            requiredPlatform: "", requiredArchitecture: "",
+            requiredLanguagesCSV: "", requiredCapabilitiesCSV: "")
+        let service = NewAssignmentDraftService(
+            req: makeSyntheticRequest(),
+            setup: APITestSetup(id: "x", manifest: "{}", zipPath: "/tmp/x", courseID: UUID()),
+            setupID: "x", userID: UUID(), courseID: UUID(),
+            formState: NewAssignmentDraftFormState.empty, payload: payload)
+
+        XCTAssertEqual(service.notebookTitle, "Linked Lists")
+    }
+}


### PR DESCRIPTION
## Summary

Architecture-review follow-up #1 — the **service-layer extraction prototype**.

The 9 draft-action verbs that `POST /instructor/new/draft` dispatches (create / upload / clear assignment & solution notebooks, replace / clear suite files, etc.) had been an inline `switch action` inside the route handler. PR #583 documented why the parser was extracted but the switch stayed inline: the per-case branches shared 5 locals (`setup`, `setupID`, `userID`, `courseID`, `formState`) that threading through per-action free helpers would have made worse, not better.

This PR addresses that by moving the shared locals **onto a service type**. Each verb becomes a `mutating` method on `NewAssignmentDraftService`. Methods read/write `self.setup` and `self.formState` instead of a thread-through.

## Handler shape, before vs after

**Before** (~290 LOC):
```swift
func updateNewAssignmentDraft(req: Request) async throws -> Response {
    // ... 30 LOC of auth + payload parsing + form state ...
    switch action {
    case "create-assignment-notebook":  // ~15 LOC of file I/O + DB save
    case "upload-assignment-notebook":  // ~40 LOC including 2 validation early-redirects
    // ... 7 more cases ...
    }
    saveDraftFormState(...)
    return redirectToNewAssignmentDraft(...)
}
```

**After** (~60 LOC):
```swift
func updateNewAssignmentDraft(req: Request) async throws -> Response {
    // ... auth + payload parsing + form state seed ...
    var service = NewAssignmentDraftService(req:, setup:, setupID:, userID:,
                                            courseID:, formState:, payload:)
    let outcome = try await service.perform()
    saveDraftFormState(req: req, draftID: setupID, state: service.formState)
    let error: String? = if case .validationFailed(let m) = outcome { m } else { nil }
    return redirectToNewAssignmentDraft(..., error: error)
}
```

The service stays HTTP-agnostic via:

```swift
enum NewAssignmentDraftActionOutcome: Sendable, Equatable {
    case applied
    case validationFailed(String)
}
```

The handler builds the HTTP redirect from the outcome. `req: Request` is still a dependency on the service because actions touch the filesystem, the db, the logger, and the per-user JupyterLite working copy under `req.application.directory.publicDirectory` — a fully-Vapor-free service would be a much larger lift than this prototype.

## Files

| File | Change |
|---|---|
| `Sources/APIServer/Services/NewAssignmentDraftService.swift` | **new** (336 LOC). Struct with one `mutating` method per action verb + `perform()` dispatcher. |
| `Sources/APIServer/Routes/Web/NewAssignmentDraftPayload.swift` | **new** (33 LOC). Moved from a `fileprivate` struct inside the handler file so the service can construct one. |
| `Sources/APIServer/Routes/Web/AssignmentRoutes+NewAssignment.swift` | Handler body shrinks from ~290 LOC to ~60 LOC; `newAssignmentSectionGradingMode(...)` lifted from a `private` method on the AssignmentRoutes extension to a file-scope function so the service can call it. |
| `Tests/APITests/NewAssignmentDraftServiceTests.swift` | **new** (302 LOC). 11 service-level unit tests. |

## Tests

- **New `NewAssignmentDraftServiceTests` (11 tests):** validation branches for both upload variants, file-system + form-state assertions for create/clear assignment notebook, no-op behaviour for unknown/empty action verbs, `notebookTitle` derivation. Runs in **~5 s** vs ~22 s for the 18 publish integration tests — adding a new action now comes with a fast inner-loop test cost.
- **`AssignmentRoutesPublishTests` (18 tests):** remains green. Behaviour parity confirmed end-to-end.

## Diff size

```
5 files changed, 767 insertions(+), 304 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build --target chickadee-server` — clean
- [x] `swift test --filter "NewAssignmentDraftServiceTests"` — 11 tests, 0 failures
- [x] `swift test --filter "AssignmentRoutesPublishTests"` — 18 tests, 0 failures (regression)
- [x] `swift test --filter "AssignmentRoutesLifecycleTests"` — 5 tests, 0 failures
- [ ] Full CI

## Sets the precedent

This is the **prototype** the long-term-shape discussion in this session was sitting on. If you like the pattern, follow-ups can apply the same shape to `saveEditedAssignment` (already partially decomposed but no per-action service yet), the helpers-as-services migration (`TestSetupZipHelpers`, `SuiteRowHelpers`, `NotebookScaffoldHelpers`), and the remaining big handlers.

If you don't like the pattern, this PR stands on its own — the handler still got 80% smaller and the service is testable in isolation — and the rest of the codebase isn't affected.

## Conflict note

`CHANGELOG.md` may conflict trivially with #587 (editor tests round 2) on `[Unreleased]`. Resolution is to keep both entries.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_