### PR TITLE
fix: editing existing tests in the unified modal opens a blank form

### DIFF
--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -276,8 +276,21 @@
         function open(opts) {
             opts = opts || {};
             editingItem = opts.editing || null;
-            var kind = opts.kind || (editingItem && editingItem.kind) || typeSelect.value;
-            var mechanism = opts.mechanism || mechanismForKind(kind) || 'script';
+            // When editing, the mechanism + kind are authoritative from the
+            // edit payload — the type dropdown is hidden and its leftover
+            // value must not decide which renderer runs. Mechanism comes from
+            // `editing.mechanism`; kind from the item (checks/families carry
+            // `.kind`, raw scripts use the 'script' catalog entry). Without
+            // this, a check/script edit resolved to whatever the dropdown last
+            // showed (default 'family'), so `enterMode` called reset() instead
+            // of populate() and the modal opened blank.
+            var mechanism = opts.mechanism
+                || (editingItem && editingItem.mechanism)
+                || mechanismForKind(opts.kind || typeSelect.value)
+                || 'script';
+            var kind = opts.kind
+                || (editingItem && editingItem.item && editingItem.item.kind)
+                || (mechanism === 'script' ? 'script' : typeSelect.value);
 
             // Editing fixes the type; creating lets the instructor switch it.
             typeRow.style.display = editingItem ? 'none' : 'flex';

--- a/changelog.d/test-editor-edit-mechanism.md
+++ b/changelog.d/test-editor-edit-mechanism.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Editing an existing test in the unified Test Editor modal now opens the right editor.** The shell resolved which renderer to show from the (hidden) type dropdown's leftover value instead of the edit payload, so editing a notebook check or a custom script silently fell through to a blank pattern-family form. Imported Marmoset suites — which are entirely raw scripts — were therefore uneditable. The modal now takes the mechanism and kind from the item being edited.


### PR DESCRIPTION
## Summary

The unified Test Editor modal ("+ Add Test", v0.4.236) resolved **which renderer to show** from the hidden type dropdown's leftover value instead of from the `editing` payload. The edit dispatchers pass the mechanism nested inside `editing` (`{ editing: { mechanism, id, item } }`), but `open()` read `opts.mechanism` (top-level, always `undefined` for edits) and fell back to `mechanismForKind(typeSelect.value)` — the dropdown's default, `boundary_equality` → `family`.

Result: in `enterMode`, `editingItem.mechanism` (`check`/`script`) didn't match the resolved mechanism (`family`), so it called the renderer's `reset()` (blank form) instead of `populate()`. Editing any **notebook check** or **custom script** opened an empty pattern-family form. Families happened to work only because they share the dropdown's default mechanism.

This is why **imported Marmoset suites were entirely uneditable** — they're all raw `script` entries (no families/checks), so *nothing* matched the default `family` mechanism.

The fix makes the edit payload authoritative: mechanism comes from `editing.mechanism`, kind from the edited item (`item.kind` for checks/families, `script` for raw scripts). The add flow is unchanged.

## Verification

Ran the dev server, imported a real Marmoset-derived course bundle (HLTH 230), opened an assignment edit page, and clicked edit on a raw script ("BMI Boundary Case 1"):

- Before: modal opened on the empty pattern-family panel.
- After: modal opens on the **script** panel (title "Edit Test Script") with the script's actual content loaded in the editor.

Confirmed via DOM inspection: `overlayVisible: true`, `visiblePanels: ["script"]`, editor text = the script's `student_module.bmi_category` body.

## Test plan

- [ ] Edit an existing custom script → script editor opens with the script body
- [ ] Edit an existing notebook check → check form opens populated with its fields
- [ ] Edit an existing pattern family → family editor opens with its cases (regression check)
- [ ] "+ Add Test" still defaults to the type picker and a fresh form

🤖 Generated with [Claude Code](https://claude.com/claude-code)