### PR TITLE
refactor(runnercore): hoist TestOutcome + TestTier into RunnerCore

### DIFF
--- a/Sources/RunnerCore/TestOutcome.swift
+++ b/Sources/RunnerCore/TestOutcome.swift
@@ -1,10 +1,10 @@
-// Core/Models/TestOutcome.swift
+// RunnerCore/TestOutcome.swift
 
 /// The complete record for a single test case execution.
 ///
 /// Fields marked "gamification" are present from day one but can be
 /// null/zero until the corresponding feature is implemented.
-public struct TestOutcome: Codable, Equatable, Sendable {
+public struct TestOutcome: Equatable, Sendable {
 
     // MARK: - Identity
     public let testName: String  // e.g. "testBitCount"
@@ -54,8 +54,14 @@ public struct TestOutcome: Codable, Equatable, Sendable {
         self.attemptNumber = attemptNumber
         self.isFirstPassSuccess = isFirstPassSuccess
     }
+}
 
-    // Custom decoder so old records without `points` default to 1.
+// Codable is unavailable in Embedded Swift (RunnerCore compiles to wasm); only
+// the native targets serialize TestOutcome. The conformance is synthesized
+// (CodingKeys + encode) except for the custom decoder below, which defaults
+// `points` to 1 for older records.
+#if !hasFeature(Embedded)
+extension TestOutcome: Codable {
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         testName = try c.decode(String.self, forKey: .testName)
@@ -71,3 +77,4 @@ public struct TestOutcome: Codable, Equatable, Sendable {
         isFirstPassSuccess = try c.decode(Bool.self, forKey: .isFirstPassSuccess)
     }
 }
+#endif

--- a/Sources/RunnerCore/TestTier.swift
+++ b/Sources/RunnerCore/TestTier.swift
@@ -1,11 +1,16 @@
-// Core/Models/TestTier.swift
+// RunnerCore/TestTier.swift
 
 /// Controls visibility of test results to students.
 ///
 /// The case is named `pub` (not `public`) because `public` is a Swift keyword.
 /// The JSON raw value is "public" to match the runner protocol.
-public enum TestTier: String, Codable, Sendable {
+public enum TestTier: String, Sendable {
     case pub = "public"  // results shown to student immediately
     case release = "release"  // run on demand, hidden until deadline
     case secret = "secret"  // never shown to student
 }
+
+// Codable is unavailable in Embedded Swift; only native targets serialize this.
+#if !hasFeature(Embedded)
+extension TestTier: Codable {}
+#endif

--- a/changelog.d/runnercore-testoutcome-hoist.md
+++ b/changelog.d/runnercore-testoutcome-hoist.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **`TestOutcome` and `TestTier` hoisted into `RunnerCore`.** The canonical
+  grading-result types now live in the wasm-safe leaf (re-exported by `Core` via
+  `@_exported import`, so call sites are unchanged). Their `Codable`
+  conformances are gated `#if !hasFeature(Embedded)` — only native targets
+  serialize them. Prepares the shared `executeSuites` orchestration. No
+  behaviour change (Codable round-trips + core tests pass; native + embedded
+  builds green).


### PR DESCRIPTION
## Summary

Stage 3 groundwork: move the canonical grading-result types into the wasm-safe `RunnerCore` leaf (per the plan's Decision-1 hoist), so the upcoming shared `executeSuites` can produce `[TestOutcome]` directly.

- `TestOutcome` + `TestTier` → `RunnerCore`. `Core` re-exports them (`@_exported import RunnerCore`, already in place), so all `import Core` call sites are unchanged.
- `Codable` conformances gated `#if !hasFeature(Embedded)` — only native targets serialize these; RunnerCore's embedded (browser wasm) build stays clean. `TestOutcome`'s hand-written decoder (the `points`-defaults-to-1 back-compat) moves into the gated extension; `encode`/`CodingKeys` synthesize.

## Test plan

- [x] `swift build` (native, whole package) — green.
- [x] Embedded build: `RunnerWasm` compiles + links for `wasm32`.
- [x] `swift test --filter 'CoreCodable|CoreModel|OutputContract'` — 68 tests pass (TestOutcome/TestTier Codable round-trips intact).
- [x] `swift-format` + SwiftLint clean.

Next: define `ScriptExecutor` + `executeSuites` in RunnerCore and migrate the worker's grading loop onto it (worker = first conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)