### PR TITLE
Tock audit: harden MCP OAuth, personalization, and browser/WASM paths for first prod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,24 @@ needed, but the architecture has been redesigned from scratch.
 
 ## Architecture Overview
 
-Three Swift targets share a clean dependency boundary:
+Swift targets share a clean dependency boundary:
 
-- **`chickadee-server`** — Vapor app. REST API + Leaf web UI. Handles auth,
-  assignment management, submission intake, result storage, and the JupyterLite
-  notebook workflow.
-- **`chickadee-runner`** — Daemon process. Polls for jobs, runs shell-script
-  test suites in subprocesses (sandboxed or unsandboxed), reports structured
-  results back to the server.
-- **`Core`** — Shared models and types. No Vapor dependency. Both targets
-  depend on this.
+- **`APIServer` / `chickadee-server`** — Vapor app. REST API + Leaf web UI.
+  Handles auth, assignment management, submission intake, result storage, the
+  JupyterLite notebook workflow, and the MCP server (see below).
+- **`Worker` / `chickadee-runner`** — Daemon process. Polls for jobs, runs
+  shell-script test suites in subprocesses (sandboxed or unsandboxed), reports
+  structured results back to the server.
+- **`RunnerCore`** — The shared, Vapor-free, **Embedded-Swift-compatible**
+  grading core. Compiled two ways: natively (linked into the worker) and to
+  **WebAssembly** (the in-browser runner). It owns suite execution
+  (`executeSuites`), output interpretation (`interpretScriptOutput`), script
+  classification, and the `TestOutcome` / `TestTier` / `TestStatus` types — so
+  the native and browser graders run one implementation and cannot drift. Pinned
+  by the shared `Tests/Fixtures/output-contract.json` contract, asserted against
+  both the native build and the *real vendored wasm* in CI.
+- **`Core`** — Shared models and types. No Vapor dependency; `@_exported import
+  RunnerCore` re-exports the grading types. Every other target depends on this.
 
 Test suites are **shell scripts** bundled by the instructor inside the test
 setup zip. The runner executes them generically. Adding a new language means
@@ -108,6 +116,22 @@ All runner↔server requests are HMAC-signed (`WorkerHMACAuthMiddleware`).
 automatically if `.local-runner-autostart` exists (or is toggled via the admin
 dashboard). This is a development convenience; production runs the runner
 separately.
+
+**MCP server (`Sources/APIServer/MCP/`).** Chickadee is its own MCP server *and*
+its own OAuth 2.1 authorization server, so an agent (e.g. the Claude connector)
+can manage course content on an instructor's behalf. Gated by `MCP_MODE`
+(`off` / `read_only` / `read_write`). The browser OAuth flow is Authorization
+Code + PKCE (S256); codes, consent tokens, and refresh tokens are stored only as
+SHA-256 hashes and are strictly single-use — consumption is an **atomic
+conditional `UPDATE … WHERE consumed = false RETURNING`** so concurrent
+exchanges can't replay a code. Refresh tokens rotate with prior-hash theft
+detection; the human's role is re-checked at consent and on every refresh.
+Scopes are clamped to the mode ceiling (`MCPMode.advertisedScopes`, the single
+source for discovery + DCR). Access tokens are short-lived ES256 JWTs minted by
+`MCPTokenAuthority`; bearer auth + per-request scope clamping live in
+`MCPBearerAuthMiddleware`. An hourly reaper drops dead OAuth rows. The consent
+POST is deliberately cookie-independent (identity + CSRF ride the single-use
+consent token) so it survives Safari/ITP cross-site cookie blocking.
 
 **Pattern-generated test families (v0.4.75+).** Instructors can define a
 `PatternFamily` (Core/) — one function, shared defaults, a table of cases —
@@ -824,6 +848,55 @@ model quickly.
   `isShadowed` unconditionally; `.chickadee` bundle exports have
   only emitted `enrollmentMode` (never `openEnrollment`) since the
   helper extraction in #501.
