### PR TITLE
Student self-service notebook reset + clearer reset icon

### DIFF
--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -71,7 +71,7 @@
                         <button class="btn action-btn action-danger" type="submit"
                                 aria-label="Reset notebook to starter" title="Reset notebook to starter (past submissions unaffected)"
                                 style="padding:.25rem .35rem">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
                         </button>
                     </form>
                 </div>

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -116,6 +116,18 @@
                     </a>
                     #endif
                     #endif
+                    #if(setup.isOpen):
+                    #if(setup.hasNotebook):
+                    <form method="post" action="/testsetups/#(setup.id)/reset-notebook" onsubmit="return confirm('Reset your notebook back to the original starter? This discards your current edits for this assignment. Your past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger" type="submit"
+                                title="Reset notebook to starter (discards current edits; past submissions unaffected)"
+                                aria-label="Reset notebook to starter" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
+                    #endif
+                    #endif
                 </div>
             </td>
         </tr>
@@ -219,6 +231,18 @@
                     </a>
                     #endif
                     #endif
+                    #if(setup.isOpen):
+                    #if(setup.hasNotebook):
+                    <form method="post" action="/testsetups/#(setup.id)/reset-notebook" onsubmit="return confirm('Reset your notebook back to the original starter? This discards your current edits for this assignment. Your past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger" type="submit"
+                                title="Reset notebook to starter (discards current edits; past submissions unaffected)"
+                                aria-label="Reset notebook to starter" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
+                    #endif
+                    #endif
                 </div>
             </td>
         </tr>
@@ -320,6 +344,18 @@
                        title="Upload" aria-label="Upload" style="padding:.3rem .45rem">
                         <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="21" x2="12" y2="4"/><polyline points="6 10 12 4 18 10"/><path d="M4 21h16"/></svg>
                     </a>
+                    #endif
+                    #endif
+                    #if(setup.isOpen):
+                    #if(setup.hasNotebook):
+                    <form method="post" action="/testsetups/#(setup.id)/reset-notebook" onsubmit="return confirm('Reset your notebook back to the original starter? This discards your current edits for this assignment. Your past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger" type="submit"
+                                title="Reset notebook to starter (discards current edits; past submissions unaffected)"
+                                aria-label="Reset notebook to starter" style="padding:.3rem .45rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
                     #endif
                     #endif
                 </div>

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -102,6 +102,53 @@ extension WebRoutes {
         ).encodeResponse(for: req)
     }
 
