### PR TITLE
Gate closed-assignment access on a durable participation record

### DIFF
--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -93,19 +93,21 @@
             </td>
             <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    #if(setup.isOpen):
+                    #if(setup.canEdit):
                     #if(setup.gradingMode == "browser"):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
-                    #else:
-                    #if(setup.hasNotebook):
+                    #elseif(setup.hasNotebook):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
                     #endif
+                    #endif
+                    #if(setup.isOpen):
+                    #if(setup.gradingMode != "browser"):
                     <a class="btn action-btn" href="#(setup.submitURL)"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
@@ -192,19 +194,21 @@
             </td>
             <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    #if(setup.isOpen):
+                    #if(setup.canEdit):
                     #if(setup.gradingMode == "browser"):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
-                    #else:
-                    #if(setup.hasNotebook):
+                    #elseif(setup.hasNotebook):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
                     #endif
+                    #endif
+                    #if(setup.isOpen):
+                    #if(setup.gradingMode != "browser"):
                     <a class="btn action-btn" href="#(setup.submitURL)"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
@@ -291,19 +295,21 @@
             </td>
             <td>
                 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                    #if(setup.isOpen):
+                    #if(setup.canEdit):
                     #if(setup.gradingMode == "browser"):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
-                    #else:
-                    #if(setup.hasNotebook):
+                    #elseif(setup.hasNotebook):
                     <a class="btn action-btn" href="#(setup.notebookURL)"
                        title="Edit" aria-label="Edit" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                     </a>
                     #endif
+                    #endif
+                    #if(setup.isOpen):
+                    #if(setup.gradingMode != "browser"):
                     <a class="btn action-btn" href="#(setup.submitURL)"
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>

