### PR TITLE
refactor(runnercore): make RunnerCore embedded-Swift compatible

### DIFF
--- a/Sources/RunnerCore/NotebookExtraction.swift
+++ b/Sources/RunnerCore/NotebookExtraction.swift
@@ -158,7 +158,13 @@ public func sanitizeCellForModule(_ source: String) -> String {
 /// skipped. `from __future__` imports must stay at module top, so those cells
 /// are emitted unwrapped.
 public func wrapCellForResilientLoad(_ body: String, label: String) -> String {
-    if body.contains("from __future__") {
+    // `from __future__` imports must stay at module top. Detected line-by-line
+    // (hasPrefix) rather than `String.contains(_: String)`, which Embedded Swift
+    // lacks (no string-processing module) — RunnerCore compiles to wasm32.
+    let hasFutureImport = splitLines(body).contains { line in
+        trimSpacesAndTabs(line).hasPrefix("from __future__")
+    }
+    if hasFutureImport {
         return body
     }
     return """
@@ -285,7 +291,7 @@ func rhsContainsFunctionCall(_ rhs: String) -> Bool {
 
 /// Split on "\n" keeping empty substrings (matches `components(separatedBy:)`).
 private func splitLines(_ s: String) -> [String] {
-    s.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    s.split(separator: "\n" as Character, omittingEmptySubsequences: false).map(String.init)
 }
 
 /// Trim leading/trailing spaces and tabs only (matches `.whitespaces`).

--- a/changelog.d/runnercore-embedded-compat.md
+++ b/changelog.d/runnercore-embedded-compat.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **`RunnerCore` is now Embedded-Swift compatible.** Two behaviour-preserving
+  tweaks (line-based `from __future__` detection instead of
+  `String.contains(_:String)`, and an explicit `Character` split separator) let
+  the shared extractor compile under the Embedded Swift wasm SDK — a ~60× smaller
+  browser artifact (≈350 KB gzipped vs ≈20 MB) than the standard wasm build.
+  No change to native worker output.


### PR DESCRIPTION
## Summary

Two behaviour-preserving tweaks so the shared `RunnerCore` extractor compiles under **Embedded Swift** (the path to a tiny browser wasm):

- Line-based `from __future__` detection instead of `String.contains(_: String)` — Embedded Swift has no string-processing module.
- Explicit `Character` split separator.

### Why this matters

Validated in a spike: under the Embedded Swift wasm SDK (+ linking `libswiftUnicodeDataTables`), `RunnerCore` + the JavaScriptKit bridge compiles, links, runs, and round-trips correctly in Node — producing a **976 KB (349 KB gzipped)** artifact, vs **61 MB (20 MB gzipped)** for the standard wasm runtime. This is the prerequisite that makes shipping the shared extractor to the browser viable.

No behaviour change to the native worker — the line-based future-import check is, if anything, more precise (only real top-level imports), and 49 extraction tests pass.

## Test plan

- [x] `swift test --filter NotebookExtract` — 49 pass (incl. `generatedModuleLoadsUnderRealPython3`).
- [x] `swift-format lint --strict` — clean.
- [x] Embedded build + Node round-trip verified in spike (5/5 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)