### PR TITLE
test: Phase 2B — migrate the final 3 Bucket B throws-heavy XCTest files

### DIFF
--- a/Tests/APITests/AuthModeGatingTests.swift
+++ b/Tests/APITests/AuthModeGatingTests.swift
@@ -114,23 +114,24 @@ import XCTVapor
     }
 
     @Test func ssoMode_customCallbackRouteRegisteredFromEnv() async throws {
-        // NOTE: EnvTestLock.shared.lock() can't be taken from async context
-        // under Swift 6 strict concurrency.  The suite-level `.serialized`
-        // gates within-suite parallelism; cross-suite env races during the
-        // migration window are mitigated by the 3× repeat-run CI job.
-        // TODO(migration): replace `setenv` with direct config injection.
-        setenv("OIDC_CALLBACK", "/oidc/duo/callback/", 1)
-        defer { unsetenv("OIDC_CALLBACK") }
+        // Cross-suite env serialization via `withAsyncEnvLock` — OIDCTests
+        // also mutates OIDC_* env vars, and without serialization the two
+        // suites' setenv/unsetenv calls have raced under `swift test
+        // --parallel` (#603 first run).
+        try await withAsyncEnvLock {
+            setenv("OIDC_CALLBACK", "/oidc/duo/callback/", 1)
+            defer { unsetenv("OIDC_CALLBACK") }
 
-        try await withApp(try await makeApp(authMode: .sso)) { app in
-            try await app.asyncTest(
-                .GET, "/oidc/duo/callback",
-                afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    #expect(
-                        res.headers.first(name: .location)?.contains("sso_not_configured") == true
-                    )
-                })
+            try await withApp(try await makeApp(authMode: .sso)) { app in
+                try await app.asyncTest(
+                    .GET, "/oidc/duo/callback",
+                    afterResponse: { res in
+                        #expect(res.status == .seeOther)
+                        #expect(
+                            res.headers.first(name: .location)?.contains("sso_not_configured") == true
+                        )
+                    })
+            }
         }
     }
 

--- a/Tests/APITests/EnvTestLock.swift
+++ b/Tests/APITests/EnvTestLock.swift
@@ -2,16 +2,63 @@
 //
 // Shared lock for tests that manipulate process environment variables.
 // `setenv` / `unsetenv` mutate process-global state, so two suites that
-// both touch env vars (APIServerAppTests, DatabaseConfigurationTests)
-// race against each other when Swift Testing runs them in parallel.
-// `@Suite(.serialized)` only serializes within a suite, not across.
+// both touch env vars race against each other when Swift Testing runs
+// them in parallel.  `@Suite(.serialized)` only serializes within a
+// suite, not across.
 //
-// Each env-touching test class acquires this lock in `init` and releases
-// it in `deinit`, so for the duration of any one such test no other
-// env-touching test (in any suite) can be running.
+// Sync path (`EnvTestLock.shared`): XCTest setUp/tearDown and Swift
+// Testing's struct/class init are sync; they can use the NSLock
+// directly.
+//
+// Async path (`EnvTestLock.withAsyncLock { ... }`): Swift 6 strict
+// concurrency disallows `NSLock.lock()` from async functions because
+// holding a sync lock across `await` is a deadlock hazard.  The actor-
+// backed `withAsyncLock` provides equivalent serialization without
+// holding any lock across suspension points — only one in-flight
+// closure can execute at a time across all callers.
 
 import Foundation
 
 enum EnvTestLock {
     static let shared = NSLock()
+}
+
+/// Serializes async env-mutating test bodies across suites.
+/// Only one `withAsyncLock` closure can be running at a time process-wide.
+func withAsyncEnvLock<R: Sendable>(_ body: @Sendable () async throws -> R) async rethrows -> R {
+    try await AsyncEnvLock.shared.run(body)
+}
+
+/// Backing actor for `withAsyncEnvLock`.  The single-entry actor
+/// serializes its `run` calls; the `body` itself runs outside the
+/// actor's isolation domain so caller-side async work is uninterrupted.
+private actor AsyncEnvLock {
+    static let shared = AsyncEnvLock()
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func run<R: Sendable>(_ body: @Sendable () async throws -> R) async rethrows -> R {
+        await acquire()
+        defer { release() }
+        return try await body()
+    }
+
+    private func acquire() async {
+        if !locked {
+            locked = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            locked = false
+        }
+    }
 }

