### PR TITLE
refactor(runnercore): hoist script-interpreter classification (stage 2)

### DIFF
--- a/Sources/RunnerCore/ScriptClassification.swift
+++ b/Sources/RunnerCore/ScriptClassification.swift
@@ -1,0 +1,119 @@
+// Shared, embedded-safe classification of "what interpreter runs this script?".
+//
+// This is the drift-prone decision behind the extensionless-Python dispatch bug
+// (#754): a recognised extension wins, else the shebang, else a Python
+// content-sniff. The native worker maps the result to a subprocess command; the
+// browser runner (a follow-up) maps it to its capabilities. Pure + dependency-
+// free so it compiles to wasm with the rest of RunnerCore.
+
+public enum ScriptInterpreter: String, Sendable, Equatable {
+    case python
+    case sh
+    case bash
+    case zsh
+    case ruby
+    case perl
+    case node
+    case php
+    case rscript
+    /// No recognised extension, shebang, or Python-looking content. The caller
+    /// decides the fallback (e.g. executable bit, else /bin/sh).
+    case unknown
+}
+
+/// Classify a script by filename + its (leading) source text.
+public func classifyScriptInterpreter(name: String, source: String) -> ScriptInterpreter {
+    switch fileExtensionLowercased(name) {
+    case "sh": return .sh
+    case "bash": return .bash
+    case "zsh": return .zsh
+    case "py": return .python
+    case "rb": return .ruby
+    case "pl": return .perl
+    case "js": return .node
+    case "php": return .php
+    case "r": return .rscript
+    default: break  // no / unrecognised extension → shebang, then content
+    }
+    if let viaShebang = interpreterFromShebang(source) {
+        return viaShebang
+    }
+    if looksLikePythonContent(source) {
+        return .python
+    }
+    return .unknown
+}
+
+/// Map a `#!` shebang on the first line to an interpreter. Order matters:
+/// "bash"/"zsh" are checked before "sh" (a substring of "bash").
+private func interpreterFromShebang(_ source: String) -> ScriptInterpreter? {
+    let firstLine = firstNonEmptyTrimmedLine(source).lowercased()
+    guard firstLine.hasPrefix("#!") else { return nil }
+    if containsSubstring(firstLine, "python") { return .python }
+    if containsSubstring(firstLine, "node") || containsSubstring(firstLine, "javascript") { return .node }
+    if containsSubstring(firstLine, "ruby") { return .ruby }
+    if containsSubstring(firstLine, "perl") { return .perl }
+    if containsSubstring(firstLine, "bash") { return .bash }
+    if containsSubstring(firstLine, "zsh") { return .zsh }
+    if containsSubstring(firstLine, "sh") { return .sh }
+    return nil
+}
+
+/// Do the first few non-comment lines look like Python?
+private func looksLikePythonContent(_ source: String) -> Bool {
+    let lines =
+        source
+        .split(separator: "\n" as Character, omittingEmptySubsequences: false)
+        .map { trimHorizontalWhitespace(String($0)) }
+        .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        .prefix(5)
+    guard !lines.isEmpty else { return false }
+    return lines.contains { line in
+        line.hasPrefix("import ")
+            || line.hasPrefix("from ")
+            || line.hasPrefix("def ")
+            || line.hasPrefix("class ")
+            || line.hasPrefix("if __name__ == ")
+    }
+}
+
+// MARK: - Embedded-safe helpers (Swift stdlib only; file-private to avoid
+// colliding with the similarly-named helpers in NotebookExtraction.swift).
+
+/// Lowercased file extension, or "" when there's none (bare name or dotfile).
+private func fileExtensionLowercased(_ name: String) -> String {
+    let baseStart = name.lastIndex(of: "/").map { name.index(after: $0) } ?? name.startIndex
+    let base = name[baseStart...]
+    guard let dot = base.lastIndex(of: "."), dot != base.startIndex else { return "" }
+    return base[base.index(after: dot)...].lowercased()
+}
+
+/// First non-empty line with leading BOM/whitespace trimmed.
+private func firstNonEmptyTrimmedLine(_ source: String) -> String {
+    let isLeading: (Character) -> Bool = {
+        $0 == " " || $0 == "\t" || $0 == "\n" || $0 == "\r" || $0 == "\u{feff}"
+    }
+    let trimmedLeading = source.drop(while: isLeading)
+    return String(trimmedLeading.prefix { $0 != "\n" })
+}
+
+private func trimHorizontalWhitespace(_ s: String) -> String {
+    let isHWS: (Character) -> Bool = { $0 == " " || $0 == "\t" }
+    return String(s.drop(while: isHWS).reversed().drop(while: isHWS).reversed())
+}
+
+/// Substring search without the string-processing module (absent in Embedded Swift).
+private func containsSubstring(_ haystack: String, _ needle: String) -> Bool {
+    if needle.isEmpty { return true }
+    let hay = Array(haystack)
+    let nee = Array(needle)
+    if nee.count > hay.count { return false }
+    var i = 0
+    while i <= hay.count - nee.count {
+        var j = 0
+        while j < nee.count && hay[i + j] == nee[j] { j += 1 }
+        if j == nee.count { return true }
+        i += 1
+    }
+    return false
+}

