### PR TITLE
test(runner): pin browser/worker script dispatch to a shared contract

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -1129,6 +1129,10 @@ for _module_name in _tr.student_module_names_in_load_order():
             SITECUSTOMIZE_PY,
             runAndSubmit,
             runScripts,
+            // Exposed so the cross-runner dispatch contract test can assert this
+            // stays in sync with Sources/Worker/ScriptInvocation.swift.
+            classifyScript,
+            scriptExtension,
             extractNotebook,
             runPyScript,
             buildCollection,

--- a/Tests/BrowserRunnerJSTests/script-dispatch-contract.test.mjs
+++ b/Tests/BrowserRunnerJSTests/script-dispatch-contract.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+// Cross-runner script-dispatch contract (browser side).
+//
+// The browser runner (Public/browser-runner.js, classifyScript) and the native
+// worker (Sources/Worker/ScriptInvocation.swift, scriptInvocation) each decide
+// how to dispatch a test script. They are independent implementations of the
+// same rules, so they drift — twice now in two weeks (extensionless Python
+// scripts misclassified as unsupported, #754). This test pins the browser side
+// to a shared fixture; Tests/WorkerTests/ScriptDispatchContractTests.swift pins
+// the worker side to the same fixture. Same input -> same kind, in both runners.
+
+async function loadExports() {
+  const runnerSource = await fs.readFile(path.resolve('Public/browser-runner.js'), 'utf8');
+  const testHooks = {};
+  const statusEl = { hidden: true, textContent: '', className: '' };
+  const document = {
+    currentScript: { dataset: { gradingMode: 'browser' } },
+    getElementById: () => statusEl,
+  };
+  const context = {
+    console,
+    document,
+    __CHICKADEE_BROWSER_RUNNER_TEST_HOOKS__: testHooks,
+  };
+  context.window = { document };
+  context.globalThis = context;
+  vm.runInNewContext(runnerSource, context, { filename: 'browser-runner.js' });
+  return testHooks.exports;
+}
+
+const fixture = JSON.parse(
+  await fs.readFile(path.resolve('Tests/Fixtures/script-dispatch-cases.json'), 'utf8'),
+);
+
+test('browser runner classifies every shared dispatch case as the contract requires', async () => {
+  const { classifyScript } = await loadExports();
+  assert.equal(typeof classifyScript, 'function', 'classifyScript must be exported via test hooks');
+
+  for (const c of fixture.cases) {
+    assert.equal(
+      classifyScript(c.name, c.content),
+      c.kind,
+      `Dispatch contract violated for "${c.name}" (${c.note}): browser classifyScript `
+        + `disagrees with Tests/Fixtures/script-dispatch-cases.json. If you changed the rules, `
+        + `update both runners (Public/browser-runner.js and Sources/Worker/ScriptInvocation.swift) `
+        + `and the fixture together.`,
+    );
+  }
+});

