### PR TITLE
test(worker): round-2 coverage — concurrency + terminal-download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Round-2 coverage for `WorkerDaemon`: job-claim concurrency +
+  terminal download failure.**  Closes the two architecture-review
+  follow-ups that PR #582 (`RunnerNetworkResilienceTests`)
+  explicitly deferred.  New cases:
+    * `testWorkerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows` —
+      feeds 5 jobs to a daemon with `maxConcurrentJobs: 5` and a
+      script runner that records peak simultaneous invocations.
+      Asserts the recording runner observed ≥ 2 concurrent calls;
+      regression-pins the `withThrowingDiscardingTaskGroup` worker-loop
+      fanout that's been silently relied on by every production
+      runner.
+    * `testWorkerDaemonReportsSyntheticFailureWhenSubmissionDownloadTerminallyFails`
+      — terminal 404 on the submission download → daemon still emits a
+      `buildStatus: .failed` report with `outcomes: []` and does NOT
+      invoke the script runner.  Complements
+      `testDownloadRetriesThroughShortServerInterruption` which
+      covers the *recoverable* download path.
+
+  Supporting fixtures: `ConcurrencyRecordingRunner` actor (peak-count
+  ScriptRunner) and `AlwaysFails404Server` (always-404 HTTP server),
+  added inline in `WorkerDaemonTests` per the existing fixture
+  convention there.  Full `WorkerDaemonTests` suite: 12 tests, 0
+  failures.
+
 - **Plug the remaining editor test gaps deferred in PR #581.**
   Adds 9 tests to `AssignmentRoutesEditorTests`:
     * **`GET /instructor/new/draft/solution-notebook`** (5 tests):

--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -939,4 +939,211 @@ final class WorkerDaemonTests: XCTestCase {
             _ = await task.result
         }
     }
