### PR TITLE
Force IdP re-auth after logout (SSO single-logout)

### DIFF
--- a/Sources/APIServer/Bootstrap/SessionCookieFactory.swift
+++ b/Sources/APIServer/Bootstrap/SessionCookieFactory.swift
@@ -31,3 +31,26 @@ func chickadeeSessionCookie(sessionID: SessionID, isSecure: Bool) -> HTTPCookies
         sameSite: .lax
     )
 }
+
+/// Name of the short-lived marker set on logout. When `/auth/sso/start` sees
+/// it, it appends `prompt=login` to the authorization request (forcing the IdP
+/// to re-authenticate) and clears the marker. This stops an explicit logout
+/// from being silently undone by Duo's still-live SSO session, while leaving
+/// normal day-to-day sign-ins as one-click SSO.
+let reauthMarkerCookieName = "chickadee_reauth"
+
+/// Session-scoped marker cookie (no `maxAge`, so it dies with the browsing
+/// session). It is consumed on the next `/auth/sso/start`, so it only ever
+/// forces re-authentication for the first sign-in after a logout.
+func chickadeeReauthMarkerCookie(isSecure: Bool) -> HTTPCookies.Value {
+    HTTPCookies.Value(
+        string: "1",
+        expires: nil,
+        maxAge: nil,
+        domain: nil,
+        path: "/",
+        isSecure: isSecure,
+        isHTTPOnly: true,
+        sameSite: .lax
+    )
+}

--- a/Sources/APIServer/Middleware/SessionIdleTimeoutMiddleware.swift
+++ b/Sources/APIServer/Middleware/SessionIdleTimeoutMiddleware.swift
@@ -70,6 +70,13 @@ struct SessionIdleTimeoutMiddleware: AsyncMiddleware {
         if request.url.path.hasPrefix("/api/") {
             throw Abort(.unauthorized, reason: "Session timed out")
         }
-        return request.redirect(to: "/login?error=timeout")
+        // Force IdP re-authentication on the next sign-in, same as an explicit
+        // logout — otherwise the timed-out session is silently restored by Duo's
+        // still-live SSO session on the next protected request.
+        let response = request.redirect(to: "/login?error=timeout")
+        response.cookies[reauthMarkerCookieName] = chickadeeReauthMarkerCookie(
+            isSecure: request.application.securityConfiguration.sessionCookieSecure
+        )
+        return response
     }
 }

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -231,6 +231,15 @@ struct AuthRoutes: RouteCollection {
         req.auth.logout(APIUser.self)
         req.session.destroy()
 
+        // Mark the next sign-in for forced IdP re-authentication. Duo keeps its
+        // own SSO session alive, so without this an explicit logout is silently
+        // undone the moment the user hits any protected page (it re-auths with
+        // no prompt). `/auth/sso/start` consumes this marker and adds
+        // `prompt=login`. Set on whichever redirect we return below.
+        let reauthCookie = chickadeeReauthMarkerCookie(
+            isSecure: req.application.securityConfiguration.sessionCookieSecure
+        )
+
         let oidcConfig = req.application.oidcConfig
 
         // Revoke any issued OAuth tokens at the IdP. Runs concurrently and is
@@ -278,11 +287,15 @@ struct AuthRoutes: RouteCollection {
                 components?.queryItems = items
             }
             if let url = components?.url?.absoluteString {
-                return req.redirect(to: url)
+                let response = req.redirect(to: url)
+                response.cookies[reauthMarkerCookieName] = reauthCookie
+                return response
             }
         }
 
-        return req.redirect(to: returnPath)
+        let response = req.redirect(to: returnPath)
+        response.cookies[reauthMarkerCookieName] = reauthCookie
+        return response
     }
 }
 

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -51,9 +51,16 @@ struct SSOAuthRoutes: RouteCollection {
         req.session.data["oidc_state"] = state
         req.session.data["oidc_verifier"] = codeVerifier
 
+        // If a logout/idle-timeout set the re-auth marker, force the IdP to
+        // re-authenticate (`prompt=login`) instead of silently honouring its
+        // own still-live SSO session — otherwise an explicit logout is undone
+        // the moment the user hits a protected page. Consumed once (cleared
+        // below) so normal day-to-day sign-ins stay one-click.
+        let forceReauth = req.cookies[reauthMarkerCookieName] != nil
+
         // Build the IdP authorization URL
         var components = URLComponents(string: config.discovery.authorizationEndpoint)
-        components?.queryItems = [
+        var queryItems = [
             URLQueryItem(name: "client_id", value: config.clientID),
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "scope", value: "openid profile email groups"),
@@ -62,13 +69,22 @@ struct SSOAuthRoutes: RouteCollection {
             URLQueryItem(name: "code_challenge", value: codeChallenge),
             URLQueryItem(name: "code_challenge_method", value: "S256"),
         ]
+        if forceReauth {
+            queryItems.append(URLQueryItem(name: "prompt", value: "login"))
+        }
+        components?.queryItems = queryItems
 
         guard let authURL = components?.url?.absoluteString else {
             req.logger.error("Failed to build authorization URL from: \(config.discovery.authorizationEndpoint)")
             return req.redirect(to: "/login?error=sso_failed")
         }
 
-        return req.redirect(to: authURL)
+        let response = req.redirect(to: authURL)
+        if forceReauth {
+            // Clear the marker so it only forces re-auth for this first sign-in.
+            response.cookies[reauthMarkerCookieName] = .expired
+        }
+        return response
     }
 
     // MARK: - GET /auth/sso/callback

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -235,6 +235,25 @@ import XCTVapor
         }
     }
 
