### PR TITLE
Build out instructor BrightSpace grade-sync console

### DIFF
--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -91,8 +91,22 @@
     </form>
     #if(course.brightspaceSyncEnabled):
     <p class="card-meta" style="margin-top:.5rem">
-        BrightSpace grade sync is active. Set the Org Unit ID to enable nightly grade push for this course.
-        Per-assignment grade item IDs are configured on each assignment's edit page.
+        #if(course.brightspaceOrgUnitID):
+            #if(course.brightspaceOrgUnitName):
+            <span class="tier tier-open">verified</span>
+            Linked to D2L org unit <strong>#(course.brightspaceOrgUnitName)</strong>
+            (ID <code>#(course.brightspaceOrgUnitID)</code>).
+            #else:
+            <span class="tier tier-closed">unverified</span>
+            Org Unit ID <code>#(course.brightspaceOrgUnitID)</code> could not be confirmed in D2L
+            (wrong ID, or D2L unreachable). Re-save to retry verification.
+            #endif
+        #else:
+            BrightSpace grade sync is active. Set the Org Unit ID to bind this course to its D2L
+            grade book — it's verified against D2L on save.
+        #endif
+        Per-assignment grade item IDs are configured on the
+        <a href="/instructor/brightspace">BrightSpace</a> tab.
     </p>
     #endif
 </section>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -11,12 +11,204 @@ BrightSpace
 
 <h1 style="margin:0 0 1.25rem">BrightSpace</h1>
 
-<section style="margin-bottom:2.5rem">
-    <h2 style="font-size:1.05rem;font-weight:600;margin:0 0 .5rem">Export grades</h2>
-    <p style="color:var(--gray-600);margin:0 0 .9rem;max-width:46rem">
-        Download a CSV of every enrolled student's best grade per assignment,
-        formatted for BrightSpace grade import (OrgDefinedId + per-assignment
-        points columns).
+#if(!brightspaceSyncEnabled):
+<section class="bs-section">
+    <p class="empty">
+        Automatic BrightSpace grade sync is not configured on this server.
+        You can still export grades as a CSV for manual upload below.
+    </p>
+</section>
+#elseif(!hasActiveCourse):
+<section class="bs-section">
+    <p class="empty">Select a course to manage its BrightSpace grade sync.</p>
+</section>
+#else:
+
+<!-- ── Connection & course link ──────────────────────────── -->
+<section class="bs-section">
+    <h2 class="bs-h2">Connection</h2>
+    <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap">
+        <button class="btn action-btn" type="button" id="bs-test-btn">Test connection</button>
+        <span id="bs-test-result" class="card-meta"></span>
+    </div>
+    <p class="card-meta" style="margin-top:.6rem;max-width:60ch">
+        #if(courseLinked):
+            #if(orgUnitName):
+            <span class="tier tier-open">linked</span>
+            This course pushes grades to D2L org unit <strong>#(orgUnitName)</strong>
+            (ID <code>#(orgUnitID)</code>).
+            #else:
+            <span class="tier tier-closed">unverified</span>
+            Bound to org unit <code>#(orgUnitID)</code>, but it couldn't be confirmed in D2L.
+            An admin should re-save the binding on the course page.
+            #endif
+        #else:
+            <span class="tier tier-closed">not linked</span>
+            This course isn't bound to a D2L org unit yet, so no grades will sync.
+            An admin sets the Org Unit ID on the course page.
+        #endif
+    </p>
+</section>
+
+<!-- ── Summary ───────────────────────────────────────────── -->
+<section class="bs-section">
+    <div class="bs-cards">
+        <div class="bs-card"><div class="bs-card-label">Synced</div><div class="bs-card-value">#(summary.synced)</div></div>
+        <div class="bs-card"><div class="bs-card-label">Pending</div><div class="bs-card-value">#(summary.pending)</div></div>
+        <div class="bs-card"><div class="bs-card-label">Errored</div><div class="bs-card-value">#(summary.errored)</div></div>
+        <div class="bs-card"><div class="bs-card-label">Unmapped students</div><div class="bs-card-value">#(summary.unmapped)</div></div>
+    </div>
+    #if(!courseIsArchived):
+    <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.9rem">
+        <form method="post" action="/instructor/brightspace/sync-now" style="margin:0">
+            #csrfFormField()
+            <button class="btn btn-primary" type="submit">Sync now</button>
+        </form>
+        <form method="post" action="/instructor/brightspace/retry-failed" style="margin:0">
+            #csrfFormField()
+            <button class="btn action-btn" type="submit">Retry failed</button>
+        </form>
+    </div>
+    #endif
+</section>
+
+<!-- ── Assignment → grade-item mapping ───────────────────── -->
+<section class="bs-section">
+    <h2 class="bs-h2">Grade-item mapping</h2>
+    #if(!hasAssignments):
+    <p class="empty">No assignments in this course yet.</p>
+    #else:
+    <p class="card-meta" style="margin:0 0 .6rem;max-width:62ch">
+        Map each assignment to its D2L grade item. Start typing to pick from the course's
+        grade book (when connected), or paste the numeric grade-item ID. Leave blank to skip
+        an assignment.
+    </p>
+    <datalist id="bs-grade-objects"></datalist>
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>Assignment</th>
+                <th>Grade item ID</th>
+                <th>Last sync</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        #for(row in assignmentRows):
+            <tr>
+                <td><strong>#(row.title)</strong></td>
+                <td>
+                    <form method="post" action="/instructor/#(row.assignmentID)/brightspace"
+                          style="display:flex;gap:.4rem;align-items:center;margin:0">
+                        #csrfFormField()
+                        <input type="hidden" name="returnTo" value="brightspace">
+                        <label class="visually-hidden" for="bs-go-#(row.assignmentID)">Grade item ID for #(row.title)</label>
+                        <input class="form-input" type="text" name="gradeObjectID"
+                               id="bs-go-#(row.assignmentID)" list="bs-grade-objects"
+                               value="#(row.gradeObjectID)" placeholder="e.g. 78901"
+                               style="width:11rem;font-size:.85rem;padding:.25rem .45rem">
+                        <button class="btn action-btn" type="submit">Save</button>
+                    </form>
+                </td>
+                <td>
+                    #if(row.lastSyncStatus == "success"):
+                    <span class="tier tier-open" title="#(row.lastSyncText)">synced</span>
+                    #elseif(row.lastSyncStatus == "error"):
+                    <span class="tier tier-closed" title="#if(row.lastSyncDetail):#(row.lastSyncDetail)#else:#(row.lastSyncText)#endif">error</span>
+                    #elseif(row.lastSyncStatus == "skipped"):
+                    <span class="tier" title="#if(row.lastSyncDetail):#(row.lastSyncDetail)#else:#(row.lastSyncText)#endif">skipped</span>
+                    #else:
+                    <span class="card-meta">—</span>
+                    #endif
+                    <div class="card-meta" style="font-size:.72rem">#if(row.lastSyncStatus != "none"):#(row.lastSyncText)#endif</div>
+                </td>
+                <td>
+                    #if(!courseIsArchived):
+                    <form method="post" action="/instructor/#(row.assignmentID)/brightspace/push-all"
+                          style="margin:0"
+                          onsubmit="return confirm('Re-push every student’s best grade for #(row.title) to BrightSpace?')">
+                        #csrfFormField()
+                        <button class="btn action-btn" type="submit"
+                                title="Re-push all grades for this assignment">Push all</button>
+                    </form>
+                    #endif
+                </td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+    #endif
+</section>
+
+<!-- ── Unmapped students ─────────────────────────────────── -->
+#if(hasUnmapped):
+<section class="bs-section">
+    <h2 class="bs-h2">Unmapped students (#(summary.unmapped))</h2>
+    <p class="card-meta" style="margin:0 0 .6rem;max-width:62ch">
+        These students' grades can't sync because Chickadee can't resolve a BrightSpace account
+        for them. Fix the student number on file, or confirm they're enrolled in the D2L course.
+    </p>
+    <table class="results-table">
+        <thead><tr><th>Name</th><th>Username</th><th>Reason</th></tr></thead>
+        <tbody>
+        #for(student in unmappedStudents):
+            <tr>
+                <td>#(student.displayName)</td>
+                <td><code>#(student.username)</code></td>
+                <td>#(student.reason)</td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+</section>
+#endif
+
+<!-- ── Sync log ──────────────────────────────────────────── -->
+<section class="bs-section">
+    <h2 class="bs-h2">Recent sync activity</h2>
+    #if(!hasLog):
+    <p class="empty">No grade pushes recorded yet.</p>
+    #else:
+    <table class="results-table">
+        <thead>
+            <tr>
+                <th>When</th>
+                <th>Student</th>
+                <th>Assignment</th>
+                <th>Points</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+        #for(log in logRows):
+            <tr>
+                <td style="white-space:nowrap">#(log.attemptedAt)</td>
+                <td><code>#(log.username)</code></td>
+                <td>#(log.assignmentTitle)</td>
+                <td>#(log.points)</td>
+                <td>
+                    #if(log.status == "success"):
+                    <span class="tier tier-open">success</span>
+                    #elseif(log.status == "error"):
+                    <span class="tier tier-closed" title="#if(log.detail):#(log.detail)#endif">error</span>
+                    #else:
+                    <span class="tier" title="#if(log.detail):#(log.detail)#endif">skipped</span>
+                    #endif
+                </td>
+            </tr>
+        #endfor
+        </tbody>
+    </table>
+    #endif
+</section>
+#endif
+
+<!-- ── Export grades (always available) ──────────────────── -->
+<section class="bs-section">
+    <h2 class="bs-h2">Export grades</h2>
+    <p class="card-meta" style="margin:0 0 .6rem;max-width:62ch">
+        Download a CSV of every enrolled student's best grade per assignment, formatted for
+        BrightSpace grade import (OrgDefinedId + per-assignment points columns).
     </p>
     #if(hasActiveCourse):
     <a class="btn action-btn" href="/instructor/grades.csv">Export Grades CSV</a>
@@ -25,20 +217,73 @@ BrightSpace
     #endif
 </section>
 
-<section>
-    <h2 style="font-size:1.05rem;font-weight:600;margin:0 0 .5rem">Automatic grade sync</h2>
-    #if(brightspaceSyncEnabled):
-    <p style="color:var(--gray-600);margin:0;max-width:46rem">
-        BrightSpace grade sync is <strong>enabled</strong> on this server.
-        Grades push automatically as students submit, for assignments with a
-        BrightSpace grade item ID configured on the assignment edit page.
-    </p>
-    #else:
-    <p style="color:var(--gray-600);margin:0;max-width:46rem">
-        Automatic grade sync is not configured on this server. Use the CSV
-        export above to upload grades to BrightSpace manually.
-    </p>
-    #endif
-</section>
+<style>
+.bs-section { margin-bottom: 2rem; }
+.bs-h2 { font-size: 1.05rem; font-weight: 600; margin: 0 0 .6rem; }
+.bs-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: .75rem; }
+.bs-card {
+    padding: .75rem .9rem; border: 1px solid var(--border);
+    border-radius: .5rem; background: var(--surface);
+}
+.bs-card-label { color: var(--gray-600); font-size: .82rem; }
+.bs-card-value { margin-top: .2rem; font-size: 1.4rem; font-weight: 600; color: var(--gray-900); }
+</style>
+<script>
+(function () {
+    'use strict';
+
+    // ── Test connection ──────────────────────────────────────────────
+    var testBtn = document.getElementById('bs-test-btn');
+    var testResult = document.getElementById('bs-test-result');
+    if (testBtn) {
+        testBtn.addEventListener('click', async function () {
+            var meta = document.querySelector('meta[name="csrf-token"]');
+            var csrf = meta ? meta.getAttribute('content') : '';
+            testBtn.disabled = true;
+            if (testResult) testResult.textContent = 'Testing…';
+            try {
+                var res = await fetch('/instructor/brightspace/test', {
+                    method: 'POST',
+                    headers: { 'x-csrf-token': csrf, 'Accept': 'application/json' }
+                });
+                var data = await res.json();
+                if (testResult) {
+                    testResult.textContent = data.message || (data.ok ? 'OK' : 'Failed');
+                    testResult.style.color = data.ok ? 'var(--green)' : 'var(--red)';
+                }
+            } catch (_) {
+                if (testResult) {
+                    testResult.textContent = 'Test request failed.';
+                    testResult.style.color = 'var(--red)';
+                }
+            } finally {
+                testBtn.disabled = false;
+            }
+        });
+    }
+
+    // ── Grade-item dropdown (progressive enhancement) ─────────────────
+    // Populate the shared <datalist> from D2L so the free-text inputs gain a
+    // searchable picker. If the fetch fails or returns nothing, the inputs
+    // stay as plain free-text fields — sync still works.
+    var datalist = document.getElementById('bs-grade-objects');
+    if (datalist) {
+        fetch('/instructor/brightspace/grade-objects', {
+            headers: { 'Accept': 'application/json' }, cache: 'no-store'
+        }).then(function (res) {
+            return res.ok ? res.json() : [];
+        }).then(function (items) {
+            if (!Array.isArray(items)) return;
+            datalist.innerHTML = items.map(function (it) {
+                var label = it.name + (it.maxPoints != null ? ' (' + it.maxPoints + ' pts)' : '');
+                var opt = document.createElement('option');
+                opt.value = String(it.id);
+                opt.textContent = label;
+                return opt.outerHTML;
+            }).join('');
+        }).catch(function () { /* leave free-text inputs */ });
+    }
+})();
+</script>
 #endexport
 #endextend

--- a/Sources/APIServer/Migrations/AddBrightSpaceOrgUnitName.swift
+++ b/Sources/APIServer/Migrations/AddBrightSpaceOrgUnitName.swift
@@ -1,0 +1,27 @@
+// APIServer/Migrations/AddBrightSpaceOrgUnitName.swift
+//
+// Adds the optional `brightspace_org_unit_name` column to `courses`: the
+// human-readable D2L org-unit name, cached when an admin binds a course to
+// its org unit (we look the ID up in D2L and store the name so the binding
+// is verifiable at a glance).  nil = not bound, or bound but not yet verified.
+//
+// Standalone Add* migration (not folded into CreateCourses) because
+// production databases have already applied CreateCourses without this
+// column and would never pick it up from a body change.  Fresh deploys run
+// CreateCourses then this migration; existing prod runs only this one.
+
+import Fluent
+
+struct AddBrightSpaceOrgUnitName: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("courses")
+            .field("brightspace_org_unit_name", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("courses")
+            .deleteField("brightspace_org_unit_name")
+            .update()
+    }
+}

--- a/Sources/APIServer/Migrations/CreateBrightSpaceSyncLog.swift
+++ b/Sources/APIServer/Migrations/CreateBrightSpaceSyncLog.swift
@@ -1,0 +1,47 @@
+// APIServer/Migrations/CreateBrightSpaceSyncLog.swift
+//
+// Append-only log of BrightSpace grade-push events (success / error /
+// skipped).  Backs the BrightSpace tab's sync-activity view.  No foreign
+// keys: the log snapshots identity fields and must outlive the records it
+// describes, so a course/assignment/user delete never cascades into the
+// audit trail.
+
+import Fluent
+import SQLKit
+
+struct CreateBrightSpaceSyncLog: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("brightspace_sync_log")
+            .id()
+            .field("course_id", .uuid)
+            .field("test_setup_id", .string, .required)
+            .field("assignment_title", .string, .required)
+            .field("user_id", .uuid)
+            .field("username", .string, .required)
+            .field("org_unit_id", .string)
+            .field("grade_object_id", .string)
+            .field("points", .double)
+            .field("status", .string, .required)
+            .field("detail", .string)
+            .field("attempted_at", .datetime)
+            .create()
+
+        // Panel query is "most recent N events for this course" — index the
+        // (course, time) access path so it stays cheap as the log grows.
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                """
+                CREATE INDEX IF NOT EXISTS idx_bs_sync_log_course_time
+                ON brightspace_sync_log(course_id, attempted_at)
+                """
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_bs_sync_log_course_time").run()
+        }
+        try await database.schema("brightspace_sync_log").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIBrightSpaceSyncLog.swift
+++ b/Sources/APIServer/Models/APIBrightSpaceSyncLog.swift
@@ -1,0 +1,89 @@
+// APIServer/Models/APIBrightSpaceSyncLog.swift
+//
+// Append-only audit trail for BrightSpace grade pushes.  One row is written
+// per meaningful sync event — a successful push, a failed push, or a student
+// skipped because they have no resolvable BrightSpace account.  Routine
+// no-ops (assignment with no grade item, course with no org unit) are NOT
+// logged, so the log stays signal, not noise.
+//
+// Identity fields (username, assignmentTitle) are snapshotted rather than
+// FK-joined so the log stays readable after a course/assignment/user is
+// deleted — an audit trail should survive the records it describes.
+
+import Fluent
+import Vapor
+
+final class APIBrightSpaceSyncLog: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: only mutated within a request/DB context before save.
+    static let schema = "brightspace_sync_log"
+
+    /// Terminal states recorded in the `status` column.
+    enum Status: String {
+        case success
+        case error
+        case skipped
+    }
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @OptionalField(key: "course_id")
+    var courseID: UUID?
+
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    @Field(key: "assignment_title")
+    var assignmentTitle: String
+
+    @OptionalField(key: "user_id")
+    var userID: UUID?
+
+    @Field(key: "username")
+    var username: String
+
+    @OptionalField(key: "org_unit_id")
+    var orgUnitID: String?
+
+    @OptionalField(key: "grade_object_id")
+    var gradeObjectID: String?
+
+    @OptionalField(key: "points")
+    var points: Double?
+
+    /// One of `Status` raw values: "success" | "error" | "skipped".
+    @Field(key: "status")
+    var status: String
+
+    @OptionalField(key: "detail")
+    var detail: String?
+
+    @Timestamp(key: "attempted_at", on: .create)
+    var attemptedAt: Date?
+
+    init() {}
+
+    init(
+        courseID: UUID?,
+        testSetupID: String,
+        assignmentTitle: String,
+        userID: UUID?,
+        username: String,
+        orgUnitID: String?,
+        gradeObjectID: String?,
+        points: Double?,
+        status: Status,
+        detail: String?
+    ) {
+        self.courseID = courseID
+        self.testSetupID = testSetupID
+        self.assignmentTitle = assignmentTitle
+        self.userID = userID
+        self.username = username
+        self.orgUnitID = orgUnitID
+        self.gradeObjectID = gradeObjectID
+        self.points = points
+        self.status = status.rawValue
+        self.detail = detail
+    }
+}

