### PR TITLE
fix(oauth): cookie-independent MCP consent so Safari can authorize

### DIFF
--- a/Resources/Views/oauth-consent.leaf
+++ b/Resources/Views/oauth-consent.leaf
@@ -31,13 +31,7 @@ Authorize agent
         It cannot access student data, grades, enrolment, or submissions. You can revoke access later.
     </p>
     <form class="form" method="post" action="/oauth/authorize">
-        #csrfFormField()
-        <input type="hidden" name="client_id" value="#(clientID)">
-        <input type="hidden" name="redirect_uri" value="#(redirectURI)">
-        <input type="hidden" name="scope" value="#(scopeRaw)">
-        <input type="hidden" name="state" value="#(state)">
-        <input type="hidden" name="code_challenge" value="#(codeChallenge)">
-        <input type="hidden" name="code_challenge_method" value="#(codeChallengeMethod)">
+        <input type="hidden" name="request_token" value="#(requestToken)">
         <div style="display:flex;gap:.5rem">
             <button class="btn btn-primary" type="submit" name="decision" value="authorize">Authorize</button>
             <button class="btn" type="submit" name="decision" value="deny">Deny</button>

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -75,10 +75,43 @@ struct MCPOAuthRoutes: Sendable {
 
         let firstTimeApproval = try await Self.isFirstApproval(
             req, userID: user.id, clientID: client.clientID)
-        return try await renderConsent(
-            req, client: client, scopes: scopes, query: query,
-            notPermitted: !user.isInstructor, firstTimeApproval: firstTimeApproval)
+
+        // Mint a single-use consent token only for a permitted instructor. The
+        // token (not a cookie) carries identity + CSRF protection to the POST,
+        // so the submit works even when Safari/ITP drops the session cookie on
+        // the cross-site hop. Non-instructors get the not-permitted view and no
+        // actionable token.
+        var requestToken: String?
+        if let userID = user.id, user.isInstructor {
+            let token = Self.randomToken()
+            try await MCPConsentRequest(
+                tokenHash: sha256HexDigest(token),
+                userID: userID,
+                clientID: client.clientID,
+                redirectURI: query.redirectURI,
+                scope: scopes.map(\.rawValue).sorted().joined(separator: " "),
+                state: query.state,
+                codeChallenge: query.codeChallenge,
+                codeChallengeMethod: query.codeChallengeMethod,
+                expiresAt: Date().addingTimeInterval(Self.consentRequestTTLSeconds)
+            ).save(on: req.db)
+            requestToken = token
+        }
+
+        let ordered = ContentScope.allCases.filter { scopes.contains($0) }
+        let context = ConsentContext(
+            currentUser: req.currentUserContext,
+            clientName: client.name,
+            scopeLabels: ordered.map(Self.scopeLabel),
+            redirectHost: URLComponents(string: query.redirectURI)?.host ?? query.redirectURI,
+            firstTimeApproval: firstTimeApproval,
+            notPermitted: !user.isInstructor,
+            requestToken: requestToken)
+        return try await renderConsent(req, context: context)
     }
+
+    /// How long a rendered consent screen stays submittable.
+    static let consentRequestTTLSeconds: TimeInterval = 600
 
     /// True when the user holds no existing non-revoked grant for this client —
     /// drives the "you have not approved this app before" consent warning.
