### PR TITLE
Add MCP get_server_info tool (version + capability probe)

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -94,7 +94,9 @@ enum MCPServerInstructions {
         cannot be opened (isOpen=true) until validation passes.
 
         Recommended workflow:
-        1. Discover: list_courses, then list_assignments for a course.
+        1. Discover: list_courses, then list_assignments for a course. get_server_info reports the \
+        deployed version and whether writes are honored — call it to confirm a feature/deploy is live \
+        (a tool call reflects the running process even if your tool list is cached).
         2. Inspect before editing: get_assignment, get_suite, get_notebook, get_global_inputs. Use \
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.

--- a/Sources/APIServer/MCP/Tools/GetServerInfoTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetServerInfoTool.swift
@@ -1,0 +1,72 @@
+// APIServer/MCP/Tools/GetServerInfoTool.swift
+//
+// Read tool: report the deployed server's version and MCP capability surface.
+// content:read.
+//
+// Why a tool when `initialize` already carries `serverInfo.version`: a tool
+// *call* is a live round-trip to the running process, whereas a client may
+// cache the `initialize` result and the `tools/list` catalog for the lifetime
+// of its connection.  When an operator ships a new build, an agent holding a
+// cached catalog can't tell "the server isn't updated yet" from "my catalog is
+// stale" — calling this tool answers it unambiguously, since the response comes
+// straight from the live process.  It doubles as a capability probe (mode +
+// advertised scopes) so an agent can decide whether writes are honored without
+// a trial write that 403s.
+//
+// Deliberately DB-free: it returns only static server metadata, so it stays a
+// useful liveness check even if the database is unavailable.
+
+import Core
+
+struct GetServerInfoTool: ContentTool {
+    struct Input: Decodable, Sendable {}
+
+    struct Output: Encodable, Sendable {
+        /// The deployed Chickadee version (`ChickadeeVersion.current`).
+        let version: String
+        /// The active MCP mode: "read_only" or "read_write" (the endpoint is
+        /// unmounted in "off", so a reachable call is never that).
+        let mcpMode: String
+        /// Scopes this mode advertises and honors, in stable order.
+        let advertisedScopes: [String]
+        /// Convenience flag: true when `content:write` is honored (read_write).
+        let writeEnabled: Bool
+    }
+
+    static let name = "get_server_info"
+    static let description =
+        "Report the deployed server's version and MCP capability surface: the Chickadee version, "
+        + "the active MCP mode (read_only / read_write), the advertised content scopes, and whether "
+        + "writes are honored. Use it to confirm a deploy is live (a tool call hits the running "
+        + "process, unlike a cached tool list) or to check whether write tools will work before "
+        + "calling them. Read-only; touches no course, student, or database state."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "version": .object(["type": .string("string")]),
+            "mcpMode": .object(["type": .string("string")]),
+            "advertisedScopes": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
+            "writeEnabled": .object(["type": .string("boolean")]),
+        ]),
+        "required": .array([
+            .string("version"), .string("mcpMode"), .string("advertisedScopes"), .string("writeEnabled"),
+        ]),
+    ])
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let mode = context.request.application.appConfig.mcp.mode
+        return Output(
+            version: ChickadeeVersion.current,
+            mcpMode: mode.rawValue,
+            advertisedScopes: mode.advertisedScopes.map(\.rawValue),
+            writeEnabled: mode.scopeCeiling.contains(.write))
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -17,6 +17,7 @@ enum MCPToolCatalog {
     static var live: ToolRegistry {
         ToolRegistry([
             ListCoursesTool().erased(),
+            GetServerInfoTool().erased(),
             ListAssignmentsTool().erased(),
             GetAssignmentTool().erased(),
             GetSuiteTool().erased(),

--- a/Tests/APITests/MCP/GetServerInfoToolTests.swift
+++ b/Tests/APITests/MCP/GetServerInfoToolTests.swift
@@ -1,0 +1,52 @@
+// Tests for GetServerInfoTool (deployed version + MCP capability probe).
+
+import Core
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct GetServerInfoToolTests {
+    private func mcpConfig(_ mode: MCPMode) -> MCPConfig {
+        MCPConfig(
+            mode: mode, allowedHosts: [], allowedOrigins: [],
+            tokenTTLSeconds: 3600, signingKeyPath: "unused",
+            issuer: "https://chickadee.example", resource: "https://chickadee.example/mcp")
+    }
+
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read])
+    }
+
+    @Test func reportsCurrentVersion() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let out = try await GetServerInfoTool().execute(GetServerInfoTool.Input(), context(app))
+            #expect(out.version == ChickadeeVersion.current)
+        }
+    }
+
+    @Test func reportsReadWriteModeAndScopes() async throws {
+        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcpConfig(.readWrite)))
+        try await withApp(app) { app in
+            let out = try await GetServerInfoTool().execute(GetServerInfoTool.Input(), context(app))
+            #expect(out.mcpMode == "read_write")
+            #expect(out.writeEnabled)
+            #expect(out.advertisedScopes == ["content:read", "content:write"])
+        }
+    }
+
+    @Test func reportsReadOnlyModeWithoutWrite() async throws {
+        let app = try await makeTestApp(appConfig: .testDefaults(mcp: mcpConfig(.readOnly)))
+        try await withApp(app) { app in
+            let out = try await GetServerInfoTool().execute(GetServerInfoTool.Input(), context(app))
+            #expect(out.mcpMode == "read_only")
+            #expect(!out.writeEnabled)
+            #expect(out.advertisedScopes == ["content:read"])
+        }
+    }
+}

