### PR TITLE
fix(alerts): runner-offline rule fires on runner absence, not queue depth

### DIFF
--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -14,10 +14,6 @@ Server Health Alerts
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>
 <section class="admin-section">
-    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
-        <h2 style="margin:0">Server Health Alerts</h2>
-    </div>
-
     #if(flashSuccess):
     <div class="flash flash-success" style="margin-bottom:1rem;padding:.6rem .8rem;border-radius:.4rem;background:#d4edda;color:#155724">#(flashSuccess)</div>
     #endif
@@ -72,7 +68,7 @@ Server Health Alerts
                 </td>
                 <td>
                     #if(rule.rule == "runnerOffline"):
-                        no heartbeat for #(runnerOfflineSeconds)s while jobs queued
+                        no runner heartbeat for #(runnerOfflineSeconds)s
                     #elseif(rule.rule == "queueBackedUp"):
                         ≥ #(queueDepthThreshold) pending OR oldest > #(oldestPendingSeconds)s
                     #elseif(rule.rule == "errorRateSpike"):

--- a/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
@@ -5,15 +5,10 @@ struct ServerHealthAlertConfiguration: Sendable {
     let enabled: Bool
     let checkIntervalSeconds: TimeInterval
     let cooldownSeconds: TimeInterval
-    /// Grace period for the urgent "work is waiting, nothing is processing it"
-    /// case: fire when jobs are queued and no runner has checked in within this
-    /// window.
+    /// Grace period for the runner-offline rule: fire when a runner we've seen
+    /// this session has not checked in within this window, regardless of whether
+    /// jobs are queued.
     let runnerOfflineSeconds: TimeInterval
-    /// Grace period for the proactive "a runner we've seen has gone quiet" case,
-    /// which fires even with an empty queue so capacity loss is caught before a
-    /// backlog forms. Longer than `runnerOfflineSeconds` because it's less
-    /// urgent than work actually waiting.
-    let runnerAbsentSeconds: TimeInterval
     let queueDepthThreshold: Int
     let oldestPendingSeconds: TimeInterval
     let errorRateThreshold: Double
@@ -26,7 +21,6 @@ struct ServerHealthAlertConfiguration: Sendable {
         checkIntervalSeconds: 60,
         cooldownSeconds: 1800,
         runnerOfflineSeconds: 300,
-        runnerAbsentSeconds: 600,
         queueDepthThreshold: 25,
         oldestPendingSeconds: 600,
         errorRateThreshold: 0.30,
@@ -41,7 +35,6 @@ struct ServerHealthAlertConfiguration: Sendable {
             checkIntervalSeconds: TimeInterval(environmentInt("ALERT_CHECK_INTERVAL_SECONDS") ?? 60),
             cooldownSeconds: TimeInterval(environmentInt("ALERT_COOLDOWN_SECONDS") ?? 1800),
             runnerOfflineSeconds: TimeInterval(environmentInt("ALERT_RUNNER_OFFLINE_SECONDS") ?? 300),
-            runnerAbsentSeconds: TimeInterval(environmentInt("ALERT_RUNNER_ABSENT_SECONDS") ?? 600),
             queueDepthThreshold: environmentInt("ALERT_QUEUE_DEPTH_THRESHOLD") ?? 25,
             oldestPendingSeconds: TimeInterval(environmentInt("ALERT_OLDEST_PENDING_SECONDS") ?? 600),
             errorRateThreshold: environmentDouble("ALERT_ERROR_RATE_THRESHOLD") ?? 0.30,

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -32,7 +32,6 @@ func evaluateHealthRules(
         on: application,
         pending: pendingState,
         offlineThreshold: configuration.runnerOfflineSeconds,
-        absentThreshold: configuration.runnerAbsentSeconds,
         now: now
     )
     results[.queueBackedUp] = evaluateQueueBackedUp(
@@ -71,60 +70,47 @@ private func loadPendingQueueState(on application: Application, now: Date) async
     return PendingQueueState(pendingCount: pendingCount, oldestPendingAge: oldestAge)
 }
 
-/// How long a silent-but-known runner stays "remembered" for the empty-queue
-/// proactive alert. Matches `WorkerActivityStore.snapshotsSortedByRecent`'s
-/// prune cutoff, so a runner is forgotten by the alert at the same moment the
-/// admin dashboard drops it.
+/// How long a silent-but-known runner stays "remembered" by the runner-offline
+/// alert. Matches `WorkerActivityStore.snapshotsSortedByRecent`'s prune cutoff,
+/// so a runner is forgotten by the alert (auto-resolving it) at the same moment
+/// the admin dashboard drops it.
 let runnerPresenceRememberSeconds: TimeInterval = 3600
 
 /// Runner presence as seen by the alert evaluator. Separated from the store so
 /// the firing decision is a pure, table-testable function.
 struct RunnerPresenceState: Sendable {
-    /// A runner checked in within the urgent (queue-backed) offline window.
+    /// A runner checked in within the offline window.
     let recentWithinOffline: Bool
-    /// A runner checked in within the longer proactive absence window.
-    let recentWithinAbsent: Bool
     /// We've seen at least one runner this session (still within the remember
-    /// window). Guards the empty-queue branch so a server with no runners
-    /// configured never pages.
+    /// window). Guards the rule so a server with no runners configured never
+    /// pages, and so a long-dead runner is forgotten (auto-resolves).
     let anyKnownRunner: Bool
 }
 
-/// Decides the runner-offline rule from queue + presence state.
-///
-/// Two cases, by queue state:
-/// - **Jobs queued:** urgent — fire if no runner checked in within
-///   `offlineSeconds` (work is waiting and nothing is processing it).
-/// - **Empty queue:** proactive — fire only if we've seen a runner this session
-///   and none has checked in within the longer `absentSeconds`, so capacity
-///   loss is caught before a backlog forms (and a runner-less deployment stays
-///   quiet).
+/// Decides the runner-offline rule purely from runner presence — queue state is
+/// not a gate. Fire when a runner we've seen this session has not checked in
+/// within `offlineSeconds`, regardless of whether jobs are waiting. The
+/// `anyKnownRunner` guard keeps a runner-less deployment quiet and lets a
+/// long-dead runner auto-resolve once it ages out of the remember window. The
+/// pending count is surfaced as context but never decides firing.
 func decideRunnerOffline(
     pending: PendingQueueState,
     presence: RunnerPresenceState,
-    offlineSeconds: TimeInterval,
-    absentSeconds: TimeInterval
+    offlineSeconds: TimeInterval
 ) -> RuleEvaluation {
-    if pending.pendingCount > 0 {
-        if presence.recentWithinOffline { return .ok }
-        return RuleEvaluation(
-            isFiring: true,
-            summary: "No runner heartbeat in \(Int(offlineSeconds))s; \(pending.pendingCount) submission(s) pending",
-            details: [
-                "pending_count": String(pending.pendingCount),
-                "runner_offline_threshold_seconds": String(Int(offlineSeconds)),
-                "oldest_pending_age_seconds": pending.oldestPendingAge.map { String(Int($0)) } ?? "n/a",
-            ]
-        )
+    guard presence.anyKnownRunner, !presence.recentWithinOffline else { return .ok }
+    var details: [String: String] = [
+        "pending_count": String(pending.pendingCount),
+        "runner_offline_threshold_seconds": String(Int(offlineSeconds)),
+    ]
+    if let age = pending.oldestPendingAge {
+        details["oldest_pending_age_seconds"] = String(Int(age))
     }
-    guard presence.anyKnownRunner, !presence.recentWithinAbsent else { return .ok }
+    let pendingNote = pending.pendingCount > 0 ? "; \(pending.pendingCount) submission(s) pending" : ""
     return RuleEvaluation(
         isFiring: true,
-        summary: "No runner has checked in for \(Int(absentSeconds))s (queue empty — proactive capacity warning)",
-        details: [
-            "pending_count": "0",
-            "runner_absent_threshold_seconds": String(Int(absentSeconds)),
-        ]
+        summary: "No runner heartbeat in \(Int(offlineSeconds))s\(pendingNote)",
+        details: details
     )
 }
 
@@ -132,26 +118,21 @@ private func evaluateRunnerOffline(
     on application: Application,
     pending: PendingQueueState,
     offlineThreshold: TimeInterval,
-    absentThreshold: TimeInterval,
     now: Date
 ) async -> RuleEvaluation {
-    let store = application.workerActivityStore
-    let recentWithinOffline = await store.hasRecentActivity(within: offlineThreshold, now: now)
-    let presence = await store.runnerPresence(
-        graceSeconds: absentThreshold,
-        rememberSeconds: max(runnerPresenceRememberSeconds, absentThreshold),
+    let presence = await application.workerActivityStore.runnerPresence(
+        graceSeconds: offlineThreshold,
+        rememberSeconds: runnerPresenceRememberSeconds,
         now: now
     )
     let state = RunnerPresenceState(
-        recentWithinOffline: recentWithinOffline,
-        recentWithinAbsent: presence.anyRecent,
+        recentWithinOffline: presence.anyRecent,
         anyKnownRunner: presence.anyKnown
     )
     return decideRunnerOffline(
         pending: pending,
         presence: state,
-        offlineSeconds: offlineThreshold,
-        absentSeconds: absentThreshold
+        offlineSeconds: offlineThreshold
     )
 }
 

--- a/Tests/APITests/ServerHealthAlertTests.swift
+++ b/Tests/APITests/ServerHealthAlertTests.swift
@@ -154,67 +154,62 @@ import Testing
         #expect(abs(config.errorRateThreshold - 0.30) < 0.001)
         #expect(config.cooldownSeconds == 1800)
         #expect(config.runnerOfflineSeconds == 300)
-        #expect(config.runnerAbsentSeconds == 600)
     }
 
-    // MARK: - Runner offline / absent rule
+    // MARK: - Runner offline rule
 
-    private func presence(offline: Bool, absent: Bool, known: Bool) -> RunnerPresenceState {
-        RunnerPresenceState(recentWithinOffline: offline, recentWithinAbsent: absent, anyKnownRunner: known)
+    private func presence(offline: Bool, known: Bool) -> RunnerPresenceState {
+        RunnerPresenceState(recentWithinOffline: offline, anyKnownRunner: known)
     }
 
     @Test func runnerOffline_firesWhenJobsQueuedAndNoRecentRunner() {
         let evaluation = decideRunnerOffline(
             pending: PendingQueueState(pendingCount: 3, oldestPendingAge: 120),
-            presence: presence(offline: false, absent: false, known: true),
-            offlineSeconds: 300,
-            absentSeconds: 600
+            presence: presence(offline: false, known: true),
+            offlineSeconds: 300
         )
         #expect(evaluation.isFiring)
         #expect(evaluation.details["pending_count"] == "3")
     }
 
-    @Test func runnerOffline_okWhenJobsQueuedButRunnerRecent() {
+    @Test func runnerOffline_okWhenRunnerRecent() {
         let evaluation = decideRunnerOffline(
             pending: PendingQueueState(pendingCount: 3, oldestPendingAge: 10),
-            presence: presence(offline: true, absent: true, known: true),
-            offlineSeconds: 300,
-            absentSeconds: 600
+            presence: presence(offline: true, known: true),
+            offlineSeconds: 300
         )
         #expect(evaluation.isFiring == false)
     }
 
-    @Test func runnerAbsent_firesWithEmptyQueueWhenKnownRunnerGoesQuiet() {
-        // The proactive case: queue is empty, but a runner we've seen this
-        // session hasn't checked in within the absent grace period.
+    @Test func runnerOffline_firesWithEmptyQueueWhenKnownRunnerGoesQuiet() {
+        // Queue state is not a gate: a runner we've seen this session that has
+        // gone quiet past the offline grace fires even with nothing pending.
         let evaluation = decideRunnerOffline(
             pending: .empty,
-            presence: presence(offline: false, absent: false, known: true),
-            offlineSeconds: 300,
-            absentSeconds: 600
+            presence: presence(offline: false, known: true),
+            offlineSeconds: 300
         )
         #expect(evaluation.isFiring)
-        #expect(evaluation.details["runner_absent_threshold_seconds"] == "600")
+        #expect(evaluation.details["pending_count"] == "0")
+        #expect(evaluation.details["runner_offline_threshold_seconds"] == "300")
     }
 
-    @Test func runnerAbsent_okWithEmptyQueueWhenRunnerStillChecksIn() {
+    @Test func runnerOffline_okWithEmptyQueueWhenRunnerStillChecksIn() {
         let evaluation = decideRunnerOffline(
             pending: .empty,
-            presence: presence(offline: true, absent: true, known: true),
-            offlineSeconds: 300,
-            absentSeconds: 600
+            presence: presence(offline: true, known: true),
+            offlineSeconds: 300
         )
         #expect(evaluation.isFiring == false)
     }
 
-    @Test func runnerAbsent_okWithEmptyQueueWhenNoRunnerEverConnected() {
+    @Test func runnerOffline_okWhenNoRunnerEverConnected() {
         // A deployment with no runners (e.g. browser-graded only) must not page
         // forever just because the store is empty.
         let evaluation = decideRunnerOffline(
             pending: .empty,
-            presence: presence(offline: false, absent: false, known: false),
-            offlineSeconds: 300,
-            absentSeconds: 600
+            presence: presence(offline: false, known: false),
+            offlineSeconds: 300
         )
         #expect(evaluation.isFiring == false)
     }

--- a/changelog.d/runner-offline-alert-queue-agnostic.md
+++ b/changelog.d/runner-offline-alert-queue-agnostic.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Runner-offline alert no longer depends on the queue.** The runner-offline
+  health rule now fires whenever a runner we've seen this session stops checking
+  in for `ALERT_RUNNER_OFFLINE_SECONDS` (default 300s), regardless of whether
+  any submissions are pending. It still stays quiet on a runner-less deployment
+  and auto-resolves once a long-dead runner ages out of the dashboard window.
+  This collapses the previous two-mode (urgent-while-queued vs. proactive-while-
+  empty) design and removes the now-unused `ALERT_RUNNER_ABSENT_SECONDS` setting.
+  The admin Health Alerts page reflects the new threshold wording.


### PR DESCRIPTION
## Summary
- The runner-offline health rule now fires whenever a runner we've seen this session stops checking in for `ALERT_RUNNER_OFFLINE_SECONDS` (default 300s), **regardless of whether jobs are queued**. This restores the originally-intended "alert when a runner is down" behavior.
- Collapses the previous two-mode design (urgent-while-queued at 300s vs. proactive-while-empty at 600s) into one rule and removes the now-unused `ALERT_RUNNER_ABSENT_SECONDS` setting.
- The `anyKnownRunner` guard is retained, so a runner-less deployment never pages and a long-dead runner auto-resolves once it ages out of the dashboard's 1-hour remember window. Pending count is surfaced as context in the alert but no longer gates firing.
- Admin **Health Alerts** page updated: threshold reads "no runner heartbeat for {n}s" and the redundant "Server Health Alerts" panel header was removed.

## Background
PR #691 (v0.4.242) had made the rule fire proactively on an empty queue by *adding* a second branch rather than removing the jobs-queued conditional, and the admin UI was never updated to reflect it. This change finishes that intent and re-syncs the UI.

## Test plan
- [x] `swift build --target APIServer` (clean off `main`)
- [x] `swift test --filter ServerHealthAlert` — 25/25 pass (`decideRunnerOffline` decision table updated to single-mode)
- [ ] CI green