--- a/Sources/APIServer/Models/APICourse.swift
+++ b/Sources/APIServer/Models/APICourse.swift
@@ -43,6 +43,12 @@ final class APICourse: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_org_unit_id")
     var brightspaceOrgUnitID: String?
 
+    /// Human-readable D2L org-unit name, cached when an admin binds the
+    /// course to its org unit (we look the ID up and store the name so the
+    /// binding is verifiable at a glance). Nil = unbound or unverified.
+    @OptionalField(key: "brightspace_org_unit_name")
+    var brightspaceOrgUnitName: String?
+
     /// When this course was archived. Set by `toggleCourseArchive` when a
     /// course is archived (and cleared when un-archived). Archiving is
     /// Chickadee's "end of term" signal, so this is the anchor for the
@@ -62,7 +68,8 @@ final class APICourse: Model, Content, @unchecked Sendable {
     init(
         id: UUID? = nil, code: String, name: String,
         isArchived: Bool = false, enrollmentMode: CourseEnrollmentMode = .open,
-        brightspaceOrgUnitID: String? = nil
+        brightspaceOrgUnitID: String? = nil,
+        brightspaceOrgUnitName: String? = nil
     ) {
         self.id = id
         self.code = code
@@ -70,5 +77,6 @@ final class APICourse: Model, Content, @unchecked Sendable {
         self.isArchived = isArchived
         self.enrollmentModeRaw = enrollmentMode.rawValue
         self.brightspaceOrgUnitID = brightspaceOrgUnitID
+        self.brightspaceOrgUnitName = brightspaceOrgUnitName
     }
 }

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -42,6 +42,7 @@ struct AdminCourseRow: Encodable {
     let submissionCount: Int
     let createdAt: String
     var brightspaceOrgUnitID: String?
+    var brightspaceOrgUnitName: String?
     var brightspaceSyncEnabled: Bool
 }
 

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -24,6 +24,7 @@ extension AdminRoutes {
             submissionCount: 0,
             createdAt: "",
             brightspaceOrgUnitID: nil,
+            brightspaceOrgUnitName: nil,
             brightspaceSyncEnabled: req.application.brightSpaceClient != nil
         )
         return try await req.view.render(
@@ -302,12 +303,37 @@ extension AdminRoutes {
 
         course.code = code
         course.name = name
-        if req.application.brightSpaceClient != nil {
+        if let client = req.application.brightSpaceClient {
             let rawOrgUnit = (body.brightspaceOrgUnitID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            course.brightspaceOrgUnitID = rawOrgUnit.isEmpty ? nil : rawOrgUnit
+            let newOrgUnit = rawOrgUnit.isEmpty ? nil : rawOrgUnit
+            course.brightspaceOrgUnitID = newOrgUnit
+            // Verify the binding against D2L and cache the org-unit name so the
+            // admin can confirm they pointed at the right course. Verification
+            // failures (D2L unreachable, bad ID) don't block the save — the
+            // name just stays nil and the UI shows "unverified".
+            if let orgUnit = newOrgUnit {
+                course.brightspaceOrgUnitName = await verifiedOrgUnitName(
+                    orgUnitID: orgUnit, client: client, req: req)
+            } else {
+                course.brightspaceOrgUnitName = nil
+            }
         }
         try await course.save(on: req.db)
         return req.redirect(to: "/admin/courses/\(idString)")
+    }
+
+    /// Looks the org unit up in D2L and returns its name, or nil if it can't
+    /// be verified (not found, or D2L unreachable). Never throws — a failed
+    /// verification must not block saving the course.
+    private func verifiedOrgUnitName(
+        orgUnitID: String, client: BrightSpaceAPIClient, req: Request
+    ) async -> String? {
+        do {
+            return try await client.getOrgUnit(orgUnitID: orgUnitID, on: req.application)?.name
+        } catch {
+            req.logger.warning("BrightSpace org-unit verification failed for \(orgUnitID): \(error)")
+            return nil
+        }
     }
 
     // MARK: - POST /admin/courses/:courseID/unenroll/:userID
@@ -360,6 +386,7 @@ extension AdminRoutes {
             submissionCount: (try await submissionCountFetch)[courseID] ?? 0,
             createdAt: course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—",
             brightspaceOrgUnitID: course.brightspaceOrgUnitID,
+            brightspaceOrgUnitName: course.brightspaceOrgUnitName,
             brightspaceSyncEnabled: req.application.brightSpaceClient != nil
         )
 

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -64,12 +64,61 @@ struct InstructorStudentsContext: Encodable {
     let courseIsArchived: Bool
 }
 
-/// BrightSpace tab (`GET /instructor/brightspace`): grade export + sync status.
+/// BrightSpace tab (`GET /instructor/brightspace`): connection status, the
+/// assignment→grade-item mapping, the sync log, and grade export.
 struct InstructorBrightspaceContext: Encodable {
     let currentUser: CurrentUserContext?
     let activeInstructorTab: String
     let hasActiveCourse: Bool
+    let courseIsArchived: Bool
+    /// True when the server has BrightSpace credentials configured at all.
     let brightspaceSyncEnabled: Bool
+    /// True when this course is bound to a D2L org unit (admin-set).
+    let courseLinked: Bool
+    let orgUnitID: String?
+    let orgUnitName: String?
+    let assignmentRows: [BrightspaceAssignmentRow]
+    let hasAssignments: Bool
+    let logRows: [BrightspaceLogRow]
+    let hasLog: Bool
+    let summary: BrightspaceSyncSummary
+    let unmappedStudents: [BrightspaceUnmappedStudentRow]
+    let hasUnmapped: Bool
+}
+
+/// One assignment's BrightSpace grade-item mapping + its latest sync state.
+struct BrightspaceAssignmentRow: Encodable {
+    let assignmentID: String  // publicID
+    let title: String
+    let gradeObjectID: String  // "" when unmapped
+    let lastSyncText: String  // formatted time, or "—"
+    let lastSyncStatus: String  // "success" | "error" | "skipped" | "none"
+    let lastSyncDetail: String?
+}
+
+/// One row of the sync-activity log.
+struct BrightspaceLogRow: Encodable {
+    let attemptedAt: String
+    let username: String
+    let assignmentTitle: String
+    let points: String  // formatted, or "—"
+    let status: String  // "success" | "error" | "skipped"
+    let detail: String?
+}
+
+/// Headline counts shown as cards atop the panel.
+struct BrightspaceSyncSummary: Encodable {
+    let synced: Int
+    let pending: Int
+    let errored: Int
+    let unmapped: Int
+}
+
+/// A student whose grade can't sync because they have no resolvable D2L account.
+struct BrightspaceUnmappedStudentRow: Encodable {
+    let username: String
+    let displayName: String
+    let reason: String
 }
 
 struct InstructorDashboardMetric: Encodable {

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -1,0 +1,349 @@
+// APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+//
+// The instructor BrightSpace tab: connection status, the assignment→grade-
+// item mapping, the sync-activity log, manual sync actions, and unmapped-
+// student diagnostics.  Everything here is scoped to the active course.
+//
+// Connection credentials are server-level (env, ops-managed) and never
+// exposed here; the course→org-unit binding is admin-set on the course page.
+// This tab is where an instructor wires grade items and watches grades flow.
+//
+//   GET  /instructor/brightspace                       → instructor-brightspace.leaf
+//   POST /instructor/brightspace/test                  → whoami connection test (JSON)
+//   GET  /instructor/brightspace/grade-objects         → [BrightSpaceGradeObject] (dropdown)
+//   POST /instructor/brightspace/sync-now              → run a sweep immediately
+//   POST /instructor/brightspace/retry-failed          → re-queue errored pushes
+//   POST /instructor/:assignmentID/brightspace/push-all → re-push every grade for one assignment
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension InstructorDashboardRoutes {
+
+    // MARK: - GET /instructor/brightspace
+
+    @Sendable
+    func brightspacePage(req: Request) async throws -> View {
+        let user = try req.auth.require(APIUser.self)
+        let ctx = try await buildBrightspaceContext(req: req, user: user)
+        return try await req.view.render("instructor-brightspace", ctx)
+    }
+
+    // MARK: - POST /instructor/brightspace/test
+
+    /// Validates the configured BrightSpace credentials via D2L `whoami`.
+    /// Returns JSON the panel renders inline — surfaces auth problems before
+    /// any grade push fails.
+    @Sendable
+    func brightspaceTestConnection(req: Request) async throws -> BrightspaceTestResult {
+        guard let client = req.application.brightSpaceClient else {
+            return BrightspaceTestResult(ok: false, message: "BrightSpace is not configured on this server.")
+        }
+        do {
+            let who = try await client.whoami(on: req.application)
+            let who2 = who.uniqueName.isEmpty ? who.displayName : "\(who.displayName) (\(who.uniqueName))"
+            return BrightspaceTestResult(ok: true, message: "Connected as \(who2).")
+        } catch {
+            return BrightspaceTestResult(ok: false, message: "Connection failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - GET /instructor/brightspace/grade-objects
+
+    /// Lists the active course's D2L grade items for the mapping dropdown.
+    /// Returns an empty array when sync is unconfigured or the course isn't
+    /// bound — the panel falls back to free-text entry in that case.
+    @Sendable
+    func brightspaceGradeObjects(req: Request) async throws -> [BrightSpaceGradeObject] {
+        let user = try req.auth.require(APIUser.self)
+        guard let client = req.application.brightSpaceClient else { return [] }
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db),
+            let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty
+        else { return [] }
+        do {
+            return try await client.listGradeObjects(orgUnitID: orgUnitID, on: req.application)
+        } catch {
+            req.logger.warning("BrightSpace grade-objects fetch failed: \(error)")
+            return []
+        }
+    }
+
+    // MARK: - POST /instructor/brightspace/sync-now
+
+    @Sendable
+    func brightspaceSyncNow(req: Request) async throws -> Response {
+        await runImmediateBrightspaceSweep(req: req)
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
+    // MARK: - POST /instructor/brightspace/retry-failed
+
+    @Sendable
+    func brightspaceRetryFailed(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        if let courseUUID = courseState.activeCourseUUID {
+            let setupIDs = try await courseStudentResultIDs(req: req, courseUUID: courseUUID)
+            let results =
+                setupIDs.isEmpty
+                ? []
+                : try await APIResult.query(on: req.db)
+                    .filter(\.$submissionID ~~ setupIDs)
+                    .all()
+            for result in results where (result.brightspaceSyncError ?? "").isEmpty == false {
+                result.brightspaceSyncPending = true
+                result.brightspacePendingSince = Date.distantPast
+                result.brightspaceSyncError = nil
+                try await result.save(on: req.db)
+            }
+        }
+        await runImmediateBrightspaceSweep(req: req)
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
+    // MARK: - POST /instructor/:assignmentID/brightspace/push-all
+
+    /// Re-queues every student's grade for one assignment, then sweeps — the
+    /// end-of-term / first-time backfill button.
+    @Sendable
+    func brightspacePushAllForAssignment(req: Request) async throws -> Response {
+        let idStr = try assignmentPublicIDParameter(from: req)
+        guard let assignment = try await assignmentByPublicID(idStr, on: req.db) else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(idStr)'")
+        }
+        let submissionIDs = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == assignment.testSetupID)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .all()
+            .compactMap(\.id)
+        let results =
+            submissionIDs.isEmpty
+            ? []
+            : try await APIResult.query(on: req.db)
+                .filter(\.$submissionID ~~ submissionIDs)
+                .all()
+        for result in results {
+            result.brightspaceSyncPending = true
+            result.brightspacePendingSince = Date.distantPast
+            result.brightspaceSyncError = nil
+            try await result.save(on: req.db)
+        }
+        await runImmediateBrightspaceSweep(req: req)
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
+    // MARK: - Helpers
+
+    /// Submission IDs (used as result-query keys) for all student submissions
+    /// in the active course's test setups.
+    private func courseStudentResultIDs(req: Request, courseUUID: UUID) async throws -> [String] {
+        let setupIDs = try await APIAssignment.query(on: req.db)
+            .filter(\.$courseID == courseUUID)
+            .all()
+            .map(\.testSetupID)
+        guard !setupIDs.isEmpty else { return [] }
+        return try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID ~~ Array(Set(setupIDs)))
+            .filter(\.$kind == APISubmission.Kind.student)
+            .all()
+            .compactMap(\.id)
+    }
+
+    /// Runs a grade-sync sweep immediately, bypassing the debounce window so
+    /// a manual "Sync now" click pushes everything currently pending.  No-op
+    /// when BrightSpace isn't configured.
+    private func runImmediateBrightspaceSweep(req: Request) async {
+        guard let client = req.application.brightSpaceClient,
+            let config = req.application.brightSpaceSyncConfig
+        else { return }
+        // Pass a future `now` so the debounce cutoff lands ahead of every
+        // pending row, forcing an immediate push instead of waiting out the
+        // window.
+        _ = try? await sweepBrightSpaceGradeSync(
+            on: req.db,
+            client: client,
+            config: config,
+            logger: req.logger,
+            application: req.application,
+            now: Date().addingTimeInterval(config.debounceSecs + 1)
+        )
+    }
+
+    /// Assembles the full BrightSpace-tab context for the active course.
+    private func buildBrightspaceContext(
+        req: Request, user: APIUser
+    ) async throws
+        -> InstructorBrightspaceContext
+    {
+        let courseState = try await req.resolveActiveCourse(for: user)
+        let userContext = CurrentUserContext(
+            user: user, activeCourse: courseState.active, enrolledCourses: courseState.all)
+        let syncEnabled = req.application.brightSpaceClient != nil
+
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else {
+            return InstructorBrightspaceContext(
+                currentUser: userContext, activeInstructorTab: "brightspace",
+                hasActiveCourse: courseState.active != nil, courseIsArchived: false,
+                brightspaceSyncEnabled: syncEnabled, courseLinked: false,
+                orgUnitID: nil, orgUnitName: nil,
+                assignmentRows: [], hasAssignments: false,
+                logRows: [], hasLog: false,
+                summary: BrightspaceSyncSummary(synced: 0, pending: 0, errored: 0, unmapped: 0),
+                unmappedStudents: [], hasUnmapped: false)
+        }
+
+        let orgUnitID = course.brightspaceOrgUnitID
+        let courseLinked = !(orgUnitID ?? "").isEmpty
+        let fmt = waterlooDateTimeFormatter()
+
+        // Assignments, sorted to match the dashboard ordering.
+        let assignments = try await APIAssignment.query(on: req.db)
+            .filter(\.$courseID == courseUUID)
+            .all()
+            .sorted { lhs, rhs in
+                switch (lhs.sortOrder, rhs.sortOrder) {
+                case (let l?, let r?) where l != r: return l < r
+                case (_?, nil): return true
+                case (nil, _?): return false
+                default: return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
+                }
+            }
+        let setupIDs = Array(Set(assignments.map(\.testSetupID)))
+
+        // Recent log rows for this course (most recent first, capped).
+        let logModels = try await APIBrightSpaceSyncLog.query(on: req.db)
+            .filter(\.$courseID == courseUUID)
+            .sort(\.$attemptedAt, .descending)
+            .range(..<50)
+            .all()
+
+        // Latest log per test setup → per-assignment status badge.
+        var latestBySetup: [String: APIBrightSpaceSyncLog] = [:]
+        for log in logModels where latestBySetup[log.testSetupID] == nil {
+            latestBySetup[log.testSetupID] = log
+        }
+
+        let assignmentRows = assignments.map { a -> BrightspaceAssignmentRow in
+            let last = latestBySetup[a.testSetupID]
+            return BrightspaceAssignmentRow(
+                assignmentID: a.publicID,
+                title: a.title,
+                gradeObjectID: a.brightspaceGradeObjectID ?? "",
+                lastSyncText: last?.attemptedAt.map { fmt.string(from: $0) } ?? "—",
+                lastSyncStatus: last?.status ?? "none",
+                lastSyncDetail: last?.detail)
+        }
+
+        let logRows = logModels.map { log -> BrightspaceLogRow in
+            BrightspaceLogRow(
+                attemptedAt: log.attemptedAt.map { fmt.string(from: $0) } ?? "—",
+                username: log.username,
+                assignmentTitle: log.assignmentTitle,
+                points: log.points.map { String(format: "%.1f", $0) } ?? "—",
+                status: log.status,
+                detail: log.detail)
+        }
+
+        let (summary, unmapped) = try await brightspaceSummaryAndUnmapped(
+            req: req, courseUUID: courseUUID, setupIDs: setupIDs, logModels: logModels)
+
+        return InstructorBrightspaceContext(
+            currentUser: userContext, activeInstructorTab: "brightspace",
+            hasActiveCourse: true, courseIsArchived: course.isArchived,
+            brightspaceSyncEnabled: syncEnabled, courseLinked: courseLinked,
+            orgUnitID: orgUnitID, orgUnitName: course.brightspaceOrgUnitName,
+            assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
+            logRows: logRows, hasLog: !logRows.isEmpty,
+            summary: summary, unmappedStudents: unmapped, hasUnmapped: !unmapped.isEmpty)
+    }
+
+    /// Computes the summary counts (synced / pending / errored) from result
+    /// rows and the unmapped-student list (no D2L account resolvable).
+    private func brightspaceSummaryAndUnmapped(
+        req: Request,
+        courseUUID: UUID,
+        setupIDs: [String],
+        logModels: [APIBrightSpaceSyncLog]
+    ) async throws -> (BrightspaceSyncSummary, [BrightspaceUnmappedStudentRow]) {
+        // Result-level sync state across the course's student submissions.
+        let submissionIDs =
+            setupIDs.isEmpty
+            ? []
+            : try await APISubmission.query(on: req.db)
+                .filter(\.$testSetupID ~~ setupIDs)
+                .filter(\.$kind == APISubmission.Kind.student)
+                .all()
+                .compactMap(\.id)
+        let results =
+            submissionIDs.isEmpty
+            ? []
+            : try await APIResult.query(on: req.db)
+                .filter(\.$submissionID ~~ submissionIDs)
+                .all()
+        var synced = 0
+        var pending = 0
+        var errored = 0
+        for result in results {
+            if result.brightspaceSyncPending == true { pending += 1 }
+            if (result.brightspaceSyncError ?? "").isEmpty == false {
+                errored += 1
+            } else if result.brightspaceSyncedAt != nil {
+                synced += 1
+            }
+        }
+
+        // Unmapped students: enrolled students with no usable D2L identity.
+        let enrolledUserIDs = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseUUID)
+            .all()
+            .map(\.userID)
+        let students =
+            enrolledUserIDs.isEmpty
+            ? []
+            : try await APIUser.query(on: req.db)
+                .filter(\.$id ~~ enrolledUserIDs)
+                .filter(\.$role == "student")
+                .sort(\.$username)
+                .all()
+        let noAccountUsernames = Set(
+            logModels
+                .filter {
+                    $0.status == APIBrightSpaceSyncLog.Status.skipped.rawValue
+                        && ($0.detail?.contains("No BrightSpace account") ?? false)
+                }
+                .map(\.username))
+        var unmapped: [BrightspaceUnmappedStudentRow] = []
+        for student in students {
+            let sid = student.studentID ?? ""
+            if sid.isEmpty {
+                unmapped.append(
+                    BrightspaceUnmappedStudentRow(
+                        username: student.username,
+                        displayName: student.displayName ?? student.username,
+                        reason: "No student/org-defined ID on file"))
+            } else if noAccountUsernames.contains(student.username) {
+                unmapped.append(
+                    BrightspaceUnmappedStudentRow(
+                        username: student.username,
+                        displayName: student.displayName ?? student.username,
+                        reason: "Not found in BrightSpace"))
+            }
+        }
+
+        let summary = BrightspaceSyncSummary(
+            synced: synced, pending: pending, errored: errored, unmapped: unmapped.count)
+        return (summary, unmapped)
+    }
+}
+
+/// JSON payload for the connection-test button.
+struct BrightspaceTestResult: Content {
+    let ok: Bool
+    let message: String
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -95,24 +95,4 @@ extension InstructorDashboardRoutes {
         )
         return roster.rows
     }
-
-    // MARK: - GET /instructor/brightspace
-
-    @Sendable
-    func brightspacePage(req: Request) async throws -> View {
-        let user = try req.auth.require(APIUser.self)
-        let courseState = try await req.resolveActiveCourse(for: user)
-        let userContext = CurrentUserContext(
-            user: user,
-            activeCourse: courseState.active,
-            enrolledCourses: courseState.all
-        )
-        let ctx = InstructorBrightspaceContext(
-            currentUser: userContext,
-            activeInstructorTab: "brightspace",
-            hasActiveCourse: courseState.active != nil,
-            brightspaceSyncEnabled: req.application.brightSpaceClient != nil
-        )
-        return try await req.view.render("instructor-brightspace", ctx)
-    }
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -38,8 +38,12 @@ struct InstructorDashboardRoutes: RouteCollection {
         // Students roster tab + its self-updating poll endpoint.
         r.get("students", use: studentsPage)
         r.get("students-data", use: studentsData)
-        // BrightSpace tab (grade export + sync status).
+        // BrightSpace tab: status, grade-item mapping, sync log, manual actions.
         r.get("brightspace", use: brightspacePage)
+        r.post("brightspace", "test", use: brightspaceTestConnection)
+        r.get("brightspace", "grade-objects", use: brightspaceGradeObjects)
+        r.post("brightspace", "sync-now", use: brightspaceSyncNow)
+        r.post("brightspace", "retry-failed", use: brightspaceRetryFailed)
         r.get("grades.csv", use: exportGradesCSV)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
         r.get(":assignmentID", "students", ":studentID", "history", use: studentSubmissionHistoryPage)
@@ -55,6 +59,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.get(":assignmentID", "validate", use: validatePage)
         r.get(":assignmentID", "edit", use: editPage)
         r.post(":assignmentID", "brightspace", use: saveBrightSpaceGradeObjectID)
+        r.post(":assignmentID", "brightspace", "push-all", use: brightspacePushAllForAssignment)
         r.post(":assignmentID", "status", use: updateStatus)
         r.post(":assignmentID", "open", use: openAssignment)
         r.post(":assignmentID", "close", use: closeAssignment)
@@ -305,11 +310,19 @@ struct InstructorDashboardRoutes: RouteCollection {
         guard let assignment = try await assignmentByPublicID(idStr, on: req.db) else {
             throw WebAssignmentError.notFound(resource: "Assignment '\(idStr)'")
         }
-        struct BSBody: Content { var gradeObjectID: String? }
+        struct BSBody: Content {
+            var gradeObjectID: String?
+            /// "brightspace" → return to the BrightSpace tab (mapping table);
+            /// otherwise the assignment edit page (the legacy caller).
+            var returnTo: String?
+        }
         let body = try req.content.decode(BSBody.self)
         let raw = (body.gradeObjectID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         assignment.brightspaceGradeObjectID = raw.isEmpty ? nil : raw
         try await assignment.save(on: req.db)
+        if body.returnTo == "brightspace" {
+            return req.redirect(to: "/instructor/brightspace")
+        }
         return req.redirect(to: "/instructor/\(idStr)/edit?notice=BrightSpace+grade+item+ID+saved")
     }
 

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -60,6 +60,9 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible {
     case userNotFound(orgDefinedId: String)
     case gradePushFailed(status: Int, body: String)
     case missingPoints
+    case whoamiFailed(status: Int)
+    case orgUnitLookupFailed(orgUnitID: String, status: Int)
+    case gradeObjectsFetchFailed(orgUnitID: String, status: Int)
 
     var description: String {
         switch self {
@@ -73,8 +76,37 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible {
             return "BrightSpace grade push failed (HTTP \(s)): \(b)"
         case .missingPoints:
             return "No grade points available to push"
+        case .whoamiFailed(let s):
+            return "BrightSpace whoami failed (HTTP \(s))"
+        case .orgUnitLookupFailed(let id, let s):
+            return "BrightSpace org unit lookup for '\(id)' failed (HTTP \(s))"
+        case .gradeObjectsFetchFailed(let id, let s):
+            return "BrightSpace grade-objects fetch for org unit '\(id)' failed (HTTP \(s))"
         }
     }
+}
+
+// MARK: - Read-only lookup result types
+
+/// Identity of the D2L account the configured service keys act as.
+struct BrightSpaceWhoAmI: Content, Sendable {
+    let identifier: String
+    let uniqueName: String
+    let displayName: String
+}
+
+/// Minimal org-unit info used to verify + label a course→org-unit binding.
+struct BrightSpaceOrgUnitInfo: Content, Sendable {
+    let identifier: String
+    let name: String
+    let code: String?
+}
+
+/// A grade item (grade object) within a course's grade book.
+struct BrightSpaceGradeObject: Content, Sendable {
+    let id: String
+    let name: String
+    let maxPoints: Double?
 }
 
 // MARK: - Client
@@ -184,6 +216,103 @@ actor BrightSpaceAPIClient {
         let decoded = try response.content.decode(UserListResponse.self)
         guard let first = decoded.items.first else { return nil }
         return String(first.userId)
+    }
+
+    // MARK: - Connection test (whoami)
+
+    /// Validates the configured service keys by calling the D2L `whoami`
+    /// endpoint, returning the identity the keys act as.  Used by the
+    /// "Test connection" button — surfaces auth problems before grades fail.
+    func whoami(on application: Application) async throws -> BrightSpaceWhoAmI {
+        let rawURL = "\(config.baseURL)/d2l/api/lp/\(BrightSpaceSyncConfig.lpAPIVersion)/users/whoami"
+        let url = signed(url: rawURL, method: "GET")
+        let response = try await application.client.get(URI(string: url))
+        guard response.status == .ok else {
+            throw BrightSpaceSyncError.whoamiFailed(status: Int(response.status.code))
+        }
+        struct WhoAmIResponse: Decodable {
+            let identifier: String
+            let firstName: String?
+            let lastName: String?
+            let uniqueName: String?
+            enum CodingKeys: String, CodingKey {
+                case identifier = "Identifier"
+                case firstName = "FirstName"
+                case lastName = "LastName"
+                case uniqueName = "UniqueName"
+            }
+        }
+        let decoded = try response.content.decode(WhoAmIResponse.self)
+        let display = [decoded.firstName, decoded.lastName]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return BrightSpaceWhoAmI(
+            identifier: decoded.identifier,
+            uniqueName: decoded.uniqueName ?? "",
+            displayName: display.isEmpty ? (decoded.uniqueName ?? decoded.identifier) : display
+        )
+    }
+
+    // MARK: - Org unit lookup (verify course binding)
+
+    /// Looks up an org unit by ID to confirm it exists and label it with its
+    /// D2L name/code.  Returns nil when the org unit is not found (HTTP 404),
+    /// so the caller can flag an unverified binding without throwing.
+    func getOrgUnit(orgUnitID: String, on application: Application) async throws -> BrightSpaceOrgUnitInfo? {
+        guard !orgUnitID.isEmpty else { return nil }
+        let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
+        let rawURL = "\(config.baseURL)/d2l/api/lp/\(BrightSpaceSyncConfig.lpAPIVersion)/orgstructure/\(encoded)"
+        let url = signed(url: rawURL, method: "GET")
+        let response = try await application.client.get(URI(string: url))
+        if response.status == .notFound { return nil }
+        guard response.status == .ok else {
+            throw BrightSpaceSyncError.orgUnitLookupFailed(
+                orgUnitID: orgUnitID, status: Int(response.status.code))
+        }
+        struct OrgUnitResponse: Decodable {
+            let identifier: String
+            let name: String
+            let code: String?
+            enum CodingKeys: String, CodingKey {
+                case identifier = "Identifier"
+                case name = "Name"
+                case code = "Code"
+            }
+        }
+        let decoded = try response.content.decode(OrgUnitResponse.self)
+        return BrightSpaceOrgUnitInfo(
+            identifier: decoded.identifier, name: decoded.name, code: decoded.code)
+    }
+
+    // MARK: - Grade objects (dropdown source)
+
+    /// Lists the grade items (grade objects) in a course's grade book so the
+    /// instructor can pick one instead of hand-typing the numeric ID.
+    func listGradeObjects(orgUnitID: String, on application: Application) async throws -> [BrightSpaceGradeObject] {
+        guard !orgUnitID.isEmpty else { return [] }
+        let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
+        let rawURL = "\(config.baseURL)/d2l/api/le/\(BrightSpaceSyncConfig.leAPIVersion)/\(encoded)/grades/"
+        let url = signed(url: rawURL, method: "GET")
+        let response = try await application.client.get(URI(string: url))
+        guard response.status == .ok else {
+            throw BrightSpaceSyncError.gradeObjectsFetchFailed(
+                orgUnitID: orgUnitID, status: Int(response.status.code))
+        }
+        struct GradeObjectResponse: Decodable {
+            let id: Int
+            let name: String
+            let maxPoints: Double?
+            enum CodingKeys: String, CodingKey {
+                case id = "Id"
+                case name = "Name"
+                case maxPoints = "MaxPoints"
+            }
+        }
+        let decoded = try response.content.decode([GradeObjectResponse].self)
+        return decoded.map {
+            BrightSpaceGradeObject(id: String($0.id), name: $0.name, maxPoints: $0.maxPoints)
+        }
     }
 }
 

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -135,6 +135,9 @@ private func pushGradeForResult(
         throw BrightSpaceSyncError.missingPoints
     }
 
+    // Username snapshot for the sync log (readable without a join).
+    let username = try await APIUser.find(userID, on: db)?.username ?? userID.uuidString
+
     // Resolve D2L user ID (cached on APIUser, looked up on first sync).
     let bsUserID = try await resolvedBrightSpaceUserID(
         for: userID,
@@ -143,21 +146,35 @@ private func pushGradeForResult(
         application: application
     )
     guard let bsUserID else {
-        // No BrightSpace account for this student — skip silently.
+        // No BrightSpace account for this student — record + skip.
         result.brightspaceSyncPending = false
         result.brightspaceSyncError = "Student has no BrightSpace account (orgDefinedId not found)"
         try await result.save(on: db)
+        await recordBrightSpaceSyncLog(
+            db: db, course: course, assignment: assignment, userID: userID, username: username,
+            orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: points,
+            status: .skipped, detail: "No BrightSpace account (orgDefinedId not found)")
         return
     }
 
     // Push the grade.
-    try await client.pushGrade(
-        orgUnitID: orgUnitID,
-        gradeObjectID: gradeObjectID,
-        bsUserID: bsUserID,
-        earnedPoints: points,
-        on: application
-    )
+    do {
+        try await client.pushGrade(
+            orgUnitID: orgUnitID,
+            gradeObjectID: gradeObjectID,
+            bsUserID: bsUserID,
+            earnedPoints: points,
+            on: application
+        )
+    } catch {
+        // Log with full context here (the sweep's catch lacks it), then
+        // rethrow so the existing per-result error handling still runs.
+        await recordBrightSpaceSyncLog(
+            db: db, course: course, assignment: assignment, userID: userID, username: username,
+            orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: points,
+            status: .error, detail: error.localizedDescription)
+        throw error
+    }
 
     result.brightspaceSyncPending = false
     result.brightspacePendingSince = nil
@@ -165,7 +182,41 @@ private func pushGradeForResult(
     result.brightspaceSyncError = nil
     try await result.save(on: db)
 
+    await recordBrightSpaceSyncLog(
+        db: db, course: course, assignment: assignment, userID: userID, username: username,
+        orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: points,
+        status: .success, detail: nil)
+
     logger.info("BrightSpace grade synced: user \(userID) assignment '\(assignment.title)' → \(points) pts")
+}
+
+/// Appends one row to the BrightSpace sync log.  Best-effort: a logging
+/// failure must never abort or retry a grade push, so errors are swallowed.
+private func recordBrightSpaceSyncLog(
+    db: Database,
+    course: APICourse,
+    assignment: APIAssignment,
+    userID: UUID?,
+    username: String,
+    orgUnitID: String?,
+    gradeObjectID: String?,
+    points: Double?,
+    status: APIBrightSpaceSyncLog.Status,
+    detail: String?
+) async {
+    let entry = APIBrightSpaceSyncLog(
+        courseID: course.id,
+        testSetupID: assignment.testSetupID,
+        assignmentTitle: assignment.title,
+        userID: userID,
+        username: username,
+        orgUnitID: orgUnitID,
+        gradeObjectID: gradeObjectID,
+        points: points,
+        status: status,
+        detail: detail
+    )
+    try? await entry.save(on: db)
 }
 
 /// Returns the cached D2L user ID for `userID`, looking it up via studentID if not yet cached.

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -104,39 +104,36 @@ private func pushGradeForResult(
         return
     }
 
-    // Compute best grade for this student across all results for this test setup.
-    let studentSubmissions = try await APISubmission.query(on: db)
-        .filter(\.$userID == userID)
-        .filter(\.$testSetupID == testSetupID)
-        .filter(\.$kind == APISubmission.Kind.student)
-        .all()
-
-    let submissionIDs = studentSubmissions.compactMap(\.id)
-    guard !submissionIDs.isEmpty else {
+    // Best grade for this student across the test setup. nil → no submissions
+    // yet (nothing to push); throws if submissions exist but yield no points.
+    guard let points = try await bestPointsForStudent(userID: userID, testSetupID: testSetupID, db: db)
+    else {
         result.brightspaceSyncPending = false
         try await result.save(on: db)
         return
     }
 
-    let allResults = try await APIResult.query(on: db)
-        .filter(\.$submissionID ~~ submissionIDs)
-        .all()
-
-    // Prefer worker results; fall back to browser results for best-grade computation.
-    let workerResults = allResults.filter { $0.source != "browser" }
-    let resultsForGrade = workerResults.isEmpty ? allResults : workerResults
-
-    let bestPoints =
-        resultsForGrade
-        .compactMap { gradePointsFromCollectionJSON($0.collectionJSON) }
-        .max()
-
-    guard let points = bestPoints else {
-        throw BrightSpaceSyncError.missingPoints
-    }
-
     // Username snapshot for the sync log (readable without a join).
     let username = try await APIUser.find(userID, on: db)?.username ?? userID.uuidString
+
+    // Appends one row to the sync log. Best-effort: a logging failure must
+    // never abort or retry a grade push, so errors are swallowed. Captures
+    // the surrounding push context so callers pass only status + detail.
+    func appendSyncLog(_ status: APIBrightSpaceSyncLog.Status, detail: String?) async {
+        let entry = APIBrightSpaceSyncLog(
+            courseID: course.id,
+            testSetupID: assignment.testSetupID,
+            assignmentTitle: assignment.title,
+            userID: userID,
+            username: username,
+            orgUnitID: orgUnitID,
+            gradeObjectID: gradeObjectID,
+            points: points,
+            status: status,
+            detail: detail
+        )
+        try? await entry.save(on: db)
+    }
 
     // Resolve D2L user ID (cached on APIUser, looked up on first sync).
     let bsUserID = try await resolvedBrightSpaceUserID(
@@ -150,10 +147,7 @@ private func pushGradeForResult(
         result.brightspaceSyncPending = false
         result.brightspaceSyncError = "Student has no BrightSpace account (orgDefinedId not found)"
         try await result.save(on: db)
-        await recordBrightSpaceSyncLog(
-            db: db, course: course, assignment: assignment, userID: userID, username: username,
-            orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: points,
-            status: .skipped, detail: "No BrightSpace account (orgDefinedId not found)")
+        await appendSyncLog(.skipped, detail: "No BrightSpace account (orgDefinedId not found)")
         return
     }
 
@@ -169,10 +163,7 @@ private func pushGradeForResult(
     } catch {
         // Log with full context here (the sweep's catch lacks it), then
         // rethrow so the existing per-result error handling still runs.
-        await recordBrightSpaceSyncLog(
-            db: db, course: course, assignment: assignment, userID: userID, username: username,
-            orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: points,
-            status: .error, detail: error.localizedDescription)
+        await appendSyncLog(.error, detail: error.localizedDescription)
         throw error
     }
 
@@ -182,41 +173,44 @@ private func pushGradeForResult(
     result.brightspaceSyncError = nil
     try await result.save(on: db)
 
-    await recordBrightSpaceSyncLog(
-        db: db, course: course, assignment: assignment, userID: userID, username: username,
-        orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: points,
-        status: .success, detail: nil)
+    await appendSyncLog(.success, detail: nil)
 
     logger.info("BrightSpace grade synced: user \(userID) assignment '\(assignment.title)' → \(points) pts")
 }
 
-/// Appends one row to the BrightSpace sync log.  Best-effort: a logging
-/// failure must never abort or retry a grade push, so errors are swallowed.
-private func recordBrightSpaceSyncLog(
-    db: Database,
-    course: APICourse,
-    assignment: APIAssignment,
-    userID: UUID?,
-    username: String,
-    orgUnitID: String?,
-    gradeObjectID: String?,
-    points: Double?,
-    status: APIBrightSpaceSyncLog.Status,
-    detail: String?
-) async {
-    let entry = APIBrightSpaceSyncLog(
-        courseID: course.id,
-        testSetupID: assignment.testSetupID,
-        assignmentTitle: assignment.title,
-        userID: userID,
-        username: username,
-        orgUnitID: orgUnitID,
-        gradeObjectID: gradeObjectID,
-        points: points,
-        status: status,
-        detail: detail
-    )
-    try? await entry.save(on: db)
+/// Best (max) points for this student across all results for the test setup,
+/// preferring worker results over browser ones.  Returns nil when the student
+/// has no submissions yet (nothing to push); throws `.missingPoints` when
+/// submissions exist but none yielded a parseable grade.
+private func bestPointsForStudent(
+    userID: UUID,
+    testSetupID: String,
+    db: Database
+) async throws -> Double? {
+    let submissionIDs = try await APISubmission.query(on: db)
+        .filter(\.$userID == userID)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .all()
+        .compactMap(\.id)
+    guard !submissionIDs.isEmpty else { return nil }
+
+    let allResults = try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ submissionIDs)
+        .all()
+    // Prefer worker results; fall back to browser results for best-grade computation.
+    let workerResults = allResults.filter { $0.source != "browser" }
+    let resultsForGrade = workerResults.isEmpty ? allResults : workerResults
+
+    guard
+        let points =
+            resultsForGrade
+            .compactMap({ gradePointsFromCollectionJSON($0.collectionJSON) })
+            .max()
+    else {
+        throw BrightSpaceSyncError.missingPoints
+    }
+    return points
 }
 
 /// Returns the cached D2L user ID for `userID`, looking it up via studentID if not yet cached.

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -224,6 +224,8 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateMCPGrants())
     app.migrations.add(AddPreviousRefreshTokenHashToGrants())
     app.migrations.add(AddAssignmentStartsAt())
+    app.migrations.add(AddBrightSpaceOrgUnitName())
+    app.migrations.add(CreateBrightSpaceSyncLog())
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.
     app.migrations.add(CreateHotPathIndexes())

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -194,6 +194,11 @@ func registerMigrations(on app: Application) {
     // our own).
     app.migrations.add(CreateUsers())
     app.migrations.add(CreateCourses())
+    // Must precede any migration that queries the APICourse *model* (e.g.
+    // AddCourseArchivedAt's backfill). Fluent's model query SELECTs every
+    // declared column, so the column has to exist before those run on a
+    // fresh DB. Existing prod is unaffected — only this new migration runs.
+    app.migrations.add(AddBrightSpaceOrgUnitName())
     app.migrations.add(CreateCourseEnrollments())
     app.migrations.add(CreateTestSetups())
     app.migrations.add(CreateSubmissions())
@@ -224,7 +229,6 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateMCPGrants())
     app.migrations.add(AddPreviousRefreshTokenHashToGrants())
     app.migrations.add(AddAssignmentStartsAt())
-    app.migrations.add(AddBrightSpaceOrgUnitName())
     app.migrations.add(CreateBrightSpaceSyncLog())
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -183,9 +183,9 @@ import XCTVapor
                     #expect(res.headers.first(name: .location) == "/instructor/brightspace")
                 })
 
-            let reloaded = try await APIResult.find("res_bs_push", on: app.db)
-            #expect(reloaded?.brightspaceSyncPending == true)
-            #expect((reloaded?.brightspaceSyncError ?? "").isEmpty)
+            let reloaded = try #require(try await APIResult.find("res_bs_push", on: app.db))
+            #expect(reloaded.brightspaceSyncPending == true)
+            #expect((reloaded.brightspaceSyncError ?? "").isEmpty)
         }
     }
 

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -1,0 +1,220 @@
+// Tests/APITests/BrightSpacePanelTests.swift
+//
+// Covers the instructor BrightSpace tab + the sync-log model.  These run
+// without a live D2L: in the test app `brightSpaceClient` is nil, so the
+// page renders its "not configured" state and the manual-action routes are
+// no-op redirects.  The log model is exercised directly against the DB to
+// prove the migration + schema.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct BrightSpacePanelTests {
+
+    // MARK: - Access control
+
+    @Test func studentCannotAccessBrightspaceTab() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsStudent(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in #expect(res.status == .forbidden) })
+        }
+    }
+
+    // MARK: - Page render (sync unconfigured in tests)
+
+    @Test func brightspacePageRendersNotConfigured() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("BrightSpace"))
+                    // brightSpaceClient is nil in tests → not-configured branch.
+                    #expect(html.contains("not configured on this server"))
+                })
+        }
+    }
+
+    // MARK: - Grade-objects feed
+
+    @Test func gradeObjectsEmptyWhenUnconfigured() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace/grade-objects",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let compact = res.body.string
+                        .replacingOccurrences(of: " ", with: "")
+                        .replacingOccurrences(of: "\n", with: "")
+                    #expect(compact == "[]")
+                })
+        }
+    }
+
+    // MARK: - Connection test (unconfigured)
+
+    @Test func testConnectionReportsUnconfigured() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/test",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    // The "not configured" message only appears on the ok:false
+                    // path, so it's a JSON-spacing-robust proxy for the failure.
+                    #expect(res.body.string.contains("not configured"))
+                })
+        }
+    }
+
+    // MARK: - Manual actions are no-op redirects when unconfigured
+
+    @Test func syncNowRedirectsWhenUnconfigured() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/sync-now",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+        }
+    }
+
+    @Test func retryFailedRedirectsWhenUnconfigured() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/retry-failed",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+        }
+    }
+
+    // MARK: - Grade-item mapping save (returnTo routing)
+
+    @Test func saveGradeItemReturnToBrightspaceRedirects() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "setup_bs_map", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_bs_map", title: "BS Map", isOpen: true, on: app)
+            let assignmentID = assignment.publicID
+
+            try await app.asyncTest(
+                .POST, "/instructor/\(assignmentID)/brightspace",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["gradeObjectID": "78901", "returnTo": "brightspace", "_csrf": csrf],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+
+            let updated = try await APIAssignment.query(on: app.db)
+                .filter(\.$publicID == assignmentID).first()
+            #expect(updated?.brightspaceGradeObjectID == "78901")
+        }
+    }
+
+    // MARK: - Push-all re-flags results for re-sync
+
+    @Test func pushAllFlagsResultsForResync() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "setup_bs_push", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_bs_push", title: "BS Push", isOpen: true, on: app)
+            let student = try await arInsertStudent(username: "bs_push_student", on: app)
+            _ = try await arInsertSubmission(
+                id: "sub_bs_push", testSetupID: "setup_bs_push", userID: try student.requireID(), on: app)
+
+            // A previously-synced result (not pending, has a synced timestamp).
+            let result = APIResult(
+                id: "res_bs_push", submissionID: "sub_bs_push",
+                collectionJSON: "{}", source: "worker")
+            result.brightspaceSyncPending = false
+            result.brightspaceSyncedAt = Date()
+            try await result.save(on: app.db)
+
+            try await app.asyncTest(
+                .POST, "/instructor/\(assignment.publicID)/brightspace/push-all",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+
+            let reloaded = try await APIResult.find("res_bs_push", on: app.db)
+            #expect(reloaded?.brightspaceSyncPending == true)
+            #expect((reloaded?.brightspaceSyncError ?? "").isEmpty)
+        }
+    }
+
+    // MARK: - Sync-log model + migration round-trip
+
+    @Test func syncLogModelRoundTrips() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let entry = APIBrightSpaceSyncLog(
+                courseID: courseID,
+                testSetupID: "setup_log",
+                assignmentTitle: "Logged Assignment",
+                userID: UUID(),
+                username: "log_student",
+                orgUnitID: "123456",
+                gradeObjectID: "78901",
+                points: 9.5,
+                status: .success,
+                detail: nil)
+            try await entry.save(on: app.db)
+
+            let rows = try await APIBrightSpaceSyncLog.query(on: app.db)
+                .filter(\.$courseID == courseID)
+                .all()
+            let found = try #require(rows.first { $0.username == "log_student" })
+            #expect(found.status == "success")
+            #expect(found.points == 9.5)
+            #expect(found.gradeObjectID == "78901")
+            #expect(found.attemptedAt != nil)
+        }
+    }
+}

