### PR TITLE
MCP: validate_assignment tool with live SSE validation progress

### DIFF
--- a/Sources/APIServer/MCP/Tools/MCPProgressReporter.swift
+++ b/Sources/APIServer/MCP/Tools/MCPProgressReporter.swift
@@ -1,0 +1,50 @@
+// APIServer/MCP/Tools/MCPProgressReporter.swift
+//
+// Emits MCP `notifications/progress` messages during a long-running tool call.
+// Built by the transport only when the call arrived over a progress-capable SSE
+// stream — the client both advertised `Accept: text/event-stream` and supplied a
+// `progressToken` in the request's `params._meta`. The reporter frames each
+// update as a JSON-RPC notification and hands it to a sink that writes it to the
+// open SSE stream.
+//
+// `Sendable` so it can be captured by the `@Sendable` streamed-response closure.
+
+import Core
+
+struct MCPProgressReporter: Sendable {
+    /// The opaque token the client attached to the request; echoed back on every
+    /// progress notification so the client can correlate it with the call.
+    let token: JSONValue
+    private let sink: @Sendable (JSONValue) async -> Void
+
+    init(token: JSONValue, sink: @escaping @Sendable (JSONValue) async -> Void) {
+        self.token = token
+        self.sink = sink
+    }
+
+    /// Sends one `notifications/progress`. `progress` is a fraction toward
+    /// `total` (default 1.0); `message` is a short human-readable status.
+    func report(_ progress: Double, total: Double = 1, message: String) async {
+        let notification: JSONValue = .object([
+            "jsonrpc": .string("2.0"),
+            "method": .string("notifications/progress"),
+            "params": .object([
+                "progressToken": token,
+                "progress": .double(progress),
+                "total": .double(total),
+                "message": .string(message),
+            ]),
+        ])
+        await sink(notification)
+    }
+
+    /// Extracts the client's `progressToken` from a request's `params`
+    /// (`params._meta.progressToken`), or nil when absent. Per the MCP spec a
+    /// server only sends progress when the client opted in with a token.
+    static func token(fromParams params: JSONValue?) -> JSONValue? {
+        guard case .object(let p)? = params, case .object(let meta)? = p["_meta"],
+            let token = meta["progressToken"]
+        else { return nil }
+        return token
+    }
+}

