### PR TITLE
ci: auto-vendor the RunnerCore browser wasm when source changes

### DIFF
--- a/.github/workflows/runner-wasm-vendor.yml
+++ b/.github/workflows/runner-wasm-vendor.yml
@@ -1,0 +1,109 @@
+name: Vendor RunnerCore wasm
+
+# The in-browser grader runs the shared RunnerCore grading core compiled to
+# WebAssembly and vendored under Public/runner-wasm/ (loaded by browser-runner.js
+# as core.extractPython / runnerExecuteSuites). That artifact is hand-built with
+# an Embedded-Swift wasm SDK and checked in, so a change to RunnerCore source
+# does NOT regenerate it — the browser silently keeps grading with the old
+# logic. That is exactly the failure behind #801, where a notebook-extraction
+# fix reached the native worker but the browser path needed a re-vendor.
+#
+# This job closes that gap: on main, whenever the wasm build inputs change
+# (RunnerCore / the wasm bridge / the build script), it rebuilds and re-vendors
+# the artifact and commits it back to main. Prod is built from version tags, so
+# the fresh artifact ships on the next release (one-release lag; set a
+# RELEASE_TOKEN-driven trigger if same-release is ever needed).
+#
+# Drift is gated by a source hash (scripts/runnercore-source-hash.sh) recorded
+# in Public/runner-wasm/source.sha — so the expensive SDK install + build only
+# run when the inputs actually changed, and the very first run heals whatever
+# the checked-in artifact had drifted to.
+#
+# Loop-safety: the auto-commit only touches Public/runner-wasm/ (+ the size
+# baseline), which is NOT in the trigger paths; and a push made with the default
+# GITHUB_TOKEN does not re-trigger workflows. Both independently prevent a loop.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Sources/RunnerCore/**'
+      - 'wasm/Sources/**'
+      - 'wasm/Package.swift'
+      - 'wasm/Package.resolved'
+      - 'wasm/wasm-sdk.pin'
+      - 'scripts/build-runner-wasm.sh'
+      - 'scripts/runnercore-source-hash.sh'
+      - '.github/workflows/runner-wasm-vendor.yml'
+
+concurrency:
+  group: runner-wasm-vendor
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  vendor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Decide whether a re-vendor is needed
+        id: gate
+        run: |
+          current="$(scripts/runnercore-source-hash.sh)"
+          recorded="$(cat Public/runner-wasm/source.sha 2>/dev/null || echo none)"
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          if [ "$current" = "$recorded" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::RunnerCore wasm inputs unchanged ($current) — no re-vendor."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::RunnerCore wasm inputs changed ($recorded -> $current) — re-vendoring."
+          fi
+
+      - name: Install Swift 6.3.2 + Embedded Wasm SDK
+        if: steps.gate.outputs.changed == 'true'
+        run: |
+          curl -fsSL https://swiftlang.github.io/swiftly/swiftly-install.sh | bash -s -- -y
+          . "$HOME/.local/share/swiftly/env.sh"
+          swiftly install 6.3.2
+          swiftly use 6.3.2
+          url="$(grep '^url=' wasm/wasm-sdk.pin | cut -d= -f2-)"
+          checksum="$(grep '^checksum=' wasm/wasm-sdk.pin | cut -d= -f2-)"
+          swift sdk install "$url" --checksum "$checksum"
+          swift sdk list
+
+      - name: Setup Node (esbuild + wasm-opt via npx)
+        if: steps.gate.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Rebuild + re-vendor the browser wasm
+        if: steps.gate.outputs.changed == 'true'
+        run: |
+          . "$HOME/.local/share/swiftly/env.sh"
+          scripts/build-runner-wasm.sh
+          scripts/runnercore-source-hash.sh > Public/runner-wasm/source.sha
+          # Refresh the size baseline so the delta note in check-runner-wasm-size.sh
+          # tracks the new artifact (informational only; it never fails on growth).
+          wasm="$(ls Public/runner-wasm/RunnerWasm.*.wasm | head -1)"
+          gzip -9 -c "$wasm" | wc -c | tr -d ' ' > runner-size-baseline.txt
+
+      - name: Commit re-vendored artifact to main
+        if: steps.gate.outputs.changed == 'true'
+        run: |
+          if git diff --quiet -- Public/runner-wasm runner-size-baseline.txt; then
+            echo "::notice::Rebuild produced no artifact change — nothing to commit."
+            exit 0
+          fi
+          git config user.name "chickadee-wasm[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Public/runner-wasm runner-size-baseline.txt
+          git commit -m "chore(wasm): re-vendor RunnerCore browser artifact [skip ci]"
+          git push origin HEAD:main

--- a/Public/runner-wasm/source.sha
+++ b/Public/runner-wasm/source.sha
@@ -1,0 +1,1 @@
+uninitialized

--- a/changelog.d/runner-wasm-vendor-ci.md
+++ b/changelog.d/runner-wasm-vendor-ci.md
@@ -1,0 +1,13 @@
+### Added
+
+- **CI auto-vendors the browser wasm runner.** The shared `RunnerCore` grading
+  core is compiled to WebAssembly and checked in under `Public/runner-wasm/`;
+  previously a `RunnerCore` change reached the native worker but the in-browser
+  grader kept running the stale vendored artifact until someone rebuilt it by
+  hand (the gap behind the #801 notebook-extraction fix). A new
+  `runner-wasm-vendor` workflow rebuilds and re-vendors the artifact on `main`
+  whenever the wasm build inputs change — gated by a source hash
+  (`scripts/runnercore-source-hash.sh` vs `Public/runner-wasm/source.sha`) so it
+  only runs when needed, with the Embedded-Swift wasm SDK pinned in
+  `wasm/wasm-sdk.pin`. The vendored artifact can no longer silently drift from
+  `RunnerCore` source.

--- a/docs/runner-wasm-migration.md
+++ b/docs/runner-wasm-migration.md
@@ -198,6 +198,14 @@ shared Swift, compiled once.
   plugin from `wasm/`). Output is vendored under `Public/runner-wasm/`, like
   Pyodide / CodeMirror — so CI and contributors need no wasm SDK; rebuild only
   when `RunnerCore` or the bridge changes.
+- **CI re-vendors automatically (closes the drift gap).** The
+  `runner-wasm-vendor` workflow rebuilds and commits the artifact on `main`
+  whenever the wasm build inputs change, so a `RunnerCore` fix can't reach the
+  native worker while the browser keeps grading stale logic (the #801 failure
+  mode). Drift is gated by `scripts/runnercore-source-hash.sh` vs the recorded
+  `Public/runner-wasm/source.sha`; the SDK source is pinned in `wasm/wasm-sdk.pin`.
+  Prod ships the fresh artifact on the next tag (one-release lag). Contributors
+  still don't need the wasm SDK — the gate just skips when inputs are unchanged.
 - `wasm/.build` is excluded from SwiftLint (it would otherwise lint vendored
   JavaScriptKit checkouts).
 

--- a/scripts/runnercore-source-hash.sh
+++ b/scripts/runnercore-source-hash.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Deterministic content hash of every input that determines the vendored
+# browser wasm artifact (Public/runner-wasm/). The wasm is built from the shared
+# RunnerCore grading core plus the wasm bridge; whenever any of those inputs
+# change, the vendored artifact must be rebuilt or the in-browser grader runs
+# stale logic against fresh source (the class of bug behind #801).
+#
+# `Public/runner-wasm/source.sha` records this hash at vendor time, and the
+# `runner-wasm-vendor` workflow compares the two to decide whether a re-vendor
+# is needed. Output: a single sha256 hex string on stdout.
+#
+# Note: this hashes the *inputs* (source), NOT the wasm bytes — the build is not
+# guaranteed bit-reproducible (esbuild / wasm-opt versions), so we gate on
+# source change and commit whatever bytes the build produces.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+{
+    find Sources/RunnerCore -type f -name '*.swift'
+    find wasm/Sources -type f -name '*.swift'
+    printf '%s\n' \
+        wasm/Package.swift \
+        wasm/Package.resolved \
+        scripts/build-runner-wasm.sh
+} | LC_ALL=C sort -u | while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    # filename + content hash, so a rename or an edit both change the digest
+    printf '%s  %s\n' "$f" "$(shasum -a 256 "$f" | cut -d' ' -f1)"
+done | shasum -a 256 | cut -d' ' -f1

