### PR TITLE
MCP get_suite returns full test definitions (script bodies + family cases)

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -79,7 +79,10 @@ enum MCPServerInstructions {
         - Test suite — the ordered checks that grade an assignment. Each item is a hand-written \
         script, a generated pattern family, or a notebook check, and carries a tier \
         (public/release/secret/student), points, an optional section, and prerequisites (dependsOn). \
-        Family IDs and case keys come from get_suite.
+        get_suite returns the full definition of every item, not just its metadata: each \
+        hand-written script's raw body, each pattern family's complete spec (function, paramNames, \
+        defaults, and every case's args/expected), and each notebook check's spec — so you can read \
+        exactly what a test checks (e.g. to explain why a submission lost points).
         - Starter notebook — the .ipynb a student opens, stored as Jupyter JSON.
         - Global inputs (personalization) — assignment-scoped names that vary the assignment per \
         student: literal `variables` (a name + JSON value) and `expressions` (a name + Python source \
@@ -110,9 +113,11 @@ enum MCPServerInstructions {
         the returned JSON.
         - clone_assignment lands closed, unvalidated, with no due date and no submissions, so nothing \
         is regraded; validate and open it with update_assignment when ready.
-        - You author structure, metadata, and pattern-family test cases, but not raw script bodies: \
-        update_pattern_family can edit a generated case's args/expected (validated on save), but the \
-        contents of hand-written `.sh`/`.py` test scripts are not editable through this interface.
+        - You can read everything but author only some of it. get_suite returns hand-written script \
+        bodies and full pattern-family specs for reading, but you author structure, metadata, and \
+        pattern-family test cases only: update_pattern_family can edit a generated case's \
+        args/expected (validated on save), while the contents of hand-written `.sh`/`.py` test \
+        scripts are read-only through this interface.
         - Resources: each accessible assignment's raw test.properties.json manifest is also exposed \
         as an MCP resource (resources/list, then resources/read on \
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -1,11 +1,14 @@
 // APIServer/MCP/Tools/GetSuiteTool.swift
 //
-// Read tool: returns an assignment's test-suite structure by public ID — the
-// ordered items (hand-written scripts, generated pattern families, notebook
+// Read tool: returns an assignment's full test-suite definition by public ID —
+// the ordered items (hand-written scripts, generated pattern families, notebook
 // checks) with tier/points/dependencies/section, plus the section list.
 // content:read, course-scoped. Reuses the author-facing `buildSuitePayload`
-// (without a zip path, so raw script bodies are NOT included — this is a
-// structure view; editing the suite is a later phase).
+// *with* the test setup's zip path, so the response carries the complete
+// declarative state an instructor sees in the suite editor: raw script bodies
+// (`content`), each pattern family's full spec including every case's
+// args/expected (`family`), and notebook-check specs (`check`). This is the
+// same authoring content `GET /instructor/:id/suite` returns to the browser.
 
 import Core
 import Fluent
@@ -40,6 +43,19 @@ struct GetSuiteTool: ContentTool {
             let sectionID: String?
             /// The pattern-family id, for `kind == "family"` items.
             let familyID: String?
+            /// Raw hand-written script body, for `kind == "script"` items, read
+            /// from the test setup zip. Nil for generated family/check rows
+            /// (their source is derived from the spec) or if the file is absent.
+            let content: String?
+            /// Instructor hint for a hand-written script (`kind == "script"`).
+            let hint: String?
+            /// Full pattern-family spec — function, kind, paramNames, defaults,
+            /// variables, and every case's args/expected — for `kind ==
+            /// "family"` items. This is the source of truth the grader renders
+            /// into Python, so it reveals the exact values each case checks.
+            let family: PatternFamily?
+            /// Full notebook-check spec, for `kind == "check"` items.
+            let check: NotebookCheck?
         }
         let assignmentPublicID: String
         let sections: [Section]
@@ -48,10 +64,14 @@ struct GetSuiteTool: ContentTool {
 
     static let name = "get_suite"
     static let description =
-        "Get an assignment's test-suite structure by public ID: the ordered test items "
+        "Get an assignment's full test-suite definition by public ID: the ordered test items "
         + "(hand-written scripts, generated pattern families, notebook checks) with their tier "
         + "(public/release/secret/student), points, display name, dependencies, and section, plus "
-        + "the section list. Read-only — use this to inspect the suite before editing it."
+        + "the section list. Each item also carries its source of truth: hand-written scripts "
+        + "include their raw body (`content`) and `hint`; pattern families include the full spec "
+        + "(`family`) with every case's args and expected value; notebook checks include their "
+        + "spec (`check`). Read-only — use this to inspect exactly what each test checks (e.g. to "
+        + "explain why a submission lost points) before editing the suite."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -95,6 +115,27 @@ struct GetSuiteTool: ContentTool {
                         ]),
                         "sectionID": .object(["type": .string("string")]),
                         "familyID": .object(["type": .string("string")]),
+                        "content": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Raw hand-written script body (kind == \"script\"); absent for "
+                                    + "generated family/check rows."),
+                        ]),
+                        "hint": .object([
+                            "type": .string("string"),
+                            "description": .string("Instructor hint for a hand-written script."),
+                        ]),
+                        "family": .object([
+                            "type": .string("object"),
+                            "description": .string(
+                                "Full pattern-family spec (kind == \"family\"): function, kind, "
+                                    + "paramNames, defaults, variables, and every case's "
+                                    + "args/expected — the exact values each case checks."),
+                        ]),
+                        "check": .object([
+                            "type": .string("object"),
+                            "description": .string("Full notebook-check spec (kind == \"check\")."),
+                        ]),
                     ]),
                     "required": .array([
                         .string("kind"), .string("name"), .string("tier"), .string("points"),
@@ -120,8 +161,11 @@ struct GetSuiteTool: ContentTool {
                 tool: Self.name, detail: "The assignment's test setup could not be found.")
         }
 
-        // No zip path → metadata-only rows (raw script bodies omitted).
-        let payload = buildSuitePayload(fromManifest: setup.manifest)
+        // Pass the zip path so raw hand-written script bodies are filled in
+        // (generated family/check files are derived from their specs and need
+        // no body). This gives the agent the same complete authoring view the
+        // browser suite editor receives from `GET /instructor/:id/suite`.
+        let payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
         // Section variables/expressions live on the manifest's section list,
         // not on the suite-payload DTO (which carries only id + name).
         let sectionInputs = Dictionary(
@@ -151,7 +195,11 @@ struct GetSuiteTool: ContentTool {
                 displayName: nil,
                 dependsOn: dto.dependsOn ?? family?.dependsOn ?? [],
                 sectionID: dto.sectionID,
-                familyID: family?.id)
+                familyID: family?.id,
+                content: nil,
+                hint: nil,
+                family: family,
+                check: nil)
         case "check":
             let check = dto.check
             return Output.Item(
@@ -162,7 +210,11 @@ struct GetSuiteTool: ContentTool {
                 displayName: nil,
                 dependsOn: dto.dependsOn ?? check?.dependsOn ?? [],
                 sectionID: dto.sectionID,
-                familyID: nil)
+                familyID: nil,
+                content: nil,
+                hint: nil,
+                family: nil,
+                check: check)
         default:
             let script = dto.script
             return Output.Item(
@@ -173,7 +225,11 @@ struct GetSuiteTool: ContentTool {
                 displayName: script?.displayName,
                 dependsOn: script?.dependsOn ?? [],
                 sectionID: dto.sectionID,
-                familyID: nil)
+                familyID: nil,
+                content: script?.content,
+                hint: script?.hint,
+                family: nil,
+                check: nil)
         }
     }
 }

