### PR TITLE
test(lint): drop force_try + force_cast exemptions

### DIFF
--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -4,15 +4,6 @@
 parent_config: ../.swiftlint.yml
 
 disabled_rules:
-  # force_try and force_cast remain disabled while their per-site
-  # cleanup follow-ups are staged.  Tests operate on controlled inputs
-  # (literal JSON, known-shape fixture data, etc.) where `try!` and
-  # `as!` are the idiomatic shorthand for "this cannot fail given the
-  # setup; if it does, the test failure is the right signal."
-  # TODO: convert remaining sites to `try` (+ `throws` on the test
-  # signature) and `try #require(x as? T)`, then drop these too.
-  - force_try
-  - force_cast
   # `type_body_length` is disabled for tests: large suites
   # (WorkerDaemonTests at 800 lines, AssignmentRoutesPublishTests at
   # 700+, etc.) group dozens of related tests by area.  Splitting them

--- a/Tests/APITests/AssignmentHelpersManifestTests.swift
+++ b/Tests/APITests/AssignmentHelpersManifestTests.swift
@@ -65,8 +65,8 @@ final class AssignmentHelpersManifestTests {
         #expect(submissionFilenameForStorage(uploadedName: "   ", fallback: "solution.ipynb") == "solution.ipynb")
     }
 
