### PR TITLE
test: migrate 5 standalone XCTest files to Swift Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Internal
 
+- **Migrate 5 standalone XCTest files to Swift Testing.**  First slice
+  of round-2 review item #4 (89 XCTest files total).  Picked the
+  smallest, most independent suites — no shared base class, no
+  async tearDown — to establish the conversion pattern:
+    * `Tests/APITests/COEPMiddlewareTests.swift` (3 tests)
+    * `Tests/APITests/ScanModeMiddlewareTests.swift` (3 tests)
+    * `Tests/APITests/CurrentUserContextTests.swift` (2 tests)
+    * `Tests/WorkerTests/DirectorySizeBytesTests.swift` (5 tests,
+      migrated to `@Suite final class` + `init() throws` + `deinit`
+      because the temp-dir setup/teardown needs lifecycle)
+    * `Tests/WorkerTests/WorkerRequestSignerTests.swift` (2 tests)
+
+  Pattern: `final class X: XCTestCase` → `@Suite struct X`
+  (or `@Suite final class X` when teardown is needed);
+  `func testFoo()` → `@Test func foo()`;
+  `XCTAssertEqual(a, b)` → `#expect(a == b)`;
+  `XCTAssertNil(x)` → `#expect(x == nil)`;
+  `XCTAssertNotNil(x)` → `#expect(x != nil)`.  Imports drop
+  `XCTest`, keep `XCTVapor` where Vapor test helpers are still
+  used (`Application.testable()` works inside Swift Testing
+  closures).  All 15 migrated tests pass under the new framework.
+
+  Skipped for this slice: suites that subclass shared test bases
+  (`AssignmentHelpersTestCase`, `WebRoutesTestCase`, etc.) and
+  suites with async `tearDownTestApp()` cleanup (the
+  `makeTestApp`-using files like `AuditLogReaperServiceTests`).
+  Those need a designed cleanup pattern — Swift Testing has no
+  `tearDown` and async `deinit` is unavailable for class-typed
+  suites.  Follow-up PRs can tackle them with a dedicated helper.
+
 - **Introduce general-purpose `AppError` typed error + migrate 45
   `Abort(.X, reason: "msg")` sites to it.**  PR #579 unified the
   *rendering* of bare `Abort(...)` and typed `WebAssignmentError`

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -1,10 +1,10 @@
 import Fluent
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class COEPMiddlewareTests: XCTestCase {
+@Suite struct COEPMiddlewareTests {
 
     private func makeApp() async throws -> Application {
         let app = try await Application.make(.testing)
@@ -23,32 +23,32 @@ final class COEPMiddlewareTests: XCTestCase {
         return app
     }
 
-    func testNotebookPageDoesNotReceiveCOEPHeaders() async throws {
+    @Test func notebookPageDoesNotReceiveCOEPHeaders() async throws {
         try await withApp(try await makeApp()) { app in
             try await app.testable().test(.GET, "/testsetups/setup_123/notebook") { res async in
-                XCTAssertEqual(res.status, .ok)
-                XCTAssertNil(res.headers.first(name: "Cross-Origin-Opener-Policy"))
-                XCTAssertNil(res.headers.first(name: "Cross-Origin-Embedder-Policy"))
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
             }
         }
     }
 
-    func testValidatePageStillReceivesCOEPHeaders() async throws {
+    @Test func validatePageStillReceivesCOEPHeaders() async throws {
         try await withApp(try await makeApp()) { app in
             try await app.testable().test(.GET, "/instructor/assignment_123/validate") { res async in
-                XCTAssertEqual(res.status, .ok)
-                XCTAssertEqual(res.headers.first(name: "Cross-Origin-Opener-Policy"), "same-origin")
-                XCTAssertEqual(res.headers.first(name: "Cross-Origin-Embedder-Policy"), "require-corp")
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
             }
         }
     }
 
-    func testUnrelatedPageDoesNotReceiveCOEPHeaders() async throws {
+    @Test func unrelatedPageDoesNotReceiveCOEPHeaders() async throws {
         try await withApp(try await makeApp()) { app in
             try await app.testable().test(.GET, "/plain") { res async in
-                XCTAssertEqual(res.status, .ok)
-                XCTAssertNil(res.headers.first(name: "Cross-Origin-Opener-Policy"))
-                XCTAssertNil(res.headers.first(name: "Cross-Origin-Embedder-Policy"))
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
             }
         }
     }

--- a/Tests/APITests/CurrentUserContextTests.swift
+++ b/Tests/APITests/CurrentUserContextTests.swift
@@ -1,11 +1,11 @@
 import Fluent
-import XCTest
+import Testing
 
 @testable import chickadee_server
 
-final class CurrentUserContextTests: XCTestCase {
+@Suite struct CurrentUserContextTests {
 
-    func testCurrentUserContextTrimsProfileFields() {
+    @Test func trimsProfileFields() {
         let user = APIUser(
             username: "jsmith",
             passwordHash: "",
@@ -16,13 +16,13 @@ final class CurrentUserContextTests: XCTestCase {
         )
 
         let ctx = CurrentUserContext(user: user)
-        XCTAssertEqual(ctx.username, "jsmith")
-        XCTAssertEqual(ctx.preferredName, "Jane")
-        XCTAssertEqual(ctx.displayName, "Jane Smith")
-        XCTAssertEqual(ctx.email, "jsmith@example.edu")
+        #expect(ctx.username == "jsmith")
+        #expect(ctx.preferredName == "Jane")
+        #expect(ctx.displayName == "Jane Smith")
+        #expect(ctx.email == "jsmith@example.edu")
     }
 
-    func testCurrentUserContextDropsBlankProfileFields() {
+    @Test func dropsBlankProfileFields() {
         let user = APIUser(
             username: "jsmith",
             passwordHash: "",
@@ -33,8 +33,8 @@ final class CurrentUserContextTests: XCTestCase {
         )
 
         let ctx = CurrentUserContext(user: user)
-        XCTAssertNil(ctx.preferredName)
-        XCTAssertNil(ctx.displayName)
-        XCTAssertNil(ctx.email)
+        #expect(ctx.preferredName == nil)
+        #expect(ctx.displayName == nil)
+        #expect(ctx.email == nil)
     }
 }

--- a/Tests/APITests/ScanModeMiddlewareTests.swift
+++ b/Tests/APITests/ScanModeMiddlewareTests.swift
@@ -1,10 +1,10 @@
 import Fluent
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class ScanModeMiddlewareTests: XCTestCase {
+@Suite struct ScanModeMiddlewareTests {
 
     private func makeApp(scanEnabled: Bool) async throws -> Application {
         let app = try await Application.make(.testing)
@@ -27,7 +27,7 @@ final class ScanModeMiddlewareTests: XCTestCase {
         return app
     }
 
-    func testGatedRoutesReturn503WhenEnabled() async throws {
+    @Test func gatedRoutesReturn503WhenEnabled() async throws {
         try await withApp(try await makeApp(scanEnabled: true)) { app in
             let gated: [(method: HTTPMethod, path: String)] = [
                 (.POST, "/api/v1/submissions"),
@@ -40,34 +40,34 @@ final class ScanModeMiddlewareTests: XCTestCase {
             ]
             for (method, path) in gated {
                 try await app.testable().test(method, path) { res async in
-                    XCTAssertEqual(
-                        res.status, .serviceUnavailable,
+                    #expect(
+                        res.status == .serviceUnavailable,
                         "expected 503 for \(method.rawValue) \(path), got \(res.status)"
                     )
-                    XCTAssertTrue(res.body.string.contains("scan_mode"))
+                    #expect(res.body.string.contains("scan_mode"))
                 }
             }
         }
     }
 
-    func testNonGatedRoutesStillWorkWhenEnabled() async throws {
+    @Test func nonGatedRoutesStillWorkWhenEnabled() async throws {
         try await withApp(try await makeApp(scanEnabled: true)) { app in
             try await app.testable().test(.POST, "/login") { res async in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             }
             try await app.testable().test(.GET, "/dashboard") { res async in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             }
         }
     }
 
-    func testGatedRoutesPassThroughWhenDisabled() async throws {
+    @Test func gatedRoutesPassThroughWhenDisabled() async throws {
         try await withApp(try await makeApp(scanEnabled: false)) { app in
             try await app.testable().test(.POST, "/api/v1/submissions") { res async in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             }
             try await app.testable().test(.POST, "/admin/users/x/delete") { res async in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             }
         }
     }

--- a/Tests/WorkerTests/DirectorySizeBytesTests.swift
+++ b/Tests/WorkerTests/DirectorySizeBytesTests.swift
@@ -1,51 +1,49 @@
 import Foundation
-import XCTest
+import Testing
 
 @testable import chickadee_runner
 
-final class DirectorySizeBytesTests: XCTestCase {
+@Suite final class DirectorySizeBytesTests {
 
-    private var tempDir: URL!
+    let tempDir: URL
 
-    override func setUp() {
-        super.setUp()
+    init() throws {
         tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("chickadee-directorysize-\(UUID().uuidString)", isDirectory: true)
-        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
     }
 
-    override func tearDown() {
-        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
-        super.tearDown()
+    deinit {
+        try? FileManager.default.removeItem(at: tempDir)
     }
 
-    func test_emptyDirectoryReturnsZero() throws {
-        XCTAssertEqual(directorySizeBytes(at: tempDir), 0)
+    @Test func emptyDirectoryReturnsZero() throws {
+        #expect(directorySizeBytes(at: tempDir) == 0)
     }
 
-    func test_sumsAllRegularFiles() throws {
+    @Test func sumsAllRegularFiles() throws {
         try Data(count: 100).write(to: tempDir.appendingPathComponent("a.bin"))
         try Data(count: 250).write(to: tempDir.appendingPathComponent("b.bin"))
-        XCTAssertEqual(directorySizeBytes(at: tempDir), 350)
+        #expect(directorySizeBytes(at: tempDir) == 350)
     }
 
-    func test_recursesIntoSubdirectories() throws {
+    @Test func recursesIntoSubdirectories() throws {
         let sub = tempDir.appendingPathComponent("nested/deeper", isDirectory: true)
         try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
         try Data(count: 64).write(to: tempDir.appendingPathComponent("top.bin"))
         try Data(count: 128).write(to: sub.appendingPathComponent("leaf.bin"))
-        XCTAssertEqual(directorySizeBytes(at: tempDir), 192)
+        #expect(directorySizeBytes(at: tempDir) == 192)
     }
 
-    func test_skipsHiddenFiles() throws {
+    @Test func skipsHiddenFiles() throws {
         try Data(count: 50).write(to: tempDir.appendingPathComponent("visible.bin"))
         try Data(count: 200).write(to: tempDir.appendingPathComponent(".hidden"))
         // .skipsHiddenFiles option in the enumerator means we ignore dotfiles.
-        XCTAssertEqual(directorySizeBytes(at: tempDir), 50)
+        #expect(directorySizeBytes(at: tempDir) == 50)
     }
 
-    func test_returnsNilForMissingDirectory() {
+    @Test func returnsNilForMissingDirectory() {
         let nonexistent = tempDir.appendingPathComponent("does-not-exist", isDirectory: true)
-        XCTAssertNil(directorySizeBytes(at: nonexistent))
+        #expect(directorySizeBytes(at: nonexistent) == nil)
     }
 }

--- a/Tests/WorkerTests/WorkerRequestSignerTests.swift
+++ b/Tests/WorkerTests/WorkerRequestSignerTests.swift
@@ -1,6 +1,6 @@
 import Crypto
 import Foundation
-import XCTest
+import Testing
 
 @testable import chickadee_runner
 
@@ -8,9 +8,9 @@ import XCTest
 import FoundationNetworking
 #endif
 
-final class WorkerRequestSignerTests: XCTestCase {
+@Suite struct WorkerRequestSignerTests {
 
-    func testSignerProducesExpectedHeadersAndSignature() {
+    @Test func signerProducesExpectedHeadersAndSignature() {
         let signer = WorkerRequestSigner(sharedSecret: "secret-123", workerID: "worker-1")
         let url = URL(string: "http://localhost:8080/internal/worker/ping")!
         var request = URLRequest(url: url)
@@ -24,19 +24,19 @@ final class WorkerRequestSignerTests: XCTestCase {
         let bodyBytes = Array(#"{"submission":"sub_1"}"#.utf8)
         let bodyHash = Data(SHA256.hash(data: Data(bodyBytes))).hexEncodedString()
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Worker-Id"), "worker-1")
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Worker-Timestamp"), String(timestamp))
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Worker-Nonce"), nonce)
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Worker-Body-SHA256"), bodyHash)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Id") == "worker-1")
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Timestamp") == String(timestamp))
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Nonce") == nonce)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Body-SHA256") == bodyHash)
 
         let payload = ["POST", "/internal/worker/ping", bodyHash, String(timestamp), nonce]
             .joined(separator: "\n")
         let expected = hmacSHA256Hex(message: payload, secret: "secret-123")
 
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Worker-Signature"), expected)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Signature") == expected)
     }
 
-    func testSignerOmitsWorkerIDWhenNil() {
+    @Test func signerOmitsWorkerIDWhenNil() {
         let signer = WorkerRequestSigner(sharedSecret: "secret-123", workerID: nil)
         let url = URL(string: "http://localhost:8080/internal/worker/ping")!
         var request = URLRequest(url: url)
@@ -44,11 +44,11 @@ final class WorkerRequestSignerTests: XCTestCase {
 
         signer.sign(&request, timestamp: 1_700_000_000, nonce: "nonce-xyz")
 
-        XCTAssertNil(request.value(forHTTPHeaderField: "X-Worker-Id"))
-        XCTAssertNotNil(request.value(forHTTPHeaderField: "X-Worker-Signature"))
-        XCTAssertNotNil(request.value(forHTTPHeaderField: "X-Worker-Timestamp"))
-        XCTAssertNotNil(request.value(forHTTPHeaderField: "X-Worker-Nonce"))
-        XCTAssertNotNil(request.value(forHTTPHeaderField: "X-Worker-Body-SHA256"))
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Id") == nil)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Signature") != nil)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Timestamp") != nil)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Nonce") != nil)
+        #expect(request.value(forHTTPHeaderField: "X-Worker-Body-SHA256") != nil)
     }
 
     private func hmacSHA256Hex(message: String, secret: String) -> String {


### PR DESCRIPTION
## Summary

First slice of round-2 review item **#4** — migrate 5 standalone XCTest files to Swift Testing.

89 XCTest files total are still on the old framework. This PR establishes the conversion pattern on the **smallest, most independent suites** so the next slices have a template to follow.

## Migrated

| File | Tests | Shape |
|---|---|---|
| `Tests/APITests/COEPMiddlewareTests.swift` | 3 | `@Suite struct` (no lifecycle) |
| `Tests/APITests/ScanModeMiddlewareTests.swift` | 3 | `@Suite struct` (no lifecycle) |
| `Tests/APITests/CurrentUserContextTests.swift` | 2 | `@Suite struct` (no lifecycle) |
| `Tests/WorkerTests/DirectorySizeBytesTests.swift` | 5 | **`@Suite final class`** + `init() throws` + `deinit` (temp dir lifecycle) |
| `Tests/WorkerTests/WorkerRequestSignerTests.swift` | 2 | `@Suite struct` (no lifecycle) |

Total: 15 tests, all passing under the new framework.

## Pattern

```
final class X: XCTestCase             → @Suite struct X
                                        (or @Suite final class X for teardown)
func testFoo()                        → @Test func foo()
XCTAssertEqual(a, b)                  → #expect(a == b)
XCTAssertNil(x)                       → #expect(x == nil)
XCTAssertNotNil(x)                    → #expect(x != nil)
XCTAssertTrue(b)                      → #expect(b)
XCTAssertFalse(b)                     → #expect(!b)
```

Imports drop `XCTest`, keep `XCTVapor` where Vapor's `Application.testable()` is still used — that helper works fine inside Swift Testing closures.

## `DirectorySizeBytesTests` note

XCTest's `setUp` / `tearDown` doesn't have a direct Swift Testing analog. The closest mapping for resources that need lifecycle (this suite manages a temp directory) is **`@Suite final class` + `init() throws` + `deinit`**. Swift Testing instantiates a new suite instance per `@Test` invocation by default, so `init`/`deinit` fires once per test — the same semantics as `setUp`/`tearDown`. Verified by running the full suite locally.

## What's deferred to follow-up PRs

Two categories of XCTest files are **not** good candidates for a mechanical migration:

1. **Suites that subclass shared test bases** (`AssignmentHelpersTestCase`, `WebRoutesTestCase`, `AssignmentRoutesTestCase`, `PatternFamilyTestCase`). Migrating these requires designing a Swift-Testing-equivalent shared-fixture pattern first.
2. **Suites with async `tearDownTestApp()` cleanup** — the `makeTestApp`-using files (`AuditLogReaperServiceTests`, ~40 others). Swift Testing has no `tearDown`, and async `deinit` is unavailable for class-typed suites. Needs a dedicated helper (e.g. `Confirmation` pattern or scoped `withTestApp` helper).

Both are tractable but warrant a thought-out approach rather than a mechanical sweep.

## Diff size

```
6 files changed, 98 insertions(+), 70 deletions(-)
```

## Test plan

- [x] `scripts/lint.sh` — clean
- [x] `swift test --filter "COEPMiddlewareTests|ScanModeMiddlewareTests|DirectorySizeBytesTests|CurrentUserContextTests|WorkerRequestSignerTests"` — **15 tests, 0 failures**
- [ ] Full CI

## Branch name caveat

The branch is named `claude/review-architecture-if-let-shorthand` (originally intended for item #2). On inspection, item #2 was a **non-issue** — the codebase has zero actual `if let X = X` redundant patterns (the agent's review overstated this). The branch got repurposed for the XCTest migration to keep the PR cycle moving. Title and content of this PR are the source of truth.

https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9jytG57f5pjZgNvHmGNeM)_