@@ -98,38 +131,63 @@ struct MCPOAuthRoutes: Sendable {
 
     @Sendable
     func authorizeSubmit(req: Request) async throws -> Response {
-        guard let user = req.auth.get(APIUser.self), user.isInstructor, let userID = user.id else {
-            throw Abort(.forbidden, reason: "Only instructors and admins may authorize agents.")
-        }
+        // Identity + CSRF ride on the single-use consent token, not the session
+        // cookie — so this works in the cross-site connector context where the
+        // cookie is dropped. Look the token up by hash, then burn it.
         let form = try req.content.decode(ConsentForm.self)
         guard
+            let record = try await MCPConsentRequest.query(on: req.db)
+                .filter(\.$tokenHash == sha256HexDigest(form.requestToken)).first(),
+            !record.consumed,
+            record.expiresAt > Date()
+        else {
+            throw Abort(
+                .badRequest,
+                reason: "This authorization request has expired or already been used. "
+                    + "Restart the connection to try again.")
+        }
+        // Single-use: burn before any further work so a replay loses.
+        record.consumed = true
+        try await record.save(on: req.db)
+
+        // Re-validate the client/redirect from the frozen record (defense in
+        // depth — the record is server-authored, but a stale client edit could
+        // have dropped the redirect URI between GET and POST).
+        guard
             let client = try await MCPOAuthClient.query(on: req.db)
-                .filter(\.$clientID == form.clientID).first(),
-            client.redirectURIs.contains(form.redirectURI)
+                .filter(\.$clientID == record.clientID).first(),
+            client.redirectURIs.contains(record.redirectURI)
         else {
             throw Abort(.badRequest, reason: "Invalid client or redirect_uri.")
         }
-        let state = form.state ?? ""
+        let state = record.state
         guard form.decision == "authorize" else {
-            return redirect(form.redirectURI, error: "access_denied", state: state)
+            return redirect(record.redirectURI, error: "access_denied", state: state)
         }
-        let scopes = resolveScopes(form.scope, ceiling: req.application.appConfig.mcp.mode.scopeCeiling)
-        guard !scopes.isEmpty, !form.codeChallenge.isEmpty, form.codeChallengeMethod == "S256" else {
-            return redirect(form.redirectURI, error: "invalid_request", state: state)
+        // Re-check the role from the bound user at submit time: a downgrade
+        // between rendering the consent screen and submitting it must stop here.
+        guard
+            let user = try await APIUser.find(record.userID, on: req.db), user.isInstructor
+        else {
+            throw Abort(.forbidden, reason: "Only instructors and admins may authorize agents.")
+        }
+        let scopes = resolveScopes(record.scope, ceiling: req.application.appConfig.mcp.mode.scopeCeiling)
+        guard !scopes.isEmpty, !record.codeChallenge.isEmpty, record.codeChallengeMethod == "S256" else {
+            return redirect(record.redirectURI, error: "invalid_request", state: state)
         }
 
         let code = Self.randomToken()
         let authCode = MCPAuthorizationCode(
             codeHash: sha256HexDigest(code),
             clientID: client.clientID,
-            userID: userID,
-            redirectURI: form.redirectURI,
-            codeChallenge: form.codeChallenge,
-            codeChallengeMethod: form.codeChallengeMethod,
+            userID: record.userID,
+            redirectURI: record.redirectURI,
+            codeChallenge: record.codeChallenge,
+            codeChallengeMethod: record.codeChallengeMethod,
             scope: scopes.map(\.rawValue).sorted().joined(separator: " "),
             expiresAt: Date().addingTimeInterval(60))
         try await authCode.save(on: req.db)
-        return redirect(form.redirectURI, code: code, state: state)
+        return redirect(record.redirectURI, code: code, state: state)
     }
 
     // MARK: - POST /oauth/token
@@ -362,24 +420,7 @@ struct MCPOAuthRoutes: Sendable {
             agentName: agentName)
     }
 
-    private func renderConsent(
-        _ req: Request, client: MCPOAuthClient, scopes: Set<ContentScope>,
-        query: AuthorizeQuery, notPermitted: Bool, firstTimeApproval: Bool
-    ) async throws -> Response {
-        let ordered = ContentScope.allCases.filter { scopes.contains($0) }
-        let context = ConsentContext(
-            currentUser: req.currentUserContext,
-            clientName: client.name,
-            scopeLabels: ordered.map(Self.scopeLabel),
-            scopeRaw: ordered.map(\.rawValue).joined(separator: " "),
-            clientID: client.clientID,
-            redirectURI: query.redirectURI,
-            redirectHost: URLComponents(string: query.redirectURI)?.host ?? query.redirectURI,
-            firstTimeApproval: firstTimeApproval,
-            state: query.state,
-            codeChallenge: query.codeChallenge,
-            codeChallengeMethod: query.codeChallengeMethod,
-            notPermitted: notPermitted)
+    private func renderConsent(_ req: Request, context: ConsentContext) async throws -> Response {
         let view = try await req.view.render("oauth-consent", context)
         return try await view.encodeResponse(for: req)
     }
@@ -496,20 +537,15 @@ private struct AuthorizeQuery {
 }
 
 private struct ConsentForm: Content {
-    var clientID: String
-    var redirectURI: String
-    var scope: String
-    var state: String?
-    var codeChallenge: String
-    var codeChallengeMethod: String
+    /// The single-use consent token from the rendered form; everything else
+    /// (client, redirect, scope, PKCE, the consenting user) is frozen in the
+    /// server-side `MCPConsentRequest` keyed by this token.
+    var requestToken: String
     var decision: String
 
     enum CodingKeys: String, CodingKey {
-        case clientID = "client_id"
-        case redirectURI = "redirect_uri"
-        case scope, state, decision
-        case codeChallenge = "code_challenge"
-        case codeChallengeMethod = "code_challenge_method"
+        case requestToken = "request_token"
+        case decision
     }
 }
 
@@ -601,16 +637,13 @@ private struct ConsentContext: Encodable {
     let currentUser: CurrentUserContext?
     let clientName: String
     let scopeLabels: [String]
-    let scopeRaw: String
-    let clientID: String
-    let redirectURI: String
     /// Host portion of the redirect URI, shown prominently so the human can spot
     /// an unexpected destination (DCR client names are self-asserted).
     let redirectHost: String
     /// True when the user has never approved this client — drives a warning.
     let firstTimeApproval: Bool
-    let state: String
-    let codeChallenge: String
-    let codeChallengeMethod: String
     let notPermitted: Bool
+    /// Single-use consent token embedded in the form; nil for the not-permitted
+    /// view (no submittable form is shown).
+    let requestToken: String?
 }

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -8,7 +8,6 @@
 // MCPConfig, falling back to PUBLIC_BASE_URL.  The signing-key authority itself
 // is loaded asynchronously at startup (see runAPIServer).
 
-import CSRF
 import Core
 import Vapor
 
@@ -101,10 +100,12 @@ func registerMCPRoutes(_ app: Application) throws {
 }
 
 /// Registers the Phase-2 browser OAuth flow when MCP is enabled: the consent
-/// `/oauth/authorize` (session + CSRF guarded) and the machine `/oauth/token`
-/// (no session/CSRF — a back-channel call from the agent).  A no-op otherwise.
+/// `GET /oauth/authorize` (session-guarded, mints a single-use consent token)
+/// plus the back-channel POSTs — the consent submit (guarded by that token, not
+/// a cookie) and the machine `/oauth/token`/`/revoke`/`/register`.  A no-op
+/// otherwise.
 func registerMCPOAuthRoutes(
-    _ app: Application, sessionAuth: UserSessionAuthenticator, csrf: CSRF
+    _ app: Application, sessionAuth: UserSessionAuthenticator
 ) throws {
     let mcp = app.appConfig.mcp
     guard mcp.mode.isMounted,
@@ -118,17 +119,20 @@ func registerMCPOAuthRoutes(
         maxRegisteredClients: mcp.maxRegisteredClients,
         maxRedirectURIsPerClient: mcp.maxRedirectURIsPerClient
     )
-    // Consent UI: needs a logged-in human + a CSRF-protected form.
-    let userFacing = app.grouped(sessionAuth, csrf)
-    userFacing.get("oauth", "authorize", use: oauth.authorizeForm)
-    userFacing.post("oauth", "authorize", use: oauth.authorizeSubmit)
-    // Token + revoke + register: back-channel POSTs — no session, no CSRF, but
-    // rate-limited per IP since they're unauthenticated (register is open).
+    // Consent screen (GET): needs the logged-in human so we can mint a
+    // consent token bound to them. The submit is handled separately below.
+    let consentForm = app.grouped(sessionAuth)
+    consentForm.get("oauth", "authorize", use: oauth.authorizeForm)
+    // Back-channel POSTs — rate-limited per IP, no session/CSRF middleware:
+    //   • /authorize submit is guarded by the single-use consent token (not a
+    //     cookie), so it survives Safari/ITP dropping the cross-site cookie;
+    //   • /token, /revoke, /register are machine calls from the agent.
     let limiter = MCPOAuthRateLimitMiddleware(
         perMinute: mcp.oauthRateLimitPerMin,
         trustForwardedFor: app.loginRateLimitConfiguration.trustForwardedFor
     )
     let backChannel = app.grouped(limiter)
+    backChannel.post("oauth", "authorize", use: oauth.authorizeSubmit)
     backChannel.post("oauth", "token", use: oauth.token)
     backChannel.post("oauth", "revoke", use: oauth.revoke)
     backChannel.post("oauth", "register", use: oauth.register)

--- a/Sources/APIServer/Migrations/CreateMCPConsentRequests.swift
+++ b/Sources/APIServer/Migrations/CreateMCPConsentRequests.swift
@@ -1,0 +1,32 @@
+// APIServer/Migrations/CreateMCPConsentRequests.swift
+//
+// Short-lived, single-use consent requests for the browser OAuth flow.  Lets
+// `POST /oauth/authorize` work without a session cookie (Safari/ITP drops it on
+// the cross-site submit) by carrying the consenting user + frozen OAuth params
+// server-side, keyed by an unguessable token hash.
+
+import Fluent
+
+struct CreateMCPConsentRequests: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("oauth_consent_requests")
+            .id()
+            .field("token_hash", .string, .required)
+            .field("user_id", .uuid, .required, .references("users", "id", onDelete: .cascade))
+            .field("client_id", .string, .required)
+            .field("redirect_uri", .string, .required)
+            .field("scope", .string, .required)
+            .field("state", .string, .required)
+            .field("code_challenge", .string, .required)
+            .field("code_challenge_method", .string, .required)
+            .field("expires_at", .datetime, .required)
+            .field("consumed", .bool, .required)
+            .field("created_at", .datetime, .required)
+            .unique(on: "token_hash")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("oauth_consent_requests").delete()
+    }
+}

--- a/Sources/APIServer/Models/MCPConsentRequest.swift
+++ b/Sources/APIServer/Models/MCPConsentRequest.swift
@@ -1,0 +1,96 @@
+// APIServer/Models/MCPConsentRequest.swift
+//
+// A short-lived, single-use consent request for the browser OAuth flow.  It is
+// minted at `GET /oauth/authorize` (when a logged-in instructor is shown the
+// consent screen) and redeemed once at `POST /oauth/authorize`.
+//
+// Why it exists: the consent POST runs in a cross-site browser context (the
+// Claude connector opens the flow in a popup whose POST is treated as
+// cross-site).  Safari/ITP — and increasingly every browser's third-party
+// cookie policy — will not send the session cookie on that POST, so neither the
+// session-bound CSRF token nor the authenticated user survive the hop.  This
+// record carries both *without* a cookie: the consenting user's identity is
+// frozen here at consent-render time, and the unguessable single-use token
+// (delivered only into the same-origin consent page, so an attacker can't read
+// it) is the CSRF defense.  Only the SHA-256 hash of the token is stored.
+
+import Fluent
+import Foundation
+import Vapor
+
+final class MCPConsentRequest: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
+    static let schema = "oauth_consent_requests"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    /// SHA-256 hex digest of the issued consent token (the plaintext lives only
+    /// in the rendered consent form).
+    @Field(key: "token_hash")
+    var tokenHash: String
+
+    /// The consenting human, captured from the authenticated session at GET
+    /// time.  The POST trusts this rather than re-reading the (possibly absent)
+    /// session, so identity survives a cookie-less cross-site submit.
+    @Field(key: "user_id")
+    var userID: UUID
+
+    @Field(key: "client_id")
+    var clientID: String
+
+    @Field(key: "redirect_uri")
+    var redirectURI: String
+
+    /// Space-delimited resolved scopes, already clamped to the mode ceiling.
+    @Field(key: "scope")
+    var scope: String
+
+    /// OAuth `state` (empty string when the client omitted it).
+    @Field(key: "state")
+    var state: String
+
+    @Field(key: "code_challenge")
+    var codeChallenge: String
+
+    @Field(key: "code_challenge_method")
+    var codeChallengeMethod: String
+
+    @Field(key: "expires_at")
+    var expiresAt: Date
+
+    /// Set true the moment the request is redeemed, so a replay is rejected.
+    @Field(key: "consumed")
+    var consumed: Bool
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        tokenHash: String,
+        userID: UUID,
+        clientID: String,
+        redirectURI: String,
+        scope: String,
+        state: String,
+        codeChallenge: String,
+        codeChallengeMethod: String,
+        expiresAt: Date,
+        consumed: Bool = false
+    ) {
+        self.id = id
+        self.tokenHash = tokenHash
+        self.userID = userID
+        self.clientID = clientID
+        self.redirectURI = redirectURI
+        self.scope = scope
+        self.state = state
+        self.codeChallenge = codeChallenge
+        self.codeChallengeMethod = codeChallengeMethod
+        self.expiresAt = expiresAt
+        self.consumed = consumed
+    }
+}

