### PR TITLE
MCP: expose assignment manifests as resources + refresh authoring roadmap

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -1,8 +1,8 @@
 // APIServer/MCP/Protocol/InitializeTypes.swift
 //
 // Result types for the MCP `initialize` handshake.  Capabilities advertise
-// only what v1 implements — tools, without list-change notifications, since
-// there is no server-initiated streaming yet.  The result also carries a
+// what v1 implements — tools and resources, without list-change notifications,
+// since there is no server-initiated streaming yet.  The result also carries a
 // human-readable `instructions` string so a connecting agent learns the domain
 // model, the read-before-write workflow, and the validation/safety rules up
 // front rather than reverse-engineering them from the tool list alone.
@@ -18,19 +18,28 @@ struct MCPInitializeResult: Encodable, Sendable {
     let instructions: String?
 }
 
-/// Capabilities this server advertises at initialization.  Only `tools` is
-/// advertised: v1 exposes no resources or prompts, and `listChanged` is false
-/// because it pushes no list-change notifications (no streaming).
+/// Capabilities this server advertises at initialization.  `tools` and
+/// `resources` are advertised; `prompts` is not.  `listChanged` is false on
+/// both (no server-initiated list-change notifications), and resources are not
+/// subscribable.
 struct MCPServerCapabilities: Encodable, Sendable {
     let tools: ListChanged
+    let resources: Resources
 
     struct ListChanged: Encodable, Sendable {
         let listChanged: Bool
     }
 
-    /// The capability set advertised by v1: tools only, no list-change
-    /// notifications.
-    static let v1 = MCPServerCapabilities(tools: ListChanged(listChanged: false))
+    struct Resources: Encodable, Sendable {
+        let subscribe: Bool
+        let listChanged: Bool
+    }
+
+    /// The capability set advertised by v1: tools + resources, neither pushing
+    /// list-change notifications, resources not subscribable.
+    static let v1 = MCPServerCapabilities(
+        tools: ListChanged(listChanged: false),
+        resources: Resources(subscribe: false, listChanged: false))
 }
 
 /// Identifies this server to the client in the `initialize` result.  `name` is
