### PR TITLE
feat(instructor): per-student grade override with BrightSpace sync

### DIFF
--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -65,6 +65,9 @@
             <td>
                 #if(row.bestGradeText):
                     <strong>#(row.bestGradeText)</strong>
+                    #if(row.gradeIsOverridden):
+                    <span class="grade-override-tag" title="Grade manually overridden by an instructor">overridden</span>
+                    #endif
                 #else:
                     <span class="empty">—</span>
                 #endif
@@ -121,6 +124,28 @@
                                 <button class="btn action-btn" type="submit">Save</button>
                                 #if(row.hasExtension):
                                 <button class="btn action-btn" type="submit" formaction="#(row.extensionDeletePath)" formnovalidate onclick="return confirm('Remove this student’s extension on this assignment?')">Remove</button>
+                                #endif
+                            </div>
+                        </form>
+                    </details>
+                    <details class="ext-details" style="margin:0">
+                        <summary class="btn action-btn ext-summary#if(row.gradeIsOverridden): grade-override-active#endif" title="#if(row.gradeIsOverridden):Edit this student’s grade override#else:Override this student’s grade#endif" aria-label="#if(row.gradeIsOverridden):Edit grade override#else:Override grade#endif" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="5" x2="5" y2="19"/><circle cx="6.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="17.5" r="2.5"/></svg>
+                        </summary>
+                        <form method="post" action="#(row.gradeOverrideSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                            #csrfFormField()
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Override grade (%)
+                                <input type="number" name="overridePercent" min="0" max="100" step="1" value="#(row.gradeOverridePercent)" required style="width:100%;margin-top:.2rem">
+                            </label>
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Note (optional)
+                                <input type="text" name="note" placeholder="Reason for override" style="width:100%;margin-top:.2rem">
+                            </label>
+                            <div style="display:flex;gap:.3rem">
+                                <button class="btn action-btn" type="submit">Save</button>
+                                #if(row.gradeIsOverridden):
+                                <button class="btn action-btn" type="submit" formaction="#(row.gradeOverrideClearPath)" formnovalidate onclick="return confirm('Clear this student’s grade override and revert to the auto-graded result?')">Clear</button>
                                 #endif
                             </div>
                         </form>
@@ -183,6 +208,9 @@
             <td>
                 #if(row.bestGradeText):
                     <strong>#(row.bestGradeText)</strong>
+                    #if(row.gradeIsOverridden):
+                    <span class="grade-override-tag" title="Grade manually overridden by an instructor">overridden</span>
+                    #endif
                 #else:
                     <span class="empty">—</span>
                 #endif
@@ -243,6 +271,28 @@
                             </div>
                         </form>
                     </details>
+                    <details class="ext-details" style="margin:0">
+                        <summary class="btn action-btn ext-summary#if(row.gradeIsOverridden): grade-override-active#endif" title="#if(row.gradeIsOverridden):Edit this student’s grade override#else:Override this student’s grade#endif" aria-label="#if(row.gradeIsOverridden):Edit grade override#else:Override grade#endif" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="5" x2="5" y2="19"/><circle cx="6.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="17.5" r="2.5"/></svg>
+                        </summary>
+                        <form method="post" action="#(row.gradeOverrideSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                            #csrfFormField()
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Override grade (%)
+                                <input type="number" name="overridePercent" min="0" max="100" step="1" value="#(row.gradeOverridePercent)" required style="width:100%;margin-top:.2rem">
+                            </label>
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Note (optional)
+                                <input type="text" name="note" placeholder="Reason for override" style="width:100%;margin-top:.2rem">
+                            </label>
+                            <div style="display:flex;gap:.3rem">
+                                <button class="btn action-btn" type="submit">Save</button>
+                                #if(row.gradeIsOverridden):
+                                <button class="btn action-btn" type="submit" formaction="#(row.gradeOverrideClearPath)" formnovalidate onclick="return confirm('Clear this student’s grade override and revert to the auto-graded result?')">Clear</button>
+                                #endif
+                            </div>
+                        </form>
+                    </details>
                 </div>
             </td>
         </tr>
@@ -259,6 +309,23 @@
 .ext-summary { margin-top: 0; list-style: none; }
 .ext-summary::-webkit-details-marker { display: none; }
 .ext-details[open] > .ext-summary { background: var(--gray-100); }
