### PR TITLE
test(lint): enable non_optional_string_data_conversion in Tests/

### DIFF
--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -17,14 +17,6 @@ disabled_rules:
   # does, the test failure is the right signal."
   - force_try
   - force_cast
-  # `non_optional_string_data_conversion` flags
-  # `<string>.data(using: .utf8)` and suggests `Data(<string>.utf8)`.
-  # All 29 violations are in test fixtures with controlled multi-line
-  # `"""…"""` literals where `.data(using: .utf8)!` is the standard
-  # idiom.  The transformation would require wrapping every fixture in
-  # `Data(... .utf8)` for negligible benefit.  The companion
-  # force_unwrapping exemption above covers the same reasoning.
-  - non_optional_string_data_conversion
   # `type_body_length` is disabled for tests: large XCTest classes
   # (WorkerDaemonTests at 800 lines, AssignmentRoutesPublishTests at
   # 700+, etc.) group dozens of related tests by area.  Splitting them

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -510,7 +510,7 @@ import XCTVapor
               {"cell_type":"code","source":["x = 1"],"metadata":{},"outputs":[]}
             ]}
             """
-        return json.data(using: .utf8)!
+        return Data(json.utf8)
     }
 
     private func multipartBody(

--- a/Tests/APITests/GlobalInputsTests.swift
+++ b/Tests/APITests/GlobalInputsTests.swift
@@ -354,9 +354,10 @@ import Testing
     }
 
     @Test func testProperties_missingGlobalVariablesDecodesAsEmpty() throws {
-        let json = #"""
+        let json = Data(
+            #"""
             {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}
-            """#.data(using: .utf8)!
+            """#.utf8)
         let decoded = try JSONDecoder().decode(TestProperties.self, from: json)
         #expect(decoded.globalVariables.isEmpty)
     }

--- a/Tests/APITests/JupyterLiteContentsRoutesTests.swift
+++ b/Tests/APITests/JupyterLiteContentsRoutesTests.swift
@@ -50,9 +50,10 @@ import XCTVapor
     @Test func allJSONListsNotebook() async throws {
         try await withApp(app) { _ in
             let notebookName = "setup_test-assignment.ipynb"
-            let notebookData = """
+            let notebookData = Data(
+                """
                 {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}
-                """.data(using: .utf8)!
+                """.utf8)
             try notebookData.write(to: URL(fileURLWithPath: publicDir + "jupyterlite/files/" + notebookName))
 
             try await app.asyncTest(
@@ -75,7 +76,7 @@ import XCTVapor
             let notebookJSON = """
                 {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[{"cell_type":"markdown","metadata":{},"source":["hello"]}]}
                 """
-            try notebookJSON.data(using: .utf8)!.write(
+            try Data(notebookJSON.utf8).write(
                 to: URL(fileURLWithPath: publicDir + "jupyterlite/files/" + notebookName)
             )
 

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -52,7 +52,7 @@ import XCTVapor
         // Write a dummy zip (the flat .ipynb takes priority in getAssignment).
         let dummyZipPath = app.testSetupsDirectory + "\(setupID).zip"
         try Data().write(to: URL(fileURLWithPath: dummyZipPath))
-        try notebookJSON.data(using: .utf8)!.write(to: URL(fileURLWithPath: notebookPath))
+        try Data(notebookJSON.utf8).write(to: URL(fileURLWithPath: notebookPath))
 
         let courseID = try await app.testCourseID(enrollmentMode: .auto)
         let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: dummyZipPath, courseID: courseID)
@@ -260,7 +260,7 @@ import XCTVapor
                   {"cell_type":"code","source":["x = 99"],"metadata":{},"outputs":[]}
                 ]}
                 """
-            let studentNotebookData = studentNotebookJSON.data(using: .utf8)!
+            let studentNotebookData = Data(studentNotebookJSON.utf8)
 
             // Build a minimal valid TestOutcomeCollection JSON.
             let collectionJSON = """
@@ -341,7 +341,7 @@ import XCTVapor
             let cookie = try await loginAsStudent()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
 
-            let notebookData = mixedNotebookJSON.data(using: .utf8)!
+            let notebookData = Data(mixedNotebookJSON.utf8)
             let collectionJSON = """
                 {"submissionID":"","testSetupID":"\(setupID)","attemptNumber":1,
                  "buildStatus":"passed","compilerOutput":null,"outcomes":[],
@@ -423,7 +423,7 @@ import XCTVapor
                   {"cell_type":"code","source":["y = 77"],"metadata":{},"outputs":[]}
                 ]}
                 """
