### PR TITLE
feat(mcp): expose personalization over MCP — part 3, pattern-family case editing

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -108,8 +108,9 @@ enum MCPServerInstructions {
         the returned JSON.
         - clone_assignment lands closed, unvalidated, with no due date and no submissions, so nothing \
         is regraded; validate and open it with update_assignment when ready.
-        - You author structure and metadata, not the underlying test logic: you cannot write raw \
-        script bodies or a pattern case's args/expected values.
+        - You author structure, metadata, and pattern-family test cases, but not raw script bodies: \
+        update_pattern_family can edit a generated case's args/expected (validated on save), but the \
+        contents of hand-written `.sh`/`.py` test scripts are not editable through this interface.
         - Resources: each accessible assignment's raw test.properties.json manifest is also exposed \
         as an MCP resource (resources/list, then resources/read on \
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \

--- a/Sources/APIServer/MCP/Tools/MCPWebErrorMapping.swift
+++ b/Sources/APIServer/MCP/Tools/MCPWebErrorMapping.swift
@@ -8,6 +8,7 @@
 // failures map to `executionFailed`.
 
 import Foundation
+import Vapor
 
 extension MCPToolError {
     /// Translates a `WebAssignmentError` raised by a shared web edit path into
@@ -20,5 +21,16 @@ extension MCPToolError {
             .unprocessable, .validationRequired:
             return .invalidArguments(tool: tool, detail: error.reason)
         }
+    }
+
+    /// Translates a Vapor `AbortError` (e.g. the `Abort(.unprocessableEntity,
+    /// …)` that pattern-family validation throws) into the MCP vocabulary.
+    /// Client-fixable 4xx failures become `invalidArguments`; anything else is
+    /// a genuine server-side failure.
+    static func from(_ error: any AbortError, tool: String) -> MCPToolError {
+        if (400..<500).contains(Int(error.status.code)) {
+            return .invalidArguments(tool: tool, detail: error.reason)
+        }
+        return .executionFailed(tool: tool, detail: error.reason)
     }
 }

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -1,24 +1,54 @@
 // APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
 //
-// Write tool: edit a pattern family's *metadata* for an assignment — its
-// default tier/points, and which cases are enabled — by public ID + family id.
-// content:write, course-scoped.
+// Write tool: edit a pattern family for an assignment — its default tier/points,
+// which cases are enabled, and (per case) the test logic itself: `args` and
+// `expected`.  content:write, course-scoped.
 //
 // Targeted read-modify-write through the same applySuiteEdit / applyPatternFamilies
 // path the web editor uses: loads the current authored suite, reconstructs the
-// family with the requested default + case-enabled changes (every other field —
-// function, params, case args/expected/variables — is preserved verbatim), and
-// re-saves, which regenerates the family's scripts and re-runs validation.
+// family with the requested default / case-enabled / case-arg edits (every other
+// field preserved verbatim), and re-saves, which regenerates the family's scripts
+// AND re-runs the structural + per-kind validation (arg count vs paramNames, the
+// per-kind `expected` shape, `$var` ref resolution) synchronously — so a bad edit
+// is rejected here, not silently shipped.
 //
-// The agent can re-weight/re-tier a family and turn cases on/off, but it does
-// NOT author case args or expected values (the actual test logic) — that's a
-// later, higher-risk slice, like notebook content.
+// The agent sends `args` / `expected` as raw JSON values, so types are faithful
+// (a string column stays a string); no client-side coercion is involved. When an
+// edit replaces `args`, the parallel `argVarRefs` / `argsProvided` arrays reset to
+// "all literal / all provided" unless the agent supplies them explicitly (and they
+// must then align with the new args length).
 
 import Core
 import Fluent
 import Foundation
