### PR TITLE
ci: cap nightly test parallelism to fix connection-pool flake

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -50,6 +50,19 @@ jobs:
           done
 
       - name: Run tests with coverage
+        # Swift Testing schedules many class-suite instances in parallel
+        # regardless of the swift test --parallel flag.  Each test app opens
+        # its own connection pool with one connection per EventLoop, and at
+        # unbounded parallelism the combined pool requests time out (AsyncKit
+        # "Connection request timed out") — which surfaces here as spurious
+        # test failures (e.g. empty query results, validation stuck "pending")
+        # and an occasional "Index out of range" crash that kills the whole
+        # test process.  This job is the worst case: it runs *all* targets in
+        # one process (no --filter split) with code coverage, so it's the most
+        # pool-pressured run we have, yet it was the only one missing the cap
+        # that swift-tests.yml already applies.  Match that cap here.
+        env:
+          SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "4"
         run: swift test --enable-code-coverage
 
       - name: Export coverage to lcov
@@ -138,7 +151,7 @@ jobs:
           label="nightly-clean-build"
 
           # Ensure the label exists (idempotent).
-          gh label create "$label" --color B60205 \
+          gh label create "$label" --repo "$REPO" --color B60205 \
             --description "Nightly from-scratch clean build canary failed" \
             --force >/dev/null 2>&1 || true
 

--- a/changelog.d/nightly-parallelism-cap.md
+++ b/changelog.d/nightly-parallelism-cap.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Nightly clean-build canary no longer flakes on connection-pool exhaustion.**
+  `test-coverage.yml` ran the entire test suite in one process with code
+  coverage but, unlike the per-PR `swift-tests.yml` jobs, never capped Swift
+  Testing's parallelism — so at unbounded width the combined connection pool
+  timed out, surfacing as spurious test failures and an "Index out of range"
+  crash. The nightly now sets `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4`
+  to match the existing per-PR guard. Also fixed the `report-failure` job's
+  `gh label create` (missing `--repo`), which silently failed in that
+  checkout-less job and broke the failure-tracking issue creation.


### PR DESCRIPTION
## Summary
- The nightly **Nightly Clean Build & Coverage** (`test-coverage.yml`) failed today (run [26568305679](https://github.com/JimWallace/Chickadee/actions/runs/26568305679)). It runs the entire test suite in one process with code coverage but — unlike the per-PR `swift-tests.yml` jobs — never capped Swift Testing's parallelism.
- At unbounded width the combined connection pool times out ("Connection request timed out"), surfacing as spurious test failures (`sections.count == 0`, validation stuck `pending`/`timedOut`) and an "Index out of range" crash that kills the whole process.
- This is the most pool-pressured run we have, yet it was the only one missing the guard. Set `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` to match the existing per-PR cap.
- Also fixed the `report-failure` job's `gh label create` (missing `--repo`): that job has no checkout step, so gh had no repo context — the label create failed silently (`|| true`) and issue creation then errored with `'nightly-clean-build' not found`.

## Evidence it's parallelism, not a logic break
- The failing test files (`ValidateAssignmentToolTests.swift`, `SectionRoutesTests.swift`) haven't changed since v0.4.176.
- Per-PR **Swift Tests** (which already applies the cap) is green on the exact same `main` commit (v0.4.316) the nightly failed on.

## Test plan
- [ ] Trigger `test-coverage.yml` via `workflow_dispatch` on this branch and confirm it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)