### PR TITLE
fix: unblock MCP OAuth consent redirect (CSP form-action + COOP)

### DIFF
--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -56,6 +56,16 @@ struct MCPOAuthRoutes: Sendable {
             throw Abort(.badRequest, reason: "redirect_uri is not registered for this client.")
         }
 
+        // The Authorize button POSTs here and the server 303s to the client's
+        // (now-validated) redirect_uri. Browsers enforce `form-action` across
+        // that redirect, so the default `form-action 'self'` would silently
+        // block the hop to the connector — add the redirect origin. Likewise a
+        // connector may drive this in a popup expecting a `window.opener`
+        // handshake, which the default COOP `same-origin` severs; relax it.
+        SecurityHeadersMiddleware.allowFormAction(
+            SecurityHeadersMiddleware.cspOrigin(of: query.redirectURI), on: req)
+        SecurityHeadersMiddleware.setOpenerPolicy("same-origin-allow-popups", on: req)
+
         guard query.responseType == "code" else {
             return redirect(query.redirectURI, error: "unsupported_response_type", state: query.state)
         }

--- a/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
+++ b/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
@@ -41,8 +41,13 @@
 //   Cross-Origin-Opener-Policy: same-origin
 //     Severs the `window.opener` reference when our pages are opened from a
 //     third-party origin, mitigating tab-nabbing attacks and isolating our
-//     browsing-context group.  Chickadee's auth flows are redirects, not
-//     popups, so cutting the opener reference does not break anything.
+//     browsing-context group.  Most Chickadee auth flows are redirects, not
+//     popups, so cutting the opener reference does not break anything.  The
+//     exception is the MCP OAuth consent screen: a connector (e.g. Claude)
+//     may drive `/oauth/authorize` in a popup and expect a
+//     `window.opener.postMessage` handshake after the redirect, which
+//     `same-origin` would sever.  A handler can therefore relax COOP for a
+//     single response via `SecurityHeadersMiddleware.setOpenerPolicy(_:on:)`.
 //
 //   Cross-Origin-Resource-Policy: same-origin
 //     Stops third-party origins from embedding our resources (scripts,
