### PR TITLE
test(runner): broaden browser/worker output + skip-message parity contracts

### DIFF
--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -91,6 +91,18 @@ public struct TestSuiteEntry: Codable, Equatable, Sendable {
     }
 }
 
+/// The `shortResult` emitted when a test is auto-failed because one of its
+/// `dependsOn` prerequisites did not pass.  Both grading runners emit this
+/// exact string — the native worker (`RunnerDaemon`) and the browser runner
+/// (`Public/browser-runner.js`) — and two consumers parse it back: the server
+/// results view (`parseSkip` in `SubmissionOutputFormatting`) and `notebook.js`.
+/// Keeping the wording here (and pinned by the shared
+/// `Tests/Fixtures/dependency-skip-message.json` fixture) is what stops the
+/// producers and parsers from drifting apart.
+public func skippedPrerequisiteMessage(prerequisite: String) -> String {
+    "Skipped: prerequisite '\(prerequisite)' did not pass"
+}
+
 /// A named grouping of test suite entries.  Sections drive visual
 /// grouping on the instructor suite editor and the student submission
 /// results page, and (v0.4.100+) carry an optional list of

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -555,7 +555,7 @@ extension WorkerDaemon {
                         testClass: nil,
                         tier: entry.tier,
                         status: .fail,
-                        shortResult: "Skipped: prerequisite '\(blockedBy)' did not pass",
+                        shortResult: skippedPrerequisiteMessage(prerequisite: blockedBy),
                         longResult: nil,
                         executionTimeMs: 0,
                         memoryUsageBytes: nil,

--- a/Tests/APITests/DependencySkipParseTests.swift
+++ b/Tests/APITests/DependencySkipParseTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import APIServer
+
+// Parser side of the dependency-skip-message contract. `parseSkip` (server
+// results view) must round-trip the exact wording the runners produce. Pinning
+// it to the shared fixture means that if the producer wording changes, this
+// test fails until the parser is updated to match — closing the producer/parser
+// drift gap. The other parser (SKIP_RE in notebook.js) is asserted JS-side.
+@Suite struct DependencySkipParseTests {
+
+    private struct Fixture: Decodable {
+        let prerequisite: String
+        let message: String
+        let parsedBlockerName: String
+    }
+
+    private func loadFixture() throws -> Fixture {
+        // .../Tests/APITests/DependencySkipParseTests.swift -> repo root
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // APITests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let url = root.appendingPathComponent("Tests/Fixtures/dependency-skip-message.json")
+        return try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: url))
+    }
+
+    @Test func parserRoundTripsSharedFixture() throws {
+        let fixture = try loadFixture()
+        let result = parseSkip(shortResult: fixture.message)
+        #expect(
+            result.isSkipped,
+            """
+            parseSkip no longer recognises the canonical dependency-skip wording from \
+            Tests/Fixtures/dependency-skip-message.json — the producer wording and this parser \
+            have drifted. Re-sync the prefix/suffix in SubmissionOutputFormatting.parseSkip.
+            """)
+        #expect(result.blockerName == fixture.parsedBlockerName)
+    }
+}

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -9,6 +9,12 @@ const runnerSource = await fs.readFile(
   'utf8',
 );
 
+// Shared producer/parser contract for the dependency-skip wording; the worker
+// side is pinned by Tests/CoreTests/DependencySkipMessageTests.swift.
+const skipFixture = JSON.parse(
+  await fs.readFile(path.resolve('Tests/Fixtures/dependency-skip-message.json'), 'utf8'),
+);
+
 function plain(value) {
   return JSON.parse(JSON.stringify(value));
 }
@@ -484,7 +490,9 @@ test('dependency failures are skipped without executing blocked scripts', async 
       {
         name: 'test_unit',
         status: 'fail',
-        shortResult: "Skipped: prerequisite 'test_build.py' did not pass",
+        // Pinned to the shared fixture so the browser producer can't drift from
+        // the worker producer (skippedPrerequisiteMessage) or the parsers.
+        shortResult: skipFixture.message,
       },
     ],
   );

--- a/Tests/CoreTests/DependencySkipMessageTests.swift
+++ b/Tests/CoreTests/DependencySkipMessageTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import Core
+
+// Producer side of the dependency-skip-message contract. The two grading
+// runners both emit this exact string when a test is auto-failed because a
+// `dependsOn` prerequisite did not pass: the native worker (via
+// `skippedPrerequisiteMessage`, asserted here) and the browser runner
+// (Public/browser-runner.js, asserted by Tests/BrowserRunnerJSTests/
+// browser-runner.test.mjs). Pinning both producers to the shared fixture means
+// a wording change on one side can't silently diverge from the other — or from
+// the parsers that read it back (parseSkip / notebook.js).
+@Suite struct DependencySkipMessageTests {
+
+    private struct Fixture: Decodable {
+        let prerequisite: String
+        let message: String
+        let parsedBlockerName: String
+    }
+
+    private func loadFixture() throws -> Fixture {
+        // .../Tests/CoreTests/DependencySkipMessageTests.swift -> repo root
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let url = root.appendingPathComponent("Tests/Fixtures/dependency-skip-message.json")
+        return try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: url))
+    }
+
+    @Test func producerMatchesSharedFixture() throws {
+        let fixture = try loadFixture()
+        #expect(
+            skippedPrerequisiteMessage(prerequisite: fixture.prerequisite) == fixture.message,
+            """
+            skippedPrerequisiteMessage drifted from Tests/Fixtures/dependency-skip-message.json. \
+            If you change the wording, update the fixture AND the browser runner producer \
+            (Public/browser-runner.js) AND both parsers (parseSkip in SubmissionOutputFormatting, \
+            SKIP_RE in notebook.js) together.
+            """)
+    }
+}