--- a/Sources/APIServer/Migrations/CreateAssignmentParticipations.swift
+++ b/Sources/APIServer/Migrations/CreateAssignmentParticipations.swift
@@ -1,0 +1,34 @@
+// APIServer/Migrations/CreateAssignmentParticipations.swift
+//
+// Durable per-(user, assignment) participation record — one row per student
+// who has been given an assignment's materials.  Marks "this student has
+// engaged with this assignment" so a closed assignment stays reachable for
+// review.  Cascade-deletes follow the parent user / assignment.
+
+import Fluent
+
+struct CreateAssignmentParticipations: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignment_participations")
+            .id()
+            .field(
+                "user_id",
+                .uuid,
+                .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field(
+                "assignment_id",
+                .uuid,
+                .required,
+                .references("assignments", "id", onDelete: .cascade)
+            )
+            .field("first_accessed_at", .datetime)
+            .unique(on: "user_id", "assignment_id")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("assignment_participations").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignmentParticipation.swift
+++ b/Sources/APIServer/Models/APIAssignmentParticipation.swift
@@ -1,0 +1,40 @@
+// APIServer/Models/APIAssignmentParticipation.swift
+//
+// Durable per-(user, assignment) participation record.
+//
+// One row is written the first time a student is given an assignment's
+// materials (opens the notebook page or the upload form while it is open
+// to them).  It is the authoritative answer to "has this student engaged
+// with this assignment", used to keep a closed assignment reachable for
+// students who started it — without re-deriving that fact from the
+// ephemeral on-disk notebook working copy (wiped on redeploy) or from the
+// personalization seed (a personalization primitive that only exists for
+// personalized assignments).
+
+import Fluent
+import Vapor
+
+final class APIAssignmentParticipation: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context.
+    static let schema = "assignment_participations"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "user_id")
+    var userID: UUID
+
+    @Field(key: "assignment_id")
+    var assignmentID: UUID
+
+    @Timestamp(key: "first_accessed_at", on: .create)
+    var firstAccessedAt: Date?
+
+    init() {}
+
+    init(id: UUID? = nil, userID: UUID, assignmentID: UUID) {
+        self.id = id
+        self.userID = userID
+        self.assignmentID = assignmentID
+    }
+}

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -25,6 +25,11 @@ struct TestSetupRow: Encodable {
     let dueAt: String?  // formatted due date, nil if no assignment or no due date
     let status: String  // "unpublished" | "open" | "closed"
     let isOpen: Bool
+    /// True when the Edit link should be shown: the assignment is open for
+    /// this user, OR it is closed but the student has previously opened it
+    /// (so they can keep reviewing past work).  The Upload link stays gated
+    /// on `isOpen` alone — you can never submit to a closed assignment.
+    let canEdit: Bool
     let gradingMode: String  // "browser" | "worker"
     let hasNotebook: Bool  // false → hide Edit button (no starter notebook available)
     let submissionCount: Int

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -18,7 +18,7 @@ extension WebRoutes {
     // MARK: - GET /testsetups/:id/notebook
 
     @Sendable
-    func notebookPage(req: Request) async throws -> View {
+    func notebookPage(req: Request) async throws -> Response {
         struct NotebookQuery: Content {
             var title: String?
             var submissionID: String?
@@ -53,6 +53,17 @@ extension WebRoutes {
         } else {
             isClosed = false
         }
+
+        // Closed-assignment access gate: a closed assignment is only reachable
+        // by a student who has previously engaged with it (and that access is
+        // recorded durably so it stays reachable once it closes).  Posting
+        // links in advance no longer spoils not-yet-opened labs.
+        if let redirect = try await closedAssignmentGate(
+            req: req, user: user, userID: userID, assignment: assignment, isClosed: isClosed)
+        {
+            return redirect
+        }
+
         let dbTitle = (assignment?.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let assignmentTitle = {
             if !queryTitle.isEmpty { return queryTitle }
@@ -81,14 +92,14 @@ extension WebRoutes {
                 req: req,
                 args: args,
                 submissionID: requestedSubmissionID
-            )
+            ).encodeResponse(for: req)
         }
 
         return try await renderAssignmentNotebookView(
             req: req,
             args: args,
             fileKind: fileKind
-        )
+        ).encodeResponse(for: req)
     }
 
     /// Renders the submission-view branch of `notebookPage` (read-only,
@@ -254,6 +265,21 @@ extension WebRoutes {
 
         try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
 
+        // Same closed-assignment gate as the notebook page, applied to the raw
+        // content endpoint so a student can't fetch a not-yet-opened lab's
+        // starter notebook by hitting `/notebook/source` directly.  A
+        // legitimately reachable closed assignment already has a participation
+        // row (or a submission), so this never fires on normal page loads.
+        if !user.isInstructor,
+            let assignment = try await APIAssignment.query(on: req.db)
+                .filter(\.$testSetupID == setupID)
+                .first(),
+            !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db)),
+            !(try await studentHasOpenedAssignment(assignment: assignment, userID: userID, on: req.db))
+        {
+            throw Abort(.forbidden)
+        }
+
         let query = try req.query.decode(NotebookSourceQuery.self)
 
         // When serving a submission view, read from the submission-specific
@@ -324,10 +350,57 @@ func userNotebookWorkingCopyRelativePath(
     "users/\(userID.uuidString.lowercased())/\(setupID)/\(userNotebookFilename(fileKind: fileKind))"
 }
 
-func userNotebookWorkingCopyAbsolutePath(req: Request, setupID: String, userID: UUID) -> String {
-    req.application.directory.publicDirectory
-        + "jupyterlite/files/"
-        + userNotebookWorkingCopyRelativePath(setupID: setupID, userID: userID)
+/// Whether `userID` has previously engaged with `assignment`: a durable
+/// participation row exists (written the first time they were given the
+/// assignment's materials) or they have at least one student submission.
+/// Drives the closed-assignment access gate so a student can return to a
+/// closed assignment to review past work, while a not-yet-opened lab they
+/// have never touched stays out of reach.
+///
+/// The submission check is a permanent safety net that also bridges
+/// students who submitted before the participation table existed; a closed
+/// assignment they review then lazily backfills its own participation row.
+func studentHasOpenedAssignment(
+    assignment: APIAssignment,
+    userID: UUID,
+    on db: Database
+) async throws -> Bool {
+    if let assignmentID = assignment.id,
+        try await AssignmentParticipationStore.hasParticipation(
+            userID: userID, assignmentID: assignmentID, on: db)
+    {
+        return true
+    }
+    return try await APISubmission.query(on: db)
+        .filter(\.$testSetupID == assignment.testSetupID)
+        .filter(\.$userID == userID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .count() > 0
+}
+
+/// Closed-assignment access gate for the student-facing notebook page and
+/// upload form.  Returns a redirect `Response` to the dashboard when a student
+/// must be bounced from a closed assignment they have never engaged with;
+/// otherwise records their first access durably and returns nil.  Instructors
+/// and admins always pass through (no redirect, no record).
+func closedAssignmentGate(
+    req: Request,
+    user: APIUser,
+    userID: UUID,
+    assignment: APIAssignment?,
+    isClosed: Bool
+) async throws -> Response? {
+    guard !user.isInstructor else { return nil }
+    if isClosed, let assignment,
+        !(try await studentHasOpenedAssignment(assignment: assignment, userID: userID, on: req.db))
+    {
+        return req.redirect(to: "/")
+    }
+    if let assignmentID = assignment?.id {
+        try await AssignmentParticipationStore.recordFirstAccess(
+            userID: userID, assignmentID: assignmentID, on: req.db)
+    }
+    return nil
 }
 
 /// Reads the mtime (Unix epoch seconds) of the working-copy notebook

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -90,6 +90,17 @@ extension WebRoutes {
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == setupID)
             .first()
+        // Mirror the notebook page's closed-assignment gate: a student who has
+        // never opened this (now-closed) upload-mode assignment is sent to
+        // their dashboard rather than shown an upload form they cannot submit.
+        if let userID = user.id, let assignment {
+            let isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db))
+            if let redirect = try await closedAssignmentGate(
+                req: req, user: user, userID: userID, assignment: assignment, isClosed: isClosed)
+            {
+                return redirect
+            }
+        }
         return try await req.view.render(
             "submit",
             SubmitContext(

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -107,6 +107,40 @@ struct WebRoutes: RouteCollection {
             }
         }
 
+        // Closed assignments the current student has previously engaged with
+        // stay visible (read-only review) and keep their Edit link.  Engagement
+        // = a durable participation row, or a student submission (the latter
+        // also bridges students who submitted before the participation table
+        // existed).  Empty for instructors/admins — they already see every
+        // setup in the course.
+        var previouslyOpenedSetupIDs = Set<String>()
+        if !user.isInstructor, let userID = user.id, !allAssignments.isEmpty {
+            let allSetupIDs = Set(allAssignments.map(\.testSetupID))
+            let submittedSetupIDs = try await APISubmission.query(on: req.db)
+                .filter(\.$userID == userID)
+                .filter(\.$testSetupID ~~ allSetupIDs)
+                .filter(\.$kind == APISubmission.Kind.student)
+                .all()
+                .map(\.testSetupID)
+            previouslyOpenedSetupIDs.formUnion(submittedSetupIDs)
+
+            let setupIDByParticipationAssignment = Dictionary(
+                uniqueKeysWithValues: allAssignments.compactMap { a -> (UUID, String)? in
+                    guard let id = a.id else { return nil }
+                    return (id, a.testSetupID)
+                }
+            )
+            let participations = try await APIAssignmentParticipation.query(on: req.db)
+                .filter(\.$userID == userID)
+                .filter(\.$assignmentID ~~ Set(setupIDByParticipationAssignment.keys))
+                .all()
+            for row in participations {
+                if let setupID = setupIDByParticipationAssignment[row.assignmentID] {
+                    previouslyOpenedSetupIDs.insert(setupID)
+                }
+            }
+        }
+
         let setups: [APITestSetup]
         if user.isInstructor {
             // Instructors and admins see test setups for the active course.
@@ -132,6 +166,8 @@ struct WebRoutes: RouteCollection {
                 if let baseline, extendedDueAt <= baseline { continue }
                 visibleSetupIDs.insert(setupID)
             }
+            // Closed assignments the student already opened remain on the list.
+            visibleSetupIDs.formUnion(previouslyOpenedSetupIDs)
             guard !visibleSetupIDs.isEmpty else {
                 return try await req.view.render(
                     "index",
@@ -331,6 +367,7 @@ struct WebRoutes: RouteCollection {
                     effectiveDueAt: effectiveDueAt
                 )
             }()
+            let canEdit = isOpenForThisUser || previouslyOpenedSetupIDs.contains(setupID)
             return TestSetupRow(
                 id: setupID,
                 title: assignment?.title,
@@ -342,6 +379,7 @@ struct WebRoutes: RouteCollection {
                 dueAt: assignment?.dueAt.map { fmt.string(from: $0) },
                 status: status,
                 isOpen: isOpenForThisUser,
+                canEdit: canEdit,
                 gradingMode: props?.gradingMode.rawValue ?? GradingMode.worker.rawValue,
                 hasNotebook: hasNotebook,
                 submissionCount: submissionCount,

--- a/Sources/APIServer/Services/AssignmentParticipationStore.swift
+++ b/Sources/APIServer/Services/AssignmentParticipationStore.swift
@@ -1,0 +1,51 @@
+// APIServer/Services/AssignmentParticipationStore.swift
+//
+// Reads/writes the durable per-(user, assignment) participation record.
+//
+// `recordFirstAccess` is idempotent and race-safe: the UNIQUE(user_id,
+// assignment_id) constraint on `assignment_participations` means a lost
+// INSERT race is swallowed (the winner's row already exists). Callers
+// invoke it whenever a student is *allowed* to open an assignment, so a
+// row only ever appears for an assignment the student could actually
+// reach — which is what keeps closed, never-opened labs unrecorded.
+
+import Fluent
+import Foundation
+
+enum AssignmentParticipationStore {
+
+    /// Record that `userID` has engaged with `assignmentID`. No-op if a row
+    /// already exists. Safe under concurrent first-access requests.
+    static func recordFirstAccess(
+        userID: UUID,
+        assignmentID: UUID,
+        on db: Database
+    ) async throws {
+        if try await hasParticipation(userID: userID, assignmentID: assignmentID, on: db) {
+            return
+        }
+        let row = APIAssignmentParticipation(userID: userID, assignmentID: assignmentID)
+        do {
+            try await row.save(on: db)
+        } catch {
+            // UNIQUE constraint race: another request inserted first. The row
+            // we wanted now exists, so the access is still recorded.
+            if try await hasParticipation(userID: userID, assignmentID: assignmentID, on: db) {
+                return
+            }
+            throw error
+        }
+    }
+
+    /// Whether a participation row exists for `(userID, assignmentID)`.
+    static func hasParticipation(
+        userID: UUID,
+        assignmentID: UUID,
+        on db: Database
+    ) async throws -> Bool {
+        try await APIAssignmentParticipation.query(on: db)
+            .filter(\.$userID == userID)
+            .filter(\.$assignmentID == assignmentID)
+            .count() > 0
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -217,7 +217,6 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateAssignmentParticipations())
     app.migrations.add(AddUrlTokenToUsers())
     app.migrations.add(AddUserFKConstraints())
-    app.migrations.add(AddCourseArchivedAt())
     // MCP OAuth authorization-server tables (Phase 2). FKs reference `users`.
     app.migrations.add(CreateMCPOAuthClients())
     app.migrations.add(CreateMCPAuthorizationCodes())

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -214,8 +214,10 @@ func registerMigrations(on app: Application) {
     app.migrations.add(AddSessionsCreatedAt())
     app.migrations.add(CreateAuditLog())
     app.migrations.add(CreateAssignmentExtensions())
+    app.migrations.add(CreateAssignmentParticipations())
     app.migrations.add(AddUrlTokenToUsers())
     app.migrations.add(AddUserFKConstraints())
+    app.migrations.add(AddCourseArchivedAt())
     // MCP OAuth authorization-server tables (Phase 2). FKs reference `users`.
     app.migrations.add(CreateMCPOAuthClients())
     app.migrations.add(CreateMCPAuthorizationCodes())

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -288,22 +288,30 @@ import XCTVapor
 
     @Test func notebookPageClosedAssignmentRendersReadOnlyAndHidesSubmit() async throws {
         try await withApp(app) { _ in
-            // Closed assignment (deadline past, no override): the iframe must
-            // carry data-read-only="true", the Submit button must disappear,
-            // and the closed-view notice must appear.  This is the core
-            // contract for the closed-assignment read-only view.
+            // Closed assignment (deadline past, no override) the student has
+            // previously opened: the iframe must carry data-read-only="true",
+            // the Submit button must disappear, and the closed-view notice must
+            // appear.  This is the core contract for the closed-assignment
+            // read-only review view.
             let cookie = try await loginAsStudent()
             let user = try await studentUser()
             try await enroll(user)
 
             let setupID = "setup_nb_closed"
             _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Closed"))
-            _ = try await insertAssignment(
+            let assignment = try await insertAssignment(
                 testSetupID: setupID,
                 title: "Closed Lab",
                 dueAt: Date(timeIntervalSinceNow: -3600),  // due 1h ago
                 isOpen: true  // not explicitly closed; deadline carries it
             )
+
+            // Mark the assignment as previously opened by recording a
+            // participation row — otherwise the closed-assignment gate would
+            // redirect them to the dashboard (covered by the next test).
+            try await APIAssignmentParticipation(
+                userID: try user.requireID(), assignmentID: try assignment.requireID()
+            ).save(on: app.db)
 
             try await app.asyncTest(
                 .GET, "/testsetups/\(setupID)/notebook",
@@ -324,6 +332,118 @@ import XCTVapor
                         "Closed assignment must render the view-only notice")
                 })
 
+        }
+    }
+
+    @Test func notebookPageClosedAssignmentNeverOpenedRedirectsToDashboard() async throws {
+        try await withApp(app) { _ in
+            // A student who has never opened a closed assignment (no working
+            // copy, no submission) is redirected to their dashboard instead of
+            // seeing the notebook — this keeps pre-posted links from spoiling
+            // not-yet-opened labs.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_closed_unopened"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Hidden"))
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Unopened Closed Lab",
+                dueAt: Date(timeIntervalSinceNow: -3600),
+                isOpen: true
+            )
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/")
+                })
+        }
+    }
+
+    @Test func notebookPageClosedAssignmentWithSubmissionStaysReachable() async throws {
+        try await withApp(app) { _ in
+            // Having submitted at least once also counts as "previously opened",
+            // so a closed assignment with a prior submission renders the
+            // read-only review view rather than redirecting.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_closed_submitted"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Submitted"))
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Submitted Closed Lab",
+                dueAt: Date(timeIntervalSinceNow: -3600),
+                isOpen: true
+            )
+            _ = try await insertNotebookSubmission(
+                id: "sub_nb_closed_submitted",
+                testSetupID: setupID,
+                userID: try user.requireID(),
+                notebookJSON: notebookJSON(markdown: "My answer")
+            )
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("This assignment is closed"))
+                })
+        }
+    }
+
+    @Test func openAccessRecordsParticipationSoClosedReviewStaysReachable() async throws {
+        try await withApp(app) { _ in
+            // The durable mechanism: opening an assignment while it is open
+            // records a participation row, which keeps it reachable once it
+            // later closes — without depending on the on-disk working copy.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_participation"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Lifecycle"))
+            let assignment = try await insertAssignment(
+                testSetupID: setupID, title: "Lifecycle Lab", dueAt: nil, isOpen: true)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                })
+
+            let recorded = try await AssignmentParticipationStore.hasParticipation(
+                userID: try user.requireID(), assignmentID: try assignment.requireID(), on: app.db)
+            #expect(recorded, "Opening an assignment must record a durable participation row")
+
+            // Close it (deadline now in the past) — the student must still reach it.
+            assignment.dueAt = Date(timeIntervalSinceNow: -3600)
+            try await assignment.save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .ok,
+                        "A closed assignment stays reachable for a student who opened it while open")
+                    #expect(res.body.string.contains("This assignment is closed"))
+                })
         }
     }
 

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -154,6 +154,78 @@ import XCTVapor
         }
     }
 
