### PR TITLE
MCP authoring Phase 3a (write): update_suite tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -1,0 +1,150 @@
+// APIServer/MCP/Tools/UpdateSuiteTool.swift
+//
+// Write tool: edit test-suite *script* metadata for an assignment — tier,
+// points, display name, prerequisites (dependsOn), and section — by public ID.
+// content:write, course-scoped.
+//
+// Targeted read-modify-write: loads the current authored suite (with script
+// bodies preserved from the zip), applies the named per-script edits, and
+// re-saves through the same `applySuiteEdit` path the web editor uses, then
+// re-kicks validation. The agent never sends raw script content, so it can't
+// corrupt test bodies. Pattern-family / notebook-check metadata and reordering
+// are out of scope here (later phases).
+
+import Core
+import Fluent
+import Foundation
+
+struct UpdateSuiteTool: ContentTool {
+    struct ScriptEdit: Decodable, Sendable {
+        /// Target script filename (must already exist in the suite).
+        let script: String
+        let tier: String?
+        let points: Int?
+        let displayName: String?
+        let dependsOn: [String]?
+        /// Section id to move the script into; empty string ungroups it; absent
+        /// leaves it unchanged.
+        let sectionID: String?
+    }
+
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        let edits: [ScriptEdit]
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let updatedScripts: [String]
+        /// The assignment's validation status after the edit re-kicks validation.
+        let validationStatus: String?
+    }
+
+    static let name = "update_suite"
+    static let description =
+        "Edit test-suite script metadata for an assignment, by its public ID. For each named "
+        + "script provide any of: tier (public/release/secret/student), points, displayName, "
+        + "dependsOn (prerequisite script names), and sectionID (\"\" to ungroup). Does NOT change "
+        + "script content or pattern families. Saving re-runs the assignment's validation."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "edits": .object([
+                "type": .string("array"),
+                "description": .string("Per-script metadata edits; each targets an existing script by filename."),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "script": .object([
+                            "type": .string("string"),
+                            "description": .string("Target script filename (must already exist)."),
+                        ]),
+                        "tier": .object([
+                            "type": .string("string"),
+                            "enum": .array([
+                                .string("public"), .string("release"), .string("secret"), .string("student"),
+                            ]),
+                        ]),
+                        "points": .object(["type": .string("integer")]),
+                        "displayName": .object(["type": .string("string")]),
+                        "dependsOn": .object([
+                            "type": .string("array"), "items": .object(["type": .string("string")]),
+                        ]),
+                        "sectionID": .object([
+                            "type": .string("string"),
+                            "description": .string("Section id, or \"\" to ungroup."),
+                        ]),
+                    ]),
+                    "required": .array([.string("script")]),
+                    "additionalProperties": .bool(false),
+                ]),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("edits")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard !input.edits.isEmpty else {
+            throw MCPToolError.invalidArguments(tool: Self.name, detail: "Provide at least one edit.")
+        }
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        // Load the full authored suite with script bodies preserved from the zip.
+        var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
+        var updated: [String] = []
+        for edit in input.edits {
+            let tier = try Self.parseTier(edit.tier)
+            guard
+                let idx = payload.items.firstIndex(where: {
+                    $0.kind == "script" && $0.script?.script == edit.script
+                })
+            else {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name, detail: "No script named \"\(edit.script)\" in the suite.")
+            }
+            if let tier { payload.items[idx].script?.tier = tier }
+            if let points = edit.points { payload.items[idx].script?.points = points }
+            if let displayName = edit.displayName {
+                payload.items[idx].script?.displayName = displayName.isEmpty ? nil : displayName
+            }
+            if let dependsOn = edit.dependsOn { payload.items[idx].script?.dependsOn = dependsOn }
+            if let sectionID = edit.sectionID {
+                payload.items[idx].sectionID = sectionID.isEmpty ? nil : sectionID
+            }
+            updated.append(edit.script)
+        }
+
+        try await applySuiteEdit(setup: setup, body: payload, on: context.db)
+        // Re-kick validation against the edited manifest (debounced), mirroring
+        // the web PUT /suite handler.
+        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            updatedScripts: updated,
+            validationStatus: assignment.validationStatus)
+    }
+
+    private static func parseTier(_ raw: String?) throws -> TestTier? {
+        guard let raw else { return nil }
+        guard let tier = TestTier(rawValue: raw) else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "tier must be one of: public, release, secret, student.")
+        }
+        return tier
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -21,6 +21,7 @@ enum MCPToolCatalog {
             GetAssignmentTool().erased(),
             GetSuiteTool().erased(),
             UpdateAssignmentTool().erased(),
+            UpdateSuiteTool().erased(),
         ])
     }
 }

