### PR TITLE
fix(runner): track triple-quoted strings in notebook cell extraction

### DIFF
--- a/Sources/RunnerCore/NotebookExtraction.swift
+++ b/Sources/RunnerCore/NotebookExtraction.swift
@@ -107,21 +107,22 @@ public func sanitizeCellForModule(_ source: String) -> String {
     var defLines: [String] = []
     var usageLines: [String] = []
     var inUsage = false
-    var bracketDepth = 0
+    var lex = CellLexState()
 
     for line in lines {
         let trimmed = trimSpacesAndTabs(line)
-        // Only a new top-level statement when not inside open brackets.
-        let isTopLevel = bracketDepth == 0 && !line.isEmpty && !(line.first?.isWhitespace ?? true)
+        // A new top-level statement begins only when we are NOT inside open
+        // brackets AND NOT inside a triple-quoted string opened on an earlier
+        // line (otherwise the line is a continuation), and the line itself
+        // starts in column 0.
+        let isTopLevel =
+            lex.bracketDepth == 0 && !lex.inTripleString && !line.isEmpty
+            && !(line.first?.isWhitespace ?? true)
 
-        // Update depth AFTER the isTopLevel check — depth reflects prior lines.
-        for ch in line {
-            switch ch {
-            case "(", "[", "{": bracketDepth += 1
-            case ")", "]", "}": bracketDepth = max(0, bracketDepth - 1)
-            default: break
-            }
-        }
+        // Advance the lexical state AFTER the isTopLevel check — the state must
+        // reflect the lines *before* this one. The scan skips string and comment
+        // contents so their brackets/quotes can't perturb the classification.
+        advanceLexState(line, &lex)
 
         if isTopLevel && !trimmed.isEmpty {
             inUsage = !isSafeTopLevelStatement(trimmed)
@@ -198,6 +199,85 @@ public func pythonStringLiteral(_ s: String) -> String {
     }
     out += "\""
     return out
+}
+
+// MARK: - Cross-line lexical scan
+
+/// Carried lexical state for the per-cell line classifier: how deeply brackets
+/// are nested and whether we are currently inside a triple-quoted string. Both
+/// can span multiple physical lines, so the state persists across the cell's
+/// lines. Single-line strings and `#` comments never span lines, so they are
+/// resolved inside `advanceLexState` and never leak into the carried state.
+struct CellLexState {
+    var bracketDepth = 0
+    var inTripleString = false
+    var tripleDelimiter: Character = "\""
+}
+
+/// Advance `state` across one physical line. Brackets are counted only outside
+/// string and comment context, and a triple-quoted string opened here (or on an
+/// earlier line) is tracked until its closing delimiter so its interior lines
+/// aren't misread as new top-level statements. This is the fix for student cells
+/// that park a multi-line `\"\"\"…\"\"\"` block (prose or an alternate solution) at
+/// module level: without triple-quote tracking the interior lines were ripped
+/// out into the `if __name__` quarantine, producing invalid Python that the
+/// resilient-load wrapper then silently dropped — taking every definition and
+/// variable in the cell down with it.
+func advanceLexState(_ line: String, _ state: inout CellLexState) {
+    let chars = Array(line)
+    let count = chars.count
+    var index = 0
+    while index < count {
+        let char = chars[index]
+
+        if state.inTripleString {
+            if char == state.tripleDelimiter
+                && index + 2 < count
+                && chars[index + 1] == state.tripleDelimiter
+                && chars[index + 2] == state.tripleDelimiter
+            {
+                state.inTripleString = false
+                index += 3
+            } else {
+                index += 1
+            }
+            continue
+        }
+
+        // Outside any string: `#` starts a comment that runs to end of line.
+        if char == "#" { return }
+
+        if char == "\"" || char == "'" {
+            // Triple-quoted string opener?
+            if index + 2 < count && chars[index + 1] == char && chars[index + 2] == char {
+                state.inTripleString = true
+                state.tripleDelimiter = char
+                index += 3
+                continue
+            }
+            // Single-line string: skip to its matching unescaped quote.
+            index += 1
+            while index < count {
+                if chars[index] == "\\" {
+                    index += 2
+                    continue
+                }
+                if chars[index] == char {
+                    index += 1
+                    break
+                }
+                index += 1
+            }
+            continue
+        }
+
+        switch char {
+        case "(", "[", "{": state.bracketDepth += 1
+        case ")", "]", "}": state.bracketDepth = max(0, state.bracketDepth - 1)
+        default: break
+        }
+        index += 1
+    }
 }
 
 // MARK: - Top-level statement classification

--- a/Tests/WorkerTests/NotebookExtractionTests.swift
+++ b/Tests/WorkerTests/NotebookExtractionTests.swift
@@ -97,4 +97,56 @@ import Testing
         #expect(result.executableModule.contains("daily_ml / 1000"))
         #expect(!result.executableModule.contains("\\/"))
     }
+
+    // Regression (HLTH-230 Lab 1): a cell that parks a multi-line triple-quoted
+    // block (prose / an alternate solution) at module level above the real code.
+    // Before triple-quote tracking, the interior prose lines were re-classified
+    // as new top-level statements and ripped into `if __name__`, splitting the
+    // string and producing invalid Python — which the resilient-load wrapper then
+    // silently dropped, wiping out the cell's real definitions and variables.
+    @Test func tripleQuotedBlockDoesNotSwallowFollowingDefinitions() {
+        let cell = code(
+            """
+            \"\"\"
+            This is a different way I got this to work
+            beats = beatsCalculated(72, 24*60)
+            print(beats)
+            \"\"\"
+
+            heartRate = 72
+            beats = heartRate * 60 * 24
+            print(beats)
+            """
+        )
+        let sanitized = sanitizeCellForModule(cell.source)
+
+        // The real module-level assignment survives at module level (NOT pushed
+        // into the __main__ quarantine), so `beats` is importable on the module.
+        let moduleLevel = sanitized.components(separatedBy: "if __name__").first ?? sanitized
+        #expect(moduleLevel.contains("beats = heartRate * 60 * 24"))
+
+        // The interior prose line never leaks out of the string as bare code.
+        let quarantine =
+            sanitized.range(of: "if __name__").map { String(sanitized[$0.lowerBound...]) } ?? ""
+        #expect(!quarantine.contains("This is a different way I got this to work"))
+    }
+
+    // A bare `'''…'''` block with a `def` inside it must stay intact and the
+    // function defined after it must remain at module level.
+    @Test func singleQuoteTripleBlockKeepsLaterDefAtModuleLevel() {
+        let cell = code(
+            """
+            '''
+            def shadow(price):
+                return price
+            shadow(100)
+            '''
+            def tax(price):
+                return round(price * 1.13, 2)
+            """
+        )
+        let sanitized = sanitizeCellForModule(cell.source)
+        let moduleLevel = sanitized.components(separatedBy: "if __name__").first ?? sanitized
+        #expect(moduleLevel.contains("def tax(price):"))
+    }
 }