--- a/Sources/APIServer/Services/MCPOAuthReaperService.swift
+++ b/Sources/APIServer/Services/MCPOAuthReaperService.swift
@@ -4,6 +4,8 @@
 //   • oauth_authorization_codes — single-use, 60-second-lived; one row per
 //     /authorize. They're useless the moment they expire or are consumed, but
 //     are never deleted in-flow, so they accumulate fast under any real use.
+//   • oauth_consent_requests — single-use, ~10-minute-lived; one row per
+//     rendered consent screen. Same accumulation problem.
 //   • oauth_grants — refresh-token grants that are revoked or past their
 //     expiry can never mint again, so they're safe to drop. (Reuse-detection
 //     only consults non-revoked grants, so removing revoked ones is harmless.)
@@ -15,9 +17,15 @@ import Fluent
 import Foundation
 import Vapor
 
-/// Deletes expired authorization codes and revoked/expired grants.
+/// Deletes expired authorization codes, expired consent requests, and
+/// revoked/expired grants.
 func reapExpiredMCPOAuthRecords(on db: Database, logger: Logger, now: Date = Date()) async throws {
     try await MCPAuthorizationCode.query(on: db)
+        .filter(\.$expiresAt < now)
+        .delete()
+    // Single-use consent requests: one row per rendered consent screen, dead
+    // the moment they expire or are redeemed. Like auth codes, they accumulate.
+    try await MCPConsentRequest.query(on: db)
         .filter(\.$expiresAt < now)
         .delete()
     try await MCPGrant.query(on: db)

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -230,6 +230,9 @@ func registerMigrations(on app: Application) {
     app.migrations.add(AddPreviousRefreshTokenHashToGrants())
     app.migrations.add(AddAssignmentStartsAt())
     app.migrations.add(CreateBrightSpaceSyncLog())
+    // Single-use consent requests for the browser OAuth flow (cookie-less
+    // POST /oauth/authorize). FK references `users`.
+    app.migrations.add(CreateMCPConsentRequests())
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.
     app.migrations.add(CreateHotPathIndexes())

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -75,7 +75,8 @@ func routes(_ app: Application) throws {
     // Bearer-gated /mcp transport + unauthenticated OAuth discovery metadata.
     // Mounted when MCP_MODE is read_only or read_write; a no-op when off.
     try registerMCPRoutes(app)
-    // Browser OAuth flow (/oauth/authorize consent + /oauth/token); the consent
-    // page reuses the shared session-auth + CSRF middleware.
-    try registerMCPOAuthRoutes(app, sessionAuth: sessionAuth, csrf: csrf)
+    // Browser OAuth flow (/oauth/authorize consent + /oauth/token). The consent
+    // GET reuses session auth; the submit is guarded by a single-use consent
+    // token instead of the session cookie so it survives the cross-site hop.
+    try registerMCPOAuthRoutes(app, sessionAuth: sessionAuth)
 }

--- a/Tests/APITests/MCP/MCPModeScopeContractTests.swift
+++ b/Tests/APITests/MCP/MCPModeScopeContractTests.swift
@@ -70,22 +70,26 @@ import XCTVapor
         return components.string ?? "/oauth/authorize"
     }
 
-    /// Runs the CSRF-protected consent POST and returns its 303 response.
+    /// Renders the consent screen to mint the single-use token, then submits it
+    /// (cookie-less, like the cross-site connector POST) and returns the 303.
     private func consent(
         _ app: Application, cookie: String, clientID: String, scope: String
     ) async throws -> XCTHTTPResponse {
-        let (csrf, bound) = try await csrfFields(
-            for: authorizePath(clientID: clientID, scope: scope), cookie: cookie, on: app)
+        var html = ""
+        try await app.asyncTest(
+            .GET, authorizePath(clientID: clientID, scope: scope),
+            beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+            afterResponse: { res in html = res.body.string })
+        let marker = "name=\"request_token\" value=\""
+        let after = try #require(html.range(of: marker)).upperBound
+        let tail = html[after...]
+        let end = try #require(tail.firstIndex(of: "\""))
+        let token = String(tail[..<end])
         return try await app.asyncSendRequest(
             .POST, "/oauth/authorize",
             beforeRequest: { req in
-                req.headers.add(name: .cookie, value: bound)
                 try req.content.encode(
-                    [
-                        "client_id": clientID, "redirect_uri": redirectURI, "scope": scope,
-                        "state": "xyz", "code_challenge": codeChallenge,
-                        "code_challenge_method": "S256", "decision": "authorize", "_csrf": csrf,
-                    ], as: .urlEncodedForm)
+                    ["request_token": token, "decision": "authorize"], as: .urlEncodedForm)
             })
     }
 

