### PR TITLE
docs(swift): explain the one production try! site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Document the one `try!` in production code.**  The compile-time
+  regex literal in `NotebookSubstitution.placeholderRegex`
+  (`Sources/APIServer/Services/NotebookSubstitution.swift:32`)
+  unwraps `NSRegularExpression(pattern:)` with `try!` — the
+  alternative is propagating `throws` through every call site of
+  `apply(...)` for a failure case that cannot actually fire (the
+  pattern is a string literal, not runtime input).  Comment now
+  explains the safety reasoning so the next person reading it
+  doesn't have to re-derive it.
+
+
 - **Extract `updateNewAssignmentDraft` per-action dispatch into a
   new `NewAssignmentDraftService`.**  The 9 draft-action verbs
   (create / upload / clear assignment & solution notebooks, replace

--- a/Sources/APIServer/Services/NotebookSubstitution.swift
+++ b/Sources/APIServer/Services/NotebookSubstitution.swift
@@ -30,6 +30,11 @@ enum NotebookSubstitution {
     /// characters between the braces, no spaces.  Mirrors the validator
     /// used by the editor so the on-disk shape matches what the user typed.
     private static let placeholderRegex: NSRegularExpression = {
+        // The pattern is a compile-time string literal that we know parses
+        // successfully — there is no runtime input that could change it.
+        // A `try!` here is safe; the alternative is propagating `throws`
+        // through every call site of `apply(...)`, which would give
+        // callers a failure case that can never actually fire.
         // swiftlint:disable:next force_try
         try! NSRegularExpression(pattern: #"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}"#)
     }()


### PR DESCRIPTION
## Summary

Round-2 Swift quality review item **#6** — document the one `try!` site in production code.

`NotebookSubstitution.placeholderRegex` (`Sources/APIServer/Services/NotebookSubstitution.swift:32`) unwraps `NSRegularExpression(pattern:)` with `try!`. The `swiftlint:disable:next force_try` comment was there already, but the *human-readable* rationale wasn't. This PR adds the explanation:

```swift
private static let placeholderRegex: NSRegularExpression = {
    // The pattern is a compile-time string literal that we know parses
    // successfully — there is no runtime input that could change it.
    // A `try!` here is safe; the alternative is propagating `throws`
    // through every call site of `apply(...)`, which would give
    // callers a failure case that can never actually fire.
    // swiftlint:disable:next force_try
    try! NSRegularExpression(pattern: #"\{\{([A-Za-z_][A-Za-z0-9_]*)\}\}"#)
}()
```

## Why the other "cleanliness" items aren't getting their own PRs

The round-2 review flagged two more candidates that I'm **skipping** after closer inspection — including a note here for transparency rather than silent omission:

- **Item #5 — `@unchecked Sendable` consolidation into a marker protocol.**  The agent suggested folding the ~20 Fluent model declarations under a `VaporRequestContextModel` protocol to consolidate the repeated comment.  But Swift doesn't let a marker protocol *grant* `@unchecked Sendable` to its conformers — each conforming type still has to declare `@unchecked Sendable` itself.  The "consolidation" would only collapse the *comment*, not the conformance — and each model's comment is already short and consistent.  Not worth the diff.
- **Item #7 — Named constants for repeated time literals.**  Spot-checked the flagged sites (`LoginRateLimitMiddleware`, `ClientDiagnosticsRoutes`, `ScanModeMiddleware`).  The numbers are scoped to per-feature defaults (`lockoutWindowSeconds: 900`, `cooldown: TimeInterval = 3600`) and are self-documenting in context.  A shared `Constants` struct would be premature abstraction.  Several other sites (`auditLogDefaultMaxAge`, `sessionDefaultMaxAge`) are *already* named constants, which is the right pattern when it pays off.

## Diff size

```
2 files changed, 16 insertions(+)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build --target chickadee-server` — clean
- [ ] Full CI

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_