### PR TITLE
Make student-submissions Reset button destructive-styled and rightmost

### DIFF
--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -96,12 +96,6 @@
                         </button>
                     </form>
                     #endif
-                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" style="margin:0">
-                        #csrfFormField()
-                        <button class="btn action-btn" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter" style="padding:.25rem .35rem">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
-                        </button>
-                    </form>
                     <details class="ext-details" style="margin:0">
                         <summary class="btn action-btn ext-summary" title="#if(row.hasExtension):Edit this student’s deadline extension#else:Grant this student a deadline extension#endif" aria-label="#if(row.hasExtension):Edit deadline extension#else:Grant deadline extension#endif" style="padding:.25rem .35rem">
                             #if(row.hasExtension):
@@ -150,6 +144,12 @@
                             </div>
                         </form>
                     </details>
+                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
                 </div>
             </td>
         </tr>
@@ -239,12 +239,6 @@
                         </button>
                     </form>
                     #endif
-                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" style="margin:0">
-                        #csrfFormField()
-                        <button class="btn action-btn" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter" style="padding:.25rem .35rem">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
-                        </button>
-                    </form>
                     <details class="ext-details" style="margin:0">
                         <summary class="btn action-btn ext-summary" title="#if(row.hasExtension):Edit this student’s deadline extension#else:Grant this student a deadline extension#endif" aria-label="#if(row.hasExtension):Edit deadline extension#else:Grant deadline extension#endif" style="padding:.25rem .35rem">
                             #if(row.hasExtension):
@@ -293,6 +287,12 @@
                             </div>
                         </form>
                     </details>
+                    <form method="post" action="#(row.resetPath)" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected.')" style="margin:0">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger" type="submit" aria-label="Reset this student’s working notebook" title="Reset this student’s working-copy notebook to the original starter" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                        </button>
+                    </form>
                 </div>
             </td>
         </tr>

--- a/changelog.d/student-submissions-reset-button.md
+++ b/changelog.d/student-submissions-reset-button.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Instructor student-submissions view: Reset button separated from Re-test.**
+  On the per-student course submissions page the destructive "Reset working
+  notebook" action sat directly beside "Re-test" with identical styling, an
+  easy mis-click. Reset now renders with the `action-danger` treatment used for
+  Delete/Remove elsewhere and moves to the rightmost position in the row, with
+  the Extension and Grade-override controls between it and Re-test.


### PR DESCRIPTION
## What

Small UI safety fix on the per-student course submissions view
(`/:courseCode/students/:studentID/submissions`).

The destructive **Reset working notebook** action sat directly beside
**Re-test** with identical `btn action-btn` styling — two visually
indistinguishable icon buttons next to each other, inviting a mis-click on a
destructive action.

## Changes

- **Reset now uses the `action-danger` treatment** — the same class every
  Delete/Remove button uses elsewhere (e.g. the admin user delete button), so
  it reads as destructive.
- **Reset moves to the rightmost position** in the actions row. The Extension
  and Grade-override controls now sit between Re-test and Reset, so the two are
  no longer adjacent.

Applied symmetrically to both the sectioned and the ungrouped tables in
`course-student-submissions.leaf`.

This is a presentational change only — no Leaf directives, route handlers, or
reset behavior were touched, and no tests assert on this markup.

## Testing

Pure HTML reordering + CSS class on a runtime-loaded Leaf template; nothing to
compile and no behavioral tests affected.

https://claude.ai/code/session_01V9s5S7dbJV8Zeft8uZeG9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9s5S7dbJV8Zeft8uZeG9g)_