@@ -65,6 +70,37 @@
 import Vapor
 
 struct SecurityHeadersMiddleware: AsyncMiddleware {
+    /// Per-request extra `form-action` CSP origins.  A handler that renders a
+    /// page whose form submits (directly or via a redirect) to a validated
+    /// cross-origin URL sets this so the global `form-action 'self'` doesn't
+    /// block the navigation.  The MCP consent page uses it: its Authorize
+    /// button 303s to the OAuth client's registered `redirect_uri`, and Chrome
+    /// / Firefox enforce `form-action` across that redirect chain.
+    private struct FormActionOriginsKey: StorageKey {
+        typealias Value = [String]
+    }
+
+    /// Per-request `Cross-Origin-Opener-Policy` override.  Lets a handler relax
+    /// the default `same-origin` for a single response (e.g. the OAuth consent
+    /// page, which a connector may open as a popup that needs its `opener`).
+    private struct OpenerPolicyKey: StorageKey {
+        typealias Value = String
+    }
+
+    /// Appends a validated origin (`scheme://host[:port]`) to this response's
+    /// `form-action` allow-list.  No-op when `origin` is nil.
+    static func allowFormAction(_ origin: String?, on request: Request) {
+        guard let origin else { return }
+        var origins = request.storage[FormActionOriginsKey.self] ?? []
+        if !origins.contains(origin) { origins.append(origin) }
+        request.storage[FormActionOriginsKey.self] = origins
+    }
+
+    /// Overrides the `Cross-Origin-Opener-Policy` header for this one response.
+    static func setOpenerPolicy(_ value: String, on request: Request) {
+        request.storage[OpenerPolicyKey.self] = value
+    }
+
     /// CSP for application pages.  Permissive enough to keep JupyterLite,
     /// Pyodide, and the CodeMirror-based assignment editor functional:
     ///   - 'unsafe-eval' is required by Pyodide's WASM bootstrap.
@@ -216,8 +252,10 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
         response.headers.replaceOrAdd(name: "Permissions-Policy", value: permissionsPolicy)
         // COOP is set unconditionally; COEPMiddleware may override it for the
         // narrow set of pages that need cross-origin isolation, but its value
-        // is `same-origin` too so the replaceOrAdd is a no-op there.
-        response.headers.replaceOrAdd(name: "Cross-Origin-Opener-Policy", value: crossOriginOpenerPolicy)
+        // is `same-origin` too so the replaceOrAdd is a no-op there.  A handler
+        // can relax it per-response (the OAuth consent popup) via the override.
+        let coop = request.storage[OpenerPolicyKey.self] ?? crossOriginOpenerPolicy
+        response.headers.replaceOrAdd(name: "Cross-Origin-Opener-Policy", value: coop)
         response.headers.replaceOrAdd(name: "Cross-Origin-Resource-Policy", value: crossOriginResourcePolicy)
         if let hsts = strictTransportSecurity {
             response.headers.replaceOrAdd(name: "Strict-Transport-Security", value: hsts)
@@ -229,10 +267,14 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
     /// redirected to after POST /logout.  Without it in form-action, the
     /// redirect chain is blocked and "Log out" silently does nothing.
     private func formActionExtras(for request: Request) -> [String] {
-        guard
-            let endpoint = request.application.oidcConfig?.discovery.endSessionEndpoint,
-            let origin = Self.cspOrigin(of: endpoint)
-        else { return [] }
-        return [origin]
+        // Per-request origins set by a handler (e.g. the OAuth consent page's
+        // redirect_uri) come first, then the SSO end_session_endpoint origin.
+        var origins = request.storage[FormActionOriginsKey.self] ?? []
+        if let endpoint = request.application.oidcConfig?.discovery.endSessionEndpoint,
+            let origin = Self.cspOrigin(of: endpoint), !origins.contains(origin)
+        {
+            origins.append(origin)
+        }
+        return origins
     }
 }

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -47,6 +47,14 @@ import XCTVapor
             res.headers.contentType = .html
             return res
         }
+        // Mimics the MCP consent page: a handler that relaxes form-action +
+        // COOP for a single response so its Authorize-button redirect to a
+        // cross-origin connector isn't blocked.
+        app.get("consent-style") { req -> Response in
+            SecurityHeadersMiddleware.allowFormAction("https://app.example", on: req)
+            SecurityHeadersMiddleware.setOpenerPolicy("same-origin-allow-popups", on: req)
+            return Response(status: .ok, body: .init(string: "ok"))
+        }
         return app
     }
 
@@ -205,6 +213,29 @@ import XCTVapor
                         "\(name) must contain no external origins (Pyodide is served same-origin); got: \(directive ?? "<nil>")"
                     )
                 }
+            }
+        }
+    }
+
+    @Test func consentPageRelaxesFormActionAndOpenerPolicy() async throws {
+        // Regression: the MCP consent Authorize button POSTs and the server
+        // 303s to the OAuth client's redirect_uri. Browsers enforce
+        // `form-action` across that redirect, so the default `form-action
+        // 'self'` silently blocks the hop back to the connector (the consent
+        // token burns, the page just sits there — the reported symptom). The
+        // page must add the redirect origin to form-action and relax COOP so a
+        // popup-driven connector keeps its `window.opener`.
+        try await withApp(try await makeSecurityHeadersApp()) { app in
+            try await app.asyncTest(.GET, "/consent-style") { res in
+                #expect(res.status == .ok)
+                let csp = res.headers.first(name: "Content-Security-Policy") ?? ""
+                #expect(
+                    csp.contains("form-action 'self' https://app.example"),
+                    "expected redirect origin in form-action, got: \(csp)"
+                )
+                #expect(
+                    res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin-allow-popups"
+                )
             }
         }
     }

