### PR TITLE
MCP authoring Phase 5b (write): update_notebook tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
@@ -1,0 +1,124 @@
+// APIServer/MCP/Tools/UpdateNotebookTool.swift
+//
+// Write tool: replace an assignment's starter notebook with new .ipynb JSON
+// supplied by the agent, by assignment public ID. content:write, course-scoped.
+//
+// The agent supplies the full notebook JSON (the format decided for notebook
+// writes); the server applies the same JupyterLite kernel normalization + flat-
+// file write the web editor's Save uses (AssignmentAuthoringService.write
+// AssignmentNotebook), then re-enqueues validation exactly like the suite-edit
+// tools, so the two paths can't drift and the validation loop stays closed.
+//
+// Deliberately narrow blast radius: only the flat `<setupID>.ipynb` is written
+// (the setup zip stays archival — reads prefer the flat file), and existing
+// student working copies are left untouched so a notebook edit never clobbers a
+// student's in-progress work. Students pick up the new starter notebook the
+// next time their working copy is (re)seeded.
+
+import Core
+import Fluent
+import Foundation
+
+struct UpdateNotebookTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        let notebook: JSONValue
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let cellCount: Int
+        let validationStatus: String?
+    }
+
+    static let name = "update_notebook"
+    static let description =
+        "Replace an assignment's starter notebook (the notebook students open) with new .ipynb JSON, "
+        + "by assignment public ID. Supply the full notebook as a JSON object with a \"cells\" array; "
+        + "the server normalizes it for the in-browser kernel and re-runs validation. Only the starter "
+        + "notebook changes — existing students keep their in-progress work and pick up the new notebook "
+        + "when their copy is next reset. Use get_notebook first to fetch the current notebook to edit."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "notebook": .object([
+                "type": .string("object"),
+                "description": .string(
+                    "The full notebook as .ipynb JSON (must be an object containing a \"cells\" array)."
+                ),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("notebook")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        try Self.validateNotebookShape(input.notebook)
+
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(input.notebook)
+        } catch {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The notebook could not be serialized to JSON.")
+        }
+
+        do {
+            try await AssignmentAuthoringService.writeAssignmentNotebook(
+                setup: setup, notebookData: data,
+                setupsDirectory: context.request.application.testSetupsDirectory, on: context.db)
+        } catch let error as AssignmentAuthoringError {
+            if case .setupCopyFailed(let reason) = error {
+                throw MCPToolError.executionFailed(
+                    tool: Self.name, detail: "Could not write the notebook: \(reason)")
+            }
+            throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
+        }
+
+        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            cellCount: Self.cellCount(of: input.notebook),
+            validationStatus: assignment.validationStatus)
+    }
+
+    /// A notebook must be a JSON object carrying a `cells` array — the minimal
+    /// shape every Jupyter notebook has. Stricter nbformat checks are left to
+    /// the runner, matching the web save path's lenient JSON-only validation.
+    private static func validateNotebookShape(_ notebook: JSONValue) throws {
+        guard case .object(let root) = notebook else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "notebook must be a JSON object.")
+        }
+        guard case .array? = root["cells"] else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "notebook must contain a \"cells\" array.")
+        }
+    }
+
+    private static func cellCount(of notebook: JSONValue) -> Int {
+        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
+            return 0
+        }
+        return cells.count
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -24,6 +24,7 @@ enum MCPToolCatalog {
             UpdateAssignmentTool().erased(),
             UpdateSuiteTool().erased(),
             UpdatePatternFamilyTool().erased(),
+            UpdateNotebookTool().erased(),
             CloneAssignmentTool().erased(),
         ])
     }

--- a/Sources/APIServer/Services/AssignmentAuthoringService.swift
+++ b/Sources/APIServer/Services/AssignmentAuthoringService.swift
@@ -151,6 +151,35 @@ enum AssignmentAuthoringService {
         }
     }
 
