### PR TITLE
Add MCP author_script tool for raw test/support file authoring

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -101,8 +101,8 @@ enum MCPServerInstructions {
         3. Edit: update_assignment (metadata), update_suite (script metadata), update_pattern_family \
         (family defaults/cases), update_global_inputs (personalization variables/expressions), \
         update_section_variables (a section's scoped variables/expressions), update_notebook (replace \
-        the starter notebook). To create a new assignment, clone_assignment from a known-good one and \
-        then edit the copy.
+        the starter notebook), author_script (create/replace a hand-written test or support file). To \
+        create a new assignment, clone_assignment from a known-good one and then edit the copy.
 
         Important behaviors:
         - Any content edit (suite, pattern family, notebook) re-runs validation asynchronously; \
@@ -113,11 +113,16 @@ enum MCPServerInstructions {
         the returned JSON.
         - clone_assignment lands closed, unvalidated, with no due date and no submissions, so nothing \
         is regraded; validate and open it with update_assignment when ready.
-        - You can read everything but author only some of it. get_suite returns hand-written script \
-        bodies and full pattern-family specs for reading, but you author structure, metadata, and \
-        pattern-family test cases only: update_pattern_family can edit a generated case's \
-        args/expected (validated on save), while the contents of hand-written `.sh`/`.py` test \
-        scripts are read-only through this interface.
+        - get_suite returns the full source of truth for reading: hand-written script bodies, \
+        complete pattern-family specs, and notebook-check specs. For authoring, update_pattern_family \
+        edits a generated case's args/expected (validated on save), and author_script writes a single \
+        hand-written file into the test setup. A test tier (public/release/secret/student) creates or \
+        replaces the script AND its suite entry — set points/displayName/dependsOn/sectionID alongside \
+        the body; the runner reads the per-student seed from the CHICKADEE_ASSIGNMENT_SEED env var, so \
+        a secret test can re-derive a personalized expected answer. The "support" tier writes a \
+        non-graded helper file (e.g. a data generator) that tests and personalization expressions can \
+        import by stem. Generated pattern-family / notebook-check scripts are not editable via \
+        author_script — edit the family/check instead.
         - Resources: each accessible assignment's raw test.properties.json manifest is also exposed \
         as an MCP resource (resources/list, then resources/read on \
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -1,0 +1,333 @@
+// APIServer/MCP/Tools/AuthorScriptTool.swift
+//
+// Write tool: create or replace a single hand-written test or support file in
+// an assignment's test-setup zip, by public ID.  content:write, course-scoped.
+//
+// This is the raw-script-authoring channel the other write tools deliberately
+// omit (update_suite edits metadata only; update_pattern_family edits generated
+// cases).  It mirrors the web "New Script" / per-script edit endpoints:
+//
+//   - A *test* tier (public/release/secret/student) upserts the file AND its
+//     suite (manifest) entry through the same `applySuiteEdit` path the suite
+//     editor uses, so tier/points/displayName/dependsOn/section all persist and
+//     validation re-runs.
+//   - The *support* pseudo-tier writes a helper file that is NOT a graded suite
+//     entry — importable by tests and by personalization expressions (e.g. a
+//     genome→sequence generator) — keeping the shared support directory in sync.
+//
+// Generated files (pattern-family / notebook-check output) are never editable
+// here: those are owned by their family/check and the call is rejected, exactly
+// as the web `PUT /scripts/:filename` returns 409.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+struct AuthorScriptTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        let filename: String
+        let content: String
+        /// public/release/secret/student, or "support" for a non-graded helper
+        /// file.  When omitted, an existing file keeps its current kind/tier and
+        /// a brand-new file defaults to a public test.
+        let tier: String?
+        let points: Int?
+        let displayName: String?
+        let dependsOn: [String]?
+        let sectionID: String?
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let filename: String
+        let tier: String
+        /// false for support files (not part of the graded suite).
+        let isTest: Bool
+        /// true when the file did not previously exist in the setup zip.
+        let created: Bool
+        /// The assignment's validation status; the edit re-kicks validation
+        /// asynchronously, so re-read get_assignment to see it settle.
+        let validationStatus: String?
+    }
+
+    static let name = "author_script"
+    static let description =
+        "Create or replace a single hand-written test or support file in an assignment's test "
+        + "setup, by its public ID. Provide filename (a bare name, no path separators) and content "
+        + "(the full script body). tier is public/release/secret/student for a graded test, or "
+        + "\"support\" for a helper file that tests or personalization expressions can import but that "
+        + "is not itself graded; omit tier to keep an existing file's kind (new files default to a "
+        + "public test). For test tiers you may also set points, displayName, dependsOn (prerequisite "
+        + "script names or family:<id> tokens), and sectionID (an existing section). Cannot edit "
+        + "pattern-family or notebook-check generated scripts — edit the family/check instead. Saving "
+        + "re-runs the assignment's validation."
+
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "filename": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Bare filename with no path separators, e.g. \"secrettest_marker.py\". "
+                        + "Python files should start with a `#!/usr/bin/env python3` shebang so "
+                        + "extensionless names aren't run as /bin/sh."),
+            ]),
+            "content": .object([
+                "type": .string("string"),
+                "description": .string("The full script body, written verbatim into the setup zip."),
+            ]),
+            "tier": .object([
+                "type": .string("string"),
+                "enum": .array([
+                    .string("public"), .string("release"), .string("secret"),
+                    .string("student"), .string("support"),
+                ]),
+                "description": .string(
+                    "Graded tier, or \"support\" for a non-graded helper file. "
+                        + "Omit to keep an existing file's kind; new files default to public."),
+            ]),
+            "points": .object([
+                "type": .string("integer"),
+                "description": .string("Marks for a test tier (ignored for support). Defaults to 1 on create."),
+            ]),
+            "displayName": .object([
+                "type": .string("string"),
+                "description": .string("Friendly name shown in the suite and results (test tiers only)."),
+            ]),
+            "dependsOn": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+                "description": .string(
+                    "Prerequisite script filenames or family:<id> tokens (test tiers only)."),
+            ]),
+            "sectionID": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Existing section id to place a test row into (test tiers only); "
+                        + "an unknown id is treated as ungrouped."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("filename"), .string("content")]),
+        "additionalProperties": .bool(false),
+    ])
+
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "filename": .object(["type": .string("string")]),
+            "tier": .object(["type": .string("string")]),
+            "isTest": .object(["type": .string("boolean")]),
+            "created": .object(["type": .string("boolean")]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("filename"), .string("tier"),
+            .string("isTest"), .string("created"),
+        ]),
+    ])
+
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    // MARK: - Tier resolution
+
+    private enum ResolvedTier {
+        case test(TestTier)
+        case support
+
+        var isTest: Bool {
+            if case .test = self { return true }
+            return false
+        }
+
+        var wireValue: String {
+            switch self {
+            case .test(let tier): return tier.rawValue
+            case .support: return "support"
+            }
+        }
+    }
+
+    private static func parseTier(_ raw: String) throws -> ResolvedTier {
+        if raw == "support" { return .support }
+        guard let tier = TestTier(rawValue: raw) else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "tier must be one of: public, release, secret, student, support.")
+        }
+        return .test(tier)
+    }
+
+    // MARK: - Execute
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        guard !input.content.isEmpty else {
+            throw MCPToolError.invalidArguments(tool: Self.name, detail: "`content` must not be empty.")
+        }
+        let cleaned = sanitizeSuiteFilename(input.filename)
+        guard !cleaned.isEmpty, cleaned == input.filename else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "filename must be a bare filename with no path separators (got \"\(input.filename)\").")
+        }
+
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        // Never clobber a pattern-family / notebook-check generated script —
+        // those are owned by the family/check, mirroring the web 409.
+        if let familyID = generatedByFamilyID(manifestJSON: setup.manifest, filename: cleaned) {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "\"\(cleaned)\" is generated from pattern family \"\(familyID)\"; edit the family instead.")
+        }
+
+        let manifest = setup.decodedManifest()
+        let existingTestEntry = manifest?.testSuites.first { $0.script == cleaned }
+        let existedInZip = listZipEntries(zipPath: setup.zipPath).contains(cleaned)
+
+        // Resolve the effective kind/tier: explicit input wins; otherwise keep
+        // an existing test's tier, treat an existing non-suite file as support,
+        // and default a brand-new file to a public test.
+        let resolved: ResolvedTier
+        if let raw = input.tier {
+            resolved = try Self.parseTier(raw)
+        } else if let existingTestEntry {
+            resolved = .test(existingTestEntry.tier)
+        } else if existedInZip {
+            resolved = .support
+        } else {
+            resolved = .test(.pub)
+        }
+
+        switch resolved {
+        case .support:
+            // Demoting a currently-graded test to a support file would orphan
+            // its manifest entry, so refuse it here and point at the dedicated
+            // tools instead. Promotion (support → test) is fine via the suite
+            // path below.
+            if existingTestEntry != nil {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail: "\"\(cleaned)\" is currently a graded test; change its tier with update_suite "
+                        + "or delete it before re-authoring it as a support file.")
+            }
+            try authorSupportFile(
+                filename: cleaned, content: input.content, setup: setup, assignment: assignment, context: context)
+        case .test(let tier):
+            try await authorTestScript(
+                filename: cleaned, content: input.content, tier: tier, input: input,
+                setup: setup, context: context)
+        }
+
+        // Re-kick validation against the new manifest/zip (debounced), mirroring
+        // the web suite/script edit handlers.
+        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            filename: cleaned,
+            tier: resolved.wireValue,
+            isTest: resolved.isTest,
+            created: !existedInZip,
+            validationStatus: assignment.validationStatus)
+    }
+
+    // MARK: - Test-script authoring (suite-payload path)
+
+    private func authorTestScript(
+        filename: String, content: String, tier: TestTier, input: Input,
+        setup: APITestSetup, context: ToolContext
+    ) async throws {
+        // Load the full authored suite (script bodies preserved from the zip)
+        // so applySuiteEdit rewrites the whole list without dropping the other
+        // scripts — exactly the channel UpdateSuiteTool uses.
+        var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
+        let normalizedSection = input.sectionID.flatMap { $0.isEmpty ? nil : $0 }
+        let displayName = input.displayName.flatMap { $0.isEmpty ? nil : $0 }
+        let points = max(0, input.points ?? 1)
+
+        if let idx = payload.items.firstIndex(where: { $0.kind == "script" && $0.script?.script == filename }) {
+            // Replace an existing hand-written script. Content + tier always
+            // apply; the rest only when the caller supplied them.
+            payload.items[idx].script?.content = content
+            payload.items[idx].script?.tier = tier
+            if input.points != nil { payload.items[idx].script?.points = points }
+            if let dn = input.displayName { payload.items[idx].script?.displayName = dn.isEmpty ? nil : dn }
+            if let deps = input.dependsOn { payload.items[idx].script?.dependsOn = deps }
+            if input.sectionID != nil { payload.items[idx].sectionID = normalizedSection }
+        } else {
+            // Create a new hand-written script. Insert it adjacent to its
+            // section's existing block (or the ungrouped block) so the
+            // server-side contiguity check in applyPatternFamilies passes.
+            let dto = ScriptDTO(
+                script: filename, tier: tier, points: points,
+                displayName: displayName, dependsOn: input.dependsOn ?? [],
+                content: content, hint: nil)
+            let item = SuiteItemDTO(
+                kind: "script", script: dto, family: nil, check: nil,
+                dependsOn: nil, sectionID: normalizedSection)
+            if let lastIdx = payload.items.lastIndex(where: { $0.sectionID == normalizedSection }) {
+                payload.items.insert(item, at: payload.items.index(after: lastIdx))
+            } else {
+                payload.items.append(item)
+            }
+        }
+
+        do {
+            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
+        } catch let error as WebAssignmentError {
+            throw MCPToolError.from(error, tool: Self.name)
+        } catch let error as any AbortError {
+            throw MCPToolError.from(error, tool: Self.name)
+        }
+    }
+
+    // MARK: - Support-file authoring (direct zip write)
+
+    private func authorSupportFile(
+        filename: String, content: String, setup: APITestSetup,
+        assignment: APIAssignment, context: ToolContext
+    ) throws {
+        // Inline global + section variables into a `.py` helper (no-op for
+        // other extensions or an undecodable manifest), matching the web
+        // POST /scripts support path.
+        let toWrite: String = {
+            guard let manifest = setup.decodedManifest() else { return content }
+            return TestScriptVariablePrepender.applyForRawScript(
+                filename: filename, content: content, manifest: manifest)
+        }()
+
+        do {
+            try updateScriptInZip(zipPath: setup.zipPath, filename: filename, content: toWrite)
+        } catch {
+            throw MCPToolError.executionFailed(
+                tool: Self.name, detail: "Failed to write \"\(filename)\" into the setup zip.")
+        }
+
+        // Keep the shared support directory (student working-copy symlinks +
+        // the synthetic solution.py) in sync, as the web upload path does.
+        let testSuiteScripts: Set<String> = {
+            guard let props = setup.decodedManifest() else { return [] }
+            return Set(props.testSuites.map(\.script))
+        }()
+        extractSupportFilesToSharedDirectory(
+            zipPath: setup.zipPath,
+            setupID: assignment.testSetupID,
+            testSuiteScripts: testSuiteScripts,
+            testSetupsDirectory: context.request.application.testSetupsDirectory)
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -30,6 +30,7 @@ enum MCPToolCatalog {
             UpdateSectionVariablesTool().erased(),
             UpdatePatternFamilyTool().erased(),
             UpdateNotebookTool().erased(),
+            AuthorScriptTool().erased(),
             CloneAssignmentTool().erased(),
             CreateAssignmentTool().erased(),
         ])

