### PR TITLE
perf(routes): parallelise the 7 sequential queries on courseStudentSubmissionsPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Parallelise the 7 sequential DB queries on
+  `courseStudentSubmissionsPage`.**  The
+  `/:courseCode/students/:username/submissions` handler in
+  `AssignmentRoutes+StudentCourse.swift` was running every query
+  in series — assignments, setups, submissions, preferred-results,
+  extensions, class-badges, sections — even though only one pair
+  has a real data dependency.  Restructured into two parallel
+  batches via structured `async let`:
+    * Phase 1 (independent): `assignments` + `allSections` in
+      parallel.  Sections only need `courseID`.
+    * Phase 2 (depends on assignments): `setupsByID` + `submissions`
+      + `extensionByAssignmentID` + `classBadgesBySetupID` in
+      parallel.  All four take the assignment list / setupIDs as
+      input but are otherwise independent.
+    * Serial follow-on: `preferredResultsBySubmissionID` (genuinely
+      depends on submission IDs from phase 2).
+
+  Latency goes from ~7×N round-trip to ~3×N, no JOIN gymnastics
+  — Fluent's connection pool already supports parallel queries.
+  Behaviour is unchanged; the 10 tests in
+  `AssignmentRoutesNotebookTests` and `AssignmentExtensionsTests`
+  that exercise this page pass unchanged.
+
 - **Round-2 coverage for `WorkerDaemon`: job-claim concurrency +
   terminal download failure.**  Closes the two architecture-review
   follow-ups that PR #582 (`RunnerNetworkResilienceTests`)

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+StudentCourse.swift
@@ -29,27 +29,49 @@ extension AssignmentRoutes {
             throw WebAssignmentError.notFound(resource: "Course")
         }
 
+        // Phase 1: assignments + sections in parallel.  The sections query
+        // only needs `courseID`, so it doesn't have to wait for assignments
+        // — and the page can't render without it either way.
+        //
         // Published assignments — i.e. those that have an APIAssignment row.
         // Setups without an assignment are draft/unpublished and never appear
         // in the student-facing dashboard, so they don't appear here either.
-        let assignments = try await APIAssignment.query(on: req.db)
+        async let assignmentsFuture = APIAssignment.query(on: req.db)
             .filter(\.$courseID == courseID)
             .all()
+        async let allSectionsFuture = APICourseSection.query(on: req.db)
+            .filter(\.$courseID == courseID)
+            .sort(\.$sortOrder, .ascending)
+            .all()
+        let assignments = try await assignmentsFuture
+        let allSections = try await allSectionsFuture
 
         let setupIDs = assignments.map(\.testSetupID)
-        let setupsByID = try await loadStudentCourseSetupsByID(req: req, setupIDs: setupIDs)
 
-        let submissions = try await loadStudentCourseSubmissions(
+        // Phase 2: setups + submissions + extensions + class-badges in
+        // parallel.  All four depend on the assignments / setupIDs from
+        // phase 1, but are independent of each other.  Pre-batching this
+        // way drops the page from ~7 sequential queries to two parallel
+        // groups + one dependent follow-on (preferredResults below).
+        async let setupsByIDFuture = loadStudentCourseSetupsByID(req: req, setupIDs: setupIDs)
+        async let submissionsFuture = loadStudentCourseSubmissions(
             req: req, student: student, setupIDs: setupIDs)
+        async let extensionByAssignmentIDFuture = loadStudentCourseExtensions(
+            req: req, student: student, assignments: assignments)
+        async let classBadgesBySetupIDFuture = loadStudentCourseClassBadges(
+            req: req, student: student, setupIDs: setupIDs)
+        let setupsByID = try await setupsByIDFuture
+        let submissions = try await submissionsFuture
+        let extensionByAssignmentID = try await extensionByAssignmentIDFuture
+        let classBadgesBySetupID = try await classBadgesBySetupIDFuture
+
         let submissionsBySetupID = submissionsGroupedBySetupID(submissions)
+        // preferredResults must wait until submissions resolves (it needs
+        // the submission IDs), so it stays serial after phase 2.
         let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
             for: submissions.compactMap(\.id),
             on: req.db
         )
-        let extensionByAssignmentID = try await loadStudentCourseExtensions(
-            req: req, student: student, assignments: assignments)
-        let classBadgesBySetupID = try await loadStudentCourseClassBadges(
-            req: req, student: student, setupIDs: setupIDs)
 
         let fmt = waterlooDateTimeFormatter()
         let sortedAssignments = sortedStudentCourseAssignments(assignments, setupsByID: setupsByID)
@@ -71,11 +93,6 @@ extension AssignmentRoutes {
             )
         }
 
-        // Group by course section, just like the student dashboard.
-        let allSections = try await APICourseSection.query(on: req.db)
-            .filter(\.$courseID == courseID)
-            .sort(\.$sortOrder, .ascending)
-            .all()
         let (sectionContexts, ungroupedRows) = groupStudentCourseRowsBySection(
             rows: rows,
             assignments: assignments,


### PR DESCRIPTION
## Summary

Architecture-review follow-up — closes item **#6** (DB query batching).

The architecture review flagged `AssignmentRoutes+StudentCourse.swift:22-99` specifically as the canonical N+1-style sequential querying offender:

> A single route handler chains 6+ sequential DB queries to build a single view context — no batching, no prepared loader service.

This PR restructures the handler into **two parallel batches via structured `async let`**.

## What changed

| Phase | Queries | Notes |
|---|---|---|
| **1 (independent)** | `assignments` + `allSections` | Sections only need `courseID`, don't have to wait for assignments. |
| **2 (depend on assignments, independent of each other)** | `setupsByID` + `submissions` + `extensionByAssignmentID` + `classBadgesBySetupID` | All four take the assignment list / `setupIDs` as input but are independent of each other. |
| **Serial follow-on** | `preferredResultsBySubmissionID` | Genuinely depends on submission IDs from phase 2. |

Latency goes from **~7×N** to **~3×N** round-trip on every page load. No JOIN gymnastics — Fluent's connection pool already supports parallel queries; the only constraint was the original code structure threading everything through `await` in series.

## What stays the same

- Behaviour: every input → output mapping is preserved.
- Existing tests: 10 cases in `AssignmentRoutesNotebookTests` + `AssignmentExtensionsTests` that exercise this exact endpoint pass unchanged.
- Failure semantics: if any query fails, `try await` on the corresponding `async let` propagates the error — same as before.

## Diff size

```
2 files changed, 52 insertions(+), 12 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build --target chickadee-server` — clean
- [x] `swift test --filter "AssignmentRoutesNotebookTests|AssignmentExtensionsTests"` — 10 tests, 0 failures
- [ ] Full CI

## What's NOT covered here

The architecture review pointed out this specific handler as the canonical example, but there are likely sibling N+1 cases in `AssignmentRoutes+Submissions.swift` (CSV export, history page) and `AssignmentRoutes+List.swift`. They'd benefit from the same treatment; queued for follow-ups.

## Where this fits

Item **#6** from the remaining-work list. After this lands, **#3 (Helpers → services migration)** and **#7 (error-handling Option 2)** are the remaining items.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_