### PR TITLE
Remove the "scheduled" assignment status badge

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -900,11 +900,6 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     color: var(--closed-fg);
 }
 
-.tier-scheduled {
-    background: #fff3d6;
-    color: #8a5a00;
-}
-
 .tier-unpublished {
     background: var(--gray-100);
     color: var(--gray-600);

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -58,7 +58,6 @@
                 <span class="tier
                     #if(setup.status == "open"):tier-open
                     #elseif(setup.status == "closed"):tier-closed
-                    #elseif(setup.status == "scheduled"):tier-scheduled
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
             </td>
@@ -162,7 +161,6 @@
                 <span class="tier
                     #if(setup.status == "open"):tier-open
                     #elseif(setup.status == "closed"):tier-closed
-                    #elseif(setup.status == "scheduled"):tier-scheduled
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
             </td>
@@ -266,7 +264,6 @@
                 <span class="tier
                     #if(setup.status == "open"):tier-open
                     #elseif(setup.status == "closed"):tier-closed
-                    #elseif(setup.status == "scheduled"):tier-scheduled
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
             </td>

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -23,10 +23,11 @@ struct TestSetupRow: Encodable {
     let suiteCount: Int
     let createdAt: String
     let dueAt: String?  // formatted due date, nil if no assignment or no due date
-    /// Formatted automatic open date, set only while the assignment is still
-    /// "scheduled" (start date in the future). nil once open or never scheduled.
+    /// Formatted automatic open date, set only while the start date is still
+    /// in the future. Drives the "Opens …" hint in the Due column; nil once
+    /// the assignment has opened or when no open date is set.
     let opensAtText: String?
-    let status: String  // "unpublished" | "open" | "closed" | "scheduled"
+    let status: String  // "unpublished" | "open" | "closed"
     let isOpen: Bool
     /// True when the Edit link should be shown: the assignment is open for
     /// this user, OR it is closed but the student has previously opened it

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -318,17 +318,16 @@ struct WebRoutes: RouteCollection {
             let assignment = assignmentBySetup[setupID]
             let latestSubmission = latestSubmissionBySetupID[setupID]
             let submissionCount = submissionCountBySetupID[setupID] ?? 0
+            // A future open date drives the "Opens …" hint in the Due column,
+            // but not a distinct status — every assignment is scheduled, so a
+            // "scheduled" badge would add no signal.
             let notYetOpen: Bool = {
                 guard let assignment, let startsAt = assignment.startsAt else { return false }
                 return Date() < startsAt
             }()
             let status: String
             if let assignment {
-                if notYetOpen {
-                    status = "scheduled"
-                } else {
-                    status = assignment.isOpen ? "open" : "closed"
-                }
+                status = assignment.isOpen ? "open" : "closed"
             } else {
                 status = "unpublished"
             }

--- a/changelog.d/remove-scheduled-status.md
+++ b/changelog.d/remove-scheduled-status.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **Dropped the "scheduled" assignment status badge.** A future open date no
+  longer renders a distinct `scheduled` status on the dashboard — every
+  assignment is scheduled, so the badge added no signal. The "Opens …" hint in
+  the Due column is unchanged.


### PR DESCRIPTION
## Summary
Follow-up to the assignment open-date feature (#736).

- Removes the distinct **`scheduled`** status from the dashboard (`index.leaf`, `WebRoutes`, `.tier-scheduled` CSS). Every assignment is scheduled, so the badge added no signal — a not-yet-open assignment now shows its normal open/closed status.
- **Keeps** the **"Opens …"** hint in the Due column (unchanged).
- The auto-open sweep, instructor edit/create inputs, and MCP support are untouched.

## Test plan
- [x] `swift build` clean; SwiftLint `--strict` → 0 violations
- [x] No remaining references to the `scheduled` status / `.tier-scheduled`
- [x] "Opens …" Due-column text retained in all three dashboard table variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)