### PR TITLE
test: Phase 3 — withWebRoutesApp helper + 1 pilot consumer

### DIFF
--- a/Tests/APITests/WebRoutesHelpers.swift
+++ b/Tests/APITests/WebRoutesHelpers.swift
@@ -1,0 +1,238 @@
+// Tests/APITests/WebRoutesHelpers.swift
+//
+// Free-function versions of the helpers previously hosted on
+// WebRoutesTestCase.  Swift Testing class suites don't subclass
+// XCTestCase, so the shared base-class pattern is replaced with
+// `app`-taking helpers that any suite can call.
+//
+// Tests opt in by wrapping their body in `try await withWebRoutesApp { app in ... }`.
+// See `WebRoutesSubmitHistoryTests` for the consumer pattern.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import chickadee_server
+
+/// Stands up a Vapor app configured for the WebRoutes test suite and
+/// runs the supplied body against it.  The app is shut down before the
+/// closure returns (success or failure), so per-test cleanup is
+/// deterministic.
+func withWebRoutesApp(
+    prefix: String = "chickadee-wrt",
+    _ body: (Application) async throws -> Void
+) async throws {
+    let app = try await makeTestApp(prefix: prefix)
+    try await withApp(app, body)
+}
+
+// MARK: - Auth helpers
+
+func wrLoginAsStudent(on app: Application) async throws -> String {
+    try await loginUser(username: "student1", password: "pass", role: "student", on: app)
+}
+
+func wrLoginAsInstructor(on app: Application) async throws -> String {
+    try await loginUser(username: "instructor1", password: "pass", role: "instructor", on: app)
+}
+
+// MARK: - Seeding helpers
+
+func wrStudentUser(on app: Application) async throws -> APIUser {
+    try #require(try await APIUser.query(on: app.db).filter(\.$username == "student1").first())
+}
+
+func wrMakeCourse(on app: Application) async throws -> APICourse {
+    if let existing = try await APICourse.query(on: app.db).filter(\.$code == "CS101").first() {
+        return existing
+    }
+    let course = APICourse(code: "CS101", name: "Intro CS")
+    try await course.save(on: app.db)
+    return course
+}
+
+func wrEnrollUser(_ user: APIUser, on app: Application) async throws {
+    let course = try await wrMakeCourse(on: app)
+    let courseID = try course.requireID()
+    let userID = try user.requireID()
+    if try await APICourseEnrollment.query(on: app.db)
+        .filter(\.$userID == userID)
+        .filter(\.$course.$id == courseID)
+        .first() == nil
+    {
+        let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
+        try await enrollment.save(on: app.db)
+    }
+}
+
+@discardableResult
+func wrInsertSetup(id: String, on app: Application) async throws -> APITestSetup {
+    let manifest = """
+        {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+        """
+    let course = try await wrMakeCourse(on: app)
+    let courseID = try course.requireID()
+    let setup = APITestSetup(
+        id: id, manifest: manifest, zipPath: app.testSetupsDirectory + "\(id).zip", courseID: courseID)
+    try await setup.save(on: app.db)
+    return setup
+}
+
+@discardableResult
+func wrInsertAssignment(
+    testSetupID: String,
+    title: String,
+    isOpen: Bool,
+    dueAt: Date? = nil,
+    on app: Application
+) async throws -> APIAssignment {
+    let course = try await wrMakeCourse(on: app)
+    let courseID = try course.requireID()
+    let a = APIAssignment(testSetupID: testSetupID, title: title, dueAt: dueAt, isOpen: isOpen, courseID: courseID)
+    try await a.save(on: app.db)
+    return a
+}
+
+@discardableResult
+func wrInsertSubmission(
+    id: String,
+    testSetupID: String,
+    userID: UUID,
+    attemptNumber: Int = 1,
+    status: String = "complete",
+    filename: String? = nil,
+    on app: Application
+) async throws -> APISubmission {
+    let sub = APISubmission(
+        id: id,
+        testSetupID: testSetupID,
+        zipPath: app.submissionsDirectory + "\(id).py",
+        attemptNumber: attemptNumber,
+        status: status,
+        filename: filename,
+        userID: userID,
+        kind: APISubmission.Kind.student
+    )
+    try await sub.save(on: app.db)
+    return sub
+}
+
+func wrMakeOutcome(
+    name: String,
+    tier: TestTier = .pub,
+    status: TestStatus = .pass,
+    shortResult: String? = nil,
+    longResult: String? = nil
+) -> TestOutcome {
+    TestOutcome(
+        testName: name,
+        testClass: nil,
+        tier: tier,
+        status: status,
+        shortResult: shortResult ?? (status == .pass ? "passed" : "failed"),
+        longResult: status == .pass ? longResult : (longResult ?? "test output here"),
+        executionTimeMs: 10,
+        memoryUsageBytes: nil,
+        attemptNumber: 1,
+        isFirstPassSuccess: status == .pass
+    )
+}
+
+func wrMakeCollection(
+    submissionID: String,
+    outcomes: [TestOutcome] = [],
+    warnings: [String] = []
+) -> TestOutcomeCollection {
+    TestOutcomeCollection(
+        submissionID: submissionID,
+        testSetupID: "setup_001",
+        attemptNumber: 1,
+        buildStatus: .passed,
+        compilerOutput: nil,
+        outcomes: outcomes,
+        totalTests: outcomes.count,
+        passCount: outcomes.filter { $0.status == .pass }.count,
+        failCount: outcomes.filter { $0.status == .fail }.count,
+        errorCount: outcomes.filter { $0.status == .error }.count,
+        timeoutCount: outcomes.filter { $0.status == .timeout }.count,
+        executionTimeMs: 100,
+        warnings: warnings,
+        runnerVersion: "shell-runner/1.0",
+        timestamp: Date(timeIntervalSince1970: 0)
+    )
+}
+
+@discardableResult
+func wrInsertResult(
+    submissionID: String,
+    outcomes: [TestOutcome] = [],
+    warnings: [String] = [],
+    source: String = "worker",
+    on app: Application
+) async throws -> APIResult {
+    let collection = wrMakeCollection(submissionID: submissionID, outcomes: outcomes, warnings: warnings)
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let json = try String(data: encoder.encode(collection), encoding: .utf8) ?? ""
+    let result = APIResult(
+        id: "res_\(UUID().uuidString.lowercased().prefix(8))",
+        submissionID: submissionID,
+        collectionJSON: json,
+        source: source
+    )
+    try await result.save(on: app.db)
+    return result
+}
+
+func wrSubmitMultipartBody(boundary: String, csrfToken: String) -> ByteBuffer {
+    var buf = ByteBufferAllocator().buffer(capacity: 1024)
+    buf.writeString("--\(boundary)\r\n")
+    buf.writeString("Content-Disposition: form-data; name=\"_csrf\"\r\n\r\n")
+    buf.writeString(csrfToken)
+    buf.writeString("\r\n")
+    buf.writeString("--\(boundary)\r\n")
+    buf.writeString("Content-Disposition: form-data; name=\"files\"; filename=\"submission.py\"\r\n")
+    buf.writeString("Content-Type: text/x-python\r\n\r\n")
+    buf.writeString("print('hello')\n")
+    buf.writeString("\r\n")
+    buf.writeString("--\(boundary)--\r\n")
+    return buf
+}
+
+/// Submit one file as `username` (creating the user with `role` if
+/// it doesn't exist, enrolling them, and POSTing through the same
+/// `/testsetups/:id/submit` path students use).
+func wrSubmitOnceAs(
+    username: String,
+    role: String,
+    setupID: String,
+    on app: Application
+) async throws {
+    let cookie = try await loginUser(
+        username: username, password: "pass", role: role, on: app
+    )
+    let user = try #require(
+        try await APIUser.query(on: app.db).filter(\.$username == username).first(),
+        "Could not find user \(username) after loginUser"
+    )
+    try await wrEnrollUser(user, on: app)
+    let (csrf, sessionCookie) = try await csrfFields(
+        for: "/testsetups/\(setupID)/submit", cookie: cookie, on: app
+    )
+    let boundary = "badge-test-boundary-\(username)"
+    try await app.asyncTest(
+        .POST, "/testsetups/\(setupID)/submit",
+        beforeRequest: { req in
+            req.headers.add(name: .cookie, value: sessionCookie)
+            req.headers.contentType = HTTPMediaType(
+                type: "multipart", subType: "form-data",
+                parameters: ["boundary": boundary]
+            )
+            req.body = .init(buffer: wrSubmitMultipartBody(boundary: boundary, csrfToken: csrf))
+        },
+        afterResponse: { res in
+            #expect(res.status == .seeOther, "Submit should redirect on success (got \(res.status))")
+        })
+}

