### PR TITLE
Make style checks resilient to a single non-Python cell

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -938,7 +938,7 @@ def load_student_module():
     return modules.get(_loaded_student_order[0])
 
 
-def student_source() -> str:
+def student_source_raw() -> str:
     hint = Path(".chickadee_student_source")
     try:
         if hint.exists():
@@ -959,7 +959,7 @@ def student_source() -> str:
 
 
 def student_cell_sources() -> List[Any]:
-    source = student_source()
+    source = student_source_raw()
     chunks: List[Any] = []
     label = "module"
     lines: List[str] = []
@@ -993,6 +993,23 @@ def student_ast(skipped: Optional[List[Any]] = None) -> Any:
             continue
         module.body.extend(node.body)
     return module
+
+
+def student_source() -> str:
+    import ast
+    parts: List[str] = []
+    dropped = False
+    for label, chunk in student_cell_sources():
+        if chunk.strip():
+            try:
+                ast.parse(chunk)
+            except SyntaxError:
+                dropped = True
+                continue
+        parts.append(f"# --- {label} ---\\n{chunk}")
+    if not dropped or not parts:
+        return student_source_raw()
+    return "\\n\\n".join(parts) + "\\n"
 
 
 def require_function(name: str, num_args: Optional[int] = None):

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -958,6 +958,43 @@ def student_source() -> str:
     return ""
 
 
+def student_cell_sources() -> List[Any]:
+    source = student_source()
+    chunks: List[Any] = []
+    label = "module"
+    lines: List[str] = []
+    for raw in source.split("\\n"):
+        stripped = raw.strip()
+        if stripped.startswith("# --- ") and stripped.endswith(" ---"):
+            if lines:
+                chunks.append((label, "\\n".join(lines)))
+            label = stripped[6:-4].strip() or "module"
+            lines = []
+        else:
+            lines.append(raw)
+    if lines:
+        chunks.append((label, "\\n".join(lines)))
+    if not chunks:
+        chunks.append(("module", source))
+    return chunks
+
+
+def student_ast(skipped: Optional[List[Any]] = None) -> Any:
+    import ast
+    module = ast.parse("")
+    for label, chunk in student_cell_sources():
+        if not chunk.strip():
+            continue
+        try:
+            node = ast.parse(chunk)
+        except SyntaxError as ex:
+            if skipped is not None:
+                skipped.append((label, f"{type(ex).__name__}: {ex}"))
+            continue
+        module.body.extend(node.body)
+    return module
+
+
 def require_function(name: str, num_args: Optional[int] = None):
     modules = load_student_modules()
     for key in _loaded_student_order:

