### PR TITLE
Rework instructor view into tabbed panels

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -856,12 +856,13 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     margin-bottom: .875rem;
 }
 
-/* ── Admin tab bar ───────────────────────────────────── */
-/* Inlined into each admin page rather than a Leaf fragment: LeafKit 1.x
-   raises a false-positive "cyclically referenced" error on #extend of a
-   shared partial here. */
+/* ── Section tab bar (admin + instructor) ────────────── */
+/* Inlined into each page rather than a Leaf fragment: LeafKit 1.x raises a
+   false-positive "cyclically referenced" error on #extend of a shared
+   partial here. */
 
-.admin-tabs {
+.admin-tabs,
+.instructor-tabs {
     display: flex;
     flex-wrap: wrap;
     gap: .25rem;
@@ -869,7 +870,8 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     margin-bottom: 1.5rem;
 }
 
-.admin-tab {
+.admin-tab,
+.instructor-tab {
     padding: .55rem .9rem;
     text-decoration: none;
     color: var(--gray-600);
@@ -878,11 +880,13 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     margin-bottom: -1px;
 }
 
-.admin-tab:hover {
+.admin-tab:hover,
+.instructor-tab:hover {
     color: var(--gray-900);
 }
 
-.admin-tab[aria-current="page"] {
+.admin-tab[aria-current="page"],
+.instructor-tab[aria-current="page"] {
     color: var(--gray-900);
     font-weight: 600;
     border-bottom-color: var(--gray-900);

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -3,16 +3,15 @@
 #if(currentUser.activeCourse):#(currentUser.activeCourse.code) — #(currentUser.activeCourse.name)#else:Assignments#endif
 #endexport
 #export("content"):
+<nav class="instructor-tabs" aria-label="Instructor sections">
+    <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
+    <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+</nav>
 #if(currentUser.activeCourse):
-<div style="display:flex;align-items:center;justify-content:space-between;gap:.75rem;flex-wrap:wrap;margin-bottom:1.25rem">
-    <h1 style="margin:0">#(currentUser.activeCourse.code) — #(currentUser.activeCourse.name)</h1>
-    <a class="btn action-btn" href="/instructor/grades.csv">Export Grades CSV</a>
-</div>
+<h1 style="margin:0 0 1.25rem">#(currentUser.activeCourse.code) — #(currentUser.activeCourse.name)</h1>
 #else:
-<div style="display:flex;align-items:center;justify-content:space-between;gap:.75rem;flex-wrap:wrap;margin-bottom:1.25rem">
-    <h1 style="margin:0">Assignments</h1>
-    <a class="btn action-btn" href="/instructor/grades.csv">Export Grades CSV</a>
-</div>
+<h1 style="margin:0 0 1.25rem">Assignments</h1>
 #endif
 <section class="instructor-diagnostics">
     #extend("_diagnostic-cards")
@@ -498,91 +497,6 @@
 
 #endif
 
-<!-- ── Enrolled students ──────────────────────────────────────────────── -->
-<div style="margin-top:2.5rem">
-    <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:.75rem">
-        <h2 style="font-size:1.05rem;font-weight:600;margin:0">Enrolled students (#(enrolledStudentCount))</h2>
-        #if(currentUser.activeCourse):
-        #if(!courseIsArchived):
-        <form method="post" action="/courses/#(currentUser.activeCourse.id)/enrollment-mode" style="margin:0">
-            #csrfFormField()
-            <label class="form-label" style="font-size:.875rem;margin:0">
-                <select name="enrollmentMode" class="form-input"
-                        style="display:block;font-size:.875rem"
-                        onchange="this.form.submit()">
-                    <option value="open"   #if(courseEnrollmentMode == "open"):selected#endif>Open enrolment</option>
-                    <option value="auto"   #if(courseEnrollmentMode == "auto"):selected#endif>Auto enrolment</option>
-                    <option value="closed" #if(courseEnrollmentMode == "closed"):selected#endif>Closed enrolment</option>
-                </select>
-            </label>
-        </form>
-        <a class="btn action-btn" href="/instructor/enroll-csv">Enrol from CSV</a>
-        #endif
-        #endif
-        <input id="enrolled-filter" class="form-input" type="search" autocomplete="off"
-               placeholder="Filter by name or username…"
-               style="width:220px;flex:1 1 220px;min-width:220px" aria-label="Filter enrolled students"
-               readonly onfocus="this.removeAttribute('readonly')">
-    </div>
-    #if(hasEnrolledStudents):
-    <table class="results-table" id="enrolled-students-table">
-        <thead>
-            <tr>
-                <th class="sortable" data-col="0" style="cursor:pointer;user-select:none">Name <span class="sort-icon">⇕</span></th>
-                <th class="sortable" data-col="1" style="cursor:pointer;user-select:none">Username <span class="sort-icon">⇕</span></th>
-                <th class="sortable" data-col="2" style="cursor:pointer;user-select:none">Role <span class="sort-icon">⇕</span></th>
-                <th class="sortable" data-col="3" style="cursor:pointer;user-select:none">Last Seen <span class="sort-icon">⇕</span></th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-        #for(student in enrolledStudents):
-            <tr class="student-row-link#if(student.isPending): student-row-pending#endif"
-                #if(!student.isPending):data-href="#(student.submissionsURL)"#endif>
-                <td>
-                    #if(student.isPending):
-                    <strong style="color:var(--gray-500)">#(student.displayName)</strong>
-                    <span style="font-size:.72rem;color:var(--gray-500);margin-left:.4rem">awaiting first login</span>
-                    #else:
-                    <a href="#(student.submissionsURL)"><strong>#(student.displayName)</strong></a>
-                    #endif
-                </td>
-                <td>
-                    #if(student.isPending):
-                    <code style="color:var(--gray-500)">#(student.username)</code>
-                    #else:
-                    <a href="#(student.submissionsURL)"><code>#(student.username)</code></a>
-                    #endif
-                </td>
-                <td>#(student.role)</td>
-                <td class="js-relative-time"
-                    #if(student.lastSeenAtISO):data-iso="#(student.lastSeenAtISO)"#endif>
-                    #(student.lastSeenAtText)
-                </td>
-                <td>
-                    #if(!courseIsArchived):
-                    #if(currentUser.activeCourse):
-                    <form method="post" action="#(student.unenrollURL)"
-                          style="display:inline;margin:0">
-                        #csrfFormField()
-                        <button class="btn action-btn action-danger" type="submit"
-                                title="Remove from course" aria-label="Remove from course" style="padding:.25rem .35rem"
-                                onclick="return confirm('Remove @#(student.username) from this course?')">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
-                        </button>
-                    </form>
-                    #endif
-                    #endif
-                </td>
-            </tr>
-        #endfor
-        </tbody>
-    </table>
-    #else:
-    <p class="empty">No students enrolled yet.</p>
-    #endif
-</div>
-
 <style>
 .instructor-diagnostics {
     margin-bottom: 1.25rem;
@@ -630,17 +544,6 @@
 .status-form {
     display: inline-flex;
     align-items: center;
-}
-.student-row-link {
-    cursor: pointer;
-}
-.student-row-link td a {
-    color: inherit;
-    text-decoration: none;
-}
-.student-row-link:hover td a strong,
-.student-row-link:hover td a code {
-    text-decoration: underline;
 }
 tr.assignment-draggable.dragging {
     opacity: .55;
@@ -1002,92 +905,6 @@ tr.assignment-draggable td {
         if (!warning) return;
         input.addEventListener('change', function () { checkUWDates(input.value, warning); });
     });
-
-    // ── Enrolled students table sort ──────────────────────────────────────────
-    var enrolledTable = document.getElementById('enrolled-students-table');
-    if (enrolledTable) {
-        var sortCol = 3;
-        var sortAsc = false;
-        enrolledTable.querySelectorAll('tbody tr.student-row-link').forEach(function (row) {
-            row.addEventListener('click', function (event) {
-                var target = event.target;
-                if (target instanceof Element && target.closest('a')) return;
-                var href = row.getAttribute('data-href');
-                if (href) window.location.href = href;
-            });
-        });
-        enrolledTable.querySelectorAll('th.sortable').forEach(function (th) {
-            th.addEventListener('click', function () {
-                var col = parseInt(th.getAttribute('data-col'), 10);
-                if (sortCol === col) {
-                    sortAsc = !sortAsc;
-                } else {
-                    sortCol = col;
-                    sortAsc = true;
-                }
-                enrolledTable.querySelectorAll('th.sortable .sort-icon').forEach(function (icon) {
-                    icon.textContent = '⇕';
-                });
-                th.querySelector('.sort-icon').textContent = sortAsc ? '↑' : '↓';
-                var tbody = enrolledTable.querySelector('tbody');
-                var rows = Array.from(tbody.querySelectorAll('tr'));
-                rows.sort(function (a, b) {
-                    var result;
-                    if (col === 3) {
-                        var aISO = a.cells[col] ? a.cells[col].getAttribute('data-iso') : '';
-                        var bISO = b.cells[col] ? b.cells[col].getAttribute('data-iso') : '';
-                        var aDate = aISO ? new Date(aISO).getTime() : 0;
-                        var bDate = bISO ? new Date(bISO).getTime() : 0;
-                        result = aDate - bDate;
-                    } else {
-                        var aText = (a.cells[col] ? a.cells[col].textContent : '').trim().toLowerCase();
-                        var bText = (b.cells[col] ? b.cells[col].textContent : '').trim().toLowerCase();
-                        result = aText.localeCompare(bText);
-                    }
-                    if (result === 0) {
-                        var aUsername = (a.cells[1] ? a.cells[1].textContent : '').trim().toLowerCase();
-                        var bUsername = (b.cells[1] ? b.cells[1].textContent : '').trim().toLowerCase();
-                        result = aUsername.localeCompare(bUsername);
-                    }
-                    return sortAsc ? result : -result;
-                });
-                rows.forEach(function (row) { tbody.appendChild(row); });
-            });
-        });
-
-        var defaultEnrolledSortHeader = enrolledTable.querySelector('th.sortable[data-col="3"]');
-        if (defaultEnrolledSortHeader) {
-            defaultEnrolledSortHeader.querySelector('.sort-icon').textContent = '↓';
-            var defaultEnrolledBody = enrolledTable.querySelector('tbody');
-            var defaultEnrolledRows = Array.from(defaultEnrolledBody.querySelectorAll('tr'));
-            defaultEnrolledRows.sort(function (a, b) {
-                var aISO = a.cells[3] ? a.cells[3].getAttribute('data-iso') : '';
-                var bISO = b.cells[3] ? b.cells[3].getAttribute('data-iso') : '';
-                var aDate = aISO ? new Date(aISO).getTime() : 0;
-                var bDate = bISO ? new Date(bISO).getTime() : 0;
-                var result = aDate - bDate;
-                if (result === 0) {
-                    var aUsername = (a.cells[1] ? a.cells[1].textContent : '').trim().toLowerCase();
-                    var bUsername = (b.cells[1] ? b.cells[1].textContent : '').trim().toLowerCase();
-                    result = aUsername.localeCompare(bUsername);
-                }
-                return sortAsc ? result : -result;
-            });
-            defaultEnrolledRows.forEach(function (row) { defaultEnrolledBody.appendChild(row); });
-        }
-
-        var enrolledFilter = document.getElementById('enrolled-filter');
-        if (enrolledFilter) {
-            var enrolledTbody = enrolledTable.querySelector('tbody');
-            enrolledFilter.addEventListener('input', function () {
-                var query = enrolledFilter.value.trim().toLowerCase();
-                Array.from(enrolledTbody.querySelectorAll('tr')).forEach(function (row) {
-                    if (!query) { row.hidden = false; return; }
-                    row.hidden = !(row.textContent || '').toLowerCase().includes(query);
-                });
-            });
-        }
-    }
 })();
 
 function copyAssignmentURL(btn, vanityPath) {

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -1,0 +1,44 @@
+#extend("base"):
+#export("title"):
+BrightSpace
+#endexport
+#export("content"):
+<nav class="instructor-tabs" aria-label="Instructor sections">
+    <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
+    <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+</nav>
+
+<h1 style="margin:0 0 1.25rem">BrightSpace</h1>
+
+<section style="margin-bottom:2.5rem">
+    <h2 style="font-size:1.05rem;font-weight:600;margin:0 0 .5rem">Export grades</h2>
+    <p style="color:var(--gray-600);margin:0 0 .9rem;max-width:46rem">
+        Download a CSV of every enrolled student's best grade per assignment,
+        formatted for BrightSpace grade import (OrgDefinedId + per-assignment
+        points columns).
+    </p>
+    #if(hasActiveCourse):
+    <a class="btn action-btn" href="/instructor/grades.csv">Export Grades CSV</a>
+    #else:
+    <p class="empty">Select a course to export grades.</p>
+    #endif
+</section>
+
+<section>
+    <h2 style="font-size:1.05rem;font-weight:600;margin:0 0 .5rem">Automatic grade sync</h2>
+    #if(brightspaceSyncEnabled):
+    <p style="color:var(--gray-600);margin:0;max-width:46rem">
+        BrightSpace grade sync is <strong>enabled</strong> on this server.
+        Grades push automatically as students submit, for assignments with a
+        BrightSpace grade item ID configured on the assignment edit page.
+    </p>
+    #else:
+    <p style="color:var(--gray-600);margin:0;max-width:46rem">
+        Automatic grade sync is not configured on this server. Use the CSV
+        export above to upload grades to BrightSpace manually.
+    </p>
+    #endif
+</section>
+#endexport
+#endextend

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -1,0 +1,317 @@
+#extend("base"):
+#export("title"):
+Students
+#endexport
+#export("content"):
+<nav class="instructor-tabs" aria-label="Instructor sections">
+    <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
+    <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+</nav>
+
+<div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:.75rem">
+    <h1 style="font-size:1.05rem;font-weight:600;margin:0">Enrolled students (<span id="enrolled-count">#(enrolledStudentCount)</span>)</h1>
+    #if(currentUser.activeCourse):
+    #if(!courseIsArchived):
+    <form method="post" action="/courses/#(currentUser.activeCourse.id)/enrollment-mode" style="margin:0">
+        #csrfFormField()
+        <label class="form-label" style="font-size:.875rem;margin:0">
+            <select name="enrollmentMode" class="form-input"
+                    style="display:block;font-size:.875rem"
+                    onchange="this.form.submit()">
+                <option value="open"   #if(courseEnrollmentMode == "open"):selected#endif>Open enrolment</option>
+                <option value="auto"   #if(courseEnrollmentMode == "auto"):selected#endif>Auto enrolment</option>
+                <option value="closed" #if(courseEnrollmentMode == "closed"):selected#endif>Closed enrolment</option>
+            </select>
+        </label>
+    </form>
+    <a class="btn action-btn" href="/instructor/enroll-csv">Enrol from CSV</a>
+    #endif
+    #endif
+    <input id="enrolled-filter" class="form-input" type="search" autocomplete="off"
+           placeholder="Filter by name or username…"
+           style="width:220px;flex:1 1 220px;min-width:220px" aria-label="Filter enrolled students"
+           readonly onfocus="this.removeAttribute('readonly')">
+</div>
+
+<table class="results-table" id="enrolled-students-table"
+       data-archived="#if(courseIsArchived):true#else:false#endif">
+    <thead>
+        <tr>
+            <th class="sortable" data-col="0" style="cursor:pointer;user-select:none">Name <span class="sort-icon">⇕</span></th>
+            <th class="sortable" data-col="1" style="cursor:pointer;user-select:none">Username <span class="sort-icon">⇕</span></th>
+            <th class="sortable" data-col="2" style="cursor:pointer;user-select:none">Role <span class="sort-icon">⇕</span></th>
+            <th class="sortable" data-col="3" style="cursor:pointer;user-select:none">Last Seen <span class="sort-icon">⇕</span></th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    #for(student in enrolledStudents):
+        <tr class="student-row-link#if(student.isPending): student-row-pending#endif"
+            #if(!student.isPending):data-href="#(student.submissionsURL)"#endif>
+            <td>
+                #if(student.isPending):
+                <strong style="color:var(--gray-500)">#(student.displayName)</strong>
+                <span style="font-size:.72rem;color:var(--gray-500);margin-left:.4rem">awaiting first login</span>
+                #else:
+                <a href="#(student.submissionsURL)"><strong>#(student.displayName)</strong></a>
+                #endif
+            </td>
+            <td>
+                #if(student.isPending):
+                <code style="color:var(--gray-500)">#(student.username)</code>
+                #else:
+                <a href="#(student.submissionsURL)"><code>#(student.username)</code></a>
+                #endif
+            </td>
+            <td>#(student.role)</td>
+            <td class="js-relative-time"
+                #if(student.lastSeenAtISO):data-iso="#(student.lastSeenAtISO)"#endif>
+                #(student.lastSeenAtText)
+            </td>
+            <td>
+                #if(!courseIsArchived):
+                <form method="post" action="#(student.unenrollURL)"
+                      style="display:inline;margin:0">
+                    #csrfFormField()
+                    <button class="btn action-btn action-danger" type="submit"
+                            title="Remove from course" aria-label="Remove from course" style="padding:.25rem .35rem"
+                            onclick="return confirm('Remove @#(student.username) from this course?')">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                    </button>
+                </form>
+                #endif
+            </td>
+        </tr>
+    #endfor
+    </tbody>
+</table>
+<p class="empty" id="no-students-msg"#if(hasEnrolledStudents): hidden#endif>No students enrolled yet.</p>
+
+<style>
+#enrolled-students-table th.sortable .sort-icon {
+    color: var(--gray-500);
+    font-size: .75rem;
+}
+.student-row-link {
+    cursor: pointer;
+}
+.student-row-link td a {
+    color: inherit;
+    text-decoration: none;
+}
+.student-row-link:hover td a strong,
+.student-row-link:hover td a code {
+    text-decoration: underline;
+}
+</style>
+<script>
+(function () {
+    'use strict';
+
+    var table = document.getElementById('enrolled-students-table');
+    if (!table) return;
+    var tbody = table.querySelector('tbody');
+    var filter = document.getElementById('enrolled-filter');
+    var emptyMsg = document.getElementById('no-students-msg');
+    var countEl = document.getElementById('enrolled-count');
+    var archived = table.getAttribute('data-archived') === 'true';
+
+    var sortCol = 3;
+    var sortAsc = false;
+
+    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+    function formatRelative(isoString) {
+        var date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) return isoString;
+        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
+        var abs = Math.abs(seconds);
+        if (abs < 60) return relativeFormatter.format(seconds, 'second');
+        var minutes = Math.round(seconds / 60);
+        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
+        var hours = Math.round(minutes / 60);
+        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
+        var days = Math.round(hours / 24);
+        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
+        var weeks = Math.round(days / 7);
+        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
+        var months = Math.round(days / 30);
+        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
+        var years = Math.round(days / 365);
+        return relativeFormatter.format(years, 'year');
+    }
+
+    function applyRelativeTimes(root) {
+        (root || document).querySelectorAll('.js-relative-time[data-iso]').forEach(function (el) {
+            var iso = el.getAttribute('data-iso');
+            if (!iso) return;
+            var date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+            el.textContent = formatRelative(iso);
+            el.title = date.toLocaleString();
+        });
+    }
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    var deleteIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';
+
+    function buildStudentRow(student, csrfToken) {
+        var displayName = escapeHtml(student.displayName);
+        var username = escapeHtml(student.username);
+        var role = escapeHtml(student.role);
+        var iso = student.lastSeenAtISO ? escapeHtml(student.lastSeenAtISO) : '';
+        var lastSeenText = escapeHtml(student.lastSeenAtText);
+        var subURL = escapeHtml(student.submissionsURL);
+        var unenrollURL = escapeHtml(student.unenrollURL);
+        var csrfField = '<input type="hidden" name="_csrf" value="' + escapeHtml(csrfToken) + '">';
+
+        var nameCell = student.isPending
+            ? '<strong style="color:var(--gray-500)">' + displayName + '</strong>'
+                + '<span style="font-size:.72rem;color:var(--gray-500);margin-left:.4rem">awaiting first login</span>'
+            : '<a href="' + subURL + '"><strong>' + displayName + '</strong></a>';
+        var userCell = student.isPending
+            ? '<code style="color:var(--gray-500)">' + username + '</code>'
+            : '<a href="' + subURL + '"><code>' + username + '</code></a>';
+        var actionCell = '';
+        if (!archived) {
+            actionCell = '<form method="post" action="' + unenrollURL + '" style="display:inline;margin:0">'
+                + csrfField
+                + '<button class="btn action-btn action-danger" type="submit" title="Remove from course"'
+                + ' aria-label="Remove from course" style="padding:.25rem .35rem"'
+                + ' onclick="return confirm(\'Remove @' + username + ' from this course?\')">'
+                + deleteIcon + '</button></form>';
+        }
+
+        return '<tr class="student-row-link' + (student.isPending ? ' student-row-pending' : '') + '"'
+            + (student.isPending ? '' : ' data-href="' + subURL + '"') + '>'
+            + '<td>' + nameCell + '</td>'
+            + '<td>' + userCell + '</td>'
+            + '<td>' + role + '</td>'
+            + '<td class="js-relative-time"' + (iso ? ' data-iso="' + iso + '"' : '') + '>' + lastSeenText + '</td>'
+            + '<td>' + actionCell + '</td>'
+            + '</tr>';
+    }
+
+    function updateEmptyState() {
+        if (emptyMsg) emptyMsg.hidden = tbody.querySelectorAll('tr').length > 0;
+    }
+
+    function sortRows() {
+        var rows = Array.from(tbody.querySelectorAll('tr'));
+        rows.sort(function (a, b) {
+            var result;
+            if (sortCol === 3) {
+                var aISO = a.cells[3] ? a.cells[3].getAttribute('data-iso') : '';
+                var bISO = b.cells[3] ? b.cells[3].getAttribute('data-iso') : '';
+                result = (aISO ? new Date(aISO).getTime() : 0) - (bISO ? new Date(bISO).getTime() : 0);
+            } else {
+                var aText = (a.cells[sortCol] ? a.cells[sortCol].textContent : '').trim().toLowerCase();
+                var bText = (b.cells[sortCol] ? b.cells[sortCol].textContent : '').trim().toLowerCase();
+                result = aText.localeCompare(bText);
+            }
+            if (result === 0) {
+                var aUser = (a.cells[1] ? a.cells[1].textContent : '').trim().toLowerCase();
+                var bUser = (b.cells[1] ? b.cells[1].textContent : '').trim().toLowerCase();
+                result = aUser.localeCompare(bUser);
+            }
+            return sortAsc ? result : -result;
+        });
+        rows.forEach(function (row) { tbody.appendChild(row); });
+        table.querySelectorAll('th.sortable .sort-icon').forEach(function (icon) { icon.textContent = '⇕'; });
+        var activeHeader = table.querySelector('th.sortable[data-col="' + sortCol + '"] .sort-icon');
+        if (activeHeader) activeHeader.textContent = sortAsc ? '↑' : '↓';
+    }
+
+    function applyFilter() {
+        if (!filter) return;
+        var query = filter.value.trim().toLowerCase();
+        Array.from(tbody.querySelectorAll('tr')).forEach(function (row) {
+            row.hidden = query ? !(row.textContent || '').toLowerCase().includes(query) : false;
+        });
+    }
+
+    table.querySelectorAll('th.sortable').forEach(function (th) {
+        th.addEventListener('click', function () {
+            var col = parseInt(th.getAttribute('data-col'), 10);
+            if (sortCol === col) {
+                sortAsc = !sortAsc;
+            } else {
+                sortCol = col;
+                sortAsc = true;
+            }
+            sortRows();
+        });
+    });
+
+    // Row-click navigation (delegated so it survives repaints).
+    table.addEventListener('click', function (event) {
+        var t = event.target;
+        if (!(t instanceof Element)) return;
+        if (t.closest('a') || t.closest('button') || t.closest('form')) return;
+        var row = t.closest('tr.student-row-link');
+        if (!row) return;
+        var href = row.getAttribute('data-href');
+        if (href) window.location.href = href;
+    });
+
+    if (filter) filter.addEventListener('input', applyFilter);
+
+    function repaint(rows) {
+        if (!Array.isArray(rows)) return;
+        var meta = document.querySelector('meta[name="csrf-token"]');
+        var csrfToken = meta ? meta.getAttribute('content') : '';
+        tbody.innerHTML = rows.map(function (s) { return buildStudentRow(s, csrfToken); }).join('');
+        if (countEl) {
+            // Heading counts students + pending pre-enrolments only, matching
+            // the server's enrolledStudentCount — instructor / admin users
+            // enrolled for testing appear in the table but don't inflate it.
+            countEl.textContent = String(rows.filter(function (s) {
+                return s.role === 'student' || s.role === '(pending)';
+            }).length);
+        }
+        applyRelativeTimes(tbody);
+        sortRows();
+        applyFilter();
+        updateEmptyState();
+    }
+
+    // ── Initial paint ────────────────────────────────────────────────
+    applyRelativeTimes(document);
+    sortRows();
+    updateEmptyState();
+
+    // ── Auto-refresh ─────────────────────────────────────────────────
+    // Poll /instructor/students-data every few seconds so last-seen times
+    // and newly enrolled / removed students stay current without a reload,
+    // mirroring the admin Users panel.  The X-Background-Refresh header tells
+    // the server this is a system poll so it does NOT reset the idle timer.
+    async function pollStudents() {
+        if (document.hidden) return;
+        if (table.contains(document.activeElement)) return;
+        if (filter && document.activeElement === filter) return;
+        try {
+            var res = await fetch('/instructor/students-data', {
+                headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
+                cache: 'no-store'
+            });
+            if (res.redirected || res.status === 401 || res.status === 403) {
+                window.location.reload();
+                return;
+            }
+            if (!res.ok) return;
+            repaint(await res.json());
+        } catch (_) {
+            // Keep the current rows on transient polling errors.
+        }
+    }
+    setInterval(pollStudents, 5000);
+})();
+</script>
+#endexport
+#endextend

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -7,6 +7,7 @@
 // view changes.
 
 import Foundation
+import Vapor
 
 struct AssignmentRow: Encodable {
     let setupID: String
@@ -33,13 +34,29 @@ struct CourseSectionRow: Encodable {
     let rows: [AssignmentRow]  // assignments in this section, sorted
 }
 
+/// Overview tab (`GET /instructor`): dashboard metrics + the assignment /
+/// section listing.  The enrolled-students roster and BrightSpace export
+/// moved to their own tabs (`/instructor/students`, `/instructor/brightspace`)
+/// in the v0.4 instructor-view rework, so this context no longer carries the
+/// roster — only `enrolledStudentCount`, which the per-assignment "X / Y"
+/// submitted badge still needs.
 struct AssignmentsContext: Encodable {
     let currentUser: CurrentUserContext?
+    let activeInstructorTab: String
     let metrics: [InstructorDashboardMetric]
     let sections: [CourseSectionRow]  // sections with their assignments
     let ungroupedRows: [AssignmentRow]  // assignments/setups not in any section
     let hasSections: Bool
     let hasUngrouped: Bool
+    let enrolledStudentCount: Int
+}
+
+/// Students tab (`GET /instructor/students`): the enrolled-students roster
+/// plus enrollment-mode controls.  The table self-updates by polling
+/// `GET /instructor/students-data`, which returns `[EnrolledStudentRow]`.
+struct InstructorStudentsContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let activeInstructorTab: String
     let enrolledStudents: [EnrolledStudentRow]
     let hasEnrolledStudents: Bool  // explicit flag — Leaf's array.isEmpty is unreliable
     let enrolledStudentCount: Int
@@ -47,12 +64,20 @@ struct AssignmentsContext: Encodable {
     let courseIsArchived: Bool
 }
 
+/// BrightSpace tab (`GET /instructor/brightspace`): grade export + sync status.
+struct InstructorBrightspaceContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let activeInstructorTab: String
+    let hasActiveCourse: Bool
+    let brightspaceSyncEnabled: Bool
+}
+
 struct InstructorDashboardMetric: Encodable {
     let label: String
     let value: String
 }
 
-struct EnrolledStudentRow: Encodable {
+struct EnrolledStudentRow: Content {
     let id: String
     let username: String
     let displayName: String

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -141,6 +141,41 @@ extension InstructorDashboardRoutes {
         )
     }
 
+    /// Enrolled-student rows + active-student count for the active course,
+    /// without the (relatively expensive) dashboard-metric computation.
+    /// Shared by the Students-tab page render and its polling endpoint, which
+    /// only need the roster.  Mirrors the roster half of `buildCourseRoster`:
+    /// active enrollments first (last-seen-desc), pending CSV pre-enrollments
+    /// appended as muted rows, with the count covering both.
+    func loadEnrolledStudentRows(
+        req: Request,
+        activeCourseUUID: UUID,
+        activeCourseCode: String,
+        fmt: DateFormatter,
+        isoFormatter: ISO8601DateFormatter
+    ) async throws -> (rows: [EnrolledStudentRow], count: Int) {
+        let enrolledUsers = try await loadEnrolledUsersForRoster(req: req, activeCourseUUID: activeCourseUUID)
+        var rows = buildEnrolledStudentRows(
+            enrolledUsers: enrolledUsers,
+            activeCourseUUID: activeCourseUUID,
+            activeCourseCode: activeCourseCode,
+            fmt: fmt,
+            isoFormatter: isoFormatter
+        )
+        let pendingPreEnrollments = try await APIPreEnrollment.query(on: req.db)
+            .filter(\.$course.$id == activeCourseUUID)
+            .sort(\.$username)
+            .all()
+        rows.append(
+            contentsOf: buildPendingPreEnrollmentRows(
+                pendingPreEnrollments: pendingPreEnrollments,
+                activeCourseUUID: activeCourseUUID
+            )
+        )
+        let activeStudentCount = enrolledUsers.filter { $0.role == "student" }.count
+        return (rows, activeStudentCount + pendingPreEnrollments.count)
+    }
+
     /// Loads the enrolled users for the course, sorted last-seen-desc then
     /// username-asc.  Returns an empty array if no enrollments exist.
     private func loadEnrolledUsersForRoster(

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -1,0 +1,118 @@
+// APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+//
+// The Students and BrightSpace tabs of the instructor view.  The Overview
+// tab (assignment listing + dashboard metrics) stays on the `list` handler
+// in InstructorDashboardRoutes.swift; the enrolled-students roster and the
+// grade-export controls were split into their own tabs in the v0.4
+// instructor-view rework so each panel can render — and, for the roster,
+// self-update — independently.
+//
+//   GET /instructor/students       → instructor-students.leaf
+//   GET /instructor/students-data  → [EnrolledStudentRow] JSON (5s poll)
+//   GET /instructor/brightspace    → instructor-brightspace.leaf
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension InstructorDashboardRoutes {
+
+    // MARK: - GET /instructor/students
+
+    @Sendable
+    func studentsPage(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        let userContext = CurrentUserContext(
+            user: user,
+            activeCourse: courseState.active,
+            enrolledCourses: courseState.all
+        )
+
+        // Match `list`: a user with no active course but existing courses
+        // belongs on the enrol page, not an empty roster.
+        if courseState.active == nil {
+            let courseCount = try await APICourse.query(on: req.db).count()
+            if courseCount > 0 {
+                return req.redirect(to: "/enroll")
+            }
+        }
+
+        let fmt = waterlooDateTimeFormatter()
+        let isoFormatter = ISO8601DateFormatter()
+
+        var enrolledStudents: [EnrolledStudentRow] = []
+        var enrolledStudentCount = 0
+        var courseEnrollmentMode = CourseEnrollmentMode.open.rawValue
+        var courseIsArchived = false
+
+        if let activeCourseUUID = courseState.activeCourseUUID {
+            let roster = try await loadEnrolledStudentRows(
+                req: req,
+                activeCourseUUID: activeCourseUUID,
+                activeCourseCode: courseState.active?.code ?? "",
+                fmt: fmt,
+                isoFormatter: isoFormatter
+            )
+            enrolledStudents = roster.rows
+            enrolledStudentCount = roster.count
+            if let course = try await APICourse.find(activeCourseUUID, on: req.db) {
+                courseEnrollmentMode = course.enrollmentMode.rawValue
+                courseIsArchived = course.isArchived
+            }
+        }
+
+        let ctx = InstructorStudentsContext(
+            currentUser: userContext,
+            activeInstructorTab: "students",
+            enrolledStudents: enrolledStudents,
+            hasEnrolledStudents: !enrolledStudents.isEmpty,
+            enrolledStudentCount: enrolledStudentCount,
+            courseEnrollmentMode: courseEnrollmentMode,
+            courseIsArchived: courseIsArchived
+        )
+        return try await req.view.render("instructor-students", ctx).encodeResponse(for: req)
+    }
+
+    // MARK: - GET /instructor/students-data
+
+    /// JSON feed backing the Students-tab auto-refresh.  Returns the same
+    /// rows the page rendered with, so last-seen times and newly enrolled /
+    /// removed students stay current without a manual reload.  Returns an
+    /// empty array when no course is active (the table simply clears).
+    @Sendable
+    func studentsData(req: Request) async throws -> [EnrolledStudentRow] {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let activeCourseUUID = courseState.activeCourseUUID else { return [] }
+        let roster = try await loadEnrolledStudentRows(
+            req: req,
+            activeCourseUUID: activeCourseUUID,
+            activeCourseCode: courseState.active?.code ?? "",
+            fmt: waterlooDateTimeFormatter(),
+            isoFormatter: ISO8601DateFormatter()
+        )
+        return roster.rows
+    }
+
+    // MARK: - GET /instructor/brightspace
+
+    @Sendable
+    func brightspacePage(req: Request) async throws -> View {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        let userContext = CurrentUserContext(
+            user: user,
+            activeCourse: courseState.active,
+            enrolledCourses: courseState.all
+        )
+        let ctx = InstructorBrightspaceContext(
+            currentUser: userContext,
+            activeInstructorTab: "brightspace",
+            hasActiveCourse: courseState.active != nil,
+            brightspaceSyncEnabled: req.application.brightSpaceClient != nil
+        )
+        return try await req.view.render("instructor-brightspace", ctx)
+    }
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -35,6 +35,11 @@ struct InstructorDashboardRoutes: RouteCollection {
 
         let r = routes.grouped("instructor")
         r.get(use: list)
+        // Students roster tab + its self-updating poll endpoint.
+        r.get("students", use: studentsPage)
+        r.get("students-data", use: studentsData)
+        // BrightSpace tab (grade export + sync status).
+        r.get("brightspace", use: brightspacePage)
         r.get("grades.csv", use: exportGradesCSV)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
         r.get(":assignmentID", "students", ":studentID", "history", use: studentSubmissionHistoryPage)
@@ -146,28 +151,15 @@ struct InstructorDashboardRoutes: RouteCollection {
             sectionByPublicID: sectionByPublicID
         )
 
-        // Fetch enrollment mode and archived state for the active course.
-        var courseEnrollmentMode = CourseEnrollmentMode.open.rawValue
-        var courseIsArchived = false
-        if let activeCourseUUID = courseState.activeCourseUUID,
-            let activeCourseModel = try await APICourse.find(activeCourseUUID, on: req.db)
-        {
-            courseEnrollmentMode = activeCourseModel.enrollmentMode.rawValue
-            courseIsArchived = activeCourseModel.isArchived
-        }
-
         let ctx = AssignmentsContext(
             currentUser: userContext,
+            activeInstructorTab: "overview",
             metrics: roster.metrics,
             sections: sectionContexts,
             ungroupedRows: ungroupedRows,
             hasSections: !allSections.isEmpty,
             hasUngrouped: !ungroupedRows.isEmpty,
-            enrolledStudents: roster.enrolledStudents,
-            hasEnrolledStudents: !roster.enrolledStudents.isEmpty,
-            enrolledStudentCount: roster.enrolledStudentCount,
-            courseEnrollmentMode: courseEnrollmentMode,
-            courseIsArchived: courseIsArchived
+            enrolledStudentCount: roster.enrolledStudentCount
         )
         return try await req.view.render("assignments", ctx).encodeResponse(for: req)
     }

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -252,8 +252,10 @@ import XCTVapor
             _ = try await app.testCourseID(enrollmentMode: .auto)
             let cookie = try await arLoginAsInstructor(on: app)
 
+            // The enrol-from-CSV link lives on the Students tab as of the
+            // instructor-view rework (v0.4.283+).
             try await app.asyncTest(
-                .GET, "/instructor",
+                .GET, "/instructor/students",
                 beforeRequest: { req in
                     req.headers.add(name: .cookie, value: cookie)
                 },
@@ -286,8 +288,10 @@ import XCTVapor
             try await recent.save(on: app.db)
             try await arEnrollStudentInTestCourse(recent, on: app)
 
+            // The enrolled-students roster moved to the Students tab in the
+            // instructor-view rework (v0.4.283+).
             try await app.asyncTest(
-                .GET, "/instructor",
+                .GET, "/instructor/students",
                 beforeRequest: { req in
                     req.headers.add(name: .cookie, value: cookie)
                 },

--- a/changelog.d/instructor-view-tabs.md
+++ b/changelog.d/instructor-view-tabs.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Instructor view split into tabs.** The instructor dashboard now uses the
+  same tabbed layout as the admin view. **Overview** keeps the dashboard
+  metrics and the assignment/section listing; **Students** moves the enrolled-
+  students roster to its own panel that self-updates every few seconds (like
+  the admin Users panel) via a new `GET /instructor/students-data` poll
+  endpoint; and a new **BrightSpace** tab hosts the "Export Grades CSV" button
+  (moved off the Overview header) alongside the automatic grade-sync status.


### PR DESCRIPTION
## Summary

Splits the instructor dashboard (`/instructor`) into tabbed panels, mirroring the admin view:

- **Overview** (`/instructor`) — unchanged content: dashboard metric cards + the assignment/section listing. The enrolled-students table and the "Export Grades CSV" button were removed from here.
- **Students** (`/instructor/students`) — the enrolled-students roster, enrolment-mode control, and "Enrol from CSV" link. The table **self-updates every 5s** by polling a new `GET /instructor/students-data` JSON endpoint and repainting (skipping while the tab is hidden or the instructor is filtering) — the same mechanism as the admin Users panel.
- **BrightSpace** (`/instructor/brightspace`) — hosts the moved "Export Grades CSV" button plus an automatic grade-sync status note (driven by whether `brightSpaceClient` is configured).

## Implementation notes

- `AssignmentsContext` slimmed: added `activeInstructorTab`, dropped the roster fields, kept `enrolledStudentCount` (still needed for the per-assignment "X / Y" badge). Added `InstructorStudentsContext` / `InstructorBrightspaceContext`; `EnrolledStudentRow` now conforms to `Content` for the JSON poll.
- New handlers in `InstructorDashboardRoutes+Students.swift` (`studentsPage`, `studentsData`, `brightspacePage`); shared roster helper `loadEnrolledStudentRows` added to `+List.swift` (roster without the expensive dashboard-metric computation).
- Tab nav is inlined into each Leaf page rather than a shared partial, matching the admin pattern (LeafKit 1.x raises a false-positive cycle error on `#extend` of a tab-bar partial). Tab CSS generalized to cover `.instructor-tabs` alongside `.admin-tabs`.
- Repointed two dashboard tests to `/instructor/students`; added a changelog fragment.

## Test plan

- [ ] CI green (build + format/lint + tests)
- [ ] `/instructor` Overview shows metrics + assignments; no roster, no Export CSV button
- [ ] `/instructor/students` shows the roster, sortable/filterable, and live-updates last-seen / added / removed students without a manual reload
- [ ] `/instructor/brightspace` Export Grades CSV downloads the same CSV as before; sync-status line reflects server config
- [ ] Unenrol, enrolment-mode change, and row-click drilldown still work on the Students tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)