### PR TITLE
Tidy admin MCP tab: drop prose, add empty-state placeholder

### DIFF
--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -148,21 +148,9 @@ MCP
         #endif
         </tbody>
     </table>
-    #else:
-    <h2 style="margin-top:0">MCP agents</h2>
-    <p style="color:var(--gray-600);font-size:.85rem;max-width:70ch">
-        Instructors authorize agents through single sign-on (the browser OAuth flow) — no service
-        accounts are created here. Each agent acts on the authorizing instructor's behalf, and its
-        actions are recorded in the <a href="/admin/audit">audit log</a> as
-        <code>&lt;username&gt;-MCP</code>, separate from the instructor's own.
-    </p>
     #endif
 
     <h2 style="margin-top:2rem">Connected agents</h2>
-    <p style="color:var(--gray-600);font-size:.85rem;max-width:70ch">
-        Browser-authorized OAuth grants — an instructor approved an agent to act on their behalf.
-        Revoking stops the agent immediately; any access token it holds lapses within minutes.
-    </p>
     <table class="results-table sortable-table">
         <thead>
             <tr>
@@ -198,7 +186,7 @@ MCP
             </tr>
         #endfor
         #if(grants.isEmpty):
-            <tr><td colspan="7" style="color:var(--gray-600)">No connected agents.</td></tr>
+            <tr><td colspan="7" style="color:var(--gray-600);text-align:center;padding:1rem">No agents have connected yet.</td></tr>
         #endif
         </tbody>
     </table>

--- a/Tests/APITests/MCP/AdminMCPRoutesTests.swift
+++ b/Tests/APITests/MCP/AdminMCPRoutesTests.swift
@@ -202,8 +202,7 @@ import XCTVapor
                     let body = res.body.string
                     // No manual service-account creation in SSO mode...
                     #expect(body.contains("Create account") == false)
-                    // ...but the SSO/audit explanation and Connected Agents table show.
-                    #expect(body.contains("single sign-on"))
+                    // ...but the Connected Agents table still shows.
                     #expect(body.contains("Connected agents"))
                 })
         }
@@ -252,7 +251,7 @@ import XCTVapor
                     #expect(body.contains("Connected agents"))
                     #expect(body.contains("Claude Bot"))
                     #expect(body.contains("prof-x"))
-                    #expect(body.contains("No connected agents.") == false)
+                    #expect(body.contains("No agents have connected yet.") == false)
                 })
         }
     }

--- a/changelog.d/mcp-tab-cleanup.md
+++ b/changelog.d/mcp-tab-cleanup.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **Admin MCP tab tidied.** Removed the explanatory "MCP agents" and
+  "Connected agents" prose blurbs from the admin MCP tab. The Connected
+  agents table now shows a centred "No agents have connected yet."
+  placeholder when empty, which disappears once an agent connects.


### PR DESCRIPTION
## Summary

Cleans up the admin **MCP** tab per request:

- Removes the "MCP agents" explanatory paragraph (the SSO/audit-log blurb shown when service accounts aren't used) and the "Connected agents" descriptive paragraph.
- The **Connected agents** heading and table stay. When there are no grants, the table shows a centred **"No agents have connected yet."** placeholder row that disappears once an agent connects.
- Updated two `AdminMCPRoutesTests` assertions: dropped the now-removed "single sign-on" prose check, and repointed the empty-state regression check to the new placeholder string.

## Test plan

- [ ] CI green
- [ ] `/admin/mcp` no longer shows the two prose paragraphs
- [ ] With no connected agents, the table shows "No agents have connected yet."
- [ ] With at least one grant, the placeholder is gone and the grant row(s) render

🤖 Generated with [Claude Code](https://claude.com/claude-code)