--- a/Sources/APIServer/Utilities/TestScriptTemplates.swift
+++ b/Sources/APIServer/Utilities/TestScriptTemplates.swift
@@ -382,17 +382,25 @@ func pythonTestScript(  // swiftlint:disable:this function_body_length
                 min_asserts_in_body = None                # int — require >= N asserts inside the function body
                 min_module_asserts  = None                # int — require >= N module-level asserts (anywhere)
 
-                # ── AST walk ───────────────────────────────────────────────────────
-                # `student_source()` returns the introspectable source (real
-                # module-level defs) on both runners — see RunnerCore extraction +
-                # the .chickadee_student_source sidecar. inspect.getsource on the
-                # exec(compile())-wrapped module would not expose the defs.
+                # ── AST walk (best-effort, per-cell) ───────────────────────────────
+                # Style is about the source text, not whether the whole notebook
+                # runs — so we parse each notebook cell on its own via student_ast()
+                # and merge the parseable ones. A single non-Python cell (e.g. a
+                # Markdown cell saved as code, or a half-written cell) is skipped
+                # instead of failing the style check on every other cell. We only
+                # error if NOTHING in the submission parses.
+                # (`student_source()` is the introspectable source — real
+                # module-level defs — on both runners; see RunnerCore extraction +
+                # the .chickadee_student_source sidecar.)
                 try:
-                    from test_runtime import student_source
-                    source = student_source()
-                    tree   = ast.parse(source)
+                    from test_runtime import student_ast, student_source
+                    _skipped = []
+                    tree = student_ast(_skipped)
                 except Exception as ex:
                     errored(f"Could not parse student source: {type(ex).__name__}: {ex}")
+
+                if not tree.body and not student_source().strip():
+                    errored("No student source was available to check.")
 
                 def _find_function(node, name):
                     for n in ast.walk(node):
@@ -417,9 +425,17 @@ func pythonTestScript(  // swiftlint:disable:this function_body_length
                 if target_function:
                     fn_node = _find_function(tree, target_function)
                     if fn_node is None:
+                        hint = "Hint: make sure the function name matches the assignment exactly."
+                        if _skipped:
+                            cells = ", ".join(label for label, _ in _skipped)
+                            hint = (
+                                f"Note: {len(_skipped)} cell(s) could not be parsed as Python "
+                                f"({cells}) and were skipped. If your function lives in one of "
+                                "them, fix that cell — e.g. a Markdown cell saved as a code cell."
+                            )
                         failed(
                             f"Function `{target_function}` is not defined in your submission.\\n"
-                            "Hint: make sure the function name matches the assignment exactly."
+                            + hint
                         )
 
                     if parameter_count is not None:

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -207,7 +207,13 @@ let testRuntimePy = """
         return modules.get(_loaded_student_order[0])
 
 
-    def student_source() -> str:
+    def student_source_raw() -> str:
+        # The full introspectable student source, exactly as the extractor wrote
+        # it (every cell, including any that do not parse). Written to a sidecar
+        # named by the `.chickadee_student_source` hint (both runners share one
+        # extractor); falls back to inspect.getsource on the loaded module. Use
+        # this for raw text inspection; use student_source() / student_ast() for
+        # parse-based checks.
         hint = Path(".chickadee_student_source")
         try:
             if hint.exists():
@@ -228,11 +234,11 @@ let testRuntimePy = """
 
 
     def student_cell_sources() -> List[Any]:
-        # Split student_source() into (label, source) chunks on the
+        # Split the raw student source into (label, source) chunks on the
         # `# --- cell N ---` markers the notebook extractor writes between cells,
         # so each notebook cell can be parsed on its own. A raw .py submission has
         # no markers and yields a single ("module", source) chunk.
-        source = student_source()
+        source = student_source_raw()
         chunks: List[Any] = []
         label = "module"
         lines: List[str] = []
@@ -272,6 +278,29 @@ let testRuntimePy = """
                 continue
             module.body.extend(node.body)
         return module
+
+
+    def student_source() -> str:
+        # Best-effort *parseable* introspectable source: like student_source_raw(),
+        # but any single cell that does not parse on its own is dropped, so callers
+        # that do `ast.parse(student_source())` are not blinded by one non-Python
+        # cell (e.g. a Markdown cell saved as a code cell). When nothing needs
+        # dropping the raw source is returned verbatim. Use student_source_raw()
+        # for the unfiltered text.
+        import ast
+        parts: List[str] = []
+        dropped = False
+        for label, chunk in student_cell_sources():
+            if chunk.strip():
+                try:
+                    ast.parse(chunk)
+                except SyntaxError:
+                    dropped = True
+                    continue
+            parts.append(f"# --- {label} ---\\n{chunk}")
+        if not dropped or not parts:
+            return student_source_raw()
+        return "\\n\\n".join(parts) + "\\n"
 
 
     def require_function(name: str, num_args: Optional[int] = None):

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -227,6 +227,53 @@ let testRuntimePy = """
         return ""
 
 
+    def student_cell_sources() -> List[Any]:
+        # Split student_source() into (label, source) chunks on the
+        # `# --- cell N ---` markers the notebook extractor writes between cells,
+        # so each notebook cell can be parsed on its own. A raw .py submission has
+        # no markers and yields a single ("module", source) chunk.
+        source = student_source()
+        chunks: List[Any] = []
+        label = "module"
+        lines: List[str] = []
+        for raw in source.split("\\n"):
+            stripped = raw.strip()
+            if stripped.startswith("# --- ") and stripped.endswith(" ---"):
+                if lines:
+                    chunks.append((label, "\\n".join(lines)))
+                label = stripped[6:-4].strip() or "module"
+                lines = []
+            else:
+                lines.append(raw)
+        if lines:
+            chunks.append((label, "\\n".join(lines)))
+        if not chunks:
+            chunks.append(("module", source))
+        return chunks
+
+
+    def student_ast(skipped: Optional[List[Any]] = None) -> Any:
+        # Best-effort AST of the student's source: parse each notebook cell on its
+        # own and merge the parseable cells' top-level statements into one module.
+        # A single non-Python cell (Markdown pasted into a code cell, a half-written
+        # cell) is then skipped instead of blinding a style/structure check on every
+        # other cell -- mirroring the per-cell resilience of the executable module.
+        # `skipped`, if a list, receives an (label, message) tuple per dropped cell.
+        import ast
+        module = ast.parse("")
+        for label, chunk in student_cell_sources():
+            if not chunk.strip():
+                continue
+            try:
+                node = ast.parse(chunk)
+            except SyntaxError as ex:
+                if skipped is not None:
+                    skipped.append((label, f"{type(ex).__name__}: {ex}"))
+                continue
+            module.body.extend(node.body)
+        return module
+
+
     def require_function(name: str, num_args: Optional[int] = None):
         modules = load_student_modules()
         for key in _loaded_student_order:

--- a/Tests/APITests/TestScriptTemplatesTests.swift
+++ b/Tests/APITests/TestScriptTemplatesTests.swift
@@ -226,11 +226,11 @@ import Testing
             type: .structuralCheck, functionName: "compute_bmi", paramNames: ["weight_kg", "height_m"])
         // AST-based template — no function call. Source comes from
         // student_source() (introspectable sidecar), not inspect.getsource on the
-        // exec(compile())-wrapped module.
+        // exec(compile())-wrapped module. Parsing is per-cell (student_ast) so one
+        // non-Python cell can't blind the whole style check.
         #expect(s.contains("import ast"))
-        #expect(s.contains("from test_runtime import student_source"))
-        #expect(s.contains("source = student_source()"))
-        #expect(s.contains("ast.parse(source)"))
+        #expect(s.contains("from test_runtime import student_ast"))
+        #expect(s.contains("tree = student_ast(_skipped)"))
         // All the knobs are present as TODO-friendly placeholders.
         #expect(s.contains("parameter_count"))
         #expect(s.contains("typed_parameters"))

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -201,12 +201,13 @@ def load_student_module():
     return modules.get(_loaded_student_order[0])
 
 
-def student_source() -> str:
-    # Introspectable student source (real module-level defs, side-effects
-    # quarantined into `if __name__`) for AST / source-property checks. The
-    # grading workspace writes it to a sidecar named by the
-    # `.chickadee_student_source` hint (both runners share one extractor);
-    # falls back to inspect.getsource on the loaded module.
+def student_source_raw() -> str:
+    # The full introspectable student source, exactly as the extractor wrote
+    # it (every cell, including any that do not parse). Written to a sidecar
+    # named by the `.chickadee_student_source` hint (both runners share one
+    # extractor); falls back to inspect.getsource on the loaded module. Use
+    # this for raw text inspection; use student_source() / student_ast() for
+    # parse-based checks.
     hint = Path(".chickadee_student_source")
     try:
         if hint.exists():
@@ -227,11 +228,11 @@ def student_source() -> str:
 
 
 def student_cell_sources() -> List[Any]:
-    # Split student_source() into (label, source) chunks on the
+    # Split the raw student source into (label, source) chunks on the
     # `# --- cell N ---` markers the notebook extractor writes between cells,
     # so each notebook cell can be parsed on its own. A raw .py submission has
     # no markers and yields a single ("module", source) chunk.
-    source = student_source()
+    source = student_source_raw()
     chunks: List[Any] = []
     label = "module"
     lines: List[str] = []
@@ -271,6 +272,29 @@ def student_ast(skipped: Optional[List[Any]] = None) -> Any:
             continue
         module.body.extend(node.body)
     return module
+
+
+def student_source() -> str:
+    # Best-effort *parseable* introspectable source: like student_source_raw(),
+    # but any single cell that does not parse on its own is dropped, so callers
+    # that do `ast.parse(student_source())` are not blinded by one non-Python
+    # cell (e.g. a Markdown cell saved as a code cell). When nothing needs
+    # dropping the raw source is returned verbatim. Use student_source_raw()
+    # for the unfiltered text.
+    import ast
+    parts: List[str] = []
+    dropped = False
+    for label, chunk in student_cell_sources():
+        if chunk.strip():
+            try:
+                ast.parse(chunk)
+            except SyntaxError:
+                dropped = True
+                continue
+        parts.append(f"# --- {label} ---\n{chunk}")
+    if not dropped or not parts:
+        return student_source_raw()
+    return "\n\n".join(parts) + "\n"
 
 
 def require_function(name: str, num_args: Optional[int] = None):

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -226,6 +226,53 @@ def student_source() -> str:
     return ""
 
 
+def student_cell_sources() -> List[Any]:
+    # Split student_source() into (label, source) chunks on the
+    # `# --- cell N ---` markers the notebook extractor writes between cells,
+    # so each notebook cell can be parsed on its own. A raw .py submission has
+    # no markers and yields a single ("module", source) chunk.
+    source = student_source()
+    chunks: List[Any] = []
+    label = "module"
+    lines: List[str] = []
+    for raw in source.split("\n"):
+        stripped = raw.strip()
+        if stripped.startswith("# --- ") and stripped.endswith(" ---"):
+            if lines:
+                chunks.append((label, "\n".join(lines)))
+            label = stripped[6:-4].strip() or "module"
+            lines = []
+        else:
+            lines.append(raw)
+    if lines:
+        chunks.append((label, "\n".join(lines)))
+    if not chunks:
+        chunks.append(("module", source))
+    return chunks
+
+
+def student_ast(skipped: Optional[List[Any]] = None) -> Any:
+    # Best-effort AST of the student's source: parse each notebook cell on its
+    # own and merge the parseable cells' top-level statements into one module.
+    # A single non-Python cell (Markdown pasted into a code cell, a half-written
+    # cell) is then skipped instead of blinding a style/structure check on every
+    # other cell -- mirroring the per-cell resilience of the executable module.
+    # `skipped`, if a list, receives an (label, message) tuple per dropped cell.
+    import ast
+    module = ast.parse("")
+    for label, chunk in student_cell_sources():
+        if not chunk.strip():
+            continue
+        try:
+            node = ast.parse(chunk)
+        except SyntaxError as ex:
+            if skipped is not None:
+                skipped.append((label, f"{type(ex).__name__}: {ex}"))
+            continue
+        module.body.extend(node.body)
+    return module
+
+
 def require_function(name: str, num_args: Optional[int] = None):
     modules = load_student_modules()
     for key in _loaded_student_order:

--- a/changelog.d/style-check-per-cell-parse.md
+++ b/changelog.d/style-check-per-cell-parse.md
@@ -2,12 +2,16 @@
 
 - **Style checks no longer fail just because one cell isn't valid Python.**
   The structural / style-check template parsed the entire notebook source in a
-  single `ast.parse`, so a single non-Python code cell (e.g. a Markdown cell
-  accidentally saved as a code cell, or a half-written cell) made the whole
-  check `error` out — even when the function under test was perfectly correct.
-  A new `student_ast()` runtime helper parses each notebook cell independently
-  (splitting on the extractor's `# --- cell N ---` markers) and merges the
-  parseable cells, so an unparseable cell is skipped instead of blinding the
-  check on every other cell — mirroring the per-cell resilience the executable
-  module already had. When the target function can't be found and a cell was
-  skipped, the failure message now points the student at the broken cell.
+  single `ast.parse`, so one non-Python code cell (e.g. a Markdown cell saved as
+  a code cell, or a half-written cell) made the whole check `error` out — even
+  when the function under test was perfectly correct. `student_source()` is now
+  best-effort *parseable*: it drops only the cell(s) that don't parse on their
+  own (returning the raw source verbatim when nothing needs dropping), so every
+  existing saved style check that does `ast.parse(student_source())` becomes
+  resilient site-wide on the next regrade — no per-assignment changes. A new
+  `student_ast()` helper exposes the same per-cell parse for new checks and
+  records which cells were skipped, and `student_source_raw()` keeps the
+  unfiltered text available. When the target function can't be found and a cell
+  was skipped, the failure message now points the student at the broken cell.
+  This mirrors the per-cell resilience the executable module and
+  `NotebookCheckRenderer` already had.

--- a/changelog.d/style-check-per-cell-parse.md
+++ b/changelog.d/style-check-per-cell-parse.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Style checks no longer fail just because one cell isn't valid Python.**
+  The structural / style-check template parsed the entire notebook source in a
+  single `ast.parse`, so a single non-Python code cell (e.g. a Markdown cell
+  accidentally saved as a code cell, or a half-written cell) made the whole
+  check `error` out — even when the function under test was perfectly correct.
+  A new `student_ast()` runtime helper parses each notebook cell independently
+  (splitting on the extractor's `# --- cell N ---` markers) and merges the
+  parseable cells, so an unparseable cell is skipped instead of blinding the
+  check on every other cell — mirroring the per-cell resilience the executable
+  module already had. When the target function can't be found and a cell was
+  skipped, the failure message now points the student at the broken cell.


### PR DESCRIPTION
## Problem

A style / structural check shouldn't depend on whether the *whole* notebook is interpretable — style is about source text, not execution. But the `.structuralCheck` template did one `ast.parse(student_source())` over the entire concatenated notebook source, so a **single non-Python code cell** made the whole check `error` out.

This is exactly what bit a student in **HLTH 230 Lab 2**: their `tax()` function was correct (docstring, type hints, return annotation, 5 module-level asserts), but they had pasted the "## 3. Making Decisions" instructions into a *code* cell instead of a markdown cell. That cell isn't valid Python, so `ast.parse` of the merged source raised `SyntaxError` and the **"tax - Style Checks"** test errored — costing a point for a perfectly correct function.

Notably the *executable* module already tolerates this (each cell is `exec(compile(...))`-wrapped), and `NotebookCheckRenderer+Code.swift` already parses cells one-by-one and skips ones that fail. The structural-check path was the lone outlier parsing everything at once.

## Fix (resilient site-wide)

`student_source()` is now best-effort **parseable**: it drops only the cell(s) that don't parse on their own, and returns the raw source **verbatim when nothing needs dropping** (so the common case is byte-for-byte unchanged). Because existing saved style checks call `ast.parse(student_source())` directly, they all become resilient to a single non-Python cell on the next **regrade** — no per-assignment regeneration required.

Supporting helpers (added to the shared runtime):
- `student_source_raw()` — the unfiltered text, for raw-text inspection.
- `student_cell_sources()` — splits the raw source into per-cell chunks on the extractor's `# --- cell N ---` markers (a raw `.py` submission is one chunk).
- `student_ast(skipped=None)` — parses each cell independently, merges the parseable ones into a single module, and records skipped cells.

The `.structuralCheck` template now uses `student_ast()`, only errors if **nothing** parses, and — when the target function can't be found and a cell was skipped — points the student at the broken cell ("e.g. a Markdown cell saved as a code cell").

## Scope

Applied identically to all three kept-in-sync runtime copies:
- `Tools/runner-support/test_runtime.py` (canonical)
- `Sources/Worker/TestRuntimeSources.swift` (native worker embed)
- `Public/browser-runner.js` (browser/Pyodide embed — comments omitted and `\n` escaped, per that embed's template-literal constraints)

## Verification

- Reproduced the original failure; with the fix the broken cell is dropped, `student_source()` is parseable, `student_ast` finds `tax()`, and the style check **passes**. Confirmed the clean case returns raw verbatim (minimal blast radius).
- `swift test --filter 'RuntimeSourceDriftTests|TestScriptTemplatesTests|NotebookExtractionTests'` — 43 tests pass, including the three runtime-copy drift guards and `allPythonTemplateTypes_parseAsValidPython`.
- `node --test Tests/BrowserRunnerJSTests/runtime-drift.test.mjs` — both embeds stay in sync with canonical.
- swift-format `--strict` clean.

## Rollout

Merge, then regrade all submissions: existing style checks pick up the resilient `student_source()` automatically. (The Lab 2 student's immediate workaround is still trivial: convert that one code cell back to markdown.)

https://claude.ai/code/session_01XrKhsHwNUXyqpzHywhPEH1