### PR TITLE
test(worker): de-flake env-passthrough tests against subprocess launch failures

### DIFF
--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -1,7 +1,40 @@
 import Foundation
+import RunnerCore
 import Testing
 
 @testable import chickadee_runner
+
+/// Runs `script` via `runner`, retrying only when the subprocess fails to
+/// *launch* — a transient CI flake (fork/posix_spawn under heavy parallel load,
+/// or a spuriously-fired timeout) that surfaces as the `-1` exit sentinel with
+/// no output and `timedOut == false`.
+///
+/// This is deliberately narrow: a genuine env-handling regression produces
+/// output (a wrong `seed=…` line on stderr), never this empty `-1` sentinel, so
+/// it is never retried or masked — only the ambiguous "didn't run at all"
+/// outcome is. Free function (not a method) so it can be called inside the
+/// `@Sendable` `withEnvLock` closure without capturing `self`.
+private func runRetryingLaunchFailure(
+    _ runner: UnsandboxedScriptRunner,
+    script: URL,
+    workDir: URL,
+    timeLimitSeconds: Int,
+    env: [String: String],
+    attempts: Int = 5
+) async -> ScriptOutput {
+    var output = await runner.run(
+        script: script, workDir: workDir, timeLimitSeconds: timeLimitSeconds, env: env)
+    var remaining = attempts - 1
+    while remaining > 0,
+        output.exitCode == -1, !output.timedOut,
+        output.stdout.isEmpty, output.stderr.isEmpty
+    {
+        remaining -= 1
+        output = await runner.run(
+            script: script, workDir: workDir, timeLimitSeconds: timeLimitSeconds, env: env)
+    }
+    return output
+}
 
 @Suite final class WorkerTests {
 
@@ -115,7 +148,8 @@ import Testing
         // so a concurrent `unsetenv` in another test can't mutate `environ`
         // mid-read.
         let output = try await withEnvLock {
-            await runner.run(
+            await runRetryingLaunchFailure(
+                runner,
                 script: script,
                 workDir: workDir,
                 timeLimitSeconds: 5,
@@ -154,7 +188,8 @@ import Testing
             }
             // Ensure parent doesn't have the var set in this test's environment.
             unsetenv("CHICKADEE_ASSIGNMENT_SEED")
-            return await runner.run(
+            return await runRetryingLaunchFailure(
+                runner,
                 script: script,
                 workDir: workDir,
                 timeLimitSeconds: 5,

--- a/changelog.d/worker-test-launch-flake.md
+++ b/changelog.d/worker-test-launch-flake.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Worker env-passthrough tests no longer flake on transient subprocess
+  launch failures.** `scriptReceivesEnvVarFromRunner` and
+  `scriptEnvVarUnsetWhenNoOverride` now retry only the narrow "subprocess never
+  launched" outcome (the `-1` exit sentinel with no output and no timeout — a
+  fork/posix_spawn flake under parallel CI load), so the behavioural env-leak
+  assertion runs against a real execution. A genuine env-handling regression
+  produces output rather than the empty sentinel, so it is never masked.


### PR DESCRIPTION
## Summary

Fixes the intermittent `worker-tests` failure seen on an earlier CI run, where `scriptEnvVarUnsetWhenNoOverride()` failed with `exitCode → -1` and empty `stderr` (and the same flake can hit `scriptReceivesEnvVarFromRunner()`).

## Root cause

Both tests spawn a real `/bin/sh` subprocess via `UnsandboxedScriptRunner`. Under heavy parallel CI load a transient `fork`/`posix_spawn` failure — or a spuriously-fired timeout — surfaces as the runner's `-1` exit sentinel with **no output** and `timedOut == false`. The tests conflated two concerns in one set of assertions:

1. *liveness* — did the script run at all (`exitCode == 0`)?
2. *behaviour* — given it ran, was the env var absent/present (`stderr` content)?

So a launch flake (#1) also failed the behavioural assertion (#2), and the failure looked identical to a real env-handling regression. That ambiguity is the actual defect — the property under test (the runner must not leak/inject `CHICKADEE_ASSIGNMENT_SEED`) is worth testing, but the test wasn't isolated from infra noise.

## Fix

A narrow `runRetryingLaunchFailure` helper retries **only** the unambiguous "never launched" sentinel — `exitCode == -1 && !timedOut && stdout.isEmpty && stderr.isEmpty`. A genuine env-handling regression produces output (a wrong `seed=…` line), never this empty sentinel, so it is **never retried or masked**; only the liveness flake is absorbed. It's a free function so it composes inside the `@Sendable` `withEnvLock` closure without capturing `self`.

No production code changes — test-only.

## Checks
- `swift test` (both env tests) ✓ · `swift-format` ✓ · SwiftLint `--strict` 0 violations ✓

https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk

---
_Generated by [Claude Code](https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk)_