--- a/Tests/APITests/WebRoutesSubmitHistoryTests.swift
+++ b/Tests/APITests/WebRoutesSubmitHistoryTests.swift
@@ -1,123 +1,135 @@
 // Tests/APITests/WebRoutesSubmitHistoryTests.swift
 //
-// Split from WebRoutesTests.swift.  See WebRoutesTestCase.swift for
-// shared helpers (auth, seeding, submitMultipartBody, submitOnceAs).
+// Split from WebRoutesTests.swift.  See WebRoutesHelpers.swift for the
+// `withWebRoutesApp` lifecycle wrapper and free-function helpers (auth,
+// seeding, submitMultipartBody, submitOnceAs).
 
 import Core
 import Fluent
 import Foundation
+import Testing
 import XCTVapor
-import XCTest
 
 @testable import chickadee_server
 
-final class WebRoutesSubmitHistoryTests: WebRoutesTestCase {
+@Suite struct WebRoutesSubmitHistoryTests {
 
     // MARK: - GET /testsetups/:id/submit
 
-    func testSubmitFormRendersForStudent() async throws {
-        let cookie = try await loginAsStudent()
-        let user = try await studentUser()
-        try await enrollUser(user)
-        try await insertSetup(id: "setup_sub")
+    @Test func submitFormRendersForStudent() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_sub", on: app)
 
-        try await app.asyncTest(
-            .GET, "/testsetups/setup_sub/submit",
-            beforeRequest: { req in
-                req.headers.add(name: .cookie, value: cookie)
-            },
-            afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
-            })
+            try await app.asyncTest(
+                .GET, "/testsetups/setup_sub/submit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                })
+        }
     }
 
-    func testSubmitForm404ForMissingSetup() async throws {
-        let cookie = try await loginAsStudent()
+    @Test func submitForm404ForMissingSetup() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
 
-        try await app.asyncTest(
-            .GET, "/testsetups/nonexistent/submit",
-            beforeRequest: { req in
-                req.headers.add(name: .cookie, value: cookie)
-            },
-            afterResponse: { res in
-                XCTAssertEqual(res.status, .notFound)
-            })
+            try await app.asyncTest(
+                .GET, "/testsetups/nonexistent/submit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .notFound)
+                })
+        }
     }
 
