### PR TITLE
Flag dropped students against the LEARN classlist on the Students tab

### DIFF
--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -27,6 +27,12 @@ Students
     </form>
     <a class="btn action-btn" href="/instructor/enroll-csv">Enrol from CSV</a>
     #endif
+    #if(brightspaceLinkAvailable):
+    <button type="button" class="btn action-btn" id="learn-check-btn"
+            title="Flag enrolled students who are no longer on the LEARN classlist">Check against LEARN</button>
+    <span id="learn-check-status" role="status" aria-live="polite"
+          style="font-size:.8rem;color:var(--gray-500)"></span>
+    #endif
     #endif
     <input id="enrolled-filter" class="form-input" type="search" autocomplete="off"
            placeholder="Filter by name or username…"
@@ -48,6 +54,7 @@ Students
     <tbody>
     #for(student in enrolledStudents):
         <tr class="student-row-link#if(student.isPending): student-row-pending#endif"
+            data-student-id="#(student.id)"
             #if(!student.isPending):data-href="#(student.submissionsURL)"#endif>
             <td>
                 #if(student.isPending):
@@ -103,6 +110,19 @@ Students
 .student-row-link:hover td a strong,
 .student-row-link:hover td a code {
     text-decoration: underline;
+}
+.learn-flag {
+    display: inline-block;
+    font-size: .68rem;
+    font-weight: 600;
+    color: #b42318;
+    background: rgba(180, 35, 24, .08);
+    border: 1px solid rgba(180, 35, 24, .25);
+    border-radius: 4px;
+    padding: .05rem .3rem;
+    margin-left: .4rem;
+    white-space: nowrap;
+    vertical-align: middle;
 }
 </style>
 <script>
@@ -189,6 +209,7 @@ Students
         }
 
         return '<tr class="student-row-link' + (student.isPending ? ' student-row-pending' : '') + '"'
+            + ' data-student-id="' + escapeHtml(student.id) + '"'
             + (student.isPending ? '' : ' data-href="' + subURL + '"') + '>'
             + '<td>' + nameCell + '</td>'
             + '<td>' + userCell + '</td>'
@@ -236,6 +257,60 @@ Students
         });
     }
 