+/* Grade-override affordances: a subtle tag next to an overridden grade and a
+   highlighted icon button when an override is active for the row. */
+.grade-override-tag {
+    display: inline-block;
+    margin-left: .35rem;
+    padding: 0 .3rem;
+    font-size: .68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .02em;
+    color: var(--gray-700);
+    background: var(--gray-100);
+    border: 1px solid var(--gray-300);
+    border-radius: .2rem;
+    vertical-align: middle;
+}
+.grade-override-active { border-color: var(--gray-500); background: var(--gray-100); }
 </style>
 #endexport
 #endextend

--- a/Sources/APIServer/Migrations/CreateGradeOverrides.swift
+++ b/Sources/APIServer/Migrations/CreateGradeOverrides.swift
@@ -1,0 +1,52 @@
+// APIServer/Migrations/CreateGradeOverrides.swift
+//
+// Per-student grade override table.  One row per (test_setup, user)
+// enforced by the composite UNIQUE constraint; `override_percent` is the
+// whole-number percent (0–100) that replaces the runner-assigned grade for
+// that student on that assignment.
+
+import Fluent
+import SQLKit
+
+struct CreateGradeOverrides: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("grade_overrides")
+            .id()
+            .field(
+                "test_setup_id",
+                .string,
+                .required,
+                .references("test_setups", "id", onDelete: .cascade)
+            )
+            .field(
+                "user_id",
+                .uuid,
+                .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field("override_percent", .int, .required)
+            .field("note", .string)
+            .field(
+                "granted_by_user_id",
+                .uuid,
+                .references("users", "id", onDelete: .setNull)
+            )
+            .field("granted_at", .datetime)
+            .field("updated_at", .datetime)
+            .unique(on: "test_setup_id", "user_id")
+            .create()
+
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "CREATE INDEX IF NOT EXISTS idx_grade_overrides_user ON grade_overrides(user_id)"
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_grade_overrides_user").run()
+        }
+        try await database.schema("grade_overrides").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -96,6 +96,8 @@ enum AuditAction: String, Sendable {
     case submissionRetestForStudent = "submission.retest_for_student"
     case extensionGranted = "extension.granted"
     case extensionRevoked = "extension.revoked"
+    case gradeOverrideSet = "grade_override.set"
+    case gradeOverrideCleared = "grade_override.cleared"
     case loginSuccess = "auth.login_success"
     case loginFailure = "auth.login_failure"
     case loginLocked = "auth.login_locked"

--- a/Sources/APIServer/Models/APIGradeOverride.swift
+++ b/Sources/APIServer/Models/APIGradeOverride.swift
@@ -1,0 +1,61 @@
+// APIServer/Models/APIGradeOverride.swift
+//
+// Per-student grade override on a test setup.  An override replaces the
+// runner-assigned best grade for one student on one assignment, both in the
+// instructor's per-student submissions view and in the BrightSpace grade
+// sync (see `bestPointsForStudent` in BrightSpaceGradeSyncService).  The
+// stored value is a whole-number percent (0–100); BrightSpace works in
+// points, so the sync converts it against the suite's total possible points.
+//
+// One row per (test_setup, user) — enforced by the composite UNIQUE index in
+// CreateGradeOverrides.
+
+import Fluent
+import Vapor
+
+final class APIGradeOverride: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context.
+    static let schema = "grade_overrides"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    @Field(key: "user_id")
+    var userID: UUID
+
+    @Field(key: "override_percent")
+    var overridePercent: Int
+
+    @OptionalField(key: "note")
+    var note: String?
+
+    @OptionalField(key: "granted_by_user_id")
+    var grantedByUserID: UUID?
+
+    @Timestamp(key: "granted_at", on: .create)
+    var grantedAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        testSetupID: String,
+        userID: UUID,
+        overridePercent: Int,
+        note: String? = nil,
+        grantedByUserID: UUID? = nil
+    ) {
+        self.id = id
+        self.testSetupID = testSetupID
+        self.userID = userID
+        self.overridePercent = overridePercent
+        self.note = note
+        self.grantedByUserID = grantedByUserID
+    }
+}

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -164,6 +164,20 @@ func gradePointsFromCollectionJSON(_ collectionJSON: String) -> Double? {
     return passCount
 }
 