--- a/changelog.d/mcp-get-server-info.md
+++ b/changelog.d/mcp-get-server-info.md
@@ -1,0 +1,10 @@
+### Added
+
+- **MCP `get_server_info` tool.** A read-only tool that reports the deployed
+  Chickadee version, the active MCP mode (`read_only` / `read_write`), the
+  advertised content scopes, and whether writes are honored. Because a tool
+  *call* round-trips to the running process, it answers "is this deploy live
+  yet?" unambiguously even when a client has cached the `initialize` result or
+  `tools/list` catalog — and doubles as a capability probe so an agent can tell
+  whether write tools will work before calling one. DB-free, so it stays a
+  useful liveness check even if the database is unavailable.


### PR DESCRIPTION
## What

Adds a read-only **`get_server_info`** MCP tool that reports the deployed server's version and capability surface:

```json
{ "version": "0.4.333", "mcpMode": "read_write",
  "advertisedScopes": ["content:read", "content:write"], "writeEnabled": true }
```

## Why

The version is already in the `initialize` handshake's `serverInfo`, but a client can cache the `initialize` result and the `tools/list` catalog for the life of its connection. When an operator ships a new build, an agent holding a cached catalog can't distinguish "the server isn't updated yet" from "my catalog is stale" — which is exactly the ambiguity we just hit confirming whether prod had picked up a freshly merged tool.

A tool **call** round-trips to the live process, so `get_server_info` answers "is this deploy live?" unambiguously. It also doubles as a capability probe (`mcpMode` + `advertisedScopes` + `writeEnabled`) so an agent can tell whether write tools will be honored before making a trial write that 403s.

## How

- New `GetServerInfoTool` (`requiredScopes: [.read]`), registered in `MCPToolCatalog`.
- Reads `ChickadeeVersion.current` and `appConfig.mcp.mode` (→ `rawValue`, `advertisedScopes`, `scopeCeiling`). **DB-free**, so it stays a useful liveness check even if the database is unavailable.
- `initialize` instructions mention it under the discovery step.

## Tests

`GetServerInfoToolTests` (3): reports current version; reports `read_write` mode + both scopes + `writeEnabled`; reports `read_only` mode without write. Full MCP suite (dispatcher, e2e) still passes; `swift-format` / `scripts/lint.sh` / SwiftLint `--strict` clean.

https://claude.ai/code/session_015LsMAJ1F6s2FvmPeuiLYh3

---
_Generated by [Claude Code](https://claude.ai/code/session_015LsMAJ1F6s2FvmPeuiLYh3)_