+    // ── LEARN classlist reconciliation ───────────────────────────────
+    // After a "Check against LEARN" run, rows whose student is no longer on
+    // the LEARN classlist get a "not registered on LEARN" badge.  The id set
+    // is kept in memory so the badges survive the 5s poll repaint.
+    var learnNotOnLearn = new Set();
+    var learnBtn = document.getElementById('learn-check-btn');
+    var learnStatus = document.getElementById('learn-check-status');
+
+    function applyLearnFlags() {
+        Array.from(tbody.querySelectorAll('tr')).forEach(function (row) {
+            var nameCell = row.cells[0];
+            if (!nameCell) return;
+            var existing = nameCell.querySelector('.learn-flag');
+            if (existing) existing.remove();
+            var id = row.getAttribute('data-student-id');
+            if (id && learnNotOnLearn.has(id)) {
+                var span = document.createElement('span');
+                span.className = 'learn-flag';
+                span.textContent = 'not registered on LEARN';
+                span.title = 'Not on the LEARN classlist — remove if confirmed dropped';
+                nameCell.appendChild(span);
+            }
+        });
+    }
+
+    async function checkAgainstLearn() {
+        if (learnBtn) learnBtn.disabled = true;
+        if (learnStatus) learnStatus.textContent = 'Checking against LEARN…';
+        try {
+            var res = await fetch('/instructor/students/learn-check', {
+                headers: { 'Accept': 'application/json' },
+                cache: 'no-store'
+            });
+            if (res.redirected || res.status === 401 || res.status === 403) {
+                window.location.reload();
+                return;
+            }
+            if (!res.ok) {
+                if (learnStatus) learnStatus.textContent = 'LEARN check failed (HTTP ' + res.status + ').';
+                return;
+            }
+            var data = await res.json();
+            learnNotOnLearn = new Set(Array.isArray(data.notOnLearn) ? data.notOnLearn : []);
+            applyLearnFlags();
+            if (learnStatus) learnStatus.textContent = data.message || '';
+        } catch (_) {
+            if (learnStatus) learnStatus.textContent = 'LEARN check failed (network error).';
+        } finally {
+            if (learnBtn) learnBtn.disabled = false;
+        }
+    }
+
+    if (learnBtn) learnBtn.addEventListener('click', checkAgainstLearn);
+
     table.querySelectorAll('th.sortable').forEach(function (th) {
         th.addEventListener('click', function () {
             var col = parseInt(th.getAttribute('data-col'), 10);
@@ -279,12 +354,14 @@ Students
         sortRows();
         applyFilter();
         updateEmptyState();
+        applyLearnFlags();
     }
 
     // ── Initial paint ────────────────────────────────────────────────
     applyRelativeTimes(document);
     sortRows();
     updateEmptyState();
+    applyLearnFlags();
 
     // ── Auto-refresh ─────────────────────────────────────────────────
     // Poll /instructor/students-data every few seconds so last-seen times

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -62,6 +62,9 @@ struct InstructorStudentsContext: Encodable {
     let enrolledStudentCount: Int
     let courseEnrollmentMode: String
     let courseIsArchived: Bool
+    /// True when BrightSpace is configured on the server AND the active course
+    /// is linked to a LEARN org unit — gates the "Check against LEARN" button.
+    let brightspaceLinkAvailable: Bool
 }
 
 /// BrightSpace tab (`GET /instructor/brightspace`): connection status, the

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+LearnCheck.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+LearnCheck.swift
@@ -1,0 +1,154 @@
+// APIServer/Routes/Web/InstructorDashboardRoutes+LearnCheck.swift
+//
+// GET /instructor/students/learn-check — reconciles the active course's
+// Chickadee roster against the LEARN (D2L) classlist and returns the row IDs
+// of students who are no longer registered on LEARN, so the instructor can
+// remove them from the Students tab.  Advisory only: it flags rows; the actual
+// removal stays the instructor's per-row manual action (the existing unenroll
+// / pre-unenroll buttons).
+//
+// Dormant until BrightSpace credentials are configured (pending UWaterloo
+// IST) — returns a clear `configured: false` / `courseLinked: false` payload
+// in that case so the panel can explain why nothing was flagged.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension InstructorDashboardRoutes {
+
+    // MARK: - GET /instructor/students/learn-check
+
+    @Sendable
+    func studentsLearnCheck(req: Request) async throws -> LearnRosterCheckResult {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else {
+            return .unavailable("No active course selected.")
+        }
+        guard let client = req.application.brightSpaceClient else {
+            return .unavailable(
+                "BrightSpace is not configured on this server.", configured: false)
+        }
+        guard let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty else {
+            return .unavailable(
+                "This course isn't linked to a LEARN org unit (set it on the course page).",
+                courseLinked: false)
+        }
+
+        let classlist: [BrightSpaceClasslistEntry]
+        do {
+            classlist = try await client.fetchClasslist(orgUnitID: orgUnitID, on: req.application)
+        } catch {
+            req.logger.warning("LEARN classlist fetch failed: \(error)")
+            return .unavailable("Couldn't fetch the LEARN classlist: \(error).")
+        }
+
+        let learnIdentities = LearnRosterReconciler.identitySet(from: classlist)
+
+        var notOnLearn: [String] = []
+        var unverifiable: [String] = []
+        var checkedCount = 0
+
+        // Enrolled (logged-in) students: match on student ID, fall back to
+        // username.  Only `student` rows can have "dropped"; instructor/admin
+        // test accounts aren't roster members and must never be flagged.
+        let enrollments = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseUUID)
+            .all()
+        let enrolledUserIDs = enrollments.map(\.userID)
+        let enrolledUsers =
+            enrolledUserIDs.isEmpty
+            ? []
+            : try await APIUser.query(on: req.db)
+                .filter(\.$id ~~ enrolledUserIDs)
+                .filter(\.$role == "student")
+                .all()
+        for student in enrolledUsers {
+            guard let id = student.id else { continue }
+            checkedCount += 1
+            let sid = student.studentID ?? ""
+            switch LearnRosterReconciler.classify(
+                candidateKeys: [sid, student.username],
+                hasIdentityKey: !sid.isEmpty,
+                learnIdentities: learnIdentities
+            ) {
+            case .onLearn: break
+            case .notOnLearn: notOnLearn.append(id.uuidString)
+            case .unverifiable: unverifiable.append(id.uuidString)
+            }
+        }
+
+        // Pending pre-enrollments: only a username to match on.  These are the
+        // "awaiting first login" rows the instructor most wants vetted.
+        let pending = try await APIPreEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseUUID)
+            .all()
+        for entry in pending {
+            guard let id = entry.id else { continue }
+            checkedCount += 1
+            if LearnRosterReconciler.classify(
+                candidateKeys: [entry.username],
+                hasIdentityKey: true,
+                learnIdentities: learnIdentities
+            ) == .notOnLearn {
+                notOnLearn.append(id.uuidString)
+            }
+        }
+
+        var message =
+            "Checked \(checkedCount) against \(classlist.count) on LEARN — "
+            + "\(notOnLearn.count) not registered on LEARN"
+        if !unverifiable.isEmpty {
+            message += ", \(unverifiable.count) couldn't be matched (no student ID)"
+        }
+        message += "."
+
+        return LearnRosterCheckResult(
+            ok: true,
+            message: message,
+            configured: true,
+            courseLinked: true,
+            notOnLearn: notOnLearn,
+            unverifiable: unverifiable,
+            checkedCount: checkedCount,
+            learnCount: classlist.count)
+    }
+}
+
+/// JSON payload for the Students-tab "Check against LEARN" button.  `notOnLearn`
+/// and `unverifiable` carry the same row IDs the roster rows use
+/// (`EnrolledStudentRow.id` — a user UUID for enrolled students, a
+/// pre-enrollment UUID for pending rows), so the client can flag matching rows.
+struct LearnRosterCheckResult: Content {
+    let ok: Bool
+    let message: String
+    let configured: Bool
+    let courseLinked: Bool
+    let notOnLearn: [String]
+    let unverifiable: [String]
+    let checkedCount: Int
+    let learnCount: Int
+
+    /// Builds a "couldn't run" result (not configured, no org unit, fetch
+    /// failed) with empty flag lists and a human-readable reason.
+    static func unavailable(
+        _ message: String,
+        configured: Bool = true,
+        courseLinked: Bool = true
+    ) -> LearnRosterCheckResult {
+        LearnRosterCheckResult(
+            ok: false,
+            message: message,
+            configured: configured,
+            courseLinked: courseLinked,
+            notOnLearn: [],
+            unverifiable: [],
+            checkedCount: 0,
+            learnCount: 0)
+    }
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -46,6 +46,7 @@ extension InstructorDashboardRoutes {
         var enrolledStudentCount = 0
         var courseEnrollmentMode = CourseEnrollmentMode.open.rawValue
         var courseIsArchived = false
+        var brightspaceLinkAvailable = false
 
         if let activeCourseUUID = courseState.activeCourseUUID {
             let roster = try await loadEnrolledStudentRows(
@@ -60,6 +61,9 @@ extension InstructorDashboardRoutes {
             if let course = try await APICourse.find(activeCourseUUID, on: req.db) {
                 courseEnrollmentMode = course.enrollmentMode.rawValue
                 courseIsArchived = course.isArchived
+                brightspaceLinkAvailable =
+                    req.application.brightSpaceClient != nil
+                    && !((course.brightspaceOrgUnitID ?? "").isEmpty)
             }
         }
 
@@ -70,7 +74,8 @@ extension InstructorDashboardRoutes {
             hasEnrolledStudents: !enrolledStudents.isEmpty,
             enrolledStudentCount: enrolledStudentCount,
             courseEnrollmentMode: courseEnrollmentMode,
-            courseIsArchived: courseIsArchived
+            courseIsArchived: courseIsArchived,
+            brightspaceLinkAvailable: brightspaceLinkAvailable
         )
         return try await req.view.render("instructor-students", ctx).encodeResponse(for: req)
     }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -38,6 +38,8 @@ struct InstructorDashboardRoutes: RouteCollection {
         // Students roster tab + its self-updating poll endpoint.
         r.get("students", use: studentsPage)
         r.get("students-data", use: studentsData)
+        // Reconcile the roster against the LEARN classlist (flags dropped students).
+        r.get("students", "learn-check", use: studentsLearnCheck)
         // BrightSpace tab: status, grade-item mapping, sync log, manual actions.
         r.get("brightspace", use: brightspacePage)
         r.post("brightspace", "test", use: brightspaceTestConnection)

--- a/Sources/APIServer/Routes/Web/LearnRosterReconciler.swift
+++ b/Sources/APIServer/Routes/Web/LearnRosterReconciler.swift
@@ -1,0 +1,52 @@
+// APIServer/Routes/Web/LearnRosterReconciler.swift
+//
+// Pure roster-vs-LEARN classification.  Given the LEARN classlist identities
+// and a Chickadee roster entry, decides whether the entry is still registered
+// on LEARN, has dropped, or can't be matched.  Kept free of Fluent / Request
+// so it can be unit-tested without a server or live D2L credentials — the live
+// classlist fetch lives on `BrightSpaceAPIClient.fetchClasslist`.
+
+import Foundation
+
+enum LearnRosterStatus: Equatable {
+    case onLearn
+    case notOnLearn
+    /// No authoritative identity key to match on (e.g. an enrolled user with
+    /// no student ID whose username also didn't match) — never flagged for
+    /// removal, only surfaced so the instructor knows it couldn't be checked.
+    case unverifiable
+}
+
+enum LearnRosterReconciler {
+    /// Normalises a LEARN classlist into the set of identity keys a roster
+    /// entry can be matched against (student numbers + usernames, lowercased).
+    static func identitySet(from classlist: [BrightSpaceClasslistEntry]) -> Set<String> {
+        var ids = Set<String>()
+        for entry in classlist {
+            if let org = entry.orgDefinedID { ids.insert(normalise(org)) }
+            if let user = entry.username { ids.insert(normalise(user)) }
+        }
+        ids.remove("")
+        return ids
+    }
+
+    /// Classifies one roster entry.  `candidateKeys` are the identifiers this
+    /// entry could be known by on LEARN (student ID and/or username).
+    /// `hasIdentityKey` is true when the entry carries a key we trust to be
+    /// authoritative (a student ID, or a pre-enrollment username) — when
+    /// false, an unmatched entry is `.unverifiable` rather than `.notOnLearn`,
+    /// so an account we simply couldn't look up is never flagged for removal.
+    static func classify(
+        candidateKeys: [String?],
+        hasIdentityKey: Bool,
+        learnIdentities: Set<String>
+    ) -> LearnRosterStatus {
+        let keys = candidateKeys.compactMap { $0.map(normalise) }.filter { !$0.isEmpty }
+        if keys.contains(where: { learnIdentities.contains($0) }) { return .onLearn }
+        return hasIdentityKey ? .notOnLearn : .unverifiable
+    }
+
+    private static func normalise(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -63,6 +63,7 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible {
     case whoamiFailed(status: Int)
     case orgUnitLookupFailed(orgUnitID: String, status: Int)
     case gradeObjectsFetchFailed(orgUnitID: String, status: Int)
+    case classlistFetchFailed(orgUnitID: String, status: Int)
 
     var description: String {
         switch self {
@@ -82,6 +83,8 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible {
             return "BrightSpace org unit lookup for '\(id)' failed (HTTP \(s))"
         case .gradeObjectsFetchFailed(let id, let s):
             return "BrightSpace grade-objects fetch for org unit '\(id)' failed (HTTP \(s))"
+        case .classlistFetchFailed(let id, let s):
+            return "BrightSpace classlist fetch for org unit '\(id)' failed (HTTP \(s))"
         }
     }
 }
@@ -107,6 +110,14 @@ struct BrightSpaceGradeObject: Content, Sendable {
     let id: String
     let name: String
     let maxPoints: Double?
+}
+
+/// One member of a course's LEARN classlist, reduced to the identity fields
+/// Chickadee can match a roster entry against.  `orgDefinedID` is the student
+/// number (matches `APIUser.studentID`); `username` is the D2L login name.
+struct BrightSpaceClasslistEntry: Content, Sendable {
+    let orgDefinedID: String?
+    let username: String?
 }
 
 // MARK: - Client
@@ -312,6 +323,42 @@ actor BrightSpaceAPIClient {
         let decoded = try response.content.decode([GradeObjectResponse].self)
         return decoded.map {
             BrightSpaceGradeObject(id: String($0.id), name: $0.name, maxPoints: $0.maxPoints)
+        }
+    }
+
+    // MARK: - Classlist (roster reconciliation)
+
+    /// Fetches the org unit's current classlist so the Chickadee roster can be
+    /// reconciled against LEARN.  Withdrawn / dropped students do not appear in
+    /// the classlist, which is the signal the Students tab uses to flag stale
+    /// enrollments for manual removal.
+    func fetchClasslist(
+        orgUnitID: String, on application: Application
+    ) async throws
+        -> [BrightSpaceClasslistEntry]
+    {
+        guard !orgUnitID.isEmpty else { return [] }
+        let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
+        let rawURL = "\(config.baseURL)/d2l/api/le/\(BrightSpaceSyncConfig.leAPIVersion)/\(encoded)/classlist/"
+        let url = signed(url: rawURL, method: "GET")
+        let response = try await application.client.get(URI(string: url))
+        guard response.status == .ok else {
+            throw BrightSpaceSyncError.classlistFetchFailed(
+                orgUnitID: orgUnitID, status: Int(response.status.code))
+        }
+        // D2L returns a JSON array of ClasslistUser objects; we keep only the
+        // two identity fields we match on.
+        struct ClasslistUserResponse: Decodable {
+            let orgDefinedId: String?
+            let username: String?
+            enum CodingKeys: String, CodingKey {
+                case orgDefinedId = "OrgDefinedId"
+                case username = "Username"
+            }
+        }
+        let decoded = try response.content.decode([ClasslistUserResponse].self)
+        return decoded.map {
+            BrightSpaceClasslistEntry(orgDefinedID: $0.orgDefinedId, username: $0.username)
         }
     }
 }

--- a/Tests/APITests/LearnRosterReconcilerTests.swift
+++ b/Tests/APITests/LearnRosterReconcilerTests.swift
@@ -1,0 +1,90 @@
+import Testing
+
+@testable import APIServer
+
+@Suite struct LearnRosterReconcilerTests {
+
+    private func entry(_ org: String?, _ user: String?) -> BrightSpaceClasslistEntry {
+        BrightSpaceClasslistEntry(orgDefinedID: org, username: user)
+    }
+
+    @Test func identitySetLowercasesBothFieldsAndDropsBlanks() {
+        let ids = LearnRosterReconciler.identitySet(from: [
+            entry("20851234", "JDoe"),
+            entry(nil, "ASmith"),
+            entry("  ", nil),
+            entry("", ""),
+        ])
+        #expect(ids.contains("20851234"))
+        #expect(ids.contains("jdoe"))
+        #expect(ids.contains("asmith"))
+        #expect(!ids.contains(""))
+        #expect(ids.count == 3)
+    }
+
+    @Test func studentMatchedByStudentIDIsOnLearn() {
+        let ids = LearnRosterReconciler.identitySet(from: [entry("20851234", "jdoe")])
+        let status = LearnRosterReconciler.classify(
+            candidateKeys: ["20851234", "jdoe"], hasIdentityKey: true, learnIdentities: ids)
+        #expect(status == .onLearn)
+    }
+
+    @Test func studentWithIDNotInClasslistIsNotOnLearn() {
+        let ids = LearnRosterReconciler.identitySet(from: [entry("20851234", "jdoe")])
+        let status = LearnRosterReconciler.classify(
+            candidateKeys: ["99999999", "dropped"], hasIdentityKey: true, learnIdentities: ids)
+        #expect(status == .notOnLearn)
+    }
+
+    @Test func studentWithoutIDButMatchingUsernameIsOnLearn() {
+        let ids = LearnRosterReconciler.identitySet(from: [entry("20851234", "jdoe")])
+        let status = LearnRosterReconciler.classify(
+            candidateKeys: ["", "JDOE"], hasIdentityKey: false, learnIdentities: ids)
+        #expect(status == .onLearn)
+    }
+
+    @Test func studentWithoutIDAndNoUsernameMatchIsUnverifiable() {
+        let ids = LearnRosterReconciler.identitySet(from: [entry("20851234", "jdoe")])
+        let status = LearnRosterReconciler.classify(
+            candidateKeys: ["", "mystery"], hasIdentityKey: false, learnIdentities: ids)
+        #expect(status == .unverifiable)
+    }
+
+    @Test func pendingUsernameInClasslistIsOnLearn() {
+        // Pre-enrollments carry only a username; match against either the
+        // classlist username OR its org-defined ID (CSV format varies).
+        let ids = LearnRosterReconciler.identitySet(from: [entry("20851234", "jdoe")])
+        #expect(
+            LearnRosterReconciler.classify(
+                candidateKeys: ["jdoe"], hasIdentityKey: true, learnIdentities: ids) == .onLearn)
+        #expect(
+            LearnRosterReconciler.classify(
+                candidateKeys: ["20851234"], hasIdentityKey: true, learnIdentities: ids) == .onLearn)
+    }
+
+    @Test func pendingUsernameNotInClasslistIsNotOnLearn() {
+        let ids = LearnRosterReconciler.identitySet(from: [entry("20851234", "jdoe")])
+        let status = LearnRosterReconciler.classify(
+            candidateKeys: ["someonewhodropped"], hasIdentityKey: true, learnIdentities: ids)
+        #expect(status == .notOnLearn)
+    }
+
+    @Test func matchingIsCaseAndWhitespaceInsensitive() {
+        let ids = LearnRosterReconciler.identitySet(from: [entry(nil, "JDoe")])
+        let status = LearnRosterReconciler.classify(
+            candidateKeys: ["  jDOE  "], hasIdentityKey: true, learnIdentities: ids)
+        #expect(status == .onLearn)
+    }
+
+    @Test func emptyClasslistFlagsEveryStudentWithAnID() {
+        let ids = LearnRosterReconciler.identitySet(from: [])
+        #expect(
+            LearnRosterReconciler.classify(
+                candidateKeys: ["20851234", "jdoe"], hasIdentityKey: true, learnIdentities: ids)
+                == .notOnLearn)
+        #expect(
+            LearnRosterReconciler.classify(
+                candidateKeys: ["", "jdoe"], hasIdentityKey: false, learnIdentities: ids)
+                == .unverifiable)
+    }
+}

--- a/changelog.d/learn-roster-reconcile.md
+++ b/changelog.d/learn-roster-reconcile.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Flag dropped students against the LEARN classlist.** A "Check against
+  LEARN" button on the instructor Students tab fetches the course's D2L
+  classlist and badges enrolled students (and pending "awaiting first login"
+  rows) who are no longer registered on LEARN, so the instructor can remove
+  stale accounts with the existing per-row delete action. Conservative
+  matching — students with no resolvable student ID are reported as
+  unverifiable rather than flagged for removal, and only `student` rows are
+  checked. The button is hidden unless BrightSpace is configured on the server
+  and the course is linked to a LEARN org unit, so it's inert until D2L
+  credentials are provisioned.


### PR DESCRIPTION
## Summary

Adds a **"Check against LEARN"** button to the instructor Students tab that reconciles the Chickadee roster against the course's D2L (LEARN) classlist and badges students who are no longer registered, so stale accounts can be removed with the existing per-row delete action.

- New `BrightSpaceAPIClient.fetchClasslist(orgUnitID:)` — `GET /d2l/api/le/{ver}/{orgUnitID}/classlist/`, returning each member's `OrgDefinedId` + `Username`. Reuses the existing Valence App+User key signing.
- New `LearnRosterReconciler` — pure, Fluent/Request-free classification (`onLearn` / `notOnLearn` / `unverifiable`), unit-tested without a server or live credentials.
- New `GET /instructor/students/learn-check` endpoint returns the row IDs to flag as JSON.
- Students-tab template gains the button + a "not registered on LEARN" badge that survives the 5s poll repaint.

### Conservative by design
- Enrolled students match on `studentID` first, falling back to username; a student with no resolvable student ID is reported **unverifiable** (never flagged for removal).
- Pending "awaiting first login" pre-enrollments match by username against either the LEARN username or OrgDefinedId.
- Only `role == "student"` rows are checked — instructor/admin test accounts are never flagged.

### Inert until credentials land
The button is hidden unless BrightSpace is configured on the server **and** the course is linked to a LEARN org unit. With D2L credentials still pending at UWaterloo IST, this is dormant in prod; the endpoint returns a clean "not configured" response if hit directly. **No schema or migration changes.**

## Test plan

- [x] `swift build` clean
- [x] `swift-format` + SwiftLint (strict) green
- [x] 9 `LearnRosterReconcilerTests` covering ID match, username fallback, unverifiable, pending rows, case/whitespace insensitivity, empty classlist
- [ ] Live classlist fetch → flag path — **deferred to dev-server validation once D2L credentials are provisioned** (cannot be exercised without creds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)