### PR TITLE
Login page shows the SSO button instead of auto-initiating SSO

### DIFF
--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -42,15 +42,14 @@ struct AuthRoutes: RouteCollection {
         let loggedOut = req.query[String.self, at: "loggedout"] != nil
         let authMode = req.application.authMode
 
-        // In SSO-only mode, start the SSO flow immediately so users do not
-        // need to click a button. Keep error states on /login so the message
-        // can be shown instead of creating a redirect loop. A just-logged-out
-        // user is held on the form too — otherwise logout would bounce them
-        // straight back into SSO and silently re-authenticate, defeating the
-        // whole point of the button.
-        if authMode == .sso, error == nil, !loggedOut {
-            return req.redirect(to: "/auth/sso/start")
-        }
+        // Always render the login page — including in SSO-only mode, where it
+        // shows the "Login with UWaterloo" button. We deliberately do NOT
+        // auto-redirect into `/auth/sso/start`: auto-initiating SSO made logout
+        // look broken (IRA-PIA finding). Because the IdP keeps its own SSO
+        // session alive, landing on the app would silently re-authenticate
+        // instead of showing a logged-out page. Requiring an explicit click
+        // means logout visibly takes effect; the button still runs the full
+        // SSO flow (with `prompt=login` after a logout).
 
         return try await req.view.render(
             "login",

--- a/Tests/APITests/AuthModeGatingTests.swift
+++ b/Tests/APITests/AuthModeGatingTests.swift
@@ -102,13 +102,16 @@ import XCTVapor
         }
     }
 
-    @Test func ssoMode_loginAutoRedirectsToSSOStart() async throws {
+    @Test func ssoMode_loginRendersButtonNotAutoSSO() async throws {
+        // /login must NOT auto-redirect into SSO — it renders the login page
+        // with the "Login with UWaterloo" button. Auto-initiating SSO made
+        // logout look broken: the IdP's live session silently re-authenticated
+        // instead of showing a logged-out page (IRA-PIA finding).
         try await withApp(try await makeApp(authMode: .sso)) { app in
             try await app.asyncTest(
                 .GET, "/login",
                 afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    #expect(res.headers.first(name: .location) == "/auth/sso/start")
+                    #expect(res.headers.first(name: .location) != "/auth/sso/start")
                 })
         }
     }

--- a/changelog.d/login-no-auto-sso.md
+++ b/changelog.d/login-no-auto-sso.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **The login page no longer auto-initiates SSO — it shows the "Login with
+  UWaterloo" button.** In SSO-only mode `/login` used to redirect straight into
+  `/auth/sso/start`, which made logout look broken: opening the app after
+  logging out silently re-authenticated against the IdP's still-live SSO session
+  instead of showing a logged-out page (IRA-PIA finding). Signing in now takes
+  an explicit click, so logout visibly takes effect. The button still runs the
+  full SSO flow (including `prompt=login` after a logout). One extra click per
+  sign-in is the trade-off. (`AuthRoutes.loginForm`.)


### PR DESCRIPTION
## Summary

The likely root of the IST "still logged in after logout" finding. In SSO-only mode, `/login` auto-redirected straight into `/auth/sso/start`. So opening `chickadee.uwaterloo.ca` after logging out went `/` → `/login` → **auto-SSO** → the IdP's still-live session silently returned a code → logged back in, **without ever showing a logged-out page**. That reads as "logout didn't work."

`/login` now always renders the page with the **"Login with UWaterloo"** button (it already did for `?loggedout=1`/error states — this just removes the auto-redirect for plain visits). Signing in takes an explicit click, so logout visibly takes effect. The button still runs the full SSO flow, including `prompt=login` after a logout.

**Trade-off:** one extra click per sign-in (the auto-redirect was a convenience). This is the standard, more-defensible pattern for SSO apps and is what removes the finding without depending on any Duo/ADFS-side change.

## Test plan

- [x] `ssoMode_loginRendersButtonNotAutoSSO` — `/login` no longer redirects to `/auth/sso/start`
- [x] `ssoMode_loginAfterLogoutRendersFormNotSSORestart` / `…TimeoutError…` still pass
- [x] `loginPageAfterLogout_rendersSSOLinkNotForm` (SSO button is a nav link) still passes
- [x] `swift-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)