### PR TITLE
MCP: orient connecting agents (instructions, output schemas, tool annotations)

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -1,8 +1,11 @@
 // APIServer/MCP/Protocol/InitializeTypes.swift
 //
 // Result types for the MCP `initialize` handshake.  Capabilities advertise
-// only what v1 implements — tools and resources, both without list-change
-// notifications, since there is no server-initiated streaming yet.
+// only what v1 implements — tools, without list-change notifications, since
+// there is no server-initiated streaming yet.  The result also carries a
+// human-readable `instructions` string so a connecting agent learns the domain
+// model, the read-before-write workflow, and the validation/safety rules up
+// front rather than reverse-engineering them from the tool list alone.
 // https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
 
 /// The result returned from an `initialize` request.
@@ -10,28 +13,85 @@ struct MCPInitializeResult: Encodable, Sendable {
     let protocolVersion: String
     let capabilities: MCPServerCapabilities
     let serverInfo: MCPServerInfo
+    /// Free-form guidance the client can feed to the model to improve its use
+    /// of this server (omitted from the wire when nil).
+    let instructions: String?
 }
 
-/// Capabilities this server advertises at initialization.  `listChanged` is
-/// false because v1 does not push list-change notifications (no streaming).
+/// Capabilities this server advertises at initialization.  Only `tools` is
+/// advertised: v1 exposes no resources or prompts, and `listChanged` is false
+/// because it pushes no list-change notifications (no streaming).
 struct MCPServerCapabilities: Encodable, Sendable {
     let tools: ListChanged
-    let resources: ListChanged
 
     struct ListChanged: Encodable, Sendable {
         let listChanged: Bool
     }
 
-    /// The capability set advertised by v1: tools + resources, no list-change
+    /// The capability set advertised by v1: tools only, no list-change
     /// notifications.
-    static let v1 = MCPServerCapabilities(
-        tools: ListChanged(listChanged: false),
-        resources: ListChanged(listChanged: false)
-    )
+    static let v1 = MCPServerCapabilities(tools: ListChanged(listChanged: false))
 }
 
-/// Identifies this server to the client in the `initialize` result.
+/// Identifies this server to the client in the `initialize` result.  `name` is
+/// the stable programmatic identifier; `title` is an optional human-friendly
+/// display name (omitted from the wire when nil).
 struct MCPServerInfo: Encodable, Sendable {
     let name: String
+    let title: String?
     let version: String
+
+    init(name: String, version: String, title: String? = nil) {
+        self.name = name
+        self.title = title
+        self.version = version
+    }
+}
+
+/// Server-level guidance surfaced in the `initialize` result's `instructions`
+/// field.  This is the one place an agent is taught the whole picture, so it
+/// covers the domain vocabulary, the recommended workflow, and the
+/// validation/scope/safety rules that aren't obvious from any single tool.
+enum MCPServerInstructions {
+    static let text = """
+        Chickadee is a course-content authoring and autograding platform. This server lets an \
+        authorized agent author assignment content on an instructor's behalf: assignment metadata, \
+        test suites, and starter notebooks. It never exposes student data, grades, submissions, or \
+        enrollment management.
+
+        Access scope: you may only act on courses the authenticated account is enrolled in (an admin \
+        account may act on every course); students cannot use this interface. Read tools require the \
+        content:read scope; write tools require content:write.
+
+        Key concepts:
+        - Course — identified by a short code (e.g. "CS136").
+        - Assignment — identified by a 6-character public ID; has a title, an optional due date \
+        (ISO 8601), and an open/closed state.
+        - Test suite — the ordered checks that grade an assignment. Each item is a hand-written \
+        script, a generated pattern family, or a notebook check, and carries a tier \
+        (public/release/secret/student), points, an optional section, and prerequisites (dependsOn). \
+        Family IDs and case keys come from get_suite.
+        - Starter notebook — the .ipynb a student opens, stored as Jupyter JSON.
+        - Validation — the server validates an assignment's suite against its solution; an assignment \
+        cannot be opened (isOpen=true) until validation passes.
+
+        Recommended workflow:
+        1. Discover: list_courses, then list_assignments for a course.
+        2. Inspect before editing: get_assignment, get_suite, get_notebook.
+        3. Edit: update_assignment (metadata), update_suite (script metadata), update_pattern_family \
+        (family defaults/cases), update_notebook (replace the starter notebook). To create a new \
+        assignment, clone_assignment from a known-good one and then edit the copy.
+
+        Important behaviors:
+        - Any content edit (suite, pattern family, notebook) re-runs validation asynchronously; \
+        re-read get_assignment to see validationStatus settle. Metadata-only edits via \
+        update_assignment never trigger a regrade.
+        - update_notebook replaces only the starter notebook; students keep their in-progress copies \
+        and pick up the new notebook when their copy is next reset. Call get_notebook first and edit \
+        the returned JSON.
+        - clone_assignment lands closed, unvalidated, with no due date and no submissions, so nothing \
+        is regraded; validate and open it with update_assignment when ready.
+        - You author structure and metadata, not the underlying test logic: you cannot write raw \
+        script bodies or a pattern case's args/expected values.
+        """
 }

