### PR TITLE
build(wasm): add RunnerCore wasm bridge sub-package

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -77,6 +77,7 @@ opt_in_rules:
 
 excluded:
   - .build
+  - wasm/.build     # wasm bridge sub-package build dir + vendored JavaScriptKit checkouts
   - .claude         # agent worktrees + local state (nested .build vendored deps)
   - .swiftpm
   - Packages

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,11 @@ let package = Package(
     platforms: [
         .macOS(.v15)
     ],
+    products: [
+        // Exposed so the wasm bridge sub-package (wasm/) can depend on the pure
+        // extraction logic without pulling in the rest of Chickadee.
+        .library(name: "RunnerCore", targets: ["RunnerCore"])
+    ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.121.3"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.13.0"),

--- a/changelog.d/runner-wasm-bridge.md
+++ b/changelog.d/runner-wasm-bridge.md
@@ -1,0 +1,10 @@
+### Added
+
+- **wasm bridge build for `RunnerCore` (`wasm/` sub-package + `scripts/build-runner-wasm.sh`).**
+  A separate SwiftPM package compiles the shared, substrate-free `RunnerCore`
+  extraction logic to WebAssembly via JavaScriptKit/BridgeJS, exposing
+  `extractPythonJSON(cellsJSON, filename)` to JS. Kept out of the main package's
+  native build (JavaScriptKit is wasm-only); it depends on the new `RunnerCore`
+  library product by path. This is the foundation for the browser runner calling
+  the same extractor as the native worker (verified end-to-end in Node). Wiring
+  it into `browser-runner.js` and vendoring the bundled artifact is the next step.

--- a/scripts/build-runner-wasm.sh
+++ b/scripts/build-runner-wasm.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Build the RunnerCore wasm bridge (wasm/ sub-package) and stage the artifact
+# under Public/runner-wasm/.
+#
+# RunnerCore is the substrate-free grading logic shared with the native worker.
+# This script compiles it (plus the thin JavaScriptKit @JS bridge in
+# wasm/Sources/RunnerWasm/) to wasm via the PackageToJS plugin, so the browser
+# runner can call the SAME extraction code instead of a hand-written JS copy.
+#
+# Prerequisites (one-time, see docs):
+#   * Swift toolchain matching the wasm SDK (currently 6.3.2 — see .swift-version)
+#   * The Swift WebAssembly SDK installed:
+#       swift sdk install <swift-6.3.2 wasm artifactbundle url> --checksum <sum>
+#     and exported as SWIFT_WASM_SDK (defaults to swift-6.3.2-RELEASE_wasm).
+#
+# The vendored output is checked in (like Public/pyodide, Public/vendor) so CI
+# and contributors don't need the wasm SDK; rebuild only when RunnerCore or the
+# bridge changes.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+sdk="${SWIFT_WASM_SDK:-swift-6.3.2-RELEASE_wasm}"
+out_dir="$repo_root/Public/runner-wasm"
+
+cd "$repo_root/wasm"
+
+echo "Building RunnerWasm for wasm (SDK: $sdk)…"
+swift package --swift-sdk "$sdk" js
+
+pkg=".build/plugins/PackageToJS/outputs/Package"
+
+echo "Staging artifact into $out_dir …"
+rm -rf "$out_dir"
+mkdir -p "$out_dir"
+cp -R "$pkg/." "$out_dir/"
+
+echo "Done. Vendored RunnerCore wasm bridge at Public/runner-wasm/."
+echo "NOTE: browser wiring (esbuild-bundle the wasi shim for no-CDN load + load"
+echo "      from browser-runner.js) is the next step and not done by this script yet."

--- a/wasm/Package.swift
+++ b/wasm/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+// Separate package so JavaScriptKit (wasm-only) never enters the main
+// Chickadee package's native build graph. Depends on the main package's
+// RunnerCore product by path, plus JavaScriptKit. Built for wasm only, via
+// scripts/build-runner-wasm.sh; the output is vendored under Public/runner-wasm/.
+let package = Package(
+    name: "RunnerWasm",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(name: "Chickadee", path: ".."),
+        .package(url: "https://github.com/swiftwasm/JavaScriptKit.git", from: "0.53.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "RunnerWasm",
+            dependencies: [
+                .product(name: "RunnerCore", package: "Chickadee"),
+                "JavaScriptKit",
+            ],
+            swiftSettings: [.enableExperimentalFeature("Extern")],
+            plugins: [.plugin(name: "BridgeJS", package: "JavaScriptKit")]
+        )
+    ]
+)