--- a/Sources/Worker/ScriptInvocation.swift
+++ b/Sources/Worker/ScriptInvocation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RunnerCore
 
 struct ScriptInvocation {
     let executableURL: URL
@@ -41,89 +42,6 @@ private func pythonInvocation(for script: URL) -> ScriptInvocation {
     )
 }
 
-func scriptInvocation(for script: URL) -> ScriptInvocation {
-    let ext = script.pathExtension.lowercased()
-    if let invocation = invocationForKnownExtension(ext, script: script) {
-        return invocation
-    }
-    return invocationForUnknownExtension(script: script)
-}
-
-/// Maps a lowercased file extension to a known interpreter invocation.
-/// Returns nil for extensions that need shebang/content-based detection.
-private func invocationForKnownExtension(_ ext: String, script: URL) -> ScriptInvocation? {
-    switch ext {
-    case "sh":
-        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
-    case "bash":
-        return envInvocation(interpreter: "bash", script: script)
-    case "zsh":
-        return envInvocation(interpreter: "zsh", script: script)
-    case "py":
-        return pythonInvocation(for: script)
-    case "rb":
-        return envInvocation(interpreter: "ruby", script: script)
-    case "pl":
-        return envInvocation(interpreter: "perl", script: script)
-    case "js":
-        return envInvocation(interpreter: "node", script: script)
-    case "php":
-        return envInvocation(interpreter: "php", script: script)
-    case "r":
-        return envInvocation(interpreter: "Rscript", script: script)
-    default:
-        return nil
-    }
-}
-
-/// Resolves an invocation for a script without a recognised extension by
-/// consulting the shebang, sniffing for Python-looking content, and finally
-/// falling back to executable bit / `/bin/sh`.
-private func invocationForUnknownExtension(script: URL) -> ScriptInvocation {
-    if let shebang = shebangLine(for: script),
-        let invocation = invocationFromShebang(shebang, script: script)
-    {
-        return invocation
-    }
-
-    if looksLikePythonScript(script) {
-        return pythonInvocation(for: script)
-    }
-
-    if FileManager.default.isExecutableFile(atPath: script.path) {
-        return ScriptInvocation(executableURL: script, arguments: [])
-    }
-    // Fallback for extension-less shell scripts.
-    return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
-}
-
-/// Matches a normalised (lowercased) shebang line against the interpreters
-/// we recognise. Returns nil if none match.
-private func invocationFromShebang(_ shebang: String, script: URL) -> ScriptInvocation? {
-    if shebang.contains("python") {
-        return pythonInvocation(for: script)
-    }
-    if shebang.contains("node") || shebang.contains("javascript") {
-        return envInvocation(interpreter: "node", script: script)
-    }
-    if shebang.contains("ruby") {
-        return envInvocation(interpreter: "ruby", script: script)
-    }
-    if shebang.contains("perl") {
-        return envInvocation(interpreter: "perl", script: script)
-    }
-    if shebang.contains("bash") {
-        return envInvocation(interpreter: "bash", script: script)
-    }
-    if shebang.contains("zsh") {
-        return envInvocation(interpreter: "zsh", script: script)
-    }
-    if shebang.contains("sh") {
-        return ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
-    }
-    return nil
-}
-
 private func envInvocation(interpreter: String, script: URL) -> ScriptInvocation {
     ScriptInvocation(
         executableURL: URL(fileURLWithPath: "/usr/bin/env"),
@@ -131,41 +49,37 @@ private func envInvocation(interpreter: String, script: URL) -> ScriptInvocation
     )
 }
 