--- a/Sources/APIServer/MCP/Tools/ValidateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/ValidateAssignmentTool.swift
@@ -1,0 +1,103 @@
+// APIServer/MCP/Tools/ValidateAssignmentTool.swift
+//
+// Read tool: watch an assignment's runner validation to completion and report
+// the outcome, by assignment public ID. content:read, course-scoped.
+//
+// Validation is enqueued as a side effect of the suite/notebook edit tools
+// (update_suite / update_pattern_family / update_notebook). This tool lets an
+// agent then wait for that run to finish — polling pass/fail without a manual
+// poll loop — and return the terminal status (or report that it timed out while
+// still pending).
+//
+// When the call arrives over a progress-capable SSE stream (the client accepts
+// text/event-stream and supplied a progressToken), the transport streams live
+// `notifications/progress` events (queued -> running -> done) before this final
+// result; see MCPRoutes. Over plain JSON it simply blocks for the bounded wait
+// and returns the outcome. Both paths share watchValidation().
+
+import Core
+import Fluent
+import Foundation
+
+struct ValidateAssignmentTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// Maximum seconds to wait for a terminal result (clamped 1...120,
+        /// default 30). On expiry the tool returns with `timedOut: true`.
+        let timeoutSeconds: Int?
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let validationStatus: String
+        let timedOut: Bool
+    }
+
+    static let name = "validate_assignment"
+    static let description =
+        "Watch an assignment's runner validation to completion and return the outcome, by assignment "
+        + "public ID. Validation is queued automatically when you edit the suite or notebook; this tool "
+        + "waits (up to timeoutSeconds, default 30) for it to finish and returns validationStatus "
+        + "(passed/failed/no-runner) — or timedOut:true if still pending. Over an SSE connection it also "
+        + "streams live queued -> running -> done progress."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "timeoutSeconds": .object([
+                "type": .string("integer"),
+                "description": .string("Max seconds to wait for a terminal result (1-120, default 30)."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "validationStatus": .object(["type": .string("string")]),
+            "timedOut": .object(["type": .string("boolean")]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("validationStatus"), .string("timedOut"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: true, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    /// Default / bounds for the bounded wait, shared with the streaming path.
+    static let defaultTimeoutSeconds = 30
+    static let maxTimeoutSeconds = 120
+
+    static func clampTimeout(_ seconds: Int?) -> Int {
+        min(max(seconds ?? defaultTimeoutSeconds, 1), maxTimeoutSeconds)
+    }
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+
+        let timeout = Self.clampTimeout(input.timeoutSeconds)
+        let outcome = try await watchValidation(
+            on: context.db,
+            assignmentPublicID: assignment.publicID,
+            pollInterval: .milliseconds(500),
+            deadline: ContinuousClock().now.advanced(by: .seconds(timeout)),
+            emit: { _, _ in })  // non-streaming: bounded wait, no progress events
+
+        return Output(
+            assignmentPublicID: outcome.assignmentPublicID,
+            validationStatus: outcome.validationStatus,
+            timedOut: outcome.timedOut)
+    }
+}

--- a/Sources/APIServer/MCP/Tools/ValidationWatch.swift
+++ b/Sources/APIServer/MCP/Tools/ValidationWatch.swift
@@ -1,0 +1,117 @@
+// APIServer/MCP/Tools/ValidationWatch.swift
+//
+// Shared logic for watching an assignment's runner validation to a terminal
+// state, used by both the (non-streaming) validate_assignment tool and the
+// SSE progress-streaming path in MCPRoutes. Pure `Database` access — no Vapor
+// `Request` — so it is safe to run from a request handler (`request.db`) or
+// from a `@Sendable` streamed-response closure (`application.db`).
+
+import Core
+import Fluent
+import Foundation
+
+/// Coarse phase of a validation run, derived from the assignment's
+/// `validationStatus` plus its validation submission's row status. Raw values
+/// are ordered so a caller can detect forward progress.
+enum ValidationPhase: Int, Sendable, Comparable {
+    case queued = 0  // enqueued, submission still pending
+    case running = 1  // submission claimed by a worker (assigned/running)
+    case done = 2  // assignment reached a terminal validationStatus
+
+    static func < (lhs: ValidationPhase, rhs: ValidationPhase) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    /// Fraction toward completion surfaced in `notifications/progress`.
+    var progressFraction: Double {
+        switch self {
+        case .queued: return 0.25
+        case .running: return 0.66
+        case .done: return 1.0
+        }
+    }
+}
+
+/// Terminal outcome of a validation watch.
+struct ValidationWatchOutcome: Sendable {
+    let assignmentPublicID: String
+    /// "passed" | "failed" | "no-runner" | "pending" | "none" — the assignment's
+    /// `validationStatus` at the point the watch stopped (terminal or timeout).
+    let validationStatus: String
+    /// True when the watch hit its deadline before validation reached a terminal
+    /// state (still pending/running).
+    let timedOut: Bool
+}
+
+/// The terminal `validationStatus` values that stop the watch.
+private let terminalValidationStatuses: Set<String> = ["passed", "failed", "no-runner"]
+
+/// Polls the assignment (and its validation submission) until validation reaches
+/// a terminal state or `deadline` passes, invoking `emit` once per forward phase
+/// change. `emit` receives the progress fraction and a short human message.
+@discardableResult
+func watchValidation(
+    on db: Database,
+    assignmentPublicID: String,
+    pollInterval: Duration,
+    deadline: ContinuousClock.Instant,
+    clock: ContinuousClock = ContinuousClock(),
+    emit: (Double, String) async -> Void
+) async throws -> ValidationWatchOutcome {
+    var lastPhase: ValidationPhase?
+
+    while true {
+        let (status, phase) = try await currentValidationPhase(
+            on: db, assignmentPublicID: assignmentPublicID)
+
+        if lastPhase == nil || phase > (lastPhase ?? .queued) {
+            lastPhase = phase
+            await emit(phase.progressFraction, message(for: phase, status: status))
+        }
+
+        if phase == .done {
+            return ValidationWatchOutcome(
+                assignmentPublicID: assignmentPublicID,
+                validationStatus: status ?? "none", timedOut: false)
+        }
+        if clock.now >= deadline {
+            return ValidationWatchOutcome(
+                assignmentPublicID: assignmentPublicID,
+                validationStatus: status ?? "pending", timedOut: true)
+        }
+        try await Task.sleep(for: pollInterval)
+    }
+}
+
+/// Reads the assignment's current validation status + derived phase. A missing
+/// assignment is treated as still-queued (the caller authorized it before the
+/// watch began, so this only happens on a transient read).
+private func currentValidationPhase(
+    on db: Database, assignmentPublicID: String
+) async throws -> (status: String?, phase: ValidationPhase) {
+    guard let assignment = try await assignmentByPublicID(assignmentPublicID, on: db) else {
+        return (nil, .queued)
+    }
+    let status = assignment.validationStatus
+    if let status, terminalValidationStatuses.contains(status) {
+        return (status, .done)
+    }
+    // Not terminal: distinguish "queued" from "running" via the submission row.
+    if let subID = assignment.validationSubmissionID,
+        let submission = try await APISubmission.find(subID, on: db)
+    {
+        switch submission.status {
+        case "assigned", "running": return (status, .running)
+        default: return (status, .queued)
+        }
+    }
+    return (status, .queued)
+}
+
+private func message(for phase: ValidationPhase, status: String?) -> String {
+    switch phase {
+    case .queued: return "Queued for validation"
+    case .running: return "Running on a worker"
+    case .done: return "Validation \(status ?? "complete")"
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -120,7 +120,7 @@ struct MCPDispatcher: Sendable {
     /// tracked separately from the human's own web actions in the admin audit
     /// log; the acting agent is in `via_agent` when present. Never logs tool
     /// arguments.
-    private func auditToolCall(name: String, context: ToolContext) async {
+    func auditToolCall(name: String, context: ToolContext) async {
         var metadata = ["tool": name]
         if let agent = context.actingClientName {
             metadata["via_agent"] = agent
@@ -133,12 +133,7 @@ struct MCPDispatcher: Sendable {
     }
 
     private func successToolResult(_ structured: JSONValue) -> JSONValue {
-        let text = (try? structured.encodedString()) ?? ""
-        return .object([
-            "content": .array([.object(["type": .string("text"), "text": .string(text)])]),
-            "structuredContent": structured,
-            "isError": .bool(false),
-        ])
+        mcpToolSuccessResult(structured)
     }
 
     private func errorToolResult(_ error: MCPToolError) -> JSONValue {
@@ -172,4 +167,17 @@ struct MCPDispatcher: Sendable {
             return .failure(id: id, error: .internalError("Failed to encode initialize result."))
         }
     }
+}
+
+/// Wraps a tool's structured output in the MCP `tools/call` result envelope
+/// (`content` text block + `structuredContent` + `isError:false`). Shared by the
+/// dispatcher's normal path and the transport's SSE progress-streaming path so
+/// the two produce identical result shapes.
+func mcpToolSuccessResult(_ structured: JSONValue) -> JSONValue {
+    let text = (try? structured.encodedString()) ?? ""
+    return .object([
+        "content": .array([.object(["type": .string("text"), "text": .string(text)])]),
+        "structuredContent": structured,
+        "isError": .bool(false),
+    ])
 }

--- a/Sources/APIServer/MCP/Transport/MCPRoutes.swift
+++ b/Sources/APIServer/MCP/Transport/MCPRoutes.swift
@@ -17,6 +17,7 @@
 // not do this by default — the `Host` header is pinned to an allowlist too.
 // https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
 
+import Core
 import Foundation
 import NIOCore
 import Vapor
@@ -85,6 +86,21 @@ struct MCPRoutes: RouteCollection {
             actingClientID: principal.actingClientID,
             actingClientName: principal.actingClientName
         )
+
+        // Live-progress streaming: a `validate_assignment` tools/call over an SSE
+        // connection that carries a progressToken streams `notifications/progress`
+        // (queued → running → done) while it waits, then the final result. This is
+        // the one tool wired for live progress; every other call falls through to
+        // the generic dispatch below (which still streams its single result as SSE
+        // when the client accepts it). Generalizing live progress to all tools
+        // needs a Sendable ToolContext — it currently wraps the non-Sendable
+        // Request — so the watch runs on the request-independent `application.db`
+        // and this stays a contained special case rather than threading a progress
+        // sink through the dispatcher.
+        if let streaming = try await validationProgressStream(req: req, context: context, rpc: rpcRequest) {
+            return streaming
+        }
+
         guard let rpcResponse = await dispatcher.dispatch(rpcRequest, context: context) else {
             // A notification was accepted; the spec mandates 202 with no body.
             return Response(status: .accepted)
@@ -167,27 +183,14 @@ struct MCPRoutes: RouteCollection {
     }
 
     /// Frames a single JSON-RPC response as a one-shot SSE stream: one
-    /// `event: message` carrying the compact JSON, then the stream ends. This is
-    /// the Streamable HTTP "POST returns an SSE stream" form; we emit exactly one
-    /// event (no progress notifications yet), but the shape is forward-compatible
-    /// — additional `notifications/progress` events could precede the response.
-    ///
-    /// `X-Accel-Buffering: no` + `Cache-Control: no-cache` defeat reverse-proxy
-    /// buffering (nginx/squid) that would otherwise hold the event until the
-    /// connection closes, which is fatal for incremental streaming.
+    /// `event: message` carrying the compact JSON, then the stream ends. The
+    /// generic happy path uses this — every tool except the live-progress
+    /// `validate_assignment` stream emits exactly one event. The shape is
+    /// forward-compatible: progress notifications can precede the response (which
+    /// is exactly what the validation stream does).
     private func eventStreamResponse(_ payload: JSONRPCResponse) throws -> Response {
-        let json = String(bytes: try JSONEncoder().encode(payload), encoding: .utf8) ?? ""
-        // SSE framing: `event:` line, one `data:` line (compact JSON has no
-        // newlines, so a single data line is valid), terminated by a blank line.
-        let frame = "event: message\ndata: \(json)\n\n"
-
-        var headers = HTTPHeaders()
-        headers.replaceOrAdd(name: .contentType, value: "text/event-stream")
-        headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
-        headers.replaceOrAdd(name: .connection, value: "keep-alive")
-        headers.replaceOrAdd(name: "X-Accel-Buffering", value: "no")
-
-        let response = Response(status: .ok, headers: headers)
+        let frame = try MCPRoutes.sseMessageFrame(encoding: payload)
+        let response = Response(status: .ok, headers: MCPRoutes.sseHeaders())
         response.body = .init(stream: { writer in
             var buffer = ByteBufferAllocator().buffer(capacity: frame.utf8.count)
             buffer.writeString(frame)
@@ -196,6 +199,117 @@ struct MCPRoutes: RouteCollection {
             }
         })
         return response
+    }
+
+    /// SSE response headers. `X-Accel-Buffering: no` + `Cache-Control: no-cache`
+    /// defeat reverse-proxy buffering (nginx/squid) that would otherwise hold
+    /// events until the connection closes — fatal for incremental streaming.
+    static func sseHeaders() -> HTTPHeaders {
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .contentType, value: "text/event-stream")
+        headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+        headers.replaceOrAdd(name: .connection, value: "keep-alive")
+        headers.replaceOrAdd(name: "X-Accel-Buffering", value: "no")
+        return headers
+    }
+
+    /// One SSE `message` frame: `event:` line, a single `data:` line (compact
+    /// JSON has no newlines), terminated by a blank line.
+    static func sseMessageFrame(jsonString: String) -> String {
+        "event: message\ndata: \(jsonString)\n\n"
+    }
+
+    static func sseMessageFrame(encoding value: some Encodable) throws -> String {
+        let json = String(bytes: try JSONEncoder().encode(value), encoding: .utf8) ?? ""
+        return sseMessageFrame(jsonString: json)
+    }
+
+    // MARK: - validate_assignment live progress stream
+
+    /// If `rpc` is a `validate_assignment` tools/call over an SSE connection that
+    /// carries a `progressToken`, and the caller is scope-authorized and enrolled
+    /// in the assignment's course, returns an SSE response that streams progress
+    /// then the result. Returns nil to let the generic dispatch handle every
+    /// other case (including the authorization/error responses, so this path
+    /// never has to reformat them).
+    private func validationProgressStream(
+        req: Request, context: ToolContext, rpc: JSONRPCRequest
+    ) async throws -> Response? {
+        guard clientAcceptsEventStream(req),
+            let input = Self.validateAssignmentCall(rpc),
+            let token = MCPProgressReporter.token(fromParams: rpc.params),
+            context.grantedScopes.isSuperset(of: ValidateAssignmentTool.requiredScopes),
+            let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
+        else { return nil }
+        // Authorize against the assignment's course; on failure fall back to the
+        // generic dispatch, which produces the proper not-authorized result.
+        do {
+            try await context.authorizeCourseAccess(
+                assignment.courseID, tool: ValidateAssignmentTool.name)
+        } catch {
+            return nil
+        }
+
+        // Audit the call here, since the generic dispatcher (which normally does)
+        // is bypassed for the streaming path.
+        await dispatcher.auditToolCall(name: ValidateAssignmentTool.name, context: context)
+
+        let application = req.application
+        let id = rpc.id ?? .null
+        let publicID = assignment.publicID
+        let timeout = ValidateAssignmentTool.clampTimeout(input.timeoutSeconds)
+
+        let response = Response(status: .ok, headers: Self.sseHeaders())
+        response.body = .init(asyncStream: { writer in
+            let reporter = MCPProgressReporter(
+                token: token,
+                sink: { notification in
+                    if let frame = try? Self.sseMessageFrame(encoding: notification) {
+                        try? await writer.writeBuffer(ByteBuffer(string: frame))
+                    }
+                })
+
+            let finalResponse: JSONRPCResponse
+            do {
+                let outcome = try await watchValidation(
+                    on: application.db,
+                    assignmentPublicID: publicID,
+                    pollInterval: .milliseconds(500),
+                    deadline: ContinuousClock().now.advanced(by: .seconds(timeout)),
+                    emit: { progress, message in await reporter.report(progress, message: message) })
+                let output = ValidateAssignmentTool.Output(
+                    assignmentPublicID: outcome.assignmentPublicID,
+                    validationStatus: outcome.validationStatus,
+                    timedOut: outcome.timedOut)
+                let structured = (try? JSONValue(encoding: output)) ?? .object([:])
+                finalResponse = .success(id: id, result: mcpToolSuccessResult(structured))
+            } catch {
+                finalResponse = .failure(
+                    id: id, error: .internalError("validate_assignment failed while watching validation."))
+            }
+
+            if let frame = try? Self.sseMessageFrame(encoding: finalResponse) {
+                try? await writer.writeBuffer(ByteBuffer(string: frame))
+            }
+            try? await writer.write(.end)
+        })
+        return response
+    }
+
+    /// Decodes `rpc` into a `validate_assignment` tool input, or nil if `rpc`
+    /// isn't a tools/call for that tool.
+    private static func validateAssignmentCall(_ rpc: JSONRPCRequest) -> ValidateAssignmentTool.Input? {
+        guard rpc.method == "tools/call", let params = rpc.params else { return nil }
+        struct Call: Decodable {
+            let name: String
+            let arguments: JSONValue?
+        }
+        guard let call = try? params.decoded(as: Call.self),
+            call.name == ValidateAssignmentTool.name,
+            let input = try? (call.arguments ?? .object([:])).decoded(
+                as: ValidateAssignmentTool.Input.self)
+        else { return nil }
+        return input
     }
 
     /// Builds the `WWW-Authenticate: Bearer …, error="insufficient_scope", scope="…"`

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -21,6 +21,7 @@ enum MCPToolCatalog {
             GetAssignmentTool().erased(),
             GetSuiteTool().erased(),
             GetNotebookTool().erased(),
+            ValidateAssignmentTool().erased(),
             UpdateAssignmentTool().erased(),
             UpdateSuiteTool().erased(),
             UpdatePatternFamilyTool().erased(),

--- a/Tests/APITests/MCP/MCPProgressStreamTests.swift
+++ b/Tests/APITests/MCP/MCPProgressStreamTests.swift
@@ -1,0 +1,108 @@
+// End-to-end tests for the validate_assignment live-progress SSE stream: a
+// tools/call carrying a progressToken over an SSE connection emits
+// notifications/progress before the final result; without a token it falls back
+// to a single result event.
+
+import Fluent
+import JWT
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct MCPProgressStreamTests {
+    private let issuer = "https://chickadee.example"
+    private let resource = "https://chickadee.example/mcp"
+
+    private func makeMCPApp() async throws -> (Application, MCPTokenAuthority) {
+        let mcp = MCPConfig(
+            enabled: true, allowedHosts: [], allowedOrigins: [],
+            tokenTTLSeconds: 3600, signingKeyPath: "unused",
+            issuer: issuer, resource: resource)
+        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
+        let authority = try await MCPTokenAuthority.make(
+            privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
+        app.mcpTokenAuthority = authority
+        return (app, authority)
+    }
+
+    /// Enrolled agent + a setup + an assignment already in a terminal validation
+    /// state, so the watch completes immediately (one progress event + result).
+    private func passedAssignment(on app: Application) async throws -> String {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let agent = try await makeTestUser(on: app, username: "agent", role: "mcp")
+        try await makeTestEnrollment(on: app, userID: agent.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_ps", courseID: courseID)
+        let assignment = try await makeTestAssignment(
+            on: app, testSetupID: "setup_ps", courseID: courseID, title: "Lab")
+        assignment.validationStatus = "passed"
+        try await assignment.save(on: app.db)
+        return assignment.publicID
+    }
+
+    private func post(
+        _ app: Application, body: String, token: String, accept: String
+    ) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(
+            .POST, "/mcp",
+            headers: [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(token)",
+                "Accept": accept,
+            ],
+            body: ByteBuffer(string: body))
+    }
+
+    @Test func streamsProgressThenResultWithToken() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            let publicID = try await passedAssignment(on: app)
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            // progressToken in params._meta opts the call into live progress.
+            let body = """
+                {"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"validate_assignment",\
+                "arguments":{"assignmentPublicID":"\(publicID)","timeoutSeconds":5},\
+                "_meta":{"progressToken":"p-1"}}}
+                """
+            let res = try await post(app, body: body, token: token, accept: "text/event-stream")
+
+            #expect(res.status == .ok)
+            #expect(res.headers.contentType?.description.contains("text/event-stream") == true)
+            let text = res.body.string
+            // At least one progress notification, echoing the token, then the
+            // final tool result carrying the passed status. (JSONEncoder escapes
+            // the method's slash as `notifications\/progress`, so match the
+            // method name + token rather than the literal slashed string.)
+            #expect(text.contains("notifications"))
+            #expect(text.contains("\"progressToken\":\"p-1\""))
+            #expect(text.contains("\"validationStatus\":\"passed\""))
+            #expect(text.contains("\"isError\":false"))
+        }
+    }
+
+    @Test func withoutTokenEmitsSingleResultEvent() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            let publicID = try await passedAssignment(on: app)
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            // No _meta.progressToken → generic SSE path: single result event, no
+            // progress notifications.
+            let body = """
+                {"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"validate_assignment",\
+                "arguments":{"assignmentPublicID":"\(publicID)","timeoutSeconds":5}}}
+                """
+            let res = try await post(app, body: body, token: token, accept: "text/event-stream")
+
+            #expect(res.status == .ok)
+            let text = res.body.string
+            #expect(!text.contains("notifications"))
+            #expect(!text.contains("progressToken"))
+            #expect(text.contains("\"validationStatus\":\"passed\""))
+        }
+    }
+}

--- a/Tests/APITests/MCP/ValidateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/ValidateAssignmentToolTests.swift
@@ -1,0 +1,184 @@
+// Tests for ValidateAssignmentTool + the shared watchValidation logic that backs
+// both it and the SSE progress stream. Backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct ValidateAssignmentToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read]
+        )
+    }
+
+    /// Course + enrolled instructor "tester" + setup + assignment. Returns the
+    /// assignment so the test can set its validation state.
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_val", courseID: courseID)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_val", courseID: courseID, title: "Lab")
+    }
+
+    /// Collects emitted progress messages across the watch's child task.
+    private actor MessageLog {
+        private(set) var messages: [String] = []
+        func add(_ m: String) { messages.append(m) }
+    }
+
+    // MARK: - watchValidation
+
+    @Test func watchReturnsImmediatelyWhenAlreadyTerminal() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: app.db)
+
+            let log = MessageLog()
+            let outcome = try await watchValidation(
+                on: app.db, assignmentPublicID: assignment.publicID,
+                pollInterval: .milliseconds(50),
+                deadline: ContinuousClock().now.advanced(by: .seconds(5)),
+                emit: { _, m in await log.add(m) })
+
+            #expect(outcome.validationStatus == "passed")
+            #expect(outcome.timedOut == false)
+            let messages = await log.messages
+            #expect(messages.contains { $0.contains("passed") })
+        }
+    }
+
+    @Test func watchTimesOutWhileStillPending() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            assignment.validationStatus = "pending"
+            try await assignment.save(on: app.db)
+
+            let outcome = try await watchValidation(
+                on: app.db, assignmentPublicID: assignment.publicID,
+                pollInterval: .milliseconds(50),
+                deadline: ContinuousClock().now.advanced(by: .milliseconds(150)),
+                emit: { _, _ in })
+
+            #expect(outcome.timedOut)
+            #expect(outcome.validationStatus == "pending")
+        }
+    }
+
+    @Test func watchObservesRunningThenPassedTransition() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let tester = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "tester").first())
+            // A pending validation submission the watch will observe transitioning.
+            try await makeTestSubmission(
+                on: app, id: "sub_val", setupID: "setup_val", userID: tester.requireID(),
+                kind: APISubmission.Kind.validation, status: "pending")
+            assignment.validationStatus = "pending"
+            assignment.validationSubmissionID = "sub_val"
+            try await assignment.save(on: app.db)
+
+            let log = MessageLog()
+            async let watched = watchValidation(
+                on: app.db, assignmentPublicID: assignment.publicID,
+                pollInterval: .milliseconds(40),
+                deadline: ContinuousClock().now.advanced(by: .seconds(10)),
+                emit: { _, m in await log.add(m) })
+
+            // Drive the transitions the runner would normally cause.
+            try await Task.sleep(for: .milliseconds(120))
+            let sub = try #require(try await APISubmission.find("sub_val", on: app.db))
+            sub.status = "assigned"
+            try await sub.save(on: app.db)
+            try await Task.sleep(for: .milliseconds(120))
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: app.db)
+
+            let outcome = try await watched
+            #expect(outcome.validationStatus == "passed")
+            #expect(outcome.timedOut == false)
+            let messages = await log.messages
+            #expect(messages.contains { $0.contains("Running") })
+            #expect(messages.contains { $0.contains("passed") })
+        }
+    }
+
+    // MARK: - ValidateAssignmentTool
+
+    @Test func toolReturnsTerminalStatus() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            assignment.validationStatus = "failed"
+            try await assignment.save(on: app.db)
+
+            let output = try await ValidateAssignmentTool().execute(
+                ValidateAssignmentTool.Input(
+                    assignmentPublicID: assignment.publicID, timeoutSeconds: 5),
+                context(app))
+            #expect(output.validationStatus == "failed")
+            #expect(output.timedOut == false)
+        }
+    }
+
+    @Test func toolTimesOutWhilePending() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            assignment.validationStatus = "pending"
+            try await assignment.save(on: app.db)
+
+            let output = try await ValidateAssignmentTool().execute(
+                ValidateAssignmentTool.Input(
+                    assignmentPublicID: assignment.publicID, timeoutSeconds: 1),
+                context(app))
+            #expect(output.timedOut)
+        }
+    }
+
+    @Test func toolUnknownAssignmentThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ValidateAssignmentTool().execute(
+                    ValidateAssignmentTool.Input(assignmentPublicID: "zzzzzz", timeoutSeconds: 1),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func toolDeniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_val", courseID: courseID)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_val", courseID: courseID, title: "Lab")
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: app.db)
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ValidateAssignmentTool().execute(
+                    ValidateAssignmentTool.Input(
+                        assignmentPublicID: assignment.publicID, timeoutSeconds: 1),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-validation-progress-stream.md
+++ b/changelog.d/mcp-validation-progress-stream.md
@@ -1,0 +1,14 @@
+### Added
+
+- **MCP authoring: `validate_assignment` tool with live SSE progress.** Watches an
+  assignment's runner validation to completion and returns the outcome
+  (`passed`/`failed`/`no-runner`, or `timedOut` while still pending), by
+  assignment public ID — so an agent that edited the suite/notebook can wait for
+  the auto-queued validation instead of hand-rolling a poll loop. When the call
+  arrives over an SSE connection carrying a `progressToken`, the transport streams
+  live `notifications/progress` events (queued → running → done) before the final
+  result; over plain JSON (or SSE without a token) it simply bounded-waits and
+  returns the outcome. This is the worker→stream bridge from the SSE roadmap: the
+  watch polls the request-independent `application.db`, so it runs safely inside
+  the `@Sendable` streamed-response body without touching the non-`Sendable`
+  `Request`. `content:read`, course-scoped.


### PR DESCRIPTION
## Summary

The worker→stream **progress bridge** from the SSE roadmap (§8), built on the SSE transport (#724).

- Adds the **`validate_assignment`** tool: watches an assignment's runner validation to a terminal state and returns the outcome (`passed`/`failed`/`no-runner`, or `timedOut` while still pending), by assignment public ID. Validation is auto-queued when an agent edits the suite/notebook (`update_suite` / `update_pattern_family` / `update_notebook`), so this lets the agent **wait for the result** instead of hand-rolling a poll loop. `content:read`, course-scoped.
- **Live progress over SSE:** when the call carries a `progressToken` (`params._meta.progressToken`) over an `Accept: text/event-stream` connection, the transport streams live `notifications/progress` events (`queued → running → done`) before the final result. Over plain JSON, or SSE without a token, it bounded-waits and returns the outcome — same result, no streaming.
- **Concurrency-safe:** both paths share `watchValidation()`, which polls the request-independent `application.db`. That's the key to running the watch inside the `@Sendable` streamed-response body without capturing Vapor's non-`Sendable` `Request`. Auth/scope/audit all happen up-front in the request context; only the DB poll loop runs in the stream closure.
- Live progress is a **contained special case** for this one tool (documented in `MCPRoutes`); generalizing it to every tool would need a `Sendable` `ToolContext`. The generic SSE path (#724) still delivers every other tool's single result as one SSE event.

## Test plan

- [x] `swift test --filter "ValidateAssignmentToolTests|MCPProgressStreamTests|MCPSSETransportTests"` — 13 tests pass.
- [x] `ValidateAssignmentToolTests`: `watchValidation` terminal-immediate, timeout-while-pending, and a concurrent `pending → assigned → passed` transition (asserts the `running` + `passed` progress messages); tool terminal/timeout/unknown/denied paths.
- [x] `MCPProgressStreamTests`: with a `progressToken`, the SSE body carries a `notifications/progress` event (echoing the token) then the final `passed` result; without a token, a single result event and no progress.
- [x] `swift test --filter MCP` — all 79 MCP tests pass; `scripts/swiftlint.sh --strict` clean; `scripts/format.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)