--- a/wasm/Sources/RunnerWasm/Bridge.swift
+++ b/wasm/Sources/RunnerWasm/Bridge.swift
@@ -8,8 +8,13 @@ import RunnerCore
 // uses Foundation for JSON.
 
 private struct CellDTO: Codable {
-    let cell_type: String
+    let cellType: String
     let source: String
+
+    enum CodingKeys: String, CodingKey {
+        case cellType = "cell_type"
+        case source
+    }
 }
 
 private struct ResultDTO: Codable {
@@ -29,7 +34,7 @@ private struct ResultDTO: Codable {
         return #"{"error":"failed to decode cells JSON"}"#
     }
 
-    let cells = dtos.map { NotebookCell(cellType: $0.cell_type, source: $0.source) }
+    let cells = dtos.map { NotebookCell(cellType: $0.cellType, source: $0.source) }
     let extracted = extractPython(cells: cells, filename: filename)
 
     let result = ResultDTO(
@@ -37,8 +42,10 @@ private struct ResultDTO: Codable {
         introspectableSource: extracted.introspectableSource,
         codeCellCount: extracted.codeCellCount
     )
-    guard let data = try? JSONEncoder().encode(result) else {
+    guard let data = try? JSONEncoder().encode(result),
+        let json = String(bytes: data, encoding: .utf8)
+    else {
         return #"{"error":"failed to encode result"}"#
     }
-    return String(decoding: data, as: UTF8.self)
+    return json
 }

--- a/wasm/Sources/RunnerWasm/Bridge.swift
+++ b/wasm/Sources/RunnerWasm/Bridge.swift
@@ -1,0 +1,44 @@
+import Foundation
+import JavaScriptKit
+import RunnerCore
+
+// JS-facing bridge over the pure RunnerCore extractor. Input/output cross the
+// boundary as JSON strings so the contract is trivial to call from JS. The pure
+// transform (RunnerCore) stays Foundation-free; only this thin wasm-only bridge
+// uses Foundation for JSON.
+
+private struct CellDTO: Codable {
+    let cell_type: String
+    let source: String
+}
+
+private struct ResultDTO: Codable {
+    let executableModule: String
+    let introspectableSource: String
+    let codeCellCount: Int
+}
+
+/// Exported to JS as `extractPythonJSON(cellsJSON, filename)`.
+/// `cellsJSON` is a JSON array of `{ "cell_type": "...", "source": "..." }`.
+/// Returns a JSON object `{ executableModule, introspectableSource, codeCellCount }`.
+@JS public func extractPythonJSON(cellsJSON: String, filename: String) -> String {
+    let dtos: [CellDTO]
+    do {
+        dtos = try JSONDecoder().decode([CellDTO].self, from: Data(cellsJSON.utf8))
+    } catch {
+        return #"{"error":"failed to decode cells JSON"}"#
+    }
+
+    let cells = dtos.map { NotebookCell(cellType: $0.cell_type, source: $0.source) }
+    let extracted = extractPython(cells: cells, filename: filename)
+
+    let result = ResultDTO(
+        executableModule: extracted.executableModule,
+        introspectableSource: extracted.introspectableSource,
+        codeCellCount: extracted.codeCellCount
+    )
+    guard let data = try? JSONEncoder().encode(result) else {
+        return #"{"error":"failed to encode result"}"#
+    }
+    return String(decoding: data, as: UTF8.self)
+}


### PR DESCRIPTION
## Summary

Foundation for the browser runner calling the **same** extraction code as the native worker (the drift-elimination goal). Builds the substrate-free `RunnerCore` to WebAssembly.

- New `RunnerCore` **library product** in the main package.
- New **`wasm/` sub-package** (separate SwiftPM package) with a `RunnerWasm` target that depends on `RunnerCore` (by path) + JavaScriptKit, and a thin BridgeJS `@JS` bridge exposing `extractPythonJSON(cellsJSON, filename)`. Kept out of the main package's native build, since JavaScriptKit is wasm-only.
- `scripts/build-runner-wasm.sh` drives the PackageToJS build and stages output under `Public/runner-wasm/` (mirroring how Pyodide/CodeMirror are vendored).

**Verified end-to-end in Node:** JS calls `extractPythonJSON` compiled to wasm and gets correct dual output — the `exec(compile())` executable module *and* the real-`def` introspectable source (including module-level asserts quarantined into `if __name__`, which the structural-check NotebookCheck needs).

## Not in this PR (next steps)

- esbuild-bundle the WASI shim for no-CDN browser load + wire `browser-runner.js` to call `extractPythonJSON` instead of its JS `extractNotebook` (needs in-browser verification).
- Vendor the bundled artifact under `Public/runner-wasm/`.
- Introspectable-source sidecar + `student_source()` + structural-check template → fixes the HLTH-230 lab on both runners.

## Test plan

- [x] `swift build --target RunnerCore` (native) — main package resolves with the new product.
- [x] `wasm/`: `swift package --swift-sdk swift-6.3.2-RELEASE_wasm js` builds; Node round-trip passes 5/5 checks.
- [x] `swift-format lint --strict` on changed Swift — clean.
- [ ] CI does not build `wasm/` (separate package; no wasm SDK in CI) — main package build/tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)