--- a/changelog.d/brightspace-panel.md
+++ b/changelog.d/brightspace-panel.md
@@ -1,0 +1,15 @@
+### Added
+
+- **BrightSpace tab build-out (grade-sync console).** The instructor BrightSpace
+  tab is now a working console for the D2L grade sync: a connection test
+  (`whoami`), an assignment→grade-item mapping table with a dropdown sourced
+  from the course's D2L grade book (free-text fallback), a sync-activity log,
+  summary counts (synced / pending / errored / unmapped), an "unmapped students"
+  diagnostic, and manual **Sync now** / **Retry failed** / per-assignment
+  **Push all** actions. Grade pushes now write an append-only
+  `brightspace_sync_log` audit trail (success / error / skipped-no-account).
+  Course→org-unit binding stays an admin action and is now **verified against
+  D2L on save** — the org-unit name is looked up and cached so the binding is
+  confirmable at a glance. New D2L client calls: `whoami`, `getOrgUnit`,
+  `listGradeObjects`. See [docs/architecture.md](../docs/architecture.md)
+  → "BrightSpace grade sync".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -399,6 +399,48 @@ editor reads and writes the canonical `.ipynb` files directly.
 
 ---
 
+## BrightSpace grade sync
+
+Chickadee can push grades to D2L BrightSpace. It is off unless the server has
+BrightSpace credentials configured (`AppConfig.brightspace`, set from
+`BRIGHTSPACE_*` env vars); when present, `app.brightSpaceClient` is non-nil.
+
+**Auth model.** D2L Valence "App + User" key signing — one registered app +
+one D2L service account. Every push runs *as that one account* with its
+permissions; there is no per-instructor D2L identity. Credentials live only in
+env (ops-managed) and are never shown in the UI. `BrightSpaceAPIClient` signs
+each request URL per call (HMAC-SHA256) — no token endpoint.
+
+**Where grades land** is decided entirely by two IDs, not the credentials:
+
+- **Org unit ID** (`courses.brightspace_org_unit_id`) — the D2L course. Because
+  the service account can usually write to many courses, this binding is an
+  **admin-only** action on the course page, and it is **verified on save**: the
+  server looks the ID up via `getOrgUnit` and caches the D2L name
+  (`brightspace_org_unit_name`) so the admin can confirm they pointed at the
+  right course. Instructors are then locked to their bound course.
+- **Grade object ID** (`assignments.brightspace_grade_object_id`) — the grade
+  item (column). Instructors map these on the BrightSpace tab, picking from a
+  dropdown sourced from `listGradeObjects` (free-text fallback).
+
+**Student identity.** `users.student_id` is the D2L `OrgDefinedId`;
+`users.brightspace_user_id` caches the resolved internal D2L user ID
+(`lookupUserID`, looked up lazily on first sync). Students with no resolvable
+account surface in the BrightSpace tab's "unmapped students" list.
+
+**Sync engine.** On a worker result save, `ResultRoutes` flags the `APIResult`
+row pending. `BrightSpaceGradeSyncMonitor` sweeps every 60 s and pushes the
+**best (max) points** per (student, assignment) past a debounce window
+(`BRIGHTSPACE_SYNC_DEBOUNCE_SECS`, default 90 s). Each meaningful event
+(success, push failure, or skipped-no-account) appends a row to
+`brightspace_sync_log` — an append-only audit trail snapshotting identity
+fields so it survives course/assignment/user deletes. The BrightSpace tab
+renders this log plus summary counts, and offers manual **Sync now**, **Retry
+failed**, and per-assignment **Push all** (backfill) actions that re-flag rows
+and run an immediate (debounce-bypassing) sweep.
+
+---
+
 ## Deployment
 
 ### Docker Compose (recommended)


