### PR TITLE
fix(oauth): SameSite=None session cookie so MCP connector login survives the popup

### DIFF
--- a/Sources/APIServer/Bootstrap/SessionCookieFactory.swift
+++ b/Sources/APIServer/Bootstrap/SessionCookieFactory.swift
@@ -16,6 +16,16 @@
 // Note: browsers with "continue where you left off" / session-restore resurrect
 // session cookies on relaunch, but since logout deletes the server-side row a
 // resurrected cookie no longer maps to a valid session.
+//
+// SameSite policy: `.none` over HTTPS, `.lax` otherwise. The MCP browser OAuth
+// flow runs inside a popup opened by claude.ai (a cross-site opener), so the
+// login POST that resumes /oauth/authorize is treated as cross-site. A `.lax`
+// cookie is not sent on cross-site POSTs, which dropped the session on that hop
+// and broke the flow two ways: the CSRF secret (stored in the session by the
+// CSRF middleware) went missing → 403, and the stashed `mcpOAuthReturnTo` was
+// lost → login fell through to the dashboard instead of minting an auth code.
+// `.none` requires `Secure`, so it is only used when the cookie is already
+// secure; plain-HTTP dev keeps `.lax` (browsers reject `None` without `Secure`).
 
 import Vapor
 
@@ -28,7 +38,7 @@ func chickadeeSessionCookie(sessionID: SessionID, isSecure: Bool) -> HTTPCookies
         path: "/",
         isSecure: isSecure,
         isHTTPOnly: true,
-        sameSite: .lax
+        sameSite: isSecure ? HTTPCookies.SameSitePolicy.none : .lax
     )
 }
 

--- a/Tests/APITests/APIServerAppTests.swift
+++ b/Tests/APITests/APIServerAppTests.swift
@@ -124,8 +124,24 @@ struct APIServerAppTests {
         #expect(cookie.maxAge == nil)
         #expect(cookie.isHTTPOnly)
         #expect(cookie.isSecure)
-        #expect(cookie.sameSite == .lax)
         #expect(cookie.string == "abc123")
+    }
+
+    @Test func sessionCookieUsesSameSiteNoneOverHTTPS() {
+        // The MCP OAuth popup is opened by a cross-site opener (claude.ai), so the
+        // login POST that resumes /oauth/authorize is cross-site. SameSite=None is
+        // required for the session cookie to ride along on that POST (and it must
+        // be Secure for browsers to accept None).
+        let cookie = chickadeeSessionCookie(sessionID: SessionID(string: "abc123"), isSecure: true)
+        #expect(cookie.sameSite == HTTPCookies.SameSitePolicy.none)
+    }
+
+    @Test func sessionCookieFallsBackToLaxWithoutSecure() {
+        // Plain-HTTP dev: browsers reject SameSite=None without Secure, so fall
+        // back to Lax so local development still logs in.
+        let cookie = chickadeeSessionCookie(sessionID: SessionID(string: "abc123"), isSecure: false)
+        #expect(cookie.sameSite == .lax)
+        #expect(!cookie.isSecure)
     }
 
     @Test func parseSSOIdentityAllowlistNormalizesAndDeduplicates() {

--- a/changelog.d/mcp-oauth-samesite.md
+++ b/changelog.d/mcp-oauth-samesite.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **MCP connector OAuth login over HTTPS.** The session cookie now uses
+  `SameSite=None; Secure` when served over HTTPS (falling back to `Lax` on
+  plain-HTTP dev). The Claude MCP connector runs the browser OAuth flow in a
+  popup opened by `claude.ai`, so the login POST that resumes
+  `/oauth/authorize` is treated as cross-site; the previous `SameSite=Lax`
+  cookie was dropped on that POST, which both failed CSRF validation and lost
+  the stashed authorize request, so no authorization code was ever delivered
+  to the connector.


### PR DESCRIPTION
## Summary

The Claude MCP connector fails to connect to `chickadee.uwaterloo.ca/mcp`: the OAuth discovery/registration chain is healthy, but after the `303` to `/login` the user's login never delivers a `code` to `https://claude.ai/api/mcp/auth_callback`.

**Root cause:** Claude runs the browser OAuth flow in a popup opened by `claude.ai` (a cross-site opener), so the login POST that resumes `/oauth/authorize` is treated as **cross-site**. The session cookie was hardcoded `SameSite=Lax`, which browsers do not send on cross-site POSTs. That single dropped cookie broke the flow two ways at once:

1. **CSRF 403** — the CSRF middleware stores its secret in `req.session.data["CSRFSecret"]`; no session → no secret → token mismatch.
2. **Lost resume** — `mcpOAuthReturnTo` also lives in the session, so login fell through to the dashboard instead of minting an auth code.

This is why hand-curl testing passed (curl carries the cookie jar explicitly, no SameSite enforcement) while the real browser popup failed.

The other two suspects from the investigation were ruled out:
- The pending-authorize resume mechanism is correctly implemented (stash in `MCPOAuthRoutes.authorizeForm`, honored in `postLoginRedirect`).
- Login is a native `<form method="post">`, not a credentials-less `fetch`.

## Change

`chickadeeSessionCookie` now uses `SameSite=None; Secure` over HTTPS, falling back to `Lax` on plain-HTTP dev (browsers reject `None` without `Secure`, which would break local login).

## Test plan

- [x] `swift build` clean
- [x] Cookie unit tests pass (HTTPS → `None`, dev → `Lax`)
- [ ] After deploy to `chickadee.uwaterloo.ca`, re-add the connector in Claude and confirm the authorize leg `303`s to `claude.ai/api/mcp/auth_callback?code=…&state=…` and the token exchange returns an `access_token`
- [ ] Sanity-check nginx isn't stripping `Set-Cookie` attributes (it already passed `Secure; HttpOnly` through, so `SameSite=None` should pass identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)