### PR TITLE
security: audit + enforce deleted-user FK cascade behaviour (#562)

### DIFF
--- a/Sources/APIServer/Migrations/AddUserFKConstraints.swift
+++ b/Sources/APIServer/Migrations/AddUserFKConstraints.swift
@@ -1,0 +1,71 @@
+// APIServer/Migrations/AddUserFKConstraints.swift
+//
+// Adds the two missing foreign-key constraints from `api_users.id`
+// that were originally created as bare UUID columns (#562 audit):
+//
+//   submissions.retested_by_user_id  → users.id  ON DELETE SET NULL
+//   class_achievements.user_id       → users.id  ON DELETE CASCADE
+//
+// Rationale (see docs/operational-diagnostics.md "User-row FK cascade"
+// table for the full enumeration):
+//
+//   * `submissions.retested_by_user_id` records "which instructor
+//     pressed Retest." When that instructor is deleted, the submission
+//     row must stay — it's an immutable grade-history record — but the
+//     attribution drops. SET NULL is the right shape.
+//
+//   * `class_achievements.user_id` records "this student earned this
+//     class-wide achievement on this submission." It is a denormalised
+//     derived row keyed on the student; when the student is deleted
+//     the derived row should go too. CASCADE.
+//
+// SQLite limitation: SQLite does NOT support `ALTER TABLE … ADD
+// CONSTRAINT FOREIGN KEY` on an existing column. Recreating the table
+// would require copying every row (submissions can be millions); the
+// payoff is not worth that risk on dev/test SQLite installs. So this
+// migration runs on Postgres only. On SQLite the same semantics are
+// enforced by application code in `AdminRoutes.deleteUser`, which
+// explicitly cleans these rows up before the user row is deleted.
+
+import Fluent
+import SQLKit
+
+struct AddUserFKConstraints: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+        guard sql.dialect.name == "postgresql" else {
+            database.logger.info(
+                "AddUserFKConstraints: skipping on \(sql.dialect.name) — SQLite cannot add FK constraints to existing columns; AdminRoutes.deleteUser enforces the same semantics in application code."
+            )
+            return
+        }
+
+        try await sql.raw(
+            """
+            ALTER TABLE class_achievements
+            ADD CONSTRAINT fk_class_achievements_user_id
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            """
+        ).run()
+
+        try await sql.raw(
+            """
+            ALTER TABLE submissions
+            ADD CONSTRAINT fk_submissions_retested_by_user_id
+            FOREIGN KEY (retested_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+            """
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+        guard sql.dialect.name == "postgresql" else { return }
+
+        try? await sql.raw(
+            "ALTER TABLE submissions DROP CONSTRAINT IF EXISTS fk_submissions_retested_by_user_id"
+        ).run()
+        try? await sql.raw(
+            "ALTER TABLE class_achievements DROP CONSTRAINT IF EXISTS fk_class_achievements_user_id"
+        ).run()
+    }
+}

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -396,6 +396,24 @@ struct AdminRoutes: RouteCollection {
 
         let deletedUsername = user.username
         let deletedRole = user.role
+
+        // Application-layer enforcement of the FK cascade behaviour
+        // documented in docs/operational-diagnostics.md ("User-row FK
+        // cascade").  Two rows here lack a DB-level constraint on
+        // SQLite (the AddUserFKConstraints migration only adds the
+        // constraints on Postgres because SQLite can't `ALTER TABLE
+        // ADD CONSTRAINT FOREIGN KEY` post-hoc), so we enforce them
+        // explicitly here.  Same logic runs on Postgres too — it just
+        // becomes a no-op because the DB-level cascade already cleared
+        // the same rows.
+        try await APIClassAchievement.query(on: req.db)
+            .filter(\.$userID == uuid)
+            .delete()
+        try await APISubmission.query(on: req.db)
+            .filter(\.$retestedByUserID == uuid)
+            .set(\.$retestedByUserID, to: nil)
+            .update()
+
         try await APICourseEnrollment.query(on: req.db)
             .filter(\.$userID == uuid)
             .delete()

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -215,4 +215,5 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateAuditLog())
     app.migrations.add(CreateAssignmentExtensions())
     app.migrations.add(AddUrlTokenToUsers())