--- a/changelog.d/notebook-triple-quote-extraction.md
+++ b/changelog.d/notebook-triple-quote-extraction.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **Notebook extraction now tracks triple-quoted strings.** The per-cell
+  module/`__main__` classifier (`sanitizeCellForModule` in `RunnerCore`) scanned
+  lines without any notion of triple-quoted (`"""…"""` / `'''…'''`) strings, so a
+  cell that parked a multi-line block — prose or a parked alternate solution —
+  at module level had its interior lines re-classified as new top-level
+  statements and ripped into the `if __name__` quarantine. That split the string
+  into invalid Python, which the resilient per-cell loader then silently dropped,
+  wiping out **every definition and variable in the cell** (e.g. a correct
+  `beats = 103680` reported as "Variable `beats` is not defined", a defined `tax`
+  reported as missing). The scanner now carries triple-quote and string/comment
+  state across lines, so such cells grade correctly. Shared by the native worker
+  and the browser (wasm) runner. *(The vendored `Public/runner-wasm` artifact
+  must be regenerated with `scripts/build-runner-wasm.sh` for the browser path to
+  pick this up.)*


### PR DESCRIPTION
## What

`sanitizeCellForModule` (in `Sources/RunnerCore/NotebookExtraction.swift`) — the per-cell classifier that decides which lines stay at module level (importable defs/vars) vs. get quarantined into `if __name__ == "__main__":` — scanned cells line-by-line tracking only `()[]{}` bracket depth, with **no notion of triple-quoted strings**.

