### PR TITLE
Rework MCP server gate from binary flag to three-state MCP_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ scripts/build-jupyterlite.sh
 
 ## MCP content-authoring server
 
-Chickadee ships an optional [Model Context Protocol](https://modelcontextprotocol.io/specification/2025-11-25) server at `POST /mcp` (Streamable HTTP, JSON-RPC 2.0) so AI agents can author course content. It is **disabled by default** and **scoped to authoring only** — the tools touch no student data, grades, enrolment, submissions, or administration, and the bearer gate rejects any token lacking a `content:*` scope.
+Chickadee ships an optional [Model Context Protocol](https://modelcontextprotocol.io/specification/2025-11-25) server at `POST /mcp` (Streamable HTTP, JSON-RPC 2.0) so AI agents can author course content. It is **off by default** and **scoped to authoring only** — the tools touch no student data, grades, enrolment, submissions, or administration, and the bearer gate rejects any token lacking a `content:*` scope. It has three modes: `off` (not mounted), `read_only` (agents can read content but never write — `content:write` is stripped from every request), and `read_write` (full authoring).
 
 For Phase 1, Chickadee acts as its own OAuth 2.1 authorization server: an admin provisions a service account and mints a short-lived bearer token. (Browser-based OAuth is a future phase.)
 
@@ -124,7 +124,7 @@ For Phase 1, Chickadee acts as its own OAuth 2.1 authorization server: an admin 
 Set these and restart the server:
 
 ```bash
-MCP_ENABLED=true
+MCP_MODE=read_write                      # off | read_only | read_write (default off)
 PUBLIC_BASE_URL=https://your-host        # issuer + resource are derived from this
 # Optional overrides / hardening:
 # MCP_ISSUER=https://your-host           # defaults to PUBLIC_BASE_URL

--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -19,10 +19,20 @@ MCP
 
     #if(!enabled):
     <div class="form-error" style="margin-bottom:1rem">
-        The MCP endpoint is not active, so tokens cannot be minted. Set <code>MCP_ENABLED=true</code>
+        The MCP endpoint is not active, so tokens cannot be minted. Set
+        <code>MCP_MODE=read_only</code> or <code>MCP_MODE=read_write</code>
         and <code>PUBLIC_BASE_URL</code> (or <code>MCP_ISSUER</code>/<code>MCP_RESOURCE</code>),
         then restart the server.
     </div>
+    #endif
+    #if(enabled):
+    #if(!writeAllowed):
+    <div style="margin-bottom:1rem;padding:.75rem;border:1px solid var(--gray-500);border-radius:6px;background:rgba(234,179,8,.10)">
+        MCP is in <strong>read-only</strong> mode (<code>MCP_MODE=read_only</code>): agents can read
+        course content but cannot create or edit it. Minted tokens carry <code>content:read</code> only.
+        Set <code>MCP_MODE=read_write</code> and restart to allow writes.
+    </div>
+    #endif
     #endif
     #if(error == "username_required"):
     <div class="form-error" style="margin-bottom:1rem">A username is required.</div>
@@ -116,7 +126,9 @@ MCP
                             <label class="visually-hidden" for="scope-#(account.id)">Token scope for #(account.username)</label>
                             <select id="scope-#(account.id)" name="scope" class="form-input"
                                     style="padding:.25rem .5rem;font-size:.8rem">
+                                #if(writeAllowed):
                                 <option value="readwrite">read + write</option>
+                                #endif
                                 <option value="read">read only</option>
                             </select>
                             <button class="btn action-btn" type="submit">Mint token</button>

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -28,10 +28,11 @@ public func runAPIServer() async throws {
         }
 
         // Load the MCP signing-key authority (auto-generating it on first run)
-        // when the content-authoring MCP endpoint is enabled.  The routes are
+        // when the content-authoring MCP endpoint is mounted (read_only or
+        // read_write — read_only still needs to verify tokens).  The routes are
         // already mounted by configure(); the bearer middleware reads this
         // authority per-request, so it only needs to exist before app.execute().
-        if app.appConfig.mcp.enabled {
+        if app.appConfig.mcp.mode.isMounted {
             app.mcpTokenAuthority = try await MCPTokenAuthority.loadOrGenerate(
                 path: app.appConfig.mcp.signingKeyPath, keyID: "mcp-1")
             app.logger.info("MCP token authority ready (signing key: \(app.appConfig.mcp.signingKeyPath)).")

--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -30,8 +30,9 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
     )
     app.lifecycle.use(ServerHealthAlertLifecycleHandler())
 
-    // MCP OAuth table cleanup (only when the MCP endpoint is enabled).
-    if appConfig.mcp.enabled {
+    // MCP OAuth table cleanup (only when the MCP endpoint is mounted — grants
+    // and codes exist in read_only mode too).
+    if appConfig.mcp.mode.isMounted {
         app.lifecycle.use(MCPOAuthReaperLifecycleHandler())
     }
 

--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -111,9 +111,9 @@ struct AppConfig: Sendable {
         if let proxy = outboundProxy {
             logger.info("outboundProxy: \(proxy.host):\(proxy.port)")
         }
-        if mcp.enabled {
+        if mcp.mode.isMounted {
             logger.info(
-                "mcp: enabled, tokenTTL=\(mcp.tokenTTLSeconds)s, accessTokenTTL=\(mcp.accessTokenTTLSeconds)s, grantTTL=\(mcp.grantTTLDays)d, allowedHosts=\(mcp.allowedHosts.count), allowedOrigins=\(mcp.allowedOrigins.count), signingKeyPath=\(mcp.signingKeyPath)"
+                "mcp: mode=\(mcp.mode.rawValue), tokenTTL=\(mcp.tokenTTLSeconds)s, accessTokenTTL=\(mcp.accessTokenTTLSeconds)s, grantTTL=\(mcp.grantTTLDays)d, allowedHosts=\(mcp.allowedHosts.count), allowedOrigins=\(mcp.allowedOrigins.count), signingKeyPath=\(mcp.signingKeyPath)"
             )
         }
     }

--- a/Sources/APIServer/Configuration/MCPConfig.swift
+++ b/Sources/APIServer/Configuration/MCPConfig.swift
@@ -2,12 +2,15 @@
 //
 // Environment-variable knobs for the content-authoring MCP server (the /mcp
 // endpoint and its OAuth 2.1 bearer auth).  Part of the AppConfig tree; read
-// once at startup.  The endpoint is disabled by default — an operator opts in
-// with MCP_ENABLED=true once auth is configured.
+// once at startup.  The endpoint is off by default — an operator opts in with
+// MCP_MODE=read_only (inspection without write) or MCP_MODE=read_write (full
+// content authoring) once auth is configured.
 
 struct MCPConfig: Sendable {
-    /// Whether the `/mcp` endpoint is mounted on the live app.  Default false.
-    var enabled: Bool
+    /// Operating mode for the `/mcp` endpoint: `off` (not mounted),
+    /// `read_only` (mounted, `content:write` never honored), or `read_write`
+    /// (full).  Default `off`.
+    var mode: MCPMode
     /// Permitted `Host` header values for `/mcp` (DNS-rebinding mitigation).
     /// Empty means "allow any" — development only.
     var allowedHosts: Set<String>
@@ -42,7 +45,7 @@ struct MCPConfig: Sendable {
     var maxRedirectURIsPerClient: Int
 
     init(
-        enabled: Bool,
+        mode: MCPMode,
         allowedHosts: Set<String>,
         allowedOrigins: Set<String>,
         tokenTTLSeconds: Int,
@@ -55,7 +58,7 @@ struct MCPConfig: Sendable {
         maxRegisteredClients: Int = 1000,
         maxRedirectURIsPerClient: Int = 5
     ) {
-        self.enabled = enabled
+        self.mode = mode
         self.allowedHosts = allowedHosts
         self.allowedOrigins = allowedOrigins
         self.tokenTTLSeconds = tokenTTLSeconds
@@ -71,7 +74,7 @@ struct MCPConfig: Sendable {
 
     static func fromEnvironment(workDir: String) -> MCPConfig {
         MCPConfig(
-            enabled: environmentBool("MCP_ENABLED") ?? false,
+            mode: MCPMode.parse(trimmedEnv("MCP_MODE")),
             allowedHosts: parseSSOIdentityAllowlist(trimmedEnv("MCP_ALLOWED_HOSTS")),
             allowedOrigins: parseSSOIdentityAllowlist(trimmedEnv("MCP_ALLOWED_ORIGINS")),
             tokenTTLSeconds: environmentInt("MCP_TOKEN_TTL_SECONDS") ?? 86_400,
@@ -86,10 +89,10 @@ struct MCPConfig: Sendable {
         )
     }
 
-    /// All-defaults config (disabled, allow-any guards) for tests and the lazy
+    /// All-defaults config (off, allow-any guards) for tests and the lazy
     /// `Application.appConfig` fallback.
     static let `default` = MCPConfig(
-        enabled: false,
+        mode: .off,
         allowedHosts: [],
         allowedOrigins: [],
         tokenTTLSeconds: 86_400,

--- a/Sources/APIServer/Configuration/MCPMode.swift
+++ b/Sources/APIServer/Configuration/MCPMode.swift
@@ -1,0 +1,58 @@
+// APIServer/Configuration/MCPMode.swift
+//
+// Operating mode for the content-authoring MCP server, selected by `MCP_MODE`.
+// Three states instead of a binary on/off so an operator can expose the
+// endpoint for inspection without granting write access:
+//
+//   off         — not mounted at all (/mcp and /oauth/* 404, no token authority)
+//   read_only   — mounted and authenticated, but `content:write` is never honored
+//   read_write  — full content authoring (read + write)
+//
+// `read_only` is implemented as a server-wide ceiling on the OAuth scopes any
+// request may exercise (`scopeCeiling`), enforced once in the bearer middleware.
+// Because the ceiling is applied per request — not just at token-mint time — a
+// `content:write` token issued while the server was `read_write` loses write the
+// instant an operator flips to `read_only`, without any token revocation.
+
+enum MCPMode: String, Sendable, CaseIterable {
+    case off
+    case readOnly = "read_only"
+    case readWrite = "read_write"
+
+    /// True for `read_only` and `read_write`: the `/mcp` transport, OAuth flow,
+    /// discovery metadata, and token authority are all mounted.  `off` mounts
+    /// nothing.
+    var isMounted: Bool { self != .off }
+
+    /// The maximum set of content scopes a request may exercise in this mode.
+    /// The bearer middleware intersects each token's scopes with this set, so
+    /// the rest of the stack (per-tool scope checks, `tools/list` filtering,
+    /// resources) needs no mode awareness.
+    var scopeCeiling: Set<ContentScope> {
+        switch self {
+        case .off: return []
+        case .readOnly: return [.read]
+        case .readWrite: return [.read, .write]
+        }
+    }
+
+    /// Parses `MCP_MODE`.  Canonical values are `off`, `read_only`,
+    /// `read_write`; a handful of obvious synonyms are accepted so an operator
+    /// fat-fingering `readonly` or `on` still lands on the intended mode.
+    /// Unset, empty, or unrecognized → `.off` (fail safe; the redacted startup
+    /// summary logs the resolved mode so a typo is visible).
+    static func parse(_ raw: String?) -> MCPMode {
+        guard let raw else { return .off }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "off", "false", "0", "no", "disabled", "none", "":
+            return .off
+        case "read_only", "readonly", "read-only", "read", "ro":
+            return .readOnly
+        case "read_write", "readwrite", "read-write", "rw", "on", "true", "1", "yes", "enabled", "full":
+            return .readWrite
+        default:
+            return .off
+        }
+    }
+}

--- a/Sources/APIServer/Helpers/MCPEnabledTag.swift
+++ b/Sources/APIServer/Helpers/MCPEnabledTag.swift
@@ -1,8 +1,8 @@
 // APIServer/Helpers/MCPEnabledTag.swift
 //
-// Leaf tag that reports whether the content-authoring MCP endpoint is enabled
-// (`MCP_ENABLED`). Used to hide the admin "MCP" nav tab entirely when MCP is
-// off, e.g.:
+// Leaf tag that reports whether the content-authoring MCP endpoint is mounted
+// (`MCP_MODE` is read_only or read_write). Used to hide the admin "MCP" nav tab
+// entirely when MCP is off, e.g.:
 //   #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp">MCP</a>#endif
 //
 // Boot-fixed app-global (like the app version / idle-timeout tags), so a Leaf
@@ -15,6 +15,6 @@ struct MCPEnabledTag: LeafTag {
     func render(_ ctx: LeafContext) throws -> LeafData {
         try ctx.requireParameterCount(0)
         guard let req = ctx.request else { return .bool(false) }
-        return .bool(req.application.appConfig.mcp.enabled)
+        return .bool(req.application.appConfig.mcp.mode.isMounted)
     }
 }

--- a/Sources/APIServer/MCP/Auth/MCPBearerAuthMiddleware.swift
+++ b/Sources/APIServer/MCP/Auth/MCPBearerAuthMiddleware.swift
@@ -38,12 +38,22 @@ struct MCPBearerAuthMiddleware: AsyncMiddleware {
 
         // Defence in depth: reject tokens carrying no content-authoring scope at
         // all, independent of any per-tool scope check at the dispatcher.
-        let granted = Set(ContentScope.allCases.filter { claims.scopes.contains($0.rawValue) })
+        //
+        // The token's scopes are then clamped to the server-wide ceiling for the
+        // current MCP_MODE (read_only → {read}).  Applying the ceiling per
+        // request — not just at mint time — means a content:write token issued
+        // while the server was read_write loses write the instant an operator
+        // flips to read_only, with no token revocation.  A token left with no
+        // usable scope after clamping is treated as insufficient (the only way
+        // that happens today is a write-only token under read_only).
+        let tokenScopes = Set(ContentScope.allCases.filter { claims.scopes.contains($0.rawValue) })
+        let granted = tokenScopes.intersection(request.application.appConfig.mcp.mode.scopeCeiling)
         guard !granted.isEmpty else {
             return challenge(
                 status: .forbidden,
                 error: "insufficient_scope",
-                scope: ContentScope.allCases.map(\.rawValue).joined(separator: " ")
+                scope: request.application.appConfig.mcp.mode.scopeCeiling
+                    .map(\.rawValue).sorted().joined(separator: " ")
             )
         }
 

--- a/Sources/APIServer/MCP/Auth/MCPTokenAuthority.swift
+++ b/Sources/APIServer/MCP/Auth/MCPTokenAuthority.swift
@@ -120,7 +120,8 @@ private struct MCPTokenAuthorityKey: StorageKey {
 }
 
 extension Application {
-    /// The MCP token authority, loaded at startup when `appConfig.mcp.enabled`.
+    /// The MCP token authority, loaded at startup when `appConfig.mcp.mode` is
+    /// mounted (read_only or read_write).
     var mcpTokenAuthority: MCPTokenAuthority? {
         get { storage[MCPTokenAuthorityKey.self] }
         set { storage[MCPTokenAuthorityKey.self] = newValue }

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -61,7 +61,7 @@ struct MCPOAuthRoutes: Sendable {
         guard !query.codeChallenge.isEmpty, query.codeChallengeMethod == "S256" else {
             return redirect(query.redirectURI, error: "invalid_request", state: query.state)
         }
-        let scopes = resolveScopes(query.scope)
+        let scopes = resolveScopes(query.scope, ceiling: req.application.appConfig.mcp.mode.scopeCeiling)
         guard !scopes.isEmpty else {
             return redirect(query.redirectURI, error: "invalid_scope", state: query.state)
         }
@@ -113,7 +113,7 @@ struct MCPOAuthRoutes: Sendable {
         guard form.decision == "authorize" else {
             return redirect(form.redirectURI, error: "access_denied", state: state)
         }
-        let scopes = resolveScopes(form.scope)
+        let scopes = resolveScopes(form.scope, ceiling: req.application.appConfig.mcp.mode.scopeCeiling)
         guard !scopes.isEmpty, !form.codeChallenge.isEmpty, form.codeChallengeMethod == "S256" else {
             return redirect(form.redirectURI, error: "invalid_request", state: state)
         }
@@ -297,7 +297,8 @@ struct MCPOAuthRoutes: Sendable {
             grantTypes: ["authorization_code", "refresh_token"],
             responseTypes: ["code"],
             tokenEndpointAuthMethod: "none",
-            scope: ContentScope.allCases.map(\.rawValue).joined(separator: " "))
+            scope: req.application.appConfig.mcp.mode.scopeCeiling
+                .map(\.rawValue).sorted().joined(separator: " "))
         let result = Response(status: .created)
         try result.content.encode(response, as: .json)
         result.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
@@ -380,13 +381,16 @@ struct MCPOAuthRoutes: Sendable {
         return try await view.encodeResponse(for: req)
     }
 
-    /// Keeps only valid content scopes; an empty/absent request defaults to the
-    /// full content scope set.
-    private func resolveScopes(_ scope: String?) -> Set<ContentScope> {
+    /// Keeps only valid content scopes, then clamps to the server-wide ceiling
+    /// for the current MCP_MODE so a consent request can't grant more than the
+    /// mode honors (read_only → {read}).  An empty/absent request defaults to
+    /// the full ceiling.
+    private func resolveScopes(_ scope: String?, ceiling: Set<ContentScope>) -> Set<ContentScope> {
         guard let scope, !scope.trimmingCharacters(in: .whitespaces).isEmpty else {
-            return Set(ContentScope.allCases)
+            return ceiling
         }
-        return Set(scope.split(separator: " ").compactMap { ContentScope(rawValue: String($0)) })
+        let requested = Set(scope.split(separator: " ").compactMap { ContentScope(rawValue: String($0)) })
+        return requested.intersection(ceiling)
     }
 
     private func parseScopes(_ scope: String) -> Set<ContentScope> {

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -40,7 +40,7 @@ struct MCPDispatcher: Sendable {
             // with an id, ack with an empty result rather than erroring.
             return .success(id: id, result: .object([:]))
         case .toolsList:
-            return .success(id: id, result: toolsListResult())
+            return .success(id: id, result: toolsListResult(context: context))
         case .toolsCall:
             return await toolsCallResult(id: id, params: request.params, context: context)
         case .resourcesList:
@@ -110,8 +110,18 @@ struct MCPDispatcher: Sendable {
 
     // MARK: - tools/list
 
-    private func toolsListResult() -> JSONValue {
-        let entries = tools.all.map { tool -> JSONValue in
+    /// Advertises only the tools the caller can actually invoke: a tool is
+    /// listed when the caller's granted scopes cover its `requiredScopes`.  In
+    /// read_only mode the bearer middleware has already clamped granted scopes
+    /// to {read}, so write tools drop out of the listing here rather than being
+    /// advertised only to fail with 403 on call.  When no context is available
+    /// (non-transport callers / tests), all tools are listed.
+    private func toolsListResult(context: ToolContext?) -> JSONValue {
+        let visible =
+            context.map { ctx in
+                tools.all.filter { ctx.grantedScopes.isSuperset(of: $0.requiredScopes) }
+            } ?? tools.all
+        let entries = visible.map { tool -> JSONValue in
             var fields: [String: JSONValue] = [
                 "name": .string(tool.name),
                 "description": .string(tool.description),

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -1,7 +1,8 @@
 // APIServer/MCP/Transport/MCPServerRegistration.swift
 //
 // Wires the content-authoring MCP server into the live application when
-// `appConfig.mcp.enabled`.  Mounts the bearer-gated /mcp transport, the
+// `appConfig.mcp.mode` is mounted (read_only or read_write).  Mounts the
+// bearer-gated /mcp transport, the
 // unauthenticated OAuth discovery endpoints, and (Phase 2) the browser OAuth
 // flow (/oauth/authorize + /oauth/token).  Issuer/resource are resolved from
 // MCPConfig, falling back to PUBLIC_BASE_URL.  The signing-key authority itself
@@ -65,10 +66,10 @@ struct MCPEndpoints {
 /// otherwise.  Called from `routes(_:)`.
 func registerMCPRoutes(_ app: Application) throws {
     let mcp = app.appConfig.mcp
-    guard mcp.enabled else { return }
+    guard mcp.mode.isMounted else { return }
     guard let endpoints = MCPEndpoints.resolve(mcp: mcp, security: app.appConfig.security) else {
         app.logger.warning(
-            "MCP_ENABLED=true but no issuer/resource could be resolved (set MCP_ISSUER/MCP_RESOURCE or PUBLIC_BASE_URL); /mcp not mounted."
+            "MCP_MODE=\(mcp.mode.rawValue) but no issuer/resource could be resolved (set MCP_ISSUER/MCP_RESOURCE or PUBLIC_BASE_URL); /mcp not mounted."
         )
         return
     }
@@ -105,7 +106,8 @@ func registerMCPOAuthRoutes(
     _ app: Application, sessionAuth: UserSessionAuthenticator, csrf: CSRF
 ) throws {
     let mcp = app.appConfig.mcp
-    guard mcp.enabled, let endpoints = MCPEndpoints.resolve(mcp: mcp, security: app.appConfig.security)
+    guard mcp.mode.isMounted,
+        let endpoints = MCPEndpoints.resolve(mcp: mcp, security: app.appConfig.security)
     else { return }
 
     let oauth = MCPOAuthRoutes(

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -157,9 +157,12 @@ struct AdminMCPAccountRow: Encodable {
 struct AdminMCPContext: Encodable {
     let currentUser: CurrentUserContext?
     let activeAdminTab: String
-    /// True only when MCP is enabled, the signing authority is loaded, and the
+    /// True only when MCP is mounted, the signing authority is loaded, and the
     /// issuer/resource resolve — i.e. tokens can actually be minted.
     let enabled: Bool
+    /// False in read_only mode: the page hides the read+write mint option and
+    /// shows a read-only banner.
+    let writeAllowed: Bool
     let issuer: String?
     let resource: String?
     let tokenTTLSeconds: Int

--- a/Sources/APIServer/Routes/Web/AdminRoutes+MCP.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+MCP.swift
@@ -2,8 +2,9 @@
 //
 // Admin "MCP" tab: provision non-loginable `mcp` service accounts and mint
 // short-lived access tokens for them (shown exactly once).  Token minting is
-// only possible when the MCP endpoint is active (MCP_ENABLED + a resolvable
-// issuer/resource + the signing authority loaded at startup).
+// only possible when the MCP endpoint is mounted (MCP_MODE read_only or
+// read_write + a resolvable issuer/resource + the signing authority loaded at
+// startup).  In read_only mode the minted scope is capped to content:read.
 //
 // Revocation note: access tokens are stateless JWTs with no server-side
 // denylist, so deleting an account stops *new* tokens being minted but cannot
@@ -57,7 +58,7 @@ extension AdminRoutes {
         let user = try await findMCPAccount(req)
         let mcp = req.application.appConfig.mcp
         guard
-            mcp.enabled,
+            mcp.mode.isMounted,
             let authority = req.application.mcpTokenAuthority,
             let endpoints = MCPEndpoints.resolve(mcp: mcp, security: req.application.appConfig.security)
         else {
@@ -65,7 +66,10 @@ extension AdminRoutes {
                 req: req, mintedToken: nil, mintedFor: nil, mintedScopes: nil, error: "mcp_disabled")
         }
         let scopeChoice = (try? req.content.decode(Body.self))?.scope
-        let scopes: Set<ContentScope> = scopeChoice == "read" ? [.read] : [.read, .write]
+        let requested: Set<ContentScope> = scopeChoice == "read" ? [.read] : [.read, .write]
+        // Never mint a token claiming a scope the current mode won't honor:
+        // under read_only the ceiling clamps a read+write request down to read.
+        let scopes = requested.intersection(mcp.mode.scopeCeiling)
         let token = try await authority.mint(
             subject: user.username, scopes: scopes,
             issuer: endpoints.issuer, audience: endpoints.resource, ttlSeconds: mcp.tokenTTLSeconds)
@@ -116,7 +120,7 @@ extension AdminRoutes {
     ) async throws -> View {
         let mcp = req.application.appConfig.mcp
         let endpoints = MCPEndpoints.resolve(mcp: mcp, security: req.application.appConfig.security)
-        let enabled = mcp.enabled && req.application.mcpTokenAuthority != nil && endpoints != nil
+        let enabled = mcp.mode.isMounted && req.application.mcpTokenAuthority != nil && endpoints != nil
 
         let mcpUsers = try await APIUser.query(on: req.db)
             .filter(\.$role == "mcp")
@@ -161,6 +165,7 @@ extension AdminRoutes {
             currentUser: req.currentUserContext,
             activeAdminTab: "mcp",
             enabled: enabled,
+            writeAllowed: mcp.mode.scopeCeiling.contains(.write),
             issuer: endpoints?.issuer,
             resource: endpoints?.resource,
             tokenTTLSeconds: mcp.tokenTTLSeconds,

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -73,7 +73,7 @@ func routes(_ app: Application) throws {
     // MARK: - MCP (content authoring)
 
     // Bearer-gated /mcp transport + unauthenticated OAuth discovery metadata.
-    // Mounted only when MCP_ENABLED; a no-op otherwise.
+    // Mounted when MCP_MODE is read_only or read_write; a no-op when off.
     try registerMCPRoutes(app)
     // Browser OAuth flow (/oauth/authorize consent + /oauth/token); the consent
     // page reuses the shared session-auth + CSRF middleware.

--- a/Tests/APITests/MCP/AdminMCPRoutesTests.swift
+++ b/Tests/APITests/MCP/AdminMCPRoutesTests.swift
@@ -17,20 +17,24 @@ import XCTVapor
 
     private func makeAdminApp(
         mcpEnabled: Bool, authMode: AuthMode = .local
-    ) async throws -> (
-        Application, MCPTokenAuthority?
-    ) {
+    ) async throws -> (Application, MCPTokenAuthority?) {
+        try await makeAdminApp(mode: mcpEnabled ? .readWrite : .off, authMode: authMode)
+    }
+
+    private func makeAdminApp(
+        mode: MCPMode, authMode: AuthMode = .local
+    ) async throws -> (Application, MCPTokenAuthority?) {
         let mcp: MCPConfig =
-            mcpEnabled
+            mode.isMounted
             ? MCPConfig(
-                enabled: true, allowedHosts: [], allowedOrigins: [],
+                mode: mode, allowedHosts: [], allowedOrigins: [],
                 tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource)
             : .default
         // app.authMode stays .local so the test's session login works; the
         // service-account UI reads appConfig.auth.mode, which we set here.
         let app = try await makeTestApp(appConfig: .testDefaults(authMode: authMode, mcp: mcp))
         var authority: MCPTokenAuthority?
-        if mcpEnabled {
+        if mode.isMounted {
             let made = try await MCPTokenAuthority.make(
                 privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
             app.mcpTokenAuthority = made
@@ -123,6 +127,30 @@ import XCTVapor
             #expect(claims.sub.value == "minted-bot")
             #expect(claims.scopes.contains("content:read"))
             #expect(claims.scopes.contains("content:write"))
+        }
+    }
+
+    @Test func mintTokenInReadOnlyModeCapsScopeToRead() async throws {
+        let (app, authority) = try await makeAdminApp(mode: .readOnly)
+        try await withApp(app) { app in
+            var cookie = try await loginUser(
+                username: "mcp_admin", password: "testpassword", role: "admin", on: app)
+            _ = try await adminCSRFPost(
+                app, to: "/admin/mcp/accounts", cookie: &cookie, fields: ["username": "ro-bot"])
+            let userID = try #require(try await mcpAccount(named: "ro-bot", on: app)).requireID()
+
+            // Even though the form requests read+write, read_only clamps the
+            // minted token down to content:read.
+            let res = try await adminCSRFPost(
+                app, to: "/admin/mcp/accounts/\(userID.uuidString)/token",
+                cookie: &cookie, fields: ["scope": "readwrite"])
+            #expect(res.status == .ok)
+
+            let token = try #require(extractJWT(from: res.body.string))
+            let unwrappedAuthority = try #require(authority)
+            let claims = try await unwrappedAuthority.verify(token)
+            #expect(claims.scopes.contains("content:read"))
+            #expect(!claims.scopes.contains("content:write"))
         }
     }
 

--- a/Tests/APITests/MCP/MCPBearerAuthMiddlewareTests.swift
+++ b/Tests/APITests/MCP/MCPBearerAuthMiddlewareTests.swift
@@ -19,6 +19,12 @@ import XCTVapor
         let authority = try await MCPTokenAuthority.make(
             privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "k")
         app.mcpTokenAuthority = authority
+        // The middleware clamps token scopes to the mode's ceiling; mounting it
+        // at all implies a mounted, write-capable mode in production.
+        app.appConfig = .testDefaults(
+            mcp: MCPConfig(
+                mode: .readWrite, allowedHosts: [], allowedOrigins: [],
+                tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource))
         let middleware = MCPBearerAuthMiddleware(
             expectedIssuer: issuer, expectedAudience: resource, resourceMetadataURL: metadataURL)
         app.grouped(middleware).get("guarded") { req in

--- a/Tests/APITests/MCP/MCPConfigTests.swift
+++ b/Tests/APITests/MCP/MCPConfigTests.swift
@@ -5,9 +5,9 @@ import Testing
 @testable import APIServer
 
 @Suite struct MCPConfigTests {
-    @Test func defaultIsDisabledWithSensibleValues() {
+    @Test func defaultIsOffWithSensibleValues() {
         let config = MCPConfig.default
-        #expect(config.enabled == false)
+        #expect(config.mode == .off)
         #expect(config.allowedHosts.isEmpty)
         #expect(config.allowedOrigins.isEmpty)
         #expect(config.tokenTTLSeconds == 86_400)
@@ -15,7 +15,39 @@ import Testing
         #expect(config.resource == nil)
     }
 
-    @Test func appConfigTestDefaultsIncludeDisabledMCP() {
-        #expect(AppConfig.testDefaults().mcp.enabled == false)
+    @Test func appConfigTestDefaultsIncludeOffMCP() {
+        #expect(AppConfig.testDefaults().mcp.mode == .off)
+    }
+
+    @Test(arguments: [
+        ("off", MCPMode.off),
+        ("read_only", .readOnly),
+        ("readonly", .readOnly),
+        ("read-only", .readOnly),
+        ("read", .readOnly),
+        ("read_write", .readWrite),
+        ("readwrite", .readWrite),
+        ("on", .readWrite),
+        ("true", .readWrite),
+        ("RW", .readWrite),
+        ("  read_only  ", .readOnly),
+        ("garbage", .off),
+        ("", .off),
+    ])
+    func parsesEnvValues(_ raw: String, _ expected: MCPMode) {
+        #expect(MCPMode.parse(raw) == expected)
+    }
+
+    @Test func parseNilIsOff() {
+        #expect(MCPMode.parse(nil) == .off)
+    }
+
+    @Test func scopeCeilingMatchesMode() {
+        #expect(MCPMode.off.scopeCeiling.isEmpty)
+        #expect(MCPMode.readOnly.scopeCeiling == [.read])
+        #expect(MCPMode.readWrite.scopeCeiling == [.read, .write])
+        #expect(MCPMode.off.isMounted == false)
+        #expect(MCPMode.readOnly.isMounted)
+        #expect(MCPMode.readWrite.isMounted)
     }
 }

--- a/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
+++ b/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
@@ -17,7 +17,7 @@ import XCTVapor
 
     private func makeApp() async throws -> Application {
         let mcp = MCPConfig(
-            enabled: true, allowedHosts: [], allowedOrigins: [],
+            mode: .readWrite, allowedHosts: [], allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
         app.mcpTokenAuthority = try await MCPTokenAuthority.make(

--- a/Tests/APITests/MCP/MCPEndToEndTests.swift
+++ b/Tests/APITests/MCP/MCPEndToEndTests.swift
@@ -19,7 +19,7 @@ import XCTVapor
     /// authority (matching issuer/resource) the minted tokens validate against.
     private func makeMCPApp() async throws -> (Application, MCPTokenAuthority) {
         let mcp = MCPConfig(
-            enabled: true, allowedHosts: [], allowedOrigins: [],
+            mode: .readWrite, allowedHosts: [], allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused",
             issuer: issuer, resource: resource)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
@@ -116,9 +116,28 @@ import XCTVapor
         }
     }
 
-    @Test func toolsListWithValidTokenListsTools() async throws {
+    @Test func toolsListWithFullScopeListsReadAndWriteTools() async throws {
         let (app, authority) = try await makeMCPApp()
         try await withApp(app) { app in
+            // tools/list advertises only the tools the caller's scopes cover; a
+            // full read+write token therefore sees both read and write tools.
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":4,"method":"tools/list"}"#, token: token)
+            #expect(res.status == .ok)
+            let text = String(buffer: res.body)
+            #expect(text.contains("list_assignments"))
+            #expect(text.contains("update_assignment"))
+        }
+    }
+
+    @Test func toolsListWithReadScopeHidesWriteTools() async throws {
+        let (app, authority) = try await makeMCPApp()
+        try await withApp(app) { app in
+            // A read-only token sees only read tools — write tools are filtered
+            // out of the listing rather than advertised only to 403 on call.
             let token = try await authority.mint(
                 subject: "agent", scopes: [.read],
                 issuer: issuer, audience: resource, ttlSeconds: 3600)
@@ -127,7 +146,8 @@ import XCTVapor
             #expect(res.status == .ok)
             let text = String(buffer: res.body)
             #expect(text.contains("list_assignments"))
-            #expect(text.contains("update_assignment"))
+            #expect(!text.contains("update_assignment"))
+            #expect(!text.contains("create_assignment"))
         }
     }
 

--- a/Tests/APITests/MCP/MCPOAuthFlowTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthFlowTests.swift
@@ -34,7 +34,7 @@ import XCTVapor
 
     private func makeOAuthApp() async throws -> (Application, MCPTokenAuthority) {
         let mcp = MCPConfig(
-            enabled: true, allowedHosts: [], allowedOrigins: [],
+            mode: .readWrite, allowedHosts: [], allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
         let authority = try await MCPTokenAuthority.make(

--- a/Tests/APITests/MCP/MCPProgressStreamTests.swift
+++ b/Tests/APITests/MCP/MCPProgressStreamTests.swift
@@ -16,7 +16,7 @@ import XCTVapor
 
     private func makeMCPApp() async throws -> (Application, MCPTokenAuthority) {
         let mcp = MCPConfig(
-            enabled: true, allowedHosts: [], allowedOrigins: [],
+            mode: .readWrite, allowedHosts: [], allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused",
             issuer: issuer, resource: resource)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))

--- a/Tests/APITests/MCP/MCPReadOnlyModeTests.swift
+++ b/Tests/APITests/MCP/MCPReadOnlyModeTests.swift
@@ -1,0 +1,110 @@
+// Tests for MCP_MODE=read_only: the endpoint is mounted and authenticates
+// normally, but the server clamps every request's scopes to {content:read}.
+// The clamp lives in MCPBearerAuthMiddleware and applies per request, so even a
+// content:write token minted while the server was read_write loses write the
+// instant the operator flips to read_only — no token revocation needed.
+
+import Fluent
+import JWT
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct MCPReadOnlyModeTests {
+    private let issuer = "https://chickadee.example"
+    private let resource = "https://chickadee.example/mcp"
+
+    /// Builds a test app in read_only mode with the real MCP wiring mounted and
+    /// a token authority attached (issuer/resource matched to minted tokens).
+    private func makeReadOnlyApp() async throws -> (Application, MCPTokenAuthority) {
+        let mcp = MCPConfig(
+            mode: .readOnly, allowedHosts: [], allowedOrigins: [],
+            tokenTTLSeconds: 3600, signingKeyPath: "unused",
+            issuer: issuer, resource: resource)
+        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
+        let authority = try await MCPTokenAuthority.make(
+            privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
+        app.mcpTokenAuthority = authority
+        return (app, authority)
+    }
+
+    private func post(_ app: Application, body: String, token: String) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(
+            .POST, "/mcp",
+            headers: ["Content-Type": "application/json", "Authorization": "Bearer \(token)"],
+            body: ByteBuffer(string: body))
+    }
+
+    @Test func writeToolWithWriteScopedTokenIsForbiddenInReadOnly() async throws {
+        let (app, authority) = try await makeReadOnlyApp()
+        try await withApp(app) { app in
+            // Token carries content:write, but read_only clamps it away, so the
+            // write tool is rejected at the transport with 403 insufficient_scope.
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let body = #"""
+                {"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"update_assignment","arguments":{"assignmentPublicID":"ABC123","isOpen":true}}}
+                """#
+            let res = try await post(app, body: body, token: token)
+            #expect(res.status == .forbidden)
+            #expect(res.headers.first(name: .wwwAuthenticate)?.contains("insufficient_scope") == true)
+        }
+    }
+
+    @Test func toolsListWithWriteScopedTokenHidesWriteToolsInReadOnly() async throws {
+        let (app, authority) = try await makeReadOnlyApp()
+        try await withApp(app) { app in
+            // Even a write-bearing token sees only read tools in read_only mode,
+            // because the bearer clamp strips write before tools/list filters.
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#, token: token)
+            #expect(res.status == .ok)
+            let text = String(buffer: res.body)
+            #expect(text.contains("list_assignments"))
+            #expect(text.contains("get_assignment"))
+            #expect(!text.contains("update_assignment"))
+            #expect(!text.contains("create_assignment"))
+            #expect(!text.contains("clone_assignment"))
+        }
+    }
+
+    @Test func readToolStillSucceedsInReadOnly() async throws {
+        let (app, authority) = try await makeReadOnlyApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let agent = try await makeTestUser(on: app, username: "agent", role: "mcp")
+            try await makeTestEnrollment(on: app, userID: agent.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_ro", courseID: courseID)
+            try await makeTestAssignment(
+                on: app, testSetupID: "setup_ro", courseID: courseID, title: "Tasks")
+
+            let token = try await authority.mint(
+                subject: "agent", scopes: [.read, .write],
+                issuer: issuer, audience: resource, ttlSeconds: 3600)
+            let body = #"""
+                {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_assignments","arguments":{"courseCode":"CS246"}}}
+                """#
+            let res = try await post(app, body: body, token: token)
+            #expect(res.status == .ok)
+            let text = String(buffer: res.body)
+            #expect(text.contains("CS246"))
+            #expect(text.contains("Tasks"))
+        }
+    }
+
+    @Test func discoveryMetadataIsReachableInReadOnly() async throws {
+        let (app, _) = try await makeReadOnlyApp()
+        try await withApp(app) { app in
+            try await app.testable().test(.GET, "/.well-known/oauth-protected-resource") { res async in
+                #expect(res.status == .ok)
+                #expect(String(buffer: res.body).contains("\"resource\""))
+            }
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPSSETransportTests.swift
+++ b/Tests/APITests/MCP/MCPSSETransportTests.swift
@@ -17,7 +17,7 @@ import XCTVapor
 
     private func makeMCPApp() async throws -> (Application, MCPTokenAuthority) {
         let mcp = MCPConfig(
-            enabled: true, allowedHosts: [], allowedOrigins: [],
+            mode: .readWrite, allowedHosts: [], allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused",
             issuer: issuer, resource: resource)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))

--- a/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
+++ b/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
@@ -37,17 +37,17 @@ import XCTVapor
 
     // MARK: - App builders
 
-    /// Builds a test app; when `enabled`, mounts the real MCP wiring and attaches
-    /// a token authority (issuer/resource matched to the minted tokens).
+    /// Builds a test app; when `mode` is mounted, mounts the real MCP wiring and
+    /// attaches a token authority (issuer/resource matched to the minted tokens).
     private func makeApp(
-        enabled: Bool = true, allowedHosts: Set<String> = [], maxRegisteredClients: Int = 1000
+        mode: MCPMode = .readWrite, allowedHosts: Set<String> = [], maxRegisteredClients: Int = 1000
     ) async throws -> (Application, MCPTokenAuthority?) {
         let mcp = MCPConfig(
-            enabled: enabled, allowedHosts: allowedHosts, allowedOrigins: [],
+            mode: mode, allowedHosts: allowedHosts, allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource,
             maxRegisteredClients: maxRegisteredClients)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
-        guard enabled else { return (app, nil) }
+        guard mode.isMounted else { return (app, nil) }
         let authority = try await MCPTokenAuthority.make(
             privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
         app.mcpTokenAuthority = authority
@@ -137,7 +137,7 @@ import XCTVapor
     // MARK: - Routes are not mounted when MCP is disabled at boot
 
     @Test func disabledMCPMountsNoEndpoints() async throws {
-        let (app, _) = try await makeApp(enabled: false)
+        let (app, _) = try await makeApp(mode: .off)
         try await withApp(app) { app in
             let mcp = try await app.asyncSendRequest(
                 .POST, "/mcp",

--- a/Tests/APITests/MCP/MCPTokenAttributionTests.swift
+++ b/Tests/APITests/MCP/MCPTokenAttributionTests.swift
@@ -19,6 +19,12 @@ import XCTVapor
         let authority = try await MCPTokenAuthority.make(
             privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "k")
         app.mcpTokenAuthority = authority
+        // The middleware clamps token scopes to the mode's ceiling; mounting it
+        // at all implies a mounted, write-capable mode in production.
+        app.appConfig = .testDefaults(
+            mcp: MCPConfig(
+                mode: .readWrite, allowedHosts: [], allowedOrigins: [],
+                tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource))
         let middleware = MCPBearerAuthMiddleware(
             expectedIssuer: issuer, expectedAudience: resource, resourceMetadataURL: metadataURL)
         app.grouped(middleware).get("whoami") { req -> String in

--- a/changelog.d/mcp-mode-tristate.md
+++ b/changelog.d/mcp-mode-tristate.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **MCP server gate is now three-state (`MCP_MODE`).** The content-authoring MCP
+  server replaces the binary `MCP_ENABLED` flag with `MCP_MODE`, which takes
+  `off` (not mounted — the default), `read_only` (mounted and authenticated, but
+  `content:write` is never honored), or `read_write` (full authoring). Read-only
+  is enforced as a server-wide scope ceiling clamped per request in the bearer
+  middleware, so a `content:write` token issued while the server was `read_write`
+  loses write the instant an operator flips to `read_only`, with no token
+  revocation. `tools/list` now advertises only the tools the caller's scopes
+  cover (write tools drop out in read-only mode), and both admin token minting
+  and the browser OAuth consent flow cap the granted scope to the mode's ceiling.
+  Operators must switch `MCP_ENABLED=true` to `MCP_MODE=read_write` (or
+  `read_only`); `MCP_ENABLED` is no longer read.


### PR DESCRIPTION
## Summary

Replaces the binary `MCP_ENABLED` flag with a three-state `MCP_MODE`:

- **`off`** (default) — `/mcp` and `/oauth/*` not mounted, no token authority, admin tab hidden.
- **`read_only`** — endpoint mounted and authenticated, but `content:write` is never honored.
- **`read_write`** — full content authoring (the old `MCP_ENABLED=true`).

`read_only` is implemented as a **server-wide ceiling on the OAuth scopes any request may exercise** (`MCPMode.scopeCeiling`), clamped **per request** in `MCPBearerAuthMiddleware`. Because the clamp is applied at request time rather than only at mint time, a `content:write` token issued while the server was `read_write` loses write the instant an operator flips to `read_only` — no token revocation needed. Everything downstream (per-tool scope check, `tools/list`, resources, the validation stream) already keys off `grantedScopes`, so it follows automatically.

Other touchpoints:
- `tools/list` now advertises only the tools the caller's granted scopes cover (write tools drop out in `read_only`) instead of listing them only to 403 on call.
- Admin token minting and the browser OAuth consent/registration flow cap the granted scope to the mode's ceiling.
- Admin MCP page hides the read+write mint option and shows a read-only banner in `read_only`.
- No Core changes, no migration, no token-format change — `MCPMode` lives in APIServer beside `ContentScope`.

**Breaking:** `MCP_ENABLED` is no longer read. Operators set `MCP_MODE=read_only|read_write` (chickadee-dev's live `.env` needs updating before its next deploy).

## Test plan

- [ ] CI green (build + WorkerTests + format/swift-format + SwiftLint)
- [x] `MCPConfigTests`: `MCP_MODE` parsing (aliases, whitespace, garbage → off), `scopeCeiling`/`isMounted`
- [x] `MCPReadOnlyModeTests`: write-scoped token clamped to read → write tool 403; write tools hidden from `tools/list`; read tools still succeed; discovery metadata reachable
- [x] `AdminMCPRoutesTests`: read_only mint caps token scope to `content:read`
- [x] `MCPEndToEndTests`: full-scope token lists read+write tools; read-scoped token hides write tools
- [x] `swift-format lint --strict` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)