### PR TITLE
Make the login-page Chickadee logo bigger (128 -> 200px)

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -767,9 +767,10 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
    cleanly on the page background in both light and dark mode. */
 .auth-logo {
     display: block;
-    width: 128px;
-    height: 128px;
-    margin: 0 auto .75rem;
+    width: 200px;
+    height: 200px;
+    max-width: 80%;
+    margin: 0 auto 1rem;
 }
 
 .auth-box h1 { margin-bottom: 1.5rem; }

--- a/Resources/Views/login.leaf
+++ b/Resources/Views/login.leaf
@@ -4,7 +4,7 @@ Log in
 #endexport
 #export("content"):
 <div class="auth-box">
-    <img class="auth-logo" src="/images/chickadee-icon-alt.png?v=#appVersion()" alt="" width="128" height="128">
+    <img class="auth-logo" src="/images/chickadee-icon-alt.png?v=#appVersion()" alt="" width="200" height="200">
     <h1>Log in to Chickadee</h1>
     #if(loggedOut && !error):
     <div class="notice-box" style="margin-bottom:1rem">

--- a/changelog.d/login-logo-bigger.md
+++ b/changelog.d/login-logo-bigger.md
@@ -1,0 +1,5 @@
+### Changed
+
+- **Bigger Chickadee logo on the login page** — bumped from 128px to 200px
+  (capped at 80% width on narrow screens). The source PNG is 1024px so it stays
+  crisp.


### PR DESCRIPTION
## Summary

The 128px logo felt small in the 420px login box. Bumped `.auth-logo` to **200px** (capped at 80% width on narrow screens so it never overflows). The source PNG is 1024×1024, so it stays crisp at this size — and could go larger still if wanted.

## Test plan

- [x] Existing `loginPageShowsChickadeeLogo` render test still passes (markup unchanged apart from dimensions)
- [ ] Visual confirmation on deploy (couldn't render locally — dev-server binary stalls behind a macOS first-run gate in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)