+import Vapor
 
 struct UpdatePatternFamilyTool: ContentTool {
+    /// A per-case edit. `key` is required; any of `args` / `expected` /
+    /// `argVarRefs` / `argsProvided` may be set to replace that field.
+    struct CaseEdit: Decodable, Sendable {
+        let key: String
+        let args: [JSONValue]?
+        let expected: JSONValue?
+        /// Parallel to `args`: `$name` family/section/global variable refs, or
+        /// null at a position to use the literal in `args`.
+        let argVarRefs: [String?]?
+        /// Parallel to `args`: false at a position omits that argument so
+        /// Python's own parameter default applies.
+        let argsProvided: [Bool]?
+
+        init(
+            key: String, args: [JSONValue]? = nil, expected: JSONValue? = nil,
+            argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil
+        ) {
+            self.key = key
+            self.args = args
+            self.expected = expected
+            self.argVarRefs = argVarRefs
+            self.argsProvided = argsProvided
+        }
+    }
+
     struct Input: Decodable, Sendable {
         let assignmentPublicID: String
         let familyID: String
@@ -26,6 +56,22 @@ struct UpdatePatternFamilyTool: ContentTool {
         let defaultPoints: Int?
         let enableCases: [String]?
         let disableCases: [String]?
+        /// Per-case `args` / `expected` edits (the test logic).
+        let cases: [CaseEdit]?
+
+        init(
+            assignmentPublicID: String, familyID: String, defaultTier: String? = nil,
+            defaultPoints: Int? = nil, enableCases: [String]? = nil, disableCases: [String]? = nil,
+            cases: [CaseEdit]? = nil
+        ) {
+            self.assignmentPublicID = assignmentPublicID
+            self.familyID = familyID
+            self.defaultTier = defaultTier
+            self.defaultPoints = defaultPoints
+            self.enableCases = enableCases
+            self.disableCases = disableCases
+            self.cases = cases
+        }
     }
 
     struct Output: Encodable, Sendable {
@@ -34,16 +80,20 @@ struct UpdatePatternFamilyTool: ContentTool {
         let defaultTier: String
         let defaultPoints: Int
         let enabledCaseKeys: [String]
+        /// Keys of cases whose args/expected were edited by this call.
+        let editedCaseKeys: [String]
         let validationStatus: String?
     }
 
     static let name = "update_pattern_family"
     static let description =
-        "Edit a pattern family's metadata for an assignment, by assignment public ID + family id. "
-        + "Set the family's default tier (public/release/secret/student) and/or points, and "
-        + "enable/disable individual cases by key (enableCases / disableCases). Does NOT change a "
-        + "case's args or expected value (the test logic). Saving regenerates the family's scripts "
-        + "and re-runs validation."
+        "Edit a pattern family for an assignment, by assignment public ID + family id. Set the "
+        + "family's default tier (public/release/secret/student) and/or points, enable/disable cases "
+        + "by key (enableCases / disableCases), and/or edit individual cases' test logic via `cases` "
+        + "(each { key, args?, expected? }). args/expected are raw JSON values (a list of args in "
+        + "parameter order, and the expected return). Saving regenerates the family's scripts and "
+        + "re-runs validation, which rejects a wrong arg count or an expected value of the wrong shape "
+        + "for the family's kind. Family ids and case keys come from get_suite."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -70,6 +120,36 @@ struct UpdatePatternFamilyTool: ContentTool {
                 "type": .string("array"), "items": .object(["type": .string("string")]),
                 "description": .string("Case keys to disable."),
             ]),
+            "cases": .object([
+                "type": .string("array"),
+                "description": .string("Per-case test-logic edits; each targets an existing case by key."),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "key": .object([
+                            "type": .string("string"),
+                            "description": .string("Target case key (must already exist)."),
+                        ]),
+                        "args": .object([
+                            "type": .string("array"),
+                            "description": .string("Args in parameter order (raw JSON values)."),
+                        ]),
+                        "expected": .object([
+                            "description": .string("Expected return value (raw JSON), shape per family kind.")
+                        ]),
+                        "argVarRefs": .object([
+                            "type": .string("array"),
+                            "description": .string("Parallel to args: \"name\" for a $var ref, or null for a literal."),
+                        ]),
+                        "argsProvided": .object([
+                            "type": .string("array"),
+                            "description": .string("Parallel to args: false omits the arg (use Python default)."),
+                        ]),
+                    ]),
+                    "required": .array([.string("key")]),
+                    "additionalProperties": .bool(false),
+                ]),
+            ]),
         ]),
         "required": .array([.string("assignmentPublicID"), .string("familyID")]),
         "additionalProperties": .bool(false),