### PR DESCRIPTION
## Summary

Turns the instructor **BrightSpace** tab from a status stub into a working console for the D2L grade sync (P1 of the agreed plan), in preparation for live testing once IST provides credentials.

- **Connection test** — `whoami` button surfaces auth problems before any grade fails.
- **Assignment → grade-item mapping table** — pick the D2L grade item from a dropdown sourced from the course's grade book (`listGradeObjects`), with free-text fallback when D2L is unreachable.
- **Sync activity log** — new append-only `brightspace_sync_log` table records every meaningful push (success / error / skipped-no-account); snapshots identity fields so it survives deletes.
- **Summary counts** — synced / pending / errored / unmapped.
- **Unmapped students** — enrolled students with no resolvable D2L account.
- **Manual actions** — Sync now, Retry failed, per-assignment Push all (backfill); each re-flags rows and runs an immediate (debounce-bypassing) sweep.
- **Verified course binding** — admin-set org-unit ID is now verified against D2L on save via `getOrgUnit`, caching the org-unit name (`brightspace_org_unit_name`) so the binding is confirmable at a glance.

Connection credentials stay server-side (env, ops-managed) and are never exposed in the UI; the course→org-unit binding remains an admin action.

## Changes
- D2L client: `whoami`, `getOrgUnit`, `listGradeObjects` (+ error cases).
- Schema: `CreateBrightSpaceSyncLog` table + `APIBrightSpaceSyncLog` model; `AddBrightSpaceOrgUnitName` column.
- Sync service writes log rows on success / push-failure / no-account-skip.
- New routes: `POST /instructor/brightspace/{test,sync-now,retry-failed}`, `GET /instructor/brightspace/grade-objects`, `POST /instructor/:id/brightspace/push-all`. `saveBrightSpaceGradeObjectID` gains `returnTo` routing.
- Docs: new "BrightSpace grade sync" section in `docs/architecture.md`.

## Test plan
- [ ] CI green (incl. migration applies on sqlite + Postgres)
- [ ] `/instructor/brightspace` renders; unconfigured shows the not-configured state + CSV export
- [ ] With credentials: Test connection reports the service identity; grade-item dropdown populates; Sync now / Retry / Push all move grades and write log rows
- [ ] Admin course save verifies + names the org unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)