### PR TITLE
Rotate session ID on login (session-fixation defense)

### DIFF
--- a/Sources/APIServer/Bootstrap/SessionCookieFactory.swift
+++ b/Sources/APIServer/Bootstrap/SessionCookieFactory.swift
@@ -54,3 +54,17 @@ func chickadeeReauthMarkerCookie(isSecure: Bool) -> HTTPCookies.Value {
         sameSite: .lax
     )
 }
+
+extension Session {
+    /// Session-fixation defense — call right before authenticating a user.
+    ///
+    /// Dropping the id makes `SessionsMiddleware` issue a brand-new session id
+    /// and `Set-Cookie` when it commits this (still-valid) session on the way
+    /// out, so the authenticated session gets an identifier the pre-login
+    /// cookie never had. The pre-login row keeps its old id but never receives
+    /// the auth marker (that lands on the new id), so a session id fixed onto
+    /// the victim before login can't be used to ride the resulting session.
+    func rotateID() {
+        self.id = nil
+    }
+}

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -130,6 +130,7 @@ struct AuthRoutes: RouteCollection {
         try await user.save(on: req.db)
 
         req.auth.login(user)
+        req.session.rotateID()  // session-fixation defense: fresh id on login
         req.session.authenticate(user)
         await AuditLogger.record(
             action: .loginSuccess,
@@ -200,6 +201,7 @@ struct AuthRoutes: RouteCollection {
         try await user.save(on: req.db)
 
         req.auth.login(user)
+        req.session.rotateID()  // session-fixation defense: fresh id on login
         req.session.authenticate(user)
         return try await postLoginRedirect(for: user, req: req)
     }

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -192,8 +192,12 @@ struct SSOAuthRoutes: RouteCollection {
         req.session.data["oidc_refresh_token"] = tokenResponse.refreshToken
         req.session.data["oidc_id_token"] = tokenResponse.idToken
 
-        // Establish session — identical to local login
+        // Establish session — identical to local login. rotateID() runs after
+        // the tokens are stashed (so they carry to the new session) but before
+        // authenticate(), giving the logged-in session a fresh id the pre-login
+        // cookie never had (session-fixation defense).
         req.auth.login(user)
+        req.session.rotateID()
         req.session.authenticate(user)
         return try await postLoginRedirect(for: user, req: req)
     }

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -135,6 +135,45 @@ import XCTVapor
         }
     }
 
+    @Test func loginRotatesSessionID() async throws {
+        // Session-fixation defense: the authenticated session must get a fresh
+        // id, different from the pre-login one.
+        func sessionValue(_ header: String) -> String? {
+            for part in header.split(separator: ";") {
+                let kv = part.split(separator: "=", maxSplits: 1)
+                if kv.count == 2, kv[0].trimmingCharacters(in: .whitespaces) == "vapor-session" {
+                    return String(kv[1])
+                }
+            }
+            return nil
+        }
+        try await withApp(try await makeApp()) { app in
+            let hash = try Bcrypt.hash("pass1234")
+            try await APIUser(username: "rot", passwordHash: hash, role: "student").save(on: app.db)
+
+            let (token, preCookie) = try await csrfFields(for: "/login", on: app)
+            let preID = sessionValue(preCookie)
+            #expect(preID != nil)
+
+            var postID: String?
+            try await app.asyncTest(
+                .POST, "/login",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: preCookie)
+                    try req.content.encode(
+                        ["username": "rot", "password": "pass1234", "_csrf": token], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    for sc in res.headers[.setCookie] where sessionValue(sc) != nil {
+                        postID = sessionValue(sc)
+                    }
+                })
+            #expect(postID != nil)
+            #expect(postID != preID, "session id must rotate on login (fixation defense)")
+        }
+    }
+
     @Test func loginWithWrongPasswordRedirectsWithError() async throws {
         try await withApp(try await makeApp()) { app in
             let hash = try Bcrypt.hash("mypassword")

--- a/changelog.d/session-fixation-rotate-id.md
+++ b/changelog.d/session-fixation-rotate-id.md
@@ -1,0 +1,9 @@
+### Security
+
+- **Rotate the session ID on login (session-fixation defense).** All three
+  authentication entry points — local login, registration, and the SSO callback
+  — now issue a fresh session id when the user authenticates, instead of
+  authenticating onto the pre-login session id. A session cookie fixed onto a
+  victim before they log in can no longer be used to ride the resulting
+  authenticated session. (`Session.rotateID()`; modelled on the UWaterloo FAST
+  OIDC reference, which regenerates the session post-authentication.)


### PR DESCRIPTION
## Summary

Surfaced by the UWaterloo FAST OIDC reference example (which regenerates the session right after authentication). Chickadee's three auth entry points — local login, registration, and the SSO callback — were authenticating onto the **pre-login** session id, leaving a session-fixation gap: a session cookie fixed onto a victim before they log in could ride the resulting authenticated session.

Each now calls `Session.rotateID()` right before `authenticate()`. The middleware issues a fresh session id + cookie for the valid, id-less session on the way out; the pre-login row keeps its old id but never receives the auth marker, so the old cookie is useless post-login. For the SSO callback, rotation runs *after* the OIDC tokens are stashed so they carry to the new session.

Separate from the logout/re-auth work — this is a standalone hardening the reference example highlighted, relevant to the PIA review.

## Test plan

- [x] `loginRotatesSessionID` — asserts the `vapor-session` value differs pre- vs post-login
- [x] `loginWithCorrectCredentialsRedirects` + `sSOCallbackSuccess…` still pass (login/SSO flows intact, tokens carried)
- [x] `swift-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)