### PR TITLE
fix(notebookcheck): browser wasm extraction + introspectable source (HLTH-230)

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -305,25 +305,62 @@ for _module_name in student_module_names_in_load_order():
         const ksName = (ks.name || '').toLowerCase();
         const liName = ((meta.language_info || {}).name || '').toLowerCase();
         const isR    = ksName === 'ir' || ksName === 'r' || ksName === 'webr' || liName === 'r';
-        const ext    = isR ? 'R' : 'py';
+        const stem   = filename.replace(/\.ipynb$/i, '');
 
-        const stem    = filename.replace(/\.ipynb$/i, '');
-        const outPath = `${workDir}/${stem}.${ext}`;
-
-        let code = `# Generated from ${filename}\n\n`;
-        for (const [i, cell] of (notebook.cells || []).entries()) {
-            if (cell.cell_type !== 'code') continue;
-            const src = Array.isArray(cell.source)
-                ? cell.source.join('')
-                : (cell.source || '');
-            const block = isR ? extractRCell(src) : extractPythonCell(src, `cell ${i + 1}`);
-            if (block) code += block + '\n\n';
+        if (isR) {
+            // R stays on the JS path — RunnerCore (the shared wasm extractor) is
+            // Python-only, matching the native worker.
+            let code = `# Generated from ${filename}\n\n`;
+            for (const cell of (notebook.cells || [])) {
+                if (cell.cell_type !== 'code') continue;
+                const src = Array.isArray(cell.source) ? cell.source.join('') : (cell.source || '');
+                const block = extractRCell(src);
+                if (block) code += block + '\n\n';
+            }
+            py.FS.writeFile(`${workDir}/${stem}.R`, code);
+            py.FS.writeFile(`${workDir}/.chickadee_student_module`, `${stem}.R`);
+            return;
         }
 
-        py.FS.writeFile(outPath, code);
+        // Python: extract via the shared RunnerCore wasm — the SAME code the
+        // native worker runs (Sources/RunnerCore), instead of a JS reimplementation.
+        const cells = (notebook.cells || []).map(cell => ({
+            cell_type: cell.cell_type,
+            source: Array.isArray(cell.source) ? cell.source.join('') : (cell.source || ''),
+        }));
+        const extract = await loadRunnerExtractor();
+        const result = extract(cells, filename);
 
-        // Write .chickadee_student_module hint so test_runtime.py can find the file.
-        py.FS.writeFile(`${workDir}/.chickadee_student_module`, `${stem}.${ext}`);
+        py.FS.writeFile(`${workDir}/${stem}.py`, result.executableModule);
+        py.FS.writeFile(`${workDir}/.chickadee_student_module`, `${stem}.py`);
+
+        // Sidecar: the introspectable (un-exec-wrapped) source, so structural /
+        // AST NotebookChecks can read real `def`s via student_source().
+        py.FS.writeFile(`${workDir}/${stem}.source.py`, result.introspectableSource);
+        py.FS.writeFile(`${workDir}/.chickadee_student_source`, `${stem}.source.py`);
+    }
+
+    // -------------------------------------------------------------------------
+    // RunnerCore wasm extractor (lazy singleton)
+    //
+    // Loads the vendored, embedded-Swift RunnerCore bridge and returns its
+    // `runnerExtractPython(cells, filename)` function. A test harness can preset
+    // `globalThis.runnerExtractPython` to skip loading the wasm.
+    // -------------------------------------------------------------------------
+
+    let _runnerExtractor = null;
+
+    async function loadRunnerExtractor() {
+        if (_runnerExtractor) return _runnerExtractor;
+        if (typeof globalThis.runnerExtractPython !== 'function') {
+            const mod = await import('/runner-wasm/runner-core.js');
+            await mod.init();  // runs the wasm module's entrypoint → registers the global
+        }
+        if (typeof globalThis.runnerExtractPython !== 'function') {
+            throw new Error('RunnerCore wasm did not register runnerExtractPython');
+        }
+        _runnerExtractor = globalThis.runnerExtractPython;
+        return _runnerExtractor;
     }
 
     // R cells are emitted verbatim — the browser R path (WebR) is not yet active.
