### PR TITLE
Exempt POST /logout from CSRF so timeout logout doesn't 403

### DIFF
--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -13,20 +13,34 @@
 //   POST /register   → create account (first user becomes admin), redirect to / (local/dual only)
 //   POST /logout     → clear session, redirect to /login
 
+import CSRF
 import Core
 import Fluent
 import Foundation
 import Vapor
 
 struct AuthRoutes: RouteCollection {
+    let csrf: CSRF
+
     func boot(routes: RoutesBuilder) throws {
+        // Login and register are CSRF-protected (defends against login-CSRF).
         // Tight per-endpoint body limits on the public auth POSTs: login and
         // register only carry two short form fields, so 8 KB is generous and
         // closes the OOM vector that the 10 MB global default leaves open.
-        routes.get("login", use: loginForm)
-        routes.on(.POST, "login", body: .collect(maxSize: "8kb"), use: login)
-        routes.get("register", use: registerForm)
-        routes.on(.POST, "register", body: .collect(maxSize: "8kb"), use: register)
+        let protected = routes.grouped(csrf)
+        protected.get("login", use: loginForm)
+        protected.on(.POST, "login", body: .collect(maxSize: "8kb"), use: login)
+        protected.get("register", use: registerForm)
+        protected.on(.POST, "register", body: .collect(maxSize: "8kb"), use: register)
+
+        // Logout is intentionally NOT CSRF-protected. A timed-out browser tab
+        // POSTs /logout?reason=timeout carrying the CSRF token minted when the
+        // page first loaded; by then the server-side session (and its CSRF
+        // secret) may be gone — reaped, expired, or already torn down by the
+        // idle-timeout middleware on another request — so the stale token fails
+        // validation and the user hits a 403 "Invalid CSRF token" instead of a
+        // clean logout. Logout CSRF is low risk (worst case: an unwanted
+        // sign-out) and the handler is fully idempotent, so it runs unconditionally.
         routes.post("logout", use: logout)
     }
 

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -13,7 +13,9 @@ func routes(_ app: Application) throws {
     let loginRateLimit = LoginRateLimitMiddleware(
         configuration: app.loginRateLimitConfiguration
     )
-    try app.grouped(csrf, loginRateLimit).register(collection: AuthRoutes())
+    // CSRF is applied inside AuthRoutes (login/register only) so that POST
+    // /logout stays exempt — a timed-out tab POSTs a stale token, see AuthRoutes.
+    try app.grouped(loginRateLimit).register(collection: AuthRoutes(csrf: csrf))
     if app.authMode != .local {
         try app.register(
             collection: SSOAuthRoutes(configuredCallbackPath: app.appConfig.oidc.callbackPath)

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -309,6 +309,37 @@ import XCTVapor
         }
     }
 
+    @Test func logoutWithoutCSRFTokenStillSucceeds() async throws {
+        try await withApp(try await makeApp()) { app in
+            // Logout is CSRF-exempt: a stale browser tab whose session (and CSRF
+            // secret) is already gone must still log out cleanly rather than 403.
+            try await app.asyncTest(
+                .POST, "/logout",
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/login?loggedout=1")
+                })
+        }
+    }
+
+    @Test func logoutTimeoutWithStaleCSRFTokenRedirectsNotForbidden() async throws {
+        try await withApp(try await makeApp()) { app in
+            // Reproduces the idle-logout bug: the inactivity watchdog POSTs
+            // /logout?reason=timeout with the token minted at page load, but the
+            // server-side secret has since been torn down so the token is stale.
+            // Must redirect to the timeout notice, not 403.
+            try await app.asyncTest(
+                .POST, "/logout?reason=timeout",
+                beforeRequest: { req in
+                    try req.content.encode(["_csrf": "stale-token"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/login?error=timeout")
+                })
+        }
+    }
+
     @Test func logoutInvalidatesServerSideSession() async throws {
         try await withApp(try await makeApp()) { app in
             let authCookie = try await loginUser(

--- a/changelog.d/logout-csrf-exempt.md
+++ b/changelog.d/logout-csrf-exempt.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Timeout logout no longer 403s on a stale CSRF token.** `POST /logout` is now
+  exempt from CSRF validation. When the inactivity watchdog posts
+  `/logout?reason=timeout` from a long-idle tab, the server-side session (and its
+  CSRF secret) is often already gone, so the page's stale token failed validation
+  and the user hit a `403 Invalid CSRF token` instead of landing on the
+  timeout-notice login page. Login and register stay CSRF-protected; the logout
+  handler is idempotent and logout-CSRF is low risk (worst case: an unwanted sign-out).


### PR DESCRIPTION
## Summary

Fixes an intermittent `403 Forbidden — Invalid CSRF token` shown on `/logout?reason=timeout` when a user is auto-logged out after being idle.

**Root cause.** `POST /logout` sat behind the `CSRF` middleware. The CSRF token embedded in a page is valid only while the session's `CSRFSecret` is unchanged. When the inactivity watchdog (`idle-logout.js`) finally POSTs `/logout?reason=timeout` with the token minted at page load, the server-side session is often already gone — reaped, expired, or torn down by `SessionIdleTimeoutMiddleware` on another request. With no session, `CSRF.createSecret` mints a *fresh* secret, the stale token fails validation, and the middleware 403s before the (idempotent) logout handler ever runs. The intermittency ("sometimes") matches whether the session is still alive when the POST lands.

**Fix.** Exempt `POST /logout` from CSRF. CSRF is now applied inside `AuthRoutes` to login/register only (preserving login-CSRF defense); logout is registered on the bare router. Logout-CSRF is a recognized low-risk case (worst case: an unwanted sign-out) and the handler already destroys the session safely whether or not one exists.

## Changes
- `routes.swift` — pass the CSRF middleware into `AuthRoutes` instead of wrapping the whole collection.
- `AuthRoutes.swift` — `login`/`register` stay CSRF-protected; `logout` is exempt (with explanatory comment).
- `AuthRoutesTests.swift` — two new tests: logout with no token, and the exact bug repro (`/logout?reason=timeout` + stale token → 303 `/login?error=timeout`, not 403).
- `changelog.d/logout-csrf-exempt.md` — Fixed fragment.

## Test plan
- [ ] CI: APITests pass (incl. new `logoutWithoutCSRFTokenStillSucceeds`, `logoutTimeoutWithStaleCSRFTokenRedirectsNotForbidden`)
- [ ] CI: existing CSRF tests for login/register/multipart-submit still enforce 403 on missing/invalid tokens
- [ ] CI: format-lint (swift-format + SwiftLint) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)