### PR TITLE
feat(grades): apply grade override everywhere a grade is shown

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -983,3 +983,22 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     margin-top: .875rem;
     font-size: .875rem;
 }
+
+/* Tag shown next to a grade that an instructor has manually overridden.
+   Used on the student dashboard, the submission page, and the instructor
+   roster / per-student views. */
+.grade-override-tag {
+    display: inline-block;
+    margin-left: .35rem;
+    padding: 0 .3rem;
+    font-size: .68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .02em;
+    color: var(--gray-700);
+    background: var(--gray-100);
+    border: 1px solid var(--gray-300);
+    border-radius: .2rem;
+    vertical-align: middle;
+}
+.grade-override-active { border-color: var(--gray-500); background: var(--gray-100); }

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -37,7 +37,7 @@
             <td>#(row.surname)</td>
             <td>#(row.givenNames)</td>
             <td><strong>#(row.studentID)</strong></td>
-            <td>#(row.gradeText)</td>
+            <td>#(row.gradeText)#if(row.gradeIsOverridden):<span class="grade-override-tag" title="Grade manually overridden by an instructor">overridden</span>#endif</td>
             <td data-ts="#(row.latestSubmittedAtEpoch)">
                 #if(row.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">

--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -309,23 +309,6 @@
 .ext-summary { margin-top: 0; list-style: none; }
 .ext-summary::-webkit-details-marker { display: none; }
 .ext-details[open] > .ext-summary { background: var(--gray-100); }
-/* Grade-override affordances: a subtle tag next to an overridden grade and a
-   highlighted icon button when an override is active for the row. */
-.grade-override-tag {
-    display: inline-block;
-    margin-left: .35rem;
-    padding: 0 .3rem;
-    font-size: .68rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: .02em;
-    color: var(--gray-700);
-    background: var(--gray-100);
-    border: 1px solid var(--gray-300);
-    border-radius: .2rem;
-    vertical-align: middle;
-}
-.grade-override-active { border-color: var(--gray-500); background: var(--gray-100); }
 </style>
 #endexport
 #endextend

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -75,6 +75,9 @@
             <td>
                 #if(setup.bestGradeText):
                     <strong>#(setup.bestGradeText)</strong>
+                    #if(setup.gradeIsOverridden):
+                    <span class="grade-override-tag" title="Your grade was set by your instructor">adjusted</span>
+                    #endif
                 #else:
                     <span class="empty">—</span>
                 #endif
@@ -190,6 +193,9 @@
             <td>
                 #if(setup.bestGradeText):
                     <strong>#(setup.bestGradeText)</strong>
+                    #if(setup.gradeIsOverridden):
+                    <span class="grade-override-tag" title="Your grade was set by your instructor">adjusted</span>
+                    #endif
                 #else:
                     <span class="empty">—</span>
                 #endif
@@ -305,6 +311,9 @@
             <td>
                 #if(setup.bestGradeText):
                     <strong>#(setup.bestGradeText)</strong>
+                    #if(setup.gradeIsOverridden):
+                    <span class="grade-override-tag" title="Your grade was set by your instructor">adjusted</span>
+                    #endif
                 #else:
                     <span class="empty">—</span>
                 #endif

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -22,7 +22,12 @@ Submission #(submissionID)
     #if(buildFailed):
     #else:
     <div class="submission-score-row">
+        #if(gradeIsOverridden):
+        <p class="score score-header">Grade: <span class="grade-pill grade-override-active">#(overrideGradeText)</span> <span class="grade-override-tag" title="Your instructor set this grade for the assignment">overridden</span></p>
+        <p class="score" style="font-size:.9rem;color:var(--gray-600)">Autograded: #(gradePercent)% · #if(isWeighted):#(earnedPoints) / #(totalPoints) points#else:#(passCount) / #(totalTests) tests passed#endif#if(deltaHeaderText): · <span class="delta-summary">#(deltaHeaderText)</span>#endif</p>
+        #else:
         <p class="score score-header">Grade: <span class="grade-pill">#(gradePercent)%</span> · #if(isWeighted):#(earnedPoints) / #(totalPoints) points#else:#(passCount) / #(totalTests) tests passed#endif#if(deltaHeaderText): · <span class="delta-summary">#(deltaHeaderText)</span>#endif</p>