--- a/Tests/APITests/MCP/MCPOAuthFlowTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthFlowTests.swift
@@ -4,6 +4,7 @@
 // /mcp, and the refresh token rotates.  Plus the guard rails: PKCE mismatch,
 // deny, and the instructor/admin-only consent gate.
 
+import Core
 import Crypto
 import Fluent
 import Foundation
@@ -63,22 +64,50 @@ import XCTVapor
         return components.string ?? "/oauth/authorize"
     }
 
-    /// Runs the consent step and returns the POST response (a 303 to the client).
+    /// Renders the consent screen (authenticated) and returns its single-use
+    /// `request_token`.
+    private func mintConsentToken(
+        _ app: Application, cookie: String, scope: String
+    ) async throws -> String {
+        var html = ""
+        try await app.asyncTest(
+            .GET, authorizePath(scope: scope),
+            beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+            afterResponse: { res in html = res.body.string })
+        return try Self.extractRequestToken(html)
+    }
+
+    /// Pulls the value of the hidden `request_token` input out of the consent HTML.
+    private static func extractRequestToken(_ html: String) throws -> String {
+        let marker = "name=\"request_token\" value=\""
+        let after = try #require(html.range(of: marker)).upperBound
+        let tail = html[after...]
+        let end = try #require(tail.firstIndex(of: "\""))
+        return String(tail[..<end])
+    }
+
+    /// Submits the consent decision. By default the session cookie is *not* sent
+    /// on the POST — the single-use token alone must carry identity + CSRF, which
+    /// is the whole point (Safari/ITP drops the cookie on this cross-site hop).
+    private func submitConsent(
+        _ app: Application, token: String, decision: String, cookie: String? = nil
+    ) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(
+            .POST, "/oauth/authorize",
+            beforeRequest: { req in
+                if let cookie { req.headers.add(name: .cookie, value: cookie) }
+                try req.content.encode(
+                    ["request_token": token, "decision": decision], as: .urlEncodedForm)
+            })
+    }
+
+    /// Runs the consent step (GET to mint the token, then a cookie-less POST) and
+    /// returns the POST response (a 303 to the client).
     private func consent(
         _ app: Application, cookie: String, scope: String, decision: String
     ) async throws -> XCTHTTPResponse {
-        let (csrf, bound) = try await csrfFields(for: authorizePath(scope: scope), cookie: cookie, on: app)
-        return try await app.asyncSendRequest(
-            .POST, "/oauth/authorize",
-            beforeRequest: { req in
-                req.headers.add(name: .cookie, value: bound)
-                try req.content.encode(
-                    [
-                        "client_id": clientID, "redirect_uri": redirectURI, "scope": scope,
-                        "state": "xyz", "code_challenge": codeChallenge,
-                        "code_challenge_method": "S256", "decision": decision, "_csrf": csrf,
-                    ], as: .urlEncodedForm)
-            })
+        let token = try await mintConsentToken(app, cookie: cookie, scope: scope)
+        return try await submitConsent(app, token: token, decision: decision)
     }
 
     private func queryValue(_ name: String, in location: String?) -> String? {
@@ -216,6 +245,87 @@ import XCTVapor
                 app, cookie: cookie, scope: "content:read", decision: "deny")
             #expect(res.status == .seeOther)
             #expect(queryValue("error", in: res.headers.first(name: .location)) == "access_denied")