@@ -332,36 +369,9 @@ for _module_name in student_module_names_in_load_order():
         return trimmed.trim() ? trimmed : '';
     }
 
-    // Each Python cell is compiled and executed as its own unit inside
-    // try/except so that one broken cell can't take down the rest of the module:
-    //   • a SYNTAX error (a typo, or an unfilled comment-only "# Your code here"
-    //     cell) is raised by compile() and caught here — only this cell is
-    //     skipped.  A plain inline wrap can't do this: a syntax error anywhere
-    //     fails the whole-module compile before any try/except runs.
-    //   • a RUNTIME error (e.g. `x = ____` → NameError) is raised by exec() and
-    //     caught here too.
-    //   • exec(..., globals()) defines names in the module namespace, so
-    //     functions/variables defined in one cell stay visible to later cells
-    //     and to the test scripts — identical to plain module scope.
-    // IPython magics (% / !) are stripped so a cell that mixes a magic with real
-    // code still runs the real code.  `from __future__` imports must stay at
-    // module top as raw statements (a per-cell compile would scope them away).
-    function extractPythonCell(src, label) {
-        const cleaned = src
-            .split('\n')
-            .filter(line => {
-                const s = line.trim();
-                return !s.startsWith('%') && !s.startsWith('!');
-            })
-            .join('\n');
-        const trimmed = cleaned.replace(/\s+$/, '');
-        if (!trimmed.trim()) return '';
-
-        if (/(^|\n)\s*from\s+__future__\s+import\b/.test(trimmed)) return trimmed;
-
-        return `try:\n    exec(compile(${JSON.stringify(trimmed)}, ${JSON.stringify(label)}, "exec"), globals())\n`
-            + `except Exception:\n    pass`;
-    }
+    // Python per-cell extraction (magic stripping, def/usage split,
+    // exec(compile()) wrapping) now lives in RunnerCore (Swift, compiled to
+    // wasm) and is shared with the native worker — see extractNotebook above.
 
     // -------------------------------------------------------------------------
     // Python script execution
