### PR TITLE
fix(mcp): drive advertised OAuth scopes from MCP_MODE

### DIFF
--- a/Sources/APIServer/Configuration/MCPMode.swift
+++ b/Sources/APIServer/Configuration/MCPMode.swift
@@ -24,17 +24,25 @@ enum MCPMode: String, Sendable, CaseIterable {
     /// nothing.
     var isMounted: Bool { self != .off }
 
-    /// The maximum set of content scopes a request may exercise in this mode.
-    /// The bearer middleware intersects each token's scopes with this set, so
-    /// the rest of the stack (per-tool scope checks, `tools/list` filtering,
-    /// resources) needs no mode awareness.
-    var scopeCeiling: Set<ContentScope> {
+    /// The scopes this mode advertises and grants, in stable display order
+    /// (read before write).  This is the single source of truth for every
+    /// spec-facing surface — the two `.well-known` discovery documents, the
+    /// `scope` granted by DCR (`/oauth/register`), and the consent screen — so
+    /// the metadata never advertises more (or less) than the server honors.
+    /// `scopeCeiling` is the set projection of this list.
+    var advertisedScopes: [ContentScope] {
         switch self {
         case .off: return []
         case .readOnly: return [.read]
         case .readWrite: return [.read, .write]
         }
     }
+
+    /// Set form of `advertisedScopes`, used for membership/intersection checks:
+    /// the bearer middleware intersects each token's scopes with this set, so
+    /// the rest of the stack (per-tool scope checks, `tools/list` filtering,
+    /// resources) needs no mode awareness.
+    var scopeCeiling: Set<ContentScope> { Set(advertisedScopes) }
 
     /// Parses `MCP_MODE`.  Canonical values are `off`, `read_only`,
     /// `read_write`; a handful of obvious synonyms are accepted so an operator

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -297,8 +297,11 @@ struct MCPOAuthRoutes: Sendable {
             grantTypes: ["authorization_code", "refresh_token"],
             responseTypes: ["code"],
             tokenEndpointAuthMethod: "none",
-            scope: req.application.appConfig.mcp.mode.scopeCeiling
-                .map(\.rawValue).sorted().joined(separator: " "))
+            // Grant exactly what the discovery metadata advertises — same
+            // source (MCPMode.advertisedScopes) so DCR and the .well-known docs
+            // can never disagree.
+            scope: req.application.appConfig.mcp.mode.advertisedScopes
+                .map(\.rawValue).joined(separator: " "))
         let result = Response(status: .created)
         try result.content.encode(response, as: .json)
         result.headers.replaceOrAdd(name: .cacheControl, value: "no-store")

--- a/Sources/APIServer/MCP/Transport/MCPMetadataRoutes.swift
+++ b/Sources/APIServer/MCP/Transport/MCPMetadataRoutes.swift
@@ -17,6 +17,11 @@ import Vapor
 
 struct MCPMetadataRoutes: RouteCollection {
     let endpoints: MCPEndpoints
+    /// Scopes advertised in both discovery documents, derived from `MCP_MODE`
+    /// (`MCPMode.advertisedScopes`) at registration so the metadata can never
+    /// claim a scope the server won't grant — read_only advertises only
+    /// `content:read`, read_write advertises read + write.
+    let advertisedScopes: [ContentScope]
 
     func boot(routes: RoutesBuilder) throws {
         let wellKnown = routes.grouped(".well-known")
@@ -27,7 +32,7 @@ struct MCPMetadataRoutes: RouteCollection {
 
     /// RFC 9728 protected-resource metadata.
     func protectedResourceMetadata(req: Request) throws -> Response {
-        let scopes = ContentScope.allCases.map { JSONValue.string($0.rawValue) }
+        let scopes = advertisedScopes.map { JSONValue.string($0.rawValue) }
         let metadata = JSONValue.object([
             "resource": .string(endpoints.resource),
             "authorization_servers": .array([.string(endpoints.issuer)]),
@@ -39,7 +44,7 @@ struct MCPMetadataRoutes: RouteCollection {
 
     /// RFC 8414 authorization-server metadata for the browser flow.
     func authorizationServerMetadata(req: Request) throws -> Response {
-        let scopes = ContentScope.allCases.map { JSONValue.string($0.rawValue) }
+        let scopes = advertisedScopes.map { JSONValue.string($0.rawValue) }
         let metadata = JSONValue.object([
             "issuer": .string(endpoints.issuer),
             "authorization_endpoint": .string(endpoints.authorizationEndpoint),

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -93,7 +93,8 @@ func registerMCPRoutes(_ app: Application) throws {
 
     try app.grouped(bearer).register(
         collection: MCPRoutes(dispatcher: dispatcher, configuration: routeConfiguration))
-    try app.register(collection: MCPMetadataRoutes(endpoints: endpoints))
+    try app.register(
+        collection: MCPMetadataRoutes(endpoints: endpoints, advertisedScopes: mcp.mode.advertisedScopes))
 
     app.logger.info(
         "MCP endpoint mounted at /mcp — issuer=\(endpoints.issuer), resource=\(endpoints.resource)")

--- a/Tests/APITests/MCP/MCPConfigTests.swift
+++ b/Tests/APITests/MCP/MCPConfigTests.swift
@@ -50,4 +50,22 @@ import Testing
         #expect(MCPMode.readOnly.isMounted)
         #expect(MCPMode.readWrite.isMounted)
     }
+
+    /// `advertisedScopes` is the single source of truth for the discovery
+    /// metadata and DCR; order is stable (read before write) for deterministic
+    /// JSON output.
+    @Test func advertisedScopesMatchMode() {
+        #expect(MCPMode.off.advertisedScopes.isEmpty)
+        #expect(MCPMode.readOnly.advertisedScopes == [.read])
+        #expect(MCPMode.readWrite.advertisedScopes == [.read, .write])
+    }
+
+    /// `scopeCeiling` (the set used for per-request clamping) must always be the
+    /// set projection of `advertisedScopes`, so the runtime can never honor a
+    /// scope the metadata didn't advertise — or vice versa.
+    @Test func scopeCeilingIsTheSetOfAdvertisedScopes() {
+        for mode in MCPMode.allCases {
+            #expect(mode.scopeCeiling == Set(mode.advertisedScopes))
+        }
+    }
 }

--- a/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
+++ b/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
@@ -15,9 +15,9 @@ import XCTVapor
     private let resource = "https://chickadee.example/mcp"
     private let redirectURI = "https://app.example/cb"
 
-    private func makeApp() async throws -> Application {
+    private func makeApp(mode: MCPMode = .readWrite) async throws -> Application {
         let mcp = MCPConfig(
-            mode: .readWrite, allowedHosts: [], allowedOrigins: [],
+            mode: mode, allowedHosts: [], allowedOrigins: [],
             tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource)
         let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
         app.mcpTokenAuthority = try await MCPTokenAuthority.make(
@@ -43,12 +43,26 @@ import XCTVapor
             let object = jsonObject(res)
             let clientID = try #require(object?["client_id"] as? String)
             #expect(object?["token_endpoint_auth_method"] as? String == "none")
+            // read_write grants the full advertised scope set.
+            #expect(object?["scope"] as? String == "content:read content:write")
 
             let client = try #require(
                 try await MCPOAuthClient.query(on: app.db).filter(\.$clientID == clientID).first())
             #expect(client.name == "My Agent")
             #expect(client.redirectURIs == [redirectURI])
             #expect(client.isPublic)
+        }
+    }
+
+    /// In read_only, DCR must grant only `content:read` — matching the
+    /// discovery metadata — so a client never asks for `content:write` and gets
+    /// silently downgraded (or, before the fix, refused at /authorize).
+    @Test func registrationGrantsReadOnlyScopeInReadOnlyMode() async throws {
+        try await withApp(try await makeApp(mode: .readOnly)) { app in
+            let res = try await register(
+                app, body: #"{"client_name":"RO Agent","redirect_uris":["\#(redirectURI)"]}"#)
+            #expect(res.status == .created)
+            #expect(jsonObject(res)?["scope"] as? String == "content:read")
         }
     }
 

--- a/Tests/APITests/MCP/MCPMetadataRoutesTests.swift
+++ b/Tests/APITests/MCP/MCPMetadataRoutesTests.swift
@@ -12,15 +12,24 @@ import XCTVapor
     private let issuer = "https://chickadee.example"
     private let resource = "https://chickadee.example/mcp"
 
-    private func makeApp() async throws -> Application {
+    private func makeApp(
+        advertisedScopes: [ContentScope] = MCPMode.readWrite.advertisedScopes
+    ) async throws -> Application {
         let app = try await Application.make(.testing)
         let authority = try await MCPTokenAuthority.make(
             privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
         app.mcpTokenAuthority = authority
         try app.register(
             collection: MCPMetadataRoutes(
-                endpoints: MCPEndpoints(issuer: issuer, resource: resource, metadataOrigin: issuer)))
+                endpoints: MCPEndpoints(issuer: issuer, resource: resource, metadataOrigin: issuer),
+                advertisedScopes: advertisedScopes))
         return app
+    }
+
+    private func scopesSupported(_ res: XCTHTTPResponse) -> [String]? {
+        let object =
+            (try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8))) as? [String: Any]
+        return object?["scopes_supported"] as? [String]
     }
 
     @Test func protectedResourceMetadataAdvertisesServerAndScopes() async throws {
@@ -32,8 +41,19 @@ import XCTVapor
                 #expect(body.contains("\"resource\""))
                 #expect(body.contains("\"authorization_servers\""))
                 #expect(body.contains("chickadee.example"))
-                #expect(body.contains("content:read"))
-                #expect(body.contains("content:write"))
+                #expect(self.scopesSupported(res) == ["content:read", "content:write"])
+            }
+        }
+    }
+
+    /// In read_only the protected-resource metadata must advertise only
+    /// `content:read` — advertising `content:write` here is what made Claude
+    /// request a scope the server then refused, breaking the connect flow.
+    @Test func protectedResourceMetadataReadOnlyAdvertisesOnlyRead() async throws {
+        try await withApp(try await makeApp(advertisedScopes: MCPMode.readOnly.advertisedScopes)) { app in
+            try await app.testable().test(.GET, "/.well-known/oauth-protected-resource") { res async in
+                #expect(res.status == .ok)
+                #expect(self.scopesSupported(res) == ["content:read"])
             }
         }
     }
@@ -51,6 +71,18 @@ import XCTVapor
                 #expect((object?["token_endpoint"] as? String)?.hasSuffix("/oauth/token") == true)
                 #expect((object?["registration_endpoint"] as? String)?.hasSuffix("/oauth/register") == true)
                 #expect((object?["code_challenge_methods_supported"] as? [String])?.contains("S256") == true)
+                #expect((object?["scopes_supported"] as? [String]) == ["content:read", "content:write"])
+            }
+        }
+    }
+
+    /// The authorization-server metadata must mirror the mode too: read_only
+    /// advertises only `content:read`.
+    @Test func authorizationServerMetadataReadOnlyAdvertisesOnlyRead() async throws {
+        try await withApp(try await makeApp(advertisedScopes: MCPMode.readOnly.advertisedScopes)) { app in
+            try await app.testable().test(.GET, "/.well-known/oauth-authorization-server") { res async in
+                #expect(res.status == .ok)
+                #expect(self.scopesSupported(res) == ["content:read"])
             }
         }
     }
@@ -73,7 +105,8 @@ import XCTVapor
         let app = try await Application.make(.testing)
         try app.register(
             collection: MCPMetadataRoutes(
-                endpoints: MCPEndpoints(issuer: issuer, resource: resource, metadataOrigin: issuer)))
+                endpoints: MCPEndpoints(issuer: issuer, resource: resource, metadataOrigin: issuer),
+                advertisedScopes: MCPMode.readWrite.advertisedScopes))
         try await withApp(app) { app in
             try await app.testable().test(.GET, "/.well-known/jwks.json") { res async in
                 #expect(res.status == .ok)

--- a/Tests/APITests/MCP/MCPModeScopeContractTests.swift
+++ b/Tests/APITests/MCP/MCPModeScopeContractTests.swift
@@ -1,0 +1,222 @@
+// MCP_MODE is the single source of truth for advertised OAuth scopes. These
+// tests drive the full custom-connector handshake — DCR → authorize → token →
+// initialize → tools/list — through the real `registerMCPRoutes` wiring for
+// both read_only and read_write, asserting every spec-facing surface agrees
+// with the mode. The regression they guard against: the .well-known docs once
+// advertised content:write unconditionally while read_only DCR granted only
+// content:read, so Claude asked for a scope the authorize handler refused and
+// the browser connect flow died on a claude.ai error page.
+
+import Crypto
+import Fluent
+import Foundation
+import JWT
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct MCPModeScopeContractTests {
+    private let issuer = "https://chickadee.example"
+    private let resource = "https://chickadee.example/mcp"
+    private let redirectURI = "https://app.example/callback"
+    private let codeVerifier = "abcdefghijklmnopqrstuvwxyz0123456789-._~ABCDEFGH"
+
+    private var codeChallenge: String {
+        Self.base64url(Data(SHA256.hash(data: Data(codeVerifier.utf8))))
+    }
+
+    private static func base64url(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Builds a test app in `mode` with the real MCP wiring mounted (the same
+    /// path the server uses) and a token authority matched to issuer/resource.
+    private func makeApp(mode: MCPMode) async throws -> (Application, MCPTokenAuthority) {
+        let mcp = MCPConfig(
+            mode: mode, allowedHosts: [], allowedOrigins: [],
+            tokenTTLSeconds: 3600, signingKeyPath: "unused", issuer: issuer, resource: resource)
+        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcp))
+        let authority = try await MCPTokenAuthority.make(
+            privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "mcp-1")
+        app.mcpTokenAuthority = authority
+        return (app, authority)
+    }
+
+    // MARK: - Request helpers (mirror the real client handshake)
+
+    private func register(_ app: Application) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(
+            .POST, "/oauth/register",
+            headers: ["Content-Type": "application/json"],
+            body: ByteBuffer(string: #"{"client_name":"Claude","redirect_uris":["\#(redirectURI)"]}"#))
+    }
+
+    private func authorizePath(clientID: String, scope: String) -> String {
+        var components = URLComponents()
+        components.path = "/oauth/authorize"
+        components.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "state", value: "xyz"),
+            URLQueryItem(name: "code_challenge", value: codeChallenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        return components.string ?? "/oauth/authorize"
+    }
+
+    /// Runs the CSRF-protected consent POST and returns its 303 response.
+    private func consent(
+        _ app: Application, cookie: String, clientID: String, scope: String
+    ) async throws -> XCTHTTPResponse {
+        let (csrf, bound) = try await csrfFields(
+            for: authorizePath(clientID: clientID, scope: scope), cookie: cookie, on: app)
+        return try await app.asyncSendRequest(
+            .POST, "/oauth/authorize",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: bound)
+                try req.content.encode(
+                    [
+                        "client_id": clientID, "redirect_uri": redirectURI, "scope": scope,
+                        "state": "xyz", "code_challenge": codeChallenge,
+                        "code_challenge_method": "S256", "decision": "authorize", "_csrf": csrf,
+                    ], as: .urlEncodedForm)
+            })
+    }
+
+    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(
+            .POST, "/oauth/token",
+            beforeRequest: { req in try req.content.encode(fields, as: .urlEncodedForm) })
+    }
+
+    private func queryValue(_ name: String, in location: String?) -> String? {
+        guard let location, let components = URLComponents(string: location) else { return nil }
+        return components.queryItems?.first(where: { $0.name == name })?.value
+    }
+
+    private func jsonField(_ name: String, in res: XCTHTTPResponse) -> String? {
+        let object = try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8)) as? [String: Any]
+        return object?[name] as? String
+    }
+
+    private func scopesSupported(_ res: XCTHTTPResponse) -> [String]? {
+        let object =
+            (try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8))) as? [String: Any]
+        return object?["scopes_supported"] as? [String]
+    }
+
+    // MARK: - Full connect flow, both modes
+
+    /// The end-to-end custom-connector handshake must succeed in both modes, and
+    /// every surface must reflect the mode: discovery scopes, DCR grant, the
+    /// scope the agent requests, and the tools it can see.
+    @Test(arguments: [MCPMode.readOnly, MCPMode.readWrite])
+    func connectFlowSucceedsAndScopesMatchMode(_ mode: MCPMode) async throws {
+        let expectedScopes = mode.advertisedScopes.map(\.rawValue)
+        let (app, _) = try await makeApp(mode: mode)
+        try await withApp(app) { app in
+            // 1. Discovery: both well-known docs advertise exactly the mode's scopes.
+            for path in ["/.well-known/oauth-protected-resource", "/.well-known/oauth-authorization-server"] {
+                try await app.testable().test(.GET, path) { res async in
+                    #expect(res.status == .ok)
+                    #expect(self.scopesSupported(res) == expectedScopes)
+                }
+            }
+
+            // 2. DCR grants exactly the advertised scopes.
+            let regRes = try await register(app)
+            #expect(regRes.status == .created)
+            let clientID = try #require(jsonField("client_id", in: regRes))
+            #expect(jsonField("scope", in: regRes) == expectedScopes.joined(separator: " "))
+
+            // 3. Authorize: the agent requests the granted scope; consent yields a code.
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            let consentRes = try await consent(
+                app, cookie: cookie, clientID: clientID, scope: expectedScopes.joined(separator: " "))
+            #expect(consentRes.status == .seeOther)
+            let code = try #require(queryValue("code", in: consentRes.headers.first(name: .location)))
+
+            // 4. Token exchange (authorization_code + PKCE) → access token.
+            let tokenRes = try await tokenPost(
+                app,
+                fields: [
+                    "grant_type": "authorization_code", "code": code,
+                    "redirect_uri": redirectURI, "client_id": clientID, "code_verifier": codeVerifier,
+                ])
+            #expect(tokenRes.status == .ok)
+            #expect(jsonField("scope", in: tokenRes) == expectedScopes.joined(separator: " "))
+            let accessToken = try #require(jsonField("access_token", in: tokenRes))
+
+            // 5. initialize over /mcp with the bearer token succeeds.
+            let initRes = try await app.asyncSendRequest(
+                .POST, "/mcp",
+                headers: ["Content-Type": "application/json", "Authorization": "Bearer \(accessToken)"],
+                body: ByteBuffer(
+                    string: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#))
+            #expect(initRes.status == .ok)
+            #expect(initRes.body.string.contains("Chickadee MCP"))
+
+            // 6. tools/list reflects the mode: read tools always; write tools only in read_write.
+            let listRes = try await app.asyncSendRequest(
+                .POST, "/mcp",
+                headers: ["Content-Type": "application/json", "Authorization": "Bearer \(accessToken)"],
+                body: ByteBuffer(string: #"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#))
+            #expect(listRes.status == .ok)
+            let listText = listRes.body.string
+            #expect(listText.contains("list_assignments"))
+            #expect(listText.contains("update_assignment") == (mode == .readWrite))
+            #expect(listText.contains("create_assignment") == (mode == .readWrite))
+        }
+    }
+
+    // MARK: - Out-of-mode scope is an OAuth error redirect, not a bare 4xx
+
+    /// In read_only, requesting `content:write` at /authorize must redirect to
+    /// the client with `error=invalid_scope` (preserving `state`), per OAuth
+    /// 2.1 — never a plain HTML/JSON 4xx, which is what left Claude's tab stuck.
+    @Test func authorizeRejectsOutOfModeScopeViaErrorRedirect() async throws {
+        let (app, _) = try await makeApp(mode: .readOnly)
+        try await withApp(app) { app in
+            let clientID = try #require(jsonField("client_id", in: try await register(app)))
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await app.asyncTest(
+                .GET, authorizePath(clientID: clientID, scope: "content:write"),
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    let location = res.headers.first(name: .location)
+                    #expect(queryValue("error", in: location) == "invalid_scope")
+                    #expect(queryValue("state", in: location) == "xyz")
+                    // The redirect goes back to the registered client, not an error page.
+                    #expect(location?.hasPrefix(redirectURI) == true)
+                })
+        }
+    }
+
+    /// read_only still accepts a `content:read` request (the subset that fits
+    /// the mode), proving the rejection above is scope-specific, not blanket.
+    @Test func authorizeAcceptsInModeScopeInReadOnly() async throws {
+        let (app, _) = try await makeApp(mode: .readOnly)
+        try await withApp(app) { app in
+            let clientID = try #require(jsonField("client_id", in: try await register(app)))
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await app.asyncTest(
+                .GET, authorizePath(clientID: clientID, scope: "content:read"),
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    // Renders the consent screen rather than redirecting with an error.
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("Claude"))
+                })
+        }
+    }
+}

