### PR TITLE
perf(runnercore): ASCII-only string ops to slim the Embedded-Swift wasm build

### DIFF
--- a/Sources/RunnerCore/JSONLite.swift
+++ b/Sources/RunnerCore/JSONLite.swift
@@ -131,11 +131,25 @@ private struct JSONParser {
         guard pos + 4 <= chars.count else { return nil }
         var value: UInt32 = 0
         for _ in 0..<4 {
-            guard let digit = chars[pos].hexDigitValue else { return nil }
-            value = value * 16 + UInt32(digit)
+            guard let digit = asciiHexValue(chars[pos]) else { return nil }
+            value = value * 16 + digit
             pos += 1
         }
         return Unicode.Scalar(value)
+    }
+
+    /// ASCII hex digit value (0–15), or nil.  JSON `\uXXXX` escapes are ASCII
+    /// hex by definition, so this is behaviour-identical to
+    /// `Character.hexDigitValue` — but it avoids pulling Unicode numeric-property
+    /// tables into the Embedded wasm build.
+    private func asciiHexValue(_ c: Character) -> UInt32? {
+        guard let b = c.asciiValue else { return nil }
+        switch b {
+        case 0x30...0x39: return UInt32(b - 0x30)  // 0–9
+        case 0x41...0x46: return UInt32(b - 0x41 + 10)  // A–F
+        case 0x61...0x66: return UInt32(b - 0x61 + 10)  // a–f
+        default: return nil
+        }
     }
 
     private mutating func parseNumber() -> JSONValue? {

--- a/Sources/RunnerCore/ScriptClassification.swift
+++ b/Sources/RunnerCore/ScriptClassification.swift
@@ -47,7 +47,7 @@ public func classifyScriptInterpreter(name: String, source: String) -> ScriptInt
 /// Map a `#!` shebang on the first line to an interpreter. Order matters:
 /// "bash"/"zsh" are checked before "sh" (a substring of "bash").
 private func interpreterFromShebang(_ source: String) -> ScriptInterpreter? {
-    let firstLine = firstNonEmptyTrimmedLine(source).lowercased()
+    let firstLine = asciiLowercased(firstNonEmptyTrimmedLine(source))
     guard firstLine.hasPrefix("#!") else { return nil }
     if containsSubstring(firstLine, "python") { return .python }
     if containsSubstring(firstLine, "node") || containsSubstring(firstLine, "javascript") { return .node }
@@ -85,7 +85,7 @@ private func fileExtensionLowercased(_ name: String) -> String {
     let baseStart = name.lastIndex(of: "/").map { name.index(after: $0) } ?? name.startIndex
     let base = name[baseStart...]
     guard let dot = base.lastIndex(of: "."), dot != base.startIndex else { return "" }
-    return base[base.index(after: dot)...].lowercased()
+    return asciiLowercased(String(base[base.index(after: dot)...]))
 }
 
 /// First non-empty line with leading BOM/whitespace trimmed.
@@ -100,6 +100,22 @@ private func firstNonEmptyTrimmedLine(_ source: String) -> String {
 private func trimHorizontalWhitespace(_ s: String) -> String {
     let isHWS: (Character) -> Bool = { $0 == " " || $0 == "\t" }
     return String(s.drop(while: isHWS).reversed().drop(while: isHWS).reversed())
+}
+
+/// ASCII-only lowercase.  Shebang lines and file extensions are ASCII, so this
+/// is behaviour-identical to `lowercased()` for the inputs we classify — but it
+/// avoids linking Embedded Swift's Unicode case-folding tables into the wasm
+/// binary (and sidesteps locale-style folding surprises like Turkish İ).
+private func asciiLowercased(_ s: String) -> String {
+    var out = ""
+    for scalar in s.unicodeScalars {
+        if scalar.value >= 0x41 && scalar.value <= 0x5A {  // A–Z → a–z
+            out.unicodeScalars.append(Unicode.Scalar(UInt8(scalar.value + 0x20)))
+        } else {
+            out.unicodeScalars.append(scalar)
+        }
+    }
+    return out
 }
 
 /// Substring search without the string-processing module (absent in Embedded Swift).

--- a/changelog.d/wasm-ascii-shrink.md
+++ b/changelog.d/wasm-ascii-shrink.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Leaner Embedded-Swift wasm runner.** `RunnerCore`'s ASCII-domain string
+  operations (shebang/extension lowercasing, JSON `\uXXXX` hex parsing) now use
+  ASCII-only helpers instead of `lowercased()` / `Character.hexDigitValue`,
+  which avoids linking Unicode case-folding / numeric-property tables into the
+  browser wasm build. Behaviour is identical for these ASCII inputs (pinned by
+  the shared `output-contract.json`). The `wasm-opt` invocation also gains
+  `--converge --strip-producers`. The shipped bytes change only when the wasm is
+  re-vendored (`scripts/build-runner-wasm.sh`).

--- a/scripts/build-runner-wasm.sh
+++ b/scripts/build-runner-wasm.sh
@@ -56,8 +56,11 @@ unopt_size=$(wc -c < "$pkg/RunnerWasm.wasm")
 # a correct, working artifact.
 opt_wasm="$out_dir/.RunnerWasm.opt.wasm"
 if npx --yes wasm-opt --version >/dev/null 2>&1; then
-    echo "Optimizing with wasm-opt -Oz…"
-    npx --yes wasm-opt -Oz "$pkg/RunnerWasm.wasm" -o "$opt_wasm"
+    echo "Optimizing with wasm-opt -Oz --converge --strip-producers…"
+    # --converge: re-run passes to fixpoint for a little extra size.
+    # --strip-producers: drop the toolchain "producers" metadata section (the
+    # exported grading functions the JS loader calls are unaffected).
+    npx --yes wasm-opt -Oz --converge --strip-producers "$pkg/RunnerWasm.wasm" -o "$opt_wasm"
 else
     echo "WARNING: wasm-opt unavailable — vendoring the UNOPTIMIZED module."
     cp "$pkg/RunnerWasm.wasm" "$opt_wasm"


### PR DESCRIPTION
## What

The "safe-only" slice of the WASM-shrink investigation. The browser wasm is already well-optimized (`-Oz`, `wasm-opt -Oz`, content-hashed, brotli ~394 KB, immutably cached). The one remaining lever is the **Embedded-Swift Unicode property tables**, which get linked in by full-Unicode `String` operations in `RunnerCore`.

This PR removes the **behaviour-identical** ones:
- `lowercased()` → an ASCII-only helper in `ScriptClassification.swift` (shebang line + file extension — both ASCII domains; also avoids locale-style folding like Turkish İ).
- `Character.hexDigitValue` → an ASCII hex helper in `JSONLite.swift` (JSON `\uXXXX` escapes are ASCII hex by definition).
- `wasm-opt` gains `--converge --strip-producers` (drops toolchain metadata; exported grading functions are unaffected).

The `NotebookExtraction` property checks (`isLetter`/`isNumber`/`isWhitespace`) are **deliberately left alone** — Python 3 allows non-ASCII identifiers, so ASCII-only checks there would be a real (if rare) behaviour change in the bare-code-wrapping heuristic, which isn't covered by the parity contract.

## Honest caveats
- **Shipped bytes don't change in this PR.** `Public/runner-wasm/*.wasm` is checked-in generated output; regenerating it needs the Swift wasm SDK (not available in the session that wrote this). This is **source + build groundwork** so the *next* re-vendor (`scripts/build-runner-wasm.sh`) is leaner — the byte delta then shows up in CI's `runner-size-baseline.txt` report.
- **The win may be modest.** Because some `String` machinery is used elsewhere, removing these sites may not drop the tables entirely (which is why I left this as the "safe-only" slice rather than the full conversion). The compressed-wire impact is smaller than the uncompressed, since tables compress well.

## Testing
- Native `swift build` ✅ · swift-format `--strict` ✅ · SwiftLint `--strict` (0/483) ✅
- `OutputContractTests`, `SuiteExecutionTests`, `JSONFooterNumberParsingTests`, `ScriptInvocationTests`, `NotebookFunctionScannerTests` (50 tests) ✅ — behaviour identical.

Marked **draft**: it's groundwork pending a re-vendor to measure the actual byte delta. Happy to do the full conversion (incl. `NotebookExtraction`, with added Unicode-identifier tests) if the maintainer wants the bigger swing.

https://claude.ai/code/session_01BcnneMQbfkdE7Rojd6J6Db

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcnneMQbfkdE7Rojd6J6Db)_