### PR TITLE
MCP authoring Phase 3b (write): update_pattern_family tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -1,0 +1,173 @@
+// APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+//
+// Write tool: edit a pattern family's *metadata* for an assignment — its
+// default tier/points, and which cases are enabled — by public ID + family id.
+// content:write, course-scoped.
+//
+// Targeted read-modify-write through the same applySuiteEdit / applyPatternFamilies
+// path the web editor uses: loads the current authored suite, reconstructs the
+// family with the requested default + case-enabled changes (every other field —
+// function, params, case args/expected/variables — is preserved verbatim), and
+// re-saves, which regenerates the family's scripts and re-runs validation.
+//
+// The agent can re-weight/re-tier a family and turn cases on/off, but it does
+// NOT author case args or expected values (the actual test logic) — that's a
+// later, higher-risk slice, like notebook content.
+
+import Core
+import Fluent
+import Foundation
+
+struct UpdatePatternFamilyTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        let familyID: String
+        let defaultTier: String?
+        let defaultPoints: Int?
+        let enableCases: [String]?
+        let disableCases: [String]?
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let familyID: String
+        let defaultTier: String
+        let defaultPoints: Int
+        let enabledCaseKeys: [String]
+        let validationStatus: String?
+    }
+
+    static let name = "update_pattern_family"
+    static let description =
+        "Edit a pattern family's metadata for an assignment, by assignment public ID + family id. "
+        + "Set the family's default tier (public/release/secret/student) and/or points, and "
+        + "enable/disable individual cases by key (enableCases / disableCases). Does NOT change a "
+        + "case's args or expected value (the test logic). Saving regenerates the family's scripts "
+        + "and re-runs validation."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "familyID": .object([
+                "type": .string("string"),
+                "description": .string("The pattern family's id (from get_suite)."),
+            ]),
+            "defaultTier": .object([
+                "type": .string("string"),
+                "enum": .array([
+                    .string("public"), .string("release"), .string("secret"), .string("student"),
+                ]),
+            ]),
+            "defaultPoints": .object(["type": .string("integer")]),
+            "enableCases": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+                "description": .string("Case keys to enable."),
+            ]),
+            "disableCases": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+                "description": .string("Case keys to disable."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("familyID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let newTier = try Self.parseTier(input.defaultTier)
+        let enable = Set(input.enableCases ?? [])
+        let disable = Set(input.disableCases ?? [])
+        guard newTier != nil || input.defaultPoints != nil || !enable.isEmpty || !disable.isEmpty else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "Specify at least one of: defaultTier, defaultPoints, enableCases, disableCases.")
+        }
+        guard enable.isDisjoint(with: disable) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "A case key cannot be in both enableCases and disableCases.")
+        }
+
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
+        guard
+            let idx = payload.items.firstIndex(where: {
+                $0.kind == "family" && $0.family?.id == input.familyID
+            }),
+            let family = payload.items[idx].family
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No pattern family with id \"\(input.familyID)\" in the suite.")
+        }
+
+        let caseKeys = Set(family.cases.map(\.key))
+        let unknown = enable.union(disable).subtracting(caseKeys)
+        guard unknown.isEmpty else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "Unknown case key(s): \(unknown.sorted().joined(separator: ", ")).")
+        }
+
+        let updatedFamily = Self.rebuild(
+            family, newTier: newTier, newPoints: input.defaultPoints, enable: enable, disable: disable)
+        payload.items[idx].family = updatedFamily
+
+        try await applySuiteEdit(setup: setup, body: payload, on: context.db)
+        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            familyID: updatedFamily.id,
+            defaultTier: updatedFamily.defaults.tier.rawValue,
+            defaultPoints: updatedFamily.defaults.points,
+            enabledCaseKeys: updatedFamily.cases.filter(\.enabled).map(\.key),
+            validationStatus: assignment.validationStatus)
+    }
+
+    /// Reconstructs the family with new defaults and per-case enabled flags;
+    /// every other field is copied verbatim.
+    private static func rebuild(
+        _ family: PatternFamily, newTier: TestTier?, newPoints: Int?,
+        enable: Set<String>, disable: Set<String>
+    ) -> PatternFamily {
+        let defaults = PatternDefaults(
+            tier: newTier ?? family.defaults.tier,
+            points: newPoints ?? family.defaults.points,
+            hint: family.defaults.hint,
+            tolerance: family.defaults.tolerance)
+        let cases = family.cases.map { caseSpec -> PatternCase in
+            let enabled =
+                enable.contains(caseSpec.key)
+                ? true : (disable.contains(caseSpec.key) ? false : caseSpec.enabled)
+            return PatternCase(
+                key: caseSpec.key, label: caseSpec.label, args: caseSpec.args,
+                expected: caseSpec.expected, argsProvided: caseSpec.argsProvided,
+                argVarRefs: caseSpec.argVarRefs, hint: caseSpec.hint, tier: caseSpec.tier,
+                points: caseSpec.points, enabled: enabled)
+        }
+        return PatternFamily(
+            id: family.id, name: family.name, kind: family.kind, functionName: family.functionName,
+            paramNames: family.paramNames, defaults: defaults, cases: cases,
+            variables: family.variables, dependsOn: family.dependsOn)
+    }
+
+    private static func parseTier(_ raw: String?) throws -> TestTier? {
+        guard let raw else { return nil }
+        guard let tier = TestTier(rawValue: raw) else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "defaultTier must be one of: public, release, secret, student.")
+        }
+        return tier
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -22,6 +22,7 @@ enum MCPToolCatalog {
             GetSuiteTool().erased(),
             UpdateAssignmentTool().erased(),
             UpdateSuiteTool().erased(),
+            UpdatePatternFamilyTool().erased(),
         ])
     }
 }

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -1,0 +1,191 @@
+// Tests for UpdatePatternFamilyTool (pattern-family metadata edits: defaults +
+// case enable/disable), backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct UpdatePatternFamilyToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+
+    /// Course + enrolled instructor + setup seeded with the BMI pattern family
+    /// (three cases, all enabled) + assignment.  Returns the assignment.
+    private func fixture(
+        on app: Application, family: PatternFamily = pfBMIFamily()
+    ) async throws
+        -> APIAssignment
+    {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        let setup = try await makeTestSetup(
+            on: app, id: "setup_pf", courseID: courseID, manifest: emptyManifest)
+        // The fixture's empty-bytes zip can't be rebuilt; replace it with a
+        // valid (placeholder-only) archive so applyPatternFamilies can re-save.
+        try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_pf.zip")
+        try await applyPatternFamilies(
+            to: setup, nextFamilies: [family],
+            authoredItems: [.family(id: family.id, sectionID: nil)], on: app.db)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_pf", courseID: courseID, title: "Lab")
+    }
+
+    private func reloadFamily(
+        _ assignment: APIAssignment, on db: Database
+    ) async throws
+        -> PatternFamily
+    {
+        let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: db))
+        let items = buildSuitePayload(fromManifest: reloaded.manifest).items
+        return try #require(items.compactMap(\.family).first { $0.id == "bmi_category" })
+    }
+
+    @Test func disablesACase() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultTier: nil, defaultPoints: nil, enableCases: nil, disableCases: ["02"]),
+                context(app))
+            #expect(output.enabledCaseKeys == ["01", "03"])
+
+            let family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.cases.first { $0.key == "02" }?.enabled == false)
+            #expect(family.cases.first { $0.key == "01" }?.enabled == true)
+        }
+    }
+
+    @Test func setsDefaultsTierAndPoints() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultTier: "secret", defaultPoints: 4, enableCases: nil, disableCases: nil),
+                context(app))
+            #expect(output.defaultTier == "secret")
+            #expect(output.defaultPoints == 4)
+
+            let family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.defaults.tier == .secret)
+            #expect(family.defaults.points == 4)
+            // Cases (args/expected) are untouched.
+            #expect(family.cases.count == 3)
+            #expect(family.cases.first { $0.key == "01" }?.expected == .string("underweight"))
+        }
+    }
+
+    @Test func unknownFamilyThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "nope",
+                        defaultTier: nil, defaultPoints: 2, enableCases: nil, disableCases: nil),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func unknownCaseKeyThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        defaultTier: nil, defaultPoints: nil, enableCases: nil,
+                        disableCases: ["99"]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func invalidTierThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        defaultTier: "bogus", defaultPoints: nil, enableCases: nil,
+                        disableCases: nil),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func emptyChangeSetThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        defaultTier: nil, defaultPoints: nil, enableCases: nil, disableCases: nil),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func overlappingEnableDisableThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        defaultTier: nil, defaultPoints: nil, enableCases: ["01"],
+                        disableCases: ["01"]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            let setup = try await makeTestSetup(
+                on: app, id: "setup_pf", courseID: courseID, manifest: emptyManifest)
+            try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_pf.zip")
+            try await applyPatternFamilies(
+                to: setup, nextFamilies: [pfBMIFamily()],
+                authoredItems: [.family(id: "bmi_category", sectionID: nil)], on: app.db)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_pf", courseID: courseID, title: "Lab")
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        defaultTier: nil, defaultPoints: 2, enableCases: nil, disableCases: nil),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-update-pattern-family.md
+++ b/changelog.d/mcp-update-pattern-family.md
@@ -1,0 +1,10 @@
+### Added
+
+- **MCP authoring (write): `update_pattern_family` tool.** Lets an authorized
+  agent edit a pattern family's metadata for an assignment — its default tier
+  and points, and which cases are enabled — by assignment public ID + family id.
+  A targeted read-modify-write through the same suite-edit path the web editor
+  uses: every other field (function, params, case args/expected/variables) is
+  preserved verbatim, and saving regenerates the family's scripts and re-runs
+  validation. It does **not** author case args or expected values (the test
+  logic itself).


### PR DESCRIPTION
## Summary

- Adds the **`update_pattern_family`** MCP write tool: an authorized agent can edit a pattern family's *metadata* for an assignment — its default tier/points, and which cases are enabled — by assignment public ID + family id.
- Targeted read-modify-write through the same `applySuiteEdit` / `applyPatternFamilies` path the web editor uses. Every other field (function, params, case args/expected/variables) is preserved verbatim; saving regenerates the family's scripts and re-runs validation.
- The agent can re-weight/re-tier a family and toggle cases on/off, but it does **not** author case args or expected values (the actual test logic) — that's a later, higher-risk slice.
- Registered in `MCPToolCatalog.live`; `content:write`, course-scoped (rejects students via `requireEligibleSubject`).

## Test plan

- [x] `swift test --filter UpdatePatternFamilyToolTests` — 8 tests pass (disable case, set defaults tier/points, unknown family/case, invalid tier, empty change set, overlapping enable/disable, denies non-enrolled subject).
- [x] `scripts/swiftlint.sh --strict` — 0 violations.
- [x] `scripts/format.sh` clean.
- [x] `scripts/assemble-release.sh --dry-run` previews the changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)