-            let studentNotebookData = studentNotebookJSON.data(using: .utf8)!
+            let studentNotebookData = Data(studentNotebookJSON.utf8)
 
             var savedSubID = ""
 

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -113,7 +113,7 @@ import XCTVapor
         let notebookPath = tmpDir + "testsetups/\(id).ipynb"
         let entries = zipEntries.isEmpty ? [("assignment.ipynb", notebookJSON)] : zipEntries
         try makeZipAt(zipPath: zipPath, entries: entries)
-        try notebookJSON.data(using: .utf8)!.write(to: URL(fileURLWithPath: notebookPath))
+        try Data(notebookJSON.utf8).write(to: URL(fileURLWithPath: notebookPath))
 
         let setup = APITestSetup(
             id: id,
@@ -153,7 +153,7 @@ import XCTVapor
         attemptNumber: Int = 1
     ) async throws -> APISubmission {
         let path = tmpDir + "submissions/\(id).ipynb"
-        try notebookJSON.data(using: .utf8)!.write(to: URL(fileURLWithPath: path))
+        try Data(notebookJSON.utf8).write(to: URL(fileURLWithPath: path))
         let submission = APISubmission(
             id: id,
             testSetupID: testSetupID,
@@ -341,8 +341,7 @@ import XCTVapor
                 atPath: (workingCopy as NSString).deletingLastPathComponent,
                 withIntermediateDirectories: true
             )
-            try notebookJSON(markdown: "Saved working copy")
-                .data(using: .utf8)!
+            try Data(notebookJSON(markdown: "Saved working copy").utf8)
                 .write(to: URL(fileURLWithPath: workingCopy))
 
             try await app.asyncTest(
@@ -386,8 +385,7 @@ import XCTVapor
                 atPath: (staleCopyPath as NSString).deletingLastPathComponent,
                 withIntermediateDirectories: true
             )
-            try notebookJSON(markdown: "Stale working copy")
-                .data(using: .utf8)!
+            try Data(notebookJSON(markdown: "Stale working copy").utf8)
                 .write(to: URL(fileURLWithPath: staleCopyPath))
 
             try await app.asyncTest(
@@ -436,7 +434,7 @@ import XCTVapor
 
             let sharedDir = tmpDir + "testsetups/shared/\(setupID)/"
             try FileManager.default.createDirectory(atPath: sharedDir, withIntermediateDirectories: true)
-            try "def bmi():\n    return 22\n".data(using: .utf8)!.write(
+            try Data("def bmi():\n    return 22\n".utf8).write(
                 to: URL(fileURLWithPath: sharedDir + "bmi.py")
             )
 

--- a/Tests/CoreTests/CoreCodableTests.swift
+++ b/Tests/CoreTests/CoreCodableTests.swift
@@ -41,7 +41,8 @@ struct CoreCodableTests {
     // MARK: - TestOutcome — custom decoder (points defaults to 1)
 
     @Test func testOutcomePointsDefaultsToOne() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "testName": "testFoo",
               "tier": "public",
@@ -51,7 +52,7 @@ struct CoreCodableTests {
               "attemptNumber": 1,
               "isFirstPassSuccess": true
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let outcome = try decoder.decode(TestOutcome.self, from: json)
         #expect(outcome.points == 1)
@@ -61,7 +62,8 @@ struct CoreCodableTests {
     }
 
     @Test func testOutcomeExplicitPoints() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "testName": "testBar",
               "tier": "release",
@@ -73,7 +75,7 @@ struct CoreCodableTests {
               "attemptNumber": 2,
               "isFirstPassSuccess": false
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let outcome = try decoder.decode(TestOutcome.self, from: json)
         #expect(outcome.points == 3)
@@ -104,7 +106,8 @@ struct CoreCodableTests {
 
     @Test func collectionTotalPointsFallsBackToTotalTests() throws {
         // Old JSON without totalPoints/earnedPoints/warnings/jobStartedAt
-        let json = """
+        let json = Data(
+            """
             {
               "submissionID": "sub_001",
               "testSetupID": "setup_001",
@@ -120,7 +123,7 @@ struct CoreCodableTests {
               "runnerVersion": "shell-runner/1.0",
               "timestamp": "1970-01-01T00:00:00Z"
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let col = try decoder.decode(TestOutcomeCollection.self, from: json)
         #expect(col.totalPoints == 5)  // falls back to totalTests
@@ -179,9 +182,10 @@ struct CoreCodableTests {
     @Test func jobRoundTrip() throws {
         let manifest = try decoder.decode(
             TestProperties.self,
-            from: """
+            from: Data(
+                """
                 { "schemaVersion": 1, "testSuites": [], "timeLimitSeconds": 5 }
-                """.data(using: .utf8)!)
+                """.utf8))
 
         let job = Job(
             submissionID: "sub_job",
@@ -205,9 +209,10 @@ struct CoreCodableTests {
     @Test func jobSubmissionFilenameNilRoundTrip() throws {
         let manifest = try decoder.decode(
             TestProperties.self,
-            from: """
+            from: Data(
+                """
                 { "schemaVersion": 1, "testSuites": [], "timeLimitSeconds": 10 }
-                """.data(using: .utf8)!)
+                """.utf8))
 
         let job = Job(
             submissionID: "sub_zip",
@@ -342,7 +347,7 @@ struct CoreCodableTests {
               "expectedColumns": ["a", "b"]
             }
             """
-        let decoded = try decoder.decode(NotebookCheck.self, from: json.data(using: .utf8)!)
+        let decoded = try decoder.decode(NotebookCheck.self, from: Data(json.utf8))
         #expect(decoded.columnMatch == nil)
     }
 
@@ -579,7 +584,7 @@ struct CoreCodableTests {
               "expectedCSV": "a,b\\n1,2\\n"
             }
             """
-        let decoded = try decoder.decode(NotebookCheck.self, from: json.data(using: .utf8)!)
+        let decoded = try decoder.decode(NotebookCheck.self, from: Data(json.utf8))
         #expect(decoded.checkDtype == nil)
         #expect(decoded.checkLike == nil)
         #expect(decoded.rtol == nil)
@@ -607,9 +612,10 @@ struct CoreCodableTests {
         // decoder must default to [].
         let manifest = try decoder.decode(
             TestProperties.self,
-            from: """
+            from: Data(
+                """
                 { "schemaVersion": 1, "testSuites": [], "timeLimitSeconds": 10 }
-                """.data(using: .utf8)!)
+                """.utf8))
         #expect(manifest.notebookChecks.isEmpty)
     }
 
@@ -704,7 +710,8 @@ struct CoreCodableTests {
         // Older runners predate the disk-usage fields. Verify the synthesized
         // Codable decoder still accepts those payloads with the new optional
         // fields landing as nil.
-        let legacyJSON = """
+        let legacyJSON = Data(
+            """
             {
                 "runnerID": "runner-legacy",
                 "startedAt": "2024-01-01T00:00:00Z",
@@ -720,7 +727,7 @@ struct CoreCodableTests {
                 "stderrBytes": null,
                 "stageTimings": null
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601

--- a/Tests/CoreTests/CoreModelTests.swift
+++ b/Tests/CoreTests/CoreModelTests.swift
@@ -47,7 +47,7 @@ struct CoreModelTests {
     // MARK: - GradingMode
 
     @Test func gradingModeDefaultsWorkerWhenAbsent() throws {
-        let json = #"{ "schemaVersion": 1 }"#.data(using: .utf8)!
+        let json = Data(#"{ "schemaVersion": 1 }"#.utf8)
         let manifest = try decoder.decode(TestProperties.self, from: json)
         #expect(manifest.gradingMode == .worker)
     }
@@ -61,7 +61,7 @@ struct CoreModelTests {
             [GradingMode.browser, GradingMode.worker]
         ))
     func gradingModeExplicit(json: String, expected: GradingMode) throws {
-        let manifest = try decoder.decode(TestProperties.self, from: json.data(using: .utf8)!)
+        let manifest = try decoder.decode(TestProperties.self, from: Data(json.utf8))
         #expect(manifest.gradingMode == expected)
     }
 
@@ -75,7 +75,8 @@ struct CoreModelTests {
     // MARK: - TestProperties (no Makefile)
 
     @Test func testPropertiesRoundTrip() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "schemaVersion": 1,
               "gradingMode": "worker",
@@ -86,7 +87,7 @@ struct CoreModelTests {
               ],
               "timeLimitSeconds": 10
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
         #expect(manifest.schemaVersion == 1)
@@ -106,7 +107,8 @@ struct CoreModelTests {
     // MARK: - TestProperties (with Makefile)
 
     @Test func testPropertiesWithMakefileRoundTrip() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "schemaVersion": 1,
               "gradingMode": "worker",
@@ -117,7 +119,7 @@ struct CoreModelTests {
               "timeLimitSeconds": 10,
               "makefile": { "target": "build" }
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
         #expect(manifest.makefile != nil)
@@ -129,7 +131,8 @@ struct CoreModelTests {
     }
 
     @Test func testPropertiesWithDefaultMakeTarget() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "schemaVersion": 1,
               "gradingMode": "worker",
@@ -140,7 +143,7 @@ struct CoreModelTests {
               "timeLimitSeconds": 10,
               "makefile": { "target": null }
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
         #expect(manifest.makefile != nil)
@@ -150,14 +153,14 @@ struct CoreModelTests {
     // MARK: - TestSuiteEntry dependsOn
 
     @Test func testSuiteEntryDefaultsEmptyDependsOn() throws {
-        let json = #"{ "tier": "public", "script": "test_foo.sh" }"#.data(using: .utf8)!
+        let json = Data(#"{ "tier": "public", "script": "test_foo.sh" }"#.utf8)
         let entry = try decoder.decode(TestSuiteEntry.self, from: json)
         #expect(entry.dependsOn.isEmpty)
     }
 
     @Test func testSuiteEntryWithDependsOnRoundTrip() throws {
-        let json = #"{ "tier": "release", "script": "test_bar.sh", "dependsOn": ["test_foo.sh"] }"#
-            .data(using: .utf8)!
+        let json = Data(
+            #"{ "tier": "release", "script": "test_bar.sh", "dependsOn": ["test_foo.sh"] }"#.utf8)
         let entry = try decoder.decode(TestSuiteEntry.self, from: json)
         #expect(entry.script == "test_bar.sh")
         #expect(entry.dependsOn == ["test_foo.sh"])
@@ -168,7 +171,8 @@ struct CoreModelTests {
     }
 
     @Test func testPropertiesWithDependencyChainRoundTrip() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "schemaVersion": 1,
               "gradingMode": "worker",
@@ -179,7 +183,7 @@ struct CoreModelTests {
               ],
               "timeLimitSeconds": 10
             }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let manifest = try decoder.decode(TestProperties.self, from: json)
         #expect(manifest.testSuites.count == 3)

--- a/Tests/CoreTests/CourseBundleManifestTests.swift
+++ b/Tests/CoreTests/CourseBundleManifestTests.swift
@@ -110,9 +110,10 @@ struct CourseBundleManifestTests {
     // MARK: - bundledCourseEnrollmentMode resolver
 
     @Test func bundledCourseEnrollmentModePresent() throws {
-        let json = """
+        let json = Data(
+            """
             { "code": "CS101", "name": "Intro CS", "enrollmentMode": "auto" }
-            """.data(using: .utf8)!
+            """.utf8)
 
         let course = try decoder.decode(BundledCourse.self, from: json)
         #expect(course.enrollmentMode == .auto)

--- a/Tests/CoreTests/NotebookFunctionScannerTests.swift
+++ b/Tests/CoreTests/NotebookFunctionScannerTests.swift
@@ -167,7 +167,8 @@ struct NotebookFunctionScannerTests {
     }
 
     @Test func isShadowedDecodes() throws {
-        let json = """
+        let json = Data(
+            """
             {
               "name": "tax",
               "paramNames": ["price"],
@@ -175,7 +176,7 @@ struct NotebookFunctionScannerTests {
               "hasDocstring": false,
               "isShadowed": true
             }
-            """.data(using: .utf8)!
+            """.utf8)
         let decoded = try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
         #expect(decoded.isShadowed == true)
     }
@@ -183,14 +184,15 @@ struct NotebookFunctionScannerTests {
     @Test func isShadowedDecodeRequiresField() {
         // v0.6.0 removed the `decodeIfPresent ?? false` fallback; missing
         // `isShadowed` is now a decode error rather than silently false.
-        let json = """
+        let json = Data(
+            """
             {
               "name": "tax",
               "paramNames": ["price"],
               "hasTypeHints": true,
               "hasDocstring": false
             }
-            """.data(using: .utf8)!
+            """.utf8)
         #expect(throws: DecodingError.self) {
             try JSONDecoder().decode(NotebookFunctionInfo.self, from: json)
         }

--- a/Tests/WorkerTests/JobPollerTests.swift
+++ b/Tests/WorkerTests/JobPollerTests.swift
@@ -65,7 +65,7 @@ import FoundationNetworking
     @Test func throwsDuplicateWorkerID_on409_withJSONBody() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
-            let body = #"{"error":"worker already registered"}"#.data(using: .utf8)!
+            let body = Data(#"{"error":"worker already registered"}"#.utf8)
             MockURLProtocol.enqueue(.status(409, body: body))
             let poller = makePoller()
 
@@ -84,7 +84,7 @@ import FoundationNetworking
     @Test func throwsDuplicateWorkerID_on409_withPlainBody() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
-            let body = "worker conflict".data(using: .utf8)!
+            let body = Data("worker conflict".utf8)
             MockURLProtocol.enqueue(.status(409, body: body))
             let poller = makePoller()
 
@@ -103,7 +103,7 @@ import FoundationNetworking
     @Test func throwsHTTPError_on500() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
-            let body = "internal server error".data(using: .utf8)!
+            let body = Data("internal server error".utf8)
             MockURLProtocol.enqueue(.status(500, body: body))
             let poller = makePoller()
 
@@ -123,7 +123,7 @@ import FoundationNetworking
     @Test func throwsHTTPError_on400() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
-            MockURLProtocol.enqueue(.status(400, body: "bad request".data(using: .utf8)!))
+            MockURLProtocol.enqueue(.status(400, body: Data("bad request".utf8)))
             let poller = makePoller()
 
             do {
@@ -161,7 +161,7 @@ import FoundationNetworking
     @Test func throwsTransportError_onMalformedJson200() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
-            MockURLProtocol.enqueue(.status(200, body: "not json".data(using: .utf8)!))
+            MockURLProtocol.enqueue(.status(200, body: Data("not json".utf8)))
             let poller = makePoller()
 
             do {

--- a/Tests/WorkerTests/ReporterTests.swift
+++ b/Tests/WorkerTests/ReporterTests.swift
@@ -145,7 +145,7 @@ import FoundationNetworking
     @Test func report_terminatesOn401() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
-            MockURLProtocol.enqueue(.status(401, body: "unauthorized".data(using: .utf8)!))
+            MockURLProtocol.enqueue(.status(401, body: Data("unauthorized".utf8)))
             let reporter = makeReporter(uploadMaxAttempts: 5)
             await expectHTTPError(401) { try await reporter.report(self.sampleExecutionReport()) }
             #expect(MockURLProtocol.capturedRequests.count == 1)

--- a/Tests/WorkerTests/WorkerRequestSignerTests.swift
+++ b/Tests/WorkerTests/WorkerRequestSignerTests.swift
@@ -15,7 +15,7 @@ import FoundationNetworking
         let url = URL(string: "http://localhost:8080/internal/worker/ping")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.httpBody = #"{"submission":"sub_1"}"#.data(using: .utf8)
+        request.httpBody = Data(#"{"submission":"sub_1"}"#.utf8)
 
         let timestamp: Int64 = 1_700_000_000
         let nonce = "nonce-abc"


### PR DESCRIPTION
## Summary

First tranche of the test-folder lint cleanup the user asked for.  Goal: get test code passing the same SwiftLint rules as production code, removing the per-rule exemptions in [Tests/.swiftlint.yml](Tests/.swiftlint.yml).

This PR enables `non_optional_string_data_conversion` by converting 27 sites of `<string>.data(using: .utf8)!` to the non-optional `Data(<string>.utf8)` initializer.  Faster (no encoding-failure branch) and removes a force-unwrap of a value that can never actually be nil for `String`.

Files touched:
- `CoreTests/{CoreModelTests, CoreCodableTests, CourseBundleManifestTests, NotebookFunctionScannerTests}`
- `APITests/{BrowserRunnerRoutesTests, GlobalInputsTests, JupyterLiteContentsRoutesTests, NotebookDownloadTests, NotebookWebRoutesTests}`
- `WorkerTests/{JobPollerTests, ReporterTests, WorkerRequestSignerTests}`

## Coming in follow-up tranches

The bigger one — drop `force_unwrapping` / `force_try` / `force_cast` (~175 sites).  Will be done as 2–3 mechanical PRs once this lands.

## Test plan
- [ ] CI green across all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)