### PR TITLE
MCP admin: hide tab when disabled + exclude students

### DIFF
--- a/Resources/Views/admin-audit.leaf
+++ b/Resources/Views/admin-audit.leaf
@@ -8,7 +8,7 @@ Audit Log
     <a class="admin-tab" href="/admin"#if(activeAdminTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
-    <a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>
+    #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>

--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -8,7 +8,7 @@ MCP
     <a class="admin-tab" href="/admin"#if(activeAdminTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
-    <a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>
+    #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>

--- a/Resources/Views/admin-storage.leaf
+++ b/Resources/Views/admin-storage.leaf
@@ -8,7 +8,7 @@ Storage
     <a class="admin-tab" href="/admin"#if(activeAdminTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
-    <a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>
+    #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -8,7 +8,7 @@ Users
     <a class="admin-tab" href="/admin"#if(activeAdminTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
-    <a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>
+    #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -8,7 +8,7 @@ Admin
     <a class="admin-tab" href="/admin"#if(activeAdminTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
-    <a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>
+    #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>

--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -8,7 +8,7 @@ Server Health Alerts
     <a class="admin-tab" href="/admin"#if(activeAdminTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
-    <a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>
+    #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>

--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -117,6 +117,7 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     app.leaf.tags["csrfFormField"] = CSRFFormFieldTag()
     app.leaf.tags["csrfToken"] = CSRFTokenTag()
     app.leaf.tags["appVersion"] = AppVersionTag()
+    app.leaf.tags["mcpEnabled"] = MCPEnabledTag()
     app.leaf.tags["sessionIdleTimeoutSeconds"] = SessionIdleTimeoutTag()
     app.leaf.tags["sessionIdleWarningSeconds"] = SessionIdleWarningTag()
     app.leaf.tags["rawJSON"] = RawJSONTag()

--- a/Sources/APIServer/Helpers/MCPEnabledTag.swift
+++ b/Sources/APIServer/Helpers/MCPEnabledTag.swift
@@ -1,0 +1,20 @@
+// APIServer/Helpers/MCPEnabledTag.swift
+//
+// Leaf tag that reports whether the content-authoring MCP endpoint is enabled
+// (`MCP_ENABLED`). Used to hide the admin "MCP" nav tab entirely when MCP is
+// off, e.g.:
+//   #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp">MCP</a>#endif
+//
+// Boot-fixed app-global (like the app version / idle-timeout tags), so a Leaf
+// tag reading it once per render is the right fit — no per-context plumbing.
+
+import Leaf
+import Vapor
+
+struct MCPEnabledTag: LeafTag {
+    func render(_ ctx: LeafContext) throws -> LeafData {
+        try ctx.requireParameterCount(0)
+        guard let req = ctx.request else { return .bool(false) }
+        return .bool(req.application.appConfig.mcp.enabled)
+    }
+}