-private func shebangLine(for script: URL) -> String? {
-    guard let data = try? Data(contentsOf: script),
-        let text = String(data: data.prefix(512), encoding: .utf8)
-    else {
-        return nil
-    }
-    let normalizedText =
-        text
-        .trimmingCharacters(in: CharacterSet(charactersIn: "\u{feff}"))
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-    let firstLine = normalizedText.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first.map(
-        String.init)
-    guard let firstLine, firstLine.hasPrefix("#!") else { return nil }
-    return firstLine.lowercased()
+private func shInvocation(for script: URL) -> ScriptInvocation {
+    ScriptInvocation(executableURL: URL(fileURLWithPath: "/bin/sh"), arguments: [script.path])
 }
 
-private func looksLikePythonScript(_ script: URL) -> Bool {
-    guard let data = try? Data(contentsOf: script),
-        let text = String(data: data.prefix(2048), encoding: .utf8)
-    else {
-        return false
+/// Build the subprocess invocation for a test script. Classification (the
+/// drift-prone "which interpreter?" decision) lives in RunnerCore and is shared
+/// with the browser runner; this maps the interpreter to a concrete command and
+/// owns the substrate-only bits (reading the file, the executable-bit fallback).
+func scriptInvocation(for script: URL) -> ScriptInvocation {
+    // Leading source for shebang / content classification (substrate I/O).
+    let source: String
+    if let data = try? Data(contentsOf: script) {
+        source = String(data: data.prefix(2048), encoding: .utf8) ?? ""
+    } else {
+        source = ""
     }
-    let lines =
-        text
-        .split(separator: "\n")
-        .map { $0.trimmingCharacters(in: .whitespaces) }
-        .filter { !$0.isEmpty && !$0.hasPrefix("#") }
-        .prefix(5)
 
-    guard !lines.isEmpty else { return false }
-    return lines.contains { line in
-        line.hasPrefix("import ")
-            || line.hasPrefix("from ")
-            || line.hasPrefix("def ")
-            || line.hasPrefix("class ")
-            || line.hasPrefix("if __name__ == ")
+    switch classifyScriptInterpreter(name: script.lastPathComponent, source: source) {
+    case .python: return pythonInvocation(for: script)
+    case .sh: return shInvocation(for: script)
+    case .bash: return envInvocation(interpreter: "bash", script: script)
+    case .zsh: return envInvocation(interpreter: "zsh", script: script)
+    case .ruby: return envInvocation(interpreter: "ruby", script: script)
+    case .perl: return envInvocation(interpreter: "perl", script: script)
+    case .node: return envInvocation(interpreter: "node", script: script)
+    case .php: return envInvocation(interpreter: "php", script: script)
+    case .rscript: return envInvocation(interpreter: "Rscript", script: script)
+    case .unknown:
+        if FileManager.default.isExecutableFile(atPath: script.path) {
+            return ScriptInvocation(executableURL: script, arguments: [])
+        }
+        return shInvocation(for: script)  // extensionless shell-script fallback
     }
 }

--- a/Tests/WorkerTests/ScriptClassificationTests.swift
+++ b/Tests/WorkerTests/ScriptClassificationTests.swift
@@ -1,0 +1,45 @@
+import Testing
+
+@testable import RunnerCore
+
+// Direct tests for RunnerCore.classifyScriptInterpreter — the shared "which
+// interpreter?" decision the native worker maps to a subprocess command (and
+// the browser runner will adopt). Covers the fine-grained interpreters the
+// coarse cross-runner dispatch fixture intentionally omits.
+@Suite struct ScriptClassificationTests {
+
+    @Test func recognisedExtensions() {
+        #expect(classifyScriptInterpreter(name: "t.py", source: "") == .python)
+        #expect(classifyScriptInterpreter(name: "t.sh", source: "") == .sh)
+        #expect(classifyScriptInterpreter(name: "t.bash", source: "") == .bash)
+        #expect(classifyScriptInterpreter(name: "t.zsh", source: "") == .zsh)
+        #expect(classifyScriptInterpreter(name: "t.rb", source: "") == .ruby)
+        #expect(classifyScriptInterpreter(name: "t.pl", source: "") == .perl)
+        #expect(classifyScriptInterpreter(name: "t.js", source: "") == .node)
+        #expect(classifyScriptInterpreter(name: "t.php", source: "") == .php)
+        #expect(classifyScriptInterpreter(name: "t.R", source: "") == .rscript)
+        #expect(classifyScriptInterpreter(name: "t.r", source: "") == .rscript)
+    }
+
+    @Test func extensionlessShebang() {
+        // The #754 case: extensionless file with a Python shebang.
+        #expect(classifyScriptInterpreter(name: "beats", source: "#!/usr/bin/env python3\nx = 1") == .python)
+        #expect(classifyScriptInterpreter(name: "run", source: "#!/bin/sh\necho hi") == .sh)
+        #expect(classifyScriptInterpreter(name: "run", source: "#!/usr/bin/env bash\necho hi") == .bash)
+        #expect(classifyScriptInterpreter(name: "run", source: "#!/usr/bin/env zsh\necho hi") == .zsh)
+        #expect(classifyScriptInterpreter(name: "run", source: "#!/usr/bin/env ruby\nputs 1") == .ruby)
+        #expect(classifyScriptInterpreter(name: "run", source: "#!/usr/bin/perl\nprint 1") == .perl)
+        #expect(classifyScriptInterpreter(name: "run", source: "#!/usr/bin/env node\nconsole.log(1)") == .node)
+    }
+
+    @Test func unknownExtensionFallsToShebangThenContent() {
+        // Unknown extension still consults shebang…
+        #expect(classifyScriptInterpreter(name: "t.txt", source: "#!/usr/bin/env node\n1") == .node)
+        // …then a Python content-sniff…
+        #expect(classifyScriptInterpreter(name: "t.txt", source: "import os\nprint(os)") == .python)
+        #expect(classifyScriptInterpreter(name: "weird", source: "# c\ndef f():\n    pass") == .python)
+        // …else unknown (caller decides executable-bit vs /bin/sh).
+        #expect(classifyScriptInterpreter(name: "weird", source: "just some text") == .unknown)
+        #expect(classifyScriptInterpreter(name: "weird", source: "") == .unknown)
+    }
+}

--- a/changelog.d/runnercore-classify.md
+++ b/changelog.d/runnercore-classify.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Script-interpreter classification hoisted into `RunnerCore`.** The
+  drift-prone "which interpreter runs this script?" decision (recognised
+  extension → shebang → Python content-sniff) now lives in
+  `RunnerCore.classifyScriptInterpreter` (embedded-safe, shared). The native
+  worker's `scriptInvocation` delegates to it and maps the result to a
+  subprocess command; behaviour is unchanged (dispatch contract + classify tests
+  pass). The browser runner adopts it via wasm in a follow-up, retiring the JS copy.


### PR DESCRIPTION
## Summary

Stage 2 of the runner-unification migration ([docs/runner-wasm-migration.md](docs/runner-wasm-migration.md)): move the drift-prone "which interpreter runs this script?" decision into `RunnerCore`.

- New `RunnerCore.classifyScriptInterpreter(name:source:) -> ScriptInterpreter` — recognised extension → shebang → Python content-sniff. Embedded-safe (no Foundation, no string-processing module; hand-rolled substring search).
- The worker's `scriptInvocation` now **delegates** to it and maps the `ScriptInterpreter` to a subprocess command, keeping only the substrate bits (reading the file, the executable-bit fallback). The ~120-line classification logic is removed from `ScriptInvocation.swift`.
- Behaviour unchanged.

The browser runner adopts this via the wasm bridge in a follow-up (which retires its JS `classifyScript` copy and the cross-runner dispatch contract test's reason to exist).

## Test plan

- [x] `swift test --filter ScriptDispatch` — worker dispatch contract preserved (parity).
- [x] `swift test --filter ScriptClassification` — new direct tests (all interpreters, extensionless shebang incl. the #754 case, content-sniff, unknown).
- [x] Embedded build: `RunnerWasm` (RunnerCore + the new classifier) compiles + links for `wasm32`.
- [x] `swift-format` + SwiftLint clean (0 violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)