### PR TITLE
ci(wasm): install swiftly via binary release (fix Ubuntu 24.04)

### DIFF
--- a/.github/workflows/runner-wasm-vendor.yml
+++ b/.github/workflows/runner-wasm-vendor.yml
@@ -69,10 +69,17 @@ jobs:
       - name: Install Swift 6.3.2 + Embedded Wasm SDK
         if: steps.gate.outputs.changed == 'true'
         run: |
-          curl -fsSL https://swiftlang.github.io/swiftly/swiftly-install.sh | bash -s -- -y
+          set -euxo pipefail
+          # Install swiftly from its binary release (the legacy swiftly-install.sh
+          # shell script does not support Ubuntu 24.04, the ubuntu-latest runner).
+          arch="$(uname -m)"
+          curl -fsSLO "https://download.swift.org/swiftly/linux/swiftly-${arch}.tar.gz"
+          tar zxf "swiftly-${arch}.tar.gz"
+          ./swiftly init -y --skip-install --quiet-shell-followup
           . "$HOME/.local/share/swiftly/env.sh"
           swiftly install 6.3.2
           swiftly use 6.3.2
+          swift --version
           url="$(grep '^url=' wasm/wasm-sdk.pin | cut -d= -f2-)"
           checksum="$(grep '^checksum=' wasm/wasm-sdk.pin | cut -d= -f2-)"
           swift sdk install "$url" --checksum "$checksum"


### PR DESCRIPTION
## What

Fixes the first `runner-wasm-vendor` run (#803), which failed at the toolchain-install step:

```
curl … swiftly-install.sh | bash -s -- -y
Error: Unsupported platform: Ubuntu 24.04.4 LTS
```

The legacy `swiftly-install.sh` shell script doesn't support Ubuntu 24.04 (the `ubuntu-latest` runner). Switched to the supported **swiftly binary release** from `download.swift.org` + `swiftly init --skip-install`, then `swiftly install 6.3.2`. Added `set -euxo pipefail` + a `swift --version` echo so any further first-run issue is legible.

## The design itself is validated

The run got far enough to prove the important parts work end-to-end on CI:
- The **source-hash gate** computed `be4072…` (matching the local value) and correctly detected drift against the `uninitialized` sentinel: `RunnerCore wasm inputs changed (uninitialized -> be4072…) — re-vendoring.`
- So drift detection + the first-run heal path are sound; only the toolchain bootstrap needed fixing.

## Note

I still can't run Actions from the dev container, so the swiftly-binary path + the actual `swift sdk install` / wasm build are exercised for the first time when this merges. The SDK pin (`wasm/wasm-sdk.pin`) is unchanged and already verified against swift.org. I'm watching the run and will iterate if anything else surfaces.

https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ)_