### PR TITLE
Fix: deleting a test wipes all sections (manifest rebuild drops sections/checks/globals)

### DIFF
--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -377,8 +377,15 @@
                 var body = bySection[sid];
                 var logical = sid || null;
                 var visual = visualOrderForSection(logical);
+                // An empty section's only drop target is this row, so label it
+                // as a "move into" target; a populated section's row keeps the
+                // "remove dependency" meaning (dropping a child here within its
+                // own section promotes it to a top-level root).
+                var rootLabel = visual.length
+                    ? '&#9660; Drop here to remove dependency'
+                    : '&#9660; Drop tests here';
                 body.innerHTML = visual.map(function (v) { return rowHTML(v.item, v.depth); }).join('')
-                    + '<tr class="suite-root-drop"><td colspan="4">&#9660; Drop here to remove dependency</td></tr>';
+                    + '<tr class="suite-root-drop"><td colspan="4">' + rootLabel + '</td></tr>';
             });
             // Items whose sectionID doesn't resolve to any server-rendered
             // tbody (shouldn't happen given `normaliseItems` nils orphans,
@@ -556,6 +563,57 @@
             });
         }
 
+        // ── Auto-scroll while dragging ──
+        // HTML5 drag-and-drop doesn't scroll the page on its own, so a suite
+        // list taller than one screen can't be reorganised across the fold
+        // (e.g. dragging a freed test up to its proper section).  When the
+        // pointer nears the top/bottom edge of the viewport during an active
+        // drag, scroll the window — driven by a requestAnimationFrame loop
+        // keyed off the latest pointer Y so the speed ramps with proximity.
+        var autoScrollRAF = null;
+        var autoScrollVel = 0;
+        var AUTO_SCROLL_EDGE = 80;   // px from a viewport edge that triggers scrolling
+        var AUTO_SCROLL_MAX  = 20;   // max px per frame, reached at the very edge
+
+        function autoScrollStep() {
+            if (!autoScrollVel || (!dragID && !dragSectionID)) {
+                autoScrollRAF = null;
+                return;
+            }
+            window.scrollBy(0, autoScrollVel);
+            autoScrollRAF = window.requestAnimationFrame(autoScrollStep);
+        }
+
+        function updateAutoScroll(clientY) {
+            var vh = window.innerHeight || document.documentElement.clientHeight;
+            var vel = 0;
+            if (clientY < AUTO_SCROLL_EDGE) {
+                vel = -AUTO_SCROLL_MAX * (1 - clientY / AUTO_SCROLL_EDGE);
+            } else if (clientY > vh - AUTO_SCROLL_EDGE) {
+                vel = AUTO_SCROLL_MAX * (1 - (vh - clientY) / AUTO_SCROLL_EDGE);
+            }
+            autoScrollVel = vel;
+            if (vel && autoScrollRAF == null) {
+                autoScrollRAF = window.requestAnimationFrame(autoScrollStep);
+            }
+        }
+
+        function stopAutoScroll() {
+            autoScrollVel = 0;
+            if (autoScrollRAF != null) {
+                window.cancelAnimationFrame(autoScrollRAF);
+                autoScrollRAF = null;
+            }
+        }
+
+        // Document-level so the pointer can leave the suite container (into the
+        // page header/footer) and still drive the scroll near the edges.  Only
+        // acts while one of our drags is in flight; never calls preventDefault
+        // so the container's own dragover keeps owning the drop indicators.
+        document.addEventListener('dragover', function (e) {
+            if (dragID || dragSectionID) updateAutoScroll(e.clientY);
+        });
+
         container.addEventListener('dragstart', function (e) {
             var t = e.target;
             if (!t || !t.closest) { e.preventDefault(); return; }
@@ -590,6 +648,7 @@
         container.addEventListener('dragend', function () {
             dragID = null;
             dragSectionID = null;
+            stopAutoScroll();
             container.querySelectorAll('.suite-row-dragging').forEach(function (r) { r.classList.remove('suite-row-dragging'); });
             container.querySelectorAll('.section-dragging').forEach(function (r) { r.classList.remove('section-dragging'); });
             clearDropIndicators();
@@ -651,6 +710,7 @@
 
         container.addEventListener('drop', function (e) {
             e.preventDefault();
+            stopAutoScroll();
             // Section-drag: reorder server-rendered sections via AJAX.
             // On 200, update DOM order (we already did client-side) and
             // persist via a POST to /suite-sections/reorder.  No reload —
@@ -676,8 +736,34 @@
             if (rootZone) {
                 var tbody = rootZone.closest('tbody[data-section-id]');
                 var newSid = tbody ? (tbody.getAttribute('data-section-id') || null) : null;
-                dragItem.sectionID = newSid || null;
-                dragItem.dependsOn = [];
+                var curSid = dragItem.sectionID || null;
+                if ((newSid || null) === curSid) {
+                    // Same section: this zone promotes the item to a top-level
+                    // root by removing its dependency.
+                    dragItem.dependsOn = [];
+                } else {
+                    // Different section (e.g. a freshly created, empty
+                    // section whose only drop target is this row): move the
+                    // whole connected dependency group so dependents and
+                    // prerequisites travel together instead of being
+                    // stranded.  Deps are preserved — the group is
+                    // internally closed — and it lands as a contiguous block
+                    // at the end of the target section.
+                    var groupSet = {};
+                    connectedDependencyGroup(dragID).forEach(function (id) { groupSet[id] = true; });
+                    var moving = items.filter(function (it) { return groupSet[it.id]; });
+                    moving.forEach(function (it) { it.sectionID = newSid || null; });
+                    items = items.filter(function (it) { return !groupSet[it.id]; });
+                    var lastIdx = -1;
+                    items.forEach(function (it, idx) {
+                        if ((it.sectionID || null) === (newSid || null)) lastIdx = idx;
+                    });
+                    if (lastIdx < 0) {
+                        items = items.concat(moving);
+                    } else {
+                        items.splice.apply(items, [lastIdx + 1, 0].concat(moving));
+                    }
+                }
                 renderTree(); schedulePush(); return;
             }
 

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -46,8 +46,10 @@ func setupHasAnyTestEntries(manifestJSON: String) throws -> Bool {
 }
 
 /// Returns updated manifest JSON with a new `TestSuiteEntry` appended.
-/// Preserves all existing entries, grading mode, makefile config,
-/// starterNotebook, and pattern families.
+/// Preserves all existing entries (including their `sectionID`,
+/// `generatedByCheck`, and `hint`), grading mode, makefile config,
+/// starterNotebook, pattern families, notebook checks, the `sections`
+/// list, and the assignment-scope global variables/expressions.
 /// Returns `nil` if the manifest JSON cannot be decoded.
 func updateManifestAddingScript(
     manifestJSON: String,
@@ -66,7 +68,10 @@ func updateManifestAddingScript(
             dependsOn: e.dependsOn,
             points: e.points,
             displayName: e.name,
-            generatedBy: e.generatedBy
+            generatedBy: e.generatedBy,
+            generatedByCheck: e.generatedByCheck,
+            sectionID: e.sectionID,
+            hint: e.hint
         )
     }
     let nextOrder = (existing.map(\.order).max() ?? 0) + 1
@@ -77,7 +82,10 @@ func updateManifestAddingScript(
         dependsOn: entry.dependsOn,
         points: entry.points,
         displayName: entry.displayName,
-        generatedBy: entry.generatedBy
+        generatedBy: entry.generatedBy,
+        generatedByCheck: entry.generatedByCheck,
+        sectionID: entry.sectionID,
+        hint: entry.hint
     )
     let updated = existing + [newEntry]
     return try? makeWorkerManifestJSON(
@@ -85,12 +93,20 @@ func updateManifestAddingScript(
         includeMakefile: props.makefile != nil,
         gradingMode: props.gradingMode.rawValue,
         starterNotebook: props.starterNotebook,
-        patternFamilies: props.patternFamilies
+        patternFamilies: props.patternFamilies,
+        notebookChecks: props.notebookChecks,
+        sections: props.sections,
+        globalVariables: props.globalVariables,
+        globalExpressions: props.globalExpressions
     )
 }
 
 /// Returns updated manifest JSON with the entry for `filename` removed.
 /// Also clears references to `filename` in other entries' `dependsOn` arrays.
+/// Preserves the surviving entries' `sectionID` / `generatedByCheck` /
+/// `hint`, plus the manifest's pattern families, notebook checks,
+/// `sections` list, and assignment-scope global variables/expressions —
+/// deleting one script must never drop sections or other suite metadata.
 /// Returns `nil` if the manifest JSON cannot be decoded.
 func updateManifestRemovingScript(manifestJSON: String, filename: String) -> String? {
     guard let props = decodeManifest(fromJSON: manifestJSON)
@@ -109,7 +125,10 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
                 dependsOn: e.dependsOn.filter { $0 != filename },
                 points: e.points,
                 displayName: e.name,
-                generatedBy: e.generatedBy
+                generatedBy: e.generatedBy,
+                generatedByCheck: e.generatedByCheck,
+                sectionID: e.sectionID,
+                hint: e.hint
             )
         }
     return try? makeWorkerManifestJSON(
@@ -117,7 +136,11 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
         includeMakefile: props.makefile != nil,
         gradingMode: props.gradingMode.rawValue,
         starterNotebook: props.starterNotebook,
-        patternFamilies: props.patternFamilies
+        patternFamilies: props.patternFamilies,
+        notebookChecks: props.notebookChecks,
+        sections: props.sections,
+        globalVariables: props.globalVariables,
+        globalExpressions: props.globalExpressions
     )
 }
 

--- a/Tests/APITests/AssignmentHelpersManifestTests.swift
+++ b/Tests/APITests/AssignmentHelpersManifestTests.swift
@@ -172,6 +172,69 @@ final class AssignmentHelpersManifestTests {
         #expect(props.testSuites.first?.dependsOn.isEmpty ?? true)
     }
 
+    // Regression: deleting one script must never wipe the manifest's
+    // sections list, the surviving entries' sectionID membership, or the
+    // assignment-scope globals.  Previously `updateManifestRemovingScript`
+    // rebuilt the manifest without forwarding any of these, so a single
+    // delete dropped every section.
+    @Test func updateManifestRemovingScriptPreservesSectionsAndMembership() throws {
+        let original = try makeWorkerManifestJSON(
+            testSuites: [
+                ConfiguredSuiteEntry(
+                    script: "01_public.py", tier: "public", order: 1,
+                    dependsOn: [], points: 1, displayName: nil, sectionID: "sec-1"),
+                ConfiguredSuiteEntry(
+                    script: "02_release.py", tier: "release", order: 2,
+                    dependsOn: [], points: 1, displayName: nil, sectionID: "sec-2"),
+            ],
+            includeMakefile: false,
+            sections: [
+                TestSuiteSection(id: "sec-1", name: "Question 1"),
+                TestSuiteSection(id: "sec-2", name: "Question 2"),
+            ],
+            globalVariables: [FamilyVariable(name: "limit", value: .int(5))]
+        )
+
+        let updated = try #require(
+            updateManifestRemovingScript(manifestJSON: original, filename: "01_public.py")
+        )
+
+        let props = try JSONDecoder().decode(TestProperties.self, from: Data(updated.utf8))
+        #expect(props.testSuites.map(\.script) == ["02_release.py"])
+        // Both sections survive even though one was emptied by the delete.
+        #expect(props.sections.map(\.id) == ["sec-1", "sec-2"])
+        // The surviving entry keeps its section membership.
+        #expect(props.testSuites.first?.sectionID == "sec-2")
+        // Assignment-scope globals are untouched.
+        #expect(props.globalVariables.map(\.name) == ["limit"])
+    }
+
+    @Test func updateManifestAddingScriptPreservesSections() throws {
+        let original = try makeWorkerManifestJSON(
+            testSuites: [
+                ConfiguredSuiteEntry(
+                    script: "01_public.py", tier: "public", order: 1,
+                    dependsOn: [], points: 1, displayName: nil, sectionID: "sec-1")
+            ],
+            includeMakefile: false,
+            sections: [TestSuiteSection(id: "sec-1", name: "Question 1")]
+        )
+
+        let updated = try #require(
+            updateManifestAddingScript(
+                manifestJSON: original,
+                entry: ConfiguredSuiteEntry(
+                    script: "02_public.py", tier: "public", order: 99,
+                    dependsOn: [], points: 1, displayName: nil)
+            )
+        )
+
+        let props = try JSONDecoder().decode(TestProperties.self, from: Data(updated.utf8))
+        #expect(props.testSuites.map(\.script).sorted() == ["01_public.py", "02_public.py"])
+        #expect(props.sections.map(\.id) == ["sec-1"])
+        #expect(props.testSuites.first(where: { $0.script == "01_public.py" })?.sectionID == "sec-1")
+    }
+
     @Test func detectRequirementSuggestionsIgnoresSolutionNotebookImports() throws {
         let zipPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("detect-requirements-\(UUID().uuidString).zip")

--- a/changelog.d/fix-delete-script-wipes-sections.md
+++ b/changelog.d/fix-delete-script-wipes-sections.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Deleting a test no longer wipes all sections.** The manifest-rebuild
+  helpers used by the add-script and delete-script endpoints
+  (`updateManifestAddingScript` / `updateManifestRemovingScript`) only
+  forwarded the test list and pattern families to the manifest builder, so
+  every other field — the `sections` list, each surviving entry's
+  `sectionID` membership, notebook checks, `generatedByCheck`/`hint`, and the
+  assignment-scope global variables/expressions — was silently dropped on
+  every single-script add or delete. Deleting one test therefore deleted all
+  of an assignment's sections. The helpers now carry the full manifest
+  through the rebuild.

--- a/changelog.d/suite-editor-section-drag-autoscroll.md
+++ b/changelog.d/suite-editor-section-drag-autoscroll.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Suite editor: drag whole test blocks into new sections, and auto-scroll
+  while dragging.** Dropping a test onto a freshly created (empty) section's
+  drop row now moves the entire connected dependency group into that section
+  with its prerequisites/dependents intact, instead of stranding the children
+  and silently wiping the parent's dependencies. The drop row in an empty
+  section is now labelled "Drop tests here" (it keeps the "remove dependency"
+  meaning only inside a populated section). The suite list also auto-scrolls
+  the page when a drag nears the top or bottom of the viewport, so long suites
+  taller than one screen can be reorganised without manually scrolling.


### PR DESCRIPTION
## Bug

Deleting a single test in the assignment suite editor **deleted every section** on that assignment (reported as a major usability/data-loss bug). Adding a script had the same latent fault.

## Root cause

The manifest-rebuild helpers used by the add-script and delete-script endpoints — `updateManifestAddingScript` and `updateManifestRemovingScript` in `ManifestFileHelpers.swift` — rebuild the manifest by calling `makeWorkerManifestJSON(...)`, but only passed `testSuites` and `patternFamilies`. Every other parameter of `makeWorkerManifestJSON` has an empty default, so each rebuild silently dropped:

- the `sections` list (→ **all sections deleted**)
- each surviving entry's `sectionID` (→ section membership lost)
- `notebookChecks`
- per-entry `generatedByCheck` and `hint`
- assignment-scope `globalVariables` / `globalExpressions`

The main `PUT /suite` path (`applyPatternFamilies`) already forwarded these correctly; only the single-script add/delete helpers were lossy.

## Fix

Both helpers now:
- reconstruct each `ConfiguredSuiteEntry` with its `sectionID`, `generatedByCheck`, and `hint` preserved, and
- forward `props.notebookChecks`, `props.sections`, `props.globalVariables`, and `props.globalExpressions` to `makeWorkerManifestJSON`.

## Tests

Added two regression tests in `AssignmentHelpersManifestTests`:
- `updateManifestRemovingScriptPreservesSectionsAndMembership` — removing a script keeps both sections (even an emptied one), the surviving entry's `sectionID`, and global variables.
- `updateManifestAddingScriptPreservesSections` — adding a script keeps the existing section and membership.

All 19 tests in the suite pass; `APIServer` builds clean.

https://claude.ai/code/session_015S9sEm2hLPMQqvKdw3rMCt

---
_Generated by [Claude Code](https://claude.ai/code/session_015S9sEm2hLPMQqvKdw3rMCt)_