So when a student parks a multi-line `"""…"""` block (prose, or an alternate solution they've commented out) at module level, the interior lines get re-classified as new top-level statements and ripped out into the `__main__` quarantine. That splits the string into invalid Python, and the resilient per-cell loader (`try: exec(compile(...)) except: pass`, which exists so one broken cell can't kill the module) then **silently swallows the whole cell** — wiping out every definition and variable in it.

## Why (real student impact)

Found while debugging why a HLTH 230 **Lab 1** submission lost credit despite correct answers. Two of the four cells opened with a `"""…"""` block above the real code:

- Warm-up cell → cell dropped → `beats` reported as **"Variable `beats` is not defined"**, even though the student correctly wrote `beats = heartRate * 60 * 24` (= 103680).
- Functions cell → cell dropped → `tax` reported missing → the `require_function("tax")` check **and** all four `tax` boundary-family cases failed.

The two cells *without* a module-level triple-quoted block (`add_and_double`, `myAverage`) graded fine. Net: the student silently lost all of Q1 + Q2 (~6/19 checks) to a grading-pipeline bug, not a mistake. This hits **any** student who parks a multi-line string at module level, which is common.

## How

A small cross-line lexical scanner (`CellLexState` + `advanceLexState`) carries bracket depth **and** triple-quote / string-skip / comment state across the cell's lines:

- Lines inside an open `"""`/`'''` block are continuations, never new top-level statements, so the string stays intact in whichever bucket its opening line landed in (a bare docstring is "safe" → module level).
- Brackets and stray quotes inside string literals and after `#` comments no longer perturb the classification (a strict improvement over the old all-brackets-counted scan).

Embedded-Swift / wasm-safe (stdlib-only, no Foundation), consistent with the rest of `RunnerCore`.

## Tests

- New `NotebookExtractionTests`: `tripleQuotedBlockDoesNotSwallowFollowingDefinitions` (the warm-up scenario — real assignment survives at module level, prose never leaks into `__main__`) and `singleQuoteTripleBlockKeepsLaterDefAtModuleLevel`.
- `swift test --filter "NotebookExtractionTests|NotebookExtractorTests"` → **51/51 pass**, including the existing docstring / module-assert / quarantine expectations and `generatedModuleLoadsUnderRealPython3` (compiles + runs extracted output under real `python3`).
- `scripts/lint.sh` clean.

## ⚠️ Follow-up required for the browser path

`RunnerCore` is shared by the native worker **and** the browser runner via the vendored wasm (`Public/runner-wasm/`, loaded as `core.extractPython`). HLTH 230 notebooks are **browser-graded**, so the browser path won't pick up this fix until the wasm artifact is regenerated on a SwiftWasm-capable box and committed (the SDK isn't available in the web container):

```bash
scripts/build-runner-wasm.sh   # regenerate Public/runner-wasm/RunnerWasm.<hash>.wasm + runner-core.js
git add Public/runner-wasm && git commit
```

This is the same source-only-then-regenerate-artifact pattern as #743. The native worker (and the worker backstop for browser-mode jobs) gets the fix immediately from the source change. CI should stay green meanwhile — `check-runner-wasm-size.sh` is size-only and the content-hashed wasm filename is unchanged.

https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ)_