+/// Returns the total possible points recorded on a submission result, used as
+/// the denominator when converting a percent grade override into BrightSpace
+/// points.  Nil when the result predates weighted grading (no `totalPoints`).
+func gradeTotalPointsFromCollectionJSON(_ collectionJSON: String) -> Double? {
+    guard let data = collectionJSON.data(using: .utf8),
+        let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+        return nil
+    }
+    let totalPoints = (root["totalPoints"] as? Double) ?? (root["totalPoints"] as? Int).map(Double.init)
+    if let total = totalPoints, total > 0 { return total }
+    return nil
+}
+
 func gradePercentFromCollectionJSON(_ collectionJSON: String) -> Int? {
     guard let data = collectionJSON.data(using: .utf8),
         let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
+++ b/Sources/APIServer/Routes/Web/StudentCoursePaths.swift
@@ -60,6 +60,29 @@ enum StudentCoursePaths {
         ) + "/reset-notebook"
     }
 
+    /// POST target — upsert a grade override for one student × one assignment.
+    static func gradeOverrideSave(
+        courseCode: String,
+        urlToken: String,
+        assignmentID: String
+    ) -> String {
+        baseAssignmentPath(
+            courseCode: courseCode,
+            urlToken: urlToken,
+            assignmentID: assignmentID
+        ) + "/grade-override"
+    }
+
+    /// POST target — clear an existing grade override.
+    static func gradeOverrideClear(
+        courseCode: String,
+        urlToken: String,
+        assignmentID: String
+    ) -> String {
+        gradeOverrideSave(courseCode: courseCode, urlToken: urlToken, assignmentID: assignmentID)
+            + "/delete"
+    }
+
     /// POST target — upsert an extension for one student × one assignment.
     static func extensionSave(
         courseCode: String,

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -65,10 +65,13 @@ extension StudentCourseRoutes {
             req: req, student: student, assignments: assignments)
         async let classBadgesBySetupIDFuture = loadStudentCourseClassBadges(
             req: req, student: student, setupIDs: setupIDs)
+        async let overrideBySetupIDFuture = loadStudentCourseOverrides(
+            req: req, student: student, setupIDs: setupIDs)
         let setupsByID = try await setupsByIDFuture
         let submissions = try await submissionsFuture
         let extensionByAssignmentID = try await extensionByAssignmentIDFuture
         let classBadgesBySetupID = try await classBadgesBySetupIDFuture
+        let overrideBySetupID = try await overrideBySetupIDFuture
 
         let submissionsBySetupID = submissionsGroupedBySetupID(submissions)
         // preferredResults must wait until submissions resolves (it needs
@@ -94,6 +97,7 @@ extension StudentCourseRoutes {
                 history: submissionsBySetupID[assignment.testSetupID] ?? [],
                 classBadges: classBadgesBySetupID[assignment.testSetupID] ?? [],
                 activeExtension: assignment.id.flatMap { extensionByAssignmentID[$0] },
+                activeOverride: overrideBySetupID[assignment.testSetupID],
                 context: rowContext
             )
         }
@@ -189,6 +193,21 @@ extension StudentCourseRoutes {
             }
         }
         return classBadgesBySetupID
+    }
+
+    fileprivate func loadStudentCourseOverrides(
+        req: Request, student: APIUser, setupIDs: [String]
+    ) async throws -> [String: APIGradeOverride] {
+        guard let studentUUID = student.id, !setupIDs.isEmpty else { return [:] }
+        let overrides = try await APIGradeOverride.query(on: req.db)
+            .filter(\.$testSetupID ~~ Set(setupIDs))
+            .filter(\.$userID == studentUUID)
+            .all()
+        var overrideBySetupID: [String: APIGradeOverride] = [:]
+        for row in overrides {
+            overrideBySetupID[row.testSetupID] = row
+        }
+        return overrideBySetupID
     }
 
     /// Sort comparator matches the student dashboard (`WebRoutes.swift`):
@@ -549,6 +568,161 @@ extension StudentCourseRoutes {
             )
         )
     }
