### PR TITLE
docs: runner WASM migration plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -855,6 +855,7 @@ model quickly.
 - `docs/architecture.md` — system architecture: targets, grading pipeline, auth, sandboxing, deployment
 - `docs/operational-diagnostics.md` — observability tables, structured log events, metrics endpoint, ops runbook
 - `docs/runner-capability-profiles.md` — runner capability matching, assignment requirements, rollout rules
+- `docs/runner-wasm-migration.md` — plan to share one Swift grading core (RunnerCore) between the worker + browser runner via SwiftWasm; staging, the ScriptExecutor protocol, type-hoist
 - `docs/ci-followups.md` — historical CI reshaping notes from v0.4.6 (WorkerTests are back in the per-PR gate as of the 2026 cleanup)
 - `reference/` — original Java source for behavioural reference only
 - `CHANGELOG.md` — release history

--- a/docs/runner-wasm-migration.md
+++ b/docs/runner-wasm-migration.md
@@ -1,0 +1,174 @@
+# Runner WASM Migration — one Swift grading core for both runners
+
+Status: **in progress** (Stage 0 landed). Owner: see git history. This is the
+authoritative plan; the staging here is what we execute against.
+
+## Why
+
+Chickadee grades submissions in two places:
+
+- the **native worker** (`chickadee-runner`, Swift) — runs scripts in a
+  subprocess under a sandbox;
+- the **browser runner** (`Public/browser-runner.js`, JS + Pyodide) — runs the
+  same scripts locally in the student's browser.
+
+The browser runner is a **hand-written JS reimplementation of the worker's
+logic**, and the two drift. Three production incidents in ~two weeks were all
+this same shape:
+
+1. extensionless-Python dispatch (the browser said "unsupported" while the
+   worker ran it) — #754;
+2. output-interpretation / dependency-skip wording parity — #755/#756;
+3. `inspect.getsource`-based structural NotebookChecks fail in the browser
+   because both runners `exec(compile())`-wrap notebook cells, so neither
+   exposes real source (the HLTH-230 lab).
+
+Cross-runner contract tests (Stage 0) catch drift, but they don't *remove* the
+duplication, and they only catch what we thought to pin. The durable fix is to
+have **one Swift implementation of all grading logic**, compiled to WebAssembly
+so the browser runs the exact same code as the worker.
+
+## The principle
+
+Sort every browser-runner responsibility by one question: **does it have a
+worker counterpart it could drift against?**
+
+- **Has a worker twin → must be Swift, exactly once.** Notebook extraction,
+  script dispatch, output interpretation, the suite-execution loop (dependency
+  checks, skip messages, collection building). *This is the entire drift
+  surface.*
+- **No worker twin → may stay JS forever, no drift risk.** DOM glue (Submit
+  button, status bar), loading Pyodide + the wasm module, fetching the test-setup
+  zip, POSTing results. Nothing on the worker side for these to disagree with.
+- **The one irreducible seam:** running Python — subprocess `python3` (worker)
+  vs Pyodide (browser).
+
+A fully JS-free browser is impossible: Pyodide's only contract is its JS API, and
+two wasm modules in a browser communicate through the JS host. So Swift-in-wasm
+*drives* Pyodide through JS (via JavaScriptKit). "Pure Swift" here means **all
+logic is one Swift codebase**; JS shrinks to a thin bootstrap.
+
+## End-state architecture
+
+```
+RunnerCore  (Swift · dependency-free · wasm-safe · the foundational leaf)
+  • canonical runtime grading model: RunnerManifest, SuiteItem,
+    TestOutcome, TestStatus, TestTier, ScriptOutput
+  • shared logic: extract · classifyScript · interpretScriptOutput · executeSuites
+  • protocol ScriptExecutor { run(script,kind,timeLimit) -> ScriptOutput; file I/O }
+
+NativeScriptExecutor (Worker)            BrowserScriptExecutor (wasm bridge)
+  subprocess + sandbox                     Pyodide via JavaScriptKit
+
+Core / APIServer / Worker  ── depend up on ──►  RunnerCore
+browser-runner.js  →  ~50-line bootstrap (DOM + loaders + POST, zero logic)
+```
+
+`RunnerCore` is a **leaf** (depends on nothing, wasm-safe). Everything else
+depends *up* on it. Because the wasm build compiles only `RunnerCore` + the
+bridge, it never drags `Core`'s heavy deps (swift-crypto) into the browser.
+
+## The protocol
+
+The seam is deliberately **narrow** — the more the substrate must implement, the
+less is shared. "A runner" is not a protocol; it's the composition
+`executeSuites + some ScriptExecutor`.
+
+```swift
+public struct ScriptOutput: Sendable, Equatable {
+    public let exitCode: Int32
+    public let stdout: String
+    public let stderr: String
+    public let timedOut: Bool
+}
+
+public enum ScriptKind: Sendable { case python, shell, r, unknown }
+
+public protocol ScriptExecutor {
+    func writeFile(_ path: String, _ bytes: [UInt8]) async throws
+    func readFile(_ path: String) async -> [UInt8]?
+    func run(scriptPath: String, kind: ScriptKind, timeLimitSeconds: Int) async -> ScriptOutput
+}
+
+// Shared orchestration — the loop that has drifted lives here, once.
+public func executeSuites(
+    suites: [SuiteItem],
+    workspaceFiles: [WorkspaceFile],
+    executor: some ScriptExecutor
+) async -> [TestOutcome]
+```
+
+**The worker is the first conformance.** When `executeSuites` + `ScriptExecutor`
+land, we immediately refactor the worker's existing subprocess loop into
+`NativeScriptExecutor` and route it through `executeSuites`. The protocol is
+born *exercised* by a real caller — never a floating, speculative interface. The
+browser's `BrowserScriptExecutor` (Pyodide via JavaScriptKit) is then a drop-in
+second conformance.
+
+## Data-type ownership (resolves the "mirror types vs make-Core-wasm-safe" question)
+
+Neither. **Hoist the canonical runtime model *down* into `RunnerCore`** and have
+everyone depend up. No mirror types, no mapping layer, no swift-crypto in the
+wasm build, and a single source of truth.
+
+The split line already exists as `TestProperties.runnerSanitized()`:
+
+- **Runtime model → `RunnerCore`:** the sanitized manifest the runner sees,
+  suite entries, `TestOutcome` / `TestStatus` / `TestTier`, `ScriptOutput`.
+- **Authoring model → stays in `Core`, built on top:** `PatternFamily`,
+  `NotebookCheck`, sections, the full `TestProperties` with its authoring fields.
+
+Hoisting is incremental and one-directional (always *into* `RunnerCore`); the
+compiler chases every `import`, and we never create a type we later discard.
+
+## Staging
+
+- **Stage 0 — done (#754–#759).** `RunnerCore` exists; the worker delegates
+  notebook extraction to it (byte-identical). Dispatch + output/skip contract
+  tests. The wasm bridge sub-package (`wasm/`, JavaScriptKit 0.53 + BridgeJS)
+  exposes `extractPythonJSON` and is verified end-to-end in Node.
+
+- **Stage 1 — finish the extraction bridge + fix HLTH-230.** esbuild-bundle the
+  WASI shim for no-CDN browser load; wire `browser-runner.js` to call
+  `extractPythonJSON`; vendor the artifact under `Public/runner-wasm/`. Then emit
+  the introspectable-source sidecar on both runners, add a `student_source()`
+  runtime helper, and point the structural-check template at it — fixing the
+  lab on both runners. No type hoist needed yet.
+
+- **Stage 2 — hoist the leaf logic.** Move `classifyScript` and
+  `interpretScriptOutput` (and the types they touch — `ScriptOutput`,
+  `TestStatus`) into `RunnerCore`. The cross-runner contract tests become plain
+  unit tests (one implementation can't disagree with itself).
+
+- **Stage 3 — the protocol + the loop.** Define `ScriptExecutor` and
+  `executeSuites` in `RunnerCore`, hoisting the suite/outcome/manifest types
+  with them. **Migrate the worker onto it first** (`NativeScriptExecutor`). Add
+  `BrowserScriptExecutor` (Pyodide via JavaScriptKit). Delete the duplicated
+  loop in `browser-runner.js`.
+
+- **Stage 4 — thin the shell.** `browser-runner.js` becomes a ~50-line
+  bootstrap: load Pyodide + wasm, hand Swift the Pyodide handle and notebook
+  bytes, take back the result collection, POST it. Zero grading logic remains in
+  JS.
+
+## What stays JS forever
+
+The bootstrap above, and Pyodide itself. Everything with a worker counterpart is
+shared Swift, compiled once.
+
+## Toolchain & build
+
+- Host Swift toolchain **must match** the wasm SDK version. Currently Swift
+  **6.3.2** (via swiftly) + the `swift-6.3.2-RELEASE_wasm` SDK.
+- Build the bridge: `scripts/build-runner-wasm.sh` (drives the PackageToJS `js`
+  plugin from `wasm/`). Output is vendored under `Public/runner-wasm/`, like
+  Pyodide / CodeMirror — so CI and contributors need no wasm SDK; rebuild only
+  when `RunnerCore` or the bridge changes.
+- `wasm/.build` is excluded from SwiftLint (it would otherwise lint vendored
+  JavaScriptKit checkouts).
+
+## Open decisions
+
+- **Stage 1 timing.** Whether to push the browser-wiring + HLTH-230 fix through
+  immediately (it un-breaks the lab but is the step most needing in-browser
+  verification). The lab stays broken until it lands.


### PR DESCRIPTION
## Summary

Writes down the agreed plan for unifying the two grading runners onto one Swift core compiled to WebAssembly, so the staging is unambiguous when we start the next stages.

`docs/runner-wasm-migration.md` covers:
- **Why** — the three browser/worker drift incidents this month; contract tests catch drift but don't remove the duplication.
- **The principle** — "has a worker twin → Swift once; no twin (DOM/IO bootstrap) → JS is fine." The one irreducible seam is Python execution (subprocess vs Pyodide).
- **End-state** — `RunnerCore` as the dependency-free, wasm-safe foundational leaf; everyone depends *up* on it; `browser-runner.js` → ~50-line bootstrap.
- **The `ScriptExecutor` protocol** — deliberately narrow; **the worker is the first conformance** (born exercised, not speculative); the browser is a drop-in second conformance via JavaScriptKit.
- **Data-type ownership** — hoist the runtime model *into* `RunnerCore` (no mirror types, no making `Core` wasm-safe, no swift-crypto in the wasm build); split line = `runnerSanitized()`.
- **Stage 0→4** staging, with Stage 0 (#754–#759) marked done.
- Toolchain/build + open decisions.

Linked from CLAUDE.md's Reference Material.

Docs-only; no code change.

## Test plan

- [x] Docs + one CLAUDE.md reference line. No build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)