@@ -84,11 +164,14 @@ struct UpdatePatternFamilyTool: ContentTool {
             "enabledCaseKeys": .object([
                 "type": .string("array"), "items": .object(["type": .string("string")]),
             ]),
+            "editedCaseKeys": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
             "validationStatus": .object(["type": .string("string")]),
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("familyID"), .string("defaultTier"),
-            .string("defaultPoints"), .string("enabledCaseKeys"),
+            .string("defaultPoints"), .string("enabledCaseKeys"), .string("editedCaseKeys"),
         ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
@@ -99,15 +182,20 @@ struct UpdatePatternFamilyTool: ContentTool {
         let newTier = try Self.parseTier(input.defaultTier)
         let enable = Set(input.enableCases ?? [])
         let disable = Set(input.disableCases ?? [])
-        guard newTier != nil || input.defaultPoints != nil || !enable.isEmpty || !disable.isEmpty else {
+        let caseEdits = input.cases ?? []
+        guard
+            newTier != nil || input.defaultPoints != nil || !enable.isEmpty || !disable.isEmpty
+                || !caseEdits.isEmpty
+        else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
-                detail: "Specify at least one of: defaultTier, defaultPoints, enableCases, disableCases.")
+                detail: "Specify at least one of: defaultTier, defaultPoints, enableCases, disableCases, cases.")
         }
         guard enable.isDisjoint(with: disable) else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "A case key cannot be in both enableCases and disableCases.")
         }
+        let editsByKey = try Self.indexCaseEdits(caseEdits)
 
         guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
             throw MCPToolError.invalidArguments(
@@ -131,18 +219,28 @@ struct UpdatePatternFamilyTool: ContentTool {
         }
 
         let caseKeys = Set(family.cases.map(\.key))
-        let unknown = enable.union(disable).subtracting(caseKeys)
+        let unknown = enable.union(disable).union(editsByKey.keys).subtracting(caseKeys)
         guard unknown.isEmpty else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
                 detail: "Unknown case key(s): \(unknown.sorted().joined(separator: ", ")).")
         }
 
-        let updatedFamily = Self.rebuild(
-            family, newTier: newTier, newPoints: input.defaultPoints, enable: enable, disable: disable)
+        let updatedFamily = try Self.rebuild(
+            family, newTier: newTier, newPoints: input.defaultPoints,
+            enable: enable, disable: disable, edits: editsByKey)
         payload.items[idx].family = updatedFamily
 
-        try await applySuiteEdit(setup: setup, body: payload, on: context.db)
+        // applySuiteEdit -> applyPatternFamilies -> validatePatternFamilies runs
+        // the structural + per-kind case checks synchronously; surface those as
+        // clean MCP errors rather than opaque protocol failures.
+        do {
+            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
+        } catch let error as WebAssignmentError {
+            throw MCPToolError.from(error, tool: Self.name)
+        } catch let error as any AbortError {
+            throw MCPToolError.from(error, tool: Self.name)
+        }
         await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
 
         return Output(
@@ -151,34 +249,89 @@ struct UpdatePatternFamilyTool: ContentTool {
             defaultTier: updatedFamily.defaults.tier.rawValue,
             defaultPoints: updatedFamily.defaults.points,
             enabledCaseKeys: updatedFamily.cases.filter(\.enabled).map(\.key),
+            editedCaseKeys: editsByKey.keys.sorted(),
             validationStatus: assignment.validationStatus)
     }
 