+        #endif
         #if(!badges.isEmpty):
         <div class="achievement-badges achievement-badges-full">
             #for(badge in badges):

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -165,6 +165,9 @@ struct AssignmentStudentRow: Encodable {
     let surname: String
     let givenNames: String
     let gradeText: String
+    /// True when `gradeText` is an instructor override rather than the
+    /// runner-computed best grade.
+    let gradeIsOverridden: Bool
     let submissionCount: Int
     let hasLatestSubmission: Bool
     let latestSubmissionID: String

--- a/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
+++ b/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
@@ -1,0 +1,59 @@
+// APIServer/Routes/Web/GradeOverrideHelpers.swift
+//
+// Shared lookups for the per-student grade override (`APIGradeOverride`,
+// keyed on (test_setup, user)).  An override is the student's effective
+// grade for an assignment and must replace the runner-computed grade
+// everywhere a grade is shown — the student dashboard, the submission
+// detail page, the instructor roster/median, the grades CSV, and the
+// BrightSpace sync.  These helpers centralise the (setupID, userID) lookup
+// so each display site applies the override the same way.
+
+import Fluent
+import Foundation
+import Vapor
+
+/// Composite key for one override: a single (test setup, user) pair.
+struct GradeOverrideKey: Hashable {
+    let setupID: String
+    let userID: UUID
+}
+
+/// Batch-loads grade overrides for the given test setups in one query,
+/// keyed by (setupID, userID).  Callers index by whichever pair they hold
+/// in scope.  The value is the override percent (0–100).
+func loadGradeOverridePercents(
+    setupIDs: some Collection<String>, on db: Database
+) async throws -> [GradeOverrideKey: Int] {
+    guard !setupIDs.isEmpty else { return [:] }
+    let rows = try await APIGradeOverride.query(on: db)
+        .filter(\.$testSetupID ~~ Set(setupIDs))
+        .all()
+    var map: [GradeOverrideKey: Int] = [:]
+    for row in rows {
+        map[GradeOverrideKey(setupID: row.testSetupID, userID: row.userID)] = row.overridePercent
+    }
+    return map
+}
+
+/// One-off override lookup for single-submission pages.  Returns the
+/// override percent (0–100) for this (setup, user), or nil when none.
+func gradeOverridePercent(
+    setupID: String, userID: UUID, on db: Database
+) async throws -> Int? {
+    try await APIGradeOverride.query(on: db)
+        .filter(\.$testSetupID == setupID)
+        .filter(\.$userID == userID)
+        .first()?
+        .overridePercent
+}
+
+/// Converts an override percent into points against a test setup's total
+/// possible points (the sum of its suite items' weights), for points-based
+/// exports such as the grades CSV and BrightSpace.  Nil when the manifest
+/// is missing/malformed or sums to zero.
+func gradeOverridePoints(percent: Int, setup: APITestSetup) -> Double? {
+    guard let props = setup.decodedManifest() else { return nil }
+    let total = props.testSuites.map(\.points).reduce(0, +)
+    guard total > 0 else { return nil }
+    return Double(percent) / 100.0 * Double(total)
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -42,10 +42,23 @@ extension InstructorDashboardRoutes {
         // Serial follow-on: needs submission IDs from phase 2.
         let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
             for: submissionIDs, on: req.db)
-        let bestPointsByUserAndSetup = bestPointsByUserAndSetup(
+        var bestPointsByUserAndSetup = bestPointsByUserAndSetup(
             submissions: submissions,
             preferredResultBySubmissionID: preferredResultBySubmissionID
         )
+
+        // Instructor grade overrides replace the runner-computed points. They
+        // apply even when the student has no submission, so this overlays the
+        // map rather than filtering within it. The override percent is
+        // converted to points against the setup's total possible points.
+        let overrideMap = try await loadGradeOverridePercents(setupIDs: setupIDs, on: req.db)
+        for (key, pct) in overrideMap {
+            guard let setup = setupByID[key.setupID],
+                let points = gradeOverridePoints(percent: pct, setup: setup)
+            else { continue }
+            let mapKey = "\(key.userID.uuidString.lowercased())::\(key.setupID)"
+            bestPointsByUserAndSetup[mapKey] = points
+        }
 
         let csv = renderGradesCSV(
             students: students,
@@ -225,12 +238,21 @@ extension InstructorDashboardRoutes {
         let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
             for: submissionIDs, on: req.db)
 
+        // Instructor grade overrides for this assignment, indexed by student.
+        let overrideMap = try await loadGradeOverridePercents(
+            setupIDs: [assignment.testSetupID], on: req.db)
+        var overrideByStudentID: [UUID: Int] = [:]
+        for (key, pct) in overrideMap where key.setupID == assignment.testSetupID {
+            overrideByStudentID[key.userID] = pct
+        }
+
         let fmt = waterlooDateTimeFormatter()
         let rows = students.compactMap { student -> AssignmentStudentRow? in
             buildAssignmentStudentRow(
                 student: student,
                 submissionsByStudentID: submissionsByStudentID,
                 preferredResultBySubmissionID: preferredResultBySubmissionID,
+                overrideByStudentID: overrideByStudentID,
                 assignmentIDRaw: assignmentIDRaw,
                 fmt: fmt
             )
@@ -299,13 +321,14 @@ extension InstructorDashboardRoutes {
         student: APIUser,
         submissionsByStudentID: [UUID: [APISubmission]],
         preferredResultBySubmissionID: [String: APIResult],
+        overrideByStudentID: [UUID: Int],
         assignmentIDRaw: String,
         fmt: DateFormatter
     ) -> AssignmentStudentRow? {
         guard let studentID = student.id else { return nil }
         let history = submissionsByStudentID[studentID] ?? []
         let latest = history.first
-        let bestGradePercent: Int? = {
+        let runnerBestGradePercent: Int? = {
             var best = -1
             for submission in history {
                 guard let subID = submission.id,
@@ -318,6 +341,10 @@ extension InstructorDashboardRoutes {
             }
             return best >= 0 ? best : nil
         }()
+        // An instructor override is the student's effective grade — it feeds
+        // both the displayed grade and the median metric.
+        let override = overrideByStudentID[studentID]
+        let bestGradePercent = override ?? runnerBestGradePercent
         let inferredName =
             splitHumanName(student.displayName)
             ?? splitHumanName(student.preferredName)
@@ -328,6 +355,7 @@ extension InstructorDashboardRoutes {
             surname: inferredName.surname,
             givenNames: inferredName.givenNames,
             gradeText: bestGradePercent.map { "\($0)%" } ?? "—",
+            gradeIsOverridden: override != nil,
             submissionCount: history.count,
             hasLatestSubmission: latest != nil,
             latestSubmissionID: latest?.id ?? "",

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -42,6 +42,9 @@ struct TestSetupRow: Encodable {
     let latestSubmittedAtText: String
     let additionalSubmissionCount: Int
     let bestGradeText: String?
+    /// True when `bestGradeText` is an instructor override rather than the
+    /// runner-computed grade.  Drives the "overridden" tag in the template.
+    let gradeIsOverridden: Bool
     let badges: [AchievementBadge]
     /// True when this student has an active deadline extension on this
     /// assignment.  Used by the template to show the Submit button and
@@ -294,6 +297,12 @@ struct SubmissionContext: Encodable {
     let passCount: Int
     let totalTests: Int
     let gradePercent: Int
+    /// True when an instructor has overridden this student's grade for the
+    /// assignment.  The override is the effective grade regardless of this
+    /// attempt's autograded score; the template shows `overrideGradeText`.
+    let gradeIsOverridden: Bool
+    /// Formatted override grade (e.g. "85%"), nil when not overridden.
+    let overrideGradeText: String?
     let executionTimeMs: Int
     /// True when any test has points > 1 (i.e. grade uses weighted points).
     let isWeighted: Bool

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -360,11 +360,20 @@ extension WebRoutes {
             currentAttempt: currentAttempt
         )
 
+        // An instructor override is the student's effective grade for the
+        // assignment; surface it above this attempt's autograded breakdown.
+        var overrideGradePercent: Int?
+        if let submissionUserID = submission.userID {
+            overrideGradePercent = try await gradeOverridePercent(
+                setupID: submission.testSetupID, userID: submissionUserID, on: req.db)
+        }
+
         let ctx = buildSubmissionContext(
             subID: subID,
             submission: submission,
             processed: processed,
             sectionedOutcomes: sectionedOutcomes,
+            overrideGradePercent: overrideGradePercent,
             decorations: SubmissionDecorations(badges: badges, currentUser: req.currentUserContext),
             delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText)
         )
@@ -650,6 +659,7 @@ extension WebRoutes {
         submission: APISubmission,
         processed: ProcessedCollection,
         sectionedOutcomes: [SectionedOutcomes],
+        overrideGradePercent: Int?,
         decorations: SubmissionDecorations,
         delta: DeltaBanner
     ) -> SubmissionContext {
@@ -682,6 +692,8 @@ extension WebRoutes {
             passCount: processed.passCount,
             totalTests: processed.totalTests,
             gradePercent: processed.gradePercent,
+            gradeIsOverridden: overrideGradePercent != nil,
+            overrideGradeText: overrideGradePercent.map { "\($0)%" },
             executionTimeMs: processed.executionTimeMs,
             isWeighted: processed.totalPoints != processed.totalTests,
             totalPoints: processed.totalPoints,

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -373,8 +373,11 @@ extension WebRoutes {
             submission: submission,
             processed: processed,
             sectionedOutcomes: sectionedOutcomes,
-            overrideGradePercent: overrideGradePercent,
-            decorations: SubmissionDecorations(badges: badges, currentUser: req.currentUserContext),
+            decorations: SubmissionDecorations(
+                badges: badges,
+                currentUser: req.currentUserContext,
+                overrideGradePercent: overrideGradePercent
+            ),
             delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText)
         )
         return try await req.view.render("submission", ctx)
@@ -659,10 +662,10 @@ extension WebRoutes {
         submission: APISubmission,
         processed: ProcessedCollection,
         sectionedOutcomes: [SectionedOutcomes],
-        overrideGradePercent: Int?,
         decorations: SubmissionDecorations,
         delta: DeltaBanner
     ) -> SubmissionContext {
+        let overrideGradePercent = decorations.overrideGradePercent
         let badges = decorations.badges
         let currentUser = decorations.currentUser
         let isPending = submission.status == "pending" || submission.status == "assigned"
@@ -818,6 +821,9 @@ private struct DeltaBanner {
 private struct SubmissionDecorations {
     let badges: [AchievementBadge]
     let currentUser: CurrentUserContext?
+    /// Instructor override percent for this student × assignment, nil when
+    /// none.  The effective grade shown above the autograded breakdown.
+    let overrideGradePercent: Int?
 }
 
 // `SubmitFormBody` and the submission-output formatting helpers live in

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -186,10 +186,19 @@ struct WebRoutes: RouteCollection {
         var latestSubmissionBySetupID: [String: LatestSubmissionItem] = [:]
         var submissionCountBySetupID: [String: Int] = [:]
         var bestGradePercentBySetupID: [String: Int] = [:]
+        var overridePercentBySetupID: [String: Int] = [:]
         var latestBadgesBySetupID: [String: [AchievementBadge]] = [:]
         if let userID = user.id {
             let setupIDs = setups.compactMap(\.id)
             if !setupIDs.isEmpty {
+                // Instructor grade overrides for this student take precedence
+                // over the runner-computed best grade below.
+                let overrideMap = try await loadGradeOverridePercents(setupIDs: setupIDs, on: req.db)
+                for setupID in setupIDs {
+                    if let pct = overrideMap[GradeOverrideKey(setupID: setupID, userID: userID)] {
+                        overridePercentBySetupID[setupID] = pct
+                    }
+                }
                 let submissions = try await APISubmission.query(on: req.db)
                     .filter(\.$userID == userID)
                     .filter(\.$testSetupID ~~ setupIDs)
@@ -397,7 +406,9 @@ struct WebRoutes: RouteCollection {
                 latestSubmissionID: latestSubmission?.submissionID ?? "",
                 latestSubmittedAtText: latestSubmission?.submittedAtText ?? "—",
                 additionalSubmissionCount: max(submissionCount - 1, 0),
-                bestGradeText: bestGradePercentBySetupID[setupID].map { "\($0)%" },
+                bestGradeText: overridePercentBySetupID[setupID].map { "\($0)%" }
+                    ?? bestGradePercentBySetupID[setupID].map { "\($0)%" },
+                gradeIsOverridden: overridePercentBySetupID[setupID] != nil,
                 badges: latestBadgesBySetupID[setupID] ?? [],
                 hasActiveExtension: hasActiveExtension,
                 effectiveDueAtText: effectiveDueAt.map { fmt.string(from: $0) }

--- a/Tests/APITests/GradeOverridesTests.swift
+++ b/Tests/APITests/GradeOverridesTests.swift
@@ -233,4 +233,149 @@ import XCTVapor
             )
         }
     }
+
+    // MARK: - Instructor roster + median
+
+    @Test func overrideReplacesGradeOnInstructorRosterAndMedian() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            let student = try await arInsertStudent(username: "ovr_roster_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "ovr_roster_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ovr_roster_setup", title: "Roster Lab", isOpen: true, on: app
+            )
+            _ = try await arInsertSubmission(
+                id: "sub_ovr_roster", testSetupID: "ovr_roster_setup",
+                userID: try student.requireID(), on: app
+            )
+            // Runner grade 25% (1/4) — should be replaced by the 90% override.
+            let result = APIResult(
+                id: "res_ovr_roster",
+                submissionID: "sub_ovr_roster",
+                collectionJSON: #"{"earnedPoints":1,"totalPoints":4,"passCount":1,"totalTests":4}"#
+            )
+            try await result.save(on: app.db)
+            try await APIGradeOverride(
+                testSetupID: "ovr_roster_setup",
+                userID: try student.requireID(),
+                overridePercent: 90
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/submissions",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("90%"), "Override grade must appear on the roster")
+                    #expect(body.contains("overridden"), "Override must carry the tag")
+                    #expect(!body.contains("25%"), "Runner grade must be replaced by the override")
+                    // Median metric is computed from the (overridden) best grade.
+                    #expect(body.contains("Median Grade"))
+                }
+            )
+        }
+    }
+
+    // MARK: - Grades CSV export
+
+    @Test func overrideAppliedToGradesCSVAsPoints() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            // Setup whose suite is worth 4 points, so a 50% override = 2.0 pts.
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let manifest = """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":\
+                [{"tier":"public","script":"t.sh","points":4}],"timeLimitSeconds":10}
+                """
+            let setup = APITestSetup(
+                id: "ovr_csv_setup",
+                manifest: manifest,
+                zipPath: app.testSetupsDirectory + "ovr_csv_setup.zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ovr_csv_setup", title: "CSV Lab", isOpen: true, on: app
+            )
+            _ = assignment
+            let student = try await arInsertStudent(username: "ovr_csv_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            _ = try await arInsertSubmission(
+                id: "sub_ovr_csv", testSetupID: "ovr_csv_setup",
+                userID: try student.requireID(), on: app
+            )
+            let result = APIResult(
+                id: "res_ovr_csv",
+                submissionID: "sub_ovr_csv",
+                collectionJSON: #"{"earnedPoints":4,"totalPoints":4,"passCount":4,"totalTests":4}"#
+            )
+            try await result.save(on: app.db)
+            try await APIGradeOverride(
+                testSetupID: "ovr_csv_setup",
+                userID: try student.requireID(),
+                overridePercent: 50
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/instructor/grades.csv",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("2.0"), "Override (50% of 4 pts) must export as 2.0")
+                    #expect(!body.contains("4.0"), "Runner points must be replaced by the override")
+                }
+            )
+        }
+    }
+
+    // MARK: - Student submission page banner
+
+    @Test func overrideBannerShownOnSubmissionPage() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            try await wrEnrollUser(student, on: app)
+            try await wrInsertSetup(id: "ovr_subpage_setup", on: app)
+            _ = try await wrInsertAssignment(
+                testSetupID: "ovr_subpage_setup", title: "Sub Page Lab", isOpen: true, on: app
+            )
+            _ = try await wrInsertSubmission(
+                id: "sub_ovr_page", testSetupID: "ovr_subpage_setup",
+                userID: try student.requireID(), on: app
+            )
+            _ = try await wrInsertResult(
+                submissionID: "sub_ovr_page",
+                outcomes: [wrMakeOutcome(name: "t1", status: .pass)],
+                on: app
+            )
+            try await APIGradeOverride(
+                testSetupID: "ovr_subpage_setup",
+                userID: try student.requireID(),
+                overridePercent: 55
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_ovr_page",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("55%"), "Override grade must headline the submission page")
+                    #expect(body.contains("overridden"), "Override must carry the tag")
+                    #expect(body.contains("Autograded:"), "Autograde breakdown must be labelled")
+                }
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Extends the per-student grade override (added in #792) so it is the student's **effective grade everywhere a grade is shown**, not just the instructor per-student page + BrightSpace sync.

Now applies the override at:
- **Student dashboard** best grade — shows the override with an `adjusted` tag.
- **Submission detail page** (`/submissions/:id`) — the override headlines the grade; the per-attempt autograded score is kept below, labelled `Autograded:`.
- **Instructor per-assignment roster** — grade column + the **Median Grade** metric both use the override.
- **Grades CSV export** — the override percent is converted to points against the assignment's total possible points (and applies even when the student has no submission).

Already covered by #792 and unchanged here: the instructor per-student course page and the BrightSpace grade sweep.

## Implementation
- New `GradeOverrideHelpers.swift`: a batch loader (`loadGradeOverridePercents`, keyed by (setupID, userID)), a single-pair lookup for one-off pages, and a percent→points converter.
- New `gradeIsOverridden` flags on `TestSetupRow` / `AssignmentStudentRow` and `gradeIsOverridden` + `overrideGradeText` on `SubmissionContext`.
- Override-tag CSS moved into the global `styles.css` (was inline in one template).

## Test plan
- [ ] `GradeOverridesTests`: roster shows override + tag and replaces the runner grade (median path exercised); CSV exports the override as points; submission page headlines the override and labels the autograde detail.
- [ ] swift-format clean locally; CI (build + postgres/worker tests + SwiftLint) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