--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -66,6 +66,24 @@ struct CloneAssignmentTool: ContentTool {
         ]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "publicID": .object(["type": .string("string")]),
+            "title": .object(["type": .string("string")]),
+            "slug": .object(["type": .string("string")]),
+            "courseCode": .object(["type": .string("string")]),
+            "sourceAssignmentPublicID": .object(["type": .string("string")]),
+            "isOpen": .object(["type": .string("boolean")]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([
+            .string("publicID"), .string("title"), .string("slug"), .string("courseCode"),
+            .string("sourceAssignmentPublicID"), .string("isOpen"),
+        ]),
+    ])
+    static let annotations = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: false)
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -66,7 +66,7 @@ struct CloneAssignmentTool: ContentTool {
         ]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "publicID": .object(["type": .string("string")]),
@@ -82,7 +82,7 @@ struct CloneAssignmentTool: ContentTool {
             .string("sourceAssignmentPublicID"), .string("isOpen"),
         ]),
     ])
-    static let annotations = MCPToolAnnotations(
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: false, idempotentHint: false)
     static let requiredScopes: Set<ContentScope> = [.write]
 

--- a/Sources/APIServer/MCP/Tools/ContentTool.swift
+++ b/Sources/APIServer/MCP/Tools/ContentTool.swift
@@ -19,10 +19,61 @@ protocol ContentTool: Sendable {
     static var description: String { get }
     /// JSON Schema (draft 2020-12) describing `Input`, surfaced in `tools/list`.
     static var inputSchema: JSONValue { get }
+    /// JSON Schema (draft 2020-12) describing `Output`, surfaced as the tool's
+    /// `outputSchema` so clients can validate the `structuredContent` it
+    /// returns.  Defaults to nil (no declared output schema).
+    static var outputSchema: JSONValue? { get }
+    /// Behavioural hints surfaced as the tool's `annotations` (read-only,
+    /// destructive, idempotent…).  Defaults to a read-only hint inferred from
+    /// `requiredScopes`.
+    static var annotations: MCPToolAnnotations? { get }
     /// Scopes the caller's token must carry before the dispatcher invokes this tool.
     static var requiredScopes: Set<ContentScope> { get }
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output
+}
+
+/// Behavioural hints for a tool, surfaced in `tools/list` under `annotations`.
+/// All fields are optional; nil fields are omitted from the wire.  These are
+/// hints, not a security boundary — enforcement still lives in `requiredScopes`
+/// and the per-tool authorization checks.
+/// https://modelcontextprotocol.io/specification/2025-11-25/server/tools
+struct MCPToolAnnotations: Encodable, Sendable {
+    /// Human-friendly display title for the tool.
+    var title: String?
+    /// The tool does not modify its environment.
+    var readOnlyHint: Bool?
+    /// The tool may perform destructive updates (meaningful only when not read-only).
+    var destructiveHint: Bool?
+    /// Repeated calls with the same arguments have no additional effect beyond the first.
+    var idempotentHint: Bool?
+    /// The tool interacts with an open world of external entities.
+    var openWorldHint: Bool?
+
+    init(
+        title: String? = nil,
+        readOnlyHint: Bool? = nil,
+        destructiveHint: Bool? = nil,
+        idempotentHint: Bool? = nil,
+        openWorldHint: Bool? = nil
+    ) {
+        self.title = title
+        self.readOnlyHint = readOnlyHint
+        self.destructiveHint = destructiveHint
+        self.idempotentHint = idempotentHint
+        self.openWorldHint = openWorldHint
+    }
+}
+
+extension ContentTool {
+    /// Tools declare no output schema unless they override this.
+    static var outputSchema: JSONValue? { nil }
+    /// By default a tool is annotated read-only iff its only required scope is
+    /// `content:read`; write tools override this to add destructive/idempotent
+    /// hints.
+    static var annotations: MCPToolAnnotations? {
+        MCPToolAnnotations(readOnlyHint: requiredScopes == [.read])
+    }
 }
 
 // MARK: - Errors