-    /// Reconstructs the family with new defaults and per-case enabled flags;
-    /// every other field is copied verbatim.
+    /// Indexes case edits by key, rejecting duplicates so the last-write-wins
+    /// ambiguity never reaches the rebuild.
+    private static func indexCaseEdits(_ edits: [CaseEdit]) throws -> [String: CaseEdit] {
+        var byKey: [String: CaseEdit] = [:]
+        for edit in edits {
+            guard byKey.updateValue(edit, forKey: edit.key) == nil else {
+                throw MCPToolError.invalidArguments(
+                    tool: name, detail: "Duplicate case edit for key \"\(edit.key)\".")
+            }
+        }
+        return byKey
+    }
+
+    /// Reconstructs the family with new defaults, per-case enabled flags, and
+    /// per-case arg/expected edits; every other field is copied verbatim.
     private static func rebuild(
         _ family: PatternFamily, newTier: TestTier?, newPoints: Int?,
-        enable: Set<String>, disable: Set<String>
-    ) -> PatternFamily {
+        enable: Set<String>, disable: Set<String>, edits: [String: CaseEdit]
+    ) throws -> PatternFamily {
         let defaults = PatternDefaults(
             tier: newTier ?? family.defaults.tier,
             points: newPoints ?? family.defaults.points,
             hint: family.defaults.hint,
             tolerance: family.defaults.tolerance)
-        let cases = family.cases.map { caseSpec -> PatternCase in
+        let cases = try family.cases.map { caseSpec -> PatternCase in
             let enabled =
                 enable.contains(caseSpec.key)
                 ? true : (disable.contains(caseSpec.key) ? false : caseSpec.enabled)
-            return PatternCase(
-                key: caseSpec.key, label: caseSpec.label, args: caseSpec.args,
-                expected: caseSpec.expected, argsProvided: caseSpec.argsProvided,
-                argVarRefs: caseSpec.argVarRefs, hint: caseSpec.hint, tier: caseSpec.tier,
-                points: caseSpec.points, enabled: enabled)
+            return try applyCaseEdit(edits[caseSpec.key], to: caseSpec, enabled: enabled)
         }
         return PatternFamily(
             id: family.id, name: family.name, kind: family.kind, functionName: family.functionName,
             paramNames: family.paramNames, defaults: defaults, cases: cases,
             variables: family.variables, dependsOn: family.dependsOn)
+    }
+
+    /// Applies one case's arg/expected edit, keeping the parallel
+    /// `argVarRefs` / `argsProvided` arrays aligned with the resolved args.
+    private static func applyCaseEdit(
+        _ edit: CaseEdit?, to caseSpec: PatternCase, enabled: Bool
+    ) throws -> PatternCase {
+        guard let edit else {
+            return caseSpec.with(enabled: enabled)
+        }
+        let finalArgs = edit.args ?? caseSpec.args
+        let finalExpected = edit.expected ?? caseSpec.expected
+        let finalVarRefs = try resolveParallel(
+            explicit: edit.argVarRefs, argsReplaced: edit.args != nil,
+            existing: caseSpec.argVarRefs, argCount: finalArgs.count,
+            field: "argVarRefs", caseKey: caseSpec.key)
+        let finalProvided = try resolveParallel(
+            explicit: edit.argsProvided, argsReplaced: edit.args != nil,
+            existing: caseSpec.argsProvided, argCount: finalArgs.count,
+            field: "argsProvided", caseKey: caseSpec.key)
+        return PatternCase(
+            key: caseSpec.key, label: caseSpec.label, args: finalArgs, expected: finalExpected,
+            argsProvided: finalProvided, argVarRefs: finalVarRefs, hint: caseSpec.hint,
+            tier: caseSpec.tier, points: caseSpec.points, enabled: enabled)
+    }
+
+    /// Resolves a parallel array (argVarRefs / argsProvided) for an edited case:
+    /// an explicit value wins (and must align with the new args length); when
+    /// the args were replaced the parallel array resets to empty so it can't
+    /// reference stale positions; otherwise the existing value carries over.
+    private static func resolveParallel<T>(
+        explicit: [T]?, argsReplaced: Bool, existing: [T],
+        argCount: Int, field: String, caseKey: String
+    ) throws -> [T] {
+        if let explicit {
+            guard explicit.count == argCount else {
+                throw MCPToolError.invalidArguments(
+                    tool: name,
+                    detail:
+                        "case '\(caseKey)': \(field) length (\(explicit.count)) must match args length (\(argCount)).")
+            }
+            return explicit
+        }
+        // args replaced → reset (stale positions can't carry over); else keep.
+        return argsReplaced ? [] : existing
     }
 
     private static func parseTier(_ raw: String?) throws -> TestTier? {
@@ -188,5 +341,15 @@ struct UpdatePatternFamilyTool: ContentTool {
                 tool: name, detail: "defaultTier must be one of: public, release, secret, student.")
         }
         return tier
+    }
+}
+
+extension PatternCase {
+    /// Copy with a new `enabled` flag; every other field preserved.
+    fileprivate func with(enabled: Bool) -> PatternCase {
+        PatternCase(
+            key: key, label: label, args: args, expected: expected,
+            argsProvided: argsProvided, argVarRefs: argVarRefs, hint: hint,
+            tier: tier, points: points, enabled: enabled)
     }
 }

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -91,6 +91,99 @@ import Vapor
         }
     }
 