+    @Test func indexShowsClosedAssignmentWithEditLinkWhenPreviouslyOpened() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            try await wrEnrollUser(user, on: app)
+
+            let setupID = "setup_closed_opened"
+            let courseID = try await wrMakeCourse(on: app).requireID()
+            let notebookPath = app.testSetupsDirectory + "\(setupID).ipynb"
+            let notebookJSON = """
+                {"cells":[],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"name":"python"}},"nbformat":4,"nbformat_minor":5}
+                """
+            try Data(notebookJSON.utf8).write(to: URL(fileURLWithPath: notebookPath))
+            let manifest = """
+                {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"test_browser.py"}],"timeLimitSeconds":10}
+                """
+            let setup = APITestSetup(
+                id: setupID,
+                manifest: manifest,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip",
+                notebookPath: notebookPath,
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+            // Deliberately closed (isOpen=false), but the student already
+            // opened it — modelled here by a prior submission.
+            try await wrInsertAssignment(testSetupID: setupID, title: "Past Lab", isOpen: false, on: app)
+            try await wrInsertSubmission(
+                id: "sub_closed_opened", testSetupID: setupID, userID: try user.requireID(), on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains("Past Lab"),
+                        "A closed assignment the student opened must stay on the dashboard")
+                    #expect(
+                        html.contains(#"title="Edit""#),
+                        "The Edit link must show for a previously-opened closed assignment")
+                })
+        }
+    }
+
+    @Test func indexHidesClosedAssignmentNeverOpenedFromStudent() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            try await wrEnrollUser(user, on: app)
+
+            try await wrInsertSetup(id: "setup_closed_unopened", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_closed_unopened", title: "Secret Lab", isOpen: false, on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.body.string.contains("Secret Lab") == false,
+                        "A closed assignment the student never opened must not appear on the dashboard")
+                })
+        }
+    }
+
     @Test func indexHidesUnpublishedSetupsFromStudent() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsStudent(on: app)

