### PR TITLE
chore(changelog): add missing fragments to cut v0.4.327

### DIFF
--- a/changelog.d/790-notebook-reset-course-students.md
+++ b/changelog.d/790-notebook-reset-course-students.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Notebook reset on the course-student submissions page.** The existing
+  "reset working-copy notebook to starter" action is now surfaced on the
+  per-student course submissions page alongside the per-row retest and
+  extension controls, via a course-scoped
+  `POST /:courseCode/students/:urlToken/assignments/:assignmentID/reset-notebook`
+  handler that redirects back to the same page.

--- a/changelog.d/791-suite-editor-cross-section-deps.md
+++ b/changelog.d/791-suite-editor-cross-section-deps.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Suite editor preserves dependencies when moving a test across sections.**
+  Dragging a test into a different section previously cleared its `dependsOn`
+  and stranded any tests depending on it in the old section, breaking the
+  dependency graph. Cross-section drops now move the whole connected
+  dependency cluster (transitive dependents + prerequisites) as a contiguous
+  block into the target section, preserving each member's `dependsOn` and
+  their topologically valid relative order. Same-section reorder is unchanged.

--- a/changelog.d/792-per-student-grade-override.md
+++ b/changelog.d/792-per-student-grade-override.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Per-student grade override with BrightSpace sync.** Instructors can set a
+  whole-number percent override on the grouped per-student submissions page
+  (`/:courseCode/students/:urlToken/submissions`), keyed on
+  (test setup, user). The override takes precedence over the runner-assigned
+  best grade both in the page and in the BrightSpace grade sweep, where it is
+  converted to points against the suite's total possible points. Setting or
+  clearing an override re-flags the student's results as sync-pending so
+  BrightSpace re-pushes.


### PR DESCRIPTION
## Why

The last few merges didn't produce a release. `VERSION` is still `0.4.326`, but three PRs have landed on `main` since the last `chore(release)` commit:

- **#790** — `feat(instructor)`: notebook reset action on course-student submissions page
- **#791** — `fix(suite-editor)`: carry dependency group when moving a test across sections
- **#792** — `feat(instructor)`: per-student grade override with BrightSpace sync

## Root cause

`auto-release.yml` only cuts a release when `changelog.d/` contains fragments. `assemble-release.sh` exits `3` ("nothing to release") otherwise. All three PRs above merged **without** a changelog fragment, so each `push` to `main` ran the workflow with nothing to fold and skipped the version bump entirely.

Per the documented process, a PR must *not* touch `VERSION` / `ChickadeeVersion.swift` / `CHANGELOG.md` directly — the merge-time workflow owns those. The correct fix is to supply the missing fragments.

## What this does

Adds the three missing `changelog.d/` fragments (one per PR). No source, `VERSION`, or `CHANGELOG.md` changes.

`scripts/assemble-release.sh --dry-run` confirms that merging this will cut **v0.4.327**, which tags the release and triggers the downstream build/deploy.

https://claude.ai/code/session_01Sy4shcwSKXPREK7eQU6rYU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy4shcwSKXPREK7eQU6rYU)_