### PR TITLE
feat(audit): cover SSO logins and the full MCP OAuth flow

### DIFF
--- a/Resources/Views/admin-audit.leaf
+++ b/Resources/Views/admin-audit.leaf
@@ -19,20 +19,45 @@ Audit Log
     </div>
 
     <p style="color:var(--muted);margin-top:0">
-        Records sensitive admin actions and authentication events.  The
-        most recent 200 entries are shown.  Older entries remain in the
-        database.
+        Records sensitive admin actions, authentication events, and agent
+        (MCP / OAuth) activity.  The most recent 200 matching entries are
+        shown; older entries remain in the database.
     </p>
 
+    <form method="get" action="/admin/audit"
+        style="display:flex;align-items:flex-end;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem">
+        <label style="display:flex;flex-direction:column;gap:.25rem;font-size:.85rem">
+            <span style="color:var(--muted)">Action</span>
+            <select name="action" style="min-width:18rem">
+                <option value="">All actions</option>
+                #for(option in actionOptions):
+                <option value="#(option.value)"#if(option.selected): selected#endif>#(option.label)</option>
+                #endfor
+            </select>
+        </label>
+        <label style="display:flex;flex-direction:column;gap:.25rem;font-size:.85rem">
+            <span style="color:var(--muted)">Actor contains</span>
+            <input type="text" name="actor" value="#(filterActor)" placeholder="username" />
+        </label>
+        <button type="submit" class="btn">Filter</button>
+        #if(filtered):
+        <a href="/admin/audit" class="btn btn--secondary">Clear</a>
+        #endif
+    </form>
+
     #if(!rows.count):
-    <p style="color:var(--muted)">No audit entries recorded yet.</p>
+    <p style="color:var(--muted)">#if(filtered):No audit entries match this filter.#else:No audit entries recorded yet.#endif</p>
     #else:
+    <p style="color:var(--muted);font-size:.85rem;margin-top:0">
+        Showing #count(rows) of #(matchCount) matching #if(matchCount == 1):entry#else:entries#endif.
+    </p>
     <table class="results-table">
         <thead>
             <tr>
                 <th style="width:11rem">Time</th>
-                <th style="width:9rem">Actor</th>
-                <th style="width:13rem">Action</th>
+                <th style="width:8rem">Actor</th>
+                <th style="width:9rem">Category</th>
+                <th style="width:14rem">Action</th>
                 <th style="width:9rem">Target</th>
                 <th>Metadata</th>
                 <th style="width:9rem">Remote</th>
@@ -43,7 +68,8 @@ Audit Log
             <tr>
                 <td style="font-family:var(--font-mono,monospace);font-size:.85rem">#(row.timestamp)</td>
                 <td>#(row.actor)</td>
-                <td><code>#(row.action)</code></td>
+                <td>#(row.category)</td>
+                <td>#(row.label)<br><code style="font-size:.75rem;color:var(--muted)">#(row.action)</code></td>
                 <td>#if(row.targetType):#(row.targetType)#if(row.targetID): · <code>#(row.targetID)</code>#endif#else:—#endif</td>
                 <td style="font-family:var(--font-mono,monospace);font-size:.8rem;white-space:pre-wrap;word-break:break-word">#(row.metadata)</td>
                 <td style="font-family:var(--font-mono,monospace);font-size:.85rem">#(row.remoteAddr)</td>

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -207,6 +207,23 @@ struct MCPOAuthRoutes: Sendable {
             scope: scopes.map(\.rawValue).sorted().joined(separator: " "),
             expiresAt: Date().addingTimeInterval(60))
         try await authCode.save(on: req.db)
+        // The human consenting to an agent is the single most security-sensitive
+        // event in the MCP flow — record it (the headline "I authorized MCP and
+        // saw nothing in the audit log" gap).
+        await AuditLogger.record(
+            action: .mcpConsentGranted,
+            targetType: .user,
+            targetID: record.userID.uuidString,
+            metadata: [
+                "username": user.username,
+                "client_id": client.clientID,
+                "client_name": client.name,
+                "scope": authCode.scope,
+                "redirect_host": URLComponents(string: record.redirectURI)?.host ?? record.redirectURI,
+            ],
+            actorOverride: user,
+            on: req
+        )
         return redirect(record.redirectURI, code: code, state: state)
     }
 