--- a/Tests/APITests/WebRoutesSubmitHistoryTests.swift
+++ b/Tests/APITests/WebRoutesSubmitHistoryTests.swift
@@ -62,6 +62,15 @@ import XCTVapor
                 dueAt: Date().addingTimeInterval(-60),
                 on: app
             )
+            // The student opened this while it was open (here: a prior
+            // submission) so the closed-assignment gate lets them reach the
+            // submit form; the POST is still rejected for being past due.
+            try await wrInsertSubmission(
+                id: "sub_overdue_prior",
+                testSetupID: "setup_submit_overdue",
+                userID: try user.requireID(),
+                on: app
+            )
 
             let (csrf, sessionCookie) = try await csrfFields(
                 for: "/testsetups/setup_submit_overdue/submit",

--- a/changelog.d/closed-assignment-participation-gate.md
+++ b/changelog.d/closed-assignment-participation-gate.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Closed assignments are gated on a durable participation record.** A
+  student only reaches a closed assignment's notebook or upload form if they
+  previously engaged with it; everyone else is sent to their dashboard, so
+  assignment links can be posted in advance without spoiling not-yet-opened
+  labs. "Engaged" is now recorded in a new `assignment_participations` table
+  (one row per student per assignment, written the first time they open it
+  while it's open), which survives redeploys — rather than being inferred from
+  the on-disk notebook working copy. Existing student submissions still count,
+  so anyone who has submitted keeps access. Previously-opened closed
+  assignments also stay on the dashboard with their Edit link.


### PR DESCRIPTION
## Summary

Students who click a link to a **closed** assignment now only reach its notebook / upload form if they **previously engaged** with it; everyone else is redirected to their dashboard. This lets assignment links be posted in advance without spoiling not-yet-opened labs, while students keep access to labs they've already started (to review past solutions).

- New `assignment_participations` table — one row per `(student, assignment)`, written on first *allowed* access (notebook page or upload form while open). Durable in the DB, so it **survives redeploys** (unlike the on-disk notebook working copy, which the Docker entrypoint wipes on every start).
- Existing **student submissions** still count as engagement, and a closed assignment a submitter reviews **lazily backfills** its own participation row — so no migration backfill is needed and prior submitters aren't locked out.
- The gate covers the notebook page, the raw `/notebook/source` content endpoint (returns 403 — closes the direct-URL bypass), and the upload form.
- Dashboard: previously-engaged closed assignments stay listed with their **Edit** link (`canEdit`); the Upload link stays gated on open.
- Instructors/admins bypass the gate entirely.

## Notes

- Replaces the earlier filesystem-based signal (notebook working copy existence) with the durable participation record — the architecturally "right" hook discussed in review.
- No `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` edits; a `changelog.d/` fragment is included per the release process.

## Test plan

- [ ] CI green (builds + APITests against Postgres + swift-format + SwiftLint).
- New/updated tests:
  - `notebookPageClosedAssignmentRendersReadOnlyAndHidesSubmit` — participation row grants read-only review.
  - `notebookPageClosedAssignmentNeverOpenedRedirectsToDashboard` — never-engaged → redirect to `/`.
  - `notebookPageClosedAssignmentWithSubmissionStaysReachable` — submission fallback.
  - `openAccessRecordsParticipationSoClosedReviewStaysReachable` — end-to-end: open while open → records → still reachable after close.
  - `indexShowsClosedAssignmentWithEditLinkWhenPreviouslyOpened` / `indexHidesClosedAssignmentNeverOpenedFromStudent` — dashboard visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)