--- a/Tests/APITests/MCP/GetSuiteToolTests.swift
+++ b/Tests/APITests/MCP/GetSuiteToolTests.swift
@@ -83,6 +83,42 @@ import Vapor
         }
     }
 
+    /// Manifest with a pattern family + its generated entry, so we can assert
+    /// the family's full spec (function, params, cases with args/expected) is
+    /// surfaced — this is what an agent needs to explain a submission's score.
+    private let familyManifest = #"""
+        {"schemaVersion":1,"testSuites":[{"tier":"public","script":"publictest_tax_01.py","generatedBy":"tax","sectionID":"sec1"}],"patternFamilies":[{"id":"tax","name":"tax — boundary cases","kind":"boundary_equality","functionName":"tax","paramNames":["price"],"defaults":{"tier":"public","points":1},"cases":[{"key":"01","label":"tax(100)","args":[100],"expected":113.0,"enabled":true}]}],"sections":[{"id":"sec1","name":"Functions"}],"timeLimitSeconds":10}
+        """#
+
+    @Test func surfacesPatternFamilyCases() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(
+                on: app, id: "setup_fam", courseID: courseID, manifest: familyManifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_fam", courseID: courseID, title: "Lab")
+
+            let output = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), context(app))
+
+            let row = try #require(output.items.first { $0.kind == "family" })
+            #expect(row.familyID == "tax")
+            let family = try #require(row.family)
+            #expect(family.functionName == "tax")
+            #expect(family.paramNames == ["price"])
+            let testCase = try #require(family.cases.first)
+            #expect(testCase.key == "01")
+            #expect(testCase.label == "tax(100)")
+            #expect(testCase.args == [.int(100)])
+            // JSONValue normalises the whole-number literal 113.0 to .int(113).
+            #expect(testCase.expected == .int(113))
+        }
+    }
+
     @Test func deniesWhenSubjectNotEnrolled() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/changelog.d/mcp-get-suite-full-definition.md
+++ b/changelog.d/mcp-get-suite-full-definition.md
@@ -1,0 +1,11 @@
+### Added
+
+- **MCP `get_suite` returns full test definitions.** The `get_suite` tool now
+  surfaces each item's source of truth alongside its metadata: hand-written
+  scripts include their raw body (`content`) and `hint`, pattern families
+  include the full spec with every case's `args`/`expected` (`family`), and
+  notebook checks include their spec (`check`). This lets an authoring agent
+  read exactly what a test checks — e.g. to explain why a submission lost
+  points — without leaving the read-only `content:read` scope. Exposes only
+  authoring content the instructor already sees in the browser suite editor; no
+  student, grade, or submission data is involved.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -28,7 +28,7 @@ tools, all `content:read` / `content:write` scoped and course-scoped:
 | `list_courses` | `content:read` | Courses the subject may act on |
 | `list_assignments` | `content:read` | A course's assignments (id, title, slug, open/closed, due date) |
 | `get_assignment` | `content:read` | One assignment's full detail |
-| `get_suite` | `content:read` | Test-suite structure (items, tiers, points, deps, sections) |
+| `get_suite` | `content:read` | Full test-suite definition: items, tiers, points, deps, sections, plus each script's raw body, each family's full spec (cases' args/expected), and each notebook check's spec |
 | `get_notebook` | `content:read` | The starter notebook (.ipynb JSON) |
 | `validate_assignment` | `content:read` | Watch validation to completion; live SSE progress |
 | `update_assignment` | `content:write` | Metadata: title, due date, open/close |
@@ -41,7 +41,8 @@ tools, all `content:read` / `content:write` scoped and course-scoped:
 In addition to tools, the server exposes **resources**: `resources/list` /
 `resources/read` surface each accessible assignment's raw `test.properties.json`
 manifest at `chickadee://assignment/<publicID>/manifest` (the verbatim authoring
-spec; `get_suite` is the structured view). See
+spec; `get_suite` is the structured view — and now carries the same full detail,
+including script bodies and pattern-family cases). See
 `Sources/APIServer/MCP/Resources/MCPResourceProvider.swift`.
 
 The legacy `update_assignment_title` tool folded into `update_assignment`.


### PR DESCRIPTION
## Summary

`get_suite` previously returned only the suite *structure* (tier, points, dependencies, section). It now also surfaces each item's **source of truth**, so an authoring agent can read exactly what a test checks — e.g. to explain why a student submission lost points — without leaving the read-only `content:read` scope:

- **scripts** → raw body (`content`) + `hint`
- **pattern families** → full spec including every case's `args`/`expected` (`family`)
- **notebook checks** → full spec (`check`)

Implementation reuses the author-facing `buildSuitePayload(...zipPath:)` — the same complete view the browser suite editor gets from `GET /instructor/:id/suite`.

**Scope unchanged:** this exposes only authoring content the instructor already sees in the editor. No student, grade, or submission data is involved.

## Discoverability / docs

Updated every agent-facing surface so the new fields are discoverable:
- Tool `description` (returned in `tools/list`)
- `outputSchema` — new `content`/`hint`/`family`/`check` properties, each with a `description`
- Server-level `initialize` `instructions` (Test-suite concept + read-vs-author behavior)
- `docs/mcp-authoring-roadmap.md` capability table + resources note

## Test plan

- [x] `swift build` clean
- [x] `scripts/swiftlint.sh` — 0 violations
- [x] `swift test --filter GetSuiteToolTests` — all pass, incl. new `surfacesPatternFamilyCases` asserting family `args`/`expected` are surfaced
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)