-    @Test func manifestDependentsReturnsScriptsThatReferenceDependency() {
-        let manifest = try! makeWorkerManifestJSON(
+    @Test func manifestDependentsReturnsScriptsThatReferenceDependency() throws {
+        let manifest = try makeWorkerManifestJSON(
             testSuites: [
                 ConfiguredSuiteEntry(
                     script: "01_public.py",

--- a/Tests/APITests/GlobalInputsTests.swift
+++ b/Tests/APITests/GlobalInputsTests.swift
@@ -160,7 +160,7 @@ import Testing
 
     // MARK: - NotebookSubstitution
 
-    private func minimalNotebook(cellSources: [String]) -> Data {
+    private func minimalNotebook(cellSources: [String]) throws -> Data {
         let cells: [[String: Any]] = cellSources.map { src in
             [
                 "cell_type": "code",
@@ -176,7 +176,7 @@ import Testing
             "nbformat": 4,
             "nbformat_minor": 5,
         ]
-        return try! JSONSerialization.data(withJSONObject: nb)
+        return try JSONSerialization.data(withJSONObject: nb)
     }
 
     @Test func substitution_replacesPlaceholderInCodeCell() throws {
@@ -185,7 +185,7 @@ import Testing
         // i.e. `repr("Khoor")` = `'"Khoor"'`).  Mirrors the design doc's
         // contract: substitution drops a `repr()` directly into Python
         // source.
-        let data = minimalNotebook(cellSources: ["ciphertext = {{ciphertext}}"])
+        let data = try minimalNotebook(cellSources: ["ciphertext = {{ciphertext}}"])
         let result = try NotebookSubstitution.apply(
             notebookData: data,
             substitutions: ["ciphertext": "\"Khoor\""],
@@ -202,7 +202,7 @@ import Testing
     }
 
     @Test func substitution_tagsRewrittenCellWithFencedMetadata() throws {
-        let data = minimalNotebook(cellSources: ["x = \"{{name}}\""])
+        let data = try minimalNotebook(cellSources: ["x = \"{{name}}\""])
         let result = try NotebookSubstitution.apply(
             notebookData: data,
             substitutions: ["name": "\"Alice\""],
@@ -218,8 +218,8 @@ import Testing
         #expect(metadata[NotebookSubstitution.fencedCellMetadataKey] as? String == "name")
     }
 
-    @Test func substitution_strictThrowsOnUnknown() {
-        let data = minimalNotebook(cellSources: ["x = \"{{nope}}\""])
+    @Test func substitution_strictThrowsOnUnknown() throws {
+        let data = try minimalNotebook(cellSources: ["x = \"{{nope}}\""])
         #expect {
             try NotebookSubstitution.apply(
                 notebookData: data,
@@ -235,7 +235,7 @@ import Testing
     }
 
     @Test func substitution_nonStrictLeavesUnknownAlone() throws {
-        let data = minimalNotebook(cellSources: ["x = \"{{nope}}\""])
+        let data = try minimalNotebook(cellSources: ["x = \"{{nope}}\""])
         let result = try NotebookSubstitution.apply(
             notebookData: data,
             substitutions: [:],
@@ -281,8 +281,8 @@ import Testing
         #expect(source == "Welcome {{name}}")
     }
 
-    @Test func substitution_placeholderNamesReturnsSortedDedupedNames() {
-        let data = minimalNotebook(cellSources: [
+    @Test func substitution_placeholderNamesReturnsSortedDedupedNames() throws {
+        let data = try minimalNotebook(cellSources: [
             "a = \"{{name}}\"",
             "b = {{shift}} + {{name}}",
         ])
@@ -290,7 +290,7 @@ import Testing
     }
 
     @Test func substitution_multiplePlaceholdersInOneCell() throws {
-        let data = minimalNotebook(cellSources: ["pair = ({{a}}, {{b}})"])
+        let data = try minimalNotebook(cellSources: ["pair = ({{a}}, {{b}})"])
         let result = try NotebookSubstitution.apply(
             notebookData: data,
             substitutions: ["a": "1", "b": "2"],

--- a/Tests/APITests/MarmosetImportParserTests.swift
+++ b/Tests/APITests/MarmosetImportParserTests.swift
@@ -203,14 +203,14 @@ import Testing
             suggestedTitle: nil
         )
         let json = try convertToChickadeeManifest(project: project)
-        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
+        let decoded = try #require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
 
         #expect(decoded["schemaVersion"] as? Int == 1)
         #expect(decoded["gradingMode"] as? String == "worker")
         #expect(decoded["timeLimitSeconds"] as? Int == 10)
         #expect(decoded["starterNotebook"] as? String == "assignment.ipynb")
 
-        let suites = decoded["testSuites"] as! [[String: String]]
+        let suites = try #require(decoded["testSuites"] as? [[String: String]])
         #expect(suites.count == 2)
         #expect(suites.contains { $0["tier"] == "public" && $0["script"] == "test_public.sh" })
         #expect(suites.contains { $0["tier"] == "release" && $0["script"] == "test_release.sh" })
@@ -226,8 +226,8 @@ import Testing
             suggestedTitle: "Project 2"
         )
         let json = try convertToChickadeeManifest(project: project)
-        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
-        let suites = decoded["testSuites"] as! [[String: String]]
+        let decoded = try #require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let suites = try #require(decoded["testSuites"] as? [[String: String]])
 
         #expect(suites.count == 5)
         #expect(suites.filter { $0["tier"] == "public" }.count == 2)
@@ -241,8 +241,8 @@ import Testing
             hasMakefile: false, suggestedTitle: nil
         )
         let json = try convertToChickadeeManifest(project: project)
-        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8)) as! [String: Any]
-        let suites = decoded["testSuites"] as! [[String: String]]
+        let decoded = try #require(JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let suites = try #require(decoded["testSuites"] as? [[String: String]])
         #expect(suites.isEmpty)
     }
 

--- a/Tests/APITests/SupportImportTests.swift
+++ b/Tests/APITests/SupportImportTests.swift
@@ -75,12 +75,12 @@ import Testing
         #expect(onDisk == instructorOwn)
     }
 
-    @Test func extractor_skipsEmptyNotebook() {
+    @Test func extractor_skipsEmptyNotebook() throws {
         let nb: [String: Any] = [
             "cells": [["cell_type": "markdown", "source": "Just text"]],
             "metadata": [:], "nbformat": 4, "nbformat_minor": 5,
         ]
-        let data = try! JSONSerialization.data(withJSONObject: nb)
+        let data = try JSONSerialization.data(withJSONObject: nb)
         let didWrite = SolutionNotebookExtractor.writeSolutionPyIfNeeded(
             notebookData: data, sharedDirectory: tempDir.path + "/"
         )


### PR DESCRIPTION
## Summary

Final tranche of the test-folder lint cleanup.  Enables both `force_try` and `force_cast` for `Tests/`; [Tests/.swiftlint.yml](Tests/.swiftlint.yml) now only overrides `type_body_length` (deliberately relaxed for the large-suite-grouping pattern).

### `force_try` (3 sites)

- `try! makeWorkerManifestJSON(...)` etc. → `try` with `throws` added to the surrounding `@Test func`.

### `force_cast` (6 sites, all in MarmosetImportParserTests)

- `JSONSerialization.jsonObject(...) as! [String: Any]` → `try #require(JSONSerialization.jsonObject(...) as? [String: Any])`
- Same shape for the inner `as! [[String: String]]` casts.

## State after this lands

Tests/ passes the same SwiftLint vocabulary as Sources/ except for the one deliberate `type_body_length` carve-out for large grouped suites.

## Test plan
- [x] `scripts/swiftlint.sh` clean
- [x] Local build passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)