### PR TITLE
feat(mcp): expose personalization over MCP — part 2, section variables

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -85,7 +85,8 @@ enum MCPServerInstructions {
         student: literal `variables` (a name + JSON value) and `expressions` (a name + Python source \
         evaluated against the student's `seed`). They inline into generated/raw tests and substitute \
         into the starter notebook's `{{name}}` placeholders. Read with get_global_inputs, replace \
-        with update_global_inputs.
+        with update_global_inputs. Sections can also carry their own scoped variables/expressions \
+        (same shape); get_suite returns them per section and update_section_variables replaces them.
         - Validation — the server validates an assignment's suite against its solution; an assignment \
         cannot be opened (isOpen=true) until validation passes.
 
@@ -94,8 +95,9 @@ enum MCPServerInstructions {
         2. Inspect before editing: get_assignment, get_suite, get_notebook, get_global_inputs.
         3. Edit: update_assignment (metadata), update_suite (script metadata), update_pattern_family \
         (family defaults/cases), update_global_inputs (personalization variables/expressions), \
-        update_notebook (replace the starter notebook). To create a new assignment, clone_assignment \
-        from a known-good one and then edit the copy.
+        update_section_variables (a section's scoped variables/expressions), update_notebook (replace \
+        the starter notebook). To create a new assignment, clone_assignment from a known-good one and \
+        then edit the copy.
 
         Important behaviors:
         - Any content edit (suite, pattern family, notebook) re-runs validation asynchronously; \

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -20,6 +20,10 @@ struct GetSuiteTool: ContentTool {
         struct Section: Encodable, Sendable {
             let id: String
             let name: String
+            /// Section-scoped literal personalization values (name + JSON value).
+            let variables: [FamilyVariable]
+            /// Section-scoped per-student expressions (name + Python source).
+            let expressions: [PersonalizationExpression]
         }
         struct Item: Encodable, Sendable {
             /// "script", "family", or "check".
@@ -70,6 +74,8 @@ struct GetSuiteTool: ContentTool {
                     "properties": .object([
                         "id": .object(["type": .string("string")]),
                         "name": .object(["type": .string("string")]),
+                        "variables": .object(["type": .string("array")]),
+                        "expressions": .object(["type": .string("array")]),
                     ]),
                     "required": .array([.string("id"), .string("name")]),
                 ]),
@@ -116,7 +122,19 @@ struct GetSuiteTool: ContentTool {
 
         // No zip path → metadata-only rows (raw script bodies omitted).
         let payload = buildSuitePayload(fromManifest: setup.manifest)
-        let sections = payload.sections.map { Output.Section(id: $0.id, name: $0.name) }
+        // Section variables/expressions live on the manifest's section list,
+        // not on the suite-payload DTO (which carries only id + name).
+        let sectionInputs = Dictionary(
+            uniqueKeysWithValues: (setup.decodedManifest()?.sections ?? []).map {
+                ($0.id, (variables: $0.variables, expressions: $0.expressions))
+            })
+        let sections = payload.sections.map { section in
+            Output.Section(
+                id: section.id,
+                name: section.name,
+                variables: sectionInputs[section.id]?.variables ?? [],
+                expressions: sectionInputs[section.id]?.expressions ?? [])
+        }
         let items = payload.items.map { Self.item(from: $0) }
         return Output(assignmentPublicID: assignment.publicID, sections: sections, items: items)
     }

--- a/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
@@ -1,0 +1,149 @@
+// APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
+//
+// Write tool: replace one test-suite section's personalization inputs — the
+// section-scoped literal `variables` and per-student `expressions` — by
+// assignment public ID + section id.  content:write, course-scoped.  Mirrors
+// `POST /instructor/:assignmentID/suite-sections/:sectionID/variables` and drives
+// the same `SectionInputsService.apply` path the web editor uses, so the same
+// validation runs (identifier-shape names, the reserved `seed` name, uniqueness
+// within the section, no clash with globals or any other section, and a
+// save-time eval against the acting account's own seed).
+//
+// Both lists are REPLACED wholesale — send the complete desired set.  Section
+// ids come from get_suite.  This only touches the section's variables/
+// expressions; it does not re-render generated tests.
+
+import Core
+import Fluent
+import Foundation
+
+struct UpdateSectionVariablesTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        let sectionID: String
+        let variables: [FamilyVariable]
+        let expressions: [PersonalizationExpression]?
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let sectionID: String
+        let variables: [FamilyVariable]
+        let expressions: [PersonalizationExpression]
+    }
+
+    static let name = "update_section_variables"
+    static let description =
+        "Replace one test-suite section's personalization inputs, by assignment public ID + section "
+        + "id (from get_suite). Provide the full desired `variables` (literal name + JSON value) and "
+        + "`expressions` (name + Python source evaluated per-student against `seed`); both lists are "
+        + "replaced wholesale, not merged. Names must be valid Python identifiers, unique within the "
+        + "section, and must not clash with global inputs or any other section; `seed` is reserved. "
+        + "Each expression is eval-checked against your own seed before saving."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "sectionID": .object([
+                "type": .string("string"),
+                "description": .string("The section's id (from get_suite)."),
+            ]),
+            "variables": .object([
+                "type": .string("array"),
+                "description": .string("Replacement literal values; send [] to clear."),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "name": .object([
+                            "type": .string("string"),
+                            "description": .string("Valid Python identifier; not \"seed\"."),
+                        ]),
+                        "value": .object([
+                            "description": .string("Any JSON-expressible Python literal (scalar, list, dict).")
+                        ]),
+                    ]),
+                    "required": .array([.string("name"), .string("value")]),
+                    "additionalProperties": .bool(false),
+                ]),
+            ]),
+            "expressions": .object([
+                "type": .string("array"),
+                "description": .string("Replacement per-student expressions; omit or send [] to clear."),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "name": .object([
+                            "type": .string("string"),
+                            "description": .string("Valid Python identifier; not \"seed\"."),
+                        ]),
+                        "expression": .object([
+                            "type": .string("string"),
+                            "description": .string("Python expression; `seed` and every variable are in scope."),
+                        ]),
+                    ]),
+                    "required": .array([.string("name"), .string("expression")]),
+                    "additionalProperties": .bool(false),
+                ]),
+            ]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("sectionID"), .string("variables"),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "sectionID": .object(["type": .string("string")]),
+            "variables": .object(["type": .string("array")]),
+            "expressions": .object(["type": .string("array")]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("sectionID"), .string("variables"),
+            .string("expressions"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        let actingUser = try await context.requireEligibleSubject(tool: Self.name)
+
+        do {
+            try await SectionInputsService.apply(
+                setup: setup,
+                sectionID: input.sectionID,
+                inputs: .init(variables: input.variables, expressions: input.expressions ?? []),
+                seed: .init(
+                    actingUserID: actingUser.id,
+                    assignmentID: assignment.id,
+                    testSetupID: assignment.testSetupID,
+                    testSetupsDirectory: context.request.application.testSetupsDirectory),
+                on: context.db)
+        } catch let error as WebAssignmentError {
+            throw MCPToolError.from(error, tool: Self.name)
+        }
+
+        let reloaded = try SectionInputsService.current(setup: setup, sectionID: input.sectionID)
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            sectionID: input.sectionID,
+            variables: reloaded?.variables ?? input.variables,
+            expressions: reloaded?.expressions ?? (input.expressions ?? []))
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -26,6 +26,7 @@ enum MCPToolCatalog {
             UpdateAssignmentTool().erased(),
             UpdateSuiteTool().erased(),
             UpdateGlobalInputsTool().erased(),
+            UpdateSectionVariablesTool().erased(),
             UpdatePatternFamilyTool().erased(),
             UpdateNotebookTool().erased(),
             CloneAssignmentTool().erased(),

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SuiteSections.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SuiteSections.swift
@@ -136,204 +136,23 @@ extension PublishedAssignmentRoutes {
             throw WebAssignmentError.notFound(resource: "Section")
         }
         let body = try req.content.decode(Body.self)
-        let expressions = body.expressions ?? []
 
-        // Per-row validation across both literal vars and expressions in
-        // this section.  Names are unique across both kinds (single
-        // Python namespace at evaluation time).
-        let seenNames = try validateSectionInputNames(
-            variables: body.variables, expressions: expressions)
+        // The save-time eval runs against the acting instructor's own seed.
+        let actingUserID = (try? req.auth.require(APIUser.self))?.id
 
-        // Cross-section + global clash check.
-        guard let manifestData = setup.manifest.data(using: .utf8),
-            let manifest = try? ManifestCodec.decoder.decode(
-                TestProperties.self,
-                from: manifestData)
-        else {
-            throw WebAssignmentError.internalFailure(reason: "Manifest is not valid JSON.")
-        }
-        try validateSectionInputsAgainstOtherScopes(
-            seenNames: seenNames,
-            manifest: manifest,
-            sectionID: sectionID
-        )
-
-        // Save-time eval check: run every expression once against the
-        // instructor's own seed so typos surface as a 400.
-        try await evaluateSectionExpressionsForInstructorSeed(
-            req: req,
-            assignment: assignment,
-            manifest: manifest,
-            sectionID: sectionID,
-            variables: body.variables,
-            expressions: expressions
-        )
-
-        try await persistSectionVariablesAndExpressions(
-            req: req,
+        try await SectionInputsService.apply(
             setup: setup,
             sectionID: sectionID,
-            variables: body.variables,
-            expressions: expressions
+            inputs: .init(variables: body.variables, expressions: body.expressions ?? []),
+            seed: .init(
+                actingUserID: actingUserID,
+                assignmentID: assignment.id,
+                testSetupID: assignment.testSetupID,
+                testSetupsDirectory: req.application.testSetupsDirectory),
+            on: req.db
         )
 
         return redirectToEdit(req: req)
-    }
-
-    // MARK: - updateSuiteSectionVariables helpers
-
-    /// Validates that every variable/expression name is a valid Python
-    /// identifier, not the reserved `seed`, and unique across both kinds.
-    /// Returns the deduplicated name set for downstream cross-scope
-    /// checks.
-    private func validateSectionInputNames(
-        variables: [FamilyVariable],
-        expressions: [PersonalizationExpression]
-    ) throws -> Set<String> {
-        var seenNames: Set<String> = []
-        for v in variables {
-            guard isValidPythonIdentifier(v.name) else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Section input name '\(v.name)' is not a valid Python identifier.")
-            }
-            guard v.name != "seed" else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "'seed' is reserved for Chickadee's personalization seed.")
-            }
-            guard seenNames.insert(v.name).inserted else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Duplicate section input name '\(v.name)'.")
-            }
-        }
-        for e in expressions {
-            guard isValidPythonIdentifier(e.name) else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Section expression name '\(e.name)' is not a valid Python identifier.")
-            }
-            guard e.name != "seed" else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "'seed' is reserved for Chickadee's personalization seed.")
-            }
-            let trimmed = e.expression.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Section expression '\(e.name)' has an empty body. "
-                        + "Provide a Python expression after the leading `=`.")
-            }
-            guard seenNames.insert(e.name).inserted else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Duplicate section input name '\(e.name)'. "
-                        + "Names must be unique across literal values and expressions.")
-            }
-        }
-        return seenNames
-    }
-
-    /// Cross-section + global clash: no name in this section's combined
-    /// namespace may collide with a name in `globalVariables`,
-    /// `globalExpressions`, or any OTHER section's variables/expressions.
-    private func validateSectionInputsAgainstOtherScopes(
-        seenNames: Set<String>,
-        manifest: TestProperties,
-        sectionID: String
-    ) throws {
-        var otherNames: Set<String> = []
-        for v in manifest.globalVariables { otherNames.insert(v.name) }
-        for e in manifest.globalExpressions { otherNames.insert(e.name) }
-        for section in manifest.sections where section.id != sectionID {
-            for v in section.variables { otherNames.insert(v.name) }
-            for e in section.expressions { otherNames.insert(e.name) }
-        }
-        for n in seenNames where otherNames.contains(n) {
-            throw WebAssignmentError.unprocessable(
-                reason: "Section input '\(n)' is already used by a global input or another section. "
-                    + "Names share one namespace across the assignment; rename to avoid shadowing.")
-        }
-    }
-
-    /// Runs every expression once against the instructor's own seed so
-    /// typos surface as a 400.  No-op when `expressions` is empty.
-    private func evaluateSectionExpressionsForInstructorSeed(
-        req: Request,
-        assignment: APIAssignment,
-        manifest: TestProperties,
-        sectionID: String,
-        variables: [FamilyVariable],
-        expressions: [PersonalizationExpression]
-    ) async throws {
-        guard !expressions.isEmpty,
-            let userID = (try req.auth.require(APIUser.self)).id,
-            let assignmentID = assignment.id
-        else { return }
-
-        let seedHex = try await AssignmentSeedStore.ensureSeed(
-            userID: userID, assignmentID: assignmentID, on: req.db)
-        // Combine: globals + section vars from THIS section's new
-        // list + other sections' vars (matches the runtime scope
-        // the evaluator will use at first-open).
-        var staticVars: [FamilyVariable] = manifest.globalVariables
-        staticVars.append(contentsOf: variables)
-        for section in manifest.sections where section.id != sectionID {
-            staticVars.append(contentsOf: section.variables)
-        }
-        do {
-            _ = try await PersonalizationEvaluator.evaluate(
-                seedHex: seedHex,
-                staticVariables: staticVars,
-                expressions: expressions,
-                supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(assignment.testSetupID)/"
-            )
-        } catch let PersonalizationEvaluatorError.nonZeroExit(_, stderr) {
-            let tail = stderr.split(separator: "\n").suffix(3).joined(separator: " ")
-            throw WebAssignmentError.unprocessable(
-                reason: "One of your section expressions failed to evaluate: \(tail). "
-                    + "Fix the expression(s) and save again.")
-        } catch PersonalizationEvaluatorError.timedOut {
-            throw WebAssignmentError.unprocessable(
-                reason: "Expression evaluation timed out (>5s). "
-                    + "Simplify the expressions or move heavy lifting into a support module.")
-        } catch {
-            throw WebAssignmentError.internalFailure(
-                reason: "Expression evaluator failed: \(error)")
-        }
-    }
-
-    private func persistSectionVariablesAndExpressions(
-        req: Request,
-        setup: APITestSetup,
-        sectionID: String,
-        variables: [FamilyVariable],
-        expressions: [PersonalizationExpression]
-    ) async throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let varData = try encoder.encode(variables)
-        let exprData = try encoder.encode(expressions)
-        guard let parsedVars = try JSONSerialization.jsonObject(with: varData) as? [Any],
-            let parsedExprs = try JSONSerialization.jsonObject(with: exprData) as? [Any]
-        else {
-            throw WebAssignmentError.internalFailure(reason: "Failed to re-serialise section inputs.")
-        }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            guard var sections = dict["sections"] as? [[String: Any]] else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            guard let idx = sections.firstIndex(where: { ($0["id"] as? String) == sectionID }) else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            if parsedVars.isEmpty {
-                sections[idx].removeValue(forKey: "variables")
-            } else {
-                sections[idx]["variables"] = parsedVars
-            }
-            if parsedExprs.isEmpty {
-                sections[idx].removeValue(forKey: "expressions")
-            } else {
-                sections[idx]["expressions"] = parsedExprs
-            }
-            dict["sections"] = sections
-        }
     }
 
     // MARK: - POST /instructor/:assignmentID/suite-sections/reorder