--- a/changelog.d/mcp-mode-advertised-scopes.md
+++ b/changelog.d/mcp-mode-advertised-scopes.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`MCP_MODE` now drives the advertised OAuth scopes.** The two `.well-known`
+  discovery documents (`oauth-protected-resource`, `oauth-authorization-server`)
+  previously advertised `content:read content:write` unconditionally, even under
+  `MCP_MODE=read_only` where DCR grants only `content:read`. The mismatch made
+  Claude Desktop request `content:write` at `/oauth/authorize`, get refused, and
+  leave the connect flow stuck on a `claude.ai` error page. `MCPMode.advertisedScopes`
+  is now the single source of truth — the discovery metadata, DCR's granted
+  `scope`, and the per-request scope ceiling all derive from it, so `read_only`
+  advertises and grants only `content:read` and the custom-connector handshake
+  completes in both modes.


### PR DESCRIPTION
## Summary

The two `.well-known` discovery documents advertised `content:read content:write` unconditionally, even under `MCP_MODE=read_only` where DCR grants only `content:read`. Claude Desktop read the metadata, requested `content:write` at `/oauth/authorize`, was refused, and left the connect flow stuck on a `claude.ai` error page.

`MCPMode.advertisedScopes` is now the **single source of truth**: the discovery metadata, DCR's granted `scope`, and the per-request scope ceiling all derive from it. The OAuth machinery was already mode-aware everywhere *except* the two metadata docs (they hard-coded `ContentScope.allCases`) — that was the only drift, and it's exactly the mismatch the connect failure pointed at.