--- a/Tests/Fixtures/script-dispatch-cases.json
+++ b/Tests/Fixtures/script-dispatch-cases.json
@@ -1,0 +1,36 @@
+{
+  "_comment": [
+    "Cross-runner script-dispatch contract. Each case MUST classify to the same",
+    "kind in both runners:",
+    "  * native worker  -> Sources/Worker/ScriptInvocation.swift (scriptInvocation)",
+    "  * browser runner -> Public/browser-runner.js              (classifyScript)",
+    "Asserted by Tests/WorkerTests/ScriptDispatchContractTests.swift and",
+    "Tests/BrowserRunnerJSTests/script-dispatch-contract.test.mjs.",
+    "",
+    "Scope: the categories that real Chickadee assignments use and that both",
+    "runners must agree on -- python (the only browser-runnable kind), shell, and r.",
+    "Other interpreters (node/ruby/perl) and the last-resort fallback for an",
+    "unrecognised, non-shebang, non-Python file intentionally differ between the",
+    "runners (the worker tries /bin/sh; the browser reports unsupported) and are",
+    "therefore NOT part of this contract."
+  ],
+  "cases": [
+    { "name": "test_bit_count.py",        "content": "print('hi')\n",                                   "kind": "python", "note": "plain .py extension" },
+    { "name": "publictest_bmi_01.py",      "content": "import math\nassert True\n",                       "kind": "python", "note": "generated test script" },
+    { "name": "WARMUP.PY",                 "content": "print('hi')\n",                                   "kind": "python", "note": "uppercase extension lowercased" },
+    { "name": "beats",                     "content": "#!/usr/bin/env python3\nvariable_name = 'beats'\n", "kind": "python", "note": "extensionless + env-python shebang (the #754 bug)" },
+    { "name": "check_total",               "content": "#!/usr/bin/python3\nprint(1)\n",                  "kind": "python", "note": "extensionless + absolute-path python shebang" },
+    { "name": "leading_blank",             "content": "\n#!/usr/bin/env python3\nprint(1)\n",             "kind": "python", "note": "leading blank line before shebang" },
+    { "name": "sniff_import",              "content": "import sys\nsys.exit(0)\n",                        "kind": "python", "note": "no shebang, content-sniff: import" },
+    { "name": "sniff_def",                 "content": "# a comment\ndef test():\n    pass\n",             "kind": "python", "note": "no shebang, content-sniff: def after comment" },
+    { "name": "sniff_from",                "content": "from math import pi\n",                            "kind": "python", "note": "no shebang, content-sniff: from" },
+
+    { "name": "test_first_digit.sh",       "content": "echo hi\n",                                        "kind": "shell",  "note": "plain .sh extension" },
+    { "name": "build.bash",                "content": "echo hi\n",                                        "kind": "shell",  "note": ".bash extension" },
+    { "name": "runtests",                  "content": "#!/bin/sh\necho hi\n",                             "kind": "shell",  "note": "extensionless + /bin/sh shebang" },
+    { "name": "do_setup",                  "content": "#!/usr/bin/env bash\necho hi\n",                   "kind": "shell",  "note": "extensionless + env-bash shebang" },
+
+    { "name": "test_stats.R",              "content": "print(1)\n",                                       "kind": "r",      "note": "uppercase .R extension" },
+    { "name": "test_stats.r",              "content": "print(1)\n",                                       "kind": "r",      "note": "lowercase .r extension" }
+  ]
+}

--- a/Tests/WorkerTests/ScriptDispatchContractTests.swift
+++ b/Tests/WorkerTests/ScriptDispatchContractTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+// Cross-runner script-dispatch contract (worker side).
+//
+// `scriptInvocation` (Sources/Worker/ScriptInvocation.swift) and the browser
+// runner's `classifyScript` (Public/browser-runner.js) are independent
+// implementations of the same "how do I run this test script?" rules. They have
+// drifted twice in two weeks — most recently extensionless Python scripts being
+// reported as unsupported in the browser while the worker ran them fine (#754).
+//
+// This test pins the worker side to the shared fixture; the browser side is
+// pinned to the same fixture by
+// Tests/BrowserRunnerJSTests/script-dispatch-contract.test.mjs. Same input ->
+// same kind, in both runners.
+@Suite struct ScriptDispatchContractTests {
+
+    private struct DispatchCase: Decodable {
+        let name: String
+        let content: String
+        let kind: String
+        let note: String
+    }
+
+    private struct Fixture: Decodable {
+        let cases: [DispatchCase]
+    }
+
+    // .../Tests/WorkerTests/ScriptDispatchContractTests.swift -> repo root
+    private func repoRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // WorkerTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+    }
+
+    // Collapse a concrete ScriptInvocation down to the shared vocabulary the
+    // browser runner also emits: "python" / "shell" / "r". Other kinds map to
+    // "other" so an unexpected match fails loudly against the fixture.
+    private func kind(of invocation: ScriptInvocation) -> String {
+        let exe = invocation.executableURL.lastPathComponent
+        let first = invocation.arguments.first
+        if first == "python3" { return "python" }
+        if first == "Rscript" { return "r" }
+        if exe == "sh" || first == "bash" || first == "zsh" { return "shell" }
+        return "other"
+    }
+
+    @Test func workerDispatchMatchesSharedContract() throws {
+        let fixtureURL = repoRoot()
+            .appendingPathComponent("Tests/Fixtures/script-dispatch-cases.json")
+        let data = try Data(contentsOf: fixtureURL)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: data)
+
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("chickadee-dispatch-contract-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        for testCase in fixture.cases {
+            let scriptURL = tempDir.appendingPathComponent(testCase.name)
+            try testCase.content.write(to: scriptURL, atomically: true, encoding: .utf8)
+
+            let resolved = kind(of: scriptInvocation(for: scriptURL))
+            #expect(
+                resolved == testCase.kind,
+                """
+                Dispatch contract violated for "\(testCase.name)" (\(testCase.note)): worker \
+                scriptInvocation produced "\(resolved)" but the shared fixture \
+                (Tests/Fixtures/script-dispatch-cases.json) requires "\(testCase.kind)". If you \
+                changed the rules, update both runners (Sources/Worker/ScriptInvocation.swift and \
+                Public/browser-runner.js) and the fixture together.
+                """)
+        }
+    }
+}

