### PR TITLE
Add the Chickadee logo to the login page

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -763,6 +763,15 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     margin: 3rem auto;
 }
 
+/* Chickadee mascot above the login heading. The PNG is transparent, so it sits
+   cleanly on the page background in both light and dark mode. */
+.auth-logo {
+    display: block;
+    width: 128px;
+    height: 128px;
+    margin: 0 auto .75rem;
+}
+
 .auth-box h1 { margin-bottom: 1.5rem; }
 
 .auth-alt {

--- a/Resources/Views/login.leaf
+++ b/Resources/Views/login.leaf
@@ -4,6 +4,7 @@ Log in
 #endexport
 #export("content"):
 <div class="auth-box">
+    <img class="auth-logo" src="/images/chickadee-icon-alt.png?v=#appVersion()" alt="" width="128" height="128">
     <h1>Log in to Chickadee</h1>
     #if(loggedOut && !error):
     <div class="notice-box" style="margin-bottom:1rem">

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -358,6 +358,19 @@ import XCTVapor
         }
     }
 
+    @Test func loginPageShowsChickadeeLogo() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.asyncTest(
+                .GET, "/login",
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("class=\"auth-logo\""))
+                    #expect(body.contains("/images/chickadee-icon-alt.png"))
+                })
+        }
+    }
+
     // MARK: - Access control
 
     @Test func unauthenticatedHomeRedirectsToLogin() async throws {

--- a/changelog.d/login-page-logo.md
+++ b/changelog.d/login-page-logo.md
@@ -1,0 +1,5 @@
+### Changed
+
+- **The login page now shows the Chickadee mascot.** Added the (transparent)
+  `chickadee-icon-alt.png` logo centered above the "Log in to Chickadee"
+  heading. (`login.leaf` + `.auth-logo` in `styles.css`.)


### PR DESCRIPTION
## Summary

Adds the Chickadee mascot to the login page — the transparent `chickadee-icon-alt.png` (the same asset the nav brand uses), centered at 128px above the "Log in to Chickadee" heading. It's the transparent variant, so it sits cleanly on the page background in both light and dark mode.

## Test plan

- [x] `loginPageShowsChickadeeLogo` — rendered `/login` contains `class="auth-logo"` + the image path
- [x] Existing login-render tests still pass
- [ ] Visual check on the dev server (couldn't render locally — the dev-server binary stalls behind a macOS first-run gate in this sandbox; the markup/asset are verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)