### PR TITLE
fix(runnercore): Embedded-safe JSON number parsing (no strtod)

### DIFF
--- a/Sources/RunnerCore/JSONLite.swift
+++ b/Sources/RunnerCore/JSONLite.swift
@@ -144,9 +144,92 @@ private struct JSONParser {
         while let c = current, (c >= "0" && c <= "9") || c == "." || c == "e" || c == "E" || c == "+" || c == "-" {
             pos += 1
         }
-        let text = String(chars[start..<pos])
-        guard let d = Double(text) else { return nil }
-        return .number(d)
+        guard let value = JSONParser.parseDoubleLiteral(chars[start..<pos]) else { return nil }
+        return .number(value)
+    }
+
+    /// Parse a JSON number literal to `Double` WITHOUT `Double(String)`: the
+    /// latter lowers to `_swift_stdlib_strtod_clocale`, which the Embedded Swift
+    /// wasm runtime does not provide (it becomes a link error the moment the
+    /// browser bridge reaches this path via `executeSuites`). The value here is
+    /// a footer's reserved `score`, which `interpretScriptOutput` never reads —
+    /// we only need a finite `Double` so the enclosing object parses. Shared by
+    /// the native and embedded builds (one implementation, no drift); precise to
+    /// full `Double` for typical inputs via an integer mantissa + decimal scale.
+    static func parseDoubleLiteral(_ slice: ArraySlice<Character>) -> Double? {
+        let chars = Array(slice)
+        let count = chars.count
+        var index = 0
+        guard count > 0 else { return nil }
+
+        var sign = 1.0
+        if chars[index] == "-" {
+            sign = -1.0
+            index += 1
+        } else if chars[index] == "+" {
+            index += 1
+        }
+
+        var mantissa = 0.0
+        var fractionDigits = 0
+        var sawDigit = false
+        while index < count, let digit = asciiDigit(chars[index]) {
+            mantissa = mantissa * 10 + Double(digit)
+            index += 1
+            sawDigit = true
+        }
+        if index < count, chars[index] == "." {
+            index += 1
+            while index < count, let digit = asciiDigit(chars[index]) {
+                mantissa = mantissa * 10 + Double(digit)
+                fractionDigits += 1
+                index += 1
+                sawDigit = true
+            }
+        }
+        guard sawDigit else { return nil }
+
+        var exponent = 0
+        if index < count, chars[index] == "e" || chars[index] == "E" {
+            index += 1
+            var exponentSign = 1
+            if index < count, chars[index] == "-" {
+                exponentSign = -1
+                index += 1
+            } else if index < count, chars[index] == "+" {
+                index += 1
+            }
+            var sawExponentDigit = false
+            while index < count, let digit = asciiDigit(chars[index]) {
+                exponent = exponent * 10 + digit
+                index += 1
+                sawExponentDigit = true
+            }
+            guard sawExponentDigit else { return nil }
+            exponent *= exponentSign
+        }
+        guard index == count else { return nil }
+
+        return sign * mantissa * powerOfTen(exponent - fractionDigits)
+    }
+
+    /// ASCII digit value (0–9) or nil — avoids `wholeNumberValue` (Unicode
+    /// tables) and force-unwrapping, keeping number parsing embedded-clean.
+    private static func asciiDigit(_ c: Character) -> Int? {
+        guard let ascii = c.asciiValue, ascii >= 48, ascii <= 57 else { return nil }
+        return Int(ascii - 48)
+    }
+
+    /// `10` raised to an integer power via repeated f64 multiply/divide — no
+    /// `pow` (libm) dependency.
+    private static func powerOfTen(_ exponent: Int) -> Double {
+        var result = 1.0
+        var remaining = exponent >= 0 ? exponent : -exponent
+        while remaining > 0 {
+            result *= 10
+            remaining -= 1
+        }
+        return exponent >= 0 ? result : 1.0 / result
     }
 
     private mutating func parseBool() -> JSONValue? {

--- a/Tests/CoreTests/JSONFooterNumberParsingTests.swift
+++ b/Tests/CoreTests/JSONFooterNumberParsingTests.swift
@@ -1,0 +1,53 @@
+// Tests/CoreTests/JSONFooterNumberParsingTests.swift
+//
+// Pins RunnerCore's embedded-safe JSON number parser (JSONLite.parseDoubleLiteral,
+// which replaced `Double(String)` so the parser links under Embedded Swift wasm
+// — `Double(String)` lowers to `_swift_stdlib_strtod_clocale`, absent there).
+//
+// `parseJSON` / `parseDoubleLiteral` are internal to RunnerCore, so we exercise
+// them through the public `interpretScriptOutput`: a script's last stdout line is
+// only treated as a result footer when it parses as a JSON *object*. If a numeric
+// field (e.g. the reserved `score`) failed to parse, the whole object would fail
+// to parse, the footer would be ignored, and `shortResult` would fall back to the
+// raw line. So "shortResult == the footer's value" proves the number parsed.
+
+import Core
+import Testing
+
+@Suite struct JSONFooterNumberParsingTests {
+
+    private func interpret(stdout: String) -> InterpretedScriptResult {
+        interpretScriptOutput(
+            ScriptOutput(exitCode: 0, stdout: stdout, stderr: "", executionTimeMs: 0, timedOut: false))
+    }
+
+    @Test(arguments: [
+        "0.75",  // simple decimal (the canonical score)
+        "0",  // integer zero
+        "-0",  // negative zero
+        "200",  // plain integer
+        "-1.5",  // negative decimal
+        "123456789.0",  // large
+        "1e3",  // exponent
+        "2.5E-2",  // signed fractional exponent, capital E
+        "1.0e+4",  // explicit positive exponent
+        "0.000001",  // small magnitude
+    ])
+    func numericScoreFieldParsesSoFooterIsRecognized(score: String) {
+        let result = interpret(stdout: "work\n{\"shortResult\":\"3/4 cases passed\",\"score\":\(score)}")
+        #expect(result.shortResult == "3/4 cases passed")
+    }
+
+    @Test func malformedNumberFooterFallsBackToRawLine() {
+        // "1.2.3" is not a valid number → the object fails to parse → not a footer.
+        let line = "{\"shortResult\":\"ok\",\"score\":1.2.3}"
+        let result = interpret(stdout: line)
+        #expect(result.shortResult == line)
+    }
+
+    @Test func bareNumberLineIsValidJSONButNotAFooterObject() {
+        // A bare number parses as JSON but isn't an object, so it's not a footer.
+        let result = interpret(stdout: "42")
+        #expect(result.shortResult == "42")
+    }
+}

--- a/changelog.d/runnercore-jsonlite-embedded-number.md
+++ b/changelog.d/runnercore-jsonlite-embedded-number.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **RunnerCore JSON parser is now Embedded-Swift safe.** Its hand-rolled JSON
+  number parser used `Double(String)`, which lowers to
+  `_swift_stdlib_strtod_clocale` — a symbol the Embedded Swift wasm runtime does
+  not provide. It linked only because the path was dead code in the browser
+  build; the moment the shared `executeSuites` loop reaches it (output
+  interpretation), the wasm build fails to link. Replaced with a small,
+  dependency-free literal parser (no `strtod`, no `pow`/libm), shared by the
+  native and embedded builds. Behaviour is unchanged for output interpretation
+  (the parsed `score` is reserved and unread); pinned by new tests across many
+  numeric forms.


### PR DESCRIPTION
## Summary

Stage 4 groundwork (CI-testable slice, split out ahead of the browser wiring).

RunnerCore's `JSONLite` number parser used `Double(String)`, which lowers to `_swift_stdlib_strtod_clocale` — a symbol the **Embedded Swift wasm runtime does not provide**. It linked only because the path was dead code in the browser build. The moment the shared `executeSuites` loop reaches output interpretation (the upcoming browser-runner wiring), the wasm build fails: `wasm-ld: undefined symbol: _swift_stdlib_strtod_clocale`.

Replaced with a small, dependency-free literal parser (integer mantissa + decimal scale + exponent; no `strtod`, no `pow`/libm), shared by the native and embedded builds — one implementation, no drift.

- The parsed value is a footer's reserved `score` field, which `interpretScriptOutput` never reads → **output interpretation is unchanged**.
- New `JSONFooterNumberParsingTests` pin correctness across decimals, integers, signs, exponents, and malformed/non-object fallbacks, exercised through the public `interpretScriptOutput`.

## Test plan

- [x] `swift test` — new tests + `OutputContractTests` pass
- [x] Full native suite green (verified locally)
- [x] swift-format + SwiftLint clean
- [x] Confirmed the embedded RunnerCore + bridge build links with this fix (locally, against the wasm SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)