### PR TITLE
Rework admin Retention tab and tidy Overview

### DIFF
--- a/Resources/Views/admin-retention.leaf
+++ b/Resources/Views/admin-retention.leaf
@@ -14,10 +14,6 @@ Retention
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>
 <section class="admin-section">
-    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
-        <h2 style="margin:0">Submission Retention</h2>
-    </div>
-
     #if(flashSuccess):
     <div class="flash flash-success" role="status" style="margin-bottom:1rem;padding:.6rem .8rem;border-radius:.4rem;background:#d4edda;color:#155724">#(flashSuccess)</div>
     #endif
@@ -26,57 +22,67 @@ Retention
     #endif
 
     <p style="color:var(--muted);margin-top:0">
-        Student submissions are retained for #(retentionDays) days after a
-        course is archived — archiving marks the end of term (FIPPA /
-        UWaterloo&nbsp;TL55). After that window an admin may purge the
-        submissions here. Grades themselves are not retained in Chickadee
-        long-term: they flow to LEARN for TL60 retention. Purging removes
-        submission files and their results from this server; courses,
-        assignments, test suites, and user accounts are left intact.
-        <strong>Purging cannot be undone.</strong>
+        Archived courses can be restored at any time. #(retentionDays) days
+        after a course is archived, an admin may permanently delete it and all
+        its data. <strong>Deletion cannot be undone.</strong>
     </p>
 
     #if(rows.isEmpty):
     <p style="color:var(--muted)">No archived courses. The retention clock starts when a course is archived.</p>
     #else:
-    <p style="color:var(--muted)">
-        #if(purgeableCount > 0):#(purgeableCount) course(s) past retention and eligible to purge.#else:No courses are past their retention window yet.#endif
-    </p>
-    <table class="results-table">
+    #if(deletableCount > 0):
+    <p style="color:var(--muted)">#(deletableCount) course(s) past retention and eligible to delete.</p>
+    #endif
+    <table class="results-table sortable-table">
         <thead>
             <tr>
-                <th>Code</th>
-                <th>Name</th>
-                <th style="width:11rem">Archived</th>
-                <th style="width:7rem">Submissions</th>
-                <th style="width:11rem">Purge eligible</th>
-                <th style="width:8rem">Action</th>
+                <th data-sort-type="text"><button class="sort-header" type="button">Code</button></th>
+                <th data-sort-type="text"><button class="sort-header" type="button">Name</button></th>
+                <th data-sort-type="date" style="width:11rem"><button class="sort-header" type="button">Archived</button></th>
+                <th data-sort-type="number" style="width:7rem"><button class="sort-header" type="button">Submissions</button></th>
+                <th data-sort-type="date" style="width:11rem"><button class="sort-header" type="button">Delete eligible</button></th>
+                <th style="width:11rem">Action</th>
             </tr>
         </thead>
         <tbody>
             #for(row in rows):
-            <tr class="#if(row.isPurgeable):status-closed#else:status-open#endif">
+            <tr class="#if(row.isDeletable):status-closed#else:status-open#endif">
                 <td><a href="/admin/courses/#(row.id)"><strong>#(row.code)</strong></a></td>
                 <td>#(row.name)</td>
-                <td style="font-size:.85rem">#(row.archivedAt)</td>
+                <td style="font-size:.85rem" data-sort-value="#(row.archivedAtISO)">#(row.archivedAt)</td>
                 <td>#(row.submissionCount)</td>
-                <td style="font-size:.85rem">
-                    #if(row.isPurgeable):
+                <td style="font-size:.85rem" data-sort-value="#(row.purgeEligibleAtISO)">
+                    #if(row.isDeletable):
                     <span class="tier tier-closed">eligible</span>
                     #else:
                     #(row.purgeEligibleAt)
                     #endif
                 </td>
                 <td>
-                    #if(row.isPurgeable):
-                    <form method="post" action="/admin/courses/#(row.id)/purge-submissions" style="display:inline;margin:0">
-                        #csrfFormField()
-                        <button class="btn action-btn action-danger" type="submit"
-                                onclick="return confirm('Permanently delete all #(row.submissionCount) submission(s) for #(row.code)? This cannot be undone.')">Purge</button>
-                    </form>
-                    #else:
-                    <span style="color:var(--muted)">—</span>
-                    #endif
+                    <div style="display:flex;gap:.4rem;flex-wrap:nowrap">
+                        <form method="post" action="/admin/courses/#(row.id)/archive" style="display:inline;margin:0">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    title="Restore course" aria-label="Restore course" style="padding:.3rem .45rem"
+                                    onclick="return confirm('Restore #(row.code)? Students will be able to see it again and its retention clock resets.')">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                            </button>
+                        </form>
+                        <a class="btn action-btn" href="/admin/courses/#(row.id)/export"
+                           title="Export course bundle" aria-label="Export course bundle" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        </a>
+                        #if(row.isDeletable):
+                        <form method="post" action="/admin/courses/#(row.id)/delete" style="display:inline;margin:0">
+                            #csrfFormField()
+                            <button class="btn action-btn action-danger" type="submit"
+                                    title="Delete course" aria-label="Delete course" style="padding:.3rem .45rem"
+                                    onclick="return confirm('Permanently delete #(row.code) and ALL its data — course, assignments, test suites, and submissions? This cannot be undone.')">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                            </button>
+                        </form>
+                        #endif
+                    </div>
                 </td>
             </tr>
             #endfor