--- a/wasm/wasm-sdk.pin
+++ b/wasm/wasm-sdk.pin
@@ -1,0 +1,16 @@
+# Pinned Swift Embedded WebAssembly SDK for the `runner-wasm-vendor` CI job.
+#
+# The job installs Swift 6.3.2 via swiftly, then:
+#   swift sdk install "$url" --checksum "$checksum"
+# and builds with `--swift-sdk swift-6.3.2-RELEASE_wasm-embedded`
+# (see scripts/build-runner-wasm.sh). The SDK version MUST match the host
+# toolchain version (6.3.2) and the swiftly version pinned in the workflow.
+#
+# Source: the official swift.org WebAssembly SDK bundle for the 6.3.2 release,
+# which includes the Embedded Swift (`_wasm-embedded`) SDK. Find the exact URL
+# and checksum on https://www.swift.org/install/ (Wasm SDK) or the release's
+# download page, or run `swift sdk install <url>` locally and copy the values.
+#
+# >>> CONFIRM THESE TWO VALUES against your working 6.3.2 build box <<<
+url=https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm-embedded.artifactbundle.tar.gz
+checksum=REPLACE_WITH_SHA256_FROM_SWIFT_ORG

--- a/wasm/wasm-sdk.pin
+++ b/wasm/wasm-sdk.pin
@@ -3,14 +3,15 @@
 # The job installs Swift 6.3.2 via swiftly, then:
 #   swift sdk install "$url" --checksum "$checksum"
 # and builds with `--swift-sdk swift-6.3.2-RELEASE_wasm-embedded`