--- a/Tests/APITests/NotebookCheckVariableExistsTests.swift
+++ b/Tests/APITests/NotebookCheckVariableExistsTests.swift
@@ -7,16 +7,16 @@
 
 import Core
 import Foundation
+import Testing
 import Vapor
-import XCTest
 
 @testable import chickadee_server
 
-final class NotebookCheckVariableExistsTests: XCTestCase {
+@Suite struct NotebookCheckVariableExistsTests {
 
     // MARK: - Renderer
 
-    func testRender_existenceOnly_emitsMissingSentinelAndNoTypeCheck() {
+    @Test func render_existenceOnly_emitsMissingSentinelAndNoTypeCheck() {
         let check = NotebookCheck(
             id: "var_df",
             kind: .variableExists,
@@ -25,36 +25,30 @@ final class NotebookCheckVariableExistsTests: XCTestCase {
         let bundle = renderNotebookCheck(check)
         let source = bundle.script.source
 
-        XCTAssertTrue(
+        #expect(
             source.contains("kind=variable_exists"),
             "header should record the kind for stale-script audits")
-        XCTAssertTrue(
+        #expect(
             source.contains("name = \"df\""),
             "variable name should be embedded as a Python string literal")
-        XCTAssertTrue(
+        #expect(
             source.contains("getattr(student_module, name, _MISSING)"),
             "must use the standard _MISSING sentinel idiom")
-        XCTAssertTrue(
+        #expect(
             source.contains("is not defined in the student notebook"),
             "missing-variable failure message should be present")
-        XCTAssertTrue(
+        #expect(
             source.contains("# (no type check; existence only)"),
             "no-type branch should include the explicit no-op comment")
-        XCTAssertFalse(
-            source.contains("isinstance"),
-            "no isinstance check should appear when expectedType is nil")
-        XCTAssertFalse(
-            source.contains("__mro__"),
-            "no MRO walk should appear when expectedType is nil")
-        XCTAssertTrue(
+        #expect(source.contains("isinstance") == false, "no isinstance check should appear when expectedType is nil")
+        #expect(source.contains("__mro__") == false, "no MRO walk should appear when expectedType is nil")
+        #expect(
             source.contains("passed("),
             "must emit a pass message on success")
-        XCTAssertEqual(
-            bundle.sidecars.count, 0,
-            "variableExists never produces sidecars")
+        #expect(bundle.sidecars.isEmpty, "variableExists never produces sidecars")
     }
 
-    func testRender_withBuiltinType_emitsIsinstanceCheck() {
+    @Test func render_withBuiltinType_emitsIsinstanceCheck() {
         let check = NotebookCheck(
             id: "var_n",
             kind: .variableExists,
@@ -63,16 +57,16 @@ final class NotebookCheckVariableExistsTests: XCTestCase {
         )
         let source = renderNotebookCheck(check).script.source
 
-        XCTAssertTrue(source.contains("expected_type_name = \"int\""))
-        XCTAssertTrue(
+        #expect(source.contains("expected_type_name = \"int\""))
+        #expect(
             source.contains("isinstance(actual, int) and not isinstance(actual, bool)"),
             "int check must exclude bool (matches PatternFamilyRenderer's returnTypeCheck)")
-        XCTAssertTrue(
+        #expect(
             source.contains("has the wrong type"),
             "type mismatch failure message should be present")
     }
 
-    func testRender_withLibraryType_walksMROByName() {
+    @Test func render_withLibraryType_walksMROByName() {
         let check = NotebookCheck(
             id: "var_df",
             kind: .variableExists,
@@ -81,13 +75,13 @@ final class NotebookCheckVariableExistsTests: XCTestCase {
         )
         let source = renderNotebookCheck(check).script.source
 
-        XCTAssertTrue(
+        #expect(
             source.contains("__mro__"),
             "library types should be matched via MRO-name walk to avoid forcing imports")
-        XCTAssertTrue(source.contains(#""DataFrame""#))
+        #expect(source.contains(#""DataFrame""#))
     }
 
-    func testRender_withUnknownType_fallsBackToMROWalk() {
+    @Test func render_withUnknownType_fallsBackToMROWalk() {
         // Validator allows any non-empty type name; the renderer's MRO
         // fallback handles unknown names (student-defined classes, new
         // library types).  This mirrors `.returnTypeCheck`'s behaviour.
@@ -99,36 +93,35 @@ final class NotebookCheckVariableExistsTests: XCTestCase {
         )
         let source = renderNotebookCheck(check).script.source
 
-        XCTAssertTrue(source.contains("__mro__"))
-        XCTAssertTrue(source.contains(#""MyCustomClass""#))
+        #expect(source.contains("__mro__"))
+        #expect(source.contains(#""MyCustomClass""#))
     }
 
-    func testFilename_usesCheckPrefix_andNoSidecars() {
+    @Test func filename_usesCheckPrefix_andNoSidecars() {
         let check = NotebookCheck(
             id: "var_df", kind: .variableExists,
             tier: .release, variable: "df"
         )
         let files = notebookCheckAllGeneratedFilenames(check)
-        XCTAssertEqual(
-            files, ["releasecheck_var_df.py"],
-            "variableExists generates a single .py with the tier-prefixed name")
+        #expect(
+            files == ["releasecheck_var_df.py"], "variableExists generates a single .py with the tier-prefixed name")
     }
 
     // MARK: - Default label
 
-    func testDefaultLabel_withoutType() {
+    @Test func defaultLabel_withoutType() {
         let check = NotebookCheck(
             id: "var_results",
             kind: .variableExists,
             variable: "results"
         )
         let source = renderNotebookCheck(check).script.source
-        XCTAssertTrue(
+        #expect(
             source.contains("# Test: `results` is defined"),
             "default label should describe pure existence")
     }
 
-    func testDefaultLabel_withType() {
+    @Test func defaultLabel_withType() {
         let check = NotebookCheck(
             id: "var_df",
             kind: .variableExists,
@@ -136,62 +129,67 @@ final class NotebookCheckVariableExistsTests: XCTestCase {
             expectedType: "DataFrame"
         )
         let source = renderNotebookCheck(check).script.source
-        XCTAssertTrue(
+        #expect(
             source.contains("# Test: `df` is defined and is a DataFrame"),
             "default label should describe existence + type")
     }
 
     // MARK: - Validator
 
-    func testValidate_passesForBareExistence() throws {
+    @Test func validate_passesForBareExistence() throws {
         let checks = [
             NotebookCheck(id: "ok", kind: .variableExists, variable: "df")
         ]
-        XCTAssertNoThrow(try validateNotebookChecks(checks))
+        try validateNotebookChecks(checks)
     }
 
-    func testValidate_passesForExistencePlusType() throws {
+    @Test func validate_passesForExistencePlusType() throws {
         let checks = [
             NotebookCheck(
                 id: "ok", kind: .variableExists,
                 variable: "df", expectedType: "DataFrame")
         ]
-        XCTAssertNoThrow(try validateNotebookChecks(checks))
+        try validateNotebookChecks(checks)
     }
 
-    func testValidate_rejectsMissingVariable() {
+    @Test func validate_rejectsMissingVariable() throws {
         let checks = [
             NotebookCheck(id: "bad", kind: .variableExists, variable: nil)
         ]
-        XCTAssertThrowsError(try validateNotebookChecks(checks)) { err in
-            XCTAssertTrue("\(err)".contains("variable name is required"))
+        let error = try #require(throws: (any Error).self) {
+            try validateNotebookChecks(checks)
         }
+        #expect("\(error)".contains("variable name is required"))
     }
 
-    func testValidate_rejectsEmptyVariable() {
+    @Test func validate_rejectsEmptyVariable() {
         let checks = [
             NotebookCheck(id: "bad", kind: .variableExists, variable: "")
         ]
-        XCTAssertThrowsError(try validateNotebookChecks(checks))
-    }
-
-    func testValidate_rejectsNonIdentifierVariable() {
-        let checks = [
-            NotebookCheck(id: "bad", kind: .variableExists, variable: "1df")
-        ]
-        XCTAssertThrowsError(try validateNotebookChecks(checks)) { err in
-            XCTAssertTrue("\(err)".contains("not a valid Python identifier"))
+        #expect(throws: (any Error).self) {
+            try validateNotebookChecks(checks)
         }
     }
 
-    func testValidate_rejectsWhitespaceOnlyExpectedType() {
+    @Test func validate_rejectsNonIdentifierVariable() throws {
+        let checks = [
+            NotebookCheck(id: "bad", kind: .variableExists, variable: "1df")
+        ]
+        let error = try #require(throws: (any Error).self) {
+            try validateNotebookChecks(checks)
+        }
+        #expect("\(error)".contains("not a valid Python identifier"))
+    }
+
+    @Test func validate_rejectsWhitespaceOnlyExpectedType() throws {
         let checks = [
             NotebookCheck(
                 id: "bad", kind: .variableExists,
                 variable: "df", expectedType: "   ")
         ]
-        XCTAssertThrowsError(try validateNotebookChecks(checks)) { err in
-            XCTAssertTrue("\(err)".contains("expectedType"))
+        let error = try #require(throws: (any Error).self) {
+            try validateNotebookChecks(checks)
         }
+        #expect("\(error)".contains("expectedType"))
     }
 }

--- a/Tests/APITests/OIDCDiscoveryURLValidationTests.swift
+++ b/Tests/APITests/OIDCDiscoveryURLValidationTests.swift
@@ -3,164 +3,141 @@
 // Coverage for the OIDC_AUTH_SERVER URL validator added in issue #563.
 // Pure function tests — no network, no env munging.
 
-import XCTest
+import Testing
 
 @testable import chickadee_server
 
-final class OIDCDiscoveryURLValidationTests: XCTestCase {
+@Suite struct OIDCDiscoveryURLValidationTests {
+
+    /// `OIDCDiscoveryURLError` cases all carry an associated value, so we
+    /// pattern-match the case rather than asserting equality on a value.
+    private func isInsecureScheme(_ error: any Error) -> Bool {
+        if case OIDCDiscoveryURLError.insecureScheme = error { return true }
+        return false
+    }
+
+    private func isPrivateHost(_ error: any Error) -> Bool {
+        if case OIDCDiscoveryURLError.privateHost = error { return true }
+        return false
+    }
+
+    private func isMalformed(_ error: any Error) -> Bool {
+        if case OIDCDiscoveryURLError.malformed = error { return true }
+        return false
+    }
 
     // MARK: - Happy path
 
-    func testAccepts_httpsPublicHost() {
-        XCTAssertNoThrow(
-            try validateOIDCDiscoveryURL(
-                "https://sso.example.com/oidc/.well-known/openid-configuration",
-                allowInsecure: false
-            )
+    @Test func accepts_httpsPublicHost() throws {
+        try validateOIDCDiscoveryURL(
+            "https://sso.example.com/oidc/.well-known/openid-configuration",
+            allowInsecure: false
         )
     }
 
-    func testAccepts_httpsPublicIPv4() {
+    @Test func accepts_httpsPublicIPv4() throws {
         // A genuine public IPv4 (8.8.8.8) should pass — we only block the
         // private / loopback / link-local ranges.
-        XCTAssertNoThrow(
-            try validateOIDCDiscoveryURL(
-                "https://8.8.8.8/.well-known/openid-configuration",
-                allowInsecure: false
-            )
+        try validateOIDCDiscoveryURL(
+            "https://8.8.8.8/.well-known/openid-configuration",
+            allowInsecure: false
         )
     }
 
     // MARK: - Insecure scheme
 
-    func testRejects_httpScheme() {
-        XCTAssertThrowsError(
+    @Test func rejects_httpScheme() {
+        #expect {
             try validateOIDCDiscoveryURL(
                 "http://sso.example.com/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        ) { err in
-            guard case OIDCDiscoveryURLError.insecureScheme = err else {
-                XCTFail("Expected insecureScheme, got \(err)")
-                return
-            }
-        }
+        } throws: { isInsecureScheme($0) }
     }
 
-    func testAllowsInsecureOverride_httpScheme() {
-        XCTAssertNoThrow(
-            try validateOIDCDiscoveryURL(
-                "http://localhost:8080/.well-known/openid-configuration",
-                allowInsecure: true
-            )
+    @Test func allowsInsecureOverride_httpScheme() throws {
+        try validateOIDCDiscoveryURL(
+            "http://localhost:8080/.well-known/openid-configuration",
+            allowInsecure: true
         )
     }
 
     // MARK: - Private / loopback hosts
 
-    func testRejects_localhost() {
-        XCTAssertThrowsError(
+    @Test func rejects_localhost() {
+        #expect {
             try validateOIDCDiscoveryURL(
                 "https://localhost/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        ) { err in
-            guard case OIDCDiscoveryURLError.privateHost = err else {
-                XCTFail("Expected privateHost, got \(err)")
-                return
-            }
-        }
+        } throws: { isPrivateHost($0) }
     }
 
-    func testRejects_loopbackIPv4() {
-        XCTAssertThrowsError(
+    @Test func rejects_loopbackIPv4() {
+        #expect {
             try validateOIDCDiscoveryURL(
                 "https://127.0.0.1/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        ) { err in
-            guard case OIDCDiscoveryURLError.privateHost = err else {
-                XCTFail("Expected privateHost, got \(err)")
-                return
-            }
-        }
+        } throws: { isPrivateHost($0) }
     }
 
-    func testRejects_class10Range() {
-        XCTAssertThrowsError(
+    @Test func rejects_class10Range() {
+        #expect {
             try validateOIDCDiscoveryURL(
                 "https://10.1.2.3/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        ) { err in
-            guard case OIDCDiscoveryURLError.privateHost = err else {
-                XCTFail("Expected privateHost, got \(err)")
-                return
-            }
-        }
+        } throws: { isPrivateHost($0) }
     }
 
-    func testRejects_class192_168Range() {
-        XCTAssertThrowsError(
+    @Test func rejects_class192_168Range() {
+        #expect {
             try validateOIDCDiscoveryURL(
                 "https://192.168.1.1/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        ) { err in
-            guard case OIDCDiscoveryURLError.privateHost = err else {
-                XCTFail("Expected privateHost, got \(err)")
-                return
-            }
-        }
+        } throws: { isPrivateHost($0) }
     }
 
-    func testRejects_class172_16to31Range() {
-        XCTAssertThrowsError(
+    @Test func rejects_class172_16to31Range() {
+        #expect(throws: (any Error).self) {
             try validateOIDCDiscoveryURL(
                 "https://172.20.0.5/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        )
+        }
     }
 
-    func testAccepts_class172_outsidePrivateRange() {
+    @Test func accepts_class172_outsidePrivateRange() throws {
         // 172.32 is outside the 172.16/12 private range — must pass.
-        XCTAssertNoThrow(
-            try validateOIDCDiscoveryURL(
-                "https://172.32.0.1/.well-known/openid-configuration",
-                allowInsecure: false
-            )
+        try validateOIDCDiscoveryURL(
+            "https://172.32.0.1/.well-known/openid-configuration",
+            allowInsecure: false
         )
     }
 
-    func testRejects_linkLocal() {
-        XCTAssertThrowsError(
+    @Test func rejects_linkLocal() {
+        #expect(throws: (any Error).self) {
             try validateOIDCDiscoveryURL(
                 "https://169.254.0.1/.well-known/openid-configuration",
                 allowInsecure: false
             )
-        )
+        }
     }
 
-    func testAllowsInsecureOverride_loopbackIPv4() {
-        XCTAssertNoThrow(
-            try validateOIDCDiscoveryURL(
-                "https://127.0.0.1/.well-known/openid-configuration",
-                allowInsecure: true
-            )
+    @Test func allowsInsecureOverride_loopbackIPv4() throws {
+        try validateOIDCDiscoveryURL(
+            "https://127.0.0.1/.well-known/openid-configuration",
+            allowInsecure: true
         )
     }
 
     // MARK: - Malformed input
 
-    func testRejects_malformedURL() {
-        XCTAssertThrowsError(
+    @Test func rejects_malformedURL() {
+        #expect {
             try validateOIDCDiscoveryURL("not a url at all", allowInsecure: false)
-        ) { err in
-            guard case OIDCDiscoveryURLError.malformed = err else {
-                XCTFail("Expected malformed, got \(err)")
-                return
-            }
-        }
+        } throws: { isMalformed($0) }
     }
 }

--- a/Tests/APITests/OIDCTests.swift
+++ b/Tests/APITests/OIDCTests.swift
@@ -1,11 +1,16 @@
 import Fluent
 import JWT
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class OIDCTests: XCTestCase {
+// `.serialized` because every test mutates process env vars under a single
+// helper; without serialization the env mutations would race.  EnvTestLock
+// (cross-suite) plus this within-suite serialization keeps the env
+// snapshots intact.  TODO(migration): drop after Phase 4 if we move OIDC
+// config off env vars.
+@Suite(.serialized) struct OIDCTests {
 
     private struct EnvironmentOverride {
         let key: String
@@ -119,7 +124,7 @@ final class OIDCTests: XCTestCase {
         return (app, port)
     }
 
-    func testOIDCLoadBuildsRedirectURIAndFetchesDiscoveryFromConfiguredBaseURL() async throws {
+    @Test func oidcLoadBuildsRedirectURIAndFetchesDiscoveryFromConfiguredBaseURL() async throws {
         let provider = try await makeMockOIDCProvider(
             discoveryPath: "/oidc/test-client/.well-known/openid-configuration"
         )
@@ -136,16 +141,16 @@ final class OIDCTests: XCTestCase {
                 try await withApp(try await makeOIDCApp(publicBaseURL: "https://courses.example.edu/")) { app in
                     let config = try await OIDCConfiguration.load(from: app)
 
-                    XCTAssertEqual(config.clientID, "test-client")
-                    XCTAssertEqual(config.clientSecret, "super-secret")
-                    XCTAssertEqual(config.redirectURI, "https://courses.example.edu/oidc/callback")
-                    XCTAssertEqual(config.discovery.issuer, "http://127.0.0.1:\(provider.port)/issuer")
+                    #expect(config.clientID == "test-client")
+                    #expect(config.clientSecret == "super-secret")
+                    #expect(config.redirectURI == "https://courses.example.edu/oidc/callback")
+                    #expect(config.discovery.issuer == "http://127.0.0.1:\(provider.port)/issuer")
                 }
             }
         }
     }
 
-    func testOIDCLoadAcceptsFullyQualifiedDiscoveryURLAndDefaultCallback() async throws {
+    @Test func oidcLoadAcceptsFullyQualifiedDiscoveryURLAndDefaultCallback() async throws {
         let provider = try await makeMockOIDCProvider(
             discoveryPath: "/custom/.well-known/openid-configuration"
         )
@@ -159,13 +164,13 @@ final class OIDCTests: XCTestCase {
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
                     let config = try await OIDCConfiguration.load(from: app)
-                    XCTAssertEqual(config.redirectURI, "http://localhost:8080/auth/sso/callback")
+                    #expect(config.redirectURI == "http://localhost:8080/auth/sso/callback")
                 }
             }
         }
     }
 
-    func testOIDCLoadFailsWhenClientIDIsMissing() async throws {
+    @Test func oidcLoadFailsWhenClientIDIsMissing() async throws {
         try await withEnvironment([
             "OIDC_CLIENT_ID": "   ",
             "OIDC_CLIENT_SECRET": "super-secret",
@@ -173,15 +178,13 @@ final class OIDCTests: XCTestCase {
             "OIDC_CALLBACK": "",
         ]) {
             try await withApp(try await makeOIDCApp()) { app in
-                await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app)) { error in
-                    XCTAssertEqual((error as? AbortError)?.status, .internalServerError)
-                    XCTAssertTrue("\(error)".contains("OIDC_CLIENT_ID"))
-                }
+                await expectOIDCLoadError(
+                    from: app, abortStatus: .internalServerError, messageContains: "OIDC_CLIENT_ID")
             }
         }
     }
 
-    func testOIDCLoadFailsWhenClientSecretIsMissing() async throws {
+    @Test func oidcLoadFailsWhenClientSecretIsMissing() async throws {
         try await withEnvironment([
             "OIDC_CLIENT_ID": "test-client",
             "OIDC_CLIENT_SECRET": "   ",
@@ -189,15 +192,13 @@ final class OIDCTests: XCTestCase {
             "OIDC_CALLBACK": "",
         ]) {
             try await withApp(try await makeOIDCApp()) { app in
-                await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app)) { error in
-                    XCTAssertEqual((error as? AbortError)?.status, .internalServerError)
-                    XCTAssertTrue("\(error)".contains("OIDC_CLIENT_SECRET"))
-                }
+                await expectOIDCLoadError(
+                    from: app, abortStatus: .internalServerError, messageContains: "OIDC_CLIENT_SECRET")
             }
         }
     }
 
-    func testOIDCLoadFailsWhenDiscoveryFetchReturnsNonOKStatus() async throws {
+    @Test func oidcLoadFailsWhenDiscoveryFetchReturnsNonOKStatus() async throws {
         let provider = try await makeMockOIDCProvider(
             discoveryPath: "/oidc/test-client/.well-known/openid-configuration",
             discoveryStatus: .badGateway
@@ -210,16 +211,14 @@ final class OIDCTests: XCTestCase {
                 "OIDC_ALLOW_INSECURE": "true",
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
-                    await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app)) { error in
-                        XCTAssertEqual((error as? AbortError)?.status, .internalServerError)
-                        XCTAssertTrue("\(error)".contains("OIDC discovery failed"))
-                    }
+                    await expectOIDCLoadError(
+                        from: app, abortStatus: .internalServerError, messageContains: "OIDC discovery failed")
                 }
             }
         }
     }
 
-    func testOIDCLoadFailsWhenJWKSFetchReturnsNonOKStatus() async throws {
+    @Test func oidcLoadFailsWhenJWKSFetchReturnsNonOKStatus() async throws {
         let provider = try await makeMockOIDCProvider(
             discoveryPath: "/oidc/test-client/.well-known/openid-configuration",
             jwksStatus: .serviceUnavailable
@@ -232,16 +231,14 @@ final class OIDCTests: XCTestCase {
                 "OIDC_ALLOW_INSECURE": "true",
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
-                    await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app)) { error in
-                        XCTAssertEqual((error as? AbortError)?.status, .internalServerError)
-                        XCTAssertTrue("\(error)".contains("OIDC JWKS fetch failed"))
-                    }
+                    await expectOIDCLoadError(
+                        from: app, abortStatus: .internalServerError, messageContains: "OIDC JWKS fetch failed")
                 }
             }
         }
     }
 
-    func testOIDCLoadFailsWhenJWKSIsMalformed() async throws {
+    @Test func oidcLoadFailsWhenJWKSIsMalformed() async throws {
         let provider = try await makeMockOIDCProvider(
             discoveryPath: "/oidc/test-client/.well-known/openid-configuration",
             jwksBody: "not-json"
@@ -253,13 +250,15 @@ final class OIDCTests: XCTestCase {
                 "OIDC_AUTH_SERVER": "http://127.0.0.1:\(provider.port)/oidc/test-client",
             ]) {
                 try await withApp(try await makeOIDCApp()) { app in
-                    await XCTAssertThrowsErrorAsync(try await OIDCConfiguration.load(from: app))
+                    await #expect(throws: (any Error).self) {
+                        try await OIDCConfiguration.load(from: app)
+                    }
                 }
             }
         }
     }
 
-    func testOIDCIDTokenClaimsVerifyAcceptsNonExpiredTokens() async throws {
+    @Test func oidcIDTokenClaimsVerifyAcceptsNonExpiredTokens() async throws {
         let claims = OIDCIDTokenClaims(
             sub: .init(value: "subject"),
             iss: .init(value: "https://issuer.example"),
@@ -277,7 +276,7 @@ final class OIDCTests: XCTestCase {
         try await claims.verify(using: NoOpJWTAlgorithm())
     }
 
-    func testOIDCIDTokenClaimsVerifyRejectsExpiredTokens() async throws {
+    @Test func oidcIDTokenClaimsVerifyRejectsExpiredTokens() async throws {
         let claims = OIDCIDTokenClaims(
             sub: .init(value: "subject"),
             iss: .init(value: "https://issuer.example"),
@@ -286,20 +285,26 @@ final class OIDCTests: XCTestCase {
             iat: .init(value: Date().addingTimeInterval(-600))
         )
 
-        await XCTAssertThrowsErrorAsync(try await claims.verify(using: NoOpJWTAlgorithm()))
+        await #expect(throws: (any Error).self) {
+            try await claims.verify(using: NoOpJWTAlgorithm())
+        }
     }
-}
 
-private func XCTAssertThrowsErrorAsync<T>(
-    _ expression: @autoclosure () async throws -> T,
-    _ errorHandler: (Error) -> Void = { _ in },
-    file: StaticString = #filePath,
-    line: UInt = #line
-) async {
-    do {
-        _ = try await expression()
-        XCTFail("Expected error to be thrown", file: file, line: line)
-    } catch {
-        errorHandler(error)
+    // MARK: - Async throw helpers
+
+    /// Runs `OIDCConfiguration.load(from:)` and asserts it throws an `AbortError`
+    /// with the given status whose message contains `messageContains`.
+    private func expectOIDCLoadError(
+        from app: Application,
+        abortStatus: HTTPResponseStatus,
+        messageContains: String
+    ) async {
+        do {
+            _ = try await OIDCConfiguration.load(from: app)
+            Issue.record("Expected OIDCConfiguration.load to throw")
+        } catch {
+            #expect((error as? AbortError)?.status == abortStatus)
+            #expect("\(error)".contains(messageContains))
+        }
     }
 }

--- a/Tests/APITests/OIDCTests.swift
+++ b/Tests/APITests/OIDCTests.swift
@@ -49,15 +49,21 @@ import XCTVapor
 
     private func withEnvironment(
         _ values: [String: String?],
-        perform operation: () async throws -> Void
-    ) async rethrows {
-        let overrides = values.map { EnvironmentOverride(key: $0.key, value: $0.value) }
-        defer {
-            for override in overrides.reversed() {
-                override.restore()
+        perform operation: @Sendable () async throws -> Void
+    ) async throws {
+        // Cross-suite env serialization: AuthModeGatingTests, AppConfigTests,
+        // DatabaseConfigurationTests also mutate env vars.  Without this lock
+        // their setenv/unsetenv races have shown up as OIDC tests reading
+        // wrong values mid-test (#603 first run).
+        try await withAsyncEnvLock {
+            let overrides = values.map { EnvironmentOverride(key: $0.key, value: $0.value) }
+            defer {
+                for override in overrides.reversed() {
+                    override.restore()
+                }
             }
+            try await operation()
         }
-        try await operation()
     }
 
     private func makeOIDCApp(publicBaseURL: String? = nil) async throws -> Application {

--- a/scripts/xctest-allowlist.txt
+++ b/scripts/xctest-allowlist.txt
@@ -8,9 +8,6 @@ Tests/APITests/AssignmentRoutesNotebookTests.swift
 Tests/APITests/AssignmentRoutesPublishTests.swift
 Tests/APITests/AssignmentRoutesRetestTests.swift
 Tests/APITests/AssignmentRoutesTestCase.swift
-Tests/APITests/NotebookCheckVariableExistsTests.swift
-Tests/APITests/OIDCDiscoveryURLValidationTests.swift
-Tests/APITests/OIDCTests.swift
 Tests/APITests/PatternFamilyApplyTests.swift
 Tests/APITests/PatternFamilyKindsTests.swift
 Tests/APITests/PatternFamilyRendererTests.swift


### PR DESCRIPTION
## Summary

Closes out Phase 2 of the Swift Testing migration. Migrates the 3 files
that were deferred from #601 (Phase 2A) because their heavy use of
`XCTAssertThrowsError` + `XCTAssertNoThrow` + a custom
`XCTAssertThrowsErrorAsync` helper required careful per-test conversion.

**Files (3, all APITests):**
- `OIDCDiscoveryURLValidationTests`
- `NotebookCheckVariableExistsTests`
- `OIDCTests`

## Notable conversions

- `XCTAssertNoThrow(try foo())` → drop the wrapper, let `try foo()`
  propagate via `throws` on the test method (cleaner than
  `#expect(throws: Never.self)`).
- `XCTAssertThrowsError(try foo())` → `#expect(throws: (any Error).self) { try foo() }`.
- `XCTAssertThrowsError(try foo()) { error in <inspect> }` →
  `try #require(throws: (any Error).self) { try foo() }`, then `#expect` on the captured error.
- Enum cases with associated values (e.g.
  `OIDCDiscoveryURLError.insecureScheme(url:)`) use the
  `#expect { ... } throws: { error in ... }` form with a per-case
  matcher (`isInsecureScheme(_:)`) since `#expect(throws: VALUE)`
  requires Equatable, not case constructors.
- Custom `XCTAssertThrowsErrorAsync` helper replaced with a private
  `expectOIDCLoadError(from:abortStatus:messageContains:)` using Swift
  Testing primitives.
- `OIDCTests` annotated `@Suite(.serialized)` (every test mutates
  process env vars).

## Allowlist

`scripts/xctest-allowlist.txt`: 38 → 35. Swift Testing files: 69 → 72
(~67% of 108). **Bucket B is now empty** — remaining XCTest files are
all Bucket C (shared base classes + subclasses).

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `scripts/swiftlint.sh --strict` passes
- [x] `scripts/no-new-xctest.sh` passes
- [x] APITests / WorkerTests / CoreTests green locally (636 / 102 / 105)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)