### PR TITLE
refactor(types): typed throws on WorkerJobRoutes.buildJobPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Typed throws on `WorkerJobRoutes.buildJobPayload`.**  The
+  function only throws `WorkerJobError.internalInconsistency` (two
+  sites: missing id, malformed URL).  Signature tightens from
+  `async throws -> Job` to `async throws(WorkerJobError) -> Job`
+  so the compiler now enforces the error contract at the call
+  sites.  The single caller (`requestJob` route handler) stays
+  on plain `throws` — typed throws promotes to `Error`
+  automatically when caught by an untyped catch.
+
+  This is the first conversion of round-2 review item #1.  Two
+  other candidates (`BrowserResultRoutes.submitBrowserResult` and
+  `TestSetupRoutes.downloadSupportFile`) need `AppError` to land
+  on main first (#591) before they can be similarly tightened.
+  Sibling functions in `WorkerJobRoutes.swift` (e.g.
+  `encodeJobResponse`) throw Codable errors and are intentionally
+  left as untyped `throws`.
+
 - **Document the one `try!` in production code.**  The compile-time
   regex literal in `NotebookSubstitution.placeholderRegex`
   (`Sources/APIServer/Services/NotebookSubstitution.swift:32`)

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -149,7 +149,7 @@ struct WorkerJobRoutes: RouteCollection {
     /// submission/testsetup download URLs.
     private func buildJobPayload(
         req: Request, body: WorkerActivityPayload, claimed: ClaimedJob
-    ) async throws -> Job {
+    ) async throws(WorkerJobError) -> Job {
         let submission = claimed.submission
         let setup = claimed.setup
         let base = resolvedWorkerBaseURL(req: req)


### PR DESCRIPTION
## Summary

Round-2 Swift quality review item **#1** (first of three planned typed-throws conversions).

`WorkerJobRoutes.buildJobPayload` only throws `WorkerJobError.internalInconsistency` (two sites: missing id at line 176, malformed URL at line 184). Signature tightens:

```swift
// before
private func buildJobPayload(req: Request, body: ..., claimed: ClaimedJob) async throws -> Job

// after
private func buildJobPayload(req: Request, body: ..., claimed: ClaimedJob) async throws(WorkerJobError) -> Job
```

The compiler now enforces the error contract at every call site. Any future `throw` that isn't `WorkerJobError` becomes a compile error rather than a runtime surprise.

## Why this is safe

- The single caller (the `requestJob` route handler at line 34) stays on plain `throws`. Swift's typed throws auto-promotes to `Error` when caught by an untyped catch, so no caller-side change is required.
- The `try await AssignmentSeedStore.ensureSeed(...)` call inside the function (line 164) is wrapped in a `do { ... } catch { req.logger.error(...) }` block that swallows all errors locally — so the function's net error surface is purely `WorkerJobError`.

## Why this PR is small

The round-2 review flagged three typed-throws conversion candidates. The other two — `BrowserResultRoutes.submitBrowserResult` and `TestSetupRoutes.downloadSupportFile` — need `AppError` to land on main first (#591), since they throw `AppError` exclusively after the migration there. Those will get their own PR once #591 lands.

Sibling functions in `WorkerJobRoutes.swift` (e.g. `encodeJobResponse` at line 198) throw Codable encoding errors and are intentionally left as untyped `throws`. Tightening them would require wrapping the encoder error in a typed case, which is busywork without UX benefit.

## Diff size

```
2 files changed, 18 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift build --target chickadee-server` — clean (1 line changed, all call sites still compile)
- [ ] Full CI

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_