+
+    // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/grade-override
+
+    @Sendable
+    func saveStudentAssignmentGradeOverride(req: Request) async throws -> Response {
+        struct OverrideBody: Content {
+            var overridePercent: Int?
+            var note: String?
+        }
+
+        let actor = try req.auth.require(APIUser.self)
+        guard actor.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "override grades")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id,
+            let studentUUID = student.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+        let testSetupID = assignment.testSetupID
+
+        let body = try req.content.decode(OverrideBody.self)
+        guard let percent = body.overridePercent, (0...100).contains(percent) else {
+            throw WebAssignmentError.invalidParameter(
+                name: "overridePercent",
+                reason: "Provide a whole-number percent between 0 and 100."
+            )
+        }
+        let trimmedNote = body.note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let note = (trimmedNote?.isEmpty == false) ? trimmedNote : nil
+
+        let existing = try await APIGradeOverride.query(on: req.db)
+            .filter(\.$testSetupID == testSetupID)
+            .filter(\.$userID == studentUUID)
+            .first()
+
+        if let existing {
+            existing.overridePercent = percent
+            existing.note = note
+            existing.grantedByUserID = actor.id
+            try await existing.save(on: req.db)
+        } else {
+            let row = APIGradeOverride(
+                testSetupID: testSetupID,
+                userID: studentUUID,
+                overridePercent: percent,
+                note: note,
+                grantedByUserID: actor.id
+            )
+            try await row.save(on: req.db)
+        }
+
+        // The override changes what BrightSpace should receive; re-flag the
+        // student's results so the next sweep re-pushes the new grade.
+        try await flagResultsPendingSync(
+            testSetupID: testSetupID, studentUserID: studentUUID, on: req.db)
+
+        await AuditLogger.record(
+            action: .gradeOverrideSet,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: [
+                "assignment": assignmentIDRaw,
+                "student_username": student.username,
+                "override_percent": String(percent),
+            ],
+            on: req
+        )
+
+        return req.redirect(
+            to: StudentCoursePaths.submissions(
+                courseCode: course.code,
+                urlToken: try student.requireURLToken()
+            )
+        )
+    }
+
+    // MARK: - POST /:courseCode/students/:urlToken/assignments/:assignmentID/grade-override/delete
+
+    @Sendable
+    func deleteStudentAssignmentGradeOverride(req: Request) async throws -> Response {
+        let actor = try req.auth.require(APIUser.self)
+        guard actor.isInstructor else {
+            throw WebAssignmentError.forbidden(action: "clear grade overrides")
+        }
+        let (course, student) = try await resolveCourseAndStudent(req: req)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard
+            let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db),
+            assignment.courseID == course.id,
+            let studentUUID = student.id
+        else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+        let testSetupID = assignment.testSetupID
+
+        let existing = try await APIGradeOverride.query(on: req.db)
+            .filter(\.$testSetupID == testSetupID)
+            .filter(\.$userID == studentUUID)
+            .first()
+        if let existing {
+            try await existing.delete(on: req.db)
+            // Clearing reverts BrightSpace to the runner-computed grade; re-flag
+            // the student's results so the next sweep re-pushes it.
+            try await flagResultsPendingSync(
+                testSetupID: testSetupID, studentUserID: studentUUID, on: req.db)
+            await AuditLogger.record(
+                action: .gradeOverrideCleared,
+                targetType: .assignment,
+                targetID: assignment.id?.uuidString,
+                metadata: [
+                    "assignment": assignmentIDRaw,
+                    "student_username": student.username,
+                ],
+                on: req
+            )
+        }
+
+        return req.redirect(
+            to: StudentCoursePaths.submissions(
+                courseCode: course.code,
+                urlToken: try student.requireURLToken()
+            )
+        )
+    }
+
+    /// Marks every result on one student's submissions for a test setup as
+    /// pending BrightSpace sync, so the debounced sweep re-pushes the grade
+    /// after an override is set or cleared.
+    fileprivate func flagResultsPendingSync(
+        testSetupID: String, studentUserID: UUID, on db: Database
+    ) async throws {
+        let submissionIDs = try await APISubmission.query(on: db)
+            .filter(\.$userID == studentUserID)
+            .filter(\.$testSetupID == testSetupID)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .all()
+            .compactMap(\.id)
+        guard !submissionIDs.isEmpty else { return }
+        let results = try await APIResult.query(on: db)
+            .filter(\.$submissionID ~~ submissionIDs)
+            .all()
+        let now = Date()
+        for result in results {
+            result.brightspaceSyncPending = true
+            if result.brightspacePendingSince == nil {
+                result.brightspacePendingSince = now
+            }
+            try await result.save(on: db)
+        }
+    }
 }
 
 // MARK: - Private helpers