+        }
+    }
+
+    @Test func authorizeSucceedsWithoutSessionCookieOnPost() async throws {
+        // The Safari/ITP case: the cross-site consent POST carries no session
+        // cookie. The single-use token alone must authenticate the consent.
+        let (app, _) = try await makeOAuthApp()
+        try await withApp(app) { app in
+            try await seedClient(app)
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            let token = try await mintConsentToken(
+                app, cookie: cookie, scope: "content:read content:write")
+            let res = try await submitConsent(app, token: token, decision: "authorize", cookie: nil)
+            #expect(res.status == .seeOther)
+            #expect(queryValue("code", in: res.headers.first(name: .location)) != nil)
+        }
+    }
+
+    @Test func unknownConsentTokenIsRejected() async throws {
+        let (app, _) = try await makeOAuthApp()
+        try await withApp(app) { app in
+            try await seedClient(app)
+            let res = try await submitConsent(
+                app, token: "not-a-real-consent-token", decision: "authorize")
+            #expect(res.status == .badRequest)
+        }
+    }
+
+    @Test func consumedConsentTokenCannotBeReplayed() async throws {
+        let (app, _) = try await makeOAuthApp()
+        try await withApp(app) { app in
+            try await seedClient(app)
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            let token = try await mintConsentToken(app, cookie: cookie, scope: "content:read")
+            #expect(try await submitConsent(app, token: token, decision: "authorize").status == .seeOther)
+            // Single-use: replaying the same token is rejected.
+            #expect(try await submitConsent(app, token: token, decision: "authorize").status == .badRequest)
+        }
+    }
+
+    @Test func expiredConsentTokenIsRejected() async throws {
+        let (app, _) = try await makeOAuthApp()
+        try await withApp(app) { app in
+            try await seedClient(app)
+            _ = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            let prof = try #require(
+                await APIUser.query(on: app.db).filter(\.$username == "prof").first())
+            let token = "expired-consent-token-aaaaaaaaaaaaaaaaaaaaaaaa"
+            try await MCPConsentRequest(
+                tokenHash: sha256HexDigest(token),
+                userID: try prof.requireID(),
+                clientID: clientID,
+                redirectURI: redirectURI,
+                scope: "content:read",
+                state: "xyz",
+                codeChallenge: codeChallenge,
+                codeChallengeMethod: "S256",
+                expiresAt: Date().addingTimeInterval(-60)
+            ).save(on: app.db)
+            let res = try await submitConsent(app, token: token, decision: "authorize")
+            #expect(res.status == .badRequest)
+        }
+    }
+
+    @Test func roleDowngradeBetweenConsentAndSubmitIsRejected() async throws {
+        let (app, _) = try await makeOAuthApp()
+        try await withApp(app) { app in
+            try await seedClient(app)
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+            let token = try await mintConsentToken(app, cookie: cookie, scope: "content:read")
+            // Demote the consenting user after the screen rendered but before submit.
+            let prof = try #require(
+                await APIUser.query(on: app.db).filter(\.$username == "prof").first())
+            prof.role = "student"
+            try await prof.save(on: app.db)
+            let res = try await submitConsent(app, token: token, decision: "authorize")
+            #expect(res.status == .forbidden)
         }
     }
 

