### PR TITLE
feat(instructor): notebook reset action on course-student submissions page

### DIFF
--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -93,6 +93,12 @@
                         </button>
                     </form>
                     #endif
+                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
                     <details class="ext-details" style="margin:0">
                         <summary class="btn action-btn ext-summary" title="#if(row.hasExtension):Edit this student’s deadline extension#else:Grant this student a deadline extension#endif" aria-label="#if(row.hasExtension):Edit deadline extension#else:Grant deadline extension#endif" style="padding:.25rem .35rem">
                             #if(row.hasExtension):
@@ -205,6 +211,12 @@
                         </button>
                     </form>
                     #endif
+                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
                     <details class="ext-details" style="margin:0">
                         <summary class="btn action-btn ext-summary" title="#if(row.hasExtension):Edit this student’s deadline extension#else:Grant this student a deadline extension#endif" aria-label="#if(row.hasExtension):Edit deadline extension#else:Grant deadline extension#endif" style="padding:.25rem .35rem">
                             #if(row.hasExtension):

--- a/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
+++ b/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
@@ -47,6 +47,19 @@ enum StudentCoursePaths {
         ) + "/retest"
     }
 
+    /// POST target — reset the student's working-copy notebook to the starter.
+    static func reset(
+        courseCode: String,
+        urlToken: String,
+        assignmentID: String
+    ) -> String {
+        baseAssignmentPath(
+            courseCode: courseCode,
+            urlToken: urlToken,
+            assignmentID: assignmentID
+        ) + "/reset-notebook"
+    }
+
     /// POST target — upsert an extension for one student × one assignment.
     static func extensionSave(
         courseCode: String,

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -370,6 +370,63 @@ extension StudentCourseRoutes {
         )
     }
 
+    // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/reset-notebook
+
+    /// Resets one student's working-copy notebook for one assignment back to
+    /// the published starter.  Past submissions are untouched — this only
+    /// overwrites the in-progress JupyterLite copy (e.g. when a student has
+    /// corrupted their notebook and can't recover).  Mirrors the per-assignment
+    /// `resetStudentNotebook` action, scoped to this course-student page so the
+    /// redirect lands back here.
+    @Sendable
+    func resetStudentAssignmentNotebook(req: Request) async throws -> Response {
+        let actor = try req.auth.require(APIUser.self)
+        guard actor.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "reset student notebooks")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id,
+            let studentID = student.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db) else {
+            throw WebAssignmentError.notFound(resource: "Test setup")
+        }
+
+        let starter: Data
+        do {
+            starter = try notebookData(for: setup)
+        } catch {
+            throw WebAssignmentError.invalidParameter(
+                name: "setup",
+                reason: "Test setup has no starter notebook to reset to."
+            )
+        }
+
+        _ = try await ensureUserNotebookWorkingCopy(
+            req: req,
+            setupID: setup.id ?? assignment.testSetupID,
+            userID: studentID,
+            fallbackSetup: setup,
+            overwriteWith: starter
+        )
+
+        req.logger.info(
+            "student_notebook_reset assignment=\(assignmentIDRaw) student=\(student.username) by=\(actor.id?.uuidString ?? "nil")"
+        )
+
+        return req.redirect(
+            to: StudentCoursePaths.submissions(
+                courseCode: course.code,
+                urlToken: try student.requireURLToken()
+            )
+        )
+    }
+
     // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/extension
 
     @Sendable
@@ -640,6 +697,11 @@ extension StudentCourseRoutes {
                 assignmentID: assignment.publicID
             ),
             retestPath: StudentCoursePaths.retest(
+                courseCode: courseCode,
+                urlToken: urlToken,
+                assignmentID: assignment.publicID
+            ),
+            resetPath: StudentCoursePaths.reset(
                 courseCode: courseCode,
                 urlToken: urlToken,
                 assignmentID: assignment.publicID

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes.swift
@@ -27,6 +27,10 @@ struct StudentCourseRoutes: RouteCollection {
             use: retestStudentAssignment
         )
         routes.post(
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "reset-notebook",
+            use: resetStudentAssignmentNotebook
+        )
+        routes.post(
             ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "extension",
             use: saveStudentAssignmentExtension
         )

--- a/Sources/APIServer/Routes/Web/StudentSubmissionContexts.swift
+++ b/Sources/APIServer/Routes/Web/StudentSubmissionContexts.swift
@@ -61,6 +61,7 @@ struct StudentAssignmentRow: Encodable {
     let extensionSavePath: String
     let extensionDeletePath: String
     let retestPath: String
+    let resetPath: String
     let historyURL: String
     let submissionCount: Int
     let hasLatestSubmission: Bool


### PR DESCRIPTION
## Summary
Surfaces the existing notebook-reset action on the per-student **course submissions** page (`/:courseCode/students/:urlToken/submissions`), next to the existing per-row Retest and deadline-extension controls.

- New course-scoped route `POST /:courseCode/students/:urlToken/assignments/:assignmentID/reset-notebook` -> `resetStudentAssignmentNotebook`, redirecting back to the same page.
- Reuses the same building blocks as the per-assignment `resetStudentNotebook` (`notebookData(for:)` + `ensureUserNotebookWorkingCopy`); past submissions are untouched, only the in-progress JupyterLite working copy is overwritten with the starter.
- Adds a per-row reset button (icon, with confirm) to `course-student-submissions.leaf`.

## Test plan
- [ ] As an instructor, open a student's course submissions page and click the reset button on a row; confirm the working copy resets and you land back on the same page.
- [ ] Non-instructors are forbidden (403).
- [ ] CI green.
