### PR TITLE
ci: fix test-job build-cache key (missing v2 salt) so tests reuse the build

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Run CoreTests
         run: |
@@ -166,7 +166,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
         run: |
@@ -235,7 +235,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
         run: |
@@ -303,7 +303,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install worker test dependencies
         run: apt-get update -qq && apt-get install -y --no-install-recommends file


### PR DESCRIPTION
## Summary

The `build` job caches `.build/` under `…-build-`**`v2`**`-<toolchain>-<hashFiles>` (the `v2` salt landed with the TestItem struct→enum change, v0.4.228, #676), but the four test jobs restore under `…-build-<toolchain>-<hashFiles>` — **without `v2`, and with no `restore-keys` fallback**. The keys never match, so every test job misses the cache and falls through to the `else` branch (`swift test …`, no `--skip-build`) → a **full from-scratch recompile in core-tests, api-tests, api-tests-postgres, and worker-tests**. The `build` job's compile is discarded; CI does ~4 redundant package compiles per run — the exact thing the compile-once design (#523, workflow comment L44–47) was meant to avoid.

This aligns the four restore keys (L139/169/238/306) with the build job's save key (L107).

## Effect

- Test jobs hit the cache → `swift test --skip-build` → no recompile. Faster CI and much less load. (The full-recompile-under-load is also a plausible contributor to occasional `worker-tests` subprocess flakes.)

## Test plan

- This PR's own CI run is the proof: with the keys aligned, each test job should restore the build cache (`cache-hit=true`) and run `--skip-build` rather than recompiling.

No `VERSION`/`CHANGELOG` bump — CI-only workflow change.

🤖 Built with Claude Code