--- a/Tests/APITests/MCP/MCPOAuthReaperTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthReaperTests.swift
@@ -43,12 +43,26 @@ import XCTVapor
                 refreshTokenHash: "grant-live", expiresAt: now.addingTimeInterval(3600)
             ).save(on: app.db)
 
+            // Consent requests: one expired, one still live.
+            try await MCPConsentRequest(
+                tokenHash: "consent-expired", userID: uid, clientID: "c", redirectURI: "r",
+                scope: "content:read", state: "", codeChallenge: "x", codeChallengeMethod: "S256",
+                expiresAt: now.addingTimeInterval(-60)
+            ).save(on: app.db)
+            try await MCPConsentRequest(
+                tokenHash: "consent-live", userID: uid, clientID: "c", redirectURI: "r",
+                scope: "content:read", state: "", codeChallenge: "x", codeChallengeMethod: "S256",
+                expiresAt: now.addingTimeInterval(60)
+            ).save(on: app.db)
+
             try await reapExpiredMCPOAuthRecords(on: app.db, logger: app.logger, now: now)
 
             let codeHashes = try await MCPAuthorizationCode.query(on: app.db).all().map(\.codeHash)
             #expect(codeHashes == ["code-live"])
             let grantHashes = try await MCPGrant.query(on: app.db).all().map(\.refreshTokenHash).sorted()
             #expect(grantHashes == ["grant-live"])
