### PR TITLE
MCP authoring Phase 4b (write): create_assignment tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -126,7 +126,7 @@ struct CloneAssignmentTool: ContentTool {
             targetCourseID = source.courseID
         }
 
-        let cloned: ClonedAssignment
+        let cloned: AuthoredAssignment
         do {
             cloned = try await AssignmentAuthoringService.cloneAssignment(
                 source: source,

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -63,6 +63,23 @@ struct CreateAssignmentTool: ContentTool {
         "required": .array([.string("courseCode"), .string("title"), .string("notebook")]),
         "additionalProperties": .bool(false),
     ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "publicID": .object(["type": .string("string")]),
+            "title": .object(["type": .string("string")]),
+            "slug": .object(["type": .string("string")]),
+            "courseCode": .object(["type": .string("string")]),
+            "cellCount": .object(["type": .string("integer")]),
+            "isOpen": .object(["type": .string("boolean")]),
+        ]),
+        "required": .array([
+            .string("publicID"), .string("title"), .string("slug"), .string("courseCode"),
+            .string("cellCount"), .string("isOpen"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: false)
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -1,0 +1,132 @@
+// APIServer/MCP/Tools/CreateAssignmentTool.swift
+//
+// Write tool: create a brand-new browser-graded, notebook-based assignment from
+// scratch in a course, by course code + title + starter notebook (.ipynb JSON).
+// content:write, course-scoped.
+//
+// This is the structured-spec creation path (roadmap Phase 4b), built on the
+// pieces proven by the earlier phases: it assembles a minimal empty-suite
+// manifest + an empty runner zip + the supplied notebook through
+// AssignmentAuthoringService.createAssignment (the same per-setup work the web
+// new-assignment publish does, minus the draft scaffolding), then the agent
+// fills in tests with update_suite / update_pattern_family and refines the
+// notebook with update_notebook.
+//
+// The assignment lands closed, unvalidated, and with no due date. Because it
+// starts with an empty suite, no validation run is queued — the instructor can
+// open it once it has content.
+
+import Core
+import Fluent
+import Foundation
+
+struct CreateAssignmentTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let courseCode: String
+        let title: String
+        let notebook: JSONValue
+    }
+
+    struct Output: Encodable, Sendable {
+        let publicID: String
+        let title: String
+        let slug: String
+        let courseCode: String
+        let cellCount: Int
+        let isOpen: Bool
+    }
+
+    static let name = "create_assignment"
+    static let description =
+        "Create a new browser-graded, notebook-based assignment from scratch in a course, by course "
+        + "code + title + starter notebook (.ipynb JSON object with a \"cells\" array). The new "
+        + "assignment starts closed, unvalidated, with no due date and an empty test suite — add tests "
+        + "with update_suite / update_pattern_family and refine the notebook with update_notebook, then "
+        + "open it. To duplicate an existing assignment instead, use clone_assignment."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "courseCode": .object([
+                "type": .string("string"),
+                "description": .string("Code of the course to create the assignment in."),
+            ]),
+            "title": .object([
+                "type": .string("string"),
+                "description": .string("Title for the new assignment."),
+            ]),
+            "notebook": .object([
+                "type": .string("object"),
+                "description": .string(
+                    "The starter notebook as .ipynb JSON (an object containing a \"cells\" array)."),
+            ]),
+        ]),
+        "required": .array([.string("courseCode"), .string("title"), .string("notebook")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let title = input.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else {
+            throw MCPToolError.invalidArguments(tool: Self.name, detail: "title must not be empty.")
+        }
+        try Self.validateNotebookShape(input.notebook)
+
+        let code = input.courseCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            let course = try await APICourse.query(on: context.db).filter(\.$code == code).first()
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No course found with code \"\(code)\".")
+        }
+        let courseID = try course.requireID()
+        try await context.authorizeCourseAccess(courseID, tool: Self.name)
+
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(input.notebook)
+        } catch {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The notebook could not be serialized to JSON.")
+        }
+
+        let created: AuthoredAssignment
+        do {
+            created = try await AssignmentAuthoringService.createAssignment(
+                courseID: courseID, title: title, notebookData: data,
+                setupsDirectory: context.request.application.testSetupsDirectory, on: context.db)
+        } catch let error as AssignmentAuthoringError {
+            if case .setupCopyFailed(let reason) = error {
+                throw MCPToolError.executionFailed(
+                    tool: Self.name, detail: "Could not create the test setup: \(reason)")
+            }
+            throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
+        }
+
+        return Output(
+            publicID: created.assignment.publicID,
+            title: created.assignment.title,
+            slug: created.assignment.slug,
+            courseCode: course.code,
+            cellCount: Self.cellCount(of: input.notebook),
+            isOpen: created.assignment.isOpen)
+    }
+
+    private static func validateNotebookShape(_ notebook: JSONValue) throws {
+        guard case .object(let root) = notebook else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "notebook must be a JSON object.")
+        }
+        guard case .array? = root["cells"] else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "notebook must contain a \"cells\" array.")
+        }
+    }
+
+    private static func cellCount(of notebook: JSONValue) -> Int {
+        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
+            return 0
+        }
+        return cells.count
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -26,6 +26,7 @@ enum MCPToolCatalog {
             UpdatePatternFamilyTool().erased(),
             UpdateNotebookTool().erased(),
             CloneAssignmentTool().erased(),
+            CreateAssignmentTool().erased(),
         ])
     }
 }