+    @Test func editsCaseArgsAndExpected() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Use a non-integral double: an integral value (16.0) would round-trip
+            // through the manifest JSON as the integer 16, an inherent JSON
+            // normalization, not a faithfulness bug.
+            let output = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    cases: [
+                        UpdatePatternFamilyTool.CaseEdit(
+                            key: "01", args: [.double(16.5)], expected: .string("severely underweight"))
+                    ]),
+                context(app))
+            #expect(output.editedCaseKeys == ["01"])
+
+            let family = try await reloadFamily(assignment, on: app.db)
+            let edited = try #require(family.cases.first { $0.key == "01" })
+            #expect(edited.args == [.double(16.5)])
+            #expect(edited.expected == .string("severely underweight"))
+            // Other cases untouched.
+            #expect(family.cases.first { $0.key == "02" }?.expected == .string("normal"))
+        }
+    }
+
+    @Test func wrongArgCountThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // BMI family declares one parameter; two args must be rejected by
+            // the kind validation that runs on save (mapped from Vapor Abort).
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        cases: [
+                            UpdatePatternFamilyTool.CaseEdit(
+                                key: "01", args: [.double(1.0), .double(2.0)])
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func unknownCaseKeyInCasesThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        cases: [UpdatePatternFamilyTool.CaseEdit(key: "99", expected: .string("x"))]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func argVarRefsLengthMismatchThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        cases: [
+                            UpdatePatternFamilyTool.CaseEdit(
+                                key: "01", args: [.double(16.0)], argVarRefs: [nil, nil])
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func duplicateCaseEditThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        cases: [
+                            UpdatePatternFamilyTool.CaseEdit(key: "01", expected: .string("a")),
+                            UpdatePatternFamilyTool.CaseEdit(key: "01", expected: .string("b")),
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
     @Test func unknownFamilyThrows() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/changelog.d/mcp-pattern-case-editing.md
+++ b/changelog.d/mcp-pattern-case-editing.md
@@ -1,0 +1,10 @@
+### Added
+
+- **MCP personalization tools — pattern-family case editing.** `update_pattern_family`
+  can now edit a generated case's test logic — its `args` and `expected` (plus the
+  parallel `argVarRefs` / `argsProvided`) — not just the family defaults and which
+  cases are enabled. Edits re-save through the same `applySuiteEdit` →
+  `applyPatternFamilies` path the web editor uses, so the structural and per-kind
+  validation (arg count vs. parameters, the kind-specific `expected` shape, `$var`
+  resolution) runs synchronously and rejects bad edits at call time. Values are
+  sent as raw JSON, so types stay faithful (no client-side coercion).


### PR DESCRIPTION
## Summary

Third of four PRs adding **per-student personalization** authoring to the MCP server. This part lets an agent edit a pattern family's **test cases**, not just its metadata.

`update_pattern_family` now accepts a `cases` array of per-case edits (`{ key, args?, expected?, argVarRefs?, argsProvided? }`) alongside the existing `defaultTier` / `defaultPoints` / `enableCases` / `disableCases`. So an agent can now author the actual test logic of a generated family — the arguments passed and the expected return — for every pattern kind (boundary/approximate/variable equality, return-type, exception-expected, etc.).

## Design

- Edits re-save through the same `applySuiteEdit → applyPatternFamilies` path the web editor uses, which runs `validatePatternFamilies` **synchronously**. So a wrong arg count (vs. the family's `paramNames`), an `expected` of the wrong shape for the kind, or an unresolved `$var` ref is rejected **at call time** — not silently shipped to students.
- `args` / `expected` are raw JSON values, so types are faithful (a string stays a string) — none of the client-side `coerceByType` ambiguity that bit the web editor (v0.4.94).
- **Parallel-array integrity:** when an edit replaces `args`, the parallel `argVarRefs` / `argsProvided` reset to "all literal / all provided" unless the agent supplies them — and if supplied they must align with the new args length, else a clear error.
- Vapor `Abort` from validation is now mapped to `MCPToolError` (4xx → `invalidArguments`) alongside the existing `WebAssignmentError` mapping.

## Tests
- `UpdatePatternFamilyToolTests` gains: edit args+expected round-trip, wrong-arg-count rejection (the synchronous kind validation), unknown case key in `cases`, `argVarRefs` length mismatch, duplicate case edit. Existing default/enable-disable tests unchanged.

## Checks
- `swift build` ✓ · `swift-format` ✓ · SwiftLint `--strict` 0 violations ✓ · targeted tests (13) ✓

## Series
1. global inputs — **merged** (#785)
2. section variables — **merged** (#786)
3. pattern-family case editing — **this PR**
4. `preview_personalization`

https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk

---
_Generated by [Claude Code](https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk)_