### PR TITLE
docs(runnercore): link upstream Swift issue for the _Concurrency workaround

### DIFF
--- a/Sources/RunnerCore/ScriptExecutor.swift
+++ b/Sources/RunnerCore/ScriptExecutor.swift
@@ -13,7 +13,8 @@
 // resolves names against whatever workspace it owns.
 //
 // `import _Concurrency` is required for the `async` protocol requirements to
-// lower under Embedded Swift (see the note in SuiteExecution.swift).
+// lower under Embedded Swift (see the note in SuiteExecution.swift, and
+// upstream https://github.com/swiftlang/swift/issues/89492).
 import _Concurrency
 
 /// Runs a single test script and reports whether a named script exists in the

--- a/Sources/RunnerCore/SuiteExecution.swift
+++ b/Sources/RunnerCore/SuiteExecution.swift
@@ -13,7 +13,9 @@
 //
 // `import _Concurrency` is REQUIRED here: Embedded Swift only lowers `async`
 // code when the concurrency module is imported in the file. Without it, SILGen
-// crashes (signal 11) instead of emitting a diagnostic. The runtime supplies
+// crashes (signal 11) instead of emitting a diagnostic — upstream bug
+// https://github.com/swiftlang/swift/issues/89492 (when that lands as a clean
+// diagnostic / auto-import, this explicit import can go). The runtime supplies
 // the executor — on wasm it's the single cooperative executor — so `await`ing
 // the substrate (subprocess on the worker, Pyodide in the browser) just works.
 import _Concurrency


### PR DESCRIPTION
Comment-only follow-up to Stage 3 (#769). Links [swiftlang/swift#89492](https://github.com/swiftlang/swift/issues/89492) — the upstream Embedded-Swift SILGen crash that the `import _Concurrency` in `SuiteExecution.swift` / `ScriptExecutor.swift` works around — so a future maintainer has a clear "when can we drop this import" answer.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)