@@ -275,6 +292,22 @@ struct MCPOAuthRoutes: Sendable {
         let access = try await mintAccess(
             authority, subject: user.username, scope: authCode.scope,
             clientID: authCode.clientID, agentName: client?.name)
+        // Records the first access+refresh pair an agent receives after consent.
+        // (Routine hourly refresh rotation is deliberately NOT logged — high
+        // volume, low signal; refresh *theft* and downgrade-revoke are below.)
+        await AuditLogger.record(
+            action: .mcpTokenIssued,
+            targetType: .user,
+            targetID: authCode.userID.uuidString,
+            metadata: [
+                "username": user.username,
+                "client_id": authCode.clientID,
+                "client_name": client?.name ?? "",
+                "scope": authCode.scope,
+            ],
+            actorOverride: user,
+            on: req
+        )
         return try tokenSuccess(req, access: access, refresh: refresh, scope: authCode.scope)
     }
 
@@ -293,6 +326,20 @@ struct MCPOAuthRoutes: Sendable {
         {
             reused.revoked = true
             try await reused.save(on: req.db)
+            // Replay of a rotated-away token is a theft signal — record it (and
+            // who/what it was for) before refusing.
+            let reusedUsername = try await APIUser.find(reused.userID, on: req.db)?.username
+            await AuditLogger.record(
+                action: .mcpRefreshReuseDetected,
+                targetType: .user,
+                targetID: reused.userID.uuidString,
+                metadata: [
+                    "username": reusedUsername ?? reused.userID.uuidString,
+                    "client_id": reused.clientID,
+                ],
+                actorUsernameOverride: reusedUsername,
+                on: req
+            )
             return Self.tokenError(.badRequest, "invalid_grant")
         }
 
@@ -313,6 +360,18 @@ struct MCPOAuthRoutes: Sendable {
         guard user.isInstructor else {
             grant.revoked = true
             try await grant.save(on: req.db)
+            await AuditLogger.record(
+                action: .mcpGrantRevoked,
+                targetType: .user,
+                targetID: grant.userID.uuidString,
+                metadata: [
+                    "username": user.username,
+                    "client_id": grant.clientID,
+                    "reason": "role_downgrade",
+                ],
+                actorOverride: user,
+                on: req
+            )
             return Self.tokenError(.badRequest, "invalid_grant")
         }
         // Rotate: issue a new refresh token and swap it in atomically, gated on
@@ -382,6 +441,15 @@ struct MCPOAuthRoutes: Sendable {
         // until an instructor/admin consents at /authorize.
         try await MCPOAuthClient(clientID: clientID, name: name, redirectURIs: redirects, isPublic: true)
             .save(on: req.db)
+        // Open registration is anonymous, but the new client is inert until an
+        // instructor consents — still worth a record of what was registered.
+        await AuditLogger.record(
+            action: .mcpClientRegistered,
+            targetType: .oauthClient,
+            targetID: clientID,
+            metadata: ["client_name": name, "redirect_uri_count": String(redirects.count)],
+            on: req
+        )
 
         let response = RegistrationResponse(
             clientID: clientID,

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -84,24 +84,52 @@ final class APIAuditLogEntry: Model, Content, @unchecked Sendable {
 
 /// Stable identifiers for audit-logged actions.  Kept as an enum so a typo
 /// can't silently produce an orphaned action string in the table.
-enum AuditAction: String, Sendable {
-    case userDeleted = "user.deleted"
+///
+/// `CaseIterable` drives the action-filter dropdown on /admin/audit and the
+/// coverage test that asserts every action has a human-readable display
+/// mapping (`AuditActionDisplayTests`).
+enum AuditAction: String, Sendable, CaseIterable {
+    // Authentication & session
+    case loginSuccess = "auth.login_success"
+    case loginFailure = "auth.login_failure"
+    case loginLocked = "auth.login_locked"
+    case logout = "auth.logout"
+    case sessionIdleTimeout = "auth.session_idle_timeout"
+
+    // Users & roles
+    case userRegistered = "user.registered"
+    case userProvisioned = "user.provisioned"
     case userRoleChanged = "user.role_changed"
-    case runnerSecretRotated = "runner.secret_rotated"
-    case runnerAutostartChanged = "runner.autostart_changed"
+    case userDeleted = "user.deleted"
+
+    // Courses
+    case courseCreated = "course.created"
     case courseArchived = "course.archived"
     case courseUnarchived = "course.unarchived"
+    case courseDeleted = "course.deleted"
+    case courseBundleImported = "course.bundle_imported"
+    case courseBundleExported = "course.bundle_exported"
+
+    // Enrollment
+    case enrollmentBulkAdded = "enrollment.bulk_added"
+    case enrollmentRemoved = "enrollment.removed"
+
+    // Submissions
     case submissionsPurged = "submission.retention_purged"
     case submissionRetestAll = "submission.retest_all"
     case submissionRetestForStudent = "submission.retest_for_student"
+
+    // Grading overrides & extensions
     case extensionGranted = "extension.granted"
     case extensionRevoked = "extension.revoked"
     case gradeOverrideSet = "grade_override.set"
     case gradeOverrideCleared = "grade_override.cleared"
-    case loginSuccess = "auth.login_success"
-    case loginFailure = "auth.login_failure"
-    case loginLocked = "auth.login_locked"
-    case sessionIdleTimeout = "auth.session_idle_timeout"
+
+    // Runner / worker
+    case runnerSecretRotated = "runner.secret_rotated"
+    case runnerAutostartChanged = "runner.autostart_changed"
+
+    // MCP / agents
     case mcpAccountCreated = "mcp.account_created"
     case mcpAccountDeleted = "mcp.account_deleted"
     case mcpTokenMinted = "mcp.token_minted"
@@ -109,6 +137,105 @@ enum AuditAction: String, Sendable {
     case mcpGrantRevoked = "mcp.grant_revoked"
     case mcpAccountEnrolled = "mcp.account_enrolled"
     case mcpAccountUnenrolled = "mcp.account_unenrolled"
+    case mcpClientRegistered = "mcp.client_registered"
+    case mcpConsentGranted = "mcp.consent_granted"
+    case mcpTokenIssued = "mcp.token_issued"
+    case mcpRefreshReuseDetected = "mcp.refresh_reuse_detected"
+
+    /// Coarse grouping shown as the "Category" column / filter on /admin/audit.
+    var category: AuditCategory {
+        switch self {
+        case .loginSuccess, .loginFailure, .loginLocked, .logout, .sessionIdleTimeout:
+            return .authentication
+        case .userRegistered, .userProvisioned, .userRoleChanged, .userDeleted:
+            return .users
+        case .courseCreated, .courseArchived, .courseUnarchived, .courseDeleted,
+            .courseBundleImported, .courseBundleExported:
+            return .courses
+        case .enrollmentBulkAdded, .enrollmentRemoved:
+            return .enrollment
+        case .submissionsPurged, .submissionRetestAll, .submissionRetestForStudent:
+            return .submissions
+        case .extensionGranted, .extensionRevoked, .gradeOverrideSet, .gradeOverrideCleared:
+            return .grading
+        case .runnerSecretRotated, .runnerAutostartChanged:
+            return .runner
+        case .mcpAccountCreated, .mcpAccountDeleted, .mcpTokenMinted, .mcpToolCalled,
+            .mcpGrantRevoked, .mcpAccountEnrolled, .mcpAccountUnenrolled, .mcpClientRegistered,
+            .mcpConsentGranted, .mcpTokenIssued, .mcpRefreshReuseDetected:
+            return .mcp
+        }
+    }
+
+    /// Human-readable label shown in the admin table instead of the raw
+    /// machine identifier (e.g. "MCP access authorized" for
+    /// `mcp.consent_granted`).
+    var label: String {
+        switch self {
+        case .loginSuccess: return "Login"
+        case .loginFailure: return "Login failed"
+        case .loginLocked: return "Login locked out"
+        case .logout: return "Logout"
+        case .sessionIdleTimeout: return "Session idle timeout"
+        case .userRegistered: return "Account self-registered"
+        case .userProvisioned: return "Account provisioned (SSO)"
+        case .userRoleChanged: return "Role changed"
+        case .userDeleted: return "User deleted"
+        case .courseCreated: return "Course created"
+        case .courseArchived: return "Course archived"
+        case .courseUnarchived: return "Course unarchived"
+        case .courseDeleted: return "Course deleted"
+        case .courseBundleImported: return "Course bundle imported"
+        case .courseBundleExported: return "Course bundle exported"
+        case .enrollmentBulkAdded: return "Bulk enrollment"
+        case .enrollmentRemoved: return "Unenrolled"
+        case .submissionsPurged: return "Submissions purged"
+        case .submissionRetestAll: return "Retest all submissions"
+        case .submissionRetestForStudent: return "Retest student submissions"
+        case .extensionGranted: return "Extension granted"
+        case .extensionRevoked: return "Extension revoked"
+        case .gradeOverrideSet: return "Grade override set"
+        case .gradeOverrideCleared: return "Grade override cleared"
+        case .runnerSecretRotated: return "Runner secret rotated"
+        case .runnerAutostartChanged: return "Runner autostart changed"
+        case .mcpAccountCreated: return "MCP account created"
+        case .mcpAccountDeleted: return "MCP account deleted"
+        case .mcpTokenMinted: return "MCP token minted (admin)"
+        case .mcpToolCalled: return "MCP tool called"
+        case .mcpGrantRevoked: return "MCP grant revoked"
+        case .mcpAccountEnrolled: return "MCP account enrolled"
+        case .mcpAccountUnenrolled: return "MCP account unenrolled"
+        case .mcpClientRegistered: return "MCP client registered"
+        case .mcpConsentGranted: return "MCP access authorized"
+        case .mcpTokenIssued: return "MCP token issued"
+        case .mcpRefreshReuseDetected: return "MCP refresh-token reuse detected"
+        }
+    }
+}
+
+/// Coarse grouping for audit actions, surfaced as the "Category" column and the
+/// category filter on /admin/audit.
+enum AuditCategory: String, Sendable, CaseIterable {
+    case authentication = "Authentication"
+    case users = "Users & roles"
+    case courses = "Courses"
+    case enrollment = "Enrollment"
+    case submissions = "Submissions"
+    case grading = "Grading"
+    case runner = "Runner"
+    case mcp = "MCP / agents"
+}
+
+/// Resolves a stored (raw) action string to its display category + label,
+/// falling back gracefully for any historical action no longer in `AuditAction`
+/// (e.g. written by an older server, then renamed).
+enum AuditActionDisplay {
+    static func categoryLabel(forRaw raw: String) -> (category: String, label: String) {
+        if let action = AuditAction(rawValue: raw) {
+            return (action.category.rawValue, action.label)
+        }
+        return ("Other", raw)
+    }
 }
 
 enum AuditTargetType: String, Sendable {
@@ -118,4 +245,6 @@ enum AuditTargetType: String, Sendable {
     case auth
     case assignment
     case course
+    case enrollment
+    case oauthClient = "oauth_client"
 }

--- a/Sources/APIServer/Routes/Web/AdminContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/AdminContextTypes.swift
@@ -268,6 +268,11 @@ struct AdminAlertsContext: Encodable {
 struct AdminAuditRow: Encodable {
     let timestamp: String
     let actor: String
+    /// Coarse grouping (e.g. "Authentication", "MCP / agents").
+    let category: String
+    /// Human-readable action label (e.g. "MCP access authorized").
+    let label: String
+    /// Raw machine action identifier, shown as a secondary <code> line.
     let action: String
     let targetType: String?
     let targetID: String?
@@ -275,10 +280,25 @@ struct AdminAuditRow: Encodable {
     let remoteAddr: String
 }
 
+/// One selectable option in the action-filter dropdown.
+struct AdminAuditFilterOption: Encodable {
+    let value: String
+    let label: String
+    let selected: Bool
+}
+
 struct AdminAuditContext: Encodable {
     let currentUser: CurrentUserContext?
     let activeAdminTab: String
     let rows: [AdminAuditRow]
+    /// Available action filters (grouped label shown to the admin).
+    let actionOptions: [AdminAuditFilterOption]
+    /// The actor substring currently filtered on (echoed back into the input).
+    let filterActor: String
+    /// True when any filter is active — drives the "Clear filters" affordance.
+    let filtered: Bool
+    /// Total entries matching the current filter (may exceed the 200 shown).
+    let matchCount: Int
 }
 
 /// One archived course on the retention report.

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Audit.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Audit.swift
@@ -1,0 +1,87 @@
+// APIServer/Routes/Web/AdminRoutes+Audit.swift
+//
+// Admin "Audit Log" tab: a filterable, human-readable view of the security and
+// admin audit trail (`APIAuditLogEntry`).  Each row carries a coarse category
+// and a plain-language label resolved from the stored action identifier, so the
+// most recent 200 matching entries stay legible even as high-volume events
+// (MCP tool calls, logins) accumulate.  Filters narrow by action and actor.
+
+import Fluent
+import Foundation
+import Vapor
+
+extension AdminRoutes {
+    // MARK: - GET /admin/audit
+
+    @Sendable
+    func auditPage(req: Request) async throws -> View {
+        struct AuditFilterQuery: Content {
+            var action: String?
+            var actor: String?
+        }
+        let filter = (try? req.query.decode(AuditFilterQuery.self)) ?? AuditFilterQuery()
+        func trimmedOrNil(_ value: String?) -> String? {
+            let trimmed = value?.trimmingCharacters(in: .whitespaces) ?? ""
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        let filterAction = trimmedOrNil(filter.action)
+        let filterActor = trimmedOrNil(filter.actor)
+
+        // Build the filtered query once, count it, then take the most recent 200.
+        func base() -> QueryBuilder<APIAuditLogEntry> {
+            let query = APIAuditLogEntry.query(on: req.db)
+            if let filterAction {
+                query.filter(\.$action == filterAction)
+            }
+            if let filterActor {
+                query.filter(\.$actorUsername ~~ filterActor)
+            }
+            return query
+        }
+        let matchCount = try await base().count()
+        let entries = try await base()
+            .sort(\.$createdAt, .descending)
+            .limit(200)
+            .all()
+
+        let timestampFormatter = waterlooDateTimeFormatter()
+        let rows = entries.map { entry -> AdminAuditRow in
+            let display = AuditActionDisplay.categoryLabel(forRaw: entry.action)
+            return AdminAuditRow(
+                timestamp: entry.createdAt.map { timestampFormatter.string(from: $0) } ?? "—",
+                actor: entry.actorUsername ?? "—",
+                category: display.category,
+                label: display.label,
+                action: entry.action,
+                targetType: entry.targetType,
+                targetID: entry.targetID,
+                metadata: entry.metadata ?? "",
+                remoteAddr: entry.remoteAddr ?? "—"
+            )
+        }
+
+        // Action dropdown: grouped "Category — Label", sorted, with the current
+        // selection marked.  Driven by the enum so it can't drift from reality.
+        let actionOptions =
+            AuditAction.allCases
+            .map { action in
+                AdminAuditFilterOption(
+                    value: action.rawValue,
+                    label: "\(action.category.rawValue) — \(action.label)",
+                    selected: action.rawValue == filterAction)
+            }
+            .sorted { $0.label < $1.label }
+
+        return try await req.view.render(
+            "admin-audit",
+            AdminAuditContext(
+                currentUser: req.currentUserContext,
+                activeAdminTab: "audit",
+                rows: rows,
+                actionOptions: actionOptions,
+                filterActor: filterActor ?? "",
+                filtered: filterAction != nil || filterActor != nil,
+                matchCount: matchCount)
+        )
+    }
+}

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -56,6 +56,13 @@ extension AdminRoutes {
         let course = APICourse(code: code, name: name)
         try await course.save(on: req.db)
         let id = try course.requireID().uuidString
+        await AuditLogger.record(
+            action: .courseCreated,
+            targetType: .course,
+            targetID: id,
+            metadata: ["course_code": code, "course_name": name],
+            on: req
+        )
         return req.redirect(to: "/admin/courses/\(id)")
     }
 
@@ -220,7 +227,7 @@ extension AdminRoutes {
 
         let setupsDir = req.application.testSetupsDirectory
 
-        try await req.db.transaction { db in
+        let purgedSubmissions = try await req.db.transaction { db -> Int in
             // 1. Test setups for this course.
             let setups = try await APITestSetup.query(on: db)
                 .filter(\.$courseID == courseID).all()
@@ -261,9 +268,28 @@ extension AdminRoutes {
             try await APICourseEnrollment.query(on: db)
                 .filter(\.$course.$id == courseID).delete()
             try await course.delete(on: db)
+            return submissions.count
         }
 
         req.logger.info("Admin permanently deleted course \(course.code) (\(idString))")
+        await AuditLogger.record(
+            action: .courseDeleted,
+            targetType: .course,
+            targetID: idString,
+            metadata: ["course_code": course.code, "submissions_purged": String(purgedSubmissions)],
+            on: req
+        )
+        // The one place student submissions are purged under the retention
+        // policy — record it distinctly when anything was actually removed.
+        if purgedSubmissions > 0 {
+            await AuditLogger.record(
+                action: .submissionsPurged,
+                targetType: .course,
+                targetID: idString,
+                metadata: ["course_code": course.code, "count": String(purgedSubmissions)],
+                on: req
+            )
+        }
         return req.redirect(
             to: retentionRedirect(ok: "Deleted \(course.code) and all its data."))
     }
@@ -354,6 +380,13 @@ extension AdminRoutes {
             .filter(\.$userID == userID)
             .delete()
 
+        await AuditLogger.record(
+            action: .enrollmentRemoved,
+            targetType: .enrollment,
+            targetID: userIDString,
+            metadata: ["course_id": courseIDString, "subject_user_id": userIDString],
+            on: req
+        )
         return req.redirect(to: "/admin/courses/\(courseIDString)")
     }
 
@@ -499,6 +532,13 @@ extension AdminRoutes {
             .filter(\.$course.$id == courseID)
             .delete()
 
+        await AuditLogger.record(
+            action: .enrollmentRemoved,
+            targetType: .enrollment,
+            targetID: idString,
+            metadata: ["course_id": courseIDString, "subject_user_id": idString],
+            on: req
+        )
         return req.redirect(to: "/admin/users/\(idString)")
     }
 
@@ -528,6 +568,18 @@ extension AdminRoutes {
             on: req.db
         )
 
+        await AuditLogger.record(
+            action: .enrollmentBulkAdded,
+            targetType: .course,
+            targetID: idString,
+            metadata: [
+                "course_code": course.code,
+                "enrolled": String(result.enrolledCount),
+                "pre_enrolled": String(result.preEnrolledCount),
+                "already_enrolled": String(result.alreadyEnrolledCount),
+            ],
+            on: req
+        )
         return try await req.view.render(
             "admin-enroll-csv-result",
             EnrollCSVResultContext(

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -388,34 +388,6 @@ struct AdminRoutes: RouteCollection {
         return req.redirect(to: "/admin")
     }
 
-    // MARK: - GET /admin/audit
-
-    @Sendable
-    func auditPage(req: Request) async throws -> View {
-        let entries = try await APIAuditLogEntry.query(on: req.db)
-            .sort(\.$createdAt, .descending)
-            .limit(200)
-            .all()
-
-        let iso = ISO8601DateFormatter()
-        let rows = entries.map { e -> AdminAuditRow in
-            AdminAuditRow(
-                timestamp: e.createdAt.map { iso.string(from: $0) } ?? "—",
-                actor: e.actorUsername ?? "—",
-                action: e.action,
-                targetType: e.targetType,
-                targetID: e.targetID,
-                metadata: e.metadata ?? "",
-                remoteAddr: e.remoteAddr ?? "—"
-            )
-        }
-        return try await req.view.render(
-            "admin-audit",
-            AdminAuditContext(
-                currentUser: req.currentUserContext, activeAdminTab: "audit", rows: rows)
-        )
-    }
-
     // MARK: - GET /admin/alerts
 
     @Sendable

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -149,7 +149,7 @@ struct AuthRoutes: RouteCollection {
             action: .loginSuccess,
             targetType: .auth,
             targetID: user.id?.uuidString,
-            metadata: ["username": user.username],
+            metadata: ["username": user.username, "method": "local"],
             actorOverride: user,
             on: req
         )
@@ -216,6 +216,14 @@ struct AuthRoutes: RouteCollection {
         req.auth.login(user)
         req.session.rotateID()  // session-fixation defense: fresh id on login
         req.session.authenticate(user)
+        await AuditLogger.record(
+            action: .userRegistered,
+            targetType: .user,
+            targetID: user.id?.uuidString,
+            metadata: ["username": user.username, "role": role],
+            actorOverride: user,
+            on: req
+        )
         return try await postLoginRedirect(for: user, req: req)
     }
 
@@ -230,6 +238,19 @@ struct AuthRoutes: RouteCollection {
         // re-authenticated) so it's obvious the session ended.
         let isTimeout = req.query[String.self, at: "reason"] == "timeout"
         let returnPath = isTimeout ? "/login?error=timeout" : "/login?loggedout=1"
+
+        // Audit the sign-out before the session is torn down (the actor is still
+        // resolvable from the live session here).
+        if let user = req.auth.get(APIUser.self) {
+            await AuditLogger.record(
+                action: .logout,
+                targetType: .auth,
+                targetID: user.id?.uuidString,
+                metadata: ["username": user.username, "reason": isTimeout ? "timeout" : "manual"],
+                actorOverride: user,
+                on: req
+            )
+        }
 
         // Capture any SSO tokens stashed at login before tearing the session
         // down — they're needed below to revoke at the IdP and to build the

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -118,6 +118,13 @@ extension CourseAdminRoutes {
             .filter(\.$userID == userID)
             .delete()
 
+        await AuditLogger.record(
+            action: .enrollmentRemoved,
+            targetType: .enrollment,
+            targetID: userIDString,
+            metadata: ["course_id": courseIDString, "subject_user_id": userIDString],
+            on: req
+        )
         return req.redirect(to: "/instructor")
     }
 

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -69,6 +69,13 @@ struct CourseBundleRoutes: RouteCollection {
 
         try await createZipArchive(sourceDir: stagingDir, outputPath: bundleZipPath)
 
+        await AuditLogger.record(
+            action: .courseBundleExported,
+            targetType: .course,
+            targetID: courseIDStr,
+            metadata: ["course_code": course.code],
+            on: req
+        )
         return try streamExportZip(bundleZipPath: bundleZipPath, bundleName: bundleName)
     }
 
@@ -358,6 +365,18 @@ struct CourseBundleRoutes: RouteCollection {
             subsDir: subsDir
         )
 
+        await AuditLogger.record(
+            action: .courseBundleImported,
+            targetType: .course,
+            targetID: tally.courseID.uuidString,
+            metadata: [
+                "course_code": tally.courseCode,
+                "test_setups": String(tally.testSetupsImported),
+                "assignments": String(tally.assignmentsImported),
+                "submissions": String(tally.submissionsImported),
+            ],
+            on: req
+        )
         return try await renderImportResult(req: req, tally: tally)
     }
 

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -199,6 +199,14 @@ struct SSOAuthRoutes: RouteCollection {
         req.auth.login(user)
         req.session.rotateID()
         req.session.authenticate(user)
+        await AuditLogger.record(
+            action: .loginSuccess,
+            targetType: .auth,
+            targetID: user.id?.uuidString,
+            metadata: ["username": user.username, "method": "sso"],
+            actorOverride: user,
+            on: req
+        )
         return try await postLoginRedirect(for: user, req: req)
     }
 
@@ -254,6 +262,7 @@ struct SSOAuthRoutes: RouteCollection {
             existing.studentID = studentID ?? existing.studentID
             existing.email = email ?? existing.email
             existing.displayName = displayName ?? existing.displayName
+            let previousRole = existing.role
             if let mappedRole {
                 existing.role = mappedRole
             }
@@ -261,6 +270,23 @@ struct SSOAuthRoutes: RouteCollection {
             existing.lastLoginAt = now
             existing.lastSeenAt = now
             try await existing.save(on: req.db)
+            // An allowlist-driven privilege change on login is security-relevant
+            // — record it (only when the role actually moved).
+            if let mappedRole, mappedRole != previousRole {
+                await AuditLogger.record(
+                    action: .userRoleChanged,
+                    targetType: .user,
+                    targetID: existing.id?.uuidString,
+                    metadata: [
+                        "subject_username": existing.username,
+                        "previous_role": previousRole,
+                        "new_role": mappedRole,
+                        "source": "sso_allowlist",
+                    ],
+                    actorUsernameOverride: "sso",
+                    on: req
+                )
+            }
             return existing
         }
 
@@ -280,6 +306,18 @@ struct SSOAuthRoutes: RouteCollection {
             lastSeenAt: now
         )
         try await newUser.save(on: req.db)
+        await AuditLogger.record(
+            action: .userProvisioned,
+            targetType: .user,
+            targetID: newUser.id?.uuidString,
+            metadata: [
+                "username": newUser.username,
+                "role": newUser.role,
+                "provider": "duo-oidc",
+            ],
+            actorUsernameOverride: "sso",
+            on: req
+        )
         return newUser
     }
 

--- a/Tests/APITests/AuditActionDisplayTests.swift
+++ b/Tests/APITests/AuditActionDisplayTests.swift
@@ -1,0 +1,38 @@
+// Tests/APITests/AuditActionDisplayTests.swift
+//
+// Guards the /admin/audit display layer: every audit action must map to a
+// human-readable category + label (the table no longer shows the raw machine
+// identifier alone), and the raw-string resolver must degrade gracefully for a
+// historical action no longer present in the enum.
+
+import Testing
+
+@testable import APIServer
+
+@Suite struct AuditActionDisplayTests {
+
+    @Test func everyActionHasNonEmptyCategoryAndLabel() {
+        for action in AuditAction.allCases {
+            #expect(!action.label.isEmpty, "missing label for \(action.rawValue)")
+            #expect(!action.category.rawValue.isEmpty, "missing category for \(action.rawValue)")
+        }
+    }
+
+    @Test func actionLabelsAreUnique() {
+        // A duplicated label would make the action filter dropdown ambiguous.
+        let labels = AuditAction.allCases.map(\.label)
+        #expect(Set(labels).count == labels.count)
+    }
+
+    @Test func rawResolverMapsKnownActions() {
+        let resolved = AuditActionDisplay.categoryLabel(forRaw: AuditAction.mcpConsentGranted.rawValue)
+        #expect(resolved.category == AuditCategory.mcp.rawValue)
+        #expect(resolved.label == "MCP access authorized")
+    }
+
+    @Test func rawResolverFallsBackForUnknownActions() {
+        let resolved = AuditActionDisplay.categoryLabel(forRaw: "legacy.removed_action")
+        #expect(resolved.category == "Other")
+        #expect(resolved.label == "legacy.removed_action")
+    }
+}

--- a/Tests/APITests/MCP/MCPOAuthFlowTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthFlowTests.swift
@@ -179,6 +179,40 @@ import XCTVapor
         }
     }
 
+    /// The consent grant and the first token issuance must both leave an audit
+    /// trail — the gap behind "I authorized MCP access but the audit log was
+    /// empty".  (Routine refresh rotation is intentionally NOT audited.)
+    @Test func consentAndTokenIssuanceAreAudited() async throws {
+        let (app, _) = try await makeOAuthApp()
+        try await withApp(app) { app in
+            try await seedClient(app)
+            let cookie = try await loginUser(
+                username: "prof", password: "testpassword", role: "instructor", on: app)
+
+            let consentRes = try await consent(
+                app, cookie: cookie, scope: "content:read content:write", decision: "authorize")
+            let code = try #require(queryValue("code", in: consentRes.headers.first(name: .location)))
+            _ = try await tokenPost(
+                app,
+                fields: [
+                    "grant_type": "authorization_code", "code": code,
+                    "redirect_uri": redirectURI, "client_id": clientID,
+                    "code_verifier": codeVerifier,
+                ])
+
+            let consentEntry = try #require(
+                await APIAuditLogEntry.query(on: app.db)
+                    .filter(\.$action == AuditAction.mcpConsentGranted.rawValue).first())
+            #expect(consentEntry.actorUsername == "prof")
+            #expect(consentEntry.metadata?.contains(clientID) == true)
+
+            let tokenEntry = try #require(
+                await APIAuditLogEntry.query(on: app.db)
+                    .filter(\.$action == AuditAction.mcpTokenIssued.rawValue).first())
+            #expect(tokenEntry.actorUsername == "prof")
+        }
+    }
+
     @Test func refreshAfterRoleDowngradeIsRejectedAndRevokesGrant() async throws {
         let (app, _) = try await makeOAuthApp()
         try await withApp(app) { app in

--- a/changelog.d/audit-log-coverage.md
+++ b/changelog.d/audit-log-coverage.md
@@ -1,0 +1,20 @@
+### Added
+
+- **Audit log now covers SSO logins and the full MCP OAuth flow.** The admin
+  audit log previously recorded only local username/password logins and a
+  handful of admin actions, so deployments using SSO (and the MCP "authorize an
+  agent" flow) saw an empty log. New events: SSO login success, SSO account
+  provisioning, SSO allowlist role grants, logout, local self-registration,
+  MCP consent granted, MCP token issued, MCP refresh-token reuse (theft)
+  detection, MCP grant revoke-on-downgrade, MCP dynamic client registration,
+  course create/delete, course bundle import/export, bulk enrollment, and
+  unenrollment. The previously-defined-but-unwritten `submission.retention_purged`
+  action is now emitted when a course deletion purges submissions.
+
+### Changed
+
+- **`/admin/audit` is filterable and human-readable.** Entries now show a
+  Category and a plain-language action label alongside the raw identifier, with
+  filters for action and actor and a match count, so high-volume events
+  (MCP tool calls, logins) no longer crowd out the 200-row view. Timestamps use
+  the America/Toronto formatter, matching the rest of the admin UI.


### PR DESCRIPTION
## Why

The admin audit log claims to record "sensitive admin actions and authentication events," but on prod it was effectively empty for SSO deployments. Two concrete gaps:

1. **SSO/OIDC login was never audited** — only *local* username/password login wrote an entry (`AuthRoutes.login`). On a Duo/SSO deployment, no login ever showed up.
2. **The entire MCP OAuth browser flow wrote nothing** — `GET/POST /oauth/authorize` (consent) and `POST /oauth/token` (code exchange) had no audit calls. Authorizing an MCP agent — arguably the single most security-sensitive action in the system — left no trace; only *later* `mcp.tool_called` events were recorded.

This was the reported symptom: "I authenticated my MCP access but haven't seen any of these on prod."

## What changed

Audited the full class of security-/admin-sensitive events and filled the gaps.

### New audit events
- **Auth:** SSO login success, SSO account provisioning (new user), SSO allowlist role grants (privilege change on login), logout, local self-registration. Local login now carries a `method` tag too.
- **MCP OAuth:** consent granted, token issued (code exchange), refresh-token **reuse/theft** detection, grant revoke-on-role-downgrade, dynamic client registration. *(Routine hourly refresh rotation is intentionally **not** logged — high volume, low signal.)*
- **Admin/data:** course create/delete, course bundle import/export, bulk enrollment, unenrollment. The previously-defined-but-never-written `submission.retention_purged` action now fires when a course deletion purges submissions.

### Display (`/admin/audit`)
- Human-readable **Category** + plain-language **label** alongside the raw action identifier.
- **Action** and **actor** filters with a match count, so high-volume events (MCP tool calls, logins) don't crowd out the 200-row view.
- Timestamps use the `America/Toronto` formatter, matching the rest of the admin UI.
- `AuditAction` is now `CaseIterable` (drives the filter dropdown, guarded by a coverage test). `auditPage` moved to its own `AdminRoutes+Audit.swift` extension to keep the struct under the body-length limit.

## Testing
- `AuditActionDisplayTests` — every action maps to a non-empty/unique label + category; raw-string resolver falls back gracefully for retired actions.
- `MCPOAuthFlowTests.consentAndTokenIssuanceAreAudited` — asserts the consent grant and first token issuance both leave an audit trail attributed to the human.
- Verified green locally: build + `swift-format` + SwiftLint (`--strict`, 0 violations), and 135 tests across the affected suites (audit/MCP-OAuth, auth/admin/enrollment, SSO/instructor actions).

No schema/migration changes — the existing `audit_log` table already stores arbitrary action strings + JSON metadata.

https://claude.ai/code/session_015eUadSTbi1owxXwFi7eynh

---
_Generated by [Claude Code](https://claude.ai/code/session_015eUadSTbi1owxXwFi7eynh)_