### PR TITLE
MCP Streamable HTTP: SSE response mode on /mcp POST

### DIFF
--- a/Sources/APIServer/MCP/Transport/MCPRoutes.swift
+++ b/Sources/APIServer/MCP/Transport/MCPRoutes.swift
@@ -1,8 +1,16 @@
 // APIServer/MCP/Transport/MCPRoutes.swift
 //
 // The MCP Streamable HTTP transport, mounted at a single endpoint (`/mcp`).
-// v1 returns plain JSON synchronously; there is no server-initiated SSE stream
-// yet, so GET and DELETE return 405.
+//
+// A POST carries one JSON-RPC request. The response is returned either as plain
+// JSON (the default) or — when the client advertises `Accept: text/event-stream`
+// — as a single-shot SSE stream framing the same JSON-RPC response as an
+// `event: message`. Content negotiation is the only difference; the dispatched
+// result is identical. The SSE form is what the Claude connector speaks and is
+// forward-compatible: `notifications/progress` events can later be interleaved
+// before the final response without changing the tool contract. The transport
+// stays stateless (no `Mcp-Session-Id` / `Last-Event-ID` resumability), and the
+// standalone server-initiated stream is still unsupported, so GET/DELETE 405.
 //
 // DNS-rebinding mitigation (transport spec §Security): the `Origin` header is
 // validated against an allowlist (403 on mismatch), and — because Vapor does
@@ -10,6 +18,7 @@
 // https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
 
 import Foundation
+import NIOCore
 import Vapor
 
 struct MCPRoutes: RouteCollection {
@@ -81,18 +90,26 @@ struct MCPRoutes: RouteCollection {
             return Response(status: .accepted)
         }
         // A per-tool scope denial is surfaced as HTTP 403 insufficient_scope so
-        // clients see the authorization failure at the transport layer.
+        // clients see the authorization failure at the transport layer. This
+        // (and the parse-error 400 above) stays plain JSON regardless of Accept:
+        // an SSE body must be HTTP 200, so a non-200 status couldn't carry it.
         if let error = rpcResponse.error, error.code == JSONRPCError.insufficientScopeCode {
             return try jsonResponse(
                 rpcResponse, status: .forbidden, challenge: insufficientScopeChallenge(error))
+        }
+        // Happy path (success or an in-result tool error, both HTTP 200): stream
+        // it as SSE when the client asked for it, otherwise return plain JSON.
+        if clientAcceptsEventStream(req) {
+            return try eventStreamResponse(rpcResponse)
         }
         return try jsonResponse(rpcResponse, status: .ok)
     }
 
     func streamingUnsupported(req: Request) async throws -> Response {
-        // v1 offers no server-initiated SSE stream at this endpoint.
-        // TODO: implement the Streamable HTTP GET/DELETE flows if a tool needs
-        // server-to-client streaming.
+        // POST may return an SSE stream (see eventStreamResponse), but the
+        // standalone server-initiated stream (GET) and session teardown (DELETE)
+        // are unused by the stateless model — there's no session to resume or
+        // delete — so both stay 405.
         // https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
         throw Abort(.methodNotAllowed)
     }
@@ -138,6 +155,47 @@ struct MCPRoutes: RouteCollection {
             headers.replaceOrAdd(name: .wwwAuthenticate, value: challenge)
         }
         return Response(status: status, headers: headers, body: .init(data: data))
+    }
+
+    /// True when the client advertises it can accept an SSE stream
+    /// (`Accept: …, text/event-stream`). Matches case-insensitively and ignores
+    /// any `;q=` weighting — presence is enough to opt into the stream form.
+    private func clientAcceptsEventStream(_ req: Request) -> Bool {
+        req.headers[.accept].contains { value in
+            value.lowercased().contains("text/event-stream")
+        }
+    }
+
+    /// Frames a single JSON-RPC response as a one-shot SSE stream: one
+    /// `event: message` carrying the compact JSON, then the stream ends. This is
+    /// the Streamable HTTP "POST returns an SSE stream" form; we emit exactly one
+    /// event (no progress notifications yet), but the shape is forward-compatible
+    /// — additional `notifications/progress` events could precede the response.
+    ///
+    /// `X-Accel-Buffering: no` + `Cache-Control: no-cache` defeat reverse-proxy
+    /// buffering (nginx/squid) that would otherwise hold the event until the
+    /// connection closes, which is fatal for incremental streaming.
+    private func eventStreamResponse(_ payload: JSONRPCResponse) throws -> Response {
+        let json = String(bytes: try JSONEncoder().encode(payload), encoding: .utf8) ?? ""
+        // SSE framing: `event:` line, one `data:` line (compact JSON has no
+        // newlines, so a single data line is valid), terminated by a blank line.
+        let frame = "event: message\ndata: \(json)\n\n"
+
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .contentType, value: "text/event-stream")
+        headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+        headers.replaceOrAdd(name: .connection, value: "keep-alive")
+        headers.replaceOrAdd(name: "X-Accel-Buffering", value: "no")
+
+        let response = Response(status: .ok, headers: headers)
+        response.body = .init(stream: { writer in
+            var buffer = ByteBufferAllocator().buffer(capacity: frame.utf8.count)
+            buffer.writeString(frame)
+            writer.write(.buffer(buffer)).whenComplete { _ in
+                writer.write(.end, promise: nil)
+            }
+        })
+        return response
     }
 
     /// Builds the `WWW-Authenticate: Bearer …, error="insufficient_scope", scope="…"`