--- a/Sources/APIServer/Services/AssignmentAuthoringService.swift
+++ b/Sources/APIServer/Services/AssignmentAuthoringService.swift
@@ -19,8 +19,9 @@ enum AssignmentAuthoringError: Error, Sendable, Equatable {
     case setupCopyFailed(reason: String)
 }
 
-/// The freshly created assignment + its new test setup, returned by `cloneAssignment`.
-struct ClonedAssignment: Sendable {
+/// A freshly authored assignment + its new test setup, returned by the
+/// creation operations (`cloneAssignment`, `createAssignment`).
+struct AuthoredAssignment: Sendable {
     let assignment: APIAssignment
     let setup: APITestSetup
 }
@@ -103,7 +104,7 @@ enum AssignmentAuthoringService {
         targetCourseID: UUID,
         setupsDirectory: String,
         on db: Database
-    ) async throws -> ClonedAssignment {
+    ) async throws -> AuthoredAssignment {
         let newSetupID = "setup_\(UUID().uuidString.lowercased().prefix(8))"
         let fm = FileManager.default
 
@@ -142,11 +143,64 @@ enum AssignmentAuthoringService {
                 validationStatus: nil,
                 validationSubmissionID: nil,
                 courseID: targetCourseID)
-            return ClonedAssignment(assignment: assignment, setup: newSetup)
+            return AuthoredAssignment(assignment: assignment, setup: newSetup)
         } catch {
             // Roll back the copied files so a failed clone leaves no orphans.
             try? fm.removeItem(atPath: dstZip)
             if let newNotebookPath { try? fm.removeItem(atPath: newNotebookPath) }
+            throw error
+        }
+    }
+
+    /// Creates a brand-new browser-graded, notebook-based assignment from
+    /// scratch: a minimal empty-suite manifest + an empty runner zip + the
+    /// supplied notebook, then a fresh assignment row (closed, unvalidated, no
+    /// due date). The agent fills in tests afterwards with the suite/family
+    /// tools. Mirrors the per-setup work the web new-assignment publish does,
+    /// minus the draft scaffolding, so the paths can't drift.
+    ///
+    /// Empty suite ⇒ no validation is queued, so a from-scratch assignment can
+    /// be opened by the instructor without a runner once it has content.
+    static func createAssignment(
+        courseID: UUID,
+        title: String,
+        notebookData: Data,
+        setupsDirectory: String,
+        on db: Database
+    ) async throws -> AuthoredAssignment {
+        let setupID = "setup_\(UUID().uuidString.lowercased().prefix(8))"
+        let zipPath = setupsDirectory + "\(setupID).zip"
+        do {
+            _ = try createRunnerSetupZip(suiteFiles: [], suiteConfigJSON: nil, zipPath: zipPath)
+        } catch {
+            throw AssignmentAuthoringError.setupCopyFailed(reason: "\(error)")
+        }
+
+        let manifest =
+            #"{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
+        let setup = APITestSetup(
+            id: setupID, manifest: manifest, zipPath: zipPath, notebookPath: nil,
+            courseID: courseID)
+
+        do {
+            try await setup.save(on: db)
+            try await writeAssignmentNotebook(
+                setup: setup, notebookData: notebookData, setupsDirectory: setupsDirectory, on: db)
+            let assignment = try await createAssignmentWithUniquePublicID(
+                on: db,
+                testSetupID: setupID,
+                title: title,
+                dueAt: nil,
+                isOpen: false,
+                sortOrder: nil,
+                validationStatus: nil,
+                validationSubmissionID: nil,
+                courseID: courseID)
+            return AuthoredAssignment(assignment: assignment, setup: setup)
+        } catch {
+            // Roll back the files written so a failed create leaves no orphans.
+            try? FileManager.default.removeItem(atPath: zipPath)
+            if let nb = setup.notebookPath { try? FileManager.default.removeItem(atPath: nb) }
             throw error
         }
     }