+            let consentHashes = try await MCPConsentRequest.query(on: app.db).all().map(\.tokenHash)
+            #expect(consentHashes == ["consent-live"])
         }
     }
 }

--- a/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
+++ b/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
@@ -82,19 +82,23 @@ import XCTVapor
         _ app: Application, cookie: String, clientID: String, redirectURI: String,
         scope: String, decision: String
     ) async throws -> XCTHTTPResponse {
-        let (csrf, bound) = try await csrfFields(
-            for: authorizePath(clientID: clientID, redirectURI: redirectURI, scope: scope),
-            cookie: cookie, on: app)
+        // GET the consent screen (authenticated) to mint the single-use token,
+        // then submit it. The POST carries no cookie — the token alone guards it.
+        var html = ""
+        try await app.asyncTest(
+            .GET, authorizePath(clientID: clientID, redirectURI: redirectURI, scope: scope),
+            beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+            afterResponse: { res in html = res.body.string })
+        let marker = "name=\"request_token\" value=\""
+        let after = try #require(html.range(of: marker)).upperBound
+        let tail = html[after...]
+        let end = try #require(tail.firstIndex(of: "\""))
+        let token = String(tail[..<end])
         return try await app.asyncSendRequest(
             .POST, "/oauth/authorize",
             beforeRequest: { req in
-                req.headers.add(name: .cookie, value: bound)
                 try req.content.encode(
-                    [
-                        "client_id": clientID, "redirect_uri": redirectURI, "scope": scope,
-                        "state": "xyz", "code_challenge": codeChallenge,
-                        "code_challenge_method": "S256", "decision": decision, "_csrf": csrf,
-                    ], as: .urlEncodedForm)
+                    ["request_token": token, "decision": decision], as: .urlEncodedForm)
             })
     }
 

