### PR TITLE
ci(wasm): install Swift's Ubuntu runtime deps before building

### DIFF
--- a/.github/workflows/runner-wasm-vendor.yml
+++ b/.github/workflows/runner-wasm-vendor.yml
@@ -24,6 +24,7 @@ name: Vendor RunnerCore wasm
 # GITHUB_TOKEN does not re-trigger workflows. Both independently prevent a loop.
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
     paths:
@@ -70,6 +71,16 @@ jobs:
         if: steps.gate.outputs.changed == 'true'
         run: |
           set -euxo pipefail
+          # The Swift toolchain links these system libs at runtime; the bare
+          # ubuntu-latest runner is missing some (swiftly flags libcurl), so the
+          # toolchain installs but `swift` won't run. Install the documented
+          # Swift-on-Ubuntu dependency set (apt is idempotent for ones already
+          # present).
+          sudo apt-get update
+          sudo apt-get install -y \
+            binutils libc6-dev libcurl4-openssl-dev libedit2 libgcc-13-dev \
+            libncurses-dev libpython3-dev libsqlite3-0 libstdc++-13-dev \
+            libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev
           # Install swiftly from its binary release (the legacy swiftly-install.sh
           # shell script does not support Ubuntu 24.04, the ubuntu-latest runner).
           arch="$(uname -m)"
@@ -79,6 +90,7 @@ jobs:
           . "$HOME/.local/share/swiftly/env.sh"
           swiftly install 6.3.2
           swiftly use 6.3.2
+          hash -r
           swift --version
           url="$(grep '^url=' wasm/wasm-sdk.pin | cut -d= -f2-)"
           checksum="$(grep '^checksum=' wasm/wasm-sdk.pin | cut -d= -f2-)"


### PR DESCRIPTION
## What

Third and (hopefully) last first-run fixup for the `runner-wasm-vendor` workflow.

**Progress so far on `main`:**
- Run #1 (#803): gate logic validated — correctly detected drift (`uninitialized → be4072…`) and entered the re-vendor path. Failed at toolchain install (old `swiftly-install.sh` rejects Ubuntu 24.04).
- Run #2 (#805): swiftly binary install worked — `Swift 6.3.2 is installed successfully!` — then exited 1 immediately after, with swiftly's own advisory naming the cause: the runner is missing `libcurl4-openssl-dev` (and friends), so the toolchain installs but `swift` can't actually run.

**This PR:** before using the toolchain, `apt-get install` the documented Swift-on-Ubuntu dependency set (idempotent for ones already present), add `hash -r` for PATH refresh, and add a `workflow_dispatch` trigger so the vendor job can be re-run manually.

## Confidence / testing

Higher confidence than the prior two — swiftly explicitly diagnosed the missing dependency, and `set -euxo pipefail` is in place so if anything past this surfaces, the next log shows the exact failing command. I still can't run Actions from the dev container, so the actual `swift sdk install` + wasm build run for the first time when this merges. The gate's source-hash already differs from the `uninitialized` sentinel, so the merge will re-enter the build path and produce the re-vendor commit on success.

If this round still fights bare-runner setup, the fallback is to run the job in the official `swift:6.3.2` container (toolchain + all deps preinstalled); I went with the targeted dep install first since it's the smaller change and swiftly pinpointed the cause.

https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016yaY6CVxfqpdjE15BQMsFQ)_