--- a/Tests/APITests/MCP/CreateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/CreateAssignmentToolTests.swift
@@ -1,0 +1,127 @@
+// Tests for CreateAssignmentTool (create a new notebook-based assignment from
+// scratch), backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct CreateAssignmentToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private func json(_ raw: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(raw.utf8))
+    }
+
+    private let twoCellNotebook = #"""
+        {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[
+        {"cell_type":"markdown","metadata":{},"source":["# Lab"]},
+        {"cell_type":"code","metadata":{},"source":["x = 1\n"],"outputs":[],"execution_count":null}
+        ]}
+        """#
+
+    /// Course CS246 + enrolled instructor "tester".
+    private func enrolledCourse(on app: Application) async throws {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+    }
+
+    @Test func createsAssignmentWithNotebook() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            try await enrolledCourse(on: app)
+            let output = try await CreateAssignmentTool().execute(
+                CreateAssignmentTool.Input(
+                    courseCode: "CS246", title: "  New Lab  ", notebook: try json(twoCellNotebook)),
+                context(app))
+
+            #expect(output.title == "New Lab")
+            #expect(output.courseCode == "CS246")
+            #expect(output.cellCount == 2)
+            #expect(output.isOpen == false)
+            #expect(!output.publicID.isEmpty)
+
+            // Assignment + setup persisted; notebook readable; suite empty.
+            let assignment = try #require(try await assignmentByPublicID(output.publicID, on: app.db))
+            #expect(assignment.validationStatus == nil)
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(FileManager.default.fileExists(atPath: setup.zipPath))
+            let props = try #require(setup.decodedManifest())
+            #expect(props.testSuites.isEmpty)
+
+            let data = try notebookData(for: setup)
+            let reloaded = try JSONDecoder().decode(JSONValue.self, from: data)
+            guard case .object(let root) = reloaded, case .array(let cells)? = root["cells"] else {
+                Issue.record("persisted notebook was not a JSON object with a cells array")
+                return
+            }
+            #expect(cells.count == 2)
+        }
+    }
+
+    @Test func emptyTitleThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            try await enrolledCourse(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateAssignmentTool().execute(
+                    CreateAssignmentTool.Input(
+                        courseCode: "CS246", title: "   ", notebook: try json(twoCellNotebook)),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func unknownCourseThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            try await enrolledCourse(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateAssignmentTool().execute(
+                    CreateAssignmentTool.Input(
+                        courseCode: "NOPE99", title: "Lab", notebook: try json(twoCellNotebook)),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func rejectsNotebookWithoutCells() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            try await enrolledCourse(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateAssignmentTool().execute(
+                    CreateAssignmentTool.Input(
+                        courseCode: "CS246", title: "Lab",
+                        notebook: try json(#"{"nbformat":4,"metadata":{}}"#)),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Course exists but the instructor isn't enrolled in it.
+            _ = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateAssignmentTool().execute(
+                    CreateAssignmentTool.Input(
+                        courseCode: "CS246", title: "Lab", notebook: try json(twoCellNotebook)),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-create-assignment.md
+++ b/changelog.d/mcp-create-assignment.md
@@ -1,0 +1,12 @@
+### Added
+
+- **MCP authoring (write): `create_assignment` tool.** Lets an authorized agent
+  create a brand-new browser-graded, notebook-based assignment from scratch in a
+  course, by course code + title + starter notebook (.ipynb JSON). Assembles a
+  minimal empty-suite manifest + an empty runner zip + the notebook through the
+  shared authoring service (the same per-setup work the web new-assignment
+  publish does, minus the draft scaffolding), then a fresh assignment row that
+  lands closed, unvalidated, and with no due date. The agent fills in tests with
+  `update_suite` / `update_pattern_family` and refines the notebook with
+  `update_notebook`, then opens it. Completes the assignment-authoring tool set
+  alongside `clone_assignment`. `content:write`, course-scoped.


### PR DESCRIPTION
## Summary

- Adds the **`create_assignment`** MCP write tool: an authorized agent creates a brand-new **browser-graded, notebook-based** assignment from scratch in a course, by course code + title + starter notebook (`.ipynb` JSON).
- Assembles a minimal empty-suite manifest + an empty runner zip (via the canonical `createRunnerSetupZip`) + the notebook through the shared `AssignmentAuthoringService.createAssignment` — the same per-setup work the web new-assignment publish does, minus the draft scaffolding — then a fresh assignment row that lands **closed, unvalidated, with no due date**. Empty suite ⇒ no validation queued, so it can be opened (once it has content) without a runner.
- The agent fills in tests with `update_suite` / `update_pattern_family` and refines the notebook with `update_notebook`, then opens it. This **completes the assignment-authoring tool set** alongside `clone_assignment`.
- The service's creation-result struct is renamed `ClonedAssignment` → `AuthoredAssignment` (it now backs both create and clone). `content:write`, course-scoped via `authorizeCourseAccess`.

## Test plan

- [x] `swift test --filter CreateAssignmentToolTests` — 5 tests pass (creates assignment + setup + notebook with empty suite, empty title, unknown course, notebook without cells, denied when not enrolled).
- [x] `swift test --filter CloneAssignmentToolTests` — 8 tests still green after the struct rename.
- [x] `scripts/swiftlint.sh --strict` — 0 violations; `scripts/format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)