--- a/Tests/Fixtures/dependency-skip-message.json
+++ b/Tests/Fixtures/dependency-skip-message.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Shared wording for the dependency-skip result. Both grading runners PRODUCE this string when a test's dependsOn prerequisite did not pass -- the native worker (skippedPrerequisiteMessage in Sources/Core/TestProperties.swift, used by RunnerDaemon) and the browser runner (Public/browser-runner.js). Two consumers PARSE it back: parseSkip in Sources/APIServer/Helpers/SubmissionOutputFormatting.swift and the SKIP_RE regex in Public/notebook.js. This fixture pins the wording so producers and parsers cannot drift apart. Consumed by Tests/CoreTests/DependencySkipMessageTests.swift, Tests/APITests (parseSkip round-trip), and Tests/BrowserRunnerJSTests/browser-runner.test.mjs.",
+  "prerequisite": "test_build.py",
+  "message": "Skipped: prerequisite 'test_build.py' did not pass",
+  "parsedBlockerName": "test_build"
+}

--- a/Tests/Fixtures/output-contract.json
+++ b/Tests/Fixtures/output-contract.json
@@ -48,6 +48,30 @@
       "exitCode": 1,
       "status": "fail",
       "native": { "shortResult": "failed", "longResult": null }
+    },
+    {
+      "name": "partial-credit score field present (pass)",
+      "stdout": "{\"score\":0.75,\"shortResult\":\"3/4 cases passed\",\"status\":\"pass\"}\n",
+      "stderr": "",
+      "exitCode": 0,
+      "status": "pass",
+      "native": { "shortResult": "3/4 cases passed", "longResult": null }
+    },
+    {
+      "name": "JSON footer followed by trailing blank lines (last-non-empty-line robustness)",
+      "stdout": "partial output\n{\"shortResult\":\"t: 2 of 3\",\"status\":\"fail\"}\n\n  \n",
+      "stderr": "",
+      "exitCode": 1,
+      "status": "fail",
+      "native": { "shortResult": "t: 2 of 3", "longResult": "stdout:\npartial output" }
+    },
+    {
+      "name": "pass with human stdout then JSON footer (footer stripped on the pass path)",
+      "stdout": "Nice work!\n{\"shortResult\":\"t: passed\",\"status\":\"pass\"}\n",
+      "stderr": "",
+      "exitCode": 0,
+      "status": "pass",
+      "native": { "shortResult": "t: passed", "longResult": "stdout:\nNice work!" }
     }
   ]
 }

--- a/changelog.d/runner-contract-topup.md
+++ b/changelog.d/runner-contract-topup.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Broadened browser/worker parity tests.** The shared output-interpretation
+  corpus (`Tests/Fixtures/output-contract.json`) gained cases for partial-credit
+  `score`, JSON footers trailed by blank lines, and footer-stripping on the pass
+  path. The dependency-skip result wording is now pinned by a shared fixture
+  (`Tests/Fixtures/dependency-skip-message.json`): both producers (the worker's
+  new `skippedPrerequisiteMessage` Core helper and `Public/browser-runner.js`)
+  and the server-side `parseSkip` parser assert against it, so the string can no
+  longer drift between the two runners or their consumers.


### PR DESCRIPTION
## Summary

Follow-up to [#755](https://github.com/JimWallace/Chickadee/pull/755), closing the remaining browser/worker parity gaps after auditing the shared surface. Test-and-fixture work plus one small Core helper extraction — no grading behaviour changes.

- **Output-interpretation corpus** (`Tests/Fixtures/output-contract.json`, asserted by both runners) gains three cases that flow through both `interpretScriptOutput` (worker) and `runPyScript` (browser): partial-credit `score` field present, JSON footer followed by trailing blank lines (last-non-empty-line robustness), and a pass with human stdout + JSON footer (footer-stripping on the pass path).
- **Dependency-skip wording** is now a pinned contract. The string is produced in two runners (worker `RunnerDaemon`, `browser-runner.js`) and parsed by two consumers (`parseSkip`, `notebook.js` regex) — producer-vs-producer drift is exactly our recent incident class. Extracted a `skippedPrerequisiteMessage` Core helper (used by the worker) and a shared fixture (`Tests/Fixtures/dependency-skip-message.json`), asserted from:
  - the worker producer — `Tests/CoreTests/DependencySkipMessageTests.swift`
  - the browser producer — `Tests/BrowserRunnerJSTests/browser-runner.test.mjs` (existing dep test now reads the fixture)
  - the server parser — `Tests/APITests/DependencySkipParseTests.swift` (`parseSkip` round-trips the fixture)

Not pursued (documented in the corpus): byte-identical `shortResult`/`longResult` text between runners, which diverges by design. The grading-critical guarantee (same exit code + output ⟹ same `status`) was already enforced both ways.

## Test plan

- [x] `swift test --filter 'OutputContractTests|DependencySkipMessageTests|DependencySkipParseTests'` — 3 suites pass.
- [x] `node --test Tests/BrowserRunnerJSTests/*.mjs` — 63 pass.
- [x] `swift-format lint --strict` on all changed Swift files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)