### PR TITLE
MCP authoring Phase 3a (read): get_suite tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -1,0 +1,119 @@
+// APIServer/MCP/Tools/GetSuiteTool.swift
+//
+// Read tool: returns an assignment's test-suite structure by public ID — the
+// ordered items (hand-written scripts, generated pattern families, notebook
+// checks) with tier/points/dependencies/section, plus the section list.
+// content:read, course-scoped. Reuses the author-facing `buildSuitePayload`
+// (without a zip path, so raw script bodies are NOT included — this is a
+// structure view; editing the suite is a later phase).
+
+import Core
+import Fluent
+import Foundation
+
+struct GetSuiteTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+    }
+
+    struct Output: Encodable, Sendable {
+        struct Section: Encodable, Sendable {
+            let id: String
+            let name: String
+        }
+        struct Item: Encodable, Sendable {
+            /// "script", "family", or "check".
+            let kind: String
+            /// Script filename, family name, or check name.
+            let name: String
+            /// "public", "release", "secret", or "student".
+            let tier: String
+            let points: Int
+            let displayName: String?
+            /// Prerequisite items; may contain "family:<id>" tokens (author form).
+            let dependsOn: [String]
+            /// Section this item belongs to, or nil if ungrouped.
+            let sectionID: String?
+            /// The pattern-family id, for `kind == "family"` items.
+            let familyID: String?
+        }
+        let assignmentPublicID: String
+        let sections: [Section]
+        let items: [Item]
+    }
+
+    static let name = "get_suite"
+    static let description =
+        "Get an assignment's test-suite structure by public ID: the ordered test items "
+        + "(hand-written scripts, generated pattern families, notebook checks) with their tier "
+        + "(public/release/secret/student), points, display name, dependencies, and section, plus "
+        + "the section list. Read-only — use this to inspect the suite before editing it."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ])
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        // No zip path → metadata-only rows (raw script bodies omitted).
+        let payload = buildSuitePayload(fromManifest: setup.manifest)
+        let sections = payload.sections.map { Output.Section(id: $0.id, name: $0.name) }
+        let items = payload.items.map { Self.item(from: $0) }
+        return Output(assignmentPublicID: assignment.publicID, sections: sections, items: items)
+    }
+
+    private static func item(from dto: SuiteItemDTO) -> Output.Item {
+        switch dto.kind {
+        case "family":
+            let family = dto.family
+            return Output.Item(
+                kind: "family",
+                name: family?.name ?? "(family)",
+                tier: (family?.defaults.tier ?? .pub).rawValue,
+                points: family?.defaults.points ?? 0,
+                displayName: nil,
+                dependsOn: dto.dependsOn ?? family?.dependsOn ?? [],
+                sectionID: dto.sectionID,
+                familyID: family?.id)
+        case "check":
+            let check = dto.check
+            return Output.Item(
+                kind: "check",
+                name: check?.name ?? check?.id ?? "(check)",
+                tier: (check?.tier ?? .pub).rawValue,
+                points: check?.points ?? 0,
+                displayName: nil,
+                dependsOn: dto.dependsOn ?? check?.dependsOn ?? [],
+                sectionID: dto.sectionID,
+                familyID: nil)
+        default:
+            let script = dto.script
+            return Output.Item(
+                kind: "script",
+                name: script?.script ?? "(script)",
+                tier: (script?.tier ?? .pub).rawValue,
+                points: script?.points ?? 0,
+                displayName: script?.displayName,
+                dependsOn: script?.dependsOn ?? [],
+                sectionID: dto.sectionID,
+                familyID: nil)
+        }
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -19,6 +19,7 @@ enum MCPToolCatalog {
             ListCoursesTool().erased(),
             ListAssignmentsTool().erased(),
             GetAssignmentTool().erased(),
+            GetSuiteTool().erased(),
             UpdateAssignmentTool().erased(),
         ])
     }