+    @Test func logoutSetsReauthMarkerCookie() async throws {
+        try await withApp(try await makeApp()) { app in
+            let (token, cookie) = try await csrfFields(for: "/login", on: app)
+            try await app.asyncTest(
+                .POST, "/logout",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                    try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    // Logout arms the next sign-in for forced IdP re-auth so a
+                    // logout can't be silently undone by a live SSO session.
+                    let setCookies = res.headers[.setCookie]
+                    let armed = setCookies.contains { $0.contains("chickadee_reauth=1") }
+                    #expect(armed, "expected logout to set the re-auth marker, got: \(setCookies)")
+                })
+        }
+    }
+
     @Test func logoutWithTimeoutReasonRedirectsToTimeoutMessage() async throws {
         try await withApp(try await makeApp()) { app in
             let (token, cookie) = try await csrfFields(for: "/login", on: app)

--- a/Tests/APITests/SSOAuthFlowTests.swift
+++ b/Tests/APITests/SSOAuthFlowTests.swift
@@ -317,6 +317,35 @@ import XCTVapor
         }
     }
 
+    @Test func sSOStart_withoutReauthMarker_doesNotForcePrompt() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.asyncTest(
+                .GET, "/auth/sso/start",
+                afterResponse: { res in
+                    let location = res.headers.first(name: .location) ?? ""
+                    #expect(!location.contains("prompt=login"))
+                })
+        }
+    }
+
+    @Test func sSOStart_withReauthMarker_forcesPromptLoginAndClearsMarker() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.asyncTest(
+                .GET, "/auth/sso/start",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: "\(reauthMarkerCookieName)=1")
+                },
+                afterResponse: { res in
+                    let location = res.headers.first(name: .location) ?? ""
+                    #expect(location.contains("prompt=login"))
+                    // The marker is consumed: a Set-Cookie clears it (empty value).
+                    let setCookies = res.headers[.setCookie]
+                    let cleared = setCookies.contains { $0.contains("\(reauthMarkerCookieName)=;") }
+                    #expect(cleared, "expected the re-auth marker to be cleared, got: \(setCookies)")
+                })
+        }
+    }
+
     // MARK: - Post-logout login page: SSO entry is a navigation link
 
     @Test func loginPageAfterLogout_rendersSSOLinkNotForm() async throws {

--- a/changelog.d/sso-reauth-after-logout.md
+++ b/changelog.d/sso-reauth-after-logout.md
@@ -1,0 +1,11 @@
+### Security
+
+- **Logout now forces IdP re-authentication on the next sign-in (SSO
+  single-logout).** Follow-on to v0.4.240, surfaced by the IRA-PIA review:
+  after logging out, clicking any protected link silently logged the user
+  straight back in, because Duo keeps its own SSO session alive and the
+  authorization request carried no `prompt`. Logout (and the idle timeout) now
+  set a short-lived, session-scoped marker cookie (`chickadee_reauth`);
+  `/auth/sso/start` consumes it and appends `prompt=login`, forcing Duo to
+  re-authenticate, then clears it — so normal day-to-day SSO stays one-click
+  and only an explicit logout/timeout re-prompts.


### PR DESCRIPTION
## Summary

Re-lands the SSO logout fix **under the new release process** (no version-file edits — just a `changelog.d/` fragment). Replaces #708, which was version-stamped under the old process and kept colliding.

After logging out, clicking any protected link (e.g. the "Chickadee" brand) silently logged the user straight back in — the issue IST flagged. Logout destroys the Chickadee session, but **Duo keeps its own SSO session alive**, and `/auth/sso/start` sent **no `prompt`**, so the IdP re-authenticated with no credential check.

**Fix (conditional, low-friction):** logout and the idle timeout set a short-lived, session-scoped marker cookie (`chickadee_reauth`); `/auth/sso/start` consumes it and appends `prompt=login`, forcing Duo to re-authenticate, then clears it. Normal day-to-day SSO stays one-click — only an explicit logout/timeout re-prompts.

## Test plan

- [x] `logoutSetsReauthMarkerCookie`, `sSOStart_withReauthMarker_forcesPromptLoginAndClearsMarker`, `sSOStart_withoutReauthMarker_doesNotForcePrompt`
- [x] Existing SSO/auth/idle suites pass; `swift-format` clean
- [ ] Live verification against Duo on the dev deploy (log out → click "Chickadee" → expect a credential prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)