--- a/Tests/APITests/MCP/UpdateSuiteToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSuiteToolTests.swift
@@ -1,0 +1,186 @@
+// Tests for UpdateSuiteTool (per-script suite metadata edits), backed by a real
+// test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct UpdateSuiteToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let manifest = """
+        {"schemaVersion":1,"testSuites":[\
+        {"tier":"public","script":"test_a.sh","points":1},\
+        {"tier":"public","script":"test_b.sh","points":1}\
+        ],"timeLimitSeconds":10}
+        """
+
+    /// Course + enrolled instructor + setup (manifest above, with a real zip
+    /// holding the two scripts so applySuiteEdit can rebuild it) + assignment.
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_us", courseID: courseID, manifest: manifest)
+        // Replace the empty fixture zip with one that actually contains the
+        // scripts named in the manifest, so the suite-edit zip rebuild succeeds.
+        try writeZip(
+            at: app.testSetupsDirectory + "setup_us.zip",
+            entries: [(".placeholder", "x"), ("test_a.sh", "exit 0\n"), ("test_b.sh", "exit 0\n")])
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_us", courseID: courseID, title: "Lab")
+    }
+
+    private func writeZip(at zipPath: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("us-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            let url = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.data(using: .utf8)?.write(to: url)
+        }
+        try? FileManager.default.removeItem(atPath: zipPath)
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+    }
+
+    @Test func updatesScriptTierAndPoints() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [
+                        UpdateSuiteTool.ScriptEdit(
+                            script: "test_a.sh", tier: "secret", points: 5, displayName: "First",
+                            dependsOn: nil, sectionID: nil)
+                    ]),
+                context(app))
+            #expect(output.updatedScripts == ["test_a.sh"])
+
+            // Reload the persisted manifest and confirm the edit stuck.
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest).items
+            let a = try #require(items.first { $0.script?.script == "test_a.sh" })
+            #expect(a.script?.tier == .secret)
+            #expect(a.script?.points == 5)
+            #expect(a.script?.displayName == "First")
+            // The untouched script is unchanged.
+            let b = try #require(items.first { $0.script?.script == "test_b.sh" })
+            #expect(b.script?.tier == .pub)
+            #expect(b.script?.points == 1)
+        }
+    }
+
+    @Test func setsDependsOn() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [
+                        UpdateSuiteTool.ScriptEdit(
+                            script: "test_b.sh", tier: nil, points: nil, displayName: nil,
+                            dependsOn: ["test_a.sh"], sectionID: nil)
+                    ]),
+                context(app))
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest).items
+            let b = try #require(items.first { $0.script?.script == "test_b.sh" })
+            #expect(b.script?.dependsOn == ["test_a.sh"])
+        }
+    }
+
+    @Test func unknownScriptThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSuiteTool().execute(
+                    UpdateSuiteTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        edits: [
+                            UpdateSuiteTool.ScriptEdit(
+                                script: "nope.sh", tier: "secret", points: nil, displayName: nil,
+                                dependsOn: nil, sectionID: nil)
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func invalidTierThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSuiteTool().execute(
+                    UpdateSuiteTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        edits: [
+                            UpdateSuiteTool.ScriptEdit(
+                                script: "test_a.sh", tier: "bogus", points: nil, displayName: nil,
+                                dependsOn: nil, sectionID: nil)
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func emptyEditsThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSuiteTool().execute(
+                    UpdateSuiteTool.Input(assignmentPublicID: assignment.publicID, edits: []),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_us", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_us", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSuiteTool().execute(
+                    UpdateSuiteTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        edits: [
+                            UpdateSuiteTool.ScriptEdit(
+                                script: "test_a.sh", tier: "secret", points: nil, displayName: nil,
+                                dependsOn: nil, sectionID: nil)
+                        ]),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-update-suite.md
+++ b/changelog.d/mcp-update-suite.md
@@ -1,0 +1,9 @@
+### Added
+
+- **MCP `update_suite` tool (authoring Phase 3a, write half).** Edits test-suite
+  *script* metadata for an assignment by public ID — tier, points, display name,
+  prerequisites (`dependsOn`), and section — through the same `applySuiteEdit`
+  path the web editor uses, so raw script bodies are preserved from the zip and
+  never sent by the agent. `content:write`, course-scoped; the edit re-runs the
+  assignment's validation. Pattern-family / notebook-check metadata and
+  reordering are later phases.


### PR DESCRIPTION
Phase 3a write-half of MCP test-suite authoring. Pairs with `get_suite` (read).

## `update_suite` (`content:write`, course-scoped)
Edits **per-script** suite metadata for an assignment by public ID: for each named script, set any of `tier` (public/release/secret/student), `points`, `displayName`, `dependsOn` (prerequisite script names), and `sectionID` (`""` to ungroup).

**Targeted read-modify-write** (the design decision — not whole-list): loads the current authored suite with script bodies preserved from the zip, applies only the named metadata edits, and re-saves via the same `applySuiteEdit` path the web `PUT /suite` uses, then re-kicks validation. **The agent never sends raw script content**, so it can't corrupt test bodies — important for course-content safety.

Out of scope here (later sub-slices): pattern-family / notebook-check metadata, and reordering.

## Test plan
- [x] `swift test --filter "MCP|ToolTests"` green (112 tests / 22 suites)
- [x] New tests: tier+points edit persists (and untouched script unchanged), dependsOn edit, unknown-script / invalid-tier / empty-edits rejected, not-enrolled denied. Real-zip fixture so the suite-edit rebuild round-trips.
- [x] swift-format `--strict` clean; merge-time process (changelog.d fragment, no version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)