### PR TITLE
MCP auth model: audit as <username>-MCP + tie service accounts to AUTH_MODE

### DIFF
--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -13,6 +13,7 @@ MCP
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>
 <section class="admin-section">
+    #if(showServiceAccounts):
     <h2 style="margin-top:0">MCP service accounts</h2>
 
     #if(!enabled):
@@ -134,6 +135,15 @@ MCP
         #endif
         </tbody>
     </table>
+    #else:
+    <h2 style="margin-top:0">MCP agents</h2>
+    <p style="color:var(--gray-600);font-size:.85rem;max-width:70ch">
+        Instructors authorize agents through single sign-on (the browser OAuth flow) — no service
+        accounts are created here. Each agent acts on the authorizing instructor's behalf, and its
+        actions are recorded in the <a href="/admin/audit">audit log</a> as
+        <code>&lt;username&gt;-MCP</code>, separate from the instructor's own.
+    </p>
+    #endif
 
     <h2 style="margin-top:2rem">Connected agents</h2>
     <p style="color:var(--gray-600);font-size:.85rem;max-width:70ch">

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -108,9 +108,11 @@ struct MCPDispatcher: Sendable {
         }
     }
 
-    /// Records an `mcp.tool_called` audit entry: actor = the token subject (the
-    /// human in the browser flow, or the service account otherwise), with the
-    /// acting agent in `via_agent` when present.  Never logs tool arguments.
+    /// Records an `mcp.tool_called` audit entry. The actor is the token subject
+    /// suffixed with `-MCP` (e.g. `jsmith-MCP`) so agent-made changes are
+    /// tracked separately from the human's own web actions in the admin audit
+    /// log; the acting agent is in `via_agent` when present. Never logs tool
+    /// arguments.
     private func auditToolCall(name: String, context: ToolContext) async {
         var metadata = ["tool": name]
         if let agent = context.actingClientName {
@@ -119,7 +121,7 @@ struct MCPDispatcher: Sendable {
         await AuditLogger.record(
             action: .mcpToolCalled,
             metadata: metadata,
-            actorUsernameOverride: context.subject,
+            actorUsernameOverride: "\(context.subject)-MCP",
             on: context.request)
     }
 

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -163,6 +163,10 @@ struct AdminMCPContext: Encodable {
     let issuer: String?
     let resource: String?
     let tokenTTLSeconds: Int
+    /// True only in local-auth mode: manual `mcp` service accounts are the
+    /// mechanism there. With SSO active, instructors authorize agents via the
+    /// browser flow instead, so the service-account UI is hidden.
+    let showServiceAccounts: Bool
     let accounts: [AdminMCPAccountRow]
     /// All courses, for the per-account enrollment picker.
     let allCourses: [AdminMCPCourseRef]

--- a/Sources/APIServer/Routes/Web/AdminRoutes+MCP.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+MCP.swift
@@ -164,6 +164,7 @@ extension AdminRoutes {
             issuer: endpoints?.issuer,
             resource: endpoints?.resource,
             tokenTTLSeconds: mcp.tokenTTLSeconds,
+            showServiceAccounts: req.application.appConfig.auth.mode == .local,
             accounts: accounts,
             allCourses: allCourses,
             grants: grantRows,

--- a/Tests/APITests/MCP/AdminMCPRoutesTests.swift
+++ b/Tests/APITests/MCP/AdminMCPRoutesTests.swift
@@ -15,14 +15,20 @@ import XCTVapor
     private let issuer = "https://chickadee.example"
     private let resource = "https://chickadee.example/mcp"
 
-    private func makeAdminApp(mcpEnabled: Bool) async throws -> (Application, MCPTokenAuthority?) {
+    private func makeAdminApp(
+        mcpEnabled: Bool, authMode: AuthMode = .local
+    ) async throws -> (
+        Application, MCPTokenAuthority?
+    ) {
         let mcp: MCPConfig =
             mcpEnabled
             ? MCPConfig(
                 enabled: true, allowedHosts: [], allowedOrigins: [],
                 tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource)
             : .default
-        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
+        // app.authMode stays .local so the test's session login works; the
+        // service-account UI reads appConfig.auth.mode, which we set here.
+        let app = try await makeTestApp(appConfig: .testDefaults(authMode: authMode, mcp: mcp))
         var authority: MCPTokenAuthority?
         if mcpEnabled {
             let made = try await MCPTokenAuthority.make(
@@ -152,6 +158,26 @@ import XCTVapor
             #expect(res.status == .seeOther)
             #expect(res.headers.first(name: .location) == "/admin/mcp")
             #expect(try await mcpAccount(named: "gone-bot", on: app) == nil)
+        }
+    }
+
+    @Test func ssoModeHidesServiceAccountCreation() async throws {
+        let (app, _) = try await makeAdminApp(mcpEnabled: true, authMode: .sso)
+        try await withApp(app) { app in
+            let cookie = try await loginUser(
+                username: "mcp_admin", password: "testpassword", role: "admin", on: app)
+            try await app.asyncTest(
+                .GET, "/admin/mcp",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    // No manual service-account creation in SSO mode...
+                    #expect(body.contains("Create account") == false)
+                    // ...but the SSO/audit explanation and Connected Agents table show.
+                    #expect(body.contains("single sign-on"))
+                    #expect(body.contains("Connected agents"))
+                })
         }
     }
 

--- a/Tests/APITests/MCP/MCPAuditAttributionTests.swift
+++ b/Tests/APITests/MCP/MCPAuditAttributionTests.swift
@@ -1,0 +1,46 @@
+// Verifies MCP tool calls are recorded in the audit log under a distinct
+// `<username>-MCP` actor, so agent-made changes are tracked separately from the
+// human's own web actions.
+
+import Core
+import Fluent
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPAuditAttributionTests {
+    @Test func toolCallIsAuditedAsUsernameMCP() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let prof = try await makeTestUser(on: app, username: "jsmith", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: prof.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_a", courseID: courseID)
+            try await makeTestAssignment(
+                on: app, testSetupID: "setup_a", courseID: courseID, title: "Tasks")
+
+            let registry = ToolRegistry([ListAssignmentsTool().erased()])
+            let dispatcher = MCPDispatcher(serverInfo: MCPServerInfo(name: "t", version: "t"), tools: registry)
+            let context = ToolContext(
+                request: Request(application: app, on: app.eventLoopGroup.any()),
+                subject: "jsmith", grantedScopes: [.read],
+                actingClientID: "agent-1", actingClientName: "Claude Bot")
+            let request = JSONRPCRequest(
+                jsonrpc: "2.0", id: .number(1), method: "tools/call",
+                params: .object([
+                    "name": .string("list_assignments"),
+                    "arguments": .object(["courseCode": .string("CS246")]),
+                ]))
+            _ = try #require(await dispatcher.dispatch(request, context: context))
+
+            let entry = try #require(
+                try await APIAuditLogEntry.query(on: app.db)
+                    .filter(\.$action == "mcp.tool_called")
+                    .first())
+            // Tracked separately from the human's own actions.
+            #expect(entry.actorUsername == "jsmith-MCP")
+        }
+    }
+}

--- a/changelog.d/mcp-authmode-username-mcp.md
+++ b/changelog.d/mcp-authmode-username-mcp.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **MCP actions are audited as `<username>-MCP`.** Every MCP tool call is now
+  recorded in the admin audit log under the subject's username suffixed with
+  `-MCP` (e.g. `jsmith-MCP`), so agent-made changes are tracked separately from
+  the instructor's own web actions. The token subject itself is unchanged for
+  authorization / course-scoping.
+- **MCP service-account UI is tied to the auth mode.** When SSO is active
+  (`AUTH_MODE` ≠ `local`), the admin MCP panel hides manual service-account
+  creation — instructors authorize agents through the SSO browser flow, and the
+  Connected Agents table + audit log are the tracking surface. Local-auth
+  deployments keep service-account creation.


### PR DESCRIPTION
Implements the agreed MCP auth model: SSO-auth'd instructors authorize agents via the browser flow, and agent actions are tracked distinctly.

## `<username>-MCP` audit attribution
Every MCP tool call is recorded in the **admin audit log** under the subject's username suffixed `-MCP` (e.g. `jsmith-MCP`), so agent-made changes are clearly separable from the instructor's own web actions. The token subject itself is unchanged — authorization and course-scoping still use the real identity.

## Service accounts tied to auth mode
When SSO is active (`appConfig.auth.mode` ≠ `.local`), the admin MCP panel **hides manual service-account creation**: instructors authorize agents through the SSO browser flow, and the Connected Agents table + audit log are the tracking surface. **Local-auth** deployments keep service-account creation (no IdP to authorize against).

## Test plan
- [x] Audit test: a dispatched tool call records an `mcp.tool_called` entry with actor `jsmith-MCP`.
- [x] SSO mode hides the create-account form and shows the SSO note + Connected Agents; local mode still shows creation (existing tests).
- [x] `swift test --filter "AdminMCPRoutesTests|MCPAuditAttributionTests"` green; swift-format `--strict` clean; changelog fragment only (no version bump).

Independent of #714 (`update_suite`) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)