### PR TITLE
perf(routes): parallelise the 5 sequential queries on exportGradesCSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Parallelise the 5 sequential queries on `exportGradesCSV`.**
+  Follows the `async let` pattern from PR #590 on the second-worst
+  N+1 offender flagged in the architecture review:
+    * Phase 1 (independent): `students` + `assignments` in parallel
+      — both need only `activeCourseUUID`.
+    * Phase 2 (depends on phase 1, independent of each other):
+      `setupsByID` + `submissions` in parallel — both consume
+      `setupIDs` / `studentIDs` but are otherwise independent.
+    * Serial follow-on: `preferredResultsBySubmissionID` (needs
+      submission IDs from phase 2).
+  Latency goes from ~5×N round-trip to ~3×N.  No behaviour change;
+  25 adjacent route tests (`AssignmentRoutesDashboardTests`,
+  `AssignmentRoutesLifecycleTests`, `AssignmentRoutesRetestTests`,
+  `AssignmentExtensionsTests`) pass unchanged.
+
 - **Typed throws on `WorkerJobRoutes.buildJobPayload`.**  The
   function only throws `WorkerJobError.internalInconsistency` (two
   sites: missing id, malformed URL).  Signature tightens from

--- a/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRoutes+Submissions.swift
@@ -16,20 +16,30 @@ extension AssignmentRoutes {
         let user = try req.auth.require(APIUser.self)
         let courseState = try await req.resolveActiveCourse(for: user)
 
-        let students = try await loadGradesCSVStudents(
+        // Phase 1: students + assignments in parallel.  Both only need
+        // `activeCourseUUID`; neither depends on the other.
+        async let studentsFuture = loadGradesCSVStudents(
             req: req, activeCourseUUID: courseState.activeCourseUUID)
-        let assignments = try await loadGradesCSVAssignments(
+        async let assignmentsFuture = loadGradesCSVAssignments(
             req: req, activeCourseUUID: courseState.activeCourseUUID)
+        let students = try await studentsFuture
+        let assignments = try await assignmentsFuture
 
         let setupIDs = Set(assignments.map(\.testSetupID))
-        let setupByID = try await loadGradesCSVSetupsByID(req: req, setupIDs: setupIDs)
-        let sortedAssignments = sortedGradesCSVAssignments(assignments, setupByID: setupByID)
-
         let studentIDs = Set(students.compactMap(\.id))
-        let submissions = try await loadGradesCSVSubmissions(
+
+        // Phase 2: setups-by-id + submissions in parallel.  Both depend on
+        // phase 1 (setupIDs / studentIDs), but neither depends on the other.
+        async let setupByIDFuture = loadGradesCSVSetupsByID(req: req, setupIDs: setupIDs)
+        async let submissionsFuture = loadGradesCSVSubmissions(
             req: req, setupIDs: setupIDs, studentIDs: studentIDs)
+        let setupByID = try await setupByIDFuture
+        let submissions = try await submissionsFuture
+
+        let sortedAssignments = sortedGradesCSVAssignments(assignments, setupByID: setupByID)
         let submissionIDs = submissions.map(\.id)
 
+        // Serial follow-on: needs submission IDs from phase 2.
         let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
             for: submissionIDs, on: req.db)
         let bestPointsByUserAndSetup = bestPointsByUserAndSetup(


### PR DESCRIPTION
## Summary

Round-2 Swift quality review item **#3** — follows the `async let` pattern from PR #590 on the second-worst N+1 offender flagged in the architecture review: `exportGradesCSV` in `AssignmentRoutes+Submissions.swift:15-54`.

## What changed

| Phase | Queries | Notes |
|---|---|---|
| **1 (independent)** | `students` + `assignments` | Both only need `activeCourseUUID`. |
| **2 (depends on phase 1, independent of each other)** | `setupByID` + `submissions` | Both consume `setupIDs` / `studentIDs` but are otherwise independent. |
| **Serial follow-on** | `preferredResultsBySubmissionID` | Needs submission IDs from phase 2. |

Latency goes from **~5×N** to **~3×N** round-trip per page load (CSV export over the whole course roster).

## Diff size

```
2 files changed, 32 insertions(+), 6 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build --target chickadee-server` — clean
- [x] `swift test --filter "AssignmentRoutesDashboardTests|AssignmentRoutesLifecycleTests|AssignmentRoutesRetestTests|AssignmentExtensionsTests"` — 25 tests, 0 failures (regression sweep on adjacent route tests)
- [ ] Full CI

## Note on direct test coverage

`exportGradesCSV` doesn't have a dedicated route-level test, so the regression sweep is on adjacent tests in the same file/area. Adding a test for the CSV endpoint is a separate concern and not in scope here — the parallelization is structurally equivalent to the prior sequential code (same queries, same dependencies, just dispatched in parallel where allowed).

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_