--- a/Sources/APIServer/Services/SectionInputsService.swift
+++ b/Sources/APIServer/Services/SectionInputsService.swift
@@ -1,0 +1,226 @@
+// APIServer/Services/SectionInputsService.swift
+//
+// HTTP-free core for a test-suite section's personalization inputs — the
+// section-scoped literal `variables` and per-student `expressions`.  Extracted
+// from `PublishedAssignmentRoutes+SuiteSections.swift` so the web POST handler
+// and the MCP `update_section_variables` tool drive the *same* validation +
+// persistence path.
+//
+// `apply` runs the section validation gauntlet (identifier-shape names, the
+// reserved `seed` name, uniqueness within the section, no clash with globals or
+// any OTHER section, and a save-time eval against the acting account's own
+// seed), then persists the section's variables/expressions onto the manifest.
+// Unlike global inputs it does NOT re-render through `applyPatternFamilies`:
+// section variables are read at generation/first-open time from the manifest,
+// and the web handler likewise only mutates `manifest.sections`.
+
+import Core
+import Fluent
+import Foundation
+
+enum SectionInputsService {
+
+    /// The two kinds of section input, bundled to keep the entry points within
+    /// the parameter-count budget.
+    struct Inputs: Sendable {
+        let variables: [FamilyVariable]
+        let expressions: [PersonalizationExpression]
+    }
+
+    /// Non-HTTP context for the save-time expression eval.
+    struct SeedContext: Sendable {
+        let actingUserID: UUID?
+        let assignmentID: UUID?
+        /// The test setup id, used to resolve the per-setup `shared/<id>/`
+        /// support-files directory.
+        let testSetupID: String
+        /// The app's test-setups root.
+        let testSetupsDirectory: String
+    }
+
+    /// The persisted inputs for one section (no validation).  Returns nil when
+    /// no section with `sectionID` exists.
+    static func current(setup: APITestSetup, sectionID: String) throws -> Inputs? {
+        guard let manifest = setup.decodedManifest() else {
+            throw WebAssignmentError.internalFailure(reason: "Manifest is not valid JSON.")
+        }
+        guard let section = manifest.sections.first(where: { $0.id == sectionID }) else { return nil }
+        return Inputs(variables: section.variables, expressions: section.expressions)
+    }
+
+    /// Validate + persist a replacement set of inputs for one section.
+    static func apply(
+        setup: APITestSetup,
+        sectionID: String,
+        inputs: Inputs,
+        seed: SeedContext,
+        on db: any Database
+    ) async throws {
+        guard let manifest = setup.decodedManifest() else {
+            throw WebAssignmentError.internalFailure(reason: "Manifest is not valid JSON.")
+        }
+
+        // 1. Per-row validation across this section's vars + expressions.
+        let seenNames = try validateNames(variables: inputs.variables, expressions: inputs.expressions)
+        // 2. Cross-section + global clash check.
+        try validateAgainstOtherScopes(seenNames: seenNames, manifest: manifest, sectionID: sectionID)
+        // 3. Save-time eval check against the acting account's own seed.
+        try await evaluateForActingSeed(
+            manifest: manifest, sectionID: sectionID, inputs: inputs, seed: seed, on: db)
+        // 4. Persist onto the manifest's section list.
+        try await persist(setup: setup, sectionID: sectionID, inputs: inputs, on: db)
+    }
+
+    // MARK: - Validation
+
+    /// Validates that every variable/expression name is a valid Python
+    /// identifier, not the reserved `seed`, and unique across both kinds.
+    static func validateNames(
+        variables: [FamilyVariable],
+        expressions: [PersonalizationExpression]
+    ) throws -> Set<String> {
+        var seenNames: Set<String> = []
+        for v in variables {
+            guard isValidPythonIdentifier(v.name) else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "Section input name '\(v.name)' is not a valid Python identifier.")
+            }
+            guard v.name != "seed" else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "'seed' is reserved for Chickadee's personalization seed.")
+            }
+            guard seenNames.insert(v.name).inserted else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "Duplicate section input name '\(v.name)'.")
+            }
+        }
+        for e in expressions {
+            guard isValidPythonIdentifier(e.name) else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "Section expression name '\(e.name)' is not a valid Python identifier.")
+            }
+            guard e.name != "seed" else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "'seed' is reserved for Chickadee's personalization seed.")
+            }
+            let trimmed = e.expression.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "Section expression '\(e.name)' has an empty body. "
+                        + "Provide a Python expression after the leading `=`.")
+            }
+            guard seenNames.insert(e.name).inserted else {
+                throw WebAssignmentError.unprocessable(
+                    reason: "Duplicate section input name '\(e.name)'. "
+                        + "Names must be unique across literal values and expressions.")
+            }
+        }
+        return seenNames
+    }
+
+    /// Cross-section + global clash: no name in this section's combined
+    /// namespace may collide with a name in `globalVariables`,
+    /// `globalExpressions`, or any OTHER section's variables/expressions.
+    static func validateAgainstOtherScopes(
+        seenNames: Set<String>,
+        manifest: TestProperties,
+        sectionID: String
+    ) throws {
+        var otherNames: Set<String> = []
+        for v in manifest.globalVariables { otherNames.insert(v.name) }
+        for e in manifest.globalExpressions { otherNames.insert(e.name) }
+        for section in manifest.sections where section.id != sectionID {
+            for v in section.variables { otherNames.insert(v.name) }
+            for e in section.expressions { otherNames.insert(e.name) }
+        }
+        for n in seenNames where otherNames.contains(n) {
+            throw WebAssignmentError.unprocessable(
+                reason: "Section input '\(n)' is already used by a global input or another section. "
+                    + "Names share one namespace across the assignment; rename to avoid shadowing.")
+        }
+    }
+
+    /// Runs every expression once against the acting account's own seed so
+    /// typos surface before students hit them.  No-op when there are no
+    /// expressions or no acting seed.
+    static func evaluateForActingSeed(
+        manifest: TestProperties,
+        sectionID: String,
+        inputs: Inputs,
+        seed: SeedContext,
+        on db: any Database
+    ) async throws {
+        guard !inputs.expressions.isEmpty,
+            let userID = seed.actingUserID,
+            let assignmentID = seed.assignmentID
+        else { return }
+
+        let seedHex = try await AssignmentSeedStore.ensureSeed(
+            userID: userID, assignmentID: assignmentID, on: db)
+        // Combine globals + this section's new vars + other sections' vars
+        // (matches the runtime scope the evaluator uses at first-open).
+        var staticVars: [FamilyVariable] = manifest.globalVariables
+        staticVars.append(contentsOf: inputs.variables)
+        for section in manifest.sections where section.id != sectionID {
+            staticVars.append(contentsOf: section.variables)
+        }
+        let supportDir = seed.testSetupsDirectory + "shared/\(seed.testSetupID)/"
+        do {
+            _ = try await PersonalizationEvaluator.evaluate(
+                seedHex: seedHex,
+                staticVariables: staticVars,
+                expressions: inputs.expressions,
+                supportFilesDirectory: supportDir)
+        } catch let PersonalizationEvaluatorError.nonZeroExit(_, stderr) {
+            let tail = stderr.split(separator: "\n").suffix(3).joined(separator: " ")
+            throw WebAssignmentError.unprocessable(
+                reason: "One of your section expressions failed to evaluate: \(tail). "
+                    + "Fix the expression(s) and save again.")
+        } catch PersonalizationEvaluatorError.timedOut {
+            throw WebAssignmentError.unprocessable(
+                reason: "Expression evaluation timed out (>5s). "
+                    + "Simplify the expressions or move heavy lifting into a support module.")
+        } catch {
+            throw WebAssignmentError.internalFailure(reason: "Expression evaluator failed: \(error)")
+        }
+    }
+
+    // MARK: - Persistence
+
+    static func persist(
+        setup: APITestSetup,
+        sectionID: String,
+        inputs: Inputs,
+        on db: any Database
+    ) async throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let varData = try encoder.encode(inputs.variables)
+        let exprData = try encoder.encode(inputs.expressions)
+        guard let parsedVars = try JSONSerialization.jsonObject(with: varData) as? [Any],
+            let parsedExprs = try JSONSerialization.jsonObject(with: exprData) as? [Any]
+        else {
+            throw WebAssignmentError.internalFailure(reason: "Failed to re-serialise section inputs.")
+        }
+
+        try await mutateManifest(setup: setup, on: db) { dict in
+            guard var sections = dict["sections"] as? [[String: Any]] else {
+                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
+            }
+            guard let idx = sections.firstIndex(where: { ($0["id"] as? String) == sectionID }) else {
+                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
+            }
+            if parsedVars.isEmpty {
+                sections[idx].removeValue(forKey: "variables")
+            } else {
+                sections[idx]["variables"] = parsedVars
+            }
+            if parsedExprs.isEmpty {
+                sections[idx].removeValue(forKey: "expressions")
+            } else {
+                sections[idx]["expressions"] = parsedExprs
+            }
+            dict["sections"] = sections
+        }
+    }
+}