@@ -597,9 +771,9 @@ extension StudentCourseRoutes {
         return (course, student)
     }
 
-    /// Bundles the per-table inputs that don't vary across rows.  Lets
-    /// `buildStudentAssignmentRow` stay at 5 parameters even with 9
-    /// logical inputs.  `urlToken` is the student's opaque URL token
+    /// Bundles the per-table inputs that don't vary across rows.  Keeps
+    /// `buildStudentAssignmentRow` to a handful of parameters even with
+    /// many logical inputs.  `urlToken` is the student's opaque URL token
     /// (#556) — used to build per-student action URLs without leaking
     /// the username into request logs.
     fileprivate struct StudentAssignmentRowContext {
@@ -615,6 +789,7 @@ extension StudentCourseRoutes {
         history: [APISubmission],
         classBadges: [AchievementBadge],
         activeExtension: APIAssignmentExtension?,
+        activeOverride: APIGradeOverride?,
         context: StudentAssignmentRowContext
     ) -> StudentAssignmentRow {
         let courseCode = context.courseCode
@@ -716,7 +891,20 @@ extension StudentCourseRoutes {
             latestSubmissionID: latest?.id ?? "",
             latestSubmittedAtText: latest?.submittedAt.map { fmt.string(from: $0) } ?? "—",
             additionalSubmissionCount: max(history.count - 1, 0),
-            bestGradeText: bestGradePercent.map { "\($0)%" },
+            bestGradeText: activeOverride.map { "\($0.overridePercent)%" }
+                ?? bestGradePercent.map { "\($0)%" },
+            gradeIsOverridden: activeOverride != nil,
+            gradeOverridePercent: activeOverride?.overridePercent ?? bestGradePercent ?? 0,
+            gradeOverrideSavePath: StudentCoursePaths.gradeOverrideSave(
+                courseCode: courseCode,
+                urlToken: urlToken,
+                assignmentID: assignment.publicID
+            ),
+            gradeOverrideClearPath: StudentCoursePaths.gradeOverrideClear(
+                courseCode: courseCode,
+                urlToken: urlToken,
+                assignmentID: assignment.publicID
+            ),
             badges: badges
         )
     }

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -812,36 +812,12 @@ extension StudentCourseRoutes {
             return best >= 0 ? best : nil
         }()
 
-        var badges: [AchievementBadge] = []
-        if let latestSubmission = latest,
-            let latestSubID = latestSubmission.id,
-            let result = preferredResultBySubmissionID[latestSubID],
-            let collection = visibleCollection(
-                from: result.collectionJSON,
-                for: student,
-                assignment: assignment
-            ),
-            let gradePct = gradePercent(from: collection)
-        {
-            let latestAttempt = latestSubmission.attemptNumber ?? 1
-            let priorSub = history.first(where: { $0.attemptNumber == latestAttempt - 1 })
-            let priorPct: Int? = priorSub.flatMap { ps in
-                guard let psID = ps.id, let pr = preferredResultBySubmissionID[psID] else {
-                    return nil
-                }
-                return gradePercentFromCollectionJSON(pr.collectionJSON)
-            }
-            badges.append(
-                contentsOf: AchievementBadge.forSubmission(
-                    BadgeContext(
-                        attemptNumber: latestAttempt,
-                        gradePercent: gradePct,
-                        executionTimeMs: collection.executionTimeMs,
-                        priorGradePercent: priorPct
-                    )
-                )
-            )
-        }
+        var badges = submissionBadges(
+            assignment: assignment,
+            history: history,
+            preferredResultBySubmissionID: preferredResultBySubmissionID,
+            student: student
+        )
         badges.append(contentsOf: classBadges)
 
         let dueAtText = assignment.dueAt.map { fmt.string(from: $0) }
@@ -906,6 +882,44 @@ extension StudentCourseRoutes {
                 assignmentID: assignment.publicID
             ),
             badges: badges
+        )
+    }
+
+    /// Achievement badges earned on the latest submission (attempt/speed/
+    /// improvement).  Class-wide badges are appended by the caller.
+    fileprivate func submissionBadges(
+        assignment: APIAssignment,
+        history: [APISubmission],
+        preferredResultBySubmissionID: [String: APIResult],
+        student: APIUser
+    ) -> [AchievementBadge] {
+        guard let latestSubmission = history.first,
+            let latestSubID = latestSubmission.id,
+            let result = preferredResultBySubmissionID[latestSubID],
+            let collection = visibleCollection(
+                from: result.collectionJSON,
+                for: student,
+                assignment: assignment
+            ),
+            let gradePct = gradePercent(from: collection)
+        else {
+            return []
+        }
+        let latestAttempt = latestSubmission.attemptNumber ?? 1
+        let priorSub = history.first(where: { $0.attemptNumber == latestAttempt - 1 })
+        let priorPct: Int? = priorSub.flatMap { ps in
+            guard let psID = ps.id, let pr = preferredResultBySubmissionID[psID] else {
+                return nil
+            }
+            return gradePercentFromCollectionJSON(pr.collectionJSON)
+        }
+        return AchievementBadge.forSubmission(
+            BadgeContext(
+                attemptNumber: latestAttempt,
+                gradePercent: gradePct,
+                executionTimeMs: collection.executionTimeMs,
+                priorGradePercent: priorPct
+            )
         )
     }
 }

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes.swift
@@ -39,5 +39,14 @@ struct StudentCourseRoutes: RouteCollection {
             "delete",
             use: deleteStudentAssignmentExtension
         )
