### PR TITLE
chore: exclude .claude from SwiftLint scan

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -77,6 +77,7 @@ opt_in_rules:
 
 excluded:
   - .build
+  - .claude         # agent worktrees + local state (nested .build vendored deps)
   - .swiftpm
   - Packages
   - Public          # generated JupyterLite assets


### PR DESCRIPTION
## Summary

Local `scripts/swiftlint.sh` (and the `swiftlint` SPM plugin) recursed into `.claude/worktrees/*/.build/checkouts/...` — vendored dependency sources from other agents' git worktrees — and reported `--strict` violations there. That made local runs noisy and prone to being killed mid-scan.

Adds `.claude` to the `excluded:` list in `.swiftlint.yml`. CI is unaffected: a clean checkout has no `.claude` directory, so this only changes local behaviour.

Verified locally: a full-repo `swiftlint lint --strict` now scans **0** `.claude` paths (previously 25 violations from a nested worktree's vendored deps) and reports **0** violations, exit 0.

No version bump — dev-tooling change, consistent with prior `ci:`/`tests:` commits.

## Test plan

- [x] Full-repo `swiftlint lint --strict` clean locally, no `.claude` paths scanned
- [ ] CI green (`format-lint` runs `scripts/swiftlint.sh` in a clean container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)