### PR TITLE
fix: add missing import Foundation to NotebookExtractorTests (restore main test build)

### DIFF
--- a/Tests/WorkerTests/NotebookExtractorTests.swift
+++ b/Tests/WorkerTests/NotebookExtractorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import chickadee_runner
@@ -434,7 +435,8 @@ import Testing
         try proc.run()
         proc.waitUntilExit()
 
-        let out = String(decoding: outPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let out = (String(bytes: outData, encoding: .utf8) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let defined = try #require(try? JSONDecoder().decode([String: Bool].self, from: Data(out.utf8)))
 


### PR DESCRIPTION
## Summary

Fix-forward for a broken **test build** on `main`. The end-to-end test added in #668 uses `FileManager`/`UUID`/`Process`/`Pipe`/`URL`/`Data`/`JSONDecoder`, but `Tests/WorkerTests/NotebookExtractorTests.swift` never imported Foundation (no prior test in it needed those types), so the `WorkerTests` target failed to compile. `swift-format` passed locally and doesn't compile, so it slipped through and merged.

- Add `import Foundation`.
- Switch the `Data` → `String` conversion to the failable `String(bytes:encoding:)` to satisfy SwiftLint's `optional_data_string_conversion` rule (the other thing that failed on #668).

The app build (`build-and-verify`) was never affected, so deploys/the running server were fine — only `swift test` / the test target.

## Verification

`swift build --target WorkerTests` gets **past compilation** with no errors (only the local macOS `ld: -no_warn_duplicate_libraries` quirk remains, which CI's Linux image doesn't hit). `swift-format` clean. This time the test target was actually compiled before merging.

## Test plan

- [x] `swift build --target WorkerTests` compiles (local link quirk aside)
- [x] `swift-format --strict` clean
- [ ] CI: `build` + `worker-tests` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)