+        routes.post(
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "grade-override",
+            use: saveStudentAssignmentGradeOverride
+        )
+        routes.post(
+            ":courseCode", "students", ":urlToken", "assignments", ":assignmentID", "grade-override",
+            "delete",
+            use: deleteStudentAssignmentGradeOverride
+        )
     }
 }

--- a/Sources/APIServer/Routes/Web/StudentSubmissionContexts.swift
+++ b/Sources/APIServer/Routes/Web/StudentSubmissionContexts.swift
@@ -69,6 +69,10 @@ struct StudentAssignmentRow: Encodable {
     let latestSubmittedAtText: String
     let additionalSubmissionCount: Int
     let bestGradeText: String?
+    let gradeIsOverridden: Bool
+    let gradeOverridePercent: Int  // form prefill; 0 when no override is set
+    let gradeOverrideSavePath: String
+    let gradeOverrideClearPath: String
     let badges: [AchievementBadge]
 }
 

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -187,13 +187,29 @@ private func bestPointsForStudent(
     testSetupID: String,
     db: Database
 ) async throws -> Double? {
+    // An instructor override replaces the runner-derived grade. It stores a
+    // percent, so it needs a points denominator: the suite's total possible
+    // points (the BrightSpace grade item's max).
+    let override = try await APIGradeOverride.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$userID == userID)
+        .first()
+
     let submissionIDs = try await APISubmission.query(on: db)
         .filter(\.$userID == userID)
         .filter(\.$testSetupID == testSetupID)
         .filter(\.$kind == APISubmission.Kind.student)
         .all()
         .compactMap(\.id)
-    guard !submissionIDs.isEmpty else { return nil }
+
+    guard !submissionIDs.isEmpty else {
+        // No submissions yet. Only an override gives us anything to push.
+        guard let override else { return nil }
+        guard let total = try await suiteTotalPoints(testSetupID: testSetupID, db: db) else {
+            return nil
+        }
+        return Double(override.overridePercent) / 100.0 * total
+    }
 
     let allResults = try await APIResult.query(on: db)
         .filter(\.$submissionID ~~ submissionIDs)