@@ -1148,6 +1158,7 @@ for _module_name in _tr.student_module_names_in_load_order():
             __resetStateForTests() {
                 _pyodide = null;
                 _JSZip   = null;
+                _runnerExtractor = null;
                 if (statusEl) {
                     statusEl.textContent = '';
                     statusEl.className   = '';

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -1047,6 +1047,26 @@ def load_student_module():
     return modules.get(_loaded_student_order[0])
 
 
+def student_source() -> str:
+    hint = Path(".chickadee_student_source")
+    try:
+        if hint.exists():
+            name = Path(hint.read_text(encoding="utf-8").strip()).name
+            sidecar = Path(name)
+            if name and sidecar.exists():
+                return sidecar.read_text(encoding="utf-8")
+    except Exception:
+        pass
+    try:
+        import inspect
+        module = load_student_module()
+        if module is not None:
+            return inspect.getsource(module)
+    except Exception:
+        pass
+    return ""
+
+
 def require_function(name: str, num_args: Optional[int] = None):
     modules = load_student_modules()
     for key in _loaded_student_order:

--- a/Sources/APIServer/Utilities/TestScriptTemplates.swift
+++ b/Sources/APIServer/Utilities/TestScriptTemplates.swift
@@ -373,7 +373,6 @@ func pythonTestScript(  // swiftlint:disable:this function_body_length
                 # when NotebookExtractor has quarantined them inside an
                 # `if __name__ == "__main__":` block.
                 import ast
-                import inspect
 
                 target_function     = "\(functionName)"    # "" to skip per-function checks
                 parameter_count     = None                # int — require exactly N parameters
@@ -384,8 +383,13 @@ func pythonTestScript(  // swiftlint:disable:this function_body_length
                 min_module_asserts  = None                # int — require >= N module-level asserts (anywhere)
 
                 # ── AST walk ───────────────────────────────────────────────────────
+                # `student_source()` returns the introspectable source (real
+                # module-level defs) on both runners — see RunnerCore extraction +
+                # the .chickadee_student_source sidecar. inspect.getsource on the
+                # exec(compile())-wrapped module would not expose the defs.
                 try:
-                    source = inspect.getsource(student_module)
+                    from test_runtime import student_source
+                    source = student_source()
                     tree   = ast.parse(source)
                 except Exception as ex:
                     errored(f"Could not parse student source: {type(ex).__name__}: {ex}")

--- a/Sources/Worker/NotebookExtractor.swift
+++ b/Sources/Worker/NotebookExtractor.swift
@@ -4,6 +4,7 @@ import RunnerCore
 
 struct NotebookExtraction {
     let source: String
+    let introspectableSource: String
     let codeCellCount: Int
 }
 
@@ -52,6 +53,7 @@ struct NotebookExtractor {
 
         return NotebookExtraction(
             source: extracted.executableModule,
+            introspectableSource: extracted.introspectableSource,
             codeCellCount: extracted.codeCellCount
         )
     }

--- a/Sources/Worker/SubmissionNormalizer.swift
+++ b/Sources/Worker/SubmissionNormalizer.swift
@@ -198,11 +198,30 @@ struct SubmissionNormalizer {
         )
         try extracted.source.write(to: destinationURL, atomically: true, encoding: .utf8)
         progress.producedPythonFiles.append(destinationURL)
+
+        let moduleRelative = relativePath(of: destinationURL, under: workspaceDirectory)
+
+        // Sidecar: the introspectable source (real module-level defs) so
+        // student_source()-based structural / AST NotebookChecks work — the
+        // executable module is exec(compile())-wrapped and not AST-introspectable.
+        // Written for the first root-level module, mirroring .chickadee_student_module.
+        if progress.preferredStudentModule == nil, preferredModuleIfRootLevel(moduleRelative) != nil {
+            let sidecarName = destinationURL.deletingPathExtension().lastPathComponent + ".source.py"
+            try extracted.introspectableSource.write(
+                to: workspaceDirectory.appendingPathComponent(sidecarName),
+                atomically: true,
+                encoding: .utf8
+            )
+            try sidecarName.write(
+                to: workspaceDirectory.appendingPathComponent(".chickadee_student_source"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
         progress.preferredStudentModule =
             progress.preferredStudentModule
-            ?? preferredModuleIfRootLevel(
-                relativePath(of: destinationURL, under: workspaceDirectory)
-            )
+            ?? preferredModuleIfRootLevel(moduleRelative)
 
         // v0.4.114: also preserve the original notebook bytes
         // alongside the flattened .py so source-level checks

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -207,6 +207,26 @@ let testRuntimePy = """
         return modules.get(_loaded_student_order[0])
 
 
+    def student_source() -> str:
+        hint = Path(".chickadee_student_source")
+        try:
+            if hint.exists():
+                name = Path(hint.read_text(encoding="utf-8").strip()).name
+                sidecar = Path(name)
+                if name and sidecar.exists():
+                    return sidecar.read_text(encoding="utf-8")
+        except Exception:
+            pass
+        try:
+            import inspect
+            module = load_student_module()
+            if module is not None:
+                return inspect.getsource(module)
+        except Exception:
+            pass
+        return ""
+
+
     def require_function(name: str, num_args: Optional[int] = None):
         modules = load_student_modules()
         for key in _loaded_student_order:

--- a/Tests/APITests/TestScriptTemplatesTests.swift
+++ b/Tests/APITests/TestScriptTemplatesTests.swift
@@ -224,9 +224,12 @@ import Testing
     @Test func structuralCheckTemplate_hasExpectedShape() {
         let s = pythonTestScript(
             type: .structuralCheck, functionName: "compute_bmi", paramNames: ["weight_kg", "height_m"])
-        // AST-based template — no function call.
+        // AST-based template — no function call. Source comes from
+        // student_source() (introspectable sidecar), not inspect.getsource on the
+        // exec(compile())-wrapped module.
         #expect(s.contains("import ast"))
-        #expect(s.contains("inspect.getsource(student_module)"))
+        #expect(s.contains("from test_runtime import student_source"))
+        #expect(s.contains("source = student_source()"))
         #expect(s.contains("ast.parse(source)"))
         // All the knobs are present as TODO-friendly placeholders.
         #expect(s.contains("parameter_count"))

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -328,6 +328,14 @@ async function loadRunnerHarness(options = {}) {
     fetch: fetchImpl,
     getCsrfToken: () => options.csrfToken ?? 'csrf-test-token',
     document,
+    // Test seam: preset the RunnerCore extractor so the runner never loads the
+    // real wasm bundle. The actual extraction logic is covered by the Swift
+    // RunnerCore tests; here a stub returns deterministic output.
+    runnerExtractPython: options.runnerExtractor ?? ((cells, filename) => ({
+      executableModule: `# Generated from ${filename}\n# (stub executable module)\n`,
+      introspectableSource: `# Generated from ${filename}\n# (stub introspectable source)\n`,
+      codeCellCount: (cells || []).filter(c => c.cell_type === 'code').length,
+    })),
     __CHICKADEE_BROWSER_RUNNER_TEST_HOOKS__: testHooks,
   };
 
@@ -664,56 +672,74 @@ test('manifest and setup download failures bubble up with browser-runner context
   );
 });
 
-test('extractNotebook writes python and R student module hints correctly', async () => {
-  const harness = await loadRunnerHarness();
+test('extractNotebook delegates Python to RunnerCore (module + introspectable sidecar + hints) and keeps R on the JS path', async () => {
+  // The per-cell extraction logic now lives in RunnerCore (Swift/wasm) and is
+  // covered by Tests/WorkerTests/NotebookExtractionTests.swift. Here we assert
+  // the browser glue: cells handed to the shared extractor, and its outputs
+  // (executable module + introspectable-source sidecar) written with hints.
+  let received = null;
+  const harness = await loadRunnerHarness({
+    runnerExtractor: (cells, filename) => {
+      received = { cells, filename };
+      return {
+        executableModule: '# exec module\nMODULE_BODY\n',
+        introspectableSource: '# real source\ndef tax():\n    pass\n',
+        codeCellCount: cells.filter(c => c.cell_type === 'code').length,
+      };
+    },
+  });
   const { extractNotebook } = harness.hooks;
 
   harness.py.FS.mkdir('/course');
-
   await extractNotebook(
     harness.py,
     '/course',
     'submission.ipynb',
     JSON.stringify({
       nbformat: 4,
-      metadata: {
-        kernelspec: { name: 'python3' },
-      },
+      metadata: { kernelspec: { name: 'python3' } },
       cells: [
         { cell_type: 'markdown', source: ['ignore'], metadata: {} },
         { cell_type: 'code', source: ['x = 1\n'], metadata: {} },
-        { cell_type: 'code', source: ['print(x)\n'], metadata: {} },
       ],
     }),
   );
 
+  // Cells passed through to the shared extractor (source joined, type preserved).
+  assert.equal(received.filename, 'submission.ipynb');
+  assert.deepEqual(plain(received.cells), [
+    { cell_type: 'markdown', source: 'ignore' },
+    { cell_type: 'code', source: 'x = 1\n' },
+  ]);
+  // Executable module + introspectable sidecar both written, with both hints.
   assert.equal(
     harness.py.FS.readFile('/course/submission.py', { encoding: 'utf8' }),
-    '# Generated from submission.ipynb\n\n'
-      + 'try:\n    exec(compile("x = 1", "cell 2", "exec"), globals())\nexcept Exception:\n    pass\n\n'
-      + 'try:\n    exec(compile("print(x)", "cell 3", "exec"), globals())\nexcept Exception:\n    pass\n\n',
+    '# exec module\nMODULE_BODY\n',
+  );
+  assert.equal(
+    harness.py.FS.readFile('/course/submission.source.py', { encoding: 'utf8' }),
+    '# real source\ndef tax():\n    pass\n',
   );
   assert.equal(
     harness.py.FS.readFile('/course/.chickadee_student_module', { encoding: 'utf8' }),
     'submission.py',
   );
+  assert.equal(
+    harness.py.FS.readFile('/course/.chickadee_student_source', { encoding: 'utf8' }),
+    'submission.source.py',
+  );
 
+  // R notebooks stay on the JS path (RunnerCore is Python-only) — no sidecar.
   await extractNotebook(
     harness.py,
     '/course',
     'lab.ipynb',
     JSON.stringify({
       nbformat: 4,
-      metadata: {
-        kernelspec: { name: 'webr' },
-        language_info: { name: 'r' },
-      },
-      cells: [
-        { cell_type: 'code', source: ['x <- 2\n'], metadata: {} },
-      ],
+      metadata: { kernelspec: { name: 'webr' }, language_info: { name: 'r' } },
+      cells: [{ cell_type: 'code', source: ['x <- 2\n'], metadata: {} }],
     }),
   );
-
   assert.equal(
     harness.py.FS.readFile('/course/lab.R', { encoding: 'utf8' }),
     '# Generated from lab.ipynb\n\nx <- 2\n\n',
@@ -722,72 +748,6 @@ test('extractNotebook writes python and R student module hints correctly', async
     harness.py.FS.readFile('/course/.chickadee_student_module', { encoding: 'utf8' }),
     'lab.R',
   );
-});
-
-test('extractNotebook sequesters each Python cell so one broken cell cannot fail the rest', async () => {
-  const harness = await loadRunnerHarness();
-  const { extractNotebook } = harness.hooks;
-
-  harness.py.FS.mkdir('/lab');
-
-  await extractNotebook(
-    harness.py,
-    '/lab',
-    'submission.ipynb',
-    JSON.stringify({
-      nbformat: 4,
-      metadata: { kernelspec: { name: 'python3' } },
-      cells: [
-        { cell_type: 'code', source: ['%matplotlib inline\nresting_hr = 72\n'], metadata: {} },
-        { cell_type: 'code', source: ['daily_ml = ____\n'], metadata: {} },
-      ],
-    }),
-  );
-
-  const generated = harness.py.FS.readFile('/lab/submission.py', { encoding: 'utf8' });
-
-  // IPython magic stripped, real code preserved.
-  assert.ok(!generated.includes('%matplotlib'), 'magic line must be stripped');
-  // Each cell is compiled+exec'd as its own unit.
-  assert.equal(generated.split('exec(compile(').length - 1, 2, 'each code cell compiled independently');
-  assert.ok(generated.includes('exec(compile("resting_hr = 72"'));
-  assert.ok(generated.includes('exec(compile("daily_ml = ____"'));
-  assert.equal(generated.split('except Exception:').length - 1, 2);
-});
-
-test('extractNotebook compiles each cell as a string so syntax errors and comment-only cells are isolated', async () => {
-  const harness = await loadRunnerHarness();
-  const { extractNotebook } = harness.hooks;
-
-  harness.py.FS.mkdir('/lab2');
-
-  await extractNotebook(
-    harness.py,
-    '/lab2',
-    'submission.ipynb',
-    JSON.stringify({
-      nbformat: 4,
-      metadata: { kernelspec: { name: 'python3' } },
-      cells: [
-        { cell_type: 'code', source: ['# Your code here\n'], metadata: {} },   // comment-only
-        { cell_type: 'code', source: ['good = 1\n'], metadata: {} },
-        { cell_type: 'code', source: ['broken = (\n'], metadata: {} },          // syntax error
-      ],
-    }),
-  );
-
-  const generated = harness.py.FS.readFile('/lab2/submission.py', { encoding: 'utf8' });
-
-  // All three cells become their own exec(compile()) unit — none can fail the
-  // whole-module compile.
-  assert.equal(generated.split('exec(compile(').length - 1, 3);
-  // Comment-only cell is a compiled string, NOT a bare `try:\n    # comment`
-  // (which would be an empty try body → SyntaxError zeroing the notebook).
-  assert.ok(generated.includes('exec(compile("# Your code here"'));
-  assert.ok(!generated.includes('try:\n    # Your code here'));
-  // The syntactically-broken source lives inside a compile() string literal.
-  assert.ok(generated.includes('exec(compile("good = 1"'));
-  assert.ok(generated.includes('broken = ('));
 });
 
 test('failure detail strips the trailing JSON envelope so students never see the raw payload', async () => {

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -201,6 +201,31 @@ def load_student_module():
     return modules.get(_loaded_student_order[0])
 
 
+def student_source() -> str:
+    # Introspectable student source (real module-level defs, side-effects
+    # quarantined into `if __name__`) for AST / source-property checks. The
+    # grading workspace writes it to a sidecar named by the
+    # `.chickadee_student_source` hint (both runners share one extractor);
+    # falls back to inspect.getsource on the loaded module.
+    hint = Path(".chickadee_student_source")
+    try:
+        if hint.exists():
+            name = Path(hint.read_text(encoding="utf-8").strip()).name
+            sidecar = Path(name)
+            if name and sidecar.exists():
+                return sidecar.read_text(encoding="utf-8")
+    except Exception:
+        pass
+    try:
+        import inspect
+        module = load_student_module()
+        if module is not None:
+            return inspect.getsource(module)
+    except Exception:
+        pass
+    return ""
+
+
 def require_function(name: str, num_args: Optional[int] = None):
     modules = load_student_modules()
     for key in _loaded_student_order:

--- a/changelog.d/hlth230-structural-check-fix.md
+++ b/changelog.d/hlth230-structural-check-fix.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Structural-property NotebookChecks work again on both runners.** They read
+  student source via AST, which broke because both runners wrap notebook cells in
+  `exec(compile(...))` — so `inspect.getsource` saw no real `def`s. The shared
+  RunnerCore extractor now also emits an *introspectable source* (real
+  module-level defs, side-effects quarantined into `if __name__`) as a sidecar;
+  a new `student_source()` runtime helper reads it, and the structural-check
+  template uses it instead of `inspect.getsource`. Both the browser runner and
+  the native worker write the sidecar. Fixes the HLTH-230 validation failure.


### PR DESCRIPTION
## Summary

Completes Stage 1 of the runner unification **and fixes the HLTH-230 lab**. Two parts:

**1. Browser uses the shared RunnerCore extractor.** `browser-runner.js` now loads the vendored wasm bridge and calls `runnerExtractPython` for Python notebooks (R stays on the JS path), instead of its own JS exec-wrap copy. The duplicated per-cell JS logic is deleted — it lives in RunnerCore now, shared with the worker and covered by `NotebookExtractionTests.swift`. **This is the drift elimination**: the three browser/worker extraction divergences this month can't recur, because there's one implementation.

**2. Structural NotebookChecks fixed (HLTH-230).** They read student source via AST, which broke because *both* runners `exec(compile(...))`-wrap cells, so `inspect.getsource` saw no real `def`s. Now:
- RunnerCore emits an **introspectable source** (real module-level defs, side-effects quarantined into `if __name__`) as a sidecar.
- a new `student_source()` runtime helper reads it (added to the canonical `test_runtime.py` + both embeds — drift-guarded).
- the structural-check template uses `student_source()` instead of `inspect.getsource`.
- **both** runners write the sidecar: the browser via the wasm extractor, the worker via `SubmissionNormalizer` + `NotebookExtraction`.

## Verification

- [x] 83 Swift tests (`RuntimeSourceDrift`, `TestScriptTemplates`, `NotebookExtract`) + the worker compiles.
- [x] 61 JS tests (incl. runtime-drift 3-way sync + the rewritten extractNotebook delegation test).
- [x] `swift-format` + SwiftLint clean (0 violations).
- [x] **Real headless browser** (Preview MCP): `import('/runner-wasm/runner-core.js')` + `init()` + `runnerExtractPython(...)` load and run correctly, producing the introspectable real `def` + `__main__`-quarantined asserts. No console errors.
- [ ] **End-to-end dev smoke test (yours):** open a browser-graded assignment's validation page (e.g. HLTH-230), run tests, confirm the `tax - Style Checks` structural check now passes.

The wasm load is browser-verified; the remaining check is the full Pyodide validation flow on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)