--- a/changelog.d/mcp-oauth-cookieless-consent.md
+++ b/changelog.d/mcp-oauth-cookieless-consent.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **MCP connector authorization now works in Safari (and any browser that
+  blocks cross-site cookies).** The OAuth consent submit (`POST /oauth/authorize`)
+  no longer depends on the session cookie surviving the cross-site hop — which
+  Safari/ITP drops, causing a "CSRF token" 403 on Authorize. The consent screen
+  now mints a single-use, server-stored consent token (carrying the consenting
+  user's identity and standing in for CSRF) that the form submits instead. The
+  `SameSite=None` session cookie alone could not fix this, because Safari gates
+  cross-site cookies independently of `SameSite`.


### PR DESCRIPTION
## Summary

The MCP connector OAuth flow failed with a CSRF 403 on **Authorize** in Safari (and any browser that blocks cross-site cookies). The consent submit (`POST /oauth/authorize`) runs in the connector's cross-site context, where Safari/ITP drops the session cookie — taking both the session-bound CSRF token *and* the authenticated user with it, so the CSRF middleware rejected the request before the handler ran. `SameSite=None` (PR #776) can't fix this, because Safari gates cross-site cookies independently of `SameSite`.

This makes the consent submit **cookie-independent**:

- New `MCPConsentRequest` model + migration: a single-use, ~10-min, server-stored record minted at `GET /oauth/authorize`. It freezes the OAuth params **and the consenting user's identity** (captured from the cookie that *is* present on the top-level GET). Only the SHA-256 hash of the token is stored.
- The consent form now submits just a `request_token`. `POST /oauth/authorize` looks the record up by hash, burns it (single-use), re-validates client/redirect, **re-checks the bound user's role**, and mints the auth code — no session cookie needed on the POST.
- CSRF protection comes from the token: high-entropy, single-use, short-lived, and delivered only into the same-origin consent page (so a cross-origin attacker can't read it). The POST moves off the CSRF middleware into the rate-limited group; the `GET` keeps session auth.
- Reaper sweeps expired consent requests alongside auth codes/grants.

## Test plan

- [x] `swift build` clean; `swift-format` + SwiftLint (`--strict`) 0 violations
- [x] Full MCP suite (118 tests) + auth/session suites (72 tests) pass
- [x] New coverage: cookieless POST succeeds (the Safari case), unknown/expired/consumed token rejected, role-downgrade-between-GET-and-POST rejected, deny path
- [ ] **Manual:** run the real connector in Safari and confirm Authorize completes (validates the assumption that the GET still carries the session cookie to identify the user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)