### PR TITLE
Expose test-script filenames in the get_suite MCP tool

### DIFF
--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -33,6 +33,19 @@ struct GetSuiteTool: ContentTool {
             let kind: String
             /// Script filename, family name, or check name.
             let name: String
+            /// The editable on-disk script filename, for `kind == "script"`
+            /// items only (nil for generated family/check rows). This is the
+            /// exact string to pass to `author_script(filename:)` or
+            /// `update_suite(script:)` — the `name` field carries the same
+            /// value for hand-written scripts but is a label for generated rows,
+            /// so prefer this field when you need a filename.
+            let filename: String?
+            /// The on-disk file(s) a generated row produces, for `kind ==
+            /// "family"` or `kind == "check"` items (nil for hand-written
+            /// scripts). Read-only: these files are owned by the family/check
+            /// spec and are NOT editable via `author_script` / `update_suite` —
+            /// edit the family or check instead. Order follows the manifest.
+            let generatedFilenames: [String]?
             /// "public", "release", "secret", or "student".
             let tier: String
             let points: Int
@@ -70,8 +83,11 @@ struct GetSuiteTool: ContentTool {
         + "the section list. Each item also carries its source of truth: hand-written scripts "
         + "include their raw body (`content`) and `hint`; pattern families include the full spec "
         + "(`family`) with every case's args and expected value; notebook checks include their "
-        + "spec (`check`). Read-only — use this to inspect exactly what each test checks (e.g. to "
-        + "explain why a submission lost points) before editing the suite."
+        + "spec (`check`). For hand-written scripts, `filename` is the exact value to pass to "
+        + "`author_script` / `update_suite`; generated rows list the file(s) they produce in "
+        + "`generatedFilenames` (read-only — edit the family/check instead). Read-only — use this "
+        + "to inspect exactly what each test checks (e.g. to explain why a submission lost points) "
+        + "before editing the suite."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -107,6 +123,21 @@ struct GetSuiteTool: ContentTool {
                     "properties": .object([
                         "kind": .object(["type": .string("string")]),
                         "name": .object(["type": .string("string")]),
+                        "filename": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Editable on-disk script filename (kind == \"script\"); the value "
+                                    + "to pass to author_script / update_suite. Null for generated "
+                                    + "family/check rows."),
+                        ]),
+                        "generatedFilenames": .object([
+                            "type": .string("array"),
+                            "items": .object(["type": .string("string")]),
+                            "description": .string(
+                                "On-disk file(s) a generated row produces (kind == \"family\" or "
+                                    + "\"check\"); read-only, edit the family/check instead. Null "
+                                    + "for hand-written scripts."),
+                        ]),
                         "tier": .object(["type": .string("string")]),
                         "points": .object(["type": .string("integer")]),
                         "displayName": .object(["type": .string("string")]),
@@ -166,10 +197,14 @@ struct GetSuiteTool: ContentTool {
         // no body). This gives the agent the same complete authoring view the
         // browser suite editor receives from `GET /instructor/:id/suite`.
         let payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
+        // Decode the manifest once for the two pieces of state that live on it
+        // rather than on the suite-payload DTO: section variables/expressions,
+        // and the concrete on-disk filenames each generated row produces.
+        let manifest = setup.decodedManifest()
         // Section variables/expressions live on the manifest's section list,
         // not on the suite-payload DTO (which carries only id + name).
         let sectionInputs = Dictionary(
-            uniqueKeysWithValues: (setup.decodedManifest()?.sections ?? []).map {
+            uniqueKeysWithValues: (manifest?.sections ?? []).map {
                 ($0.id, (variables: $0.variables, expressions: $0.expressions))
             })
         let sections = payload.sections.map { section in
@@ -179,17 +214,37 @@ struct GetSuiteTool: ContentTool {
                 variables: sectionInputs[section.id]?.variables ?? [],
                 expressions: sectionInputs[section.id]?.expressions ?? [])
         }
-        let items = payload.items.map { Self.item(from: $0) }
+        // Map each generator id to the concrete `testSuites` filenames it
+        // produced, preserving manifest order so multi-case families list
+        // their files in the order the runner walks them.
+        var generatedByFamily: [String: [String]] = [:]
+        var generatedByCheck: [String: [String]] = [:]
+        for entry in manifest?.testSuites ?? [] {
+            if let fid = entry.generatedBy {
+                generatedByFamily[fid, default: []].append(entry.script)
+            } else if let cid = entry.generatedByCheck {
+                generatedByCheck[cid, default: []].append(entry.script)
+            }
+        }
+        let items = payload.items.map {
+            Self.item(from: $0, generatedByFamily: generatedByFamily, generatedByCheck: generatedByCheck)
+        }
         return Output(assignmentPublicID: assignment.publicID, sections: sections, items: items)
     }
 
-    private static func item(from dto: SuiteItemDTO) -> Output.Item {
+    private static func item(
+        from dto: SuiteItemDTO,
+        generatedByFamily: [String: [String]],
+        generatedByCheck: [String: [String]]
+    ) -> Output.Item {
         switch dto.kind {
         case "family":
             let family = dto.family
             return Output.Item(
                 kind: "family",
                 name: family?.name ?? "(family)",
+                filename: nil,
+                generatedFilenames: family.flatMap { generatedByFamily[$0.id] },
                 tier: (family?.defaults.tier ?? .pub).rawValue,
                 points: family?.defaults.points ?? 0,
                 displayName: nil,
@@ -205,6 +260,8 @@ struct GetSuiteTool: ContentTool {
             return Output.Item(
                 kind: "check",
                 name: check?.name ?? check?.id ?? "(check)",
+                filename: nil,
+                generatedFilenames: check.flatMap { generatedByCheck[$0.id] },
                 tier: (check?.tier ?? .pub).rawValue,
                 points: check?.points ?? 0,
                 displayName: nil,
@@ -220,6 +277,8 @@ struct GetSuiteTool: ContentTool {
             return Output.Item(
                 kind: "script",
                 name: script?.script ?? "(script)",
+                filename: script?.script,
+                generatedFilenames: nil,
                 tier: (script?.tier ?? .pub).rawValue,
                 points: script?.points ?? 0,
                 displayName: script?.displayName,

--- a/Tests/APITests/MCP/GetSuiteToolTests.swift
+++ b/Tests/APITests/MCP/GetSuiteToolTests.swift
@@ -46,12 +46,19 @@ import Vapor
             #expect(a.points == 2)
             #expect(a.displayName == "Test A")
             #expect(a.sectionID == "sec1")
+            // Hand-written script: `filename` mirrors `name` (the editable
+            // on-disk name to pass to author_script / update_suite) and no
+            // files are "generated".
+            #expect(a.filename == "test_a.sh")
+            #expect(a.generatedFilenames == nil)
 
             let b = try #require(output.items.first { $0.name == "test_b.sh" })
             #expect(b.tier == "secret")
             #expect(b.points == 3)
             #expect(b.dependsOn == ["test_a.sh"])
             #expect(b.sectionID == "sec2")
+            #expect(b.filename == "test_b.sh")
+            #expect(b.generatedFilenames == nil)
         }
     }
 
@@ -87,7 +94,7 @@ import Vapor
     /// the family's full spec (function, params, cases with args/expected) is
     /// surfaced — this is what an agent needs to explain a submission's score.
     private let familyManifest = #"""
-        {"schemaVersion":1,"testSuites":[{"tier":"public","script":"publictest_tax_01.py","generatedBy":"tax","sectionID":"sec1"}],"patternFamilies":[{"id":"tax","name":"tax — boundary cases","kind":"boundary_equality","functionName":"tax","paramNames":["price"],"defaults":{"tier":"public","points":1},"cases":[{"key":"01","label":"tax(100)","args":[100],"expected":113.0,"enabled":true}]}],"sections":[{"id":"sec1","name":"Functions"}],"timeLimitSeconds":10}
+        {"schemaVersion":1,"testSuites":[{"tier":"public","script":"publictest_tax_01.py","generatedBy":"tax","sectionID":"sec1"},{"tier":"public","script":"publictest_tax_02.py","generatedBy":"tax","sectionID":"sec1"}],"patternFamilies":[{"id":"tax","name":"tax — boundary cases","kind":"boundary_equality","functionName":"tax","paramNames":["price"],"defaults":{"tier":"public","points":1},"cases":[{"key":"01","label":"tax(100)","args":[100],"expected":113.0,"enabled":true},{"key":"02","label":"tax(200)","args":[200],"expected":226.0,"enabled":true}]}],"sections":[{"id":"sec1","name":"Functions"}],"timeLimitSeconds":10}
         """#
 
     @Test func surfacesPatternFamilyCases() async throws {
@@ -107,6 +114,10 @@ import Vapor
 
             let row = try #require(output.items.first { $0.kind == "family" })
             #expect(row.familyID == "tax")
+            // A family row is not itself an editable file; it lists the on-disk
+            // files its enabled cases produce, in manifest order.
+            #expect(row.filename == nil)
+            #expect(row.generatedFilenames == ["publictest_tax_01.py", "publictest_tax_02.py"])
             let family = try #require(row.family)
             #expect(family.functionName == "tax")
             #expect(family.paramNames == ["price"])
@@ -116,6 +127,35 @@ import Vapor
             #expect(testCase.args == [.int(100)])
             // JSONValue normalises the whole-number literal 113.0 to .int(113).
             #expect(testCase.expected == .int(113))
+        }
+    }
+
+    /// Manifest with a notebook check + its generated entry, so we can assert
+    /// a check row exposes the on-disk file it produces (and is not itself an
+    /// editable file).
+    private let checkManifest = #"""
+        {"schemaVersion":1,"testSuites":[{"tier":"public","script":"publiccheck_df.py","generatedByCheck":"df"}],"notebookChecks":[{"id":"df","name":"DataFrame shape","kind":"data_frame_shape","variable":"df","expectedRows":1,"expectedCols":1,"tier":"public","points":1}],"timeLimitSeconds":10}
+        """#
+
+    @Test func surfacesNotebookCheckGeneratedFilename() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(
+                on: app, id: "setup_chk", courseID: courseID, manifest: checkManifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_chk", courseID: courseID, title: "Lab")
+
+            let output = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), context(app))
+
+            let row = try #require(output.items.first { $0.kind == "check" })
+            #expect(row.filename == nil)
+            #expect(row.generatedFilenames == ["publiccheck_df.py"])
+            #expect(try #require(row.check).id == "df")
         }
     }
 

--- a/changelog.d/get-suite-filenames.md
+++ b/changelog.d/get-suite-filenames.md
@@ -1,0 +1,3 @@
+### Added
+
+- **`get_suite` now exposes script filenames.** Each test item carries `filename` (the editable on-disk name to pass to `author_script` / `update_suite`, for hand-written scripts) and `generatedFilenames` (the read-only file(s) a pattern-family or notebook-check row produces). Previously the filename was only inferable from the overloaded `name` field for hand-written scripts and was absent entirely for generated rows.


### PR DESCRIPTION
## What

Adds two additive fields to each `get_suite` item:

- **`filename: String?`** — the editable on-disk script filename, set **only for `kind == "script"`** rows. This is the exact value to pass to `author_script(filename:)` / `update_suite(script:)`. `nil` for generated rows.
- **`generatedFilenames: [String]?`** — the **read-only** on-disk file(s) a generated row produces, set for `kind == "family"` / `"check"` rows (in manifest order; a multi-case family lists all its files). `nil` for hand-written scripts. These are owned by the family/check spec and aren't editable via the raw-script tools.

The tool `description` and `outputSchema` are updated to document both, including that generated rows are edited via the family/check rather than `author_script`.

## Why

`get_suite`'s `name` field is overloaded: it's the **filename** for hand-written scripts but a **label** for pattern-family / notebook-check rows, and the on-disk filename for generated rows wasn't surfaced anywhere. That makes it impossible to reliably tell, from the tool output alone, what to pass to `author_script` / `update_suite` — an agent has to guess that `name` doubles as a filename for scripts (and can't recover it at all for generated rows).

This surfaced in practice while correcting an assignment's hand-written test scripts: the filenames were only inferable from the overloaded `name`. Surfacing them explicitly removes the footgun and completes the read story for generated rows.

## Scope / safety

- **MCP-local.** `execute(...)` decodes the manifest once (reusing the existing `decodedManifest()` call) and builds `generatedBy` / `generatedByCheck` → filename maps; the shared `SuiteItemDTO` / `buildSuitePayload` and the web suite editor are untouched.
- **Additive.** `name` semantics and every other field are unchanged.

## Tests

`Tests/APITests/MCP/GetSuiteToolTests.swift`:
- hand-written rows: `filename == name`, `generatedFilenames == nil`;
- pattern family (fixture extended to **2 enabled cases**): `filename == nil`, `generatedFilenames == ["publictest_tax_01.py", "publictest_tax_02.py"]`;
- new notebook-check case: `filename == nil`, `generatedFilenames == ["publiccheck_df.py"]`.

`swift test --filter GetSuiteToolTests` → 6/6 pass; `swift format lint` clean. Changelog fragment added under `changelog.d/` (no `VERSION` / `CHANGELOG.md` edits, per repo convention).

https://claude.ai/code/session_01LnpUEqZZHcJbQu4qua8eV9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnpUEqZZHcJbQu4qua8eV9)_