+    // MARK: - POST /testsetups/:id/reset-notebook
+    //
+    // Student self-service reset of their *own* working-copy notebook back to
+    // the assignment's canonical starter.  Mirrors the instructor-driven
+    // `resetStudentNotebook`, but scoped to the caller and gated on the
+    // assignment being open to them — `requireOpenStudentAssignment` enforces
+    // course enrollment and effective-open state, throwing `.closed` for a
+    // closed / not-yet-open assignment and `.notFound` for an unenrolled
+    // student.  Past submissions are never touched: only the live working copy
+    // at jupyterlite/files/users/{userID}/{setupID}/<filename> is overwritten.
+    @Sendable
+    func resetOwnNotebook(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard let userID = user.id else { throw Abort(.unauthorized) }
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let setup = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+
+        // A bare test setup with no assignment row is not a student-facing
+        // assignment; `requireOpenStudentAssignment` returns nil there without
+        // an enrollment check, so reject it explicitly to avoid a bypass.
+        guard try await requireOpenStudentAssignment(for: setupID, user: user, on: req) != nil else {
+            throw Abort(.notFound)
+        }
+
+        let starter: Data
+        do {
+            starter = try notebookData(for: setup)
+        } catch {
+            throw Abort(.badRequest, reason: "This assignment has no starter notebook to reset to.")
+        }
+
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setupID,
+            userID: userID,
+            fallbackSetup: setup,
+            overwriteWith: starter
+        )
+
+        req.logger.info("student_self_notebook_reset setup=\(setupID) student=\(userID.uuidString)")
+        return req.redirect(to: "/")
+    }
+
     /// Renders the submission-view branch of `notebookPage` (read-only,
     /// per-submission working copy, fresh JupyterLite workspace).
     private func renderSubmissionNotebookView(

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -29,6 +29,7 @@ struct WebRoutes: RouteCollection {
         routes.get("testsetups", ":testSetupID", "history", use: submissionHistoryPage)
         routes.get("testsetups", ":testSetupID", "notebook", use: notebookPage)
         routes.get("testsetups", ":testSetupID", "notebook", "source", use: notebookSource)
+        routes.post("testsetups", ":testSetupID", "reset-notebook", use: resetOwnNotebook)
         routes.get("submissions", ":submissionID", use: submissionPage)
     }
 

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -131,12 +131,14 @@ import XCTVapor
         testSetupID: String,
         title: String,
         dueAt: Date? = nil,
+        startsAt: Date? = nil,
         isOpen: Bool = true
     ) async throws -> APIAssignment {
         let assignment = APIAssignment(
             testSetupID: testSetupID,
             title: title,
             dueAt: dueAt,
+            startsAt: startsAt,
             isOpen: isOpen,
             courseID: try await makeCourse().requireID()
         )
@@ -362,6 +364,112 @@ import XCTVapor
                 afterResponse: { res in
                     #expect(res.status == .seeOther)
                     #expect(res.headers.first(name: .location) == "/")
+                })
+        }
+    }
+
+    @Test func notebookPageNotYetOpenAssignmentRedirectsToDashboard() async throws {
+        try await withApp(app) { _ in
+            // A student following a pre-posted link to an assignment whose open
+            // date is still in the future is bounced to their dashboard rather
+            // than into the notebook — the future `startsAt` holds it closed for
+            // everyone, so the closed-assignment gate fires just as it does for a
+            // past-deadline lab.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_not_yet_open"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Future"))
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Scheduled Lab",
+                dueAt: Date(timeIntervalSinceNow: 7 * 24 * 3600),
+                startsAt: Date(timeIntervalSinceNow: 24 * 3600),
+                isOpen: false
+            )
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/")
+                })
+        }
+    }
+
+    @Test func resetOwnNotebookRestoresStarterForOpenAssignment() async throws {
+        try await withApp(app) { _ in
+            // A student self-resets their own working copy: the corrupted copy is
+            // overwritten with the canonical starter and they are bounced back to
+            // the dashboard.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+            let userID = try user.requireID()
+
+            let setupID = "setup_nb_self_reset"
+            let starterMarker = "Original starter cell"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: starterMarker))
+            _ = try await insertAssignment(testSetupID: setupID, title: "Self Reset Lab", isOpen: true)
+
+            // Simulate the student having clobbered their own working copy.
+            let copyPath = workingCopyPath(setupID: setupID, userID: userID)
+            try FileManager.default.createDirectory(
+                atPath: (copyPath as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true)
+            try Data(notebookJSON(markdown: "Broken edits").utf8)
+                .write(to: URL(fileURLWithPath: copyPath))
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/testsetups/\(setupID)/reset-notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/")
+                })
+
+            let restored = try String(contentsOf: URL(fileURLWithPath: copyPath), encoding: .utf8)
+            #expect(restored.contains(starterMarker))
+            #expect(restored.contains("Broken edits") == false)
+        }
+    }
+
+    @Test func resetOwnNotebookRejectedForClosedAssignment() async throws {
+        try await withApp(app) { _ in
+            // The self-reset route is gated on the assignment being open to the
+            // student; a past-deadline assignment is refused with 403.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_self_reset_closed"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Starter"))
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Closed Self Reset Lab",
+                dueAt: Date(timeIntervalSinceNow: -3600),
+                isOpen: true
+            )
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/testsetups/\(setupID)/reset-notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
                 })
         }
     }

--- a/changelog.d/student-notebook-reset.md
+++ b/changelog.d/student-notebook-reset.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Students can reset their own notebook to the starter.** The student
+  dashboard gains a per-assignment reset action (`POST
+  /testsetups/:id/reset-notebook`) that restores the canonical starter
+  notebook over their working copy. It is gated on course enrollment and the
+  assignment being open to that student, and never touches past submissions.
+
+### Changed
+
+- **Instructor "reset notebook" icon no longer looks like a delete button.**
+  The per-student reset control on the submissions page now uses a
+  counterclockwise "restore" glyph instead of a trash can, so it reads as
+  "restore the starter" rather than "delete submissions" (which it never did).


### PR DESCRIPTION
## Summary

- **Student dashboard reset action.** Adds `POST /testsetups/:id/reset-notebook` and a per-assignment reset button on the student dashboard so a student who has clobbered their working copy can restore the canonical starter themselves. Reuses the instructor reset mechanism (`ensureUserNotebookWorkingCopy(overwriteWith: starter)`) but is scoped to the caller and gated on **course enrollment** + the assignment being **open to that student** (`requireOpenStudentAssignment`). Past submissions are never touched; CSRF-protected like the rest of the dashboard.
- **Clearer instructor reset icon.** The per-student reset control on the instructor submissions page used a trash-can glyph, which read as "delete this student's submissions" — it never did that. Swapped for a counterclockwise "restore" arrow so the icon matches the behavior.

## Why

The trash icon was a UX trap, and there was no way for a student to recover from a broken `.ipynb` without emailing an instructor. Both fixes are small and reuse existing, tested machinery.

## Notes

- The student button shows only when the assignment `isOpen` for that student **and** `hasNotebook`; the server refuses out-of-window resets (403) regardless, so a stale link can't wipe finished work after the deadline.
- The mtime-based force-reseed in `notebook.js` means the student's JupyterLite editor picks up the fresh starter on next open without clearing site data.

## Test plan

- [x] `swift build` (local Xcode toolchain) — clean
- [x] `swift test --filter NotebookWebRoutesTests` — 19/19 pass, incl. new `resetOwnNotebookRestoresStarterForOpenAssignment` (restores starter, redirects to `/`) and `resetOwnNotebookRejectedForClosedAssignment` (403)
- [x] `scripts/format.sh` + `scripts/swiftlint.sh` — 0 violations
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)