--- a/Tests/APITests/MCP/MCPSSETransportTests.swift
+++ b/Tests/APITests/MCP/MCPSSETransportTests.swift
@@ -1,0 +1,137 @@
+// Tests for the /mcp Streamable HTTP SSE response mode: when the client sends
+// `Accept: text/event-stream`, the POST response is an SSE stream framing the
+// same JSON-RPC response as an `event: message`; otherwise it stays plain JSON.
+// Security-status responses (insufficient scope) are never masked behind a 200
+// SSE body. Drives the real registerMCPRoutes wiring via an MCP-enabled config.
+
+import Fluent
+import JWT
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct MCPSSETransportTests {
+    private let issuer = "https://chickadee.example"
+    private let resource = "https://chickadee.example/mcp"
+
+    private func makeMCPApp() async throws -> (Application, MCPTokenAuthority) {
+        let mcp = MCPConfig(
+            enabled: true, allowedHosts: [], allowedOrigins: [],
+            tokenTTLSeconds: 3600, signingKeyPath: "unused",
+            issuer: issuer, resource: resource)
+        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
+        let authority = try await MCPTokenAuthority.make(
+            privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
+        app.mcpTokenAuthority = authority
+        return (app, authority)
+    }
+
+    private func post(
+        _ app: Application, body: String, token: String, accept: String
+    ) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(
+            .POST, "/mcp",
+            headers: [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(token)",
+                "Accept": accept,
+            ],
+            body: ByteBuffer(string: body))
+    }
+
+    @Test func toolsListOverSSEReturnsEventStream() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+                token: token, accept: "application/json, text/event-stream")
+
+            #expect(res.status == .ok)
+            #expect(res.headers.contentType?.description.contains("text/event-stream") == true)
+            // Proxy-buffering defeat header is present.
+            #expect(res.headers.first(name: "X-Accel-Buffering") == "no")
+
+            let body = res.body.string
+            // SSE framing: a `message` event with a single data line, blank-line
+            // terminated, carrying the JSON-RPC result with the tool catalogue.
+            #expect(body.contains("event: message"))
+            #expect(body.contains("data: "))
+            #expect(body.hasSuffix("\n\n"))
+            #expect(body.contains("list_assignments"))
+            #expect(body.contains("\"jsonrpc\":\"2.0\""))
+        }
+    }
+
+    @Test func defaultRequestStillReturnsPlainJSON() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            // No text/event-stream in Accept → unchanged plain-JSON behaviour.
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+                token: token, accept: "application/json")
+
+            #expect(res.status == .ok)
+            #expect(res.headers.contentType == .json)
+            let body = res.body.string
+            #expect(!body.contains("event: message"))
+            #expect(body.contains("list_assignments"))
+        }
+    }
+
+    @Test func toolResultStreamsStructuredContent() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let agent = try await makeTestUser(on: app, username: "agent", role: "mcp")
+            try await makeTestEnrollment(on: app, userID: agent.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_sse", courseID: courseID)
+            try await makeTestAssignment(
+                on: app, testSetupID: "setup_sse", courseID: courseID, title: "Tasks")
+
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let body = #"""
+                {"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_assignments","arguments":{"courseCode":"CS246"}}}
+                """#
+            let res = try await post(
+                app, body: body, token: token, accept: "text/event-stream")
+
+            #expect(res.status == .ok)
+            #expect(res.headers.contentType?.description.contains("text/event-stream") == true)
+            let text = res.body.string
+            #expect(text.contains("event: message"))
+            #expect(text.contains("CS246"))
+            #expect(text.contains("Tasks"))
+        }
+    }
+
+    @Test func insufficientScopeStays403JSONEvenWhenSSERequested() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            // Read-only token calling a write tool, while asking for SSE: the
+            // 403 must NOT be swallowed by a 200 SSE body — clients must see the
+            // authorization failure at the transport layer.
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let body = #"""
+                {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"update_assignment","arguments":{"assignmentPublicID":"ABC123","isOpen":true}}}
+                """#
+            let res = try await post(
+                app, body: body, token: token, accept: "text/event-stream")
+
+            #expect(res.status == .forbidden)
+            #expect(res.headers.contentType?.description.contains("text/event-stream") != true)
+            #expect(res.headers.first(name: .wwwAuthenticate)?.contains("insufficient_scope") == true)
+        }
+    }
+}

--- a/changelog.d/mcp-sse-transport.md
+++ b/changelog.d/mcp-sse-transport.md
@@ -1,0 +1,15 @@
+### Added
+
+- **MCP Streamable HTTP: SSE response mode.** The `/mcp` POST now honours
+  `Accept: text/event-stream` and returns the JSON-RPC response as a Server-Sent
+  Events stream (one `event: message` framing the result), instead of plain
+  JSON, which is what the Claude connector speaks. Content negotiation is the
+  only change — the dispatched result is identical, and clients that don't ask
+  for SSE still get `application/json`. The shape is forward-compatible:
+  `notifications/progress` events can later precede the response without
+  changing the tool contract. The transport stays stateless (no
+  `Mcp-Session-Id` / `Last-Event-ID` resumability), and security-status
+  responses (insufficient-scope 403, parse-error 400) are never masked behind a
+  200 SSE body. Ships with `X-Accel-Buffering: no` on the stream plus a dedicated
+  `location /mcp` block (`proxy_buffering off`) in both bundled nginx configs so
+  events aren't held back by reverse-proxy buffering.

--- a/deploy/nginx-docker.conf
+++ b/deploy/nginx-docker.conf
@@ -25,6 +25,22 @@ server {
         root /var/www/certbot;
     }
 
+    # MCP Streamable HTTP transport. The POST response may be an SSE stream
+    # (Content-Type: text/event-stream), so buffering must be off or nginx holds
+    # events until the connection closes. A longer read timeout accommodates a
+    # stream that stays open while a tool call runs.
+    location /mcp {
+        proxy_pass         http://server:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_buffering    off;
+        proxy_cache        off;
+        proxy_read_timeout 3600s;
+    }
+
     location / {
         proxy_pass         http://server:8080;
         proxy_set_header   Host              $host;

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -11,6 +11,22 @@ server {
     # Increase body size limit to allow test-setup zip uploads (default 1m is too small).
     client_max_body_size 50m;
 
+    # MCP Streamable HTTP transport. The POST response may be an SSE stream
+    # (Content-Type: text/event-stream), so buffering must be off or nginx holds
+    # events until the connection closes. A longer read timeout accommodates a
+    # stream that stays open while a tool call runs.
+    location /mcp {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_buffering    off;
+        proxy_cache        off;
+        proxy_read_timeout 3600s;
+    }
+
     location / {
         proxy_pass         http://127.0.0.1:8080;
         proxy_set_header   Host              $host;


### PR DESCRIPTION
## Summary

- The `/mcp` POST now honours **`Accept: text/event-stream`** and returns the JSON-RPC response as a **Server-Sent Events** stream (one `event: message` framing the result) instead of plain JSON — the form the Claude connector speaks. Content negotiation is the only change: the dispatched result is identical, and clients that don't ask for SSE still get `application/json` (fully backward-compatible).
- **Forward-compatible:** the shape leaves room for `notifications/progress` events to precede the final response later, without changing the tool contract — the upgrade path for live validation progress (roadmap §8) lands on this foundation.
- **Stays stateless:** no `Mcp-Session-Id` / `Last-Event-ID` resumability; the standalone server-initiated stream is still unused, so GET/DELETE remain 405.
- **Security-status responses are never masked:** insufficient-scope (403) and parse-error (400) stay plain HTTP responses with their real status — an SSE body must be 200, so streaming applies only to the happy path. A test pins this (read-only token → write tool over SSE still returns 403 + `WWW-Authenticate`).
- **Proxy-buffering fix:** `X-Accel-Buffering: no` on the stream, plus a dedicated `location /mcp` block (`proxy_buffering off`, longer read timeout) in both bundled nginx configs, so events aren't held back by reverse-proxy buffering.

## Test plan

- [x] `swift test --filter MCPSSETransportTests` — 4 tests pass (tools/list over SSE returns `text/event-stream` + correct framing + `X-Accel-Buffering: no`; default request still `application/json`; tool result streams its structured content; insufficient-scope stays 403 JSON under an SSE `Accept`).
- [x] `swift test --filter MCP` — all 77 MCP transport tests pass.
- [x] `scripts/swiftlint.sh --strict` — 0 violations; `scripts/format.sh` clean.

## Follow-up (not in this PR)

The worker→stream **progress bridge** (streaming `queued → running → passed` validation events during a long tool call) is the natural next slice — it needs a long-running tool plus a submission-status observer, and rides on this transport without changing the tool contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)