-    func testSubmitPostRejectsOverdueAssignmentsAndPersistsClosure() async throws {
-        let cookie = try await loginAsStudent()
-        let user = try await studentUser()
-        try await enrollUser(user)
-        _ = try await insertSetup(id: "setup_submit_overdue")
-        let assignment = try await insertAssignment(
-            testSetupID: "setup_submit_overdue",
-            title: "Late Lab",
-            isOpen: true,
-            dueAt: Date().addingTimeInterval(-60)
-        )
+    @Test func submitPostRejectsOverdueAssignmentsAndPersistsClosure() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            try await wrEnrollUser(user, on: app)
+            _ = try await wrInsertSetup(id: "setup_submit_overdue", on: app)
+            let assignment = try await wrInsertAssignment(
+                testSetupID: "setup_submit_overdue",
+                title: "Late Lab",
+                isOpen: true,
+                dueAt: Date().addingTimeInterval(-60),
+                on: app
+            )
 
-        let (csrf, sessionCookie) = try await csrfFields(
-            for: "/testsetups/setup_submit_overdue/submit",
-            cookie: cookie,
-            on: app
-        )
-        let boundary = "late-submit-boundary"
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/testsetups/setup_submit_overdue/submit",
+                cookie: cookie,
+                on: app
+            )
+            let boundary = "late-submit-boundary"
 
-        try await app.asyncTest(
-            .POST, "/testsetups/setup_submit_overdue/submit",
-            beforeRequest: { req in
-                req.headers.add(name: .cookie, value: sessionCookie)
-                req.headers.contentType = HTTPMediaType(
-                    type: "multipart",
-                    subType: "form-data",
-                    parameters: ["boundary": boundary]
-                )
-                req.body = .init(buffer: submitMultipartBody(boundary: boundary, csrfToken: csrf))
-            },
-            afterResponse: { res in
-                XCTAssertEqual(res.status, .forbidden)
-                XCTAssertTrue(res.body.string.contains("closed"))
-            })
+            try await app.asyncTest(
+                .POST, "/testsetups/setup_submit_overdue/submit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart",
+                        subType: "form-data",
+                        parameters: ["boundary": boundary]
+                    )
+                    req.body = .init(buffer: wrSubmitMultipartBody(boundary: boundary, csrfToken: csrf))
+                },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                    #expect(res.body.string.contains("closed"))
+                })
 
-        let refreshedOptional = try await APIAssignment.find(assignment.id, on: app.db)
-        XCTAssertNotNil(refreshedOptional)
-        let refreshed = refreshedOptional!
-        XCTAssertFalse(refreshed.isOpen)
+            let refreshed = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(!refreshed.isOpen)
+        }
     }
 
     // MARK: - GET /testsetups/:id/history
 
