### PR TITLE
Add GeneratedTestSpec protocol + unified render dispatch (Phase A)

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -399,11 +399,10 @@ func applyPatternFamilies(
     // produce sidecar files (e.g. `_expected_<id>.csv` for
     // `.dataFrameEquality`); both the script and the sidecars are
     // tracked here so removing a check cleans up all of its files.
-    let oldGeneratedFilenames = Set(
-        props.patternFamilies.flatMap(patternFamilyAllGeneratedFilenames)
-    ).union(
-        props.notebookChecks.flatMap(notebookCheckAllGeneratedFilenames)
-    )
+    let oldSpecs: [any GeneratedTestSpec] =
+        props.patternFamilies.map { $0 as any GeneratedTestSpec }
+        + props.notebookChecks.map { $0 as any GeneratedTestSpec }
+    let oldGeneratedFilenames = Set(oldSpecs.flatMap(allGeneratedFilenames))
 
     // Build a familyID → sectionID map from the authored items, so we can
     // look up each family's home section and prepend its variables.  If
@@ -423,28 +422,39 @@ func applyPatternFamilies(
         guard let sid = familySectionID[fid] else { return [] }
         return sectionVarsByID[sid] ?? []
     }
-
-    var renderedByFilename: [String: GeneratedScript] = [:]
-    for family in nextFamilies {
-        for generated in renderPatternFamily(
-            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables)
-        {
-            renderedByFilename[generated.filename] = generated
-        }
+    // The variable scope a family's generated tests see: assignment-global
+    // variables plus the family's home-section variables.  Bundled into a
+    // `TestRenderContext` so family rendering flows through the unified
+    // `renderTestSpec` seam.  (The `=`-expression phase extends this
+    // context; the seam means it only has to be threaded once.)
+    func contextForFamily(_ fid: String) -> TestRenderContext {
+        TestRenderContext(
+            sectionVariables: sectionVars(forFamily: fid),
+            globalVariables: resolvedGlobalVariables)
     }
-    // Render notebook checks alongside pattern families so a single zip
-    // mutation pass writes everything.  Each check produces one `.py`
-    // file plus zero or more sidecar files (e.g. `_expected_<id>.csv`
+
+    // Render both generators through the unified `renderTestSpec` seam so
+    // a single zip mutation pass writes everything.  A family yields one
+    // `GeneratedScript` per enabled case and no sidecars; a check yields
+    // one script plus zero or more sidecar files (e.g. `_expected_<id>.csv`
     // for `.dataFrameEquality`).  Sidecars don't have a `GeneratedScript`
     // — they aren't entries in the suite — but they DO need to be in
     // `newGeneratedFilenames` so stale ones get diffed away when a check
     // changes kind or is removed.
+    var renderedByFilename: [String: GeneratedScript] = [:]
     var renderedCheckByID: [String: GeneratedScript] = [:]
     var sidecarFilesToWrite: [String: String] = [:]
+    for family in nextFamilies {
+        for generated in renderTestSpec(family, context: contextForFamily(family.id)).scripts {
+            renderedByFilename[generated.filename] = generated
+        }
+    }
     for check in resolvedChecks {
-        let bundle = renderNotebookCheck(check)
-        renderedByFilename[bundle.script.filename] = bundle.script
-        renderedCheckByID[check.id] = bundle.script
+        let bundle = renderTestSpec(check, context: TestRenderContext())
+        if let script = bundle.scripts.first {
+            renderedByFilename[script.filename] = script
+            renderedCheckByID[check.id] = script
+        }
         for (name, content) in bundle.sidecars {
             sidecarFilesToWrite[name] = content
         }
@@ -568,9 +578,7 @@ func applyPatternFamilies(
             guard let family = familyByID[fid], !emittedFamilyIDs.contains(fid) else { continue }
             emittedFamilyIDs.insert(fid)
             let inherited = expandDeps(family.dependsOn)
-            for generated in renderPatternFamily(
-                family, sectionVariables: sectionVars(forFamily: fid), globalVariables: resolvedGlobalVariables)
-            {
+            for generated in renderTestSpec(family, context: contextForFamily(fid)).scripts {
                 order += 1
                 let prior = oldEntryByScript[generated.filename]
                 let perCase = expandDeps(prior?.dependsOn ?? [])
@@ -621,9 +629,7 @@ func applyPatternFamilies(
     // the caller forgot to include a newly added family).
     for family in nextFamilies where !emittedFamilyIDs.contains(family.id) {
         let inherited = expandDeps(family.dependsOn)
-        for generated in renderPatternFamily(
-            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables)
-        {
+        for generated in renderTestSpec(family, context: contextForFamily(family.id)).scripts {
             order += 1
             let prior = oldEntryByScript[generated.filename]
             let perCase = expandDeps(prior?.dependsOn ?? [])

--- a/Sources/APIServer/Utilities/TestSpecRendering.swift
+++ b/Sources/APIServer/Utilities/TestSpecRendering.swift
@@ -1,0 +1,65 @@
+// APIServer/Utilities/TestSpecRendering.swift
+//
+// The single dispatch point that turns any `GeneratedTestSpec`
+// (`PatternFamily`, `NotebookCheck`) into rendered test files.  Today it
+// forwards verbatim to the per-generator renderers; the value is that
+// every caller in the save path now goes through ONE entry point with a
+// shared context object, so the upcoming `=`-expression work has exactly
+// one place to thread per-student evaluation context instead of forking
+// the two renderers independently.
+
+import Core
+import Foundation
+
+/// What a generated-test spec needs from the surrounding assignment in
+/// order to render.  Today that's the variable scope a generated test
+/// sees (assignment-global + the spec's home-section variables).  This is
+/// the seam the procedural (`=`-expression) phase extends — e.g. with the
+/// support-file directory and the per-student seed binding.
+struct TestRenderContext {
+    var sectionVariables: [FamilyVariable] = []
+    var globalVariables: [FamilyVariable] = []
+}
+
+/// Uniform rendered output for any spec.  A `PatternFamily` yields one
+/// `GeneratedScript` per enabled case and no sidecars; a `NotebookCheck`
+/// yields exactly one script plus zero or more sidecar files (e.g.
+/// `_expected_<id>.csv` for `.dataFrameEquality`).
+struct RenderedTestBundle: Equatable {
+    var scripts: [GeneratedScript]
+    var sidecars: [String: String]
+}
+
+/// Renders any spec to scripts + sidecars.  Pure: identical input yields
+/// byte-identical output, so it preserves the determinism the runner
+/// cache relies on.
+func renderTestSpec(_ spec: any GeneratedTestSpec, context: TestRenderContext) -> RenderedTestBundle {
+    switch spec {
+    case let family as PatternFamily:
+        let scripts = renderPatternFamily(
+            family,
+            sectionVariables: context.sectionVariables,
+            globalVariables: context.globalVariables)
+        return RenderedTestBundle(scripts: scripts, sidecars: [:])
+    case let check as NotebookCheck:
+        let bundle = renderNotebookCheck(check)
+        return RenderedTestBundle(scripts: [bundle.script], sidecars: bundle.sidecars)
+    default:
+        return RenderedTestBundle(scripts: [], sidecars: [:])
+    }
+}
+
+/// Every filename a spec *would* produce if all of its cases were enabled
+/// (scripts + sidecars).  Used by the save path's old/new diff so stale
+/// files — including previously-disabled cases and check sidecars — get
+/// cleaned out of the test setup zip.
+func allGeneratedFilenames(_ spec: any GeneratedTestSpec) -> [String] {
+    switch spec {
+    case let family as PatternFamily:
+        return patternFamilyAllGeneratedFilenames(family)
+    case let check as NotebookCheck:
+        return notebookCheckAllGeneratedFilenames(check)
+    default:
+        return []
+    }
+}

--- a/Sources/Core/GeneratedTestSpec.swift
+++ b/Sources/Core/GeneratedTestSpec.swift
@@ -1,0 +1,46 @@
+// Core/GeneratedTestSpec.swift
+//
+// Common envelope shared by the instructor-authored test generators
+// (`PatternFamily`, `NotebookCheck`).  Both expand into one or more
+// ordinary Python test scripts at manifest-save time; the runner never
+// sees the spec, only the rendered files.  This protocol captures *only*
+// what the two generators genuinely have in common — a stable id, a
+// human-readable label, and spec-level prerequisites.
+//
+// Deliberately NOT on the protocol: `tier`, `points`, and `sectionID`.
+// A `NotebookCheck` carries those once (it renders to exactly one
+// script), but a `PatternFamily` does not — its tier/points live in
+// `defaults` with per-case overrides, and its section is decided by the
+// family's position in the authored suite, not by a field on the spec.
+// Forcing them onto the protocol would be a lie for families.
+//
+// The rendering itself lives in the APIServer target (it emits Python and
+// must stay out of Core); see `renderTestSpec(_:context:)` and
+// `allGeneratedFilenames(_:)` for the dispatch that turns any spec into
+// files.
+
+import Foundation
+
+public protocol GeneratedTestSpec: Codable, Sendable {
+    /// Stable id, unique within the assignment, usable as a filename
+    /// fragment.  Satisfied by the stored `id` on both conformers.
+    var id: String { get }
+    /// Human-readable label for the editor and student results view.
+    /// `nil` lets the renderer fall back to a generator-specific default.
+    var displayName: String? { get }
+    /// Spec-level prerequisites — raw script filenames or `family:<id>`
+    /// tokens — inherited by every script the spec produces.  Satisfied
+    /// by the stored `dependsOn` on both conformers.
+    var dependsOn: [String] { get }
+}
+
+extension PatternFamily: GeneratedTestSpec {
+    /// A family always has a name; surface it as the optional envelope label.
+    public var displayName: String? { name }
+}
+
+extension NotebookCheck: GeneratedTestSpec {
+    // `displayName` is already `name` (an optional); the stored property
+    // satisfies the requirement directly.
+    public var displayName: String? { name }
+}

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -70,6 +70,59 @@ final class PatternFamilyRendererTests: PatternFamilyTestCase {
         XCTAssertEqual(first, second, "Same input must produce byte-identical output")
     }
 
+    // MARK: - GeneratedTestSpec dispatch (Phase A seam)
+
+    func testRenderTestSpecMatchesConcreteFamilyRenderer() {
+        let family = bmiFamily()
+        let viaConcrete = renderPatternFamily(family)
+        let viaDispatch = renderTestSpec(family, context: TestRenderContext())
+        XCTAssertEqual(
+            viaDispatch.scripts, viaConcrete,
+            "Dispatch must produce byte-identical scripts to renderPatternFamily")
+        XCTAssertTrue(viaDispatch.sidecars.isEmpty, "Families produce no sidecars")
+    }
+
+    func testRenderTestSpecForwardsFamilyVariableScope() {
+        // The context's variable scope must reach the family renderer
+        // exactly as a direct call would — otherwise the seam would
+        // silently drop section/global variables.
+        let family = bmiFamily()
+        let section = [FamilyVariable(name: "threshold", value: .double(18.5))]
+        let globals = [FamilyVariable(name: "label", value: .string("x"))]
+        let viaConcrete = renderPatternFamily(
+            family, sectionVariables: section, globalVariables: globals)
+        let viaDispatch = renderTestSpec(
+            family,
+            context: TestRenderContext(sectionVariables: section, globalVariables: globals))
+        XCTAssertEqual(viaDispatch.scripts, viaConcrete)
+    }
+
+    func testRenderTestSpecMatchesConcreteCheckRenderer() {
+        // `.dataFrameEquality` exercises the sidecar path too.
+        let check = NotebookCheck(
+            id: "df_eq", name: "frame matches", kind: .dataFrameEquality,
+            variable: "df", expectedCSV: "a,b\n1,2\n")
+        let viaConcrete = renderNotebookCheck(check)
+        let viaDispatch = renderTestSpec(check, context: TestRenderContext())
+        XCTAssertEqual(
+            viaDispatch.scripts, [viaConcrete.script],
+            "Dispatch must produce the same script as renderNotebookCheck")
+        XCTAssertEqual(
+            viaDispatch.sidecars, viaConcrete.sidecars,
+            "Dispatch must carry the check's sidecars unchanged")
+    }
+
+    func testAllGeneratedFilenamesMatchesConcreteHelpers() {
+        let family = bmiFamily()
+        XCTAssertEqual(
+            allGeneratedFilenames(family), patternFamilyAllGeneratedFilenames(family))
+        let check = NotebookCheck(
+            id: "df_eq", kind: .dataFrameEquality, variable: "df",
+            expectedCSV: "a,b\n1,2\n")
+        XCTAssertEqual(
+            allGeneratedFilenames(check), notebookCheckAllGeneratedFilenames(check))
+    }
+
     func testRendererSkipsDisabledCases() {
         var cases = bmiFamily().cases
         cases[1] = PatternCase(


### PR DESCRIPTION
Extract a small `GeneratedTestSpec` protocol (id, displayName, dependsOn) in Core, conformed by both PatternFamily and NotebookCheck. Tier/points/ sectionID are deliberately left off it — a family carries those per-case, not at the spec level.

Add an APIServer dispatch seam — TestRenderContext, RenderedTestBundle, renderTestSpec(_:context:), allGeneratedFilenames(_:) — and route the filename diff and render-population in applyPatternFamilies through it, so both generators flow through one render entry point. This is the seam the upcoming `=`-expression (procedural) work extends, instead of forking the two renderers independently.

Pure refactor: generated script bytes, sidecars, manifest schema, and spec_hash are unchanged, so runner caching and retest behavior are unaffected. New tests assert the dispatch is byte-identical to the concrete renderers for a family and a check (incl. sidecars).