--- a/changelog.d/runner-dispatch-contract-test.md
+++ b/changelog.d/runner-dispatch-contract-test.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Cross-runner script-dispatch contract test.** A shared fixture
+  (`Tests/Fixtures/script-dispatch-cases.json`) is now asserted from both the
+  native worker (`ScriptInvocation`) and the browser runner (`classifyScript`),
+  so the two independent implementations of "how do I run this test script?"
+  can no longer drift. Covers `.py` / extensionless+shebang / content-sniffed
+  Python, shell, and R cases — the class of bug behind #754.


### PR DESCRIPTION
## Summary

The native worker (`Sources/Worker/ScriptInvocation.swift`, `scriptInvocation`) and the browser runner (`Public/browser-runner.js`, `classifyScript`) are two independent implementations of the same question: *how do I run this test script?* They have drifted **twice in two weeks** — most recently [#754](https://github.com/JimWallace/Chickadee/pull/754), where extensionless Python scripts (e.g. a generated `beats` file with a `#!/usr/bin/env python3` shebang) were reported as `Unsupported test script type` in the browser even though the worker ran them fine.

This adds a **cross-runner contract test** so that class of drift fails CI instead of reaching students:

- `Tests/Fixtures/script-dispatch-cases.json` — single source of truth: a table of `(name, content, kind)` cases covering `.py`, extensionless+shebang, content-sniffed Python, shell (`.sh`/`.bash`/extensionless), and R.
- `Tests/WorkerTests/ScriptDispatchContractTests.swift` — asserts `scriptInvocation` resolves each case to the contract `kind`.
- `Tests/BrowserRunnerJSTests/script-dispatch-contract.test.mjs` — asserts `classifyScript` resolves each case to the same `kind`.
- `classifyScript` / `scriptExtension` exposed via the existing browser-runner test hooks.

Scope note (in the fixture): the contract covers the assignment-relevant, must-agree categories (python/shell/r). Other interpreters and the last-resort fallback for unrecognised non-shebang files intentionally differ between the runners and are excluded. This mirrors the existing runtime-source drift tests that keep the embedded Python helpers in sync.

## Test plan

- [x] `swift test --filter ScriptDispatchContractTests` — passes (worker side).
- [x] `node --test Tests/BrowserRunnerJSTests/*.mjs` — 63 pass (browser side, incl. new contract test).
- [x] Negative check: corrupting one fixture expectation fails the test with an actionable message; revert restores green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)