+    /// Replaces a test setup's flat starter notebook with `notebookData`,
+    /// applying the same JupyterLite kernel normalization + flat-file write the
+    /// web editor's no-upload Save path uses (`persistAssignmentNotebook`). The
+    /// setup's `notebookPath` is set (creating `<setupID>.ipynb` when absent)
+    /// and the setup is saved.
+    ///
+    /// The setup zip is intentionally *not* rebuilt — reads prefer the flat
+    /// file (`notebookData(for:)`), the zip stays archival, and existing student
+    /// working copies are left untouched so in-progress work isn't clobbered.
+    /// Callers that want the validation loop closed call
+    /// `scheduleValidationAfterSuiteEdit` afterwards, matching the web Save.
+    static func writeAssignmentNotebook(
+        setup: APITestSetup,
+        notebookData: Data,
+        setupsDirectory: String,
+        on db: Database
+    ) async throws {
+        let normalized = normalizeNotebookForJupyterLite(notebookData)
+        let path =
+            setup.notebookPath ?? (setupsDirectory + "\((setup.id ?? "unknown")).ipynb")
+        do {
+            try normalized.write(to: URL(fileURLWithPath: path))
+        } catch {
+            throw AssignmentAuthoringError.setupCopyFailed(reason: "\(error)")
+        }
+        setup.notebookPath = path
+        try await setup.save(on: db)
+    }
+
     /// Mutates open-state in memory (no save). Opening requires validation to
     /// have passed and sets the deadline override when the due date is past.
     private static func applyOpenState(_ assignment: APIAssignment, open: Bool, now: Date) throws {

--- a/Tests/APITests/MCP/UpdateNotebookToolTests.swift
+++ b/Tests/APITests/MCP/UpdateNotebookToolTests.swift
@@ -1,0 +1,146 @@
+// Tests for UpdateNotebookTool (replace an assignment's starter notebook),
+// backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct UpdateNotebookToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    /// Decodes a JSON string into a `JSONValue` for use as tool input.
+    private func json(_ raw: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
+    }
+
+    private let twoCellNotebook = #"""
+        {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[
+        {"cell_type":"markdown","metadata":{},"source":["# Lab"]},
+        {"cell_type":"code","metadata":{},"source":["x = 1\n"],"outputs":[],"execution_count":null}
+        ]}
+        """#
+
+    private func fixture(
+        on app: Application, withNotebook: Bool = true
+    ) async throws
+        -> APIAssignment
+    {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(
+            on: app, id: "setup_nb", courseID: courseID, withNotebook: withNotebook)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_nb", courseID: courseID, title: "Lab")
+    }
+
+    @Test func writesNotebookAndPersists() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await UpdateNotebookTool().execute(
+                UpdateNotebookTool.Input(
+                    assignmentPublicID: assignment.publicID, notebook: try json(twoCellNotebook)),
+                context(app))
+            #expect(output.cellCount == 2)
+
+            // Read the persisted notebook back through the canonical loader.
+            let setup = try #require(try await APITestSetup.find("setup_nb", on: app.db))
+            let data = try notebookData(for: setup)
+            let reloaded = try JSONDecoder().decode(JSONValue.self, from: data)
+            guard case .object(let root) = reloaded, case .array(let cells)? = root["cells"] else {
+                Issue.record("persisted notebook was not a JSON object with a cells array")
+                return
+            }
+            #expect(cells.count == 2)
+        }
+    }
+
+    @Test func createsFlatFileWhenAbsent() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, withNotebook: false)
+            // Setup begins with no flat notebook.
+            let before = try #require(try await APITestSetup.find("setup_nb", on: app.db))
+            #expect(before.notebookPath == nil)
+
+            _ = try await UpdateNotebookTool().execute(
+                UpdateNotebookTool.Input(
+                    assignmentPublicID: assignment.publicID, notebook: try json(twoCellNotebook)),
+                context(app))
+
+            let after = try #require(try await APITestSetup.find("setup_nb", on: app.db))
+            let path = try #require(after.notebookPath)
+            #expect(FileManager.default.fileExists(atPath: path))
+        }
+    }
+
+    @Test func rejectsNonObjectNotebook() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateNotebookTool().execute(
+                    UpdateNotebookTool.Input(
+                        assignmentPublicID: assignment.publicID, notebook: .array([])),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func rejectsNotebookWithoutCells() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateNotebookTool().execute(
+                    UpdateNotebookTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        notebook: try json(#"{"nbformat":4,"metadata":{}}"#)),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func unknownAssignmentThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateNotebookTool().execute(
+                    UpdateNotebookTool.Input(
+                        assignmentPublicID: "zzzzzz", notebook: try json(twoCellNotebook)),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_nb", courseID: courseID)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_nb", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateNotebookTool().execute(
+                    UpdateNotebookTool.Input(
+                        assignmentPublicID: assignment.publicID, notebook: try json(twoCellNotebook)),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-update-notebook.md
+++ b/changelog.d/mcp-update-notebook.md
@@ -1,0 +1,12 @@
+### Added
+
+- **MCP authoring (write): `update_notebook` tool.** Lets an authorized agent
+  replace an assignment's starter notebook (the notebook students open) with new
+  `.ipynb` JSON, by assignment public ID. The agent supplies the full notebook
+  (a JSON object with a `cells` array); the server applies the same JupyterLite
+  kernel normalization + flat-file write the web editor's Save uses and re-runs
+  validation, so the two paths can't drift. Narrow blast radius: only the flat
+  notebook is written (the setup zip stays archival), and existing student
+  working copies are left untouched so an edit never clobbers in-progress work —
+  students pick up the new notebook when their copy is next reset. `content:write`,
+  course-scoped.


### PR DESCRIPTION
## Summary

- Adds the **`update_notebook`** MCP write tool: an authorized agent replaces an assignment's **starter notebook** (the notebook students open) with new `.ipynb` JSON, by assignment public ID.
- The agent supplies the **full notebook** (a JSON object with a `cells` array — the format chosen for notebook writes); the server applies the same JupyterLite kernel normalization + flat-file write the web editor's Save uses (new `AssignmentAuthoringService.writeAssignmentNotebook`) and re-enqueues validation via `scheduleValidationAfterSuiteEdit`, so the MCP and web paths can't drift and the validation loop stays closed.
- **Narrow blast radius:** only the flat `<setupID>.ipynb` is written (the setup zip stays archival — reads prefer the flat file), and existing **student working copies are left untouched** so a notebook edit never clobbers a student's in-progress work; students pick up the new starter notebook when their copy is next reset.
- Light input validation (must be a JSON object with a `cells` array); stricter nbformat checks left to the runner, matching the web save path's lenient validation. `content:write`, course-scoped via `authorizeCourseAccess`.

## Test plan

- [x] `swift test --filter UpdateNotebookToolTests` — 6 tests pass (writes & persists, creates flat file when absent, rejects non-object, rejects missing cells, unknown assignment, denied when not enrolled).
- [x] `swift test --filter GetNotebookToolTests` — read tool still green (round-trips the written notebook).
- [x] `scripts/swiftlint.sh --strict` — 0 violations; `scripts/format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)