--- a/Tests/APITests/MCP/AuthorScriptToolTests.swift
+++ b/Tests/APITests/MCP/AuthorScriptToolTests.swift
@@ -1,0 +1,197 @@
+// Tests for AuthorScriptTool (create/replace a hand-written test or support
+// file in the test-setup zip), backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct AuthorScriptToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let manifest = """
+        {"schemaVersion":1,"testSuites":[\
+        {"tier":"public","script":"test_a.sh","points":1}\
+        ],"timeLimitSeconds":10}
+        """
+
+    /// Course + enrolled instructor + setup (manifest above, with a real zip
+    /// holding the script so applySuiteEdit can rebuild it) + assignment.
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_as", courseID: courseID, manifest: manifest)
+        try writeZip(
+            at: app.testSetupsDirectory + "setup_as.zip",
+            entries: [(".placeholder", "x"), ("test_a.sh", "exit 0\n")])
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_as", courseID: courseID, title: "Lab")
+    }
+
+    private func writeZip(at zipPath: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("as-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            let url = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.data(using: .utf8)?.write(to: url)
+        }
+        try? FileManager.default.removeItem(atPath: zipPath)
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+    }
+
+    private func input(
+        _ assignment: APIAssignment, filename: String, content: String,
+        tier: String? = nil, points: Int? = nil, displayName: String? = nil,
+        dependsOn: [String]? = nil, sectionID: String? = nil
+    ) -> AuthorScriptTool.Input {
+        AuthorScriptTool.Input(
+            assignmentPublicID: assignment.publicID, filename: filename, content: content,
+            tier: tier, points: points, displayName: displayName, dependsOn: dependsOn, sectionID: sectionID)
+    }
+
+    @Test func createsNewTestScriptWithMetadata() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await AuthorScriptTool().execute(
+                input(
+                    assignment, filename: "secrettest_marker.py",
+                    content: "#!/usr/bin/env python3\nprint('ok')\n",
+                    tier: "secret", points: 3, displayName: "Marker",
+                    dependsOn: ["test_a.sh"]),
+                context(app))
+            #expect(output.created)
+            #expect(output.isTest)
+            #expect(output.tier == "secret")
+
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest, zipPath: reloaded.zipPath).items
+            let row = try #require(items.first { $0.script?.script == "secrettest_marker.py" })
+            #expect(row.script?.tier == .secret)
+            #expect(row.script?.points == 3)
+            #expect(row.script?.displayName == "Marker")
+            #expect(row.script?.dependsOn == ["test_a.sh"])
+            // The body landed in the zip verbatim.
+            let body = try #require(readScriptFromZip(zipPath: reloaded.zipPath, filename: "secrettest_marker.py"))
+            #expect(body.contains("print('ok')"))
+        }
+    }
+
+    @Test func replacesExistingScriptBodyAndKeepsTierWhenOmitted() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Create as secret.
+            _ = try await AuthorScriptTool().execute(
+                input(assignment, filename: "t.py", content: "#!/usr/bin/env python3\nx=1\n", tier: "secret"),
+                context(app))
+            // Replace body without specifying tier — must stay secret.
+            let output = try await AuthorScriptTool().execute(
+                input(assignment, filename: "t.py", content: "#!/usr/bin/env python3\nx=2\n"),
+                context(app))
+            #expect(!output.created)
+            #expect(output.tier == "secret")
+
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest, zipPath: reloaded.zipPath).items
+            let row = try #require(items.first { $0.script?.script == "t.py" })
+            #expect(row.script?.tier == .secret)
+            let body = try #require(readScriptFromZip(zipPath: reloaded.zipPath, filename: "t.py"))
+            #expect(body.contains("x=2"))
+        }
+    }
+
+    @Test func writesSupportFileWithoutSuiteEntry() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await AuthorScriptTool().execute(
+                input(assignment, filename: "helpers.py", content: "def gen():\n    return 1\n", tier: "support"),
+                context(app))
+            #expect(output.created)
+            #expect(!output.isTest)
+            #expect(output.tier == "support")
+
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            // The file is in the zip but NOT a suite entry.
+            #expect(listZipEntries(zipPath: reloaded.zipPath).contains("helpers.py"))
+            let props = try #require(reloaded.decodedManifest())
+            #expect(!props.testSuites.contains { $0.script == "helpers.py" })
+        }
+    }
+
+    @Test func rejectsPathSeparatorsInFilename() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await AuthorScriptTool().execute(
+                    input(assignment, filename: "../escape.py", content: "x=1\n"), context(app))
+            }
+        }
+    }
+
+    @Test func rejectsEmptyContent() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await AuthorScriptTool().execute(
+                    input(assignment, filename: "t.py", content: ""), context(app))
+            }
+        }
+    }
+
+    @Test func rejectsInvalidTier() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await AuthorScriptTool().execute(
+                    input(assignment, filename: "t.py", content: "x=1\n", tier: "bogus"), context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            // tester NOT enrolled.
+            try await makeTestSetup(on: app, id: "setup_as", courseID: courseID, manifest: manifest)
+            try writeZip(
+                at: app.testSetupsDirectory + "setup_as.zip",
+                entries: [(".placeholder", "x"), ("test_a.sh", "exit 0\n")])
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_as", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await AuthorScriptTool().execute(
+                    input(assignment, filename: "t.py", content: "x=1\n", tier: "secret"), context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-author-script.md
+++ b/changelog.d/mcp-author-script.md
@@ -1,0 +1,12 @@
+### Added
+
+- **MCP `author_script` tool.** The content-authoring MCP server can now create
+  or replace a single hand-written test or support file in an assignment's test
+  setup. A test tier (`public`/`release`/`secret`/`student`) upserts the file
+  and its suite entry — with `points`/`displayName`/`dependsOn`/`sectionID` — and
+  re-runs validation; the `support` pseudo-tier writes a non-graded helper file
+  (e.g. a per-assignment data generator) that test scripts and personalization
+  expressions can import. Generated pattern-family / notebook-check scripts stay
+  read-only (edit the family/check instead). This closes the gap that previously
+  forced raw-script edits through the web editor, and unlocks seed-aware secret
+  tests for per-student personalized answers.


### PR DESCRIPTION
## What

Adds an **`author_script`** content-authoring MCP tool so an authorized agent can create or replace a single **hand-written test or support file** in an assignment's test-setup zip. This is the raw-script-authoring channel the existing write tools deliberately omitted (`update_suite` edits metadata only; `update_pattern_family` edits generated cases).

## Why

Two motivations:

1. **Seed-aware secret tests.** Per-student personalization (`= expression` global inputs) only substitutes into the *starter notebook*, not into pattern-family test cases. To grade a personalized answer (e.g. "which sample contains human DNA markers?" where the correct sample is shuffled per student), the secret check must be a raw Python script that reads `CHICKADEE_ASSIGNMENT_SEED` and re-derives the expected value — exactly the documented Slice-2 pattern. Until now that script could only be authored through the web editor.
2. **Custom support files.** Instructors want to feed in helper scripts (e.g. a genome→DNA-sequence generator) that tests and personalization expressions can import. The `support` tier covers this.

## How

Mirrors the proven web `POST/PUT /scripts` paths:

- **Test tiers** (`public`/`release`/`secret`/`student`) — upserts the file **and** its suite/manifest entry through the same `applySuiteEdit` → `applyPatternFamilies` path the suite editor uses, so `points`/`displayName`/`dependsOn`/`sectionID` persist and validation re-runs. New rows are inserted adjacent to their section's block so the server-side contiguity check passes. Omitting `tier` keeps an existing file's current tier (no accidental re-tiering); new files default to public.
- **`support` pseudo-tier** — writes a non-graded helper file directly into the zip (with `.py` variable inlining) and re-syncs the shared support directory (student symlinks + synthetic `solution.py`). Demoting a currently-graded test to support is refused (would orphan the manifest entry).
- **Safety** — generated pattern-family / notebook-check scripts are rejected (matching the web 409); filenames are sanitized (no path separators); empty content is rejected; course-scoped authorization via `authorizeCourseAccess`.

Registered in `MCPToolCatalog`; the `initialize` handshake instructions now document the tool and the `CHICKADEE_ASSIGNMENT_SEED` contract.

## Tests

New `AuthorScriptToolTests` (7 cases): create-with-metadata, replace-keeps-tier-when-omitted, support-file-without-suite-entry, path-separator rejection, empty-content rejection, invalid-tier rejection, and enrollment denial. All **119** MCP tests pass; `swift-format`, `scripts/lint.sh`, and SwiftLint `--strict` are clean.

## Notes

- Scope: `content:write`; gated by `MCP_MODE=read_write` like the other write tools.
- Out of scope (possible follow-ups): a `delete_script` tool; promoting/demoting tier of an existing graded test via this tool.

https://claude.ai/code/session_015LsMAJ1F6s2FvmPeuiLYh3

---
_Generated by [Claude Code](https://claude.ai/code/session_015LsMAJ1F6s2FvmPeuiLYh3)_