+
+    // MARK: - Concurrency / state-transition coverage (round 2)
+
+    /// Records the peak number of simultaneous `run(...)` invocations so a
+    /// concurrency test can prove the daemon's worker-loop fanout actually
+    /// processes jobs in parallel.  Holds each invocation open for `delay`
+    /// so the time window for overlap is reliable.
+    private actor ConcurrencyRecordingRunner: ScriptRunner {
+        private var activeCount = 0
+        private var maxObserved = 0
+        private var totalCompletions = 0
+        private let output: ScriptOutput
+        private let delay: Duration
+
+        init(output: ScriptOutput, delay: Duration) {
+            self.output = output
+            self.delay = delay
+        }
+
+        func run(
+            script: URL, workDir: URL, timeLimitSeconds: Int, env: [String: String]
+        ) async -> ScriptOutput {
+            activeCount += 1
+            maxObserved = Swift.max(maxObserved, activeCount)
+            try? await Task.sleep(for: delay)
+            activeCount -= 1
+            totalCompletions += 1
+            return output
+        }
+
+        func snapshot() -> (maxConcurrent: Int, total: Int) {
+            (maxObserved, totalCompletions)
+        }
+    }
+
+    /// Always returns a 4xx terminal HTTP error for submission downloads.
+    /// Lets us exercise the "submission download terminally fails →
+    /// daemon still reports a synthetic failure and keeps polling" path
+    /// without needing a real flaky server.
+    private final class AlwaysFails404Server {
+        let process: Process
+        let port: Int
+        private let stdout: Pipe
+
+        init() throws {
+            process = Process()
+            stdout = Pipe()
+            process.standardOutput = stdout
+            process.standardError = FileHandle.nullDevice
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [
+                "python3",
+                "-c",
+                #"""
+                import http.server
+                import socketserver
+
+                class Handler(http.server.BaseHTTPRequestHandler):
+                    def do_GET(self):
+                        self.send_response(404)
+                        self.end_headers()
+                        self.wfile.write(b"not found")
+                    def log_message(self, format, *args):
+                        pass
+
+                with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+                    print(httpd.server_address[1], flush=True)
+                    httpd.serve_forever()
+                """#,
+            ]
+            try process.run()
+            let data = stdout.fileHandleForReading.availableData
+            guard
+                let line = String(data: data, encoding: .utf8)?.split(separator: "\n").first,
+                let port = Int(line)
+            else {
+                process.terminate()
+                throw XCTSkip("python3 is unavailable for always-404 server")
+            }
+            self.port = port
+        }
+
+        func stop() {
+            guard process.isRunning else { return }
+            process.terminate()
+            for _ in 0..<20 where process.isRunning {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+            if process.isRunning {
+                #if os(Linux)
+                _ = Glibc.kill(process.processIdentifier, SIGKILL)
+                #else
+                _ = Darwin.kill(process.processIdentifier, SIGKILL)
+                #endif
+            }
+            process.waitUntilExit()
+            stdout.fileHandleForReading.closeFile()
+        }
+    }
+
+    /// With `maxConcurrentJobs > 1`, the daemon should actually run more
+    /// than one job at a time — not serialize them through a single
+    /// worker loop.  This test feeds 5 jobs and a 100 ms per-job delay,
+    /// then asserts the recording runner observed at least 2 concurrent
+    /// invocations (more is fine; less means the worker-loop fanout
+    /// regressed).
+    func testWorkerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("worker-daemon-concurrent-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-concurrent-cache")
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+
+        let server = try StaticFileServer(directory: root)
+        defer { server.stop() }
+
+        let jobs = try (0..<5).map { i in
+            try makeServedJob(root: root, serverPort: server.port, submissionID: "concurrent_\(i)")
+        }
+        let poller = MockPoller(jobs: jobs.map(Optional.some) + [nil])
+        let reporter = MockReporter()
+        let runner = ConcurrencyRecordingRunner(
+            output: ScriptOutput(exitCode: 0, stdout: "passed", stderr: "", executionTimeMs: 1, timedOut: false),
+            delay: .milliseconds(100)
+        )
+        let daemon = WorkerDaemon(
+            poller: poller,
+            reporter: reporter,
+            runner: runner,
+            apiBaseURL: URL(string: "http://localhost:8080")!,
+            workerID: "worker-concurrent",
+            workerSecret: "secret",
+            maxConcurrentJobs: 5,
+            runnerProfile: nil,
+            downloadRetryPolicy: fastRetryPolicy,
+            testSetupCache: TestSetupCache(cacheRoot: cacheRoot)
+        )
+
+        let task = Task { try await daemon.run() }
+        _ = await waitUntil(timeoutSeconds: 10) { await reporter.snapshot().count == 5 }
+        task.cancel()
+        try? await task.value
+
+        let (maxConcurrent, total) = await runner.snapshot()
+        XCTAssertEqual(total, 5, "all 5 jobs should have completed")
+        XCTAssertGreaterThanOrEqual(
+            maxConcurrent, 2,
+            "expected >= 2 concurrent script invocations, got \(maxConcurrent); fanout may have regressed")
+    }
+
+    /// When the submission download terminally fails (404, not a retryable
+    /// 5xx), the daemon should still finish the job with a synthetic
+    /// failure report rather than crashing or silently skipping the job,
+    /// AND continue polling for the next job.  Complements
+    /// `testDownloadRetriesThroughShortServerInterruption` which covers
+    /// the *recoverable* download failure path.
+    func testWorkerDaemonReportsSyntheticFailureWhenSubmissionDownloadTerminallyFails() async throws {
+        let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-dl-terminal-cache")
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+        let failServer = try AlwaysFails404Server()
+        defer { failServer.stop() }
+
+        let job = Job(
+            submissionID: "sub_dl_terminal",
+            testSetupID: "setup_dl_terminal",
+            attemptNumber: 1,
+            submissionURL: URL(string: "http://127.0.0.1:\(failServer.port)/submission.zip")!,
+            testSetupURL: URL(string: "http://127.0.0.1:\(failServer.port)/testsetup.zip")!,
+            manifest: try makeManifest(),
+            submissionFilename: "submission.ipynb"
+        )
+        let poller = MockPoller(jobs: [job, nil])
+        let reporter = MockReporter()
+        let runner = MockRunner(
+            output: ScriptOutput(exitCode: 0, stdout: "", stderr: "", executionTimeMs: 1, timedOut: false))
+        let daemon = WorkerDaemon(
+            poller: poller,
+            reporter: reporter,
+            runner: runner,
+            apiBaseURL: URL(string: "http://localhost:8080")!,
+            workerID: "worker-dl-terminal",
+            workerSecret: "secret",
+            maxConcurrentJobs: 1,
+            runnerProfile: nil,
+            downloadRetryPolicy: fastRetryPolicy,
+            testSetupCache: TestSetupCache(cacheRoot: cacheRoot)
+        )
+
+        let task = Task { try await daemon.run() }
+        _ = await waitUntil(timeoutSeconds: 5) { await reporter.snapshot().count == 1 }
+        task.cancel()
+        try? await task.value
+
+        let reports = await reporter.snapshot()
+        XCTAssertEqual(reports.count, 1, "should still produce a report for the failed job")
+        let report = try XCTUnwrap(reports.first)
+        XCTAssertEqual(report.submissionID, "sub_dl_terminal")
+        XCTAssertEqual(
+            report.buildStatus, .failed,
+            "terminal download failure should surface as buildStatus=.failed")
+        XCTAssertEqual(report.outcomes, [], "no outcomes when build fails")
+        let runnerInvocations = await runner.observedInvocationCount()
+        XCTAssertEqual(
+            runnerInvocations, 0,
+            "ScriptRunner should not have been invoked when the submission download failed")
+    }
 }


### PR DESCRIPTION
## Summary

Architecture-review follow-up — closes the two `WorkerDaemon` coverage gaps that PR #582 (`RunnerNetworkResilienceTests`) explicitly deferred: **job-claim concurrency** and **state-transition error paths**.

### New cases

| Test | What it pins |
|---|---|
| `testWorkerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows` | Feeds 5 jobs to a daemon with `maxConcurrentJobs: 5` and a script runner that records peak simultaneous invocations.  Asserts the recording runner observed ≥ 2 concurrent calls.  Regression-pins the `withThrowingDiscardingTaskGroup` worker-loop fanout that every production runner silently relies on. |
| `testWorkerDaemonReportsSyntheticFailureWhenSubmissionDownloadTerminallyFails` | Terminal 404 on the submission download.  Daemon must still emit a `buildStatus: .failed` report with `outcomes: []` and must NOT invoke the script runner.  Complements `testDownloadRetriesThroughShortServerInterruption` which covers the *recoverable* download path. |

### Supporting fixtures

Added inline per the existing convention in `WorkerDaemonTests`:

- **`ConcurrencyRecordingRunner`** — actor `ScriptRunner` with active / max / total counters and a configurable per-invocation `delay`.  The delay (100 ms) ensures the time window for overlap is reliable.
- **`AlwaysFails404Server`** — in-process Python HTTP server that 404s every request.  Lets the test exercise the terminal-failure path without orchestrating a flaky-then-failing server.

### Full `WorkerDaemonTests` suite

12 tests, 0 failures. Run time ~10 s.

## Diff size

```
2 files changed, 231 insertions(+)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift test --filter "WorkerDaemonTests"` — 12 tests, 0 failures
- [ ] Full CI

## Where this fits

This was item **#4** from the remaining-work list. Once it lands, **#3 (Helpers → services migration)** and **#6 (DB query batching)** are the remaining architecture-review items. **#7 (error-handling Option 2)** is the optional last one.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_