--- a/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
+++ b/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
@@ -32,13 +32,9 @@ struct ListCoursesTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard
-            let user = try await APIUser.query(on: context.db)
-                .filter(\.$username == context.subject)
-                .first()
-        else {
-            return Output(courses: [])
-        }
+        // Students may not use the MCP interface; only instructors/admins/mcp
+        // service accounts get past this.
+        let user = try await context.requireEligibleSubject(tool: Self.name)
 
         let courses: [APICourse]
         if user.isAdmin {

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -35,14 +35,13 @@ struct ToolContext {
     var db: any Database { request.db }
     var logger: Logger { request.logger }
 
-    /// Authorizes the token subject for an action scoped to `courseID`.
-    ///
-    /// Admins act globally; every other subject (instructor browser-flow tokens
-    /// and `mcp` service accounts alike) must be enrolled in the target course.
-    /// Throws `MCPToolError.notAuthorized` otherwise, so a tool confines itself
-    /// to the courses its account is enrolled in. Resolving the subject by
-    /// username keeps the bearer middleware DB-free.
-    func authorizeCourseAccess(_ courseID: UUID, tool: String) async throws {
+    /// Resolves the token subject and confirms it may use the MCP interface at
+    /// all: only instructors, admins, and `mcp` service accounts — never
+    /// students. Students can't obtain a token today (consent requires
+    /// instructor), but this enforces "students may not use MCP" at the tool
+    /// layer too, so the guarantee doesn't rest solely on token issuance.
+    @discardableResult
+    func requireEligibleSubject(tool: String) async throws -> APIUser {
         guard
             let user = try await APIUser.query(on: db)
                 .filter(\.$username == subject)
@@ -50,6 +49,22 @@ struct ToolContext {
         else {
             throw MCPToolError.notAuthorized(tool: tool, detail: "Unknown token subject.")
         }
+        guard user.isInstructor || user.isMCPAgent else {
+            throw MCPToolError.notAuthorized(
+                tool: tool, detail: "Students may not use the MCP interface.")
+        }
+        return user
+    }
+
+    /// Authorizes the token subject for an action scoped to `courseID`.
+    ///
+    /// The subject must be MCP-eligible (`requireEligibleSubject`), then: admins
+    /// act globally; every other subject (instructor browser-flow tokens and
+    /// `mcp` service accounts alike) must be enrolled in the target course.
+    /// Throws `MCPToolError.notAuthorized` otherwise, so a tool confines itself
+    /// to the courses its account is enrolled in.
+    func authorizeCourseAccess(_ courseID: UUID, tool: String) async throws {
+        let user = try await requireEligibleSubject(tool: tool)
         if user.isAdmin { return }
         guard let userID = user.id else {
             throw MCPToolError.notAuthorized(tool: tool, detail: "Token subject is not a valid user.")

--- a/Tests/APITests/MCP/GetAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/GetAssignmentToolTests.swift
@@ -20,7 +20,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
             let courseID = try course.requireID()
-            let tester = try await makeTestUser(on: app, username: "tester")
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
             try await makeTestSetup(on: app, id: "setup_g", courseID: courseID)
             let assignment = try await makeTestAssignment(
@@ -40,7 +40,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
             let courseID = try course.requireID()
-            _ = try await makeTestUser(on: app, username: "tester")
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestSetup(on: app, id: "setup_g", courseID: courseID)
             let assignment = try await makeTestAssignment(
                 on: app, testSetupID: "setup_g", courseID: courseID, title: "Tasks")

--- a/Tests/APITests/MCP/GetSuiteToolTests.swift
+++ b/Tests/APITests/MCP/GetSuiteToolTests.swift
@@ -28,7 +28,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
             let courseID = try course.requireID()
-            let tester = try await makeTestUser(on: app, username: "tester")
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
             try await makeTestSetup(on: app, id: "setup_s", courseID: courseID, manifest: manifest)
             let assignment = try await makeTestAssignment(
@@ -60,7 +60,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
             let courseID = try course.requireID()
-            _ = try await makeTestUser(on: app, username: "tester")
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestSetup(on: app, id: "setup_s", courseID: courseID, manifest: manifest)
             let assignment = try await makeTestAssignment(
                 on: app, testSetupID: "setup_s", courseID: courseID, title: "Lab")

--- a/Tests/APITests/MCP/ListAssignmentsToolTests.swift
+++ b/Tests/APITests/MCP/ListAssignmentsToolTests.swift
@@ -22,7 +22,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems Programming")
             let courseID = try course.requireID()
-            let tester = try await makeTestUser(on: app, username: "tester")
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
             try await makeTestSetup(on: app, id: "setup_bit", courseID: courseID)
             try await makeTestSetup(on: app, id: "setup_app", courseID: courseID)
@@ -42,7 +42,7 @@ import Vapor
             let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems Programming")
             let courseID = try course.requireID()
             // "tester" exists but is NOT enrolled in CS136.
-            _ = try await makeTestUser(on: app, username: "tester")
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestSetup(on: app, id: "setup_x", courseID: courseID)
             try await makeTestAssignment(on: app, testSetupID: "setup_x", courseID: courseID, title: "X")
 
@@ -69,6 +69,24 @@ import Vapor
         }
     }
 
+    @Test func enrolledStudentSubjectIsDenied() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems Programming")
+            let courseID = try course.requireID()
+            // A student enrolled in the course still may not use MCP.
+            let student = try await makeTestUser(on: app, username: "tester")
+            try await makeTestEnrollment(on: app, userID: student.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_s", courseID: courseID)
+            try await makeTestAssignment(on: app, testSetupID: "setup_s", courseID: courseID, title: "X")
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ListAssignmentsTool().execute(
+                    ListAssignmentsTool.Input(courseCode: "CS136"), context(app))
+            }
+        }
+    }
+
     @Test func unknownCourseThrowsToolError() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
@@ -92,7 +110,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
             let courseID = try course.requireID()
-            let tester = try await makeTestUser(on: app, username: "tester")
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
             try await makeTestSetup(on: app, id: "setup_tasks", courseID: courseID)
             try await makeTestAssignment(on: app, testSetupID: "setup_tasks", courseID: courseID, title: "Tasks")

--- a/Tests/APITests/MCP/ListCoursesToolTests.swift
+++ b/Tests/APITests/MCP/ListCoursesToolTests.swift
@@ -15,17 +15,31 @@ import Vapor
         )
     }
 
-    @Test func nonAdminSeesOnlyEnrolledCourses() async throws {
+    @Test func instructorSeesOnlyEnrolledCourses() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let cs136 = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
             _ = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
-            let tester = try await makeTestUser(on: app, username: "tester")
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: try cs136.requireID())
 
             let output = try await ListCoursesTool().execute(
                 ListCoursesTool.Input(), context(app, subject: "tester"))
             #expect(output.courses.map(\.code) == ["CS136"])
+        }
+    }
+
+    @Test func studentSubjectIsDenied() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let cs136 = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let student = try await makeTestUser(on: app, username: "stud")
+            try await makeTestEnrollment(on: app, userID: student.requireID(), courseID: try cs136.requireID())
+            // Even enrolled, a student-role subject may not use MCP.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ListCoursesTool().execute(
+                    ListCoursesTool.Input(), context(app, subject: "stud"))
+            }
         }
     }
 