@@ -84,5 +90,6 @@ Retention
     </table>
     #endif
 </section>
+<script src="/sortable-table.js?v=#appVersion()"></script>
 #endexport
 #endextend

--- a/Resources/Views/admin-storage.leaf
+++ b/Resources/Views/admin-storage.leaf
@@ -14,8 +14,7 @@ Storage
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>
 <section class="admin-section admin-diagnostics">
-    <div style="display:flex;align-items:baseline;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
-        <h2 style="margin:0">Storage</h2>
+    <div style="display:flex;align-items:baseline;justify-content:flex-end;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
         <span style="color:var(--gray-600);font-size:.85rem">Total: #(storage.totalFormatted) · DB: #(storage.dbBackend)</span>
     </div>
     <div class="diagnostics-cards">

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -14,8 +14,7 @@ Users
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>
 </nav>
 <section class="admin-section">
-    <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
-        <h2 style="margin:0">Users</h2>
+    <div style="display:flex;align-items:center;justify-content:flex-end;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
         <input id="users-filter" class="form-input" type="search" autocomplete="off"
                placeholder="Filter by name, username or role…"
                style="width:280px" aria-label="Filter users"

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -40,19 +40,7 @@ Admin
 
 <section class="admin-section">
     <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
-        <div style="display:flex;align-items:center;gap:.75rem">
-            <h2 style="margin:0">Runners</h2>
-            <form method="post" action="/admin/runner-autostart" style="display:flex;align-items:center;gap:.4rem">
-                #csrfFormField()
-                <label style="display:inline-flex;align-items:center;gap:.4rem;white-space:nowrap;font-size:.875rem;cursor:pointer">
-                    <input type="checkbox"
-                           name="localRunnerAutoStart"
-                           #if(localRunnerAutoStartEnabled):checked#endif>
-                    Auto-start local
-                </label>
-                <button class="btn" type="submit" style="font-size:.8rem;padding:.2rem .5rem">Save</button>
-            </form>
-        </div>
+        <h2 style="margin:0">Runners</h2>
         <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
             <form method="post" action="/admin/runner-secret" style="display:flex;gap:.5rem;align-items:center">
                 #csrfFormField()
@@ -139,44 +127,19 @@ Admin
             <tr>
                 <th data-sort-key="code" data-sort-type="text" tabindex="0" aria-sort="none">Code</th>
                 <th data-sort-key="name" data-sort-type="text" tabindex="0" aria-sort="none">Name</th>
-                <th data-sort-key="students" data-sort-type="text" tabindex="0" aria-sort="none">Students</th>
-                <th data-sort-key="status" data-sort-type="text" tabindex="0" aria-sort="none">Status</th>
+                <th data-sort-key="students" data-sort-type="number" tabindex="0" aria-sort="none">Students</th>
+                <th data-sort-key="submissions" data-sort-type="number" tabindex="0" aria-sort="none">Submissions</th>
                 <th>Actions</th>
             </tr>
         </thead>
         <tbody>
         #for(course in courses):
-            <tr class="#if(course.isArchived):status-closed#else:status-open#endif">
+            <tr class="status-open">
                 <td><a href="/admin/courses/#(course.id)"><strong>#(course.code)</strong></a></td>
                 <td>#(course.name)</td>
                 <td>#(course.enrollmentCount)</td>
-                <td>
-                    #if(course.isArchived):
-                    <span class="tier tier-closed">archived</span>
-                    #else:
-                    <span class="tier tier-open">active</span>
-                    #endif
-                </td>
+                <td>#(course.submissionCount)</td>
                 <td style="display:flex;gap:.4rem;flex-wrap:wrap;align-items:center">
-                    #if(course.isArchived):
-                    <a class="btn action-btn" href="/admin/courses/#(course.id)/export"
-                       title="Export course" aria-label="Export course" style="padding:.3rem .45rem">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-                    </a>
-                    <form method="post" action="/admin/courses/#(course.id)/delete" style="display:inline;margin:0">
-                        #csrfFormField()
-                        <button class="btn action-btn action-danger" type="submit"
-                                title="Delete course" aria-label="Delete course" style="padding:.3rem .45rem"
-                                onclick="return confirm('Permanently delete #(course.code) and all its data? This cannot be undone.')">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
-                        </button>
-                    </form>
-                    <form method="post" action="/admin/courses/#(course.id)/archive" style="display:inline;margin:0">
-                        #csrfFormField()
-                        <button class="btn action-btn" type="submit"
-                                onclick="return confirm('Unarchive #(course.code)? Students will be able to see it again.')">Unarchive</button>
-                    </form>
-                    #else:
                     <form method="post" action="/admin/courses/#(course.id)/copy" style="display:inline;margin:0">
                         #csrfFormField()
                         <button class="btn action-btn" type="submit"
@@ -193,7 +156,6 @@ Admin
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>
                         </button>
                     </form>