+
+### v0.4.171 – v0.4.318 highlights (themed digest)
+
+The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
+
+- **Swift→WASM grading core (RunnerCore, #764–#775).**  A staged migration
+  hoisted suite execution, output interpretation, script classification, and
+  the `TestOutcome` / `TestTier` / `TestStatus` types out of the worker into
+  the new Vapor-free, Embedded-Swift `RunnerCore` target, which compiles both
+  natively and to WebAssembly.  The browser runner now drives the *same*
+  `executeSuites` loop via the wasm bridge (Stage 4), so the in-browser and
+  native graders share one implementation.  Embedded-safe JSON (`JSONLite`, no
+  `strtod`).  The wasm is `wasm-opt -Oz`'d, content-hashed
+  (`RunnerWasm.<hash>.wasm`), immutably cached (`RunnerWasmCacheMiddleware`),
+  and size-guarded in CI.  Parity is pinned by `Tests/Fixtures/output-contract.json`,
+  asserted against the native build *and* the real vendored wasm.  This is the
+  "first use of Swift WASM in prod" path.
+
+- **MCP server + OAuth 2.1 authorization server (`Sources/APIServer/MCP/`).**
+  Chickadee exposes course-management tools to agents over MCP, gated by
+  `MCP_MODE`, with its own Authorization Code + PKCE OAuth server, rotating
+  refresh tokens, ES256 access JWTs, dynamic client registration, an hourly
+  reaper, and an admin "connected agents" view.  Recent fixes (#776, #778) made
+  the consent flow cookie-independent so it works in Safari/cross-site-cookie
+  contexts.  See the "MCP server" design decision above.
+
+- **Per-student personalization (issue #461, Slices 1–5+).**  Per-assignment
+  seeds (`AssignmentSeedStore`, deterministic per student), Global Inputs +
+  section variables, per-student expressions evaluated by a server-side
+  `python3` subprocess (`PersonalizationEvaluator`), `{{name}}` notebook
+  substitution at student first-open, and support-file/`solution.py` imports.
+  Docs: `docs/inputs.md`, `docs/personalization-phase1.md`.  Remaining UI work
+  tracked in #664.  This is the "first personalized assignments" path.
+
+- **Notebook checks, BrightSpace grade sync, AppScan/security hardening,
+  assignment-revision retest loop, sections** — see the per-version `CHANGELOG.md`.
+
+- **v0.4.x "tock" audit hardening (this pass).**  Ahead of the first prod
+  deployments of the three subsystems above: MCP single-use token consumption
+  made atomic (conditional-`UPDATE` compare-and-set, closing a code-replay
+  TOCTOU); the personalization expression subprocess no longer inherits the
+  server environment (was leaking `RUNNER_SHARED_SECRET` / DB / OIDC secrets to
+  instructor expressions — now an explicit allowlist); browser-graded results
+  reconcile their attempt number / `isFirstPassSuccess` server-side (was always
+  stamped `1`, corrupting the First-Try-Perfect badge); pattern-family arg cells
+  may reference Global Inputs via `$name` (validator was rejecting the documented
+  worked example).  Plus OAuth `no-store` headers, reaper consumed-row cleanup,
+  an `oauth_grants.previous_refresh_token_hash` index, a `timedOut`
+  output-contract case, and `@unchecked Sendable` justification comments.
 
 **Near-term roadmap:**
 

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
@@ -195,6 +195,9 @@ struct SubmissionDiagnosticsContext {
 }
 
 final class OperationalDiagnosticsService: @unchecked Sendable {
+    // @unchecked Sendable: all stored properties are immutable (`let`); the
+    // mutable state lives behind the internally-synchronized
+    // DiagnosticsMaintenanceStore / CompatibilityCounterStore collaborators.
     let configuration: DiagnosticsConfiguration
     let maintenance = DiagnosticsMaintenanceStore()
     let compatibilityCounters = CompatibilityCounterStore()

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -22,6 +22,7 @@ import Core
 import Crypto
 import Fluent
 import Foundation
+import SQLKit
 import Vapor
 
 struct MCPOAuthRoutes: Sendable {
@@ -135,10 +136,10 @@ struct MCPOAuthRoutes: Sendable {
         // cookie — so this works in the cross-site connector context where the
         // cookie is dropped. Look the token up by hash, then burn it.
         let form = try req.content.decode(ConsentForm.self)
+        let tokenHash = sha256HexDigest(form.requestToken)
         guard
             let record = try await MCPConsentRequest.query(on: req.db)
-                .filter(\.$tokenHash == sha256HexDigest(form.requestToken)).first(),
-            !record.consumed,
+                .filter(\.$tokenHash == tokenHash).first(),
             record.expiresAt > Date()
         else {
             throw Abort(
@@ -146,9 +147,18 @@ struct MCPOAuthRoutes: Sendable {
                 reason: "This authorization request has expired or already been used. "
                     + "Restart the connection to try again.")
         }
-        // Single-use: burn before any further work so a replay loses.
-        record.consumed = true
-        try await record.save(on: req.db)
+        // Single-use: atomically burn the consent token before any further work
+        // and only proceed if this submit won the burn — a concurrent replay
+        // loses the conditional UPDATE and is rejected.
+        guard
+            try await Self.burnConsumable(
+                on: req.db, table: MCPConsentRequest.schema, hashColumn: "token_hash", hash: tokenHash)
+        else {
+            throw Abort(
+                .badRequest,
+                reason: "This authorization request has expired or already been used. "
+                    + "Restart the connection to try again.")
+        }
 
         // Re-validate the client/redirect from the frozen record (defense in
         // depth — the record is server-authored, but a stale client edit could
@@ -215,17 +225,24 @@ struct MCPOAuthRoutes: Sendable {
         else {
             return Self.tokenError(.badRequest, "invalid_request")
         }
+        let codeHash = sha256HexDigest(code)
         guard
             let authCode = try await MCPAuthorizationCode.query(on: req.db)
-                .filter(\.$codeHash == sha256HexDigest(code)).first(),
-            !authCode.consumed,
+                .filter(\.$codeHash == codeHash).first(),
             authCode.expiresAt > Date()
         else {
             return Self.tokenError(.badRequest, "invalid_grant")
         }
-        // Single-use: burn the code before any further work so a replay loses.
-        authCode.consumed = true
-        try await authCode.save(on: req.db)
+        // Single-use: atomically burn the code BEFORE any further work and only
+        // proceed if this request won the burn.  A concurrent replay of the same
+        // code loses the conditional UPDATE and is rejected (the prior in-process
+        // read-modify-write could otherwise mint two token pairs from one code).
+        guard
+            try await Self.burnConsumable(
+                on: req.db, table: MCPAuthorizationCode.schema, hashColumn: "code_hash", hash: codeHash)
+        else {
+            return Self.tokenError(.badRequest, "invalid_grant")
+        }
 
         guard
             authCode.redirectURI == redirectURI,
@@ -288,10 +305,19 @@ struct MCPOAuthRoutes: Sendable {
             try await grant.save(on: req.db)
             return Self.tokenError(.badRequest, "invalid_grant")
         }
-        // Rotate: remember the spent token (for replay detection) and issue a new one.
+        // Rotate: issue a new refresh token and swap it in atomically, gated on
+        // the CURRENT hash so two concurrent rotations of the same token can't
+        // both win (the loser matches zero rows and is rejected as a replay).
         let newRefresh = Self.randomToken()
-        grant.previousRefreshTokenHash = grant.refreshTokenHash
-        grant.refreshTokenHash = sha256HexDigest(newRefresh)
+        let newHash = sha256HexDigest(newRefresh)
+        guard try await Self.rotateRefreshHash(on: req.db, currentHash: hash, newHash: newHash) else {
+            return Self.tokenError(.badRequest, "invalid_grant")
+        }
+        // We won the rotation: mirror the swap onto the in-memory model and
+        // persist last-used telemetry (kept out of the atomic UPDATE to avoid
+        // Fluent↔raw-SQL date-format skew). Only the winner reaches this save.
+        grant.previousRefreshTokenHash = hash
+        grant.refreshTokenHash = newHash
         grant.lastUsedAt = Date()
         try await grant.save(on: req.db)
 
@@ -378,6 +404,8 @@ struct MCPOAuthRoutes: Sendable {
     private static func registrationError(_ error: String, _ description: String) -> Response {
         let response = Response(status: .badRequest)
         response.headers.contentType = .json
+        // RFC 6749 §5.1: credential/token-adjacent responses must not be cached.
+        response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
         response.body = .init(string: "{\"error\":\"\(error)\",\"error_description\":\"\(description)\"}")
         return response
     }
@@ -422,7 +450,11 @@ struct MCPOAuthRoutes: Sendable {
 
     private func renderConsent(_ req: Request, context: ConsentContext) async throws -> Response {
         let view = try await req.view.render("oauth-consent", context)
-        return try await view.encodeResponse(for: req)
+        let response = try await view.encodeResponse(for: req)
+        // The consent page embeds the single-use consent token; keep it out of
+        // any shared/proxy cache.
+        response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+        return response
     }
 
     /// Keeps only valid content scopes, then clamps to the server-wide ceiling
@@ -491,6 +523,39 @@ struct MCPOAuthRoutes: Sendable {
 
     private static func pkceMatches(verifier: String, challenge: String) -> Bool {
         base64url(Data(SHA256.hash(data: Data(verifier.utf8)))) == challenge
+    }
+
+    /// Atomically flips a single-use `consumed` flag from false→true for the row
+    /// whose `hashColumn` equals `hash`, returning true iff *this* call won the
+    /// flip.  One conditional `UPDATE … WHERE consumed = false RETURNING`
+    /// statement is atomic on both SQLite (WAL) and Postgres, so two concurrent
+    /// `/token` (or `/authorize`) submits of the same code/consent token can
+    /// never both win — closing the OAuth code-replay race that the prior
+    /// read-check-then-save left open.  `table`/`hashColumn` are compile-time
+    /// schema constants (no injection surface); only the hash is bound.
+    private static func burnConsumable(
+        on db: Database, table: String, hashColumn: String, hash: String
+    ) async throws -> Bool {
+        guard let sql = db as? SQLDatabase else { return true }
+        let rows = try await sql.raw(
+            "UPDATE \(unsafeRaw: table) SET consumed = true WHERE \(unsafeRaw: hashColumn) = \(bind: hash) AND consumed = false RETURNING id"
+        ).all()
+        return !rows.isEmpty
+    }
+
+    /// Atomically rotates a grant's refresh-token hash, gated on the *current*
+    /// hash so two concurrent rotations of the same refresh token can't both
+    /// succeed (the loser matches zero rows).  Returns true iff this call won the
+    /// rotation; the caller then mirrors the swap onto the in-memory model and
+    /// persists non-security telemetry (`lastUsedAt`).
+    private static func rotateRefreshHash(
+        on db: Database, currentHash: String, newHash: String
+    ) async throws -> Bool {
+        guard let sql = db as? SQLDatabase else { return true }
+        let rows = try await sql.raw(
+            "UPDATE \(unsafeRaw: MCPGrant.schema) SET previous_refresh_token_hash = refresh_token_hash, refresh_token_hash = \(bind: newHash) WHERE refresh_token_hash = \(bind: currentHash) AND revoked = false RETURNING id"
+        ).all()
+        return !rows.isEmpty
     }
 
     private static func randomToken() -> String {

--- a/Sources/APIServer/Migrations/AddGrantPreviousRefreshTokenHashIndex.swift
+++ b/Sources/APIServer/Migrations/AddGrantPreviousRefreshTokenHashIndex.swift
@@ -1,0 +1,32 @@
+// APIServer/Migrations/AddGrantPreviousRefreshTokenHashIndex.swift
+//
+// Adds an index on `oauth_grants.previous_refresh_token_hash`.  The refresh
+// rotation theft-detection lookup (a token matching an already-rotated-away
+// hash revokes the grant) and the `POST /oauth/revoke` OR-filter both query
+// this column on every refresh / revoke.  `refresh_token_hash` is already
+// indexed by its UNIQUE constraint, but the previous-hash column was added
+// (in `AddPreviousRefreshTokenHashToGrants`) without one, so those hot-path
+// queries degrade to a full table scan as long-lived grants accumulate.
+//
+// A separate migration (rather than folding the index into the canonical
+// `CreateMCPGrants` / `CreateHotPathIndexes`) so existing production databases
+// — which already have those migrations marked applied — actually create it.
+// `IF NOT EXISTS` keeps it safe on fresh deploys.
+
+import Fluent
+import SQLKit
+
+struct AddGrantPreviousRefreshTokenHashIndex: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+        try await sql.raw(
+            "CREATE INDEX IF NOT EXISTS idx_oauth_grants_previous_refresh_token_hash "
+                + "ON oauth_grants(previous_refresh_token_hash)"
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+        try await sql.raw("DROP INDEX IF EXISTS idx_oauth_grants_previous_refresh_token_hash").run()
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -24,6 +24,7 @@ import Fluent
 import Vapor
 
 final class APIAuditLogEntry: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "audit_log"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/APIClassAchievement.swift
+++ b/Sources/APIServer/Models/APIClassAchievement.swift
@@ -11,6 +11,7 @@ import Fluent
 import Vapor
 
 final class APIClassAchievement: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "class_achievements"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/APIClientDiagnostic.swift
+++ b/Sources/APIServer/Models/APIClientDiagnostic.swift
@@ -10,6 +10,7 @@ import Vapor
 ///   - "watchdog_timeout" — the iframe mounted but the JupyterLite kernel
 ///                           did not become ready within the watchdog window
 final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "client_diagnostics"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/APIPreEnrollment.swift
+++ b/Sources/APIServer/Models/APIPreEnrollment.swift
@@ -18,6 +18,7 @@ import Fluent
 import Vapor
 
 final class APIPreEnrollment: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "pre_enrollments"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/APIRequestMetric.swift
+++ b/Sources/APIServer/Models/APIRequestMetric.swift
@@ -2,6 +2,7 @@ import Fluent
 import Vapor
 
 final class APIRequestMetric: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "request_metrics"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/APISubmissionDiagnostics.swift
+++ b/Sources/APIServer/Models/APISubmissionDiagnostics.swift
@@ -2,6 +2,7 @@ import Fluent
 import Vapor
 
 final class APISubmissionDiagnostics: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "submission_diagnostics"
 
     @ID(custom: "submission_id", generatedBy: .user)

--- a/Sources/APIServer/Models/AssignmentRequirement.swift
+++ b/Sources/APIServer/Models/AssignmentRequirement.swift
@@ -3,6 +3,7 @@ import Fluent
 import Vapor
 
 final class AssignmentRequirement: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "assignment_requirements"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/JobExecutionMetric.swift
+++ b/Sources/APIServer/Models/JobExecutionMetric.swift
@@ -2,6 +2,7 @@ import Fluent
 import Vapor
 
 final class JobExecutionMetric: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "job_execution_metrics"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/RunnerProfile.swift
+++ b/Sources/APIServer/Models/RunnerProfile.swift
@@ -3,6 +3,7 @@ import Fluent
 import Vapor
 
 final class RunnerProfile: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "runner_profiles"
 
     @ID(key: .id)

--- a/Sources/APIServer/Models/RunnerSnapshot.swift
+++ b/Sources/APIServer/Models/RunnerSnapshot.swift
@@ -2,6 +2,7 @@ import Fluent
 import Vapor
 
 final class RunnerSnapshot: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "runner_snapshots"
 
     @ID(key: .id)

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -51,10 +51,12 @@ struct BrowserResultRoutes: RouteCollection {
             throw AppError.unprocessable(reason: "Invalid TestOutcomeCollection: \(e)")
         }
 
-        // Persist the notebook to disk as the submission artifact.
-        // Merge the student's notebook with the instructor's canonical notebook
-        // so that hidden test cells (secret, release) are re-injected before
-        // the worker runs the full authoritative test suite.
+        // Persist the notebook to disk as the submission artifact.  Merge the
+        // student's notebook with the instructor's canonical notebook so the
+        // hidden test cells (secret, release) are present in the stored artifact:
+        // no native worker runs here (browser results are stored as-is), but if
+        // this submission is later re-graded by a worker (a retest, or the
+        // browser-mode backstop) the authoritative suite has its cells.
         let subsDir = req.application.submissionsDirectory
         let subID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
         let nbPath = subsDir + "\(subID).ipynb"
@@ -92,10 +94,18 @@ struct BrowserResultRoutes: RouteCollection {
         )
         try await submission.save(on: req.db)
 
-        // Persist the browser result, tagged source="browser".
+        // Persist the browser result, tagged source="browser".  The browser
+        // builds its collection before it knows the server-authoritative attempt
+        // number, so it always stamps attemptNumber=1 (and isFirstPassSuccess for
+        // every pass).  Reconcile those fields — and the submission ID — from the
+        // values the server derived above so the stored result agrees with the
+        // submission row and the First-Try-Perfect badge / per-attempt analytics
+        // stay correct for browser-graded assignments.
+        let reconciled = Self.reconcileBrowserCollection(
+            collection, submissionID: subID, attemptNumber: attemptNumber)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        let collectionJSON = try String(data: encoder.encode(collection), encoding: .utf8) ?? "{}"
+        let collectionJSON = try String(data: encoder.encode(reconciled), encoding: .utf8) ?? "{}"
 
         let browserResult = APIResult(
             id: "res_\(UUID().uuidString.lowercased().prefix(8))",
@@ -196,6 +206,48 @@ struct BrowserResultRoutes: RouteCollection {
         }
 
         return RunnerSubmissionResponse(submissionID: subID)
+    }
+
+    /// Rewrites a browser-supplied collection with the server-authoritative
+    /// submission ID and attempt number, recomputing `isFirstPassSuccess` from
+    /// the true attempt (a pass only counts as a first-pass success on attempt
+    /// 1).  Everything else is carried through verbatim.
+    static func reconcileBrowserCollection(
+        _ collection: TestOutcomeCollection, submissionID: String, attemptNumber: Int
+    ) -> TestOutcomeCollection {
+        let outcomes = collection.outcomes.map { o in
+            TestOutcome(
+                testName: o.testName,
+                testClass: o.testClass,
+                tier: o.tier,
+                status: o.status,
+                shortResult: o.shortResult,
+                longResult: o.longResult,
+                points: o.points,
+                executionTimeMs: o.executionTimeMs,
+                memoryUsageBytes: o.memoryUsageBytes,
+                attemptNumber: attemptNumber,
+                isFirstPassSuccess: attemptNumber == 1 && o.status == .pass)
+        }
+        return TestOutcomeCollection(
+            submissionID: submissionID,
+            testSetupID: collection.testSetupID,
+            attemptNumber: attemptNumber,
+            buildStatus: collection.buildStatus,
+            compilerOutput: collection.compilerOutput,
+            outcomes: outcomes,
+            totalTests: collection.totalTests,
+            passCount: collection.passCount,
+            failCount: collection.failCount,
+            errorCount: collection.errorCount,
+            timeoutCount: collection.timeoutCount,
+            executionTimeMs: collection.executionTimeMs,
+            totalPoints: collection.totalPoints,
+            earnedPoints: collection.earnedPoints,
+            warnings: collection.warnings,
+            jobStartedAt: collection.jobStartedAt,
+            runnerVersion: collection.runnerVersion,
+            timestamp: collection.timestamp)
     }
 }
 

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -243,6 +243,9 @@ func requireOpenStudentAssignment(
 }
 
 final class AssignmentDeadlineMonitor: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state (`task`) is touched solely
+    // from start()/stop() on the app lifecycle (didBoot/shutdown), never
+    // concurrently.
     private var task: Task<Void, Never>?
     private let intervalNanoseconds: UInt64
 

--- a/Sources/APIServer/Services/AuditLogReaperService.swift
+++ b/Sources/APIServer/Services/AuditLogReaperService.swift
@@ -46,6 +46,9 @@ func reapStaleAuditLogEntries(
 }
 
 final class AuditLogReaperMonitor: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state (`task`) is touched solely
+    // from start()/stop() on the app lifecycle (didBoot/shutdown), never
+    // concurrently.
     private var task: Task<Void, Never>?
     private let intervalNanoseconds: UInt64
     private let maxAge: TimeInterval

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -243,6 +243,9 @@ private func resolvedBrightSpaceUserID(
 // MARK: - Monitor
 
 final class BrightSpaceGradeSyncMonitor: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state (`task`) is touched solely
+    // from start()/stop() on the app lifecycle (didBoot/shutdown), never
+    // concurrently.
     private var task: Task<Void, Never>?
     private let sweepIntervalNanoseconds: UInt64 = 60 * 1_000_000_000
 

--- a/Sources/APIServer/Services/MCPOAuthReaperService.swift
+++ b/Sources/APIServer/Services/MCPOAuthReaperService.swift
@@ -20,13 +20,20 @@ import Vapor
 /// Deletes expired authorization codes, expired consent requests, and
 /// revoked/expired grants.
 func reapExpiredMCPOAuthRecords(on db: Database, logger: Logger, now: Date = Date()) async throws {
+    // Auth codes are dead once expired OR consumed — a consumed code can never
+    // be redeemed again (the atomic burn blocks it), so there's no reason to
+    // keep it around until its 60-second TTL lapses.
     try await MCPAuthorizationCode.query(on: db)
-        .filter(\.$expiresAt < now)
+        .group(.or) { group in
+            group.filter(\.$expiresAt < now).filter(\.$consumed == true)
+        }
         .delete()
     // Single-use consent requests: one row per rendered consent screen, dead
     // the moment they expire or are redeemed. Like auth codes, they accumulate.
     try await MCPConsentRequest.query(on: db)
-        .filter(\.$expiresAt < now)
+        .group(.or) { group in
+            group.filter(\.$expiresAt < now).filter(\.$consumed == true)
+        }
         .delete()
     try await MCPGrant.query(on: db)
         .group(.or) { group in
@@ -37,6 +44,9 @@ func reapExpiredMCPOAuthRecords(on db: Database, logger: Logger, now: Date = Dat
 }
 
 final class MCPOAuthReaperMonitor: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state (`task`) is touched solely
+    // from start()/stop() on the app lifecycle (didBoot/shutdown), never
+    // concurrently.
     private var task: Task<Void, Never>?
     private let intervalNanoseconds: UInt64
 

--- a/Sources/APIServer/Services/PersonalizationEvaluator.swift
+++ b/Sources/APIServer/Services/PersonalizationEvaluator.swift
@@ -238,7 +238,20 @@ enum PersonalizationEvaluator {
         proc.executableURL = executableURL
         proc.arguments = arguments
         proc.currentDirectoryURL = cwd
-        var mergedEnv = ProcessInfo.processInfo.environment
+        // SECURITY: do NOT inherit the parent process environment.  This
+        // subprocess runs instructor-authored expressions, and the server
+        // process holds secrets (RUNNER_SHARED_SECRET, database credentials,
+        // the OIDC client secret, BrightSpace keys, …) that must never be
+        // readable from an expression via `os.environ`.  Pass only an explicit
+        // allowlist of variables the interpreter needs to start (PATH to locate
+        // `python3`, plus HOME / locale / PYTHONHOME for the runtime), then
+        // overlay the caller-supplied vars (the assignment seed and an optional
+        // PYTHONPATH into the support-files dir).
+        let parentEnv = ProcessInfo.processInfo.environment
+        var mergedEnv: [String: String] = [:]
+        for key in ["PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "PYTHONHOME"] {
+            if let value = parentEnv[key] { mergedEnv[key] = value }
+        }
         for (k, v) in env { mergedEnv[k] = v }
         proc.environment = mergedEnv
 

--- a/Sources/APIServer/Services/SessionReaperService.swift
+++ b/Sources/APIServer/Services/SessionReaperService.swift
@@ -46,6 +46,9 @@ func reapStaleSessions(
 }
 
 final class SessionReaperMonitor: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state (`task`) is touched solely
+    // from start()/stop() on the app lifecycle (didBoot/shutdown), never
+    // concurrently.
     private var task: Task<Void, Never>?
     private let intervalNanoseconds: UInt64
     private let maxAge: TimeInterval

--- a/Sources/APIServer/Services/StuckSubmissionReaperService.swift
+++ b/Sources/APIServer/Services/StuckSubmissionReaperService.swift
@@ -37,6 +37,9 @@ func reapStuckAssignedSubmissions(
 }
 
 final class StuckSubmissionReaperMonitor: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state (`task`) is touched solely
+    // from start()/stop() on the app lifecycle (didBoot/shutdown), never
+    // concurrently.
     private var task: Task<Void, Never>?
     private let intervalNanoseconds: UInt64
     private let maxAge: TimeInterval

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -236,4 +236,5 @@ func registerMigrations(on app: Application) {
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.
     app.migrations.add(CreateHotPathIndexes())
+    app.migrations.add(AddGrantPreviousRefreshTokenHashIndex())
 }

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -366,7 +366,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         nextFamilies,
         testSuites: authoredAsTestSuites,
         sections: resolvedSections,
-        familySectionID: familySectionIDForValidation
+        familySectionID: familySectionIDForValidation,
+        globalVariableNames: Set(resolvedGlobalVariables.map(\.name))
     )
     try validateNotebookChecks(
         resolvedChecks,

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -41,7 +41,8 @@ private func validatePatternCaseHeader(
 /// section.
 private func validateFamilyVariablesAndArgRefs(
     family: PatternFamily,
-    sectionVarNamesHere: Set<String>
+    sectionVarNamesHere: Set<String>,
+    globalVarNames: Set<String>
 ) throws {
     var seenVarNames: Set<String> = []
     let paramNameSet = Set(family.paramNames)
@@ -67,12 +68,18 @@ private func validateFamilyVariablesAndArgRefs(
     for c in family.cases {
         for (i, maybeRef) in c.argVarRefs.enumerated() {
             guard let ref = maybeRef else { continue }
-            // v0.4.100: a `$name` ref resolves if EITHER the family
-            // declares the variable OR the family's home section
-            // does.  Family-level shadows section-level at render
-            // time — so both are valid refs; only "declared in
-            // neither" is an error.
-            guard seenVarNames.contains(ref) || sectionVarNamesHere.contains(ref) else {
+            // A `$name` ref resolves if the family declares the variable,
+            // the family's home section does, OR it's an assignment-scope
+            // global input.  The renderer puts all three in scope
+            // (`globalVariables + sectionVariables + family.variables`), so
+            // accepting them here matches what actually renders — only
+            // "declared in none of the three" is an error.  (Globals were
+            // previously omitted from this set, which rejected the documented
+            // `$global` worked example in docs/inputs.md.)
+            guard
+                seenVarNames.contains(ref) || sectionVarNamesHere.contains(ref)
+                    || globalVarNames.contains(ref)
+            else {
                 let paramLabel = (i < family.paramNames.count ? family.paramNames[i] : "arg \(i + 1)")
                 throw Abort(
                     .unprocessableEntity,
@@ -155,7 +162,8 @@ func validatePatternFamilies(
     _ families: [PatternFamily],
     testSuites: [TestSuiteEntry],
     sections: [TestSuiteSection] = [],
-    familySectionID: [String: String] = [:]
+    familySectionID: [String: String] = [:],
+    globalVariableNames: Set<String> = []
 ) throws {
     // v0.4.100: build a "extra names in scope for this family" set so
     // each family can reference its home section's variables too.
@@ -207,7 +215,8 @@ func validatePatternFamilies(
         // a case arg cell must resolve to a declared variable.
         try validateFamilyVariablesAndArgRefs(
             family: family,
-            sectionVarNamesHere: sectionVarNames(forFamily: family.id)
+            sectionVarNamesHere: sectionVarNames(forFamily: family.id),
+            globalVarNames: globalVariableNames
         )
     }
 

--- a/Tests/APITests/AuditTockRegressionTests.swift
+++ b/Tests/APITests/AuditTockRegressionTests.swift
@@ -1,0 +1,118 @@
+// Tests/APITests/AuditTockRegressionTests.swift
+//
+// Regression coverage for the v0.4.x "tock" audit fixes that previously had
+// no test:
+//   • Personalization M1 — the expression subprocess must not inherit (and
+//     therefore must not leak) the server's environment secrets.
+//   • Browser-runner H2 — a stored browser result must carry the
+//     server-authoritative attempt number / first-pass flag, not the
+//     browser's always-1 stamp.
+//   • Personalization H3 — a pattern-family arg cell may reference an
+//     assignment-scope global input via `$name` (the documented worked
+//     example), which the validator previously rejected.
+//
+// The OAuth single-use/replay fixes (MCP H1) are already covered by
+// MCPSecurityHardeningTests.authorizationCodeCannotBeReplayed,
+// MCPOAuthFlowTests.consumedConsentTokenCannotBeReplayed, and
+// .replayedRefreshTokenRevokesGrant — the atomic conditional UPDATE keeps
+// those green.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct AuditTockRegressionTests {
+
+    // MARK: - Personalization M1: no server-secret leakage
+
+    @Test func evaluator_doesNotLeakServerEnvironmentSecrets() async throws {
+        try await withAsyncEnvLock {
+            setenv("CHICKADEE_AUDIT_FAKE_SECRET", "super-secret-value", 1)
+            defer { unsetenv("CHICKADEE_AUDIT_FAKE_SECRET") }
+
+            let result = try await PersonalizationEvaluator.evaluate(
+                seedHex: "00ff",
+                staticVariables: [],
+                expressions: [
+                    PersonalizationExpression(
+                        name: "leaked",
+                        expression:
+                            "__import__('os').environ.get('CHICKADEE_AUDIT_FAKE_SECRET', 'LEAK_BLOCKED')"),
+                    PersonalizationExpression(name: "shift", expression: "seed % 7"),
+                ]
+            )
+
+            // The instructor expression cannot read the server's secret env var:
+            // the subprocess gets an allowlisted env, not the inherited one.
+            #expect(result["leaked"] == "'LEAK_BLOCKED'")
+            #expect(result["leaked"]?.contains("super-secret-value") == false)
+            // …and the interpreter still starts (PATH is allowlisted), so the
+            // seed-derived expression still evaluates (0x00ff % 7 == 3).
+            #expect(result["shift"] == "3")
+        }
+    }
+
+    // MARK: - Browser-runner H2: server-authoritative attempt reconciliation
+
+    @Test func reconcile_stampsServerAttemptAndRecomputesFirstPass() {
+        let pass = TestOutcome(
+            testName: "t1", testClass: nil, tier: .pub, status: .pass,
+            shortResult: "ok", longResult: nil, points: 1, executionTimeMs: 1,
+            memoryUsageBytes: nil, attemptNumber: 1, isFirstPassSuccess: true)
+        let fail = TestOutcome(
+            testName: "t2", testClass: nil, tier: .pub, status: .fail,
+            shortResult: "no", longResult: nil, points: 1, executionTimeMs: 1,
+            memoryUsageBytes: nil, attemptNumber: 1, isFirstPassSuccess: false)
+        let browserCollection = TestOutcomeCollection(
+            submissionID: "browser-local", testSetupID: "ts1", attemptNumber: 1,
+            buildStatus: .passed, compilerOutput: nil, outcomes: [pass, fail],
+            totalTests: 2, passCount: 1, failCount: 1, errorCount: 0, timeoutCount: 0,
+            executionTimeMs: 5, runnerVersion: "browser/1.0", timestamp: Date())
+
+        // A 3rd attempt: the server attempt number is stamped onto the
+        // collection and every outcome, and a pass no longer counts as a
+        // first-pass success.
+        let r3 = BrowserResultRoutes.reconcileBrowserCollection(
+            browserCollection, submissionID: "sub_abcd1234", attemptNumber: 3)
+        #expect(r3.submissionID == "sub_abcd1234")
+        #expect(r3.attemptNumber == 3)
+        #expect(r3.outcomes.allSatisfy { $0.attemptNumber == 3 })
+        #expect(r3.outcomes.first { $0.testName == "t1" }?.isFirstPassSuccess == false)
+
+        // A 1st attempt: a pass IS a first-pass success; a fail is not.
+        let r1 = BrowserResultRoutes.reconcileBrowserCollection(
+            browserCollection, submissionID: "sub_x", attemptNumber: 1)
+        #expect(r1.outcomes.first { $0.testName == "t1" }?.isFirstPassSuccess == true)
+        #expect(r1.outcomes.first { $0.testName == "t2" }?.isFirstPassSuccess == false)
+    }
+
+    // MARK: - Personalization H3: pattern-family arg may reference a global input
+
+    @Test func validator_acceptsGlobalVariableArgRef() throws {
+        let family = PatternFamily(
+            id: "greet", name: "Greeting", kind: .boundaryEquality,
+            functionName: "greet", paramNames: ["name"],
+            defaults: PatternDefaults(tier: .pub, points: 1, hint: nil),
+            cases: [
+                PatternCase(
+                    key: "01", label: "uses global roster name",
+                    args: [.string("placeholder")], expected: .string("hi"),
+                    argVarRefs: ["roster_name"])
+            ]
+        )
+
+        // Rejected when the referenced name isn't a known family/section/global
+        // variable…
+        #expect(throws: (any Error).self) {
+            try validatePatternFamilies([family], testSuites: [])
+        }
+        // …accepted once it's declared as an assignment-scope global input
+        // (matching what the renderer actually puts in scope).
+        #expect(throws: Never.self) {
+            try validatePatternFamilies(
+                [family], testSuites: [], globalVariableNames: ["roster_name"])
+        }
+    }
+}

--- a/Tests/Fixtures/output-contract.json
+++ b/Tests/Fixtures/output-contract.json
@@ -80,6 +80,24 @@
       "exitCode": 0,
       "status": "pass",
       "native": { "shortResult": "t: passed", "longResult": "stdout:\nNice work!" }
+    },
+    {
+      "name": "timeout wins over exit code (SIGKILL after the limit, empty output)",
+      "stdout": "",
+      "stderr": "",
+      "exitCode": 0,
+      "timedOut": true,
+      "status": "timeout",
+      "native": { "shortResult": "timed out", "longResult": null }
+    },
+    {
+      "name": "timeout with partial stderr surfaced (exit -1 SIGKILL)",
+      "stdout": "",
+      "stderr": "still running when killed\n",
+      "exitCode": -1,
+      "timedOut": true,
+      "status": "timeout",
+      "native": { "shortResult": "timed out", "longResult": "stderr:\nstill running when killed" }
     }
   ]
 }

--- a/Tests/WorkerTests/OutputContractTests.swift
+++ b/Tests/WorkerTests/OutputContractTests.swift
@@ -17,6 +17,7 @@ import Testing
         let stdout: String
         let stderr: String
         let exitCode: Int32
+        let timedOut: Bool?
         let status: String
         let native: Native
     }
@@ -42,7 +43,7 @@ import Testing
                 stdout: c.stdout,
                 stderr: c.stderr,
                 executionTimeMs: 0,
-                timedOut: false
+                timedOut: c.timedOut ?? false
             )
             let result = interpretScriptOutput(output)
             #expect(result.status.rawValue == c.status, "status mismatch for case '\(c.name)'")

--- a/changelog.d/audit-tock-browser-attempt.md
+++ b/changelog.d/audit-tock-browser-attempt.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Browser-graded results now record the true attempt number.** The browser
+  runner builds its result before it knows the server-side attempt number, so it
+  always stamped `attemptNumber: 1` (and therefore `isFirstPassSuccess` for every
+  pass). The server now reconciles the stored collection — submission ID, attempt
+  number, and each outcome's `isFirstPassSuccess` — against the value it derived
+  for the submission, so the First-Try-Perfect badge and per-attempt analytics
+  are correct for browser-graded assignments.

--- a/changelog.d/audit-tock-mcp-oauth-atomic.md
+++ b/changelog.d/audit-tock-mcp-oauth-atomic.md
@@ -1,0 +1,18 @@
+### Security
+
+- **MCP OAuth single-use tokens are now burned atomically.** The authorization
+  code, the consent token, and refresh-token rotation each consumed their
+  single-use record with a read-check-then-save, leaving a small TOCTOU window
+  where two concurrent `POST /oauth/token` (or `/oauth/authorize`) requests for
+  the same code could both succeed and mint two token pairs. Consumption is now
+  a single conditional `UPDATE … WHERE consumed = false RETURNING` (atomic on
+  both SQLite-WAL and Postgres), so only one caller can ever win.
+
+### Fixed
+
+- **MCP OAuth hardening.** Token-endpoint error and dynamic-registration error
+  responses (and the consent page) now send `Cache-Control: no-store`; the
+  hourly OAuth reaper now also drops consumed-but-unexpired authorization codes
+  and consent requests; and a new index on
+  `oauth_grants.previous_refresh_token_hash` keeps refresh-token theft detection
+  and `POST /oauth/revoke` off a full table scan as long-lived grants accumulate.

--- a/changelog.d/audit-tock-personalization-env.md
+++ b/changelog.d/audit-tock-personalization-env.md
@@ -1,0 +1,11 @@
+### Security
+
+- **Per-student personalization expressions no longer see the server's
+  environment.** The subprocess that evaluates instructor-authored
+  personalization expressions inherited the full server environment, so an
+  expression such as `__import__('os').environ['RUNNER_SHARED_SECRET']` could
+  read the worker secret, database credentials, the OIDC client secret, or
+  BrightSpace keys and surface them through a substituted notebook value. The
+  subprocess now receives only an explicit allowlist (`PATH`, `HOME`, locale,
+  `PYTHONHOME`) plus the assignment seed and an optional support-files
+  `PYTHONPATH` — never the inherited secrets.

--- a/changelog.d/audit-tock-personalization-globalref.md
+++ b/changelog.d/audit-tock-personalization-globalref.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Pattern-family arg cells can reference assignment-scope global inputs.** A
+  `$name` reference to a Global Input (the worked example in `docs/inputs.md`)
+  was rejected by the pattern-family validator with "references unknown
+  variable", even though the renderer puts global inputs in scope alongside
+  section and family variables. The validator now accepts `$global` references,
+  matching what actually renders.


### PR DESCRIPTION
## What this is

A "tock" finesse pass ahead of the first prod deployments of the three new subsystems — **personalized assignments**, the **MCP server**, and the **Swift WASM browser runner**. Four areas were audited in depth (MCP/OAuth, RunnerCore/WASM parity, personalization, build/CI health). The baseline was already clean (`swift build`, `--build-tests`, swift-format `--strict`, SwiftLint `--strict` all pass). This PR lands the confirmed, small, safe fixes; the one architectural item is flagged for a follow-up (your call).

## Fixes (each verified against the code)

### Security
- **`fix(mcp)`: atomic single-use OAuth token burn.** Auth-code, consent-token, and refresh-token rotation each consumed their single-use record with a read-check-then-save — a TOCTOU window where two concurrent `POST /oauth/token` for the same code could both mint token pairs. Now a single conditional `UPDATE … WHERE consumed = false RETURNING` (atomic on SQLite-WAL **and** Postgres). Sequential-replay tests already covered this and stay green.
- **`fix(personalization)`: env-secret leak.** The `python3` subprocess evaluating instructor expressions inherited the **full server environment** — `__import__('os').environ['RUNNER_SHARED_SECRET']` (or DB/OIDC/BrightSpace secrets) could be read and surfaced through a substituted notebook value. It now gets an explicit allowlist (`PATH`, `HOME`, locale, `PYTHONHOME`) + the seed + optional support `PYTHONPATH`. New regression test proves the secret is blocked while the interpreter still runs.

### Fixed
- **`fix(browser)`: attempt-number reconciliation.** Browser-graded results always stamped `attemptNumber:1` / `isFirstPassSuccess` for every pass, corrupting the First-Try-Perfect badge and per-attempt analytics. The server now reconciles submission ID + attempt number + per-outcome `isFirstPassSuccess` from its own derived value.
- **`fix(personalization)`: `$global` arg refs.** A pattern-family arg cell referencing a Global Input (`$name`, the worked example in `docs/inputs.md`) was rejected by the validator even though the renderer puts globals in scope. Now accepted.
- **MCP hardening:** `no-store` on registration-error + consent responses; reaper drops consumed-but-unexpired codes/consent rows; new index on `oauth_grants.previous_refresh_token_hash` (hot refresh/revoke path).
- **RunnerCore parity:** a `timedOut` case added to the shared `output-contract.json` so the timeout-interpretation path is pinned across the native worker and the real vendored wasm.

### Chore / docs
- `@unchecked Sendable` justification comments added to the 17 declarations missing one (project convention).
- `CLAUDE.md` refreshed: RunnerCore (native+wasm) target, MCP-server design decision, themed digest extended through v0.4.318 + this audit.

## Flagged for a follow-up (not in this PR — your call)
**Browser-graded trust model (WASM H3).** The browser path ships the *full* manifest+zip (including `secret`/`release` test scripts) to the student and stores the client-supplied result as authoritative with no worker re-grade — a student could read hidden tests in DevTools or POST a forged all-pass result. This is pre-existing browser-mode architecture, but #764–#775 made it the live grading path. The real fix (strip hidden tiers / queue an authoritative worker re-grade) is an architectural decision; happy to open an issue and design it. (Also note: the `BrowserResultRoutes` comment about a "worker re-grade" was contradictory — clarified in this PR.)

## Testing
- `swift build --build-tests` ✅ · swift-format `--strict` ✅ · SwiftLint `--strict` (0/483) ✅
- New `AuditTockRegressionTests` (3) ✅ + 107 tests across the affected suites (MCP OAuth flow/security/reaper, output-contract, personalization, pattern-family, sections, browser routes) ✅

https://claude.ai/code/session_01BcnneMQbfkdE7Rojd6J6Db

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcnneMQbfkdE7Rojd6J6Db)_