--- a/Tests/APITests/MCP/GetSuiteToolTests.swift
+++ b/Tests/APITests/MCP/GetSuiteToolTests.swift
@@ -1,0 +1,84 @@
+// Tests for GetSuiteTool, backed by a real test database.
+
+import Core
+import Fluent
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct GetSuiteToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read]
+        )
+    }
+
+    private let manifest = """
+        {"schemaVersion":1,"testSuites":[\
+        {"tier":"public","script":"test_a.sh","points":2,"name":"Test A","sectionID":"sec1"},\
+        {"tier":"secret","script":"test_b.sh","points":3,"dependsOn":["test_a.sh"],"sectionID":"sec2"}\
+        ],"sections":[{"id":"sec1","name":"Part A"},{"id":"sec2","name":"Part B"}],"timeLimitSeconds":10}
+        """
+
+    @Test func returnsSuiteStructureForEnrolledSubject() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_s", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_s", courseID: courseID, title: "Lab")
+
+            let output = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), context(app))
+
+            #expect(output.sections.map(\.name) == ["Part A", "Part B"])
+            #expect(output.items.map(\.name) == ["test_a.sh", "test_b.sh"])
+
+            let a = try #require(output.items.first { $0.name == "test_a.sh" })
+            #expect(a.kind == "script")
+            #expect(a.tier == "public")
+            #expect(a.points == 2)
+            #expect(a.displayName == "Test A")
+            #expect(a.sectionID == "sec1")
+
+            let b = try #require(output.items.first { $0.name == "test_b.sh" })
+            #expect(b.tier == "secret")
+            #expect(b.points == 3)
+            #expect(b.dependsOn == ["test_a.sh"])
+            #expect(b.sectionID == "sec2")
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester")
+            try await makeTestSetup(on: app, id: "setup_s", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_s", courseID: courseID, title: "Lab")
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetSuiteTool().execute(
+                    GetSuiteTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            }
+        }
+    }
+
+    @Test func unknownAssignmentThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetSuiteTool().execute(
+                    GetSuiteTool.Input(assignmentPublicID: "zzzzzz"), context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-get-suite.md
+++ b/changelog.d/mcp-get-suite.md
@@ -1,0 +1,8 @@
+### Added
+
+- **MCP `get_suite` tool (authoring Phase 3a, read half).** Returns an
+  assignment's test-suite structure by public ID — the ordered items
+  (hand-written scripts, generated pattern families, notebook checks) with each
+  one's tier, points, display name, dependencies, and section, plus the section
+  list. `content:read`, course-scoped, read-only (suite editing follows). Reuses
+  the author-facing `buildSuitePayload` without raw script bodies.


### PR DESCRIPTION
Phase 3a read-half of MCP test-suite authoring (see `docs/mcp-authoring-roadmap.md`).

## What it adds
- **`get_suite`** (`content:read`, course-scoped) — returns an assignment's test-suite structure by public ID: the ordered items (hand-written scripts, generated pattern families, notebook checks) with each item's tier, points, display name, dependencies (author-form `family:<id>` tokens preserved), and section, plus the section list.
- Reuses the author-facing `buildSuitePayload(fromManifest:)` **without a zip path**, so raw script bodies are intentionally omitted — this is a structure/metadata view. The write half (`update_suite`) follows as its own slice.

## Why read-only first
`update_suite` is materially heavier (the canonical `applySuiteEdit` requires the full authored payload incl. raw script content, plus validation + regrade orchestration and blast-radius reporting) and carries a content-safety design question (whole-list round-trip vs. targeted metadata ops). Shipping `get_suite` first is a clean, low-risk increment and the prerequisite the agent reads before any edit.

## Process / test plan
- Follows the merge-time release process: **changelog.d fragment only, no VERSION/CHANGELOG/ChickadeeVersion edits.** Rebased onto current `main` (v0.4.257).
- New tests: suite-structure mapping (tiers, points, displayName, dependsOn, sections), course-scoping deny, unknown assignment. Local `swift-format --strict` clean on changed files; leaning on CI (`format-lint`, `swift-tests`) for the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)