@@ -201,6 +217,16 @@ private func bestPointsForStudent(
     // Prefer worker results; fall back to browser results for best-grade computation.
     let workerResults = allResults.filter { $0.source != "browser" }
     let resultsForGrade = workerResults.isEmpty ? allResults : workerResults
+
+    if let override {
+        // Prefer the suite manifest's total; fall back to the best result's
+        // recorded totalPoints for setups whose manifest is unavailable.
+        let total =
+            try await suiteTotalPoints(testSetupID: testSetupID, db: db)
+            ?? resultsForGrade.compactMap { gradeTotalPointsFromCollectionJSON($0.collectionJSON) }.max()
+        guard let total, total > 0 else { throw BrightSpaceSyncError.missingPoints }
+        return Double(override.overridePercent) / 100.0 * total
+    }
 
     guard
         let points =
@@ -211,6 +237,19 @@ private func bestPointsForStudent(
         throw BrightSpaceSyncError.missingPoints
     }
     return points
+}
+
+/// Total possible points for a test setup — the sum of its suite items'
+/// weights, which is the BrightSpace grade item's max.  Nil when the manifest
+/// is missing/malformed or sums to zero.
+private func suiteTotalPoints(testSetupID: String, db: Database) async throws -> Double? {
+    guard let setup = try await APITestSetup.find(testSetupID, on: db),
+        let props = setup.decodedManifest()
+    else {
+        return nil
+    }
+    let total = props.testSuites.map(\.points).reduce(0, +)
+    return total > 0 ? Double(total) : nil
 }
 
 /// Returns the cached D2L user ID for `userID`, looking it up via studentID if not yet cached.

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -233,6 +233,8 @@ func registerMigrations(on app: Application) {
     // Single-use consent requests for the browser OAuth flow (cookie-less
     // POST /oauth/authorize). FK references `users`.
     app.migrations.add(CreateMCPConsentRequests())
+    // Per-student grade overrides. FKs reference `users` and `test_setups`.
+    app.migrations.add(CreateGradeOverrides())
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.
     app.migrations.add(CreateHotPathIndexes())

--- a/Tests/APITests/GradeOverridesTests.swift
+++ b/Tests/APITests/GradeOverridesTests.swift
@@ -1,0 +1,236 @@
+// Tests/APITests/GradeOverridesTests.swift
+//
+// Coverage for the per-student grade override feature surfaced on the
+// grouped /:courseCode/students/:urlToken/submissions page.
+//
+//  * Override upsert (POST grade-override)        → one row, percent stored.
+//  * Override upsert (overwrite)                  → row updated, no duplicate.
+//  * Override delete                              → row gone.
+//  * Out-of-range percent is rejected            → no row written.
+//  * Setting an override re-flags the student's results for BrightSpace sync.
+//  * Grouped page renders the override value + "overridden" tag.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct GradeOverridesTests {
+
+    // MARK: - Upsert
+
+    @Test func overridePostCreatesAndUpdatesRow() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "ovr_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "ovr_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ovr_setup", title: "Override me", isOpen: true, on: app
+            )
+
+            try await app.asyncTest(
+                .POST,
+                "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": csrf, "overridePercent": "85", "note": "Regraded by hand"],
+                        as: .urlEncodedForm
+                    )
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                }
+            )
+
+            let saved = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "ovr_setup")
+                .filter(\.$userID == (try student.requireID()))
+                .all()
+            #expect(saved.count == 1, "Upsert must create exactly one row")
+            #expect(saved.first?.overridePercent == 85)
+            #expect(saved.first?.note == "Regraded by hand")
+
+            // Second POST updates in place.
+            try await app.asyncTest(
+                .POST,
+                "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": csrf, "overridePercent": "50", "note": ""],
+                        as: .urlEncodedForm
+                    )
+                },
+                afterResponse: { _ in }
+            )
+            let updated = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "ovr_setup")
+                .filter(\.$userID == (try student.requireID()))
+                .all()
+            #expect(updated.count == 1, "Second POST must not create a duplicate")
+            #expect(updated.first?.overridePercent == 50)
+            #expect(updated.first?.note == nil, "Empty note must clear the note field")
+        }
+    }
+
+    // MARK: - Delete
+
+    @Test func overrideDeleteRemovesRow() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "ovr_delete_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "ovr_delete_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ovr_delete_setup", title: "Removable override", isOpen: true, on: app
+            )
+
+            try await APIGradeOverride(
+                testSetupID: "ovr_delete_setup",
+                userID: try student.requireID(),
+                overridePercent: 70
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .POST,
+                "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/grade-override/delete",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                }
+            )
+
+            let remaining = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "ovr_delete_setup")
+                .count()
+            #expect(remaining == 0, "Delete must remove the row")
+        }
+    }
+
+    // MARK: - Validation
+
+    @Test func overrideRejectsOutOfRangePercent() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "ovr_invalid_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "ovr_invalid_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ovr_invalid_setup", title: "Bad input", isOpen: true, on: app
+            )
+
+            try await app.asyncTest(
+                .POST,
+                "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": csrf, "overridePercent": "150"],
+                        as: .urlEncodedForm
+                    )
+                },
+                afterResponse: { res in
+                    #expect(res.status != .seeOther, "Out-of-range percent must not succeed")
+                }
+            )
+
+            let count = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "ovr_invalid_setup")
+                .count()
+            #expect(count == 0, "Rejected override must not write a row")
+        }
+    }
+
+    // MARK: - BrightSpace re-sync flag
+
+    @Test func settingOverrideReflagsResultsForSync() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "ovr_sync_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "ovr_sync_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ovr_sync_setup", title: "Synced", isOpen: true, on: app
+            )
+            _ = try await arInsertSubmission(
+                id: "sub_ovr_sync", testSetupID: "ovr_sync_setup",
+                userID: try student.requireID(), on: app
+            )
+            let result = APIResult(
+                id: "res_ovr_sync",
+                submissionID: "sub_ovr_sync",
+                collectionJSON: #"{"earnedPoints":1,"totalPoints":4,"passCount":1,"totalTests":4}"#
+            )
+            result.brightspaceSyncPending = false
+            try await result.save(on: app.db)
+
+            try await app.asyncTest(
+                .POST,
+                "/TEST101/students/\(try student.requireURLToken())/assignments/\(assignment.publicID)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": csrf, "overridePercent": "100"],
+                        as: .urlEncodedForm
+                    )
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                }
+            )
+
+            let after = try await APIResult.find("res_ovr_sync", on: app.db)
+            #expect(after?.brightspaceSyncPending == true, "Override must re-flag the result for BrightSpace sync")
+            #expect(after?.brightspacePendingSince != nil)
+        }
+    }
+
+    // MARK: - Page rendering
+
+    @Test func groupedPageShowsOverrideValueAndTag() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            let student = try await arInsertStudent(username: "ovr_render_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "ovr_render_setup", on: app)
+            _ = try await arInsertAssignment(
+                testSetupID: "ovr_render_setup", title: "Rendered Lab", isOpen: true, on: app
+            )
+            try await APIGradeOverride(
+                testSetupID: "ovr_render_setup",
+                userID: try student.requireID(),
+                overridePercent: 42
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/TEST101/students/\(try student.requireURLToken())/submissions",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("42%"), "Override value must be shown as the grade")
+                    #expect(body.contains("overridden"), "Overridden grade must carry the tag")
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds an instructor-only **grade override** on the grouped per-student submissions page (`/:courseCode/students/:urlToken/submissions`).

- New `APIGradeOverride` model + `CreateGradeOverrides` migration, keyed on `(test_setup_id, user_id)` with a composite UNIQUE constraint.
- An override stores a whole-number percent (0–100) and takes precedence over the runner-assigned best grade in the page (shown with an `overridden` tag) and in the BrightSpace grade sweep.
- BrightSpace works in points, so `bestPointsForStudent` converts the percent against the suite's total possible points (sum of `testSuites[].points`), falling back to the best result's recorded `totalPoints` when the manifest is unavailable.
- Setting or clearing an override re-flags the student's results as `brightspaceSyncPending` so the debounced sweep re-pushes the new grade.
- New routes `POST .../grade-override` and `.../grade-override/delete`, an inline override form mirroring the extension form, audit actions `grade_override.set` / `grade_override.cleared`.

## Scope note
Per the request, the override surfaces on the **instructor** per-student page and flows to **BrightSpace**. It does not (yet) change the grade shown on the student's own dashboard or the instructor dashboard summary — flag if you want those surfaces to reflect overrides too.

## Test plan
- [ ] `GradeOverridesTests`: upsert creates/updates one row; delete removes it; out-of-range percent is rejected with no row written; setting an override re-flags results for sync; grouped page renders the override value + `overridden` tag.
- [ ] swift-format lint clean locally; CI (build + postgres/worker tests + SwiftLint) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