@@ -42,13 +56,14 @@ import Vapor
         }
     }
 
-    @Test func unknownSubjectSeesNoCourses() async throws {
+    @Test func unknownSubjectIsDenied() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
             _ = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
-            let output = try await ListCoursesTool().execute(
-                ListCoursesTool.Input(), context(app, subject: "ghost"))
-            #expect(output.courses.isEmpty)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ListCoursesTool().execute(
+                    ListCoursesTool.Input(), context(app, subject: "ghost"))
+            }
         }
     }
 }

--- a/Tests/APITests/MCP/UpdateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/UpdateAssignmentToolTests.swift
@@ -21,7 +21,7 @@ import Vapor
     ) async throws -> APIAssignment {
         let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
         let courseID = try course.requireID()
-        let tester = try await makeTestUser(on: app, username: "tester")
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
         try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
         try await makeTestSetup(on: app, id: "setup_u", courseID: courseID)
         let assignment = try await makeTestAssignment(
@@ -181,7 +181,7 @@ import Vapor
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
             let courseID = try course.requireID()
-            _ = try await makeTestUser(on: app, username: "tester")
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
             try await makeTestSetup(on: app, id: "setup_u", courseID: courseID)
             let assignment = try await makeTestAssignment(
                 on: app, testSetupID: "setup_u", courseID: courseID, title: "Tasks", isOpen: false)

--- a/changelog.d/mcp-admin-hide-tab-and-student-gate.md
+++ b/changelog.d/mcp-admin-hide-tab-and-student-gate.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **Admin "MCP" tab is hidden when `MCP_ENABLED=false`.** The MCP nav tab no
+  longer appears in the admin panel unless the endpoint is enabled (new
+  `#mcpEnabled()` Leaf tag reads the boot-time flag).
+
+### Security
+
+- **Students are excluded from the MCP interface at the tool layer.** MCP tool
+  calls now require the token subject to be an instructor, admin, or `mcp`
+  service account — never a student. Students already can't complete the
+  `/oauth/authorize` consent flow (it requires instructor), so this is
+  defence-in-depth: the guarantee no longer rests solely on token issuance.


### PR DESCRIPTION
Two MCP admin/auth refinements.

## Hide the MCP tab when `MCP_ENABLED=false`
- New `#mcpEnabled()` Leaf tag (reads the boot-time flag via `req.application.appConfig.mcp.enabled`); the admin "MCP" nav tab is wrapped in `#if(mcpEnabled())` across all six admin templates. When MCP is off, the option simply isn't shown. (One tag instead of threading a flag through every admin context.)

## Exclude students from the MCP interface (defence-in-depth)
- Tool calls now require the token subject to be an **instructor, admin, or `mcp` service account — never a student**, via the new `ToolContext.requireEligibleSubject` (used by `authorizeCourseAccess` and `list_courses`).
- Students already can't complete the `/oauth/authorize` consent (it requires instructor), so previously the guarantee rested solely on token issuance; `authorizeCourseAccess` only checked *enrollment*, which a student satisfies. This closes that gap at the tool layer.

## Tests
- Tool-test subjects are now instructors (the realistic "instructor authorized the agent" case); added explicit **enrolled-student-denied** and **unknown-subject-denied** coverage.
- Local `swift test --filter "MCP|ToolTests"` green (106 tests / 21 suites); swift-format `--strict` clean. Merge-time process: changelog.d fragment only, no version bump.

Not included (follow-up): tying the service-account path to `AUTH_MODE` (SSO vs local) — discussed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)