--- a/Tests/APITests/MCP/GetSuiteToolTests.swift
+++ b/Tests/APITests/MCP/GetSuiteToolTests.swift
@@ -55,6 +55,34 @@ import Vapor
         }
     }
 
+    /// Manifest with a section carrying its own variables + expressions.
+    private let sectionInputsManifest = #"""
+        {"schemaVersion":1,"testSuites":[{"tier":"public","script":"test_a.sh","points":1,"sectionID":"sec1"}],"sections":[{"id":"sec1","name":"Part A","variables":[{"name":"cap","value":7}],"expressions":[{"name":"pick","expression":"seed % 4"}]}],"timeLimitSeconds":10}
+        """#
+
+    @Test func returnsSectionVariablesAndExpressions() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(
+                on: app, id: "setup_sv", courseID: courseID, manifest: sectionInputsManifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_sv", courseID: courseID, title: "Lab")
+
+            let output = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), context(app))
+
+            let sec = try #require(output.sections.first { $0.id == "sec1" })
+            #expect(sec.variables.map(\.name) == ["cap"])
+            #expect(sec.variables.first?.value == .int(7))
+            #expect(sec.expressions.map(\.name) == ["pick"])
+            #expect(sec.expressions.first?.expression == "seed % 4")
+        }
+    }
+
     @Test func deniesWhenSubjectNotEnrolled() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/UpdateSectionVariablesToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSectionVariablesToolTests.swift
@@ -1,0 +1,144 @@
+// Tests for UpdateSectionVariablesTool (replace one section's personalization
+// inputs), backed by a real test database.  The expression round-trip runs a
+// real `python3` subprocess for the save-time eval check.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct UpdateSectionVariablesToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    /// One section ("sec1"), one global variable ("g") to exercise the
+    /// cross-scope clash check.
+    private let manifest = #"""
+        {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"g","value":1}],"sections":[{"id":"sec1","name":"Part A"}]}
+        """#
+
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_sv", courseID: courseID, manifest: manifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_sv", courseID: courseID, title: "Lab")
+    }
+
+    private func input(
+        _ assignment: APIAssignment,
+        sectionID: String = "sec1",
+        variables: [FamilyVariable],
+        expressions: [PersonalizationExpression]? = nil
+    ) -> UpdateSectionVariablesTool.Input {
+        UpdateSectionVariablesTool.Input(
+            assignmentPublicID: assignment.publicID, sectionID: sectionID,
+            variables: variables, expressions: expressions)
+    }
+
+    private func reload(
+        _ assignment: APIAssignment, sectionID: String = "sec1", on db: Database
+    ) async throws -> SectionInputsService.Inputs? {
+        let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: db))
+        return try SectionInputsService.current(setup: setup, sectionID: sectionID)
+    }
+
+    @Test func roundTripsVariablesAndExpressions() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await UpdateSectionVariablesTool().execute(
+                input(
+                    assignment,
+                    variables: [FamilyVariable(name: "cap", value: .int(7))],
+                    expressions: [PersonalizationExpression(name: "pick", expression: "seed % 4")]),
+                context(app))
+            #expect(output.variables.map(\.name) == ["cap"])
+            #expect(output.expressions.map(\.name) == ["pick"])
+
+            let reloaded = try #require(try await reload(assignment, on: app.db))
+            #expect(reloaded.variables.first?.value == .int(7))
+            #expect(reloaded.expressions.first?.expression == "seed % 4")
+        }
+    }
+
+    @Test func clearsWithEmptyLists() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await UpdateSectionVariablesTool().execute(
+                input(assignment, variables: [FamilyVariable(name: "cap", value: .int(7))]),
+                context(app))
+            _ = try await UpdateSectionVariablesTool().execute(
+                input(assignment, variables: []), context(app))
+            let reloaded = try #require(try await reload(assignment, on: app.db))
+            #expect(reloaded.variables.isEmpty)
+            #expect(reloaded.expressions.isEmpty)
+        }
+    }
+
+    @Test func clashWithGlobalThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSectionVariablesTool().execute(
+                    input(assignment, variables: [FamilyVariable(name: "g", value: .int(2))]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func reservedSeedNameThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSectionVariablesTool().execute(
+                    input(assignment, variables: [FamilyVariable(name: "seed", value: .int(1))]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func unknownSectionThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSectionVariablesTool().execute(
+                    input(
+                        assignment, sectionID: "nope",
+                        variables: [FamilyVariable(name: "cap", value: .int(1))]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_sv", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_sv", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSectionVariablesTool().execute(
+                    input(assignment, variables: [FamilyVariable(name: "cap", value: .int(1))]),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-section-variables.md
+++ b/changelog.d/mcp-section-variables.md
@@ -1,0 +1,9 @@
+### Added
+
+- **MCP personalization tools — section variables.** The content-authoring MCP
+  server now exposes `update_section_variables` (and `get_suite` now returns each
+  section's `variables` and `expressions`), letting an authorized agent read and
+  replace a test-suite section's scoped personalization inputs. The write path
+  drives the same `SectionInputsService` the web editor uses, so name/`seed`/
+  cross-scope-uniqueness validation and the save-time expression eval run
+  identically across surfaces.


### PR DESCRIPTION
## Summary

Second of four PRs adding **per-student personalization** to the content-authoring MCP server. This part covers **test-suite section-scoped inputs**.

- **`update_section_variables`** (`content:write`) — replaces one section's literal `variables` and per-student `expressions` wholesale, by assignment public ID + section id. Mirrors `POST /instructor/:id/suite-sections/:sectionID/variables`.
- **`get_suite`** now returns each section's `variables` and `expressions` (previously id + name only) — the read side for the above.

## Design — one source of truth

The section-inputs logic is **extracted** from the web POST handler into a Vapor-free `SectionInputsService`, which both the web route and the MCP tool call. So these run identically across the browser editor and an agent:
- identifier-shape names, the reserved `seed` name, uniqueness within the section;
- no clash with global inputs or any **other** section;
- the save-time expression eval against the acting account's own seed.

Like the web handler, this only mutates `manifest.sections` — section variables are read at generation/first-open time, so no `applyPatternFamilies` re-render is needed. The web handler shrank to a thin wrapper; the shared `MCPToolError.from(WebAssignmentError:)` (added in part 1) maps errors.

## Tests
- `UpdateSectionVariablesToolTests` (round-trip, clear, cross-scope clash with a global, reserved `seed`, unknown section, unenrolled denial).
- `GetSuiteToolTests` gains a section-variables/expressions assertion.
- Existing `SectionInputsTests` still green after the refactor.

## Checks
- `swift build` ✓ · `swift-format` ✓ · SwiftLint `--strict` 0 violations ✓ · targeted tests ✓

## Series
1. global inputs — **merged** (#785)
2. section variables — **this PR**
3. `update_pattern_family` case args/expected editing
4. `preview_personalization`

https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk

---
_Generated by [Claude Code](https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk)_