@@ -51,6 +102,8 @@ struct AnyContentTool: Sendable {
     let name: String
     let description: String
     let inputSchema: JSONValue
+    let outputSchema: JSONValue?
+    let annotations: MCPToolAnnotations?
     let requiredScopes: Set<ContentScope>
     let invoke: @Sendable (_ arguments: JSONValue, _ context: ToolContext) async throws -> JSONValue
 }
@@ -62,6 +115,8 @@ extension ContentTool {
             name: Self.name,
             description: Self.description,
             inputSchema: Self.inputSchema,
+            outputSchema: Self.outputSchema,
+            annotations: Self.annotations,
             requiredScopes: Self.requiredScopes,
             invoke: { arguments, context in
                 let input: Input

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -39,7 +39,7 @@ struct GetAssignmentTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "publicID": .object(["type": .string("string")]),

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -39,6 +39,23 @@ struct GetAssignmentTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "publicID": .object(["type": .string("string")]),
+            "title": .object(["type": .string("string")]),
+            "slug": .object(["type": .string("string")]),
+            "courseCode": .object(["type": .string("string")]),
+            "isOpen": .object(["type": .string("boolean")]),
+            "dueAt": .object(["type": .string("string")]),
+            "validationStatus": .object(["type": .string("string")]),
+            "deadlineOverrideActive": .object(["type": .string("boolean")]),
+        ]),
+        "required": .array([
+            .string("publicID"), .string("title"), .string("slug"), .string("courseCode"),
+            .string("isOpen"), .string("deadlineOverrideActive"),
+        ]),
+    ])
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
@@ -45,7 +45,7 @@ struct GetNotebookTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "assignmentPublicID": .object(["type": .string("string")]),

--- a/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
@@ -45,6 +45,17 @@ struct GetNotebookTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "cellCount": .object(["type": .string("integer")]),
+            "notebook": .object(["type": .string("object")]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("cellCount"), .string("notebook"),
+        ]),
+    ])
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -59,7 +59,7 @@ struct GetSuiteTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "assignmentPublicID": .object(["type": .string("string")]),

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -59,6 +59,48 @@ struct GetSuiteTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "sections": .object([
+                "type": .string("array"),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "id": .object(["type": .string("string")]),
+                        "name": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([.string("id"), .string("name")]),
+                ]),
+            ]),
+            "items": .object([
+                "type": .string("array"),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "kind": .object(["type": .string("string")]),
+                        "name": .object(["type": .string("string")]),
+                        "tier": .object(["type": .string("string")]),
+                        "points": .object(["type": .string("integer")]),
+                        "displayName": .object(["type": .string("string")]),
+                        "dependsOn": .object([
+                            "type": .string("array"), "items": .object(["type": .string("string")]),
+                        ]),
+                        "sectionID": .object(["type": .string("string")]),
+                        "familyID": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([
+                        .string("kind"), .string("name"), .string("tier"), .string("points"),
+                        .string("dependsOn"),
+                    ]),
+                ]),
+            ]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("sections"), .string("items"),
+        ]),
+    ])
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/ListAssignmentsTool.swift
+++ b/Sources/APIServer/MCP/Tools/ListAssignmentsTool.swift
@@ -39,6 +39,29 @@ struct ListAssignmentsTool: ContentTool {
         "required": .array([.string("courseCode")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "courseCode": .object(["type": .string("string")]),
+            "assignments": .object([
+                "type": .string("array"),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "publicID": .object(["type": .string("string")]),
+                        "title": .object(["type": .string("string")]),
+                        "slug": .object(["type": .string("string")]),
+                        "isOpen": .object(["type": .string("boolean")]),
+                        "dueAt": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([
+                        .string("publicID"), .string("title"), .string("slug"), .string("isOpen"),
+                    ]),
+                ]),
+            ]),
+        ]),
+        "required": .array([.string("courseCode"), .string("assignments")]),
+    ])
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/ListAssignmentsTool.swift
+++ b/Sources/APIServer/MCP/Tools/ListAssignmentsTool.swift
@@ -39,7 +39,7 @@ struct ListAssignmentsTool: ContentTool {
         "required": .array([.string("courseCode")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "courseCode": .object(["type": .string("string")]),

--- a/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
+++ b/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
@@ -29,7 +29,7 @@ struct ListCoursesTool: ContentTool {
         "properties": .object([:]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "courses": .object([

--- a/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
+++ b/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
@@ -29,6 +29,23 @@ struct ListCoursesTool: ContentTool {
         "properties": .object([:]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "courses": .object([
+                "type": .string("array"),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "code": .object(["type": .string("string")]),
+                        "name": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([.string("code"), .string("name")]),
+                ]),
+            ])
+        ]),
+        "required": .array([.string("courses")]),
+    ])
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -65,6 +65,22 @@ struct UpdateAssignmentTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "publicID": .object(["type": .string("string")]),
+            "title": .object(["type": .string("string")]),
+            "slug": .object(["type": .string("string")]),
+            "isOpen": .object(["type": .string("boolean")]),
+            "dueAt": .object(["type": .string("string")]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([
+            .string("publicID"), .string("title"), .string("slug"), .string("isOpen"),
+        ]),
+    ])
+    static let annotations = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -65,7 +65,7 @@ struct UpdateAssignmentTool: ContentTool {
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "publicID": .object(["type": .string("string")]),
@@ -79,7 +79,7 @@ struct UpdateAssignmentTool: ContentTool {
             .string("publicID"), .string("title"), .string("slug"), .string("isOpen"),
         ]),
     ])
