### PR TITLE
MCP authoring Phase 5a (read): get_notebook tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
@@ -1,0 +1,93 @@
+// APIServer/MCP/Tools/GetNotebookTool.swift
+//
+// Read tool: returns an assignment's notebook (the starter/assignment notebook
+// the student opens) as structured .ipynb JSON, by assignment public ID.
+// content:read, course-scoped.
+//
+// This is the first, read-only slice of notebook authoring (roadmap Phase 5):
+// an agent needs to see the current notebook before it can reason about or
+// (later) edit it. Loading reuses the canonical `notebookData(for:)` helper —
+// the same flat-file-then-zip resolution + JupyterLite normalization the web
+// notebook routes use — so the agent sees exactly what the editor would.
+//
+// No cell filtering: only instructors / admins / mcp service accounts can use
+// MCP at all (students are rejected at the tool layer), so the full notebook is
+// returned the way an instructor download would.
+
+import Core
+import Fluent
+import Foundation
+
+struct GetNotebookTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let cellCount: Int
+        let notebook: JSONValue
+    }
+
+    static let name = "get_notebook"
+    static let description =
+        "Get an assignment's notebook (the starter notebook students open) as .ipynb JSON, by "
+        + "assignment public ID. Returns the full notebook plus a cell count. Read-only; use it to "
+        + "inspect an assignment's notebook before editing the suite or (later) the notebook itself."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ])
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        let data: Data
+        do {
+            data = try notebookData(for: setup)
+        } catch {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "This assignment has no notebook to return.")
+        }
+
+        let notebook: JSONValue
+        do {
+            notebook = try JSONDecoder().decode(JSONValue.self, from: data)
+        } catch {
+            throw MCPToolError.executionFailed(
+                tool: Self.name, detail: "The stored notebook is not valid JSON.")
+        }
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            cellCount: Self.cellCount(of: notebook),
+            notebook: notebook)
+    }
+
+    /// Number of cells in the notebook, or 0 if the `cells` array is absent.
+    private static func cellCount(of notebook: JSONValue) -> Int {
+        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
+            return 0
+        }
+        return cells.count
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -20,6 +20,7 @@ enum MCPToolCatalog {
             ListAssignmentsTool().erased(),
             GetAssignmentTool().erased(),
             GetSuiteTool().erased(),
+            GetNotebookTool().erased(),
             UpdateAssignmentTool().erased(),
             UpdateSuiteTool().erased(),
             UpdatePatternFamilyTool().erased(),

--- a/Tests/APITests/MCP/GetNotebookToolTests.swift
+++ b/Tests/APITests/MCP/GetNotebookToolTests.swift
@@ -1,0 +1,117 @@
+// Tests for GetNotebookTool (read an assignment's notebook), backed by a real
+// test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct GetNotebookToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read]
+        )
+    }
+
+    private let twoCellNotebook = #"""
+        {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[
+        {"cell_type":"markdown","metadata":{},"source":["# Lab"]},
+        {"cell_type":"code","metadata":{},"source":["x = 1\n"],"outputs":[],"execution_count":null}
+        ]}
+        """#
+
+    /// Course + enrolled instructor "tester" + setup (with the default empty
+    /// notebook) + assignment.  Returns the assignment.
+    private func fixture(
+        on app: Application, withNotebook: Bool = true
+    ) async throws
+        -> APIAssignment
+    {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(
+            on: app, id: "setup_nb", courseID: courseID, withNotebook: withNotebook)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_nb", courseID: courseID, title: "Lab")
+    }
+
+    @Test func returnsNotebookWithCells() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Replace the default empty notebook with a two-cell one.
+            try twoCellNotebook.write(
+                toFile: app.testSetupsDirectory + "setup_nb.ipynb", atomically: true,
+                encoding: .utf8)
+
+            let output = try await GetNotebookTool().execute(
+                GetNotebookTool.Input(assignmentPublicID: assignment.publicID), context(app))
+
+            #expect(output.assignmentPublicID == assignment.publicID)
+            #expect(output.cellCount == 2)
+            // The returned notebook is a JSON object carrying a cells array.
+            guard case .object(let root) = output.notebook, case .array(let cells)? = root["cells"]
+            else {
+                Issue.record("notebook output was not a JSON object with a cells array")
+                return
+            }
+            #expect(cells.count == 2)
+        }
+    }
+
+    @Test func returnsEmptyCellsForBlankNotebook() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await GetNotebookTool().execute(
+                GetNotebookTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            #expect(output.cellCount == 0)
+        }
+    }
+
+    @Test func unknownAssignmentThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetNotebookTool().execute(
+                    GetNotebookTool.Input(assignmentPublicID: "zzzzzz"), context(app))
+            }
+        }
+    }
+
+    @Test func throwsWhenNoNotebook() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Setup without a flat notebook and only an empty zip → nothing to return.
+            let assignment = try await fixture(on: app, withNotebook: false)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetNotebookTool().execute(
+                    GetNotebookTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_nb", courseID: courseID)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_nb", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetNotebookTool().execute(
+                    GetNotebookTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-get-notebook.md
+++ b/changelog.d/mcp-get-notebook.md
@@ -1,0 +1,9 @@
+### Added
+
+- **MCP authoring (read): `get_notebook` tool.** Returns an assignment's
+  notebook (the starter notebook students open) as structured `.ipynb` JSON,
+  plus a cell count, by assignment public ID. The first, read-only slice of
+  notebook authoring (roadmap Phase 5): an agent can now inspect a notebook
+  before reasoning about the suite or (later) editing the notebook. Loading
+  reuses the canonical `notebookData(for:)` resolution + JupyterLite
+  normalization the web notebook routes use. `content:read`, course-scoped.


### PR DESCRIPTION
## Summary

- Adds the **`get_notebook`** MCP read tool: returns an assignment's notebook (the starter notebook students open) as structured `.ipynb` JSON, plus a cell count, by assignment public ID.
- The **first, read-only slice of notebook authoring** (roadmap Phase 5): an agent can now inspect a notebook before reasoning about the suite or (in a later slice) editing the notebook itself. Notebook *writes* will land as separate, dev-verifiable slices.
- Loading reuses the canonical `notebookData(for:)` helper — the same flat-file-then-zip resolution + JupyterLite normalization the web notebook routes use — so the agent sees exactly what the editor would.
- No cell filtering: only instructors / admins / `mcp` service accounts can use MCP (students are rejected at the tool layer), so the full notebook is returned the way an instructor download would. `content:read`, course-scoped via `authorizeCourseAccess`.

## Test plan

- [x] `swift test --filter GetNotebookToolTests` — 5 tests pass (notebook with cells, blank notebook, unknown assignment, no-notebook setup, denied when not enrolled).
- [x] `swift test --filter MCP` — transport/OAuth suites green (73 tests).
- [x] `scripts/swiftlint.sh --strict` — 0 violations; `scripts/format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)