+    app.migrations.add(AddUserFKConstraints())
 }

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -326,9 +326,10 @@ final class AdminRoutesTests: XCTestCase {
             metricValue: 42
         )
         try await achievement.save(on: app.db)
-        XCTAssertEqual(
-            try await APIClassAchievement.query(on: app.db).filter(\.$userID == studentID).count(),
-            1)
+        let preDeleteCount = try await APIClassAchievement.query(on: app.db)
+            .filter(\.$userID == studentID)
+            .count()
+        XCTAssertEqual(preDeleteCount, 1)
 
         let (boundCookie, token) = try await csrfCookieAndToken(cookie)
         try await app.asyncTest(
@@ -342,10 +343,13 @@ final class AdminRoutesTests: XCTestCase {
             }
         )
 
-        XCTAssertNil(try await APIUser.find(studentID, on: app.db))
+        let reloadedUser = try await APIUser.find(studentID, on: app.db)
+        XCTAssertNil(reloadedUser)
+        let postDeleteCount = try await APIClassAchievement.query(on: app.db)
+            .filter(\.$userID == studentID)
+            .count()
         XCTAssertEqual(
-            try await APIClassAchievement.query(on: app.db).filter(\.$userID == studentID).count(),
-            0,
+            postDeleteCount, 0,
             "class_achievements rows referencing the deleted user must be removed")
     }
 
@@ -378,7 +382,8 @@ final class AdminRoutesTests: XCTestCase {
             }
         )
 
-        XCTAssertNil(try await APIUser.find(instructorID, on: app.db))
+        let reloadedInstructor = try await APIUser.find(instructorID, on: app.db)
+        XCTAssertNil(reloadedInstructor)
         let reloaded = try await APISubmission.find("fk_null_sub", on: app.db)
         XCTAssertNotNil(reloaded, "Submission row must be preserved as immutable grade history")
         XCTAssertNil(

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -300,6 +300,92 @@ final class AdminRoutesTests: XCTestCase {
             })
     }
 