--- a/changelog.d/mcp-oauth-consent-form-action.md
+++ b/changelog.d/mcp-oauth-consent-form-action.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **MCP OAuth "Authorize" button silently did nothing.** Clicking *Authorize*
+  on the connector consent screen consumed the single-use token but never
+  navigated back to the connector, so a second click reported "this
+  authorization request has expired or already been used." The consent POST
+  303-redirects to the OAuth client's `redirect_uri`, and browsers enforce the
+  CSP `form-action` directive across that redirect — the default `form-action
+  'self'` blocked the hop to the connector's origin. `GET /oauth/authorize` now
+  adds the validated `redirect_uri` origin to `form-action` (mirroring the
+  existing SSO-logout fix) and relaxes `Cross-Origin-Opener-Policy` to
+  `same-origin-allow-popups` so a popup-driven connector keeps its
+  `window.opener` handshake. Both are scoped to the consent response only.


### PR DESCRIPTION
## Symptom

Connecting Claude to the Chickadee MCP server reached the authorization page, but clicking **Authorize** did nothing. A second click reported:

> This authorization request has expired or already been used. Restart the connection to try again.

## Root cause

The first click was actually **succeeding on the server**: `authorizeSubmit` (`MCPOAuthRoutes.swift`) burned the single-use consent token, minted the authorization code, and returned a `303` redirect to the OAuth client's `redirect_uri` (`https://claude.ai/...`). That's why the second click hit the "already used" guard — the token was consumed by the first click.

The problem was that **the browser never followed that 303**. Every response gets a global CSP from `SecurityHeadersMiddleware` whose `form-action` directive is `'self'` (plus the SSO endpoint). Chrome/Firefox enforce `form-action` **across the redirect chain** after a form submission, so the `POST /oauth/authorize → 303 → https://claude.ai/...` hop was silently blocked — the consent token burned, the page just sat there.

This is the same class of bug the codebase already fixed for SSO logout (`POST /logout → 303 → end_session_endpoint`), documented at `SecurityHeadersMiddleware.swift:93‑98`. The MCP consent form has the identical shape, but its redirect target was never added to `form-action`.

A secondary issue: `Cross-Origin-Opener-Policy: same-origin` assumes "auth flows are redirects, not popups." A popup-driven connector relying on `window.opener.postMessage` would still break after the redirect was unblocked.

## Fix

`GET /oauth/authorize` now, for the validated client + `redirect_uri`:
- appends the `redirect_uri` origin to the response's `form-action` allow-list (mirrors the SSO-logout fix), and
- relaxes `Cross-Origin-Opener-Policy` to `same-origin-allow-popups`.

Both are applied **per-response only** via a new request-storage seam on `SecurityHeadersMiddleware` (`allowFormAction(_:on:)` / `setOpenerPolicy(_:on:)`); every other response keeps the strict `form-action 'self'` + `COOP: same-origin` defaults. The redirect origin is added only after the client and `redirect_uri` are validated against the registered client, so this is not an open `form-action`.

## Tests

- New `consentPageRelaxesFormActionAndOpenerPolicy` in `SecurityAndHealthTests` exercises the per-response seam through the real middleware.
- Existing `MCPOAuthFlowTests` (full consent → code → token → refresh) and the rest of `SecurityAndHealthTests` pass unchanged (33 tests green).
- `swift build`, `scripts/format.sh`, and `scripts/swiftlint.sh --strict` all clean.

## How to verify against a live connector

After deploy, the consent page (`GET /oauth/authorize?...`) response should carry `Content-Security-Policy: ...; form-action 'self' https://claude.ai` and `Cross-Origin-Opener-Policy: same-origin-allow-popups`. Clicking **Authorize** should now redirect straight back to the connector and complete the token exchange.

https://claude.ai/code/session_01HXCKCibYyBCW2DuGyJ4Fda

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXCKCibYyBCW2DuGyJ4Fda)_