-    func testHistoryShowsSubmissions() async throws {
-        let cookie = try await loginAsStudent()
-        let user = try await studentUser()
-        let userID = try user.requireID()
-        try await insertSetup(id: "setup_hist")
-        try await insertAssignment(testSetupID: "setup_hist", title: "History Test", isOpen: true)
-        try await insertSubmission(id: "sub_h1", testSetupID: "setup_hist", userID: userID, attemptNumber: 1)
-        try await insertSubmission(id: "sub_h2", testSetupID: "setup_hist", userID: userID, attemptNumber: 2)
+    @Test func historyShowsSubmissions() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrInsertSetup(id: "setup_hist", on: app)
+            try await wrInsertAssignment(testSetupID: "setup_hist", title: "History Test", isOpen: true, on: app)
+            try await wrInsertSubmission(
+                id: "sub_h1", testSetupID: "setup_hist", userID: userID, attemptNumber: 1, on: app)
+            try await wrInsertSubmission(
+                id: "sub_h2", testSetupID: "setup_hist", userID: userID, attemptNumber: 2, on: app)
 
-        try await app.asyncTest(
-            .GET, "/testsetups/setup_hist/history",
-            beforeRequest: { req in
-                req.headers.add(name: .cookie, value: cookie)
-            },
-            afterResponse: { res in
-                XCTAssertEqual(res.status, .ok)
-                let html = res.body.string
-                XCTAssertTrue(html.contains("History Test"), "Should show assignment title")
-            })
+            try await app.asyncTest(
+                .GET, "/testsetups/setup_hist/history",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("History Test"), "Should show assignment title")
+                })
+        }
     }
 
-    func testHistory404ForMissingSetup() async throws {
-        let cookie = try await loginAsStudent()
+    @Test func history404ForMissingSetup() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
 
-        try await app.asyncTest(
-            .GET, "/testsetups/nonexistent/history",
-            beforeRequest: { req in
-                req.headers.add(name: .cookie, value: cookie)
-            },
-            afterResponse: { res in
-                XCTAssertEqual(res.status, .notFound)
-            })
+            try await app.asyncTest(
+                .GET, "/testsetups/nonexistent/history",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .notFound)
+                })
+        }
     }
 }

--- a/scripts/xctest-allowlist.txt
+++ b/scripts/xctest-allowlist.txt
@@ -24,7 +24,6 @@ Tests/APITests/TestScriptTemplatesTests.swift
 Tests/APITests/WebRoutesBadgeTests.swift
 Tests/APITests/WebRoutesIndexTests.swift
 Tests/APITests/WebRoutesSubmissionPageTests.swift
-Tests/APITests/WebRoutesSubmitHistoryTests.swift
 Tests/APITests/WebRoutesTestCase.swift
 Tests/APITests/WorkerRoutesTests.swift
 Tests/APITests/ZipUploadValidationTests.swift


### PR DESCRIPTION
## Summary

Introduces the free-function helper infrastructure that replaces the
`WebRoutesTestCase` shared base class.  Swift Testing class suites don't
subclass `XCTestCase`, so the inheritance-based pattern doesn't apply;
this PR ships the replacement plumbing and migrates one consumer file
(`WebRoutesSubmitHistoryTests`) to validate the API before Phase 4
migrates the rest.

## Added: `Tests/APITests/WebRoutesHelpers.swift`

- `withWebRoutesApp { app in ... }` — owns the per-test app lifecycle.
- `wr*` free functions — `wrLoginAsStudent(on:)`, `wrInsertSetup(id:on:)`,
  `wrInsertAssignment(...:on:)`, `wrInsertSubmission(...:on:)`,
  `wrMakeOutcome(...)`, `wrMakeCollection(...)`, `wrInsertResult(...:on:)`,
  `wrSubmitMultipartBody(...)`, `wrSubmitOnceAs(username:role:setupID:on:)`.

## Migrated: WebRoutesSubmitHistoryTests (5 tests)

```swift
@Suite struct WebRoutesSubmitHistoryTests {
    @Test func submitFormRendersForStudent() async throws {
        try await withWebRoutesApp { app in
            let cookie = try await wrLoginAsStudent(on: app)
            // ...
        }
    }
}
```

`WebRoutesTestCase` and the three remaining subclasses (Index, Badge,
SubmissionPage) stay on XCTest for Phase 4. The `wr*` helpers and the
old `WebRoutesTestCase` methods coexist during the migration window;
the base class will be deleted at the end of Phase 4.

## Allowlist

`scripts/xctest-allowlist.txt`: 35 → 34. Swift Testing: 72 → 74
(~69% of 108).

## Test plan

- [x] `scripts/lint.sh` passes
- [x] `scripts/swiftlint.sh --strict` passes
- [x] `scripts/no-new-xctest.sh` passes
- [x] APITests / WorkerTests / CoreTests green locally (641 / 102 / 105)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)