-                    #endif
                 </td>
             </tr>
         #endfor

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -39,6 +39,7 @@ struct AdminCourseRow: Encodable {
     let enrollmentMode: String
     let enrollmentCount: Int
     let assignmentCount: Int
+    let submissionCount: Int
     let createdAt: String
     var brightspaceOrgUnitID: String?
     var brightspaceSyncEnabled: Bool
@@ -128,7 +129,6 @@ struct AdminContext: Encodable {
     let activeAdminTab: String
     let workers: [AdminWorkerRow]
     let workerSecret: String
-    let localRunnerAutoStartEnabled: Bool
     let courses: [AdminCourseRow]
     let version: String
 }
@@ -287,12 +287,17 @@ struct AdminRetentionRow: Encodable {
     let name: String
     /// Formatted archival timestamp, or "—" if unknown (legacy rows).
     let archivedAt: String
+    /// ISO archival timestamp for client-side date sorting ("" if unknown).
+    let archivedAtISO: String
     /// Formatted `archivedAt + retentionDays`, or "—" if archival is unknown.
     let purgeEligibleAt: String
+    /// ISO purge-eligible timestamp for client-side date sorting ("" if unknown).
+    let purgeEligibleAtISO: String
     let submissionCount: Int
-    /// True once the retention window has elapsed — the Purge button is only
-    /// rendered (and the server only honours a purge) when this is true.
-    let isPurgeable: Bool
+    /// True once the retention window has elapsed — the Delete button is only
+    /// rendered (and the server only honours a delete) when this is true.
+    /// Restore (unarchive) is offered regardless of this flag.
+    let isDeletable: Bool
 }
 
 struct AdminRetentionContext: Encodable {
@@ -300,8 +305,9 @@ struct AdminRetentionContext: Encodable {
     let activeAdminTab: String
     let retentionDays: Int
     let rows: [AdminRetentionRow]
-    /// How many of `rows` are currently purgeable (drives the summary line).
-    let purgeableCount: Int
+    /// How many of `rows` are currently past the retention window and eligible
+    /// for permanent deletion (drives the summary line).
+    let deletableCount: Int
     let flashSuccess: String?
     let flashError: String?
 }

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -21,6 +21,7 @@ extension AdminRoutes {
             enrollmentMode: CourseEnrollmentMode.open.rawValue,
             enrollmentCount: 0,
             assignmentCount: 0,
+            submissionCount: 0,
             createdAt: "",
             brightspaceOrgUnitID: nil,
             brightspaceSyncEnabled: req.application.brightSpaceClient != nil
@@ -199,8 +200,21 @@ extension AdminRoutes {
             let courseID = UUID(uuidString: idString),
             let course = try await APICourse.find(courseID, on: req.db)
         else { throw Abort(.notFound) }
-        guard course.isArchived else {
-            throw AppError.badRequest(reason: "Only archived courses can be deleted.")
+
+        // Deletion is gated on the same retention window as Purge: a course
+        // can only be deleted from the Retention tab once it has been archived
+        // and its retention window has elapsed. Never trust the posting page.
+        let retentionDays = req.application.appConfig.diagnostics.submissionRetentionDays
+        guard course.isArchived, let archivedAt = course.archivedAt else {
+            return req.redirect(
+                to: retentionRedirect(error: "\(course.code) is not archived — cannot delete."))
+        }
+        let eligibleAt = SubmissionRetentionService.purgeEligibleDate(
+            archivedAt: archivedAt, retentionDays: retentionDays)
+        guard Date() >= eligibleAt else {
+            return req.redirect(
+                to: retentionRedirect(
+                    error: "\(course.code) is not yet past its retention window."))
         }
 
         let setupsDir = req.application.testSetupsDirectory
@@ -249,7 +263,8 @@ extension AdminRoutes {
         }
 
         req.logger.info("Admin permanently deleted course \(course.code) (\(idString))")
-        return req.redirect(to: "/admin")
+        return req.redirect(
+            to: retentionRedirect(ok: "Deleted \(course.code) and all its data."))
     }
 
     // MARK: - POST /admin/courses/:courseID/edit
@@ -332,6 +347,8 @@ extension AdminRoutes {
         async let assignmentCountFetch = APIAssignment.query(on: req.db)
             .filter(\.$courseID == courseID)
             .count()
+        async let submissionCountFetch = SubmissionRetentionService.submissionCountsByCourse(
+            courseIDs: [courseID], on: req.db)
         let courseRow = AdminCourseRow(
             id: idString,
             code: course.code,
@@ -340,6 +357,7 @@ extension AdminRoutes {
             enrollmentMode: course.enrollmentMode.rawValue,
             enrollmentCount: try await enrollmentCountFetch,
             assignmentCount: try await assignmentCountFetch,
+            submissionCount: (try await submissionCountFetch)[courseID] ?? 0,
             createdAt: course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—",
             brightspaceOrgUnitID: course.brightspaceOrgUnitID,
             brightspaceSyncEnabled: req.application.brightSpaceClient != nil

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Retention.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Retention.swift
@@ -1,13 +1,15 @@
 // APIServer/Routes/Web/AdminRoutes+Retention.swift
 //
-// Admin "Retention" tab: a report-first view of the submission-retention
-// policy (student submissions purged one year after a course is archived,
-// per FIPPA / UWaterloo TL55).  Lists every archived course with its
-// archival date, the date its submissions become purgeable, and a manual
-// Purge action that only the admin can trigger and only once the retention
-// window has elapsed.  Nothing here deletes automatically.
+// Admin "Retention" tab: a report-first view of archived courses (FIPPA /
+// UWaterloo TL55 retention — student submissions are personal information
+// kept one year after the end of term, signalled here by archiving).  Lists
+// every archived course with its archival date and the date it becomes
+// eligible for permanent deletion.  Each row can be Restored (unarchived) at
+// any time; once the retention window has elapsed it can also be permanently
+// Deleted.  Nothing here deletes automatically.
 //
-// Routes are registered in AdminRoutes.boot().
+// The Restore and Delete actions reuse the course endpoints registered in
+// AdminRoutes.boot() (`/archive` toggle and `/delete`).
 
 import Core
 import Fluent
@@ -38,14 +40,15 @@ extension AdminRoutes {
 
         let now = Date()
         let df = waterlooDateTimeFormatter()
+        let iso = ISO8601DateFormatter()
 
-        // Build (course, status) pairs so we can sort by purgeability before
-        // mapping to the formatted row shape.
+        // Build (course, status) pairs so we can sort by delete-eligibility
+        // before mapping to the formatted row shape.
         struct Entry {
             let course: APICourse
             let archivedAt: Date?
             let eligibleAt: Date?
-            let isPurgeable: Bool
+            let isDeletable: Bool
             let count: Int
         }
         let entries: [Entry] = archivedCourses.compactMap { course in
@@ -54,17 +57,17 @@ extension AdminRoutes {
             guard let archivedAt = course.archivedAt else {
                 return Entry(
                     course: course, archivedAt: nil, eligibleAt: nil,
-                    isPurgeable: false, count: count)
+                    isDeletable: false, count: count)
             }
             let eligibleAt = SubmissionRetentionService.purgeEligibleDate(
                 archivedAt: archivedAt, retentionDays: retentionDays)
             return Entry(
                 course: course, archivedAt: archivedAt, eligibleAt: eligibleAt,
-                isPurgeable: now >= eligibleAt, count: count)
+                isDeletable: now >= eligibleAt, count: count)
         }
         .sorted { lhs, rhs in
-            // Purgeable courses first, then soonest-eligible, then by code.
-            if lhs.isPurgeable != rhs.isPurgeable { return lhs.isPurgeable }
+            // Delete-eligible courses first, then soonest-eligible, then by code.
+            if lhs.isDeletable != rhs.isDeletable { return lhs.isDeletable }
             switch (lhs.eligibleAt, rhs.eligibleAt) {
             case (let l?, let r?) where l != r: return l < r
             case (.some, .none): return true
@@ -80,9 +83,11 @@ extension AdminRoutes {
                 code: entry.course.code,
                 name: entry.course.name,
                 archivedAt: entry.archivedAt.map { df.string(from: $0) } ?? "—",
+                archivedAtISO: entry.archivedAt.map { iso.string(from: $0) } ?? "",
                 purgeEligibleAt: entry.eligibleAt.map { df.string(from: $0) } ?? "—",
+                purgeEligibleAtISO: entry.eligibleAt.map { iso.string(from: $0) } ?? "",
                 submissionCount: entry.count,
-                isPurgeable: entry.isPurgeable
+                isDeletable: entry.isDeletable
             )
         }
 
@@ -91,64 +96,15 @@ extension AdminRoutes {
             activeAdminTab: "retention",
             retentionDays: retentionDays,
             rows: rows,
-            purgeableCount: rows.filter { $0.isPurgeable }.count,
+            deletableCount: rows.filter { $0.isDeletable }.count,
             flashSuccess: flash.ok,
             flashError: flash.error
         )
         return try await req.view.render("admin-retention", ctx)
     }
-
-    // MARK: - POST /admin/courses/:courseID/purge-submissions
-
-    @Sendable
-    func purgeCourseSubmissions(req: Request) async throws -> Response {
-        guard
-            let idString = req.parameters.get("courseID"),
-            let courseID = UUID(uuidString: idString),
-            let course = try await APICourse.find(courseID, on: req.db)
-        else {
-            throw Abort(.notFound)
-        }
-
-        let retentionDays = req.application.appConfig.diagnostics.submissionRetentionDays
-
-        // Server-side eligibility guard. Never trust the page that posted
-        // here: a purge is only honoured for an archived course whose
-        // retention window has actually elapsed.
-        guard course.isArchived, let archivedAt = course.archivedAt else {
-            return req.redirect(
-                to: retentionRedirect(error: "\(course.code) is not archived — cannot purge."))
-        }
-        let eligibleAt = SubmissionRetentionService.purgeEligibleDate(
-            archivedAt: archivedAt, retentionDays: retentionDays)
-        guard Date() >= eligibleAt else {
-            return req.redirect(
-                to: retentionRedirect(
-                    error: "\(course.code) is not yet past its retention window."))
-        }
-
-        let deleted = try await SubmissionRetentionService.purgeSubmissions(
-            forCourseID: courseID, on: req.db)
-        req.logger.info(
-            "Admin purged \(deleted) submission(s) for archived course \(course.code) (\(idString)) under retention policy"
-        )
-        await AuditLogger.record(
-            action: .submissionsPurged,
-            targetType: .course,
-            targetID: idString,
-            metadata: [
-                "course_code": course.code,
-                "submissions_deleted": String(deleted),
-                "retention_days": String(retentionDays),
-            ],
-            on: req
-        )
-        return req.redirect(
-            to: retentionRedirect(ok: "Purged \(deleted) submission(s) for \(course.code)."))
-    }
 }
 
-private func retentionRedirect(ok: String? = nil, error: String? = nil) -> String {
+func retentionRedirect(ok: String? = nil, error: String? = nil) -> String {
     var pairs: [String] = []
     if let okValue = ok?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
         pairs.append("ok=\(okValue)")

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -41,7 +41,6 @@ struct AdminRoutes: RouteCollection {
         admin.post("courses", ":courseID", "archive", use: toggleCourseArchive)
         admin.post("courses", ":courseID", "copy", use: copyCourse)
         admin.post("courses", ":courseID", "delete", use: deleteCourse)
-        admin.post("courses", ":courseID", "purge-submissions", use: purgeCourseSubmissions)
         admin.post("courses", ":courseID", "enrollment-mode", use: setEnrollmentMode)
         admin.post("courses", ":courseID", "enroll-csv", use: adminBulkEnrollCSV)
         admin.post("courses", ":courseID", "unenroll", ":userID", use: unenrollUserFromCourse)
@@ -63,7 +62,6 @@ struct AdminRoutes: RouteCollection {
     func dashboard(req: Request) async throws -> View {
         let workerRows = try await makeWorkerRows(req: req)
         let effectiveSecret = await req.application.workerSecretStore.effectiveSecret() ?? ""
-        let localRunnerAutoStartEnabled = await req.application.localRunnerAutoStartStore.isEnabled()
 
         // Course management data — all three queries are independent so run in parallel.
         async let coursesFetch = APICourse.query(on: req.db).sort(\.$createdAt).all()
@@ -71,9 +69,15 @@ struct AdminRoutes: RouteCollection {
         async let assignmentsFetch = assignmentCountsByCourse(on: req.db)
         let (allCourses, enrollmentCounts, assignmentCounts) =
             try await (coursesFetch, enrollmentsFetch, assignmentsFetch)
+        // Submission counts need the (active) course IDs, so they run after the
+        // course fetch resolves.
+        let activeCourseIDs = allCourses.filter { !$0.isArchived }.compactMap { $0.id }
+        let submissionCounts = try await SubmissionRetentionService.submissionCountsByCourse(
+            courseIDs: activeCourseIDs, on: req.db)
         let bsSyncEnabled = req.application.brightSpaceClient != nil
+        // Archived courses move out of Overview and live on the Retention tab.
         let courseRows = allCourses.compactMap { course -> AdminCourseRow? in
-            guard let id = course.id else { return nil }
+            guard let id = course.id, !course.isArchived else { return nil }
             return AdminCourseRow(
                 id: id.uuidString,
                 code: course.code,
@@ -82,6 +86,7 @@ struct AdminRoutes: RouteCollection {
                 enrollmentMode: course.enrollmentMode.rawValue,
                 enrollmentCount: enrollmentCounts[id] ?? 0,
                 assignmentCount: assignmentCounts[id] ?? 0,
+                submissionCount: submissionCounts[id] ?? 0,
                 createdAt: course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—",
                 brightspaceOrgUnitID: course.brightspaceOrgUnitID,
                 brightspaceSyncEnabled: bsSyncEnabled
@@ -93,7 +98,6 @@ struct AdminRoutes: RouteCollection {
             activeAdminTab: "overview",
             workers: workerRows,
             workerSecret: effectiveSecret,
-            localRunnerAutoStartEnabled: localRunnerAutoStartEnabled,
             courses: courseRows,
             version: ChickadeeVersion.current
         )

--- a/Sources/APIServer/Services/SubmissionRetentionService.swift
+++ b/Sources/APIServer/Services/SubmissionRetentionService.swift
@@ -1,20 +1,22 @@
 // APIServer/Services/SubmissionRetentionService.swift
 //
-// Submission-retention policy: student submissions are kept for one year
-// (the SUBMISSION_RETENTION_DAYS window) after the END OF TERM, then purged.
-// Chickadee has no term/semester concept, so "end of term" is signalled by
-// archiving the course — the retention clock starts at `APICourse.archivedAt`.
+// Submission-retention policy: a course's data is kept for one year
+// (the SUBMISSION_RETENTION_DAYS window) after the END OF TERM, then becomes
+// eligible for permanent deletion. Chickadee has no term/semester concept, so
+// "end of term" is signalled by archiving the course — the retention clock
+// starts at `APICourse.archivedAt`.
 //
 // This is FIPPA / UWaterloo TL55 retention: assignments (submissions) are
 // personal information that must be retained for one year after term end and
 // then disposed of. Grades themselves are not kept here long-term — they flow
 // to LEARN (D2L) for TL60 retention via BrightSpaceGradeSyncService.
 //
-// The policy is deliberately *report-first*: this service surfaces what is
-// (and will be) purgeable and performs a purge only when an admin explicitly
-// triggers it from /admin/retention. There is no timer and nothing deletes
-// student work automatically — mirroring how cautiously a privacy-impacting
-// deletion should be rolled out.
+// The policy is deliberately *report-first*: this service only computes the
+// eligibility date and counts submissions for the /admin/retention report.
+// The actual destructive action is the admin-triggered `deleteCourse`
+// (gated on `purgeEligibleDate`). There is no timer and nothing deletes
+// automatically — mirroring how cautiously a privacy-impacting deletion
+// should be rolled out.
 
 import Core
 import Fluent
@@ -22,19 +24,9 @@ import Foundation
 
 enum SubmissionRetentionService {
 
-    /// Retention status for one archived course, used to render the report.
-    struct CourseRetentionStatus: Sendable {
-        /// When the course was archived (the retention-clock anchor).
-        let archivedAt: Date
-        /// `archivedAt + retentionDays` — when submissions become purgeable.
-        let purgeEligibleAt: Date
-        /// True once `now >= purgeEligibleAt`.
-        let isPurgeable: Bool
-        /// How many submissions would be removed by a purge.
-        let submissionCount: Int
-    }
-
-    /// The date an archived course's submissions become eligible for purging.
+    /// The date an archived course becomes eligible for permanent deletion
+    /// (`archivedAt + retentionDays`). Named historically for the retention
+    /// "purge" window; `AdminRoutes.deleteCourse` gates on this.
     static func purgeEligibleDate(archivedAt: Date, retentionDays: Int) -> Date {
         archivedAt.addingTimeInterval(TimeInterval(retentionDays) * 86_400)
     }
@@ -72,52 +64,5 @@ enum SubmissionRetentionService {
             }
         }
         return counts
-    }
-
-    /// Deletes every submission belonging to `courseID`'s test setups: the
-    /// submission rows, their `results` rows, and the on-disk submission
-    /// artifacts. `submission_diagnostics` rows cascade away via their
-    /// `onDelete: .cascade` FK on `submission_id`.
-    ///
-    /// Deliberately scoped to *submission data only* — the course, its
-    /// assignments, test setups, enrollments, and user accounts are left
-    /// intact (a user may have submissions in other, still-active courses).
-    /// Mirrors the submission-deletion portion of `deleteCourse`.
-    ///
-    /// Returns the number of submission rows removed.
-    @discardableResult
-    static func purgeSubmissions(
-        forCourseID courseID: UUID,
-        on db: Database
-    ) async throws -> Int {
-        try await db.transaction { tx -> Int in
-            let setups = try await APITestSetup.query(on: tx)
-                .filter(\.$courseID == courseID)
-                .all()
-            let setupIDs = setups.compactMap { $0.id }
-            guard !setupIDs.isEmpty else { return 0 }
-
-            let submissions = try await APISubmission.query(on: tx)
-                .filter(\.$testSetupID ~~ setupIDs)
-                .all()
-            guard !submissions.isEmpty else { return 0 }
-
-            let submissionIDs = submissions.compactMap { $0.id }
-            if !submissionIDs.isEmpty {
-                try await APIResult.query(on: tx)
-                    .filter(\.$submissionID ~~ submissionIDs)
-                    .delete()
-            }
-
-            for submission in submissions {
-                try? FileManager.default.removeItem(atPath: submission.zipPath)
-            }
-
-            try await APISubmission.query(on: tx)
-                .filter(\.$testSetupID ~~ setupIDs)
-                .delete()
-
-            return submissions.count
-        }
     }
 }

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -256,6 +256,8 @@ private struct PassthroughResponder: AsyncResponder {
                 })
 
             // The Storage panel must no longer appear on the Overview tab.
+            // (Use a storage-only label — the Overview courses table now has its
+            // own "Submissions" column header.)
             try await app.asyncTest(
                 .GET, "/admin",
                 beforeRequest: { req in
@@ -264,7 +266,7 @@ private struct PassthroughResponder: AsyncResponder {
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let body = String(buffer: res.body)
-                    #expect(body.contains(">Submissions<") == false)
+                    #expect(body.contains(">Test Setups<") == false)
                 })
         }
     }
@@ -513,6 +515,9 @@ private struct PassthroughResponder: AsyncResponder {
             let student = try await makeUser(username: "delete_student", role: "student")
             let studentID = try student.requireID()
             let course = try await makeCourse(code: "DEL101", name: "Delete Me", archived: true)
+            // Past the 365-day retention window so deletion is permitted.
+            course.archivedAt = Date().addingTimeInterval(-400 * 86_400)
+            try await course.save(on: app.db)
             let courseID = try course.requireID()
             let setup = try await makeSetup(id: "setup_delete_admin", courseID: courseID)
             _ = try await makeAssignment(testSetupID: "setup_delete_admin", courseID: courseID)
@@ -531,7 +536,7 @@ private struct PassthroughResponder: AsyncResponder {
                 },
                 afterResponse: { res in
                     #expect(res.status == .seeOther)
-                    #expect(res.headers.first(name: .location) == "/admin")
+                    #expect(res.headers.first(name: .location)?.hasPrefix("/admin/retention") == true)
                 })
 
             let deletedCourse = try await APICourse.find(courseID, on: app.db)
@@ -556,6 +561,34 @@ private struct PassthroughResponder: AsyncResponder {
             #expect(FileManager.default.fileExists(atPath: submission.zipPath) == false)
             _ = setup
 
+        }
+    }
+
+    @Test func deleteCourseRejectedWhenRetentionWindowNotElapsed() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+            let course = try await makeCourse(code: "DELRECENT", name: "Recently Archived", archived: true)
+            // Archived just now — well inside the retention window.
+            course.archivedAt = Date()
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+            let (boundCookie, token) = try await csrfCookieAndToken(
+                cookie, path: "/admin/courses/\(courseID.uuidString)")
+
+            try await app.asyncTest(
+                .POST, "/admin/courses/\(courseID.uuidString)/delete",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: boundCookie)
+                    try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location)?.contains("error=") == true)
+                })
+
+            // The course must survive — deletion was refused.
+            let survivor = try await APICourse.find(courseID, on: app.db)
+            #expect(survivor != nil)
         }
     }
 

--- a/Tests/APITests/SubmissionRetentionTests.swift
+++ b/Tests/APITests/SubmissionRetentionTests.swift
@@ -7,8 +7,8 @@ import XCTVapor
 @testable import APIServer
 
 /// Covers the submission-retention policy: archiving stamps `archived_at`,
-/// the retention service counts/purges submission data, and the manual
-/// purge route enforces eligibility server-side.
+/// the retention service counts submissions per course, and the Retention
+/// report lists archived courses with Restore + (once eligible) Delete.
 @Suite(.serialized) final class SubmissionRetentionTests {
 
     let app: Application
@@ -94,121 +94,6 @@ import XCTVapor
         }
     }
 
-    // MARK: - Service: purging
-
-    @Test func purgeSubmissionsRemovesSubmissionDataButKeepsCourse() async throws {
-        try await withApp(app) { _ in
-            let student = try await makeTestUser(on: app, username: "ret_purge_student", role: "student")
-            let studentID = try student.requireID()
-            let course = try await makeTestCourse(on: app, code: "RETP1", name: "Purge Me", archived: true)
-            let courseID = try course.requireID()
-            _ = try await makeTestSetup(on: app, id: "ret_purge_setup", courseID: courseID, withNotebook: false)
-            _ = try await makeTestAssignment(on: app, testSetupID: "ret_purge_setup", courseID: courseID)
-            let submission = try await makeTestSubmission(
-                on: app, id: "ret_purge_sub", setupID: "ret_purge_setup", userID: studentID)
-            _ = try await makeTestResult(on: app, submissionID: try submission.requireID())
-            #expect(FileManager.default.fileExists(atPath: submission.zipPath))
-
-            let deleted = try await SubmissionRetentionService.purgeSubmissions(
-                forCourseID: courseID, on: app.db)
-            #expect(deleted == 1)
-
-            // Submission data gone…
-            let subCount = try await APISubmission.query(on: app.db)
-                .filter(\.$testSetupID == "ret_purge_setup").count()
-            let resultCount = try await APIResult.query(on: app.db).count()
-            #expect(subCount == 0)
-            #expect(resultCount == 0)
-            #expect(FileManager.default.fileExists(atPath: submission.zipPath) == false)
-
-            // …course, setup, assignment, and user preserved.
-            #expect(try await APICourse.find(courseID, on: app.db) != nil)
-            #expect(try await APITestSetup.find("ret_purge_setup", on: app.db) != nil)
-            let assignmentCount = try await APIAssignment.query(on: app.db)
-                .filter(\.$courseID == courseID).count()
-            #expect(assignmentCount == 1)
-            #expect(try await APIUser.find(studentID, on: app.db) != nil)
-        }
-    }
-
-    // MARK: - Route: eligibility guard
-
-    @Test func purgeRouteRejectsCourseStillWithinRetentionWindow() async throws {
-        try await withApp(app) { _ in
-            let cookie = try await loginAsAdmin()
-            let student = try await makeTestUser(on: app, username: "ret_recent_student", role: "student")
-            let studentID = try student.requireID()
-            let course = try await makeTestCourse(on: app, code: "RETR1", name: "Recent Archive", archived: true)
-            let courseID = try course.requireID()
-            // Archived just now → within the 365-day default window.
-            course.archivedAt = Date()
-            try await course.save(on: app.db)
-            _ = try await makeTestSetup(on: app, id: "ret_recent_setup", courseID: courseID, withNotebook: false)
-            _ = try await makeTestSubmission(
-                on: app, id: "ret_recent_sub", setupID: "ret_recent_setup", userID: studentID)
-
-            let (boundCookie, token) = try await csrfCookieAndToken(cookie)
-            try await app.asyncTest(
-                .POST, "/admin/courses/\(courseID.uuidString)/purge-submissions",
-                beforeRequest: { req in
-                    req.headers.add(name: .cookie, value: boundCookie)
-                    try req.content.encode(["_csrf": token], as: .urlEncodedForm)
-                },
-                afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    // Redirects back to the report with an error flash.
-                    #expect(res.headers.first(name: .location)?.contains("/admin/retention") == true)
-                    #expect(res.headers.first(name: .location)?.contains("error=") == true)
-                })
-
-            // Submission must survive — the window hasn't elapsed.
-            let subCount = try await APISubmission.query(on: app.db)
-                .filter(\.$testSetupID == "ret_recent_setup").count()
-            #expect(subCount == 1)
-        }
-    }
-
-    @Test func purgeRoutePurgesEligibleCourseAndWritesAudit() async throws {
-        try await withApp(app) { _ in
-            let cookie = try await loginAsAdmin()
-            let student = try await makeTestUser(on: app, username: "ret_old_student", role: "student")
-            let studentID = try student.requireID()
-            let course = try await makeTestCourse(on: app, code: "RETO1", name: "Old Archive", archived: true)
-            let courseID = try course.requireID()
-            // Archived 400 days ago → past the 365-day default window.
-            course.archivedAt = Date().addingTimeInterval(-400 * dayInSeconds)
-            try await course.save(on: app.db)
-            _ = try await makeTestSetup(on: app, id: "ret_old_setup", courseID: courseID, withNotebook: false)
-            let submission = try await makeTestSubmission(
-                on: app, id: "ret_old_sub", setupID: "ret_old_setup", userID: studentID)
-            _ = try await makeTestResult(on: app, submissionID: try submission.requireID())
-
-            let (boundCookie, token) = try await csrfCookieAndToken(cookie)
-            try await app.asyncTest(
-                .POST, "/admin/courses/\(courseID.uuidString)/purge-submissions",
-                beforeRequest: { req in
-                    req.headers.add(name: .cookie, value: boundCookie)
-                    try req.content.encode(["_csrf": token], as: .urlEncodedForm)
-                },
-                afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    #expect(res.headers.first(name: .location)?.contains("ok=") == true)
-                })
-
-            let subCount = try await APISubmission.query(on: app.db)
-                .filter(\.$testSetupID == "ret_old_setup").count()
-            #expect(subCount == 0)
-            #expect(FileManager.default.fileExists(atPath: submission.zipPath) == false)
-            // Course itself is preserved.
-            #expect(try await APICourse.find(courseID, on: app.db) != nil)
-
-            let purgeAudits = try await APIAuditLogEntry.query(on: app.db)
-                .filter(\.$action == "submission.retention_purged").all()
-            #expect(purgeAudits.count == 1)
-            #expect(purgeAudits.first?.targetID == courseID.uuidString)
-        }
-    }
-
     // MARK: - Report page
 
     @Test func retentionPageListsArchivedCoursesAndMarksEligible() async throws {
@@ -229,8 +114,11 @@ import XCTVapor
 
             // Resolve IDs up front: a `try` inside the #expect string
             // interpolation isn't handled by the macro expansion.
-            let eligiblePurgeURL = "/admin/courses/\(try eligible.requireID().uuidString)/purge-submissions"
-            let pendingPurgeURL = "/admin/courses/\(try pending.requireID().uuidString)/purge-submissions"
+            let eligibleID = try eligible.requireID().uuidString
+            let pendingID = try pending.requireID().uuidString
+            let eligibleDeleteURL = "/admin/courses/\(eligibleID)/delete"
+            let pendingDeleteURL = "/admin/courses/\(pendingID)/delete"
+            let pendingRestoreURL = "/admin/courses/\(pendingID)/archive"
 
             try await app.asyncTest(
                 .GET, "/admin/retention",
@@ -243,10 +131,11 @@ import XCTVapor
                     #expect(body.contains(">RETPAGEPEND<"))
                     // Active (non-archived) course is not subject to retention yet.
                     #expect(body.contains(">RETPAGEACTIVE<") == false)
-                    // Eligible course offers the purge action.
-                    #expect(body.contains(eligiblePurgeURL))
-                    // Pending course does not.
-                    #expect(body.contains(pendingPurgeURL) == false)
+                    // Eligible course offers the permanent Delete action.
+                    #expect(body.contains(eligibleDeleteURL))
+                    // Pending course can be restored but not yet deleted.
+                    #expect(body.contains(pendingRestoreURL))
+                    #expect(body.contains(pendingDeleteURL) == false)
                     // Retention tab is active.
                     #expect(body.contains("href=\"/admin/retention\" aria-current=\"page\""))
                 })

--- a/changelog.d/admin-retention-overview-cleanup.md
+++ b/changelog.d/admin-retention-overview-cleanup.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Admin Retention tab reworked around Restore + Delete.** Archived courses now live only on the Retention tab (they no longer appear on the Overview). Each row has icon actions to Restore (unarchive) and Export a course bundle at any time, plus a permanent Delete once the course is past its retention window. The table is sortable by column.
+- **Overview courses table shows a Submissions count** in place of the always-"active" Status column.
+
+### Removed
+
+- **Submission "Purge" action**, folded into the retention lifecycle (restore any time; permanently delete course + data once the retention window elapses).
+- **"Auto-start local" runner checkbox** from the admin Overview (the worker-secret control is unchanged).
+- **Redundant page-title headers** on the admin Storage and Users tabs.


### PR DESCRIPTION
## Summary

Move the archived-course lifecycle fully onto the **Retention** tab and retire the old submission **Purge** action.

- **Retention tab** lists archived courses with icon actions: **Restore** (unarchive) and **Export bundle** on every row, plus **Delete** once the course is past its retention window. The table is sortable by column. Delete is gated server-side on the retention window (mirrors the old Purge guard) and redirects back with a flash.
- **Purge removed** — its role is covered by Restore (any time) + Delete (course + all data, once eligible). The unused `purgeSubmissions` service method and `/purge-submissions` route are deleted.
- **Overview** no longer lists archived courses (they live on Retention now) and shows a per-course **Submissions** count in place of the always-"active" Status column.
- **Removed the unused "Auto-start local" runner checkbox** from Overview (the autostart mechanism + `/runner-autostart` endpoint are unchanged) and the redundant page-title headers on the **Storage** and **Users** tabs.

## Test plan

- [x] `swift build` (chickadee-server) green against `main`
- [x] `swift format lint --strict` clean on changed files
- [x] `AdminRoutesTests` + `SubmissionRetentionTests` pass (29 tests), including new coverage: delete gated on retention window, and the report page offers Restore/Delete (not Purge)
- [x] Browser-verified: Restore unarchives (course leaves Retention, reappears on Overview); eligible row shows Restore+Export+Delete, pending row shows Restore+Export; Export streams a `.chickadee` zip; Overview shows Submissions counts and only active courses; autostart control gone, Save-secret intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)