-    static let annotations = MCPToolAnnotations(
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: false, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 

--- a/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
@@ -55,7 +55,7 @@ struct UpdateNotebookTool: ContentTool {
         "required": .array([.string("assignmentPublicID"), .string("notebook")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "assignmentPublicID": .object(["type": .string("string")]),
@@ -64,7 +64,7 @@ struct UpdateNotebookTool: ContentTool {
         ]),
         "required": .array([.string("assignmentPublicID"), .string("cellCount")]),
     ])
-    static let annotations = MCPToolAnnotations(
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: true, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 

--- a/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
@@ -55,6 +55,17 @@ struct UpdateNotebookTool: ContentTool {
         "required": .array([.string("assignmentPublicID"), .string("notebook")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "cellCount": .object(["type": .string("integer")]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("cellCount")]),
+    ])
+    static let annotations = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: true, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -74,6 +74,25 @@ struct UpdatePatternFamilyTool: ContentTool {
         "required": .array([.string("assignmentPublicID"), .string("familyID")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "familyID": .object(["type": .string("string")]),
+            "defaultTier": .object(["type": .string("string")]),
+            "defaultPoints": .object(["type": .string("integer")]),
+            "enabledCaseKeys": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("familyID"), .string("defaultTier"),
+            .string("defaultPoints"), .string("enabledCaseKeys"),
+        ]),
+    ])
+    static let annotations = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -74,7 +74,7 @@ struct UpdatePatternFamilyTool: ContentTool {
         "required": .array([.string("assignmentPublicID"), .string("familyID")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "assignmentPublicID": .object(["type": .string("string")]),
@@ -91,7 +91,7 @@ struct UpdatePatternFamilyTool: ContentTool {
             .string("defaultPoints"), .string("enabledCaseKeys"),
         ]),
     ])
-    static let annotations = MCPToolAnnotations(
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: false, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 

--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -87,7 +87,7 @@ struct UpdateSuiteTool: ContentTool {
         "required": .array([.string("assignmentPublicID"), .string("edits")]),
         "additionalProperties": .bool(false),
     ])
-    static let outputSchema: JSONValue = .object([
+    static let outputSchema: JSONValue? = .object([
         "type": .string("object"),
         "properties": .object([
             "assignmentPublicID": .object(["type": .string("string")]),
@@ -98,7 +98,7 @@ struct UpdateSuiteTool: ContentTool {
         ]),
         "required": .array([.string("assignmentPublicID"), .string("updatedScripts")]),
     ])
-    static let annotations = MCPToolAnnotations(
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: false, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 

--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -87,6 +87,19 @@ struct UpdateSuiteTool: ContentTool {
         "required": .array([.string("assignmentPublicID"), .string("edits")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "updatedScripts": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("updatedScripts")]),
+    ])
+    static let annotations = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -55,12 +55,19 @@ struct MCPDispatcher: Sendable {
     // MARK: - tools/list
 
     private func toolsListResult() -> JSONValue {
-        let entries = tools.all.map { tool in
-            JSONValue.object([
+        let entries = tools.all.map { tool -> JSONValue in
+            var fields: [String: JSONValue] = [
                 "name": .string(tool.name),
                 "description": .string(tool.description),
                 "inputSchema": tool.inputSchema,
-            ])
+            ]
+            if let outputSchema = tool.outputSchema {
+                fields["outputSchema"] = outputSchema
+            }
+            if let annotations = tool.annotations, let encoded = try? JSONValue(encoding: annotations) {
+                fields["annotations"] = encoded
+            }
+            return .object(fields)
         }
         return .object(["tools": .array(entries)])
     }
@@ -156,7 +163,8 @@ struct MCPDispatcher: Sendable {
         let result = MCPInitializeResult(
             protocolVersion: MCPProtocol.version,
             capabilities: .v1,
-            serverInfo: serverInfo
+            serverInfo: serverInfo,
+            instructions: MCPServerInstructions.text
         )
         do {
             return .success(id: id, result: try JSONValue(encoding: result))

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -72,7 +72,9 @@ func registerMCPRoutes(_ app: Application) throws {
     }
 
     let dispatcher = MCPDispatcher(
-        serverInfo: MCPServerInfo(name: "Chickadee MCP", version: ChickadeeVersion.current),
+        serverInfo: MCPServerInfo(
+            name: "Chickadee MCP", version: ChickadeeVersion.current,
+            title: "Chickadee Content Authoring"),
         tools: MCPToolCatalog.live
     )
     let routeConfiguration = MCPRoutes.Configuration(

--- a/Tests/APITests/MCP/ListAssignmentsToolTests.swift
+++ b/Tests/APITests/MCP/ListAssignmentsToolTests.swift
@@ -103,6 +103,16 @@ import Vapor
         let request = JSONRPCRequest(jsonrpc: "2.0", id: .number(1), method: "tools/list", params: nil)
         let response = try #require(await dispatcher.dispatch(request))
         #expect(toolNames(in: response.result) == ["list_assignments", "update_assignment"])
+
+        // Each entry advertises an output schema and behavioural annotations;
+        // the read tool is read-only, the write tool is not.
+        let entries = toolEntries(in: response.result)
+        let readTool = try #require(entries["list_assignments"])
+        #expect(readTool["outputSchema"] != nil)
+        #expect(readTool["annotations"]?.objectFields?["readOnlyHint"] == .bool(true))
+        let writeTool = try #require(entries["update_assignment"])
+        #expect(writeTool["outputSchema"] != nil)
+        #expect(writeTool["annotations"]?.objectFields?["readOnlyHint"] == .bool(false))
     }
 
     @Test func dispatcherToolsCallReturnsContentAndStructured() async throws {
@@ -173,6 +183,17 @@ private func toolNames(in result: JSONValue?) -> [String] {
         guard case .object(let fields) = entry, case .string(let name)? = fields["name"] else { return nil }
         return name
     }
+}
+
+/// The `tools/list` entries keyed by tool name, each as its raw field map.
+private func toolEntries(in result: JSONValue?) -> [String: [String: JSONValue]] {
+    guard case .object(let object)? = result, case .array(let tools)? = object["tools"] else { return [:] }
+    var byName: [String: [String: JSONValue]] = [:]
+    for entry in tools {
+        guard case .object(let fields) = entry, case .string(let name)? = fields["name"] else { continue }
+        byName[name] = fields
+    }
+    return byName
 }
 
 private extension JSONValue {

--- a/Tests/APITests/MCP/ListAssignmentsToolTests.swift
+++ b/Tests/APITests/MCP/ListAssignmentsToolTests.swift
@@ -113,6 +113,9 @@ import Vapor
         let writeTool = try #require(entries["update_assignment"])
         #expect(writeTool["outputSchema"] != nil)
         #expect(writeTool["annotations"]?.objectFields?["readOnlyHint"] == .bool(false))
+        // The write tool's per-tool annotation override must actually win over
+        // the inferred default (it carries an idempotent hint the default lacks).
+        #expect(writeTool["annotations"]?.objectFields?["idempotentHint"] == .bool(true))
     }
 
     @Test func dispatcherToolsCallReturnsContentAndStructured() async throws {

--- a/Tests/APITests/MCP/MCPDispatcherTests.swift
+++ b/Tests/APITests/MCP/MCPDispatcherTests.swift
@@ -27,10 +27,20 @@ import Testing
         let serverInfo = try #require(result["serverInfo"]?.objectFields)
         #expect(serverInfo["name"] == .string("Chickadee MCP"))
         #expect(serverInfo["version"] == .string("test-1.2.3"))
+        // No title was supplied here, so it is omitted from the wire.
+        #expect(serverInfo["title"] == nil)
 
         let capabilities = try #require(result["capabilities"]?.objectFields)
         #expect(capabilities["tools"] == .object(["listChanged": .bool(false)]))
-        #expect(capabilities["resources"] == .object(["listChanged": .bool(false)]))
+        // v1 advertises tools only — the unimplemented `resources` capability is
+        // no longer advertised.
+        #expect(capabilities["resources"] == nil)
+
+        // The result carries server-level instructions that teach the agent the
+        // domain model and workflow up front.
+        let instructions = try #require(result["instructions"]?.stringValue)
+        #expect(instructions.contains("list_courses"))
+        #expect(instructions.contains("validation"))
     }
 
     @Test func pingReturnsEmptyObject() async throws {
@@ -75,6 +85,12 @@ private extension JSONValue {
     /// The underlying object dictionary, or nil if this value is not an object.
     var objectFields: [String: JSONValue]? {
         if case .object(let fields) = self { return fields }
+        return nil
+    }
+
+    /// The underlying string, or nil if this value is not a string.
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
         return nil
     }
 }

--- a/changelog.d/mcp-agent-affordances.md
+++ b/changelog.d/mcp-agent-affordances.md
@@ -1,0 +1,14 @@
+### Added
+
+- **MCP server now orients connecting agents.** The `initialize` result carries
+  server-level `instructions` (the domain model, the read-before-write workflow,
+  and the validation/scope/safety rules), and every content tool now advertises
+  an `outputSchema` for its structured result plus behavioural `annotations`
+  (read-only / destructive / idempotent hints). The server also reports a
+  human-friendly `title`.
+
+### Changed
+
+- **MCP `initialize` no longer advertises an unimplemented `resources`
+  capability.** v1 announces tools only; the dormant resources endpoints remain
+  as scaffolding for a later release but are no longer claimed in the handshake.


### PR DESCRIPTION
## Summary

Improves what an MCP client/agent sees when it connects to Chickadee's content-authoring server, so agents can make optimal use of it on the first try.

- **`initialize` now returns server-level `instructions`** — the domain model (course / assignment / test suite / tier / pattern family / notebook / validation), the read-before-write workflow, and the scope/safety rules. Biggest lever for first-try success: previously an agent had to reverse-engineer all of that from ten isolated tool blurbs.
- **Every tool advertises an `outputSchema`** (MCP 2025-11-25) describing its `structuredContent`, so clients can validate / typed-parse results.
- **Every tool advertises `annotations`** — `readOnlyHint` on the five read tools, plus `destructiveHint`/`idempotentHint` on the writers (`update_notebook` is the destructive full-replace; `clone_assignment` is additive + non-idempotent). Lets clients auto-approve reads and gate writes. These are hints only — enforcement still lives in `requiredScopes` + the per-tool authorization checks.
- **`serverInfo.title`** ("Chickadee Content Authoring") for a human-friendly display name.
- **Stops advertising the unimplemented `resources` capability.** v1 announces tools only; the dormant `resources/list` + `resources/read` handlers stay as scaffolding for a later release but are no longer claimed in the handshake (fixes a capability/behaviour mismatch).

## Test plan

- [x] `swift-format lint --strict` clean on all changed files (toolchain 6.3.1, matches CI).
- [ ] CI green — Linux `swift test` + format-lint/SwiftLint could not be run locally (this Mac is macOS 13; the package floor is macOS 14).
- Updated `MCPDispatcherTests` (initialize omits `resources`, includes `instructions`, omits `title` when unset) and `ListAssignmentsToolTests` (tools/list entries carry `outputSchema` + read/write `annotations`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