-# (see scripts/build-runner-wasm.sh). The SDK version MUST match the host
-# toolchain version (6.3.2) and the swiftly version pinned in the workflow.
+# (see scripts/build-runner-wasm.sh).
 #
-# Source: the official swift.org WebAssembly SDK bundle for the 6.3.2 release,
-# which includes the Embedded Swift (`_wasm-embedded`) SDK. Find the exact URL
-# and checksum on https://www.swift.org/install/ (Wasm SDK) or the release's
-# download page, or run `swift sdk install <url>` locally and copy the values.
-#
-# >>> CONFIRM THESE TWO VALUES against your working 6.3.2 build box <<<
-url=https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm-embedded.artifactbundle.tar.gz
-checksum=REPLACE_WITH_SHA256_FROM_SWIFT_ORG
+# This is the official swift.org WebAssembly SDK bundle for the 6.3.2 release.
+# Installing this ONE bundle provides BOTH SDK identifiers:
+#   * swift-6.3.2-RELEASE_wasm           (full Swift)
+#   * swift-6.3.2-RELEASE_wasm-embedded  (Embedded Swift — what we build with)
+# URL + checksum are the values published at
+# https://www.swift.org/documentation/articles/wasm-getting-started.html
+# Update both when bumping the Swift toolchain (must stay matched to the swiftly
+# version pinned in .github/workflows/runner-wasm-vendor.yml).
+url=https://download.swift.org/swift-6.3.2-release/wasm-sdk/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE_wasm.artifactbundle.tar.gz
+checksum=a61f0584c93283589f8b2f42db05c1f9a182b506c2957271402992655591dd7c


### PR DESCRIPTION
## Why

`RunnerCore` (the shared grading core) is compiled to WebAssembly and **checked in** under `Public/runner-wasm/`, then loaded by the in-browser grader (`browser-runner.js` → `core.extractPython` / `runnerExecuteSuites`). Nothing rebuilds that artifact automatically — not CI (only a gzip **size** check runs), not the Docker build (`COPY Public`). So a change to `RunnerCore` ships to the **native worker** while the **browser keeps grading with the stale wasm**, with no guard.

That's precisely the gap behind **#801**: the notebook triple-quote extraction fix reached the worker, but HLTH 230 notebooks are browser-graded, so the actual student path needed a manual re-vendor on a SwiftWasm box. This makes that automatic.

## What

A `runner-wasm-vendor` workflow that, on `main`, rebuilds and re-vendors the artifact whenever the wasm build inputs change, and commits it back to `main`:

- **Source-hash gate** — `scripts/runnercore-source-hash.sh` hashes the inputs that determine the wasm (`Sources/RunnerCore/**`, `wasm/Sources/**`, `wasm/Package.{swift,resolved}`, `scripts/build-runner-wasm.sh`), compared against the recorded `Public/runner-wasm/source.sha`; the expensive SDK install + build only run on a mismatch. Verified deterministic + sensitive locally.
- **Build** — installs Swift 6.3.2 (swiftly) + the official swift.org Wasm SDK, runs the existing `scripts/build-runner-wasm.sh`, updates `source.sha` + the size baseline, commits.
- **First run heals the current drift** — `source.sha` ships as `uninitialized`, so the first run after merge mismatches and re-vendors, picking up **#801's** fix for the browser path.
- **SDK pin** — `wasm/wasm-sdk.pin` carries the authoritative swift.org `_wasm` artifactbundle URL + checksum (one bundle provides both the `_wasm` and `_wasm-embedded` SDK ids).
- **Loop-safe** — the auto-commit touches only `Public/runner-wasm/` (+ size baseline), which is *not* in the trigger paths; GITHUB_TOKEN pushes don't re-trigger workflows; the commit carries `[skip ci]`. Three independent guards.

This also subsumes the standalone "parity guard" idea — `source.sha` *is* the parity record, but instead of failing the build it auto-heals.

## SDK values are now self-resolved (no input needed)

Earlier this needed a checksum from your build box; I pulled the authoritative **URL + sha256** from the [swift.org WebAssembly SDK docs](https://www.swift.org/documentation/articles/wasm-getting-started.html) instead, so `wasm/wasm-sdk.pin` is filled and tamper-evident (not a blind download). The one thing I genuinely can't exercise from the web container is a live Actions run / the 6.3.2 SDK install end-to-end, so **the first run on `main` is the real integration test** — expect possibly one fixup iteration there.

## Design notes / tradeoffs

- **Main-side auto-commit** (your pick) over PR-side: tolerant of non-deterministic builds (esbuild/wasm-opt versions), no fork/branch-push issues, prod always matches source.
- **One-release lag:** the commit lands via GITHUB_TOKEN, which doesn't trigger `auto-release`, so the fresh wasm ships on the *next* tag rather than the same one. Eliminating the lag would mean folding the rebuild into `auto-release.yml` (couples release reliability to the wasm toolchain) — deliberately avoided here to keep the blast radius small. Easy follow-up if you want same-release.

https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