### PR TITLE
feat(mcp): expose personalization over MCP — part 4, preview_personalization

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -92,7 +92,9 @@ enum MCPServerInstructions {
 
         Recommended workflow:
         1. Discover: list_courses, then list_assignments for a course.
-        2. Inspect before editing: get_assignment, get_suite, get_notebook, get_global_inputs.
+        2. Inspect before editing: get_assignment, get_suite, get_notebook, get_global_inputs. Use \
+        preview_personalization to see the name→value map and starter-notebook placeholder audit a \
+        student (or a given seed) would get.
         3. Edit: update_assignment (metadata), update_suite (script metadata), update_pattern_family \
         (family defaults/cases), update_global_inputs (personalization variables/expressions), \
         update_section_variables (a section's scoped variables/expressions), update_notebook (replace \

--- a/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+++ b/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
@@ -1,0 +1,187 @@
+// APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+//
+// Read tool: previews what a student with a given seed would see for an
+// assignment's personalization — the resolved `name → Python-literal` values
+// (literals + per-seed-evaluated expressions) and a `{{placeholder}}` audit of
+// the starter notebook (which placeholders resolve, which don't).  content:read,
+// course-scoped.
+//
+// Drives the same `PersonalizationSubstitution.resolve` the student first-open
+// path uses, so the preview matches reality. When no seed is supplied it uses
+// the acting account's own per-assignment seed (deterministic). Read-only: it
+// evaluates expressions in the sandboxed `python3` subprocess but writes
+// nothing.
+
+import Core
+import Fluent
+import Foundation
+
+struct PreviewPersonalizationTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// Optional hex seed to preview a specific student. When omitted, the
+        /// acting account's own per-assignment seed is used.
+        let seedHex: String?
+    }
+
+    struct Output: Encodable, Sendable {
+        struct ResolvedValue: Encodable, Sendable {
+            let name: String
+            /// The Python literal substituted into `{{name}}`.
+            let value: String
+        }
+        struct Placeholders: Encodable, Sendable {
+            /// `{{name}}` markers found in the starter notebook.
+            let used: [String]
+            /// Used markers with no matching declared input (would fail at save).
+            let unresolved: [String]
+        }
+        let assignmentPublicID: String
+        /// The seed actually used (nil when the assignment has no expressions
+        /// and no seed was supplied — only literals were resolved).
+        let seedHex: String?
+        let values: [ResolvedValue]
+        /// Expression names that evaluated for this seed.
+        let evaluatedExpressionNames: [String]
+        /// Non-nil when expression evaluation failed (values then carry literals only).
+        let evaluationError: String?
+        let placeholders: Placeholders
+    }
+
+    static let name = "preview_personalization"
+    static let description =
+        "Preview what a student would see for an assignment's personalization, by public ID. Resolves "
+        + "every global + section variable and evaluates the per-student expressions against a seed "
+        + "(supply `seedHex` to preview a specific student; omitted uses your own seed), returning the "
+        + "name→value map plus a starter-notebook `{{placeholder}}` audit (which resolve, which don't). "
+        + "Read-only — runs the same resolution the student first-open path uses, but writes nothing."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "seedHex": .object([
+                "type": .string("string"),
+                "description": .string("Optional hex seed to preview a specific student."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "seedHex": .object(["type": .string("string")]),
+            "values": .object([
+                "type": .string("array"),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "name": .object(["type": .string("string")]),
+                        "value": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([.string("name"), .string("value")]),
+                ]),
+            ]),
+            "evaluatedExpressionNames": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
+            "evaluationError": .object(["type": .string("string")]),
+            "placeholders": .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "used": .object([
+                        "type": .string("array"), "items": .object(["type": .string("string")]),
+                    ]),
+                    "unresolved": .object([
+                        "type": .string("array"), "items": .object(["type": .string("string")]),
+                    ]),
+                ]),
+                "required": .array([.string("used"), .string("unresolved")]),
+            ]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("values"),
+            .string("evaluatedExpressionNames"), .string("placeholders"),
+        ]),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+        guard let manifest = setup.decodedManifest() else {
+            throw MCPToolError.executionFailed(tool: Self.name, detail: "Manifest is not valid JSON.")
+        }
+
+        let seedHex = try await resolveSeed(
+            input: input, assignment: assignment, manifest: manifest, context: context)
+
+        let supportDir = context.request.application.testSetupsDirectory + "shared/\(assignment.testSetupID)/"
+        let resolution = await PersonalizationSubstitution.resolve(
+            manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportDir)
+
+        let placeholders = Self.placeholderAudit(manifest: manifest, setup: setup, resolution: resolution)
+        let values = resolution.substitutions
+            .map { Output.ResolvedValue(name: $0.key, value: $0.value) }
+            .sorted { $0.name < $1.name }
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            seedHex: seedHex,
+            values: values,
+            evaluatedExpressionNames: resolution.evaluatedExpressionNames.sorted(),
+            evaluationError: resolution.evaluationError,
+            placeholders: placeholders)
+    }
+
+    /// The seed to preview with: the explicit `seedHex` (validated as hex) when
+    /// supplied; otherwise the acting account's own per-assignment seed, but
+    /// only when the assignment actually declares expressions (literal-only
+    /// assignments need no seed).
+    private func resolveSeed(
+        input: Input, assignment: APIAssignment, manifest: TestProperties, context: ToolContext
+    ) async throws -> String? {
+        if let provided = input.seedHex {
+            let trimmed = provided.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, trimmed.allSatisfy(\.isHexDigit) else {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name, detail: "seedHex must be a non-empty hexadecimal string.")
+            }
+            return trimmed.lowercased()
+        }
+        // No seed is needed for a literal-only assignment.
+        let hasExpressions =
+            !manifest.globalExpressions.isEmpty
+            || manifest.sections.contains { !$0.expressions.isEmpty }
+        guard hasExpressions else { return nil }
+        let actingUser = try await context.requireEligibleSubject(tool: Self.name)
+        guard let userID = actingUser.id, let assignmentID = assignment.id else { return nil }
+        return try await AssignmentSeedStore.ensureSeed(
+            userID: userID, assignmentID: assignmentID, on: context.db)
+    }
+
+    private static func placeholderAudit(
+        manifest: TestProperties, setup: APITestSetup, resolution: PersonalizationSubstitution.Resolution
+    ) -> Output.Placeholders {
+        guard let starterName = manifest.starterNotebook,
+            let notebookData = extractZipEntry(zipPath: setup.zipPath, entryName: starterName)
+        else {
+            return Output.Placeholders(used: [], unresolved: [])
+        }
+        let used = NotebookSubstitution.placeholderNames(in: notebookData)
+        let resolved = Set(resolution.substitutions.keys)
+        let unresolved = used.filter { !resolved.contains($0) }
+        return Output.Placeholders(used: used.sorted(), unresolved: unresolved.sorted())
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -22,6 +22,7 @@ enum MCPToolCatalog {
             GetSuiteTool().erased(),
             GetNotebookTool().erased(),
             GetGlobalInputsTool().erased(),
+            PreviewPersonalizationTool().erased(),
             ValidateAssignmentTool().erased(),
             UpdateAssignmentTool().erased(),
             UpdateSuiteTool().erased(),

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -563,70 +563,42 @@ private func applyNotebookSubstitutionsIfNeeded(
     else {
         return seedData
     }
-    // Combined static name pool — same precedence rules the runner sees.
-    var staticVars: [FamilyVariable] = manifest.globalVariables
-    for section in manifest.sections {
-        staticVars.append(contentsOf: section.variables)
-    }
-    var substitutions: [String: String] = [:]
-    for v in staticVars {
-        substitutions[v.name] = v.value.pythonLiteral
-    }
 
-    // Slice 2 + Slice 4: evaluate per-student expressions if any are
-    // declared.  Combine globals and section expressions in declared
-    // order (globals first, then sections) so same-named section
-    // expressions shadow globals, matching the literal precedence
-    // already applied to staticVars above.
-    var allExpressions: [PersonalizationExpression] = manifest.globalExpressions
-    for section in manifest.sections {
-        allExpressions.append(contentsOf: section.expressions)
-    }
-    if !allExpressions.isEmpty {
-        do {
-            guard let setupID = setup.id else {
-                logger.warning("Setup has no id; skipping expression eval.")
-                return try applySubstitutions(seedData, substitutions: substitutions, setup: setup, logger: logger)
-            }
-            guard
-                let assignment = try await APIAssignment.query(on: db)
-                    .filter(\.$testSetupID == setupID)
-                    .first(),
-                let assignmentID = assignment.id
-            else {
-                logger.warning("No assignment found for setup \(setupID); skipping expression eval.")
-                return try applySubstitutions(seedData, substitutions: substitutions, setup: setup, logger: logger)
-            }
-            let seedHex = try await AssignmentSeedStore.ensureSeed(
-                userID: userID,
-                assignmentID: assignmentID,
-                on: db
-            )
-            let evaluated = try await PersonalizationEvaluator.evaluate(
-                seedHex: seedHex,
-                staticVariables: staticVars,
-                expressions: allExpressions,
-                supportFilesDirectory: supportFilesDirectory
-            )
-            // Per-student values override literals on name collision —
-            // matches the editor's "expressions shadow same-named
-            // literals" precedence (and the validator enforces no clash
-            // at save time anyway, so this is belt-and-suspenders).
-            for (name, literal) in evaluated {
-                substitutions[name] = literal
-            }
-        } catch {
-            let msg =
-                "Personalization evaluator failed for setup \(setup.id ?? "<nil>"): \(error). "
-                + "Notebook will be substituted with literal values only."
-            logger.warning(Logger.Message(stringLiteral: msg))
+    // A seed is only needed to evaluate per-student expressions; literal-only
+    // assignments substitute without one (and without an assignment lookup).
+    let hasExpressions =
+        !manifest.globalExpressions.isEmpty
+        || manifest.sections.contains { !$0.expressions.isEmpty }
+    var seedHex: String?
+    if hasExpressions, let setupID = setup.id {
+        if let assignment = try? await APIAssignment.query(on: db)
+            .filter(\.$testSetupID == setupID)
+            .first(),
+            let assignmentID = assignment.id
+        {
+            seedHex = try? await AssignmentSeedStore.ensureSeed(
+                userID: userID, assignmentID: assignmentID, on: db)
+        }
+        if seedHex == nil {
+            logger.warning(
+                "Could not resolve a seed for setup \(setupID); substituting literal values only.")
         }
     }
 
-    guard !substitutions.isEmpty else { return seedData }
+    let resolution = await PersonalizationSubstitution.resolve(
+        manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportFilesDirectory)
+    if let evalError = resolution.evaluationError {
+        logger.warning(
+            Logger.Message(
+                stringLiteral:
+                    "Personalization evaluator failed for setup \(setup.id ?? "<nil>"): \(evalError). "
+                    + "Notebook will be substituted with literal values only."))
+    }
+
+    guard !resolution.substitutions.isEmpty else { return seedData }
     return
         (try? applySubstitutions(
-            seedData, substitutions: substitutions,
+            seedData, substitutions: resolution.substitutions,
             setup: setup, logger: logger)) ?? seedData
 }
 

--- a/Sources/APIServer/Services/PersonalizationSubstitution.swift
+++ b/Sources/APIServer/Services/PersonalizationSubstitution.swift
@@ -1,0 +1,86 @@
+// APIServer/Services/PersonalizationSubstitution.swift
+//
+// HTTP-free core that builds the `{{name}}` substitution map a student with a
+// given seed would see at notebook first-open: every global + section literal
+// value, then every global + section expression evaluated against the seed
+// (expressions override same-named literals, matching the editor's precedence).
+//
+// Extracted from `WebRoutes+Notebook.applyNotebookSubstitutionsIfNeeded` so the
+// student first-open path and the MCP `preview_personalization` tool resolve
+// personalization identically. Expression eval failures are returned (not
+// logged) so each caller decides whether to log or surface them.
+
+import Core
+import Foundation
+
+enum PersonalizationSubstitution {
+
+    struct Resolution: Sendable {
+        /// Resolved `name → Python-literal` map (literals + evaluated expressions).
+        let substitutions: [String: String]
+        /// Literal (static) input names in scope, global-then-section order.
+        let staticNames: [String]
+        /// Expression names that successfully evaluated for this seed.
+        let evaluatedExpressionNames: [String]
+        /// Non-nil when expressions were declared + a seed was supplied but the
+        /// per-seed eval failed; the map then carries literals only.
+        let evaluationError: String?
+    }
+
+    /// Builds the substitution map for `seedHex`.  When `seedHex` is nil, or no
+    /// expressions are declared, only literal values are returned (no eval is
+    /// attempted).
+    static func resolve(
+        manifest: TestProperties,
+        seedHex: String?,
+        supportFilesDirectory: String?
+    ) async -> Resolution {
+        // Combined static name pool — global first, then sections, so a
+        // same-named section variable shadows a global (matches the runner).
+        var staticVars: [FamilyVariable] = manifest.globalVariables
+        for section in manifest.sections {
+            staticVars.append(contentsOf: section.variables)
+        }
+        var substitutions: [String: String] = [:]
+        for v in staticVars {
+            substitutions[v.name] = v.value.pythonLiteral
+        }
+
+        var allExpressions: [PersonalizationExpression] = manifest.globalExpressions
+        for section in manifest.sections {
+            allExpressions.append(contentsOf: section.expressions)
+        }
+
+        guard !allExpressions.isEmpty, let seedHex else {
+            return Resolution(
+                substitutions: substitutions,
+                staticNames: staticVars.map(\.name),
+                evaluatedExpressionNames: [],
+                evaluationError: nil)
+        }
+
+        do {
+            let evaluated = try await PersonalizationEvaluator.evaluate(
+                seedHex: seedHex,
+                staticVariables: staticVars,
+                expressions: allExpressions,
+                supportFilesDirectory: supportFilesDirectory)
+            // Per-student values override literals on name collision (the
+            // validator forbids cross-kind clashes at save time anyway).
+            for (name, literal) in evaluated {
+                substitutions[name] = literal
+            }
+            return Resolution(
+                substitutions: substitutions,
+                staticNames: staticVars.map(\.name),
+                evaluatedExpressionNames: allExpressions.map(\.name),
+                evaluationError: nil)
+        } catch {
+            return Resolution(
+                substitutions: substitutions,
+                staticNames: staticVars.map(\.name),
+                evaluatedExpressionNames: [],
+                evaluationError: "\(error)")
+        }
+    }
+}

--- a/Tests/APITests/MCP/PreviewPersonalizationToolTests.swift
+++ b/Tests/APITests/MCP/PreviewPersonalizationToolTests.swift
@@ -1,0 +1,145 @@
+// Tests for PreviewPersonalizationTool, backed by a real test database. The
+// expression-eval paths run a real `python3` subprocess (like the
+// PersonalizationEvaluator tests).
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct PreviewPersonalizationToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read]
+        )
+    }
+
+    private func enrolledFixture(
+        on app: Application, id: String, manifest: String
+    ) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: id, courseID: courseID, manifest: manifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: id, courseID: courseID, title: "Lab")
+    }
+
+    /// Writes a zip at `zipPath` containing the named entries (name -> contents).
+    private func writeZip(at zipPath: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preview-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            try content.data(using: .utf8)?
+                .write(to: root.appendingPathComponent(name))
+        }
+        try? FileManager.default.removeItem(atPath: zipPath)
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+    }
+
+    @Test func resolvesLiteralsAndExpressionsForExplicitSeed() async throws {
+        let manifest = #"""
+            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"cap","value":5}],"globalExpressions":[{"name":"offset","expression":"seed % 3"}]}
+            """#
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await enrolledFixture(on: app, id: "setup_pv", manifest: manifest)
+            // seed = 0xff = 255; 255 % 3 == 0.
+            let output = try await PreviewPersonalizationTool().execute(
+                PreviewPersonalizationTool.Input(
+                    assignmentPublicID: assignment.publicID, seedHex: "ff"),
+                context(app))
+            #expect(output.seedHex == "ff")
+            let byName = Dictionary(uniqueKeysWithValues: output.values.map { ($0.name, $0.value) })
+            #expect(byName["cap"] == "5")
+            #expect(byName["offset"] == "0")
+            #expect(output.evaluatedExpressionNames == ["offset"])
+            #expect(output.evaluationError == nil)
+        }
+    }
+
+    @Test func literalOnlyNeedsNoSeed() async throws {
+        let manifest = #"""
+            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"globalVariables":[{"name":"cap","value":5}]}
+            """#
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await enrolledFixture(on: app, id: "setup_pv", manifest: manifest)
+            let output = try await PreviewPersonalizationTool().execute(
+                PreviewPersonalizationTool.Input(assignmentPublicID: assignment.publicID, seedHex: nil),
+                context(app))
+            #expect(output.seedHex == nil)
+            #expect(output.values.map(\.name) == ["cap"])
+            #expect(output.evaluatedExpressionNames.isEmpty)
+        }
+    }
+
+    @Test func invalidSeedThrows() async throws {
+        let manifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await enrolledFixture(on: app, id: "setup_pv", manifest: manifest)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await PreviewPersonalizationTool().execute(
+                    PreviewPersonalizationTool.Input(
+                        assignmentPublicID: assignment.publicID, seedHex: "nothex"),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func placeholderAuditFlagsUnresolved() async throws {
+        let manifest = #"""
+            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,"starterNotebook":"starter.ipynb","globalVariables":[{"name":"cap","value":5}]}
+            """#
+        let notebook = #"""
+            {"cells":[{"cell_type":"code","metadata":{},"source":["x = {{cap}}\n","y = {{missing}}"]}],"metadata":{},"nbformat":4,"nbformat_minor":5}
+            """#
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await enrolledFixture(on: app, id: "setup_pv", manifest: manifest)
+            try writeZip(
+                at: app.testSetupsDirectory + "setup_pv.zip",
+                entries: [("starter.ipynb", notebook)])
+
+            let output = try await PreviewPersonalizationTool().execute(
+                PreviewPersonalizationTool.Input(assignmentPublicID: assignment.publicID, seedHex: nil),
+                context(app))
+            #expect(output.placeholders.used == ["cap", "missing"])
+            #expect(output.placeholders.unresolved == ["missing"])
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let manifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_pv", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_pv", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await PreviewPersonalizationTool().execute(
+                    PreviewPersonalizationTool.Input(assignmentPublicID: assignment.publicID, seedHex: nil),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-preview-personalization.md
+++ b/changelog.d/mcp-preview-personalization.md
@@ -1,0 +1,10 @@
+### Added
+
+- **MCP personalization tools — preview.** New read-only `preview_personalization`
+  tool resolves what a student would see for an assignment: the `name → value`
+  map (global + section literals, plus per-student expressions evaluated against
+  a seed — supply `seedHex` for a specific student or use your own) and a
+  starter-notebook `{{placeholder}}` audit (which resolve, which don't). It drives
+  the same `PersonalizationSubstitution` resolver the student first-open path now
+  uses, so the preview matches reality. Completes the four-part series exposing
+  per-student personalization authoring over MCP.


### PR DESCRIPTION
## Summary

Fourth and final PR of the **per-student personalization over MCP** series. Adds a read-only preview so an agent can see what students actually get before opening an assignment.

`preview_personalization` (`content:read`) resolves, for an assignment:
- the **`name → value` map** — global + section literal variables, plus per-student expressions evaluated against a seed (`seedHex` previews a specific student; omitted uses the acting account's own per-assignment seed);
- a **starter-notebook `{{placeholder}}` audit** — which placeholders resolve and which don't (the latter would fail a save).

It writes nothing (it runs expression eval in the sandboxed `python3` subprocess, same as first-open).

## Design — one source of truth

The first-open substitution math (combine global+section literals, evaluate global+section expressions against the seed, expressions override same-named literals) is **extracted** from `WebRoutes+Notebook.applyNotebookSubstitutionsIfNeeded` into a Vapor-free `PersonalizationSubstitution.resolve`. Both the student first-open path and this tool call it, so the preview matches reality. The web path keeps its seed-resolution + logging; it now delegates the map-building and surfaces eval errors via the resolver's returned error rather than inline.

## Tests
- `PreviewPersonalizationToolTests`: literals+expression resolution for an explicit seed, literal-only-needs-no-seed, invalid (non-hex) seed rejection, placeholder audit flagging an unresolved `{{missing}}`, unenrolled denial.
- `GlobalInputsTests` / `SectionInputsTests` substitution suites still green after the refactor (33 tests total in the run).

## Checks
- `swift build` ✓ · `swift-format` ✓ · SwiftLint `--strict` 0 violations ✓ · targeted tests ✓

## Series — complete
1. global inputs — **merged** (#785)
2. section variables — **merged** (#786)
3. pattern-family case editing — **merged** (#788)
4. preview — **this PR**

(Plus the worker-test de-flake, #787.)

https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk

---
_Generated by [Claude Code](https://claude.ai/code/session_012jdPAyfEtjp7sKrUZtuyzk)_