@@ -93,5 +102,9 @@ enum MCPServerInstructions {
         is regraded; validate and open it with update_assignment when ready.
         - You author structure and metadata, not the underlying test logic: you cannot write raw \
         script bodies or a pattern case's args/expected values.
+        - Resources: each accessible assignment's raw test.properties.json manifest is also exposed \
+        as an MCP resource (resources/list, then resources/read on \
+        chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \
+        is the verbatim canonical JSON, useful to read the full authoring spec into context.
         """
 }

--- a/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
+++ b/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
@@ -1,0 +1,119 @@
+// APIServer/MCP/Resources/MCPResourceProvider.swift
+//
+// Backs the MCP `resources/list` and `resources/read` methods. The one resource
+// kind exposed is an assignment's raw test-suite manifest (`test.properties.json`)
+// — the canonical authoring spec (suites, pattern families, sections, required
+// files). `get_suite` is the structured, filtered view; the resource is the
+// verbatim JSON, which is the MCP-idiomatic way to hand the model a document it
+// can read into context.
+//
+// Course-scoped exactly like the tools: the listing is confined to courses the
+// subject can act on (admins: all non-archived; everyone else: their
+// enrolments), and a read re-checks `authorizeCourseAccess`. Nothing here
+// touches student data, grades, or submissions — only authoring content.
+
+import Core
+import Fluent
+import Vapor
+
+struct MCPResourceProvider: Sendable {
+    /// `chickadee://assignment/<publicID>/manifest`
+    static func manifestURI(publicID: String) -> String {
+        "chickadee://assignment/\(publicID)/manifest"
+    }
+
+    /// Parses an assignment public ID out of a manifest resource URI, or nil if
+    /// `uri` is not a well-formed manifest URI.
+    static func manifestPublicID(fromURI uri: String) -> String? {
+        let prefix = "chickadee://assignment/"
+        let suffix = "/manifest"
+        guard uri.hasPrefix(prefix), uri.hasSuffix(suffix) else { return nil }
+        let inner = String(uri.dropFirst(prefix.count).dropLast(suffix.count))
+        guard !inner.isEmpty, !inner.contains("/") else { return nil }
+        return inner
+    }
+
+    /// `resources/list`: one manifest resource per assignment the subject may
+    /// act on. Result shape: `{ "resources": [ { uri, name, description,
+    /// mimeType } ] }`.
+    func list(context: ToolContext) async throws -> JSONValue {
+        let user = try await context.requireEligibleSubject(tool: "resources/list")
+
+        let courses: [APICourse]
+        if user.isAdmin {
+            courses = try await APICourse.query(on: context.db)
+                .filter(\.$isArchived == false)
+                .all()
+        } else if let userID = user.id {
+            let enrollments = try await APICourseEnrollment.query(on: context.db)
+                .filter(\.$userID == userID)
+                .all()
+            let courseIDs = Array(Set(enrollments.map { $0.$course.id }))
+            courses =
+                courseIDs.isEmpty
+                ? []
+                : try await APICourse.query(on: context.db).filter(\.$id ~~ courseIDs).all()
+        } else {
+            courses = []
+        }
+
+        let courseByID = Dictionary(
+            courses.compactMap { course in course.id.map { ($0, course) } },
+            uniquingKeysWith: { first, _ in first })
+        guard !courseByID.isEmpty else { return .object(["resources": .array([])]) }
+
+        let assignments = try await APIAssignment.query(on: context.db)
+            .filter(\.$courseID ~~ Array(courseByID.keys))
+            .sort(\.$title)
+            .all()
+
+        let resources: [JSONValue] = assignments.compactMap { assignment in
+            guard let course = courseByID[assignment.courseID] else { return nil }
+            return .object([
+                "uri": .string(Self.manifestURI(publicID: assignment.publicID)),
+                "name": .string("\(course.code) — \(assignment.title) (test suite manifest)"),
+                "description": .string(
+                    "Raw test.properties.json for assignment \(assignment.publicID) in "
+                        + "\(course.code): test suites, pattern families, sections, and required "
+                        + "files. The canonical authoring spec; get_suite is the structured view."),
+                "mimeType": .string("application/json"),
+            ])
+        }
+        return .object(["resources": .array(resources)])
+    }
+
+    /// `resources/read`: returns the manifest JSON for the assignment named by
+    /// `uri`. Course-scoped; an unknown URI and an inaccessible assignment are
+    /// reported identically so a caller can't probe for assignments in courses
+    /// it isn't enrolled in. Result shape: `{ "contents": [ { uri, mimeType,
+    /// text } ] }`.
+    func read(uri: String, context: ToolContext) async throws -> JSONValue {
+        guard let publicID = Self.manifestPublicID(fromURI: uri),
+            let assignment = try await assignmentByPublicID(publicID, on: context.db)
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: "resources/read", detail: "Unknown or inaccessible resource: \(uri)")
+        }
+        do {
+            try await context.authorizeCourseAccess(assignment.courseID, tool: "resources/read")
+        } catch {
+            // Collapse a course-authorization failure into the same "unknown
+            // resource" response so the URI space can't be enumerated.
+            throw MCPToolError.invalidArguments(
+                tool: "resources/read", detail: "Unknown or inaccessible resource: \(uri)")
+        }
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.executionFailed(
+                tool: "resources/read", detail: "The assignment's test setup could not be found.")
+        }
+        return .object([
+            "contents": .array([
+                .object([
+                    "uri": .string(uri),
+                    "mimeType": .string("application/json"),
+                    "text": .string(setup.manifest),
+                ])
+            ])
+        ])
+    }
+}

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -2,7 +2,7 @@
 //
 // Read tool: returns one assignment's details by public ID. content:read.
 // Course-scoped — the subject must be enrolled in the assignment's course
-// (admins excepted). Full test-suite detail comes later via get_suite (Phase 3).
+// (admins excepted). Full test-suite structure is available via get_suite.
 
 import Core
 import Fluent

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -44,11 +44,67 @@ struct MCPDispatcher: Sendable {
         case .toolsCall:
             return await toolsCallResult(id: id, params: request.params, context: context)
         case .resourcesList:
-            return .success(id: id, result: .object(["resources": .array([])]))
+            return await resourcesListResult(id: id, context: context)
         case .resourcesRead:
-            // TODO(PR B): expose authoring content (e.g. suite manifests) as resources.
-            // https://modelcontextprotocol.io/specification/2025-11-25/server/resources
-            return .failure(id: id, error: .invalidParams("No resources are registered yet."))
+            return await resourcesReadResult(id: id, params: request.params, context: context)
+        }
+    }
+
+    // MARK: - resources/list, resources/read
+
+    private let resources = MCPResourceProvider()
+
+    private func resourcesListResult(id: JSONRPCID, context: ToolContext?) async -> JSONRPCResponse {
+        guard let context else {
+            return .failure(id: id, error: .internalError("Resource execution context is unavailable."))
+        }
+        guard context.grantedScopes.contains(.read) else {
+            return .failure(id: id, error: .insufficientScope(ContentScope.read.rawValue))
+        }
+        do {
+            return .success(id: id, result: try await resources.list(context: context))
+        } catch {
+            return .failure(id: id, error: .internalError("Failed to list resources."))
+        }
+    }
+
+    private struct ResourceReadParams: Decodable {
+        let uri: String
+    }
+
+    private func resourcesReadResult(
+        id: JSONRPCID, params: JSONValue?, context: ToolContext?
+    ) async -> JSONRPCResponse {
+        guard let context else {
+            return .failure(id: id, error: .internalError("Resource execution context is unavailable."))
+        }
+        guard context.grantedScopes.contains(.read) else {
+            return .failure(id: id, error: .insufficientScope(ContentScope.read.rawValue))
+        }
+        let read: ResourceReadParams
+        do {
+            read = try (params ?? .object([:])).decoded(as: ResourceReadParams.self)
+        } catch {
+            return .failure(id: id, error: .invalidParams("resources/read requires a \"uri\"."))
+        }
+        do {
+            return .success(id: id, result: try await resources.read(uri: read.uri, context: context))
+        } catch let error as MCPToolError {
+            // Unknown/inaccessible resource → invalidParams; a genuine lookup
+            // failure → internalError. Mirrors the tool path's error mapping.
+            if case .executionFailed(_, let detail) = error {
+                return .failure(id: id, error: .internalError(detail))
+            }
+            let detail: String
+            switch error {
+            case .invalidArguments(_, let message), .notAuthorized(_, let message):
+                detail = message
+            default:
+                detail = "Unknown resource."
+            }
+            return .failure(id: id, error: .invalidParams(detail))
+        } catch {
+            return .failure(id: id, error: .internalError("Failed to read resource."))
         }
     }
 

--- a/Tests/APITests/MCP/MCPDispatcherTests.swift
+++ b/Tests/APITests/MCP/MCPDispatcherTests.swift
@@ -32,9 +32,11 @@ import Testing
 
         let capabilities = try #require(result["capabilities"]?.objectFields)
         #expect(capabilities["tools"] == .object(["listChanged": .bool(false)]))
-        // v1 advertises tools only — the unimplemented `resources` capability is
-        // no longer advertised.
-        #expect(capabilities["resources"] == nil)
+        // v1 advertises tools + resources; neither pushes list-change
+        // notifications and resources are not subscribable.
+        #expect(
+            capabilities["resources"]
+                == .object(["subscribe": .bool(false), "listChanged": .bool(false)]))
 
         // The result carries server-level instructions that teach the agent the
         // domain model and workflow up front.
@@ -75,9 +77,20 @@ import Testing
         #expect(response.result == .object(["tools": .array([])]))
     }
 
-    @Test func resourcesListIsEmptyForNow() async throws {
+    @Test func resourcesListWithoutContextErrors() async throws {
+        // resources/list is course-scoped, so it needs an execution context;
+        // dispatched without one (as here) it reports an internal error rather
+        // than leaking an unscoped listing. The DB-backed happy path is covered
+        // in MCPResourcesTests.
         let response = try #require(await dispatcher.dispatch(request("resources/list")))
-        #expect(response.result == .object(["resources": .array([])]))
+        #expect(response.error?.code == -32_603)
+    }
+
+    @Test func resourcesReadWithoutContextErrors() async throws {
+        let response = try #require(
+            await dispatcher.dispatch(
+                request("resources/read", params: .object(["uri": .string("chickadee://x")]))))
+        #expect(response.error?.code == -32_603)
     }
 }
 

--- a/Tests/APITests/MCP/MCPResourcesTests.swift
+++ b/Tests/APITests/MCP/MCPResourcesTests.swift
@@ -1,0 +1,175 @@
+// Tests for MCPResourceProvider — the backing for resources/list and
+// resources/read. Backed by a real test database. Verifies course-scoping
+// (listing confined to accessible courses; reads denied for inaccessible
+// assignments), admin breadth, and URI parsing.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPResourcesTests {
+    private func context(
+        _ app: Application, subject: String, scopes: Set<ContentScope> = [.read]
+    ) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: subject,
+            grantedScopes: scopes)
+    }
+
+    private let sampleManifest =
+        #"{"schemaVersion":1,"gradingMode":"browser","testSuites":[],"timeLimitSeconds":10}"#
+
+    // MARK: - resources/list
+
+    @Test func listReturnsManifestsOnlyForAccessibleCourses() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let courseA = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            let courseB = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let prof = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            try await makeTestEnrollment(
+                on: app, userID: prof.requireID(), courseID: courseA.requireID())
+            try await makeTestSetup(
+                on: app, id: "setup_a", courseID: courseA.requireID(), manifest: sampleManifest)
+            try await makeTestSetup(on: app, id: "setup_b", courseID: courseB.requireID())
+            let a = try await makeTestAssignment(
+                on: app, testSetupID: "setup_a", courseID: courseA.requireID(), title: "Lab A")
+            let b = try await makeTestAssignment(
+                on: app, testSetupID: "setup_b", courseID: courseB.requireID(), title: "Lab B")
+
+            let result = try await MCPResourceProvider().list(context: context(app, subject: "prof"))
+            let uris = Self.resourceURIs(result)
+            #expect(uris.contains(MCPResourceProvider.manifestURI(publicID: a.publicID)))
+            #expect(!uris.contains(MCPResourceProvider.manifestURI(publicID: b.publicID)))
+        }
+    }
+
+    @Test func listForAdminIncludesEveryCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let courseA = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            let courseB = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            _ = try await makeTestUser(on: app, username: "boss", role: "admin")
+            try await makeTestSetup(on: app, id: "setup_a", courseID: courseA.requireID())
+            try await makeTestSetup(on: app, id: "setup_b", courseID: courseB.requireID())
+            let a = try await makeTestAssignment(
+                on: app, testSetupID: "setup_a", courseID: courseA.requireID(), title: "Lab A")
+            let b = try await makeTestAssignment(
+                on: app, testSetupID: "setup_b", courseID: courseB.requireID(), title: "Lab B")
+
+            let result = try await MCPResourceProvider().list(context: context(app, subject: "boss"))
+            let uris = Self.resourceURIs(result)
+            #expect(uris.contains(MCPResourceProvider.manifestURI(publicID: a.publicID)))
+            #expect(uris.contains(MCPResourceProvider.manifestURI(publicID: b.publicID)))
+        }
+    }
+
+    @Test func listRejectsStudentSubject() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            let student = try await makeTestUser(on: app, username: "stu", role: "student")
+            try await makeTestEnrollment(
+                on: app, userID: student.requireID(), courseID: course.requireID())
+            await #expect(throws: MCPToolError.self) {
+                _ = try await MCPResourceProvider().list(context: context(app, subject: "stu"))
+            }
+        }
+    }
+
+    // MARK: - resources/read
+
+    @Test func readReturnsManifestJSON() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            let prof = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            try await makeTestEnrollment(
+                on: app, userID: prof.requireID(), courseID: course.requireID())
+            try await makeTestSetup(
+                on: app, id: "setup_a", courseID: course.requireID(), manifest: sampleManifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_a", courseID: course.requireID(), title: "Lab A")
+
+            let uri = MCPResourceProvider.manifestURI(publicID: assignment.publicID)
+            let result = try await MCPResourceProvider().read(
+                uri: uri, context: context(app, subject: "prof"))
+            #expect(Self.firstContentText(result) == sampleManifest)
+        }
+    }
+
+    @Test func readDeniesInaccessibleAssignment() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let courseA = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            let courseB = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let prof = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            // Enrolled in A only.
+            try await makeTestEnrollment(
+                on: app, userID: prof.requireID(), courseID: courseA.requireID())
+            try await makeTestSetup(on: app, id: "setup_b", courseID: courseB.requireID())
+            let b = try await makeTestAssignment(
+                on: app, testSetupID: "setup_b", courseID: courseB.requireID(), title: "Lab B")
+
+            let uri = MCPResourceProvider.manifestURI(publicID: b.publicID)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await MCPResourceProvider().read(
+                    uri: uri, context: context(app, subject: "prof"))
+            }
+        }
+    }
+
+    @Test func readRejectsMalformedURI() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            let prof = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            try await makeTestEnrollment(
+                on: app, userID: prof.requireID(), courseID: course.requireID())
+            for uri in ["chickadee://assignment/zzzzzz/manifest", "not-a-uri", "chickadee://assignment//manifest"] {
+                await #expect(throws: MCPToolError.self) {
+                    _ = try await MCPResourceProvider().read(
+                        uri: uri, context: context(app, subject: "prof"))
+                }
+            }
+        }
+    }
+
+    // MARK: - URI round-trip
+
+    @Test func manifestURIRoundTrips() {
+        #expect(
+            MCPResourceProvider.manifestPublicID(fromURI: MCPResourceProvider.manifestURI(publicID: "abc123"))
+                == "abc123")
+        #expect(MCPResourceProvider.manifestPublicID(fromURI: "chickadee://assignment//manifest") == nil)
+        #expect(MCPResourceProvider.manifestPublicID(fromURI: "chickadee://assignment/a/b/manifest") == nil)
+        #expect(MCPResourceProvider.manifestPublicID(fromURI: "http://evil/manifest") == nil)
+    }
+
+    // MARK: - Helpers
+
+    private static func resourceURIs(_ value: JSONValue) -> [String] {
+        guard case .object(let root) = value, case .array(let items)? = root["resources"] else {
+            return []
+        }
+        return items.compactMap { item in
+            guard case .object(let fields) = item, case .string(let uri)? = fields["uri"] else {
+                return nil
+            }
+            return uri
+        }
+    }
+
+    private static func firstContentText(_ value: JSONValue) -> String? {
+        guard case .object(let root) = value, case .array(let contents)? = root["contents"],
+            let first = contents.first, case .object(let fields) = first,
+            case .string(let text)? = fields["text"]
+        else { return nil }
+        return text
+    }
+}

--- a/changelog.d/mcp-resources.md
+++ b/changelog.d/mcp-resources.md
@@ -1,0 +1,14 @@
+### Added
+
+- **MCP resources: assignment test-suite manifests.** The MCP server now
+  advertises the `resources` capability and implements `resources/list` /
+  `resources/read`, exposing each accessible assignment's raw
+  `test.properties.json` manifest at `chickadee://assignment/<publicID>/manifest`
+  (`application/json`). `get_suite` remains the structured view; the resource is
+  the verbatim canonical authoring spec (suites, pattern families, sections,
+  required files), which an agent can read straight into context. Listing is
+  confined to courses the subject can act on (admins: all non-archived; everyone
+  else: their enrolments) and reads re-check course access — an inaccessible or
+  unknown URI is reported identically so the URI space can't be enumerated.
+  Requires the `content:read` scope. Replaces the previous placeholder that
+  returned an empty list and a "no resources registered" error.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -1,8 +1,12 @@
 # MCP Assignment-Authoring Roadmap
 
-Status: **planning**. Goal: let MCP agents help instructors **create and edit
-assignments**, built out in phases. This document is the agreed sequencing and
-the file/function-level plan for the early phases.
+Status: **largely delivered**. Goal: let MCP agents help instructors **create
+and edit assignments**, built out in phases. Every tool phase (1–5) plus the SSE
+streaming track has shipped; this document is kept as the design record and the
+sequencing/rationale behind the work. The "where we are today" and
+sequencing/open-question sections below are updated to mark what landed; the
+design-principle sections (§2–§5) remain the rationale that still governs new
+tools.
 
 It builds on the MCP server foundation already shipped: the OAuth 2.1 bearer
 flow, `content:read` / `content:write` scopes, per-tool scope enforcement, and
@@ -13,20 +17,34 @@ added in the `mcp-course-scoping-and-hardening` work, PR #704).
 
 ## 1. Where we are today
 
-The live tool catalog (`MCPToolCatalog.live` in
-`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) is exactly two
-tools:
+The original vertical slice (two tools, proving the auth/transport/dispatch
+pipeline) has grown into the full feature. The live tool catalog
+(`MCPToolCatalog.live` in
+`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) now ships twelve
+tools, all `content:read` / `content:write` scoped and course-scoped:
 
 | Tool | Scope | Capability |
 |------|-------|------------|
-| `list_assignments` | `content:read` | List a course's assignments (id, title, slug, open/closed, due date) |
-| `update_assignment_title` | `content:write` | Rename one assignment (title only) |
+| `list_courses` | `content:read` | Courses the subject may act on |
+| `list_assignments` | `content:read` | A course's assignments (id, title, slug, open/closed, due date) |
+| `get_assignment` | `content:read` | One assignment's full detail |
+| `get_suite` | `content:read` | Test-suite structure (items, tiers, points, deps, sections) |
+| `get_notebook` | `content:read` | The starter notebook (.ipynb JSON) |
+| `validate_assignment` | `content:read` | Watch validation to completion; live SSE progress |
+| `update_assignment` | `content:write` | Metadata: title, due date, open/close |
+| `update_suite` | `content:write` | Script metadata: tier, points, displayName, dependsOn, section |
+| `update_pattern_family` | `content:write` | Family defaults + per-case enable/disable |
+| `update_notebook` | `content:write` | Replace the starter notebook |
+| `clone_assignment` | `content:write` | Duplicate an assignment (closed, unvalidated) |
+| `create_assignment` | `content:write` | New notebook-based assignment from scratch |
 
-Everything else an instructor does when authoring — due dates, open/close,
-sections, test suites, pattern families, notebooks, creation — is **not**
-exposed. The two tools were a deliberate vertical slice to prove the
-auth/transport/dispatch pipeline; this roadmap turns that slice into the
-feature.
+In addition to tools, the server exposes **resources**: `resources/list` /
+`resources/read` surface each accessible assignment's raw `test.properties.json`
+manifest at `chickadee://assignment/<publicID>/manifest` (the verbatim authoring
+spec; `get_suite` is the structured view). See
+`Sources/APIServer/MCP/Resources/MCPResourceProvider.swift`.
+
+The legacy `update_assignment_title` tool folded into `update_assignment`.
 
 ### The authoring domain (what a full assignment is)
 
@@ -182,49 +200,63 @@ Ship (b) first; layer (a) on once Phase 3 tools are proven.
 
 ---
 
-## 6. Sequencing / PR plan
+## 6. Sequencing / PR plan — **all shipped**
 
-1. **PR: Phase 0 + Phase 1.** Extract `AssignmentAuthoringService`, refactor web
-   handlers to use it (no behavior change), ship `get_assignment` +
-   `list_courses`. Low risk, fully CI-testable, de-risks everything after.
-2. **PR: Phase 2.** `update_assignment` (metadata).
-3. **PR: Phase 3a.** `get_suite` / `update_suite`.
-4. **PR: Phase 3b.** Pattern-family editing.
-5. **PR: Phase 4a.** `clone_assignment`.
-6. **PR: Phase 4b.** `create_assignment` (structured spec).
-7. **PR(s): Phase 5.** Notebook content — small slices.
+1. ✅ **Phase 0 + Phase 1.** `AssignmentAuthoringService` extracted; web handlers
+   refactored to use it; `get_assignment` + `list_courses` shipped.
+2. ✅ **Phase 2.** `update_assignment` (metadata).
+3. ✅ **Phase 3a.** `get_suite` / `update_suite`.
+4. ✅ **Phase 3b.** Pattern-family editing (`update_pattern_family`).
+5. ✅ **Phase 4a.** `clone_assignment`.
+6. ✅ **Phase 4b.** `create_assignment` (structured spec).
+7. ✅ **Phase 5.** Notebook content: `get_notebook` (read) + `update_notebook`
+   (write).
 
-Each PR: `content:*` scope + `authorizeCourseAccess`, blast-radius reporting on
-manifest-changing tools, swift-format + SwiftLint `--strict` clean, tests green.
+Plus, beyond the original plan: the SSE streaming track (§8) and the
+`validate_assignment` tool that closes the validation loop (§7), and MCP
+resources for manifests (§1).
+
+Each PR held to: `content:*` scope + `authorizeCourseAccess`, swift-format +
+SwiftLint `--strict` clean, tests green.
 
 ---
 
 ## 7. Open questions
 
-- **Validation feedback shape** — leaning toward the **bounded-wait hybrid**
-  (§8): write tools return fast with a validation handle + status, optionally
-  blocking a short capped window (~20s, likely on by default) to return the
-  result inline for the common fast case; the agent polls `get_assignment`'s
-  `validationStatus` otherwise. Open: default wait window + whether it's on by
-  default. SSE (§8) later upgrades this to live progress without changing the
-  tool contract.
-- **Destructive-edit confirmation** — do we want a `dryRun` flag on
-  suite/family/metadata edits that would trigger a regrade?
-- **Notebook input format for Phase 5** — `.ipynb` JSON vs. a simpler source
-  representation.
-- **Tool granularity** — one `update_suite` taking the whole authored list vs.
-  fine-grained add/remove/reorder tools (the former matches `PUT /suite`).
+- ✅ **Validation feedback shape** — *resolved.* Shipped as the
+  `validate_assignment` tool: write tools enqueue validation as a side effect,
+  and an agent then calls `validate_assignment` to bounded-wait (default 30s,
+  clamped 1–120) for the terminal status — or, over an SSE connection carrying a
+  `progressToken`, receive live `queued → running → done` progress before the
+  result (§8). The agent can also poll `get_assignment`'s `validationStatus`.
+- ✅ **Notebook input format** — *resolved.* The agent supplies full `.ipynb`
+  JSON (`update_notebook` / `create_assignment`); the server normalizes it for
+  the in-browser kernel.
+- ✅ **Tool granularity** — *resolved.* `update_suite` takes per-script metadata
+  edits and `update_pattern_family` takes family-level edits; both re-save
+  through the same `applySuiteEdit` the `PUT /suite` web path uses.
+- **Destructive-edit confirmation** — *still open.* No `dryRun` flag yet, and
+  manifest-changing tools do not yet report a blast-radius (affected-submission)
+  count in their result (design principle #3). A follow-up could add both.
 
 ---
 
-## 8. Transport track: SSE / streaming progress (parallel, not a prerequisite)
+## 8. Transport track: SSE / streaming progress — **shipped**
+
+**Delivered in two PRs:** #724 made the `/mcp` POST response negotiable to an
+SSE stream (`Accept: text/event-stream`); #726 added the worker→stream bridge so
+`validate_assignment` emits live `notifications/progress` (`queued → running →
+done`) before the final result when the call carries a `progressToken`. The
+transport stays stateless (no `Mcp-Session-Id` / `Last-Event-ID` resumability);
+the standalone server-initiated GET stream remains unimplemented (405). The
+design notes below are retained as the rationale.
 
 **Target client:** the **Claude connector**, which speaks Streamable HTTP with
 SSE — so the streaming UX pays off, and resumability is not required.
 
-Today the `/mcp` POST returns a single JSON response; GET/DELETE 405
-(`streamingUnsupported`). Streamable HTTP also allows the POST response to be an
-**SSE stream** (`text/event-stream`), letting the server emit
+The `/mcp` POST returns either a single JSON response or an SSE stream
+(`text/event-stream`) by content negotiation; GET/DELETE 405
+(`streamingUnsupported`). The SSE form lets the server emit
 `notifications/progress` during a long tool call and then the final result.
 
 **What it buys us:** a tight, live agent loop on validation —


### PR DESCRIPTION
## Summary

Closes the last open item from the pre-testing MCP audit: the `resources/*` methods were a placeholder (`resources/list` returned an empty array; `resources/read` returned a "no resources registered" error behind a `TODO(PR B)`), and the roadmap doc was stale.

- **Implements the MCP `resources` capability.** Advertises `resources` in the `initialize` capabilities and serves each accessible assignment's raw `test.properties.json` manifest:
  - `resources/list` → one entry per assignment the subject may act on, URI `chickadee://assignment/<publicID>/manifest`, `application/json`.
  - `resources/read` → the verbatim manifest text.
  - New `Sources/APIServer/MCP/Resources/MCPResourceProvider.swift`; dispatcher wired in `MCPDispatcher.swift`.
- **Course-scoped exactly like the tools.** Listing is confined to the subject's courses (admins: all non-archived; everyone else: their enrolments) via `requireEligibleSubject`; reads re-check `authorizeCourseAccess`. An unknown URI and an inaccessible assignment return the *same* error so the URI space can't be enumerated. Requires `content:read`; students are rejected at the resource layer.
- **`get_suite` vs. resource.** `get_suite` stays the structured/filtered view; the resource is the canonical raw JSON an agent can read straight into context. Instructions (`initialize`) updated to mention it.
- **Refreshes `docs/mcp-authoring-roadmap.md`**, which still claimed "exactly two tools." Now documents the shipped 12-tool catalog, marks every tool phase + the SSE track delivered, records `validate_assignment` as the validation-loop resolution, and notes resources. (Also fixes a stale `get_suite` "comes later" comment in `GetAssignmentTool`.)

No `VERSION`/`CHANGELOG` edits — a `changelog.d/` fragment is included per the merge-time release workflow.

## Test plan

- [x] `swift build --target APIServer` — compiles clean.
- [x] `scripts/lint.sh` (swift-format) — clean.
- [ ] CI: `api-tests` / `api-tests-postgres` run the new `MCPResourcesTests` (list scoping, admin breadth, student rejection, read round-trip, inaccessible-assignment denial, malformed-URI rejection, URI round-trip) + updated `MCPDispatcherTests` (capabilities now advertise `resources`; resources methods require an execution context). SwiftLint runs in CI (can't run locally — sourcekit load failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)