### Changes
- **`MCPMode.swift`** — `advertisedScopes: [ContentScope]` is now the primitive (ordered: read before write); `scopeCeiling` is its set projection. One switch, one source.
- **`MCPMetadataRoutes.swift`** — both discovery docs emit `advertisedScopes`, passed in at registration from `mcp.mode.advertisedScopes`.
- **`MCPOAuthRoutes.swift`** — DCR's granted `scope` reads `advertisedScopes` (same source as the metadata), replacing the separate `scopeCeiling.sorted()` literal.

`/oauth/authorize` was already spec-compliant (subset → granted, out-of-set → `invalid_scope` error redirect with `state`); the bearer clamp and `tools/list` filtering already derived from `scopeCeiling`. Those are unchanged.

### Decisions
- **Default mode unchanged: `.off`.** The current production default is "not mounted at all," which is stricter than `read_only`. Per the ticket's out-of-scope note, deployment env and the default are untouched.
- **Tool registration needed no code change.** Write tools are already excluded at runtime in `read_only` — the bearer clamp strips `content:write`, so `tools/list` hides write tools and a write call 403s. The new e2e test asserts this for both modes.

## Test plan
- [x] `MCPConfigTests` — `advertisedScopes` per mode + `scopeCeiling == Set(advertisedScopes)`
- [x] `MCPMetadataRoutesTests` — both docs assert exact `scopes_supported` for read_only and read_write
- [x] `MCPDynamicRegistrationTests` — DCR grants `content:read` in read_only, both in read_write
- [x] New `MCPModeScopeContractTests` — full DCR → authorize → token → initialize → tools/list for **both modes**, plus read_only `invalid_scope` error-redirect and in-mode acceptance
- [x] 54 MCP tests pass; `scripts/lint.sh` + `scripts/swiftlint.sh --strict` clean; no UW SSO regression (authorize path untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)