### PR TITLE
test: Phase 1C — migrate the final 5 Bucket A files to Swift Testing

### DIFF
--- a/Tests/APITests/CourseBundleTests.swift
+++ b/Tests/APITests/CourseBundleTests.swift
@@ -10,20 +10,22 @@
 import Core
 import Fluent
 import Foundation
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class CourseBundleTests: XCTestCase {
+@Suite(.serialized) final class CourseBundleTests {
 
-    private var app: Application!
-    override func setUp() async throws {
-        app = try await makeTestApp(prefix: "chickadee-cbtest")
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-cbtest")
     }
 
-    override func tearDown() async throws {
-        try await app.tearDownTestApp()
+    deinit {
+        let appLocal = app
+        Task { try? await appLocal.asyncShutdown() }
     }
 
     // MARK: - Auth helpers
@@ -181,7 +183,7 @@ final class CourseBundleTests: XCTestCase {
 
     // MARK: - GET /admin/courses/:courseID/export
 
-    func testExportRequiresAdmin() async throws {
+    @Test func exportRequiresAdmin() async throws {
         let cookie = try await loginAsStudent()
         let course = try await makeTestCourse(code: "EXP_AUTH")
         let id = try course.requireID().uuidString
@@ -189,20 +191,20 @@ final class CourseBundleTests: XCTestCase {
         try await app.asyncTest(
             .GET, "/admin/courses/\(id)/export",
             beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
-            afterResponse: { res in XCTAssertEqual(res.status, .forbidden) }
+            afterResponse: { res in #expect(res.status == .forbidden) }
         )
     }
 
-    func testExportNotFoundForUnknownCourse() async throws {
+    @Test func exportNotFoundForUnknownCourse() async throws {
         let cookie = try await loginAsAdmin()
         try await app.asyncTest(
             .GET, "/admin/courses/\(UUID().uuidString)/export",
             beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
-            afterResponse: { res in XCTAssertEqual(res.status, .notFound) }
+            afterResponse: { res in #expect(res.status == .notFound) }
         )
     }
 
-    func testExportEmptyCourseReturnsZip() async throws {
+    @Test func exportEmptyCourseReturnsZip() async throws {
         let cookie = try await loginAsAdmin()
         let course = try await makeTestCourse(code: "EXP_EMPTY")
         let id = try course.requireID().uuidString
@@ -211,17 +213,17 @@ final class CourseBundleTests: XCTestCase {
             .GET, "/admin/courses/\(id)/export",
             beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
-                XCTAssertTrue(
+                #expect(res.status == .ok)
+                #expect(
                     res.headers.first(name: .contentType)?.contains("zip") == true,
                     "Expected application/zip, got: \(res.headers.first(name: .contentType) ?? "(none)")"
                 )
-                XCTAssertTrue(res.headers.first(name: .contentDisposition)?.contains(".zip") == true)
+                #expect(res.headers.first(name: .contentDisposition)?.contains(".zip") == true)
             }
         )
     }
 
-    func testExportManifestContainsCorrectCounts() async throws {
+    @Test func exportManifestContainsCorrectCounts() async throws {
         let cookie = try await loginAsAdmin()
         let course = try await makeTestCourse(code: "EXP_COUNTS")
         let courseID = try course.requireID()
@@ -234,7 +236,7 @@ final class CourseBundleTests: XCTestCase {
             .GET, "/admin/courses/\(courseID.uuidString)/export",
             beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
                 zipData = Data(res.body.readableBytesView)
             }
         )
@@ -257,26 +259,26 @@ final class CourseBundleTests: XCTestCase {
         decoder.dateDecodingStrategy = .iso8601
         let manifest = try decoder.decode(CourseBundleManifest.self, from: manifestData)
 
-        XCTAssertEqual(manifest.schemaVersion, 1)
-        XCTAssertEqual(manifest.course.code, "EXP_COUNTS")
-        XCTAssertEqual(manifest.testSetups.count, 1)
-        XCTAssertEqual(manifest.assignments.count, 1)
-        XCTAssertEqual(manifest.assignments.first?.title, "Test Lab")
-        XCTAssertEqual(manifest.submissions.count, 0)
+        #expect(manifest.schemaVersion == 1)
+        #expect(manifest.course.code == "EXP_COUNTS")
+        #expect(manifest.testSetups.count == 1)
+        #expect(manifest.assignments.count == 1)
+        #expect(manifest.assignments.first?.title == "Test Lab")
+        #expect(manifest.submissions.isEmpty)
     }
 
     // MARK: - POST /admin/courses/import — access control
 
-    func testImportRequiresAdmin() async throws {
+    @Test func importRequiresAdmin() async throws {
         let cookie = try await loginAsStudent()
         let zipData = try await makeMinimalBundleZip(courseCode: "IMP_AUTH")
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertEqual(status, .forbidden)
+        #expect(status == .forbidden)
     }
 
     // MARK: - POST /admin/courses/import — validation errors
 
-    func testImportRejectsMissingBundleJSON() async throws {
+    @Test func importRejectsMissingBundleJSON() async throws {
         let cookie = try await loginAsAdmin()
 
         let stagingDir = FileManager.default.temporaryDirectory
@@ -289,10 +291,10 @@ final class CourseBundleTests: XCTestCase {
 
         let zipData = try await zipDir(stagingDir)
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertEqual(status, .badRequest)
+        #expect(status == .badRequest)
     }
 
-    func testImportRejectsInvalidBundleJSON() async throws {
+    @Test func importRejectsInvalidBundleJSON() async throws {
         let cookie = try await loginAsAdmin()
 
         let stagingDir = FileManager.default.temporaryDirectory
@@ -305,10 +307,10 @@ final class CourseBundleTests: XCTestCase {
 
         let zipData = try await zipDir(stagingDir)
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertEqual(status, .badRequest)
+        #expect(status == .badRequest)
     }
 
-    func testImportRejectsWrongSchemaVersion() async throws {
+    @Test func importRejectsWrongSchemaVersion() async throws {
         let cookie = try await loginAsAdmin()
 
         let badJSON = """
@@ -327,10 +329,10 @@ final class CourseBundleTests: XCTestCase {
 
         let zipData = try await zipDir(stagingDir)
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertEqual(status, .badRequest)
+        #expect(status == .badRequest)
     }
 
-    func testImportRejectsMissingSetupFile() async throws {
+    @Test func importRejectsMissingSetupFile() async throws {
         let cookie = try await loginAsAdmin()
 
         // Manifest references a setup zip that isn't in the archive
@@ -353,19 +355,19 @@ final class CourseBundleTests: XCTestCase {
 
         let zipData = try await zipDir(stagingDir)
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertEqual(status, .badRequest)
+        #expect(status == .badRequest)
     }
 
-    func testImportRejectsActiveCourseDuplicate() async throws {
+    @Test func importRejectsActiveCourseDuplicate() async throws {
         let cookie = try await loginAsAdmin()
         _ = try await makeTestCourse(code: "DUPLICATE101")  // active course
 
         let zipData = try await makeMinimalBundleZip(courseCode: "DUPLICATE101")
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertEqual(status, .conflict)
+        #expect(status == .conflict)
     }
 
-    func testImportAllowsArchivedCourseDuplicate() async throws {
+    @Test func importAllowsArchivedCourseDuplicate() async throws {
         let cookie = try await loginAsAdmin()
         let archived = try await makeTestCourse(code: "ARCHIVED_IMP")
         archived.isArchived = true
@@ -374,21 +376,21 @@ final class CourseBundleTests: XCTestCase {
         let zipData = try await makeMinimalBundleZip(courseCode: "ARCHIVED_IMP")
         let (status, _) = try await postImport(cookie: cookie, zipData: zipData)
         // 500 expected (Leaf not configured), but NOT a 4xx rejection
-        XCTAssertNotEqual(status, .conflict)
-        XCTAssertNotEqual(status, .forbidden)
-        XCTAssertNotEqual(status, .badRequest)
+        #expect(status != .conflict)
+        #expect(status != .forbidden)
+        #expect(status != .badRequest)
     }
 
     // MARK: - POST /admin/courses/import — DB record creation
 
-    func testImportCreatesExpectedDBRecords() async throws {
+    @Test func importCreatesExpectedDBRecords() async throws {
         let cookie = try await loginAsAdmin()
         let zipData = try await makeMinimalBundleZip(courseCode: "IMP_RECORDS")
 
         let (status, body) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertNotEqual(status, .badRequest, "Import failed: \(body.prefix(200))")
-        XCTAssertNotEqual(status, .conflict)
-        XCTAssertNotEqual(status, .forbidden)
+        #expect(status != .badRequest, "Import failed: \(body.prefix(200))")
+        #expect(status != .conflict)
+        #expect(status != .forbidden)
 
         guard
             let course = try await APICourse.query(on: app.db)
@@ -400,16 +402,16 @@ final class CourseBundleTests: XCTestCase {
         let courseID = try course.requireID()
         let setups = try await APITestSetup.query(on: app.db)
             .filter(\.$courseID == courseID).all()
-        XCTAssertEqual(setups.count, 1, "Expected 1 imported test setup")
+        #expect(setups.count == 1, "Expected 1 imported test setup")
 
         let assignments = try await APIAssignment.query(on: app.db)
             .filter(\.$courseID == courseID).all()
-        XCTAssertEqual(assignments.count, 1, "Expected 1 imported assignment")
-        XCTAssertEqual(assignments.first?.title, "Lab 1")
-        XCTAssertEqual(assignments.first?.isOpen, false)  // bundle sets isOpen: false
+        #expect(assignments.count == 1, "Expected 1 imported assignment")
+        #expect(assignments.first?.title == "Lab 1")
+        #expect(assignments.first?.isOpen == false)  // bundle sets isOpen: false
     }
 
-    func testImportMatchesExistingUser() async throws {
+    @Test func importMatchesExistingUser() async throws {
         let cookie = try await loginAsAdmin()
 
         // Pre-create the user that the bundle will reference
@@ -424,31 +426,27 @@ final class CourseBundleTests: XCTestCase {
             username: "cb_existing_student"
         )
         let (status, body) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertNotEqual(status, .forbidden, body)
-        XCTAssertNotEqual(status, .badRequest, body)
+        #expect(status != .forbidden, "\(body)")
+        #expect(status != .badRequest, "\(body)")
 
         // No new user should have been created
         let userCountAfter = try await APIUser.query(on: app.db).count()
-        XCTAssertEqual(
-            userCountAfter, userCountBefore,
-            "No new user should be created when username already exists")
+        #expect(userCountAfter == userCountBefore, "No new user should be created when username already exists")
 
         // The enrollment should reference the pre-existing user
         let course = try await APICourse.query(on: app.db)
             .filter(\.$code == "USERMATCH_CB").first()
-        XCTAssertNotNil(course)
+        #expect(course != nil)
         guard let courseID2 = try course?.requireID() else {
             XCTFail("Imported course USERMATCH_CB not found in DB")
             return
         }
         let enrollment = try await APICourseEnrollment.query(on: app.db)
             .filter(\.$course.$id == courseID2).first()
-        XCTAssertEqual(
-            enrollment?.userID, existingID,
-            "Enrollment should point to the pre-existing user")
+        #expect(enrollment?.userID == existingID, "Enrollment should point to the pre-existing user")
     }
 
-    func testImportCreatesPlaceholderUser() async throws {
+    @Test func importCreatesPlaceholderUser() async throws {
         let cookie = try await loginAsAdmin()
 
         let zipData = try await makeBundleZipWithUser(
@@ -456,20 +454,18 @@ final class CourseBundleTests: XCTestCase {
             username: "cb_brand_new_user"
         )
         let (status, body) = try await postImport(cookie: cookie, zipData: zipData)
-        XCTAssertNotEqual(status, .forbidden, body)
-        XCTAssertNotEqual(status, .badRequest, body)
+        #expect(status != .forbidden, "\(body)")
+        #expect(status != .badRequest, "\(body)")
 
         let placeholder = try await APIUser.query(on: app.db)
             .filter(\.$username == "cb_brand_new_user").first()
-        XCTAssertNotNil(placeholder, "Placeholder user should be created")
-        XCTAssertEqual(
-            placeholder?.passwordHash, "",
-            "Placeholder user should have empty passwordHash (inert account)")
+        #expect(placeholder != nil, "Placeholder user should be created")
+        #expect(placeholder?.passwordHash.isEmpty == true, "Placeholder user should have empty passwordHash (inert account)")
     }
 
     // MARK: - Round-trip: export → import
 
-    func testRoundTripExportImport() async throws {
+    @Test func roundTripExportImport() async throws {
         let cookie = try await loginAsAdmin()
 
         // Set up source course
@@ -484,11 +480,11 @@ final class CourseBundleTests: XCTestCase {
             .GET, "/admin/courses/\(courseID.uuidString)/export",
             beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
                 exportedZip = Data(res.body.readableBytesView)
             }
         )
-        XCTAssertFalse(exportedZip.isEmpty, "Exported ZIP should not be empty")
+        #expect(exportedZip.isEmpty == false, "Exported ZIP should not be empty")
 
         // Archive the original so the import does not hit a 409
         course.isArchived = true
@@ -496,9 +492,9 @@ final class CourseBundleTests: XCTestCase {
 
         // Import the exported ZIP
         let (status, body) = try await postImport(cookie: cookie, zipData: exportedZip)
-        XCTAssertNotEqual(status, .badRequest, "Import should not fail: \(body.prefix(300))")
-        XCTAssertNotEqual(status, .conflict, body)
-        XCTAssertNotEqual(status, .forbidden, body)
+        #expect(status != .badRequest, "Import should not fail: \(body.prefix(300))")
+        #expect(status != .conflict, "\(body)")
+        #expect(status != .forbidden, "\(body)")
 
         // Verify the imported course has the same structure
         guard
@@ -513,12 +509,12 @@ final class CourseBundleTests: XCTestCase {
         let importedID = try imported.requireID()
         let importedSetups = try await APITestSetup.query(on: app.db)
             .filter(\.$courseID == importedID).all()
-        XCTAssertEqual(importedSetups.count, 1, "Round-trip: expected 1 test setup")
+        #expect(importedSetups.count == 1, "Round-trip: expected 1 test setup")
 
         let importedAssignments = try await APIAssignment.query(on: app.db)
             .filter(\.$courseID == importedID).all()
-        XCTAssertEqual(importedAssignments.count, 1, "Round-trip: expected 1 assignment")
-        XCTAssertEqual(importedAssignments.first?.title, "RT Lab")
+        #expect(importedAssignments.count == 1, "Round-trip: expected 1 assignment")
+        #expect(importedAssignments.first?.title == "RT Lab")
     }
 
     // MARK: - Bundle builder with a user (used by user-matching tests)

--- a/Tests/APITests/CourseBundleTests.swift
+++ b/Tests/APITests/CourseBundleTests.swift
@@ -460,7 +460,10 @@ import XCTVapor
         let placeholder = try await APIUser.query(on: app.db)
             .filter(\.$username == "cb_brand_new_user").first()
         #expect(placeholder != nil, "Placeholder user should be created")
-        #expect(placeholder?.passwordHash.isEmpty == true, "Placeholder user should have empty passwordHash (inert account)")
+        #expect(
+            placeholder?.passwordHash.isEmpty == true,
+            "Placeholder user should have empty passwordHash (inert account)"
+        )
     }
 
     // MARK: - Round-trip: export → import

--- a/Tests/APITests/EnrollmentRoutesTests.swift
+++ b/Tests/APITests/EnrollmentRoutesTests.swift
@@ -12,20 +12,22 @@ import Core
 import Crypto
 import Fluent
 import Foundation
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class EnrollmentRoutesTests: XCTestCase {
+@Suite(.serialized) final class EnrollmentRoutesTests {
 
-    private var app: Application!
-    override func setUp() async throws {
-        app = try await makeTestApp(prefix: "chickadee-enr")
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-enr")
     }
 
-    override func tearDown() async throws {
-        try await app.tearDownTestApp()
+    deinit {
+        let appLocal = app
+        Task { try? await appLocal.asyncShutdown() }
     }
 
     // MARK: - Helpers
@@ -44,7 +46,7 @@ final class EnrollmentRoutesTests: XCTestCase {
 
     // MARK: - GET /enroll
 
-    func testEnrollPage_showsOnlyOpenCourses() async throws {
+    @Test func enrollPage_showsOnlyOpenCourses() async throws {
         let open = try await makeCourse(code: "ENR_OPEN1", mode: .open)
         let auto = try await makeCourse(code: "ENR_AUTO1", mode: .auto)
         let closed = try await makeCourse(code: "ENR_CLOSED1", mode: .closed)
@@ -60,25 +62,25 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.headers.add(name: .cookie, value: cookie)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
                 let html = res.body.string
-                XCTAssertTrue(html.contains(open.code), "Open course should appear")
-                XCTAssertFalse(html.contains(auto.code), "Auto course should not appear on /enroll")
-                XCTAssertFalse(html.contains(closed.code), "Closed course should not appear")
-                XCTAssertFalse(html.contains(archived.code), "Archived course should not appear")
+                #expect(html.contains(open.code), "Open course should appear")
+                #expect(html.contains(auto.code) == false, "Auto course should not appear on /enroll")
+                #expect(html.contains(closed.code) == false, "Closed course should not appear")
+                #expect(html.contains(archived.code) == false, "Archived course should not appear")
             })
     }
 
-    func testEnrollPage_unauthenticated_redirects() async throws {
+    @Test func enrollPage_unauthenticated_redirects() async throws {
         try await app.asyncTest(.GET, "/enroll") { res in
-            XCTAssertEqual(res.status, .seeOther)
-            XCTAssertEqual(res.headers.first(name: .location), "/login")
+            #expect(res.status == .seeOther)
+            #expect(res.headers.first(name: .location) == "/login")
         }
     }
 
     // MARK: - POST /enroll
 
-    func testSaveEnrollment_enrollsInSelectedCourses() async throws {
+    @Test func saveEnrollment_enrollsInSelectedCourses() async throws {
         let course = try await makeCourse(code: "ENR_SAVE1", mode: .open)
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -94,19 +96,19 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "courseIDs=\(courseID.uuidString)&_csrf=\(token)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
-                XCTAssertEqual(res.headers.first(name: .location), "/")
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: .location) == "/")
             })
 
         let user = try await APIUser.query(on: app.db).filter(\.$username == "enr_student2").first()
         let enrollments = try await APICourseEnrollment.query(on: app.db)
             .filter(\.$userID == user!.requireID())
             .all()
-        XCTAssertEqual(enrollments.count, 1)
-        XCTAssertEqual(enrollments.first?.$course.id, courseID)
+        #expect(enrollments.count == 1)
+        #expect(enrollments.first?.$course.id == courseID)
     }
 
-    func testSaveEnrollment_noneSelected_redirectsWithError() async throws {
+    @Test func saveEnrollment_noneSelected_redirectsWithError() async throws {
         let cookie = try await loginUser(
             username: "enr_student3", password: "pw",
             role: "student", on: app)
@@ -119,15 +121,15 @@ final class EnrollmentRoutesTests: XCTestCase {
                 try req.content.encode(["_csrf": token], as: .urlEncodedForm)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
                 let loc = res.headers.first(name: .location) ?? ""
-                XCTAssertTrue(
+                #expect(
                     loc.contains("error=none_selected"),
                     "Should redirect with none_selected error, got: \(loc)")
             })
     }
 
-    func testSaveEnrollment_ignoresClosedCourse() async throws {
+    @Test func saveEnrollment_ignoresClosedCourse() async throws {
         let closed = try await makeCourse(code: "ENR_CLOSED2", mode: .closed)
         let closedID = try closed.requireID()
         let cookie = try await loginUser(
@@ -143,18 +145,18 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "courseIDs=\(closedID.uuidString)&_csrf=\(token)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
                 let loc = res.headers.first(name: .location) ?? ""
-                XCTAssertTrue(loc.contains("error=none_selected"))
+                #expect(loc.contains("error=none_selected"))
             })
 
         let user = try await APIUser.query(on: app.db).filter(\.$username == "enr_student4").first()
         let enrollments = try await APICourseEnrollment.query(on: app.db)
             .filter(\.$userID == user!.requireID()).all()
-        XCTAssertTrue(enrollments.isEmpty, "Should not be enrolled in a closed course")
+        #expect(enrollments.isEmpty, "Should not be enrolled in a closed course")
     }
 
-    func testSaveEnrollment_ignoresAutoCourse() async throws {
+    @Test func saveEnrollment_ignoresAutoCourse() async throws {
         // Auto courses are not shown on /enroll and must not be self-enrollable via POST.
         let auto = try await makeCourse(code: "ENR_AUTO2", mode: .auto)
         let autoID = try auto.requireID()
@@ -174,15 +176,15 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "courseIDs=\(autoID.uuidString)&_csrf=\(token)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
                 let loc = res.headers.first(name: .location) ?? ""
-                XCTAssertTrue(
+                #expect(
                     loc.contains("error=none_selected"),
                     "Auto course should not be self-enrollable via /enroll, got: \(loc)")
             })
     }
 
-    func testSaveEnrollment_doesNotDuplicate() async throws {
+    @Test func saveEnrollment_doesNotDuplicate() async throws {
         let course = try await makeCourse(code: "ENR_DUP1", mode: .open)
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -204,12 +206,12 @@ final class EnrollmentRoutesTests: XCTestCase {
         let user = try await APIUser.query(on: app.db).filter(\.$username == "enr_student5").first()
         let enrollments = try await APICourseEnrollment.query(on: app.db)
             .filter(\.$userID == user!.requireID()).all()
-        XCTAssertEqual(enrollments.count, 1, "Should not create duplicate enrollments")
+        #expect(enrollments.count == 1, "Should not create duplicate enrollments")
     }
 
     // MARK: - Auto-enrolment (resolveActiveCourse)
 
-    func testAutoEnroll_onResolveActiveCourse_enrollsInAutoCourse() async throws {
+    @Test func autoEnroll_onResolveActiveCourse_enrollsInAutoCourse() async throws {
         let auto = try await makeCourse(code: "AUT_RESOLVE1", mode: .auto)
         let autoID = try auto.requireID()
 
@@ -222,12 +224,12 @@ final class EnrollmentRoutesTests: XCTestCase {
         let enrollments = try await APICourseEnrollment.query(on: app.db)
             .filter(\.$userID == user!.requireID())
             .all()
-        XCTAssertEqual(enrollments.count, 1)
-        XCTAssertEqual(enrollments.first?.$course.id, autoID)
+        #expect(enrollments.count == 1)
+        #expect(enrollments.first?.$course.id == autoID)
         _ = cookie
     }
 
-    func testAutoEnroll_multipleAutoCourses_enrollsAll() async throws {
+    @Test func autoEnroll_multipleAutoCourses_enrollsAll() async throws {
         let a1 = try await makeCourse(code: "AUT_MULTI1", mode: .auto)
         let a2 = try await makeCourse(code: "AUT_MULTI2", mode: .auto)
         let id1 = try a1.requireID()
@@ -244,12 +246,12 @@ final class EnrollmentRoutesTests: XCTestCase {
             .all()
             .map { $0.$course.id }
 
-        XCTAssertTrue(enrolledIDs.contains(id1), "Should be enrolled in first auto course")
-        XCTAssertTrue(enrolledIDs.contains(id2), "Should be enrolled in second auto course")
+        #expect(enrolledIDs.contains(id1), "Should be enrolled in first auto course")
+        #expect(enrolledIDs.contains(id2), "Should be enrolled in second auto course")
         _ = cookie
     }
 
-    func testAutoEnroll_doesNotEnrollInOpenOrClosedCourses() async throws {
+    @Test func autoEnroll_doesNotEnrollInOpenOrClosedCourses() async throws {
         let open = try await makeCourse(code: "AUT_OPEN1", mode: .open)
         let closed = try await makeCourse(code: "AUT_CLOSED1", mode: .closed)
         let auto = try await makeCourse(code: "AUT_AUTO1", mode: .auto)
@@ -269,13 +271,13 @@ final class EnrollmentRoutesTests: XCTestCase {
                 .all()
                 .map { $0.$course.id })
 
-        XCTAssertTrue(enrolledIDs.contains(autoID), "Should be auto-enrolled in .auto course")
-        XCTAssertFalse(enrolledIDs.contains(openID), "Should NOT be auto-enrolled in .open course")
-        XCTAssertFalse(enrolledIDs.contains(closedID), "Should NOT be auto-enrolled in .closed course")
+        #expect(enrolledIDs.contains(autoID), "Should be auto-enrolled in .auto course")
+        #expect(enrolledIDs.contains(openID) == false, "Should NOT be auto-enrolled in .open course")
+        #expect(enrolledIDs.contains(closedID) == false, "Should NOT be auto-enrolled in .closed course")
         _ = cookie
     }
 
-    func testAutoEnroll_doesNotDuplicateExistingEnrollment() async throws {
+    @Test func autoEnroll_doesNotDuplicateExistingEnrollment() async throws {
         let auto = try await makeCourse(code: "AUT_NODUP1", mode: .auto)
         let autoID = try auto.requireID()
 
@@ -292,12 +294,12 @@ final class EnrollmentRoutesTests: XCTestCase {
             .filter(\.$userID == user!.requireID())
             .filter(\.$course.$id == autoID)
             .count()
-        XCTAssertEqual(count, 1, "Should not create duplicate enrollment on repeated login")
+        #expect(count == 1, "Should not create duplicate enrollment on repeated login")
     }
 
     // MARK: - postLoginRedirect behaviour
 
-    func testPostLoginRedirect_withClosedCourseOnly_redirectsToHome() async throws {
+    @Test func postLoginRedirect_withClosedCourseOnly_redirectsToHome() async throws {
         // Only a closed course → user can't self-enroll → redirect to / (empty state).
         try await makeCourse(code: "PLR_CLOSED1", mode: .closed)
 
@@ -315,14 +317,12 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "username=plr_closed_student&password=pw&_csrf=\(csrf)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
-                XCTAssertEqual(
-                    res.headers.first(name: .location), "/",
-                    "User with only closed course should go to /")
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: .location) == "/", "User with only closed course should go to /")
             })
     }
 
-    func testPostLoginRedirect_withOpenCourseOnly_redirectsToEnroll() async throws {
+    @Test func postLoginRedirect_withOpenCourseOnly_redirectsToEnroll() async throws {
         // Only an open course → user has no enrollment → redirect to /enroll.
         try await makeCourse(code: "PLR_OPEN1", mode: .open)
 
@@ -340,14 +340,14 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "username=plr_open_student&password=pw&_csrf=\(csrf)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
-                XCTAssertEqual(
-                    res.headers.first(name: .location), "/enroll",
+                #expect(res.status == .seeOther)
+                #expect(
+                    res.headers.first(name: .location) == "/enroll",
                     "User with open course and no enrollments should go to /enroll")
             })
     }
 
-    func testPostLoginRedirect_withAutoCourse_enrollsAndRedirectsToHome() async throws {
+    @Test func postLoginRedirect_withAutoCourse_enrollsAndRedirectsToHome() async throws {
         // Auto course → user gets enrolled → redirect to /.
         try await makeCourse(code: "PLR_AUTO1", mode: .auto)
 
@@ -366,21 +366,19 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "username=plr_auto_student&password=pw&_csrf=\(csrf)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
-                XCTAssertEqual(
-                    res.headers.first(name: .location), "/",
-                    "Auto-enrolled user should go to /")
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: .location) == "/", "Auto-enrolled user should go to /")
             })
 
         let count = try await APICourseEnrollment.query(on: app.db)
             .filter(\.$userID == userID)
             .count()
-        XCTAssertEqual(count, 1, "User should be enrolled in the auto course after login")
+        #expect(count == 1, "User should be enrolled in the auto course after login")
     }
 
     // MARK: - POST /courses/:courseID/activate
 
-    func testActivateCourse_enrolledUser_setsSession() async throws {
+    @Test func activateCourse_enrolledUser_setsSession() async throws {
         let course = try await makeCourse(code: "ACT_COURSE1", mode: .auto)
         let courseID = try course.requireID()
         // auto mode: loginUser triggers auto-enrolment, so the student is enrolled.
@@ -396,11 +394,11 @@ final class EnrollmentRoutesTests: XCTestCase {
                 try req.content.encode(["_csrf": token], as: .urlEncodedForm)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
     }
 
-    func testActivateCourse_notEnrolled_doesNotSetSession() async throws {
+    @Test func activateCourse_notEnrolled_doesNotSetSession() async throws {
         let course = try await makeCourse(code: "ACT_COURSE2", mode: .open)
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -416,11 +414,11 @@ final class EnrollmentRoutesTests: XCTestCase {
                 try req.content.encode(["_csrf": token], as: .urlEncodedForm)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
     }
 
-    func testActivateCourse_invalidCourseID_returns400() async throws {
+    @Test func activateCourse_invalidCourseID_returns400() async throws {
         let cookie = try await loginUser(
             username: "act_student3", password: "pw",
             role: "student", on: app)
@@ -433,13 +431,13 @@ final class EnrollmentRoutesTests: XCTestCase {
                 try req.content.encode(["_csrf": token], as: .urlEncodedForm)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .badRequest)
+                #expect(res.status == .badRequest)
             })
     }
 
     // MARK: - Admin enrollment-mode route
 
-    func testAdminSetEnrollmentMode_setsMode() async throws {
+    @Test func adminSetEnrollmentMode_setsMode() async throws {
         let course = try await makeCourse(code: "ADM_MODE1", mode: .open)
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -456,14 +454,14 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "enrollmentMode=auto&_csrf=\(token)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let updated = try await APICourse.find(courseID, on: app.db)
-        XCTAssertEqual(updated?.enrollmentMode, .auto, "Enrollment mode should be .auto after update")
+        #expect(updated?.enrollmentMode == .auto, "Enrollment mode should be .auto after update")
     }
 
-    func testAdminSetEnrollmentMode_unknownValue_defaultsToOpen() async throws {
+    @Test func adminSetEnrollmentMode_unknownValue_defaultsToOpen() async throws {
         let course = try await makeCourse(code: "ADM_MODE2", mode: .auto)
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -480,14 +478,14 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "enrollmentMode=bogus&_csrf=\(token)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let updated = try await APICourse.find(courseID, on: app.db)
-        XCTAssertEqual(updated?.enrollmentMode, .open, "Unknown value should default to .open")
+        #expect(updated?.enrollmentMode == .open, "Unknown value should default to .open")
     }
 
-    func testInstructorSetEnrollmentMode_setsMode() async throws {
+    @Test func instructorSetEnrollmentMode_setsMode() async throws {
         let course = try await makeCourse(code: "INS_MODE1", mode: .open)
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -503,10 +501,10 @@ final class EnrollmentRoutesTests: XCTestCase {
                 req.body = .init(string: "enrollmentMode=closed&_csrf=\(token)")
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let updated = try await APICourse.find(courseID, on: app.db)
-        XCTAssertEqual(updated?.enrollmentMode, .closed)
+        #expect(updated?.enrollmentMode == .closed)
     }
 }

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -1,25 +1,27 @@
 import Fluent
 import Foundation
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import Core
 @testable import chickadee_server
 
-final class ObservabilityTests: XCTestCase {
-    private var app: Application!
+@Suite(.serialized) final class ObservabilityTests {
     private let workerSecret = "observability-secret"
 
-    override func setUp() async throws {
-        app = try await makeTestApp(prefix: "chickadee-obs")
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-obs")
         app.workerSecretStore = WorkerSecretStore(initialOverride: workerSecret)
     }
 
-    override func tearDown() async throws {
-        try await app.tearDownTestApp()
+    deinit {
+        let appLocal = app
+        Task { try? await appLocal.asyncShutdown() }
     }
 
-    func testQueueWaitMetricCalculationPersistsExpectedMilliseconds() async throws {
+    @Test func queueWaitMetricCalculationPersistsExpectedMilliseconds() async throws {
         let (_, submission) = try await makeSubmission(submissionID: "sub_queue_wait")
         let enqueuedAt = Date(timeIntervalSince1970: 1_000)
         let assignedAt = Date(timeIntervalSince1970: 1_003.5)
@@ -37,10 +39,10 @@ final class ObservabilityTests: XCTestCase {
         let metric = try await JobExecutionMetric.query(on: app.db)
             .filter(\.$submissionID == "sub_queue_wait")
             .first()
-        XCTAssertEqual(metric?.queueWaitMs, 3500)
+        #expect(metric?.queueWaitMs == 3500)
     }
 
-    func testExecutionDurationAndFinalStatusPersistence() async throws {
+    @Test func executionDurationAndFinalStatusPersistence() async throws {
         let (_, submission) = try await makeSubmission(submissionID: "sub_exec_metric")
         let enqueuedAt = Date(timeIntervalSince1970: 2_000)
         let assignedAt = Date(timeIntervalSince1970: 2_002)
@@ -97,16 +99,16 @@ final class ObservabilityTests: XCTestCase {
         let metric = try await JobExecutionMetric.query(on: app.db)
             .filter(\.$submissionID == "sub_exec_metric")
             .first()
-        XCTAssertEqual(metric?.executionMs, 3250)
+        #expect(metric?.executionMs == 3250)
         // totalProcessingMs is the sum of queueWaitMs (2000) and executionMs
         // (3250), not `completedAt − enqueuedAt`. Summing avoids mixing
         // server `enqueuedAt` with runner `completedAt`, which under any
         // runner clock skew would let `total < queueWait` slip through.
-        XCTAssertEqual(metric?.totalProcessingMs, 5250)
-        XCTAssertEqual(metric?.finalStatus, JobFinalStatus.error.rawValue)
+        #expect(metric?.totalProcessingMs == 5250)
+        #expect(metric?.finalStatus == JobFinalStatus.error.rawValue)
     }
 
-    func testWrappedExecutionReportPersistsStageTimingMetrics() async throws {
+    @Test func wrappedExecutionReportPersistsStageTimingMetrics() async throws {
         let (_, submission) = try await makeSubmission(submissionID: "sub_stage_metrics")
         submission.submittedAt = Date(timeIntervalSince1970: 3_000)
         submission.workerID = "runner-stage"
@@ -171,19 +173,19 @@ final class ObservabilityTests: XCTestCase {
         let metric = try await JobExecutionMetric.query(on: app.db)
             .filter(\.$submissionID == "sub_stage_metrics")
             .first()
-        XCTAssertEqual(metric?.workdirSetupMs, 10)
-        XCTAssertEqual(metric?.submissionDirSetupMs, 15)
-        XCTAssertEqual(metric?.submissionDownloadMs, 20)
-        XCTAssertEqual(metric?.testSetupAcquireMs, 25)
-        XCTAssertEqual(metric?.submissionUnpackMs, 30)
-        XCTAssertEqual(metric?.starterCleanupMs, 5)
-        XCTAssertEqual(metric?.submissionPrepareMs, 40)
-        XCTAssertEqual(metric?.makeStepMs, 50)
-        XCTAssertEqual(metric?.runtimeHelperSetupMs, 12)
-        XCTAssertEqual(metric?.testExecutionMs, 250)
+        #expect(metric?.workdirSetupMs == 10)
+        #expect(metric?.submissionDirSetupMs == 15)
+        #expect(metric?.submissionDownloadMs == 20)
+        #expect(metric?.testSetupAcquireMs == 25)
+        #expect(metric?.submissionUnpackMs == 30)
+        #expect(metric?.starterCleanupMs == 5)
+        #expect(metric?.submissionPrepareMs == 40)
+        #expect(metric?.makeStepMs == 50)
+        #expect(metric?.runtimeHelperSetupMs == 12)
+        #expect(metric?.testExecutionMs == 250)
     }
 
-    func testWorkerHeartbeatUpdatesRunnerSnapshot() async throws {
+    @Test func workerHeartbeatUpdatesRunnerSnapshot() async throws {
         let payload = WorkerActivityPayload(
             workerID: "runner-heartbeat",
             hostname: "host-a",
@@ -213,26 +215,26 @@ final class ObservabilityTests: XCTestCase {
                 req.body = body
             },
             afterResponse: { response in
-                XCTAssertEqual(response.status, .ok)
+                #expect(response.status == .ok)
             })
 
         let snapshot = try await RunnerSnapshot.query(on: app.db)
             .filter(\.$runnerID == "runner-heartbeat")
             .sort(\.$recordedAt, .descending)
             .first()
-        XCTAssertEqual(snapshot?.activeJobs, 2)
-        XCTAssertEqual(snapshot?.maxJobs, 4)
-        XCTAssertEqual(snapshot?.availableCapacity, 2)
-        XCTAssertNotNil(snapshot?.lastHeartbeatAt)
+        #expect(snapshot?.activeJobs == 2)
+        #expect(snapshot?.maxJobs == 4)
+        #expect(snapshot?.availableCapacity == 2)
+        #expect(snapshot?.lastHeartbeatAt != nil)
 
         let runnerProfile = try await RunnerProfile.query(on: app.db)
             .filter(\.$runnerID == "runner-heartbeat")
             .first()
-        XCTAssertEqual(runnerProfile?.platform, "linux")
+        #expect(runnerProfile?.platform == "linux")
     }
 
     // swiftlint:disable:next function_body_length
-    func testAdminMetricsAuthorizationAndResponseShape() async throws {
+    @Test func adminMetricsAuthorizationAndResponseShape() async throws {
         let (setup, submission) = try await makeSubmission(submissionID: "sub_metrics")
         let recentMetric = JobExecutionMetric(
             submissionID: try submission.requireID(),
@@ -299,7 +301,7 @@ final class ObservabilityTests: XCTestCase {
         try await app.asyncTest(
             .GET, "/admin/metrics",
             afterResponse: { response in
-                XCTAssertEqual(response.status, .seeOther)
+                #expect(response.status == .seeOther)
             })
 
         let cookie = try await loginUser(
@@ -315,14 +317,14 @@ final class ObservabilityTests: XCTestCase {
                 req.headers.add(name: .cookie, value: cookie)
             },
             afterResponse: { response in
-                XCTAssertEqual(response.status, .ok)
+                #expect(response.status == .ok)
                 let payload = try response.content.decode(InternalMetricsResponse.self)
                 XCTAssertGreaterThanOrEqual(payload.activeRunners, 1)
-                XCTAssertEqual(payload.jobsProcessed24h, 1)
-                XCTAssertNotNil(payload.queueWait.averageMs)
-                XCTAssertEqual(payload.jobStatusCounts.first(where: { $0.status == "passed" })?.count, 1)
-                XCTAssertFalse(payload.runnerLoads.isEmpty)
-                XCTAssertEqual(payload.compatibility.compatibleAssignmentAttempts, 0)
+                #expect(payload.jobsProcessed24h == 1)
+                #expect(payload.queueWait.averageMs != nil)
+                #expect(payload.jobStatusCounts.first(where: { $0.status == "passed" })?.count == 1)
+                #expect(payload.runnerLoads.isEmpty == false)
+                #expect(payload.compatibility.compatibleAssignmentAttempts == 0)
             })
 
         try await app.asyncTest(
@@ -331,19 +333,19 @@ final class ObservabilityTests: XCTestCase {
                 req.headers.add(name: .cookie, value: cookie)
             },
             afterResponse: { response in
-                XCTAssertEqual(response.status, .ok)
+                #expect(response.status == .ok)
                 let payload = try response.content.decode(InternalMetricsTimeSeriesResponse.self)
-                XCTAssertEqual(payload.windowHours, 24)
-                XCTAssertEqual(payload.bucketMinutes, 15)
-                XCTAssertFalse(payload.buckets.isEmpty)
-                XCTAssertTrue(payload.buckets.contains(where: { $0.completedJobs == 1 }))
-                XCTAssertTrue(
+                #expect(payload.windowHours == 24)
+                #expect(payload.bucketMinutes == 15)
+                #expect(payload.buckets.isEmpty == false)
+                #expect(payload.buckets.contains(where: { $0.completedJobs == 1 }))
+                #expect(
                     payload.buckets.contains(where: { ($0.requestCount > 0) || ($0.avgRunnerUtilizationPercent != nil) }
                     ))
             })
     }
 
-    func testQueueDepthExcludesBrowserModePendingJobs() async throws {
+    @Test func queueDepthExcludesBrowserModePendingJobs() async throws {
         // Only worker-mode submissions should contribute to the native worker queue depth.
         _ = try await makeSubmission(submissionID: "sub_worker_pending", gradingMode: "worker")
         _ = try await makeSubmission(submissionID: "sub_browser_pending", gradingMode: "browser")
@@ -361,9 +363,9 @@ final class ObservabilityTests: XCTestCase {
                 req.headers.add(name: .cookie, value: cookie)
             },
             afterResponse: { response in
-                XCTAssertEqual(response.status, .ok)
+                #expect(response.status == .ok)
                 let payload = try response.content.decode(InternalMetricsResponse.self)
-                XCTAssertEqual(payload.maxQueueDepth, 1)
+                #expect(payload.maxQueueDepth == 1)
             })
     }
 
@@ -375,7 +377,7 @@ final class ObservabilityTests: XCTestCase {
     /// (`completedAt − enqueuedAt`) straddled the two clocks and produced
     /// totals smaller than the queue wait. `totalProcessingMs` must now
     /// be `queueWaitMs + executionMs`, which never inverts.
-    func testTotalProcessingMsIsResilientToRunnerClockSkew() async throws {
+    @Test func totalProcessingMsIsResilientToRunnerClockSkew() async throws {
         let (_, submission) = try await makeSubmission(submissionID: "sub_clock_skew")
 
         // Server clock: submitted at T+0, assigned 210 ms later.
@@ -421,12 +423,12 @@ final class ObservabilityTests: XCTestCase {
         let metric = try await JobExecutionMetric.query(on: app.db)
             .filter(\.$submissionID == "sub_clock_skew")
             .first()
-        XCTAssertEqual(metric?.queueWaitMs, 210)
-        XCTAssertEqual(metric?.executionMs, 101)
+        #expect(metric?.queueWaitMs == 210)
+        #expect(metric?.executionMs == 101)
         // The invariant: total >= queueWait. The old formula yielded 111ms
         // (a clock-skewed completedAt − enqueuedAt), inverting against
         // the 210ms queueWait. The summed formula yields 311ms.
-        XCTAssertEqual(metric?.totalProcessingMs, 311)
+        #expect(metric?.totalProcessingMs == 311)
         if let total = metric?.totalProcessingMs, let queue = metric?.queueWaitMs {
             XCTAssertGreaterThanOrEqual(total, queue)
         } else {
@@ -435,7 +437,7 @@ final class ObservabilityTests: XCTestCase {
 
         // Same invariant on APISubmissionDiagnostics.turnaroundMs.
         let diag = try await APISubmissionDiagnostics.find("sub_clock_skew", on: app.db)
-        XCTAssertEqual(diag?.turnaroundMs, 311)
+        #expect(diag?.turnaroundMs == 311)
         if let turnaround = diag?.turnaroundMs, let queue = diag?.queueWaitMs {
             XCTAssertGreaterThanOrEqual(turnaround, queue)
         }
@@ -450,7 +452,7 @@ final class ObservabilityTests: XCTestCase {
     ///    `totalProcessingMs`, `executionMs`, stage timings, etc.) are
     ///    cleared, so an in-flight retest never renders with `Total <
     ///    Queue Wait` on the admin runner page.
-    func testRetestClearsStalePerAttemptFieldsAndRebaselinesEnqueue() async throws {
+    @Test func retestClearsStalePerAttemptFieldsAndRebaselinesEnqueue() async throws {
         let (_, submission) = try await makeSubmission(submissionID: "sub_retest")
 
         // --- Attempt 1: submit, assign, complete. ---
@@ -493,9 +495,9 @@ final class ObservabilityTests: XCTestCase {
         let postFirstRun = try await JobExecutionMetric.query(on: app.db)
             .filter(\.$submissionID == "sub_retest")
             .first()
-        XCTAssertEqual(postFirstRun?.totalProcessingMs, 9_000)  // queueWait 2_000 + execution 7_000
-        XCTAssertEqual(postFirstRun?.queueWaitMs, 2_000)  //  1_002 − 1_000
-        XCTAssertNotNil(postFirstRun?.completedAt)
+        #expect(postFirstRun?.totalProcessingMs == 9_000)  // queueWait 2_000 + execution 7_000
+        #expect(postFirstRun?.queueWaitMs == 2_000)  //  1_002 − 1_000
+        #expect(postFirstRun?.completedAt != nil)
 
         // --- Retest is triggered later, gets re-assigned. ---
         let retestedAt = Date(timeIntervalSince1970: 50_000)
@@ -513,13 +515,13 @@ final class ObservabilityTests: XCTestCase {
             .first()
         // Queue wait reflects the retest window only (4s), not 49,004s since
         // the original submission.
-        XCTAssertEqual(postRetestAssign?.queueWaitMs, 4_000)
+        #expect(postRetestAssign?.queueWaitMs == 4_000)
         // Per-attempt fields from the previous run are cleared.
-        XCTAssertNil(postRetestAssign?.completedAt)
-        XCTAssertNil(postRetestAssign?.startedAt)
-        XCTAssertNil(postRetestAssign?.executionMs)
-        XCTAssertNil(postRetestAssign?.totalProcessingMs)
-        XCTAssertNil(postRetestAssign?.finalStatus)
+        #expect(postRetestAssign?.completedAt == nil)
+        #expect(postRetestAssign?.startedAt == nil)
+        #expect(postRetestAssign?.executionMs == nil)
+        #expect(postRetestAssign?.totalProcessingMs == nil)
+        #expect(postRetestAssign?.finalStatus == nil)
         // Specifically: Total < Queue Wait is no longer possible because
         // totalProcessingMs is nil — the admin page will show "—" until
         // the retest completes.

--- a/Tests/APITests/SectionRoutesTests.swift
+++ b/Tests/APITests/SectionRoutesTests.swift
@@ -10,20 +10,22 @@
 import Core
 import Fluent
 import Foundation
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class SectionRoutesTests: XCTestCase {
+@Suite(.serialized) final class SectionRoutesTests {
 
-    private var app: Application!
-    override func setUp() async throws {
-        app = try await makeTestApp(prefix: "chickadee-sect")
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-sect")
     }
 
-    override func tearDown() async throws {
-        try await app.tearDownTestApp()
+    deinit {
+        let appLocal = app
+        Task { try? await appLocal.asyncShutdown() }
     }
 
     // MARK: - Helpers
@@ -71,7 +73,7 @@ final class SectionRoutesTests: XCTestCase {
 
     // MARK: - POST /instructor/sections — create
 
-    func testCreateSection_instructorCanCreateSection() async throws {
+    @Test func createSection_instructorCanCreateSection() async throws {
         let course = try await makeCourse(code: "SECT_CREATE1")
         let courseID = try course.requireID()
         let cookie = try await loginUser(
@@ -89,19 +91,19 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let sections = try await APICourseSection.query(on: app.db)
             .filter(\.$courseID == courseID)
             .all()
-        XCTAssertEqual(sections.count, 1)
-        XCTAssertEqual(sections[0].name, "Labs")
-        XCTAssertEqual(sections[0].defaultGradingMode, "browser")
-        XCTAssertEqual(sections[0].sortOrder, 1)
+        #expect(sections.count == 1)
+        #expect(sections[0].name == "Labs")
+        #expect(sections[0].defaultGradingMode == "browser")
+        #expect(sections[0].sortOrder == 1)
     }
 
-    func testCreateSection_secondSectionGetsHigherSortOrder() async throws {
+    @Test func createSection_secondSectionGetsHigherSortOrder() async throws {
         let course = try await makeCourse(code: "SECT_CREATE2")
         let courseID = try course.requireID()
         try await makeSection(name: "Existing", order: 1, courseID: courseID)
@@ -121,17 +123,17 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let exams = try await APICourseSection.query(on: app.db)
             .filter(\.$courseID == courseID)
             .filter(\.$name == "Exams")
             .first()
-        XCTAssertEqual(exams?.sortOrder, 2)
+        #expect(exams?.sortOrder == 2)
     }
 
-    func testCreateSection_emptyNameRejected() async throws {
+    @Test func createSection_emptyNameRejected() async throws {
         try await makeCourse(code: "SECT_EMPTY")
         let cookie = try await loginUser(
             username: "sect_instructor3", password: "pw",
@@ -148,11 +150,11 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .badRequest)
+                #expect(res.status == .badRequest)
             })
     }
 
-    func testCreateSection_invalidGradingModeRejected() async throws {
+    @Test func createSection_invalidGradingModeRejected() async throws {
         try await makeCourse(code: "SECT_BADMODE")
         let cookie = try await loginUser(
             username: "sect_instructor4", password: "pw",
@@ -169,11 +171,11 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .badRequest)
+                #expect(res.status == .badRequest)
             })
     }
 
-    func testCreateSection_studentForbidden() async throws {
+    @Test func createSection_studentForbidden() async throws {
         try await makeCourse(code: "SECT_STUDENT1")
         let cookie = try await loginUser(
             username: "sect_student1", password: "pw",
@@ -191,13 +193,13 @@ final class SectionRoutesTests: XCTestCase {
             },
             afterResponse: { res in
                 // Redirected to login (role middleware) or 403.
-                XCTAssertTrue(res.status == .seeOther || res.status == .forbidden)
+                #expect(res.status == .seeOther || res.status == .forbidden)
             })
     }
 
     // MARK: - POST /instructor/sections/reorder
 
-    func testReorderSections_updatesOrder() async throws {
+    @Test func reorderSections_updatesOrder() async throws {
         let course = try await makeCourse(code: "SECT_REORDER1")
         let courseID = try course.requireID()
         let s1 = try await makeSection(name: "A", order: 1, courseID: courseID)
@@ -223,17 +225,17 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(ReorderBody(sectionIDs: [id3, id2, id1]))
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             })
 
         let updated = try await APICourseSection.query(on: app.db)
             .filter(\.$courseID == courseID)
             .sort(\.$sortOrder)
             .all()
-        XCTAssertEqual(updated.map { $0.name }, ["C", "B", "A"])
+        #expect(updated.map { $0.name } == ["C", "B", "A"])
     }
 
-    func testReorderSections_invalidUUIDRejected() async throws {
+    @Test func reorderSections_invalidUUIDRejected() async throws {
         try await makeCourse(code: "SECT_REORDER2")
         let cookie = try await loginUser(
             username: "sect_instructor_ri", password: "pw",
@@ -250,13 +252,13 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(ReorderBody(sectionIDs: ["not-a-uuid"]))
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .badRequest)
+                #expect(res.status == .badRequest)
             })
     }
 
     // MARK: - POST /instructor/sections/:sectionID/rename
 
-    func testRenameSection_updatesNameAndMode() async throws {
+    @Test func renameSection_updatesNameAndMode() async throws {
         let course = try await makeCourse(code: "SECT_RENAME1")
         let courseID = try course.requireID()
         let section = try await makeSection(
@@ -279,15 +281,15 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let updated = try await APICourseSection.find(section.id, on: app.db)
-        XCTAssertEqual(updated?.name, "NewName")
-        XCTAssertEqual(updated?.defaultGradingMode, "browser")
+        #expect(updated?.name == "NewName")
+        #expect(updated?.defaultGradingMode == "browser")
     }
 
-    func testRenameSection_emptyNameRejected() async throws {
+    @Test func renameSection_emptyNameRejected() async throws {
         let course = try await makeCourse(code: "SECT_RENAME2")
         let courseID = try course.requireID()
         let section = try await makeSection(name: "Good", order: 1, courseID: courseID)
@@ -308,11 +310,11 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .badRequest)
+                #expect(res.status == .badRequest)
             })
     }
 
-    func testRenameSection_notFoundForUnknownID() async throws {
+    @Test func renameSection_notFoundForUnknownID() async throws {
         try await makeCourse(code: "SECT_RENAME3")
         let cookie = try await loginUser(
             username: "sect_instructor_rnf", password: "pw",
@@ -330,13 +332,13 @@ final class SectionRoutesTests: XCTestCase {
                 )
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .notFound)
+                #expect(res.status == .notFound)
             })
     }
 
     // MARK: - POST /instructor/sections/:sectionID/delete
 
-    func testDeleteSection_removesSection() async throws {
+    @Test func deleteSection_removesSection() async throws {
         let course = try await makeCourse(code: "SECT_DEL1")
         let courseID = try course.requireID()
         let section = try await makeSection(name: "ToDelete", order: 1, courseID: courseID)
@@ -354,14 +356,14 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(["_csrf": token], as: .urlEncodedForm)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         let deleted = try await APICourseSection.find(sectionID, on: app.db)
-        XCTAssertNil(deleted)
+        #expect(deleted == nil)
     }
 
-    func testDeleteSection_assignmentsBecomesUngrouped() async throws {
+    @Test func deleteSection_assignmentsBecomesUngrouped() async throws {
         let course = try await makeCourse(code: "SECT_DEL2")
         let courseID = try course.requireID()
         let section = try await makeSection(name: "Doomed", order: 1, courseID: courseID)
@@ -386,18 +388,18 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(["_csrf": token], as: .urlEncodedForm)
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .seeOther)
+                #expect(res.status == .seeOther)
             })
 
         // The assignment should still exist but be ungrouped.
         let updated = try await APIAssignment.find(assignment.id, on: app.db)
-        XCTAssertNotNil(updated)
-        XCTAssertNil(updated?.sectionID)
+        #expect(updated != nil)
+        #expect(updated?.sectionID == nil)
     }
 
     // MARK: - POST /instructor/:assignmentID/section
 
-    func testMoveToSection_setsSection() async throws {
+    @Test func moveToSection_setsSection() async throws {
         let course = try await makeCourse(code: "SECT_MOVE1")
         let courseID = try course.requireID()
         let section = try await makeSection(name: "Target", order: 1, courseID: courseID)
@@ -422,14 +424,14 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(MoveBody(sectionID: sectionID.uuidString))
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             })
 
         let updated = try await APIAssignment.find(assignment.id, on: app.db)
-        XCTAssertEqual(updated?.sectionID, sectionID)
+        #expect(updated?.sectionID == sectionID)
     }
 
-    func testMoveToSection_emptyIDClearsSection() async throws {
+    @Test func moveToSection_emptyIDClearsSection() async throws {
         let course = try await makeCourse(code: "SECT_MOVE2")
         let courseID = try course.requireID()
         let section = try await makeSection(name: "ASection", order: 1, courseID: courseID)
@@ -456,14 +458,14 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(MoveBody(sectionID: ""))
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             })
 
         let updated = try await APIAssignment.find(assignment.id, on: app.db)
-        XCTAssertNil(updated?.sectionID)
+        #expect(updated?.sectionID == nil)
     }
 
-    func testMoveToSection_syncsBrowserGradingMode() async throws {
+    @Test func moveToSection_syncsBrowserGradingMode() async throws {
         let course = try await makeCourse(code: "SECT_MOVE3")
         let courseID = try course.requireID()
         let section = try await makeSection(
@@ -501,13 +503,13 @@ final class SectionRoutesTests: XCTestCase {
                 try req.content.encode(MoveBody(sectionID: sectionID.uuidString))
             },
             afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
+                #expect(res.status == .ok)
             })
 
         // The test setup manifest should now have gradingMode = "browser"
         let updatedSetup = try await APITestSetup.find(setup.id, on: app.db)
         let manifestData = Data((updatedSetup?.manifest ?? "").utf8)
         let dict = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
-        XCTAssertEqual(dict?["gradingMode"] as? String, "browser")
+        #expect(dict?["gradingMode"] as? String == "browser")
     }
 }

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -12,7 +12,6 @@ import Leaf
 import LeafKit
 import SQLKit
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 

--- a/scripts/xctest-allowlist.txt
+++ b/scripts/xctest-allowlist.txt
@@ -13,10 +13,8 @@ Tests/APITests/AssignmentRoutesRetestTests.swift
 Tests/APITests/AssignmentRoutesTestCase.swift
 Tests/APITests/AuditLogReaperServiceTests.swift
 Tests/APITests/BrowserRunnerRoutesTests.swift
-Tests/APITests/CourseBundleTests.swift
 Tests/APITests/DraftNotebookChecksRoutesTests.swift
 Tests/APITests/DraftSuiteSectionRoutesTests.swift
-Tests/APITests/EnrollmentRoutesTests.swift
 Tests/APITests/GlobalInputsTests.swift
 Tests/APITests/JupyterLiteContentsRoutesTests.swift
 Tests/APITests/NotebookCheckVariableExistsTests.swift
@@ -24,7 +22,6 @@ Tests/APITests/NotebookDownloadTests.swift
 Tests/APITests/NotebookWebRoutesTests.swift
 Tests/APITests/OIDCDiscoveryURLValidationTests.swift
 Tests/APITests/OIDCTests.swift
-Tests/APITests/ObservabilityTests.swift
 Tests/APITests/PatternFamilyApplyTests.swift
 Tests/APITests/PatternFamilyKindsTests.swift
 Tests/APITests/PatternFamilyRendererTests.swift
@@ -33,13 +30,11 @@ Tests/APITests/PatternFamilyTestCase.swift
 Tests/APITests/RunnerCompatibilityTests.swift
 Tests/APITests/SSOAuthFlowTests.swift
 Tests/APITests/ScriptEditRoutesTests.swift
-Tests/APITests/SectionRoutesTests.swift
 Tests/APITests/SubmissionQueryRoutesTests.swift
 Tests/APITests/SubmissionRoutesTests.swift
 Tests/APITests/SuiteRouteTests.swift
 Tests/APITests/SuiteSectionRoutesTests.swift
 Tests/APITests/SupportImportTests.swift
-Tests/APITests/TestHelpers.swift
 Tests/APITests/TestScriptTemplatesTests.swift
 Tests/APITests/WebRoutesBadgeTests.swift
 Tests/APITests/WebRoutesIndexTests.swift


### PR DESCRIPTION
## Summary

Closes out Phase 1 of the Swift Testing migration (after #597 / #598 / #599).
Migrates the last four standalone Bucket A files plus the `TestHelpers.swift`
shared helper (the latter only needed an `import XCTest` removal — it never
used XCTest APIs).

**APITests (4 test files):**
- `CourseBundleTests`, `EnrollmentRoutesTests`, `ObservabilityTests`,
  `SectionRoutesTests`

**APITests (1 helper file):**
- `TestHelpers` — dead `import XCTest` dropped

## Pattern

`@Suite(.serialized) final class` with stored `let app: Application`,
matching Phase 1B.

## Notable conversions

- `#expect(X, body)` where `body` is a runtime `String` → `#expect(X, "\(body)")`
  (Swift Testing's `Comment?` is `ExpressibleByStringInterpolation`, not implicitly
  convertible from a runtime `String`).
- `placeholder?.passwordHash == ""` → `placeholder?.passwordHash.isEmpty == true`
  (SwiftLint `empty_string`).

## Allowlist

`scripts/xctest-allowlist.txt`: 55 → 50. Swift Testing files: 53 → 57 (~53% of 108).
**Bucket A is now empty** — every remaining XCTest file is either feature-heavy
(Bucket B) or subclassed off a shared base class (Bucket C).

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `scripts/swiftlint.sh --strict` passes (0 violations)
- [x] `scripts/no-new-xctest.sh` passes
- [x] APITests / WorkerTests / CoreTests all green locally
- [ ] CI green across all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)