+    // MARK: - POST /admin/users/:userID/delete — FK cleanup (#562)
+
+    /// Deleting a user must CASCADE-delete the `class_achievements` rows
+    /// that reference them.  The DB-level FK constraint added by
+    /// `AddUserFKConstraints` covers Postgres; the admin handler enforces
+    /// the same semantics in application code so SQLite (which can't add
+    /// FK constraints to existing columns) behaves identically.
+    func testDeleteUserCascadesClassAchievements() async throws {
+        let cookie = try await loginAsAdmin()
+        let student = try await makeUser(username: "fk_cascade_student", role: "student")
+        let studentID = try student.requireID()
+        let course = try await makeCourse(code: "FKC101", name: "FK Cascade")
+        let courseID = try course.requireID()
+        let setup = try await makeSetup(id: "fk_cascade_setup", courseID: courseID)
+        _ = setup
+        let submission = try await makeSubmission(
+            id: "fk_cascade_sub", setupID: "fk_cascade_setup", userID: studentID)
+
+        let achievement = APIClassAchievement(
+            testSetupID: "fk_cascade_setup",
+            achievementID: "speed_champion",
+            userID: studentID,
+            submissionID: try submission.requireID(),
+            metricValue: 42
+        )
+        try await achievement.save(on: app.db)
+        XCTAssertEqual(
+            try await APIClassAchievement.query(on: app.db).filter(\.$userID == studentID).count(),
+            1)
+
+        let (boundCookie, token) = try await csrfCookieAndToken(cookie)
+        try await app.asyncTest(
+            .POST, "/admin/users/\(studentID.uuidString)/delete",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: boundCookie)
+                try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+            }
+        )
+
+        XCTAssertNil(try await APIUser.find(studentID, on: app.db))
+        XCTAssertEqual(
+            try await APIClassAchievement.query(on: app.db).filter(\.$userID == studentID).count(),
+            0,
+            "class_achievements rows referencing the deleted user must be removed")
+    }
+
+    /// Deleting an instructor who has retested submissions must NULL out
+    /// `submissions.retested_by_user_id` — the submission row stays
+    /// (immutable grade history) but the retest attribution drops.
+    func testDeleteUserNullsRetestedByReferences() async throws {
+        let cookie = try await loginAsAdmin()
+        let student = try await makeUser(username: "fk_null_student", role: "student")
+        let studentID = try student.requireID()
+        let instructor = try await makeUser(username: "fk_null_instructor", role: "instructor")
+        let instructorID = try instructor.requireID()
+        let course = try await makeCourse(code: "FKN101", name: "FK Null")
+        let courseID = try course.requireID()
+        _ = try await makeSetup(id: "fk_null_setup", courseID: courseID)
+        let submission = try await makeSubmission(
+            id: "fk_null_sub", setupID: "fk_null_setup", userID: studentID)
+        submission.retestedByUserID = instructorID
+        try await submission.save(on: app.db)
+
+        let (boundCookie, token) = try await csrfCookieAndToken(cookie)
+        try await app.asyncTest(
+            .POST, "/admin/users/\(instructorID.uuidString)/delete",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: boundCookie)
+                try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                XCTAssertEqual(res.status, .seeOther)
+            }
+        )
+
+        XCTAssertNil(try await APIUser.find(instructorID, on: app.db))
+        let reloaded = try await APISubmission.find("fk_null_sub", on: app.db)
+        XCTAssertNotNil(reloaded, "Submission row must be preserved as immutable grade history")
+        XCTAssertNil(
+            reloaded?.retestedByUserID,
+            "retested_by_user_id must clear when the referenced user is deleted")
+    }
+
     func testAdminUserActionsRenderDeleteInUsersTableOnly() async throws {
         let cookie = try await loginAsAdmin()
         let managedUser = try await makeUser(username: "managed_for_actions", role: "student")

--- a/docs/operational-diagnostics.md
+++ b/docs/operational-diagnostics.md
@@ -316,3 +316,33 @@ usage and descendant count, but it is not a kernel-level cgroup peak:
 
 The abstraction is intentionally generic so container-specific metrics can be
 added later without changing the stored schema.
+
+## User-row foreign-key cascade
+
+Every column that references `api_users.id` and the policy that fires when
+the user row is hard-deleted via `POST /admin/users/:userID/delete`.
+
+| Table | Column | On delete | Notes |
+|---|---|---|---|
+| `submissions` | `user_id` | SET NULL | Submission row preserved as immutable grade history; "anonymous attempt." |
+| `submissions` | `retested_by_user_id` | SET NULL | Submission row preserved; retest attribution drops. **Enforced by `AddUserFKConstraints` on Postgres; by `AdminRoutes.deleteUser` on SQLite.** |
+| `course_enrollments` | `user_id` | CASCADE | Enrollment row goes when the user goes. |
+| `class_achievements` | `user_id` | CASCADE | Derived per-user row; goes with the user. **Enforced by `AddUserFKConstraints` on Postgres; by `AdminRoutes.deleteUser` on SQLite.** |
+| `client_diagnostics` | `user_id` | CASCADE | Browser-error breadcrumb; tied to the user. |
+| `assignment_personalization_seeds` | `user_id` | CASCADE | Per-user seed; gone with the user. |
+| `job_execution_metrics` | `user_id` | SET NULL | Metric row preserved for capacity reporting; user attribution drops. |
+| `audit_log` | `actor_user_id` | SET NULL | Audit row preserved; actor link drops. |
+| `audit_log` | `actor_username` (denormalised string, no FK) | **preserved verbatim** | Audit log is a forensic record. "Who did what" must survive even when the user row is gone — otherwise incident-response queries blank out. The denormalised column is the only attribution that remains after the FK breaks. |
+| `pre_enrollments` | `username` (string) | **N/A** | Not an FK to `api_users` — pre-enrollment rows pre-date the user row and resolve by username on first login. |
+
+### Implementation note
+
+Of the FK constraints above, two (`submissions.retested_by_user_id` and
+`class_achievements.user_id`) were created as bare UUID columns and lack
+a DB-level constraint on existing deployments. The `AddUserFKConstraints`
+migration adds them on Postgres. SQLite cannot add an FK to an existing
+column without recreating the table, so on SQLite the same semantics are
+enforced by application code in `AdminRoutes.deleteUser` — it explicitly
+clears `class_achievements` rows and nulls `retested_by_user_id`
+references before deleting the user row. Both backends end up with the
+same observable behaviour.


### PR DESCRIPTION
Closes [#562](https://github.com/JimWallace/Chickadee/issues/562).

## Summary

Audit of every column referencing \`api_users.id\` plus the missing-FK fixes the audit surfaced.

### Audit table (now documented in [docs/operational-diagnostics.md](docs/operational-diagnostics.md))

| Table | Column | On delete | Source |
|---|---|---|---|
| \`submissions\` | \`user_id\` | SET NULL | existing FK |
| \`submissions\` | \`retested_by_user_id\` | **SET NULL** | **added here** |
| \`course_enrollments\` | \`user_id\` | CASCADE | existing FK |
| \`class_achievements\` | \`user_id\` | **CASCADE** | **added here** |
| \`client_diagnostics\` | \`user_id\` | CASCADE | existing FK |
| \`assignment_personalization_seeds\` | \`user_id\` | CASCADE | existing FK |
| \`job_execution_metrics\` | \`user_id\` | SET NULL | existing FK |
| \`audit_log\` | \`actor_user_id\` | SET NULL | existing FK |
| \`audit_log\` | \`actor_username\` (denorm string) | **preserved verbatim** | policy |
| \`pre_enrollments\` | \`username\` (no FK) | N/A | resolves on login |

### Migration: \`AddUserFKConstraints\`

Adds the two missing FKs on **Postgres**. SQLite skips with a log line — it cannot \`ALTER TABLE … ADD CONSTRAINT FOREIGN KEY\` to an existing column post-hoc without recreating the table, and a recreate on a multi-million-row \`submissions\` table isn't worth the risk for a constraint that's defense-in-depth.

### Application-layer enforcement in \`AdminRoutes.deleteUser\`

Both backends end up with identical observable behaviour:

\`\`\`swift
// Application-layer enforcement of the FK cascade behaviour
// documented in docs/operational-diagnostics.md ("User-row FK cascade").
try await APIClassAchievement.query(on: req.db)
    .filter(\\.\$userID == uuid)
    .delete()
try await APISubmission.query(on: req.db)
    .filter(\\.\$retestedByUserID == uuid)
    .set(\\.\$retestedByUserID, to: nil)
    .update()
\`\`\`

Child rows first, then the user — so neither backend hits a constraint violation mid-flow.

### Policy call: \`audit_log.actor_username\` is preserved verbatim

Audit log is a forensic record. "Who did what" needs to survive even when the user row is gone, otherwise incident-response queries blank out. The denorm column is the only attribution that remains after the FK breaks. Documented in the doc table.

### Why hard-delete and not soft-delete

The existing FK cascade shapes (SET NULL for forensic / preserved data, CASCADE for derived per-user rows) already give the right semantics under hard-delete. Pivoting to soft-delete would require a \`WHERE deleted_at IS NULL\` clause on every user-facing query — not worth the cost given the small admin surface.

## Tests

- \`testDeleteUserCascadesClassAchievements\` — student with a class achievement is deleted; verifies the achievement row is gone.
- \`testDeleteUserNullsRetestedByReferences\` — instructor who retested a submission is deleted; verifies the submission row stays but its \`retested_by_user_id\` is NULL.

## Test plan
- [x] \`scripts/lint.sh\` passes.
- [ ] CI Swift suite incl. format-lint, all test jobs, CodeQL JS/TS.
- [ ] Post-deploy smoke (Postgres): admin deletes a test user with retested submissions and class achievements; verify rows are cleaned and submissions are preserved with NULL attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)