### PR TITLE
feat(personalization): per-student pattern families — worker grading path (#461 slice A)

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -835,7 +835,7 @@ def _candidate_student_files() -> List[Path]:
     files: List[Path] = []
     for p in cwd.glob("*.py"):
         name = p.name
-        if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py"}:
+        if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py", "_ck_inputs.py"}:
             continue
         lower = name.lower()
         if lower.startswith("publictest") or lower.startswith("secrettest") or lower.startswith("releasetest"):

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -183,6 +183,32 @@ struct WorkerJobRoutes: RouteCollection {
         else {
             throw WorkerJobError.internalInconsistency(reason: "Failed to build worker download URLs from base=\(base)")
         }
+
+        // Resolve per-student personalization inputs (issue #461 — pattern
+        // families with per-student values) for this seed, server-side, so the
+        // worker can bind them in generated scripts via `_ck_inputs.py`. Only
+        // the values of `=` expressions are shipped (literal variables are
+        // inlined into scripts at save time). Best-effort: on evaluation error
+        // the value is simply absent and the generated test fails closed with a
+        // clear message — non-personalized assignments are unaffected.
+        var personalizedInputs: [String: String]?
+        let fullManifest = claimed.manifest
+        let hasExpressions =
+            !fullManifest.globalExpressions.isEmpty
+            || fullManifest.sections.contains { !$0.expressions.isEmpty }
+        if let seed = assignmentSeed, hasExpressions {
+            let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+            let resolution = await PersonalizationSubstitution.resolve(
+                manifest: fullManifest, seedHex: seed, supportFilesDirectory: supportDir)
+            if let evalError = resolution.evaluationError {
+                req.logger.warning(
+                    "Personalization eval failed for submission \(submissionID): \(evalError)")
+            }
+            let exprNames = Set(resolution.evaluatedExpressionNames)
+            let values = resolution.substitutions.filter { exprNames.contains($0.key) }
+            if !values.isEmpty { personalizedInputs = values }
+        }
+
         return Job(
             submissionID: submissionID,
             testSetupID: setupID,
@@ -191,7 +217,8 @@ struct WorkerJobRoutes: RouteCollection {
             testSetupURL: testSetupURL,
             manifest: claimed.manifest.runnerSanitized(),
             submissionFilename: submission.filename,
-            assignmentSeed: assignmentSeed
+            assignmentSeed: assignmentSeed,
+            personalizedInputs: personalizedInputs
         )
     }
 

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -180,6 +180,16 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     // flow straight into the manifest write.
     let resolvedGlobalExpressions: [PersonalizationExpression] =
         globalExpressions ?? props.globalExpressions
+
+    // Per-student personalization input names (global + section `=`
+    // expressions).  The renderer uses this set to tell a `$name` arg / an
+    // `expectedVarRef` that resolves to a per-student value — loaded from
+    // `_ck_inputs.py` at grading time — apart from one naming a literal
+    // variable (prepended at save time).
+    let perStudentExpressionNames: Set<String> = Set(
+        resolvedGlobalExpressions.map(\.name)
+            + resolvedSections.flatMap { $0.expressions.map(\.name) }
+    )
     var seenSectionIDs: Set<String> = []
     for s in resolvedSections {
         guard seenSectionIDs.insert(s.id).inserted else {
@@ -367,7 +377,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         testSuites: authoredAsTestSuites,
         sections: resolvedSections,
         familySectionID: familySectionIDForValidation,
-        globalVariableNames: Set(resolvedGlobalVariables.map(\.name))
+        globalVariableNames: Set(resolvedGlobalVariables.map(\.name)),
+        perStudentExpressionNames: perStudentExpressionNames
     )
     try validateNotebookChecks(
         resolvedChecks,
@@ -458,7 +469,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     var renderedByFilename: [String: GeneratedScript] = [:]
     for family in nextFamilies {
         for generated in renderPatternFamily(
-            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables)
+            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables,
+            perStudentNames: perStudentExpressionNames)
         {
             renderedByFilename[generated.filename] = generated
         }
@@ -617,7 +629,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
             emittedFamilyIDs.insert(fid)
             let inherited = expandDeps(family.dependsOn)
             for generated in renderPatternFamily(
-                family, sectionVariables: sectionVars(forFamily: fid), globalVariables: resolvedGlobalVariables)
+                family, sectionVariables: sectionVars(forFamily: fid), globalVariables: resolvedGlobalVariables,
+                perStudentNames: perStudentExpressionNames)
             {
                 order += 1
                 let prior = oldEntryByScript[generated.filename]
@@ -670,7 +683,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     for family in nextFamilies where !emittedFamilyIDs.contains(family.id) {
         let inherited = expandDeps(family.dependsOn)
         for generated in renderPatternFamily(
-            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables)
+            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables,
+            perStudentNames: perStudentExpressionNames)
         {
             order += 1
             let prior = oldEntryByScript[generated.filename]

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
@@ -37,7 +37,8 @@ struct GeneratedScript: Equatable {
 func renderPatternFamily(
     _ family: PatternFamily,
     sectionVariables: [FamilyVariable] = [],
-    globalVariables: [FamilyVariable] = []
+    globalVariables: [FamilyVariable] = [],
+    perStudentNames: Set<String> = []
 ) -> [GeneratedScript] {
     // Pre-combine globals and section vars into a single "scope" list so the
     // existing render-* helpers stay parameterised on a single prepend list.
@@ -50,7 +51,8 @@ func renderPatternFamily(
         guard c.enabled else { return nil }
         return renderCase(
             family: family, case: c,
-            sectionVariables: scopeVariables, specHash: hash)
+            sectionVariables: scopeVariables, specHash: hash,
+            perStudentNames: perStudentNames)
     }
 }
 
@@ -102,11 +104,13 @@ private func renderCase(
     family: PatternFamily,
     case c: PatternCase,
     sectionVariables: [FamilyVariable],
-    specHash: String
+    specHash: String,
+    perStudentNames: Set<String>
 ) -> GeneratedScript {
     let source = patternKindHandler(for: family.kind).render(
         family: family, case: c,
-        sectionVariables: sectionVariables, specHash: specHash)
+        sectionVariables: sectionVariables, specHash: specHash,
+        perStudentNames: perStudentNames)
 
     let tier = c.resolvedTier(defaults: family.defaults)
     return GeneratedScript(
@@ -259,16 +263,81 @@ private func generatedCaseHeader(family: PatternFamily, case c: PatternCase, spe
 // results-display time (see the `hintByFilename` join in
 // `WebRoutes+Submission.swift`), decoupled from the test script.
 
+// MARK: - Personalization (per-student inputs)
+
+/// The Python expression assigned to `expected` in a generated equality case:
+/// a bare identifier when the case pins `expectedVarRef` (bound from a
+/// per-student `_ck_inputs` value), otherwise the baked literal.
+func expectedExpression(for c: PatternCase) -> String {
+    if let ref = c.expectedVarRef, !ref.isEmpty { return ref }
+    return c.expected.pythonLiteral
+}
+
+/// Names referenced by this case — arg `$name` refs plus the expected ref —
+/// that name a per-student `=` expression (vs. a literal variable).  Sorted +
+/// deduped so generated output is deterministic.
+private func perStudentRefsForCase(_ c: PatternCase, perStudentNames: Set<String>) -> [String] {
+    guard !perStudentNames.isEmpty else { return [] }
+    var names = Set<String>()
+    for ref in c.argVarRefs.compactMap({ $0 }) where perStudentNames.contains(ref) {
+        names.insert(ref)
+    }
+    if let ref = c.expectedVarRef, perStudentNames.contains(ref) { names.insert(ref) }
+    return names.sorted()
+}
+
+/// The per-student input preamble for a generated case, or "" when the case
+/// references no per-student expressions.  Loads `_ck_inputs.py` (written by
+/// the runner from the job's resolved values) by path — so it works
+/// regardless of sys.path — fails the test closed with a clear message when a
+/// value is missing (e.g. no assignment seed), then binds each referenced name
+/// as a module-level global the case body uses by bare identifier.
+private func personalizationPreambleForCase(
+    _ c: PatternCase, perStudentNames: Set<String>
+) -> String {
+    let names = perStudentRefsForCase(c, perStudentNames: perStudentNames)
+    guard !names.isEmpty else { return "" }
+    let keyItems = names.map { "\"\(escapeForPythonStringLiteral($0))\"" }
+    let keyTuple = names.count == 1 ? "(\(keyItems[0]),)" : "(\(keyItems.joined(separator: ", ")))"
+    let bindings =
+        names
+        .map { "\($0) = _ck[\"\(escapeForPythonStringLiteral($0))\"]" }
+        .joined(separator: "\n")
+    return """
+        # Per-student personalization inputs, resolved at grading time from the
+        # assignment seed (see _ck_inputs.py, written by the runner).  Do not edit.
+        import importlib.util as _ck_ilu, os as _ck_os
+        _ck = {}
+        if _ck_os.path.exists("_ck_inputs.py"):
+            _ck_spec = _ck_ilu.spec_from_file_location("_ck_inputs", "_ck_inputs.py")
+            _ck_mod = _ck_ilu.module_from_spec(_ck_spec)
+            _ck_spec.loader.exec_module(_ck_mod)
+            _ck = getattr(_ck_mod, "_ck", {})
+        for _ck_k in \(keyTuple):
+            if _ck_k not in _ck:
+                failed(f"Personalization input '{_ck_k}' is unavailable — is the assignment seed set?")
+        \(bindings)
+        """
+}
+
 func renderBoundaryEquality(
     family: PatternFamily,
     case c: PatternCase,
     sectionVariables: [FamilyVariable],
-    specHash: String
+    specHash: String,
+    perStudentNames: Set<String> = []
 ) -> String {
     let ctx = callContext(for: family, case: c)
 
     let variableDecls = combinedVariableDecls(sectionVariables: sectionVariables, family: family)
     let variableBlock = variableDecls.isEmpty ? "" : variableDecls + "\n\n"
+
+    // Per-student inputs (arg refs + the expected ref that resolve to a
+    // global/section `=` expression) are bound at grading time from
+    // `_ck_inputs.py`; see personalizationPreambleForCase.
+    let preamble = personalizationPreambleForCase(c, perStudentNames: perStudentNames)
+    let preambleBlock = preamble.isEmpty ? "" : preamble + "\n\n"
+    let expectedExpr = expectedExpression(for: c)
 
     // The `# Test:` line comes FIRST so test_runtime's _first_comment_label()
     // picks up the case label.  Provenance comes second — a reader opening
@@ -277,8 +346,8 @@ func renderBoundaryEquality(
     return """
         \(generatedCaseHeader(family: family, case: c, specHash: specHash))
 
-        \(variableBlock)\(ctx.declLines.isEmpty ? "# (no input arguments)" : ctx.declLines)
-        expected = \(c.expected.pythonLiteral)
+        \(preambleBlock)\(variableBlock)\(ctx.declLines.isEmpty ? "# (no input arguments)" : ctx.declLines)
+        expected = \(expectedExpr)
 
         try:
             result = student_module.\(family.functionName)(\(ctx.callArgs))

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -42,7 +42,8 @@ private func validatePatternCaseHeader(
 private func validateFamilyVariablesAndArgRefs(
     family: PatternFamily,
     sectionVarNamesHere: Set<String>,
-    globalVarNames: Set<String>
+    globalVarNames: Set<String>,
+    perStudentExpressionNames: Set<String>
 ) throws {
     var seenVarNames: Set<String> = []
     let paramNameSet = Set(family.paramNames)
@@ -69,22 +70,48 @@ private func validateFamilyVariablesAndArgRefs(
         for (i, maybeRef) in c.argVarRefs.enumerated() {
             guard let ref = maybeRef else { continue }
             // A `$name` ref resolves if the family declares the variable,
-            // the family's home section does, OR it's an assignment-scope
-            // global input.  The renderer puts all three in scope
-            // (`globalVariables + sectionVariables + family.variables`), so
-            // accepting them here matches what actually renders — only
-            // "declared in none of the three" is an error.  (Globals were
-            // previously omitted from this set, which rejected the documented
-            // `$global` worked example in docs/inputs.md.)
-            guard
+            // the family's home section does, it's an assignment-scope
+            // global input, OR it's a per-student `=` expression (global or
+            // section).  Literal refs are inlined at save time; per-student
+            // refs are bound at grading time from `_ck_inputs.py`.  Only
+            // "declared in none of these" is an error.
+            let isPerStudent = perStudentExpressionNames.contains(ref)
+            let isLiteralVar =
                 seenVarNames.contains(ref) || sectionVarNamesHere.contains(ref)
-                    || globalVarNames.contains(ref)
-            else {
+                || globalVarNames.contains(ref)
+            guard isPerStudent || isLiteralVar else {
                 let paramLabel = (i < family.paramNames.count ? family.paramNames[i] : "arg \(i + 1)")
                 throw Abort(
                     .unprocessableEntity,
                     reason:
                         "Pattern family '\(family.id)': case '\(c.key)' arg '\(paramLabel)' references unknown variable '$\(ref)'"
+                )
+            }
+            // Per-student arg refs are bound by the boundary_equality
+            // preamble only (the other kinds don't emit it yet).
+            if isPerStudent, family.kind != .boundaryEquality {
+                throw Abort(
+                    .unprocessableEntity,
+                    reason:
+                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in boundary_equality families for now."
+                )
+            }
+        }
+        // A per-student expected ref must name a declared `=` expression and
+        // is (for now) supported only in boundary_equality families.
+        if let eref = c.expectedVarRef {
+            guard perStudentExpressionNames.contains(eref) else {
+                throw Abort(
+                    .unprocessableEntity,
+                    reason:
+                        "Pattern family '\(family.id)': case '\(c.key)' expected reference '$\(eref)' must name a per-student input (a global or section `=` expression)."
+                )
+            }
+            guard family.kind == .boundaryEquality else {
+                throw Abort(
+                    .unprocessableEntity,
+                    reason:
+                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in boundary_equality families for now."
                 )
             }
         }
@@ -163,7 +190,8 @@ func validatePatternFamilies(
     testSuites: [TestSuiteEntry],
     sections: [TestSuiteSection] = [],
     familySectionID: [String: String] = [:],
-    globalVariableNames: Set<String> = []
+    globalVariableNames: Set<String> = [],
+    perStudentExpressionNames: Set<String> = []
 ) throws {
     // v0.4.100: build a "extra names in scope for this family" set so
     // each family can reference its home section's variables too.
@@ -216,7 +244,8 @@ func validatePatternFamilies(
         try validateFamilyVariablesAndArgRefs(
             family: family,
             sectionVarNamesHere: sectionVarNames(forFamily: family.id),
-            globalVarNames: globalVariableNames
+            globalVarNames: globalVariableNames,
+            perStudentExpressionNames: perStudentExpressionNames
         )
     }
 

--- a/Sources/APIServer/Utilities/PatternKindHandler.swift
+++ b/Sources/APIServer/Utilities/PatternKindHandler.swift
@@ -31,7 +31,8 @@ protocol PatternKindHandler: Sendable {
     /// `render*` function in `PatternFamilyRenderer.swift`.
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String
 
     /// Family-level validation (e.g. tolerance bounds).  Default: no-op.
@@ -86,9 +87,12 @@ private func validatePatternArgCount(
 struct BoundaryEqualityKind: PatternKindHandler {
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
-        renderBoundaryEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
+        renderBoundaryEquality(
+            family: family, case: c, sectionVariables: sectionVariables,
+            specHash: specHash, perStudentNames: perStudentNames)
     }
 
     func validateCase(family: PatternFamily, case c: PatternCase) throws {
@@ -101,7 +105,8 @@ struct BoundaryEqualityKind: PatternKindHandler {
 struct ApproximateEqualityKind: PatternKindHandler {
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
         renderApproximateEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
@@ -126,7 +131,8 @@ struct VariableEqualityKind: PatternKindHandler {
 
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
         renderVariableEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
@@ -168,7 +174,8 @@ struct VariableEqualityKind: PatternKindHandler {
 struct ReturnTypeCheckKind: PatternKindHandler {
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
         renderReturnTypeCheck(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
@@ -192,7 +199,8 @@ struct ReturnTypeCheckKind: PatternKindHandler {
 struct ExceptionExpectedKind: PatternKindHandler {
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
         renderExceptionExpected(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
@@ -216,7 +224,8 @@ struct ExceptionExpectedKind: PatternKindHandler {
 struct PerformanceThresholdKind: PatternKindHandler {
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
         renderPerformanceThreshold(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }
@@ -245,7 +254,8 @@ struct PerformanceThresholdKind: PatternKindHandler {
 struct StdoutEqualityKind: PatternKindHandler {
     func render(
         family: PatternFamily, case c: PatternCase,
-        sectionVariables: [FamilyVariable], specHash: String
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
     ) -> String {
         renderStdoutEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
     }

--- a/Sources/Core/Job.swift
+++ b/Sources/Core/Job.swift
@@ -29,6 +29,18 @@ public struct Job: Codable, Sendable {
     /// runner skips env-var injection and grading proceeds without a seed.
     public let assignmentSeed: String?
 
+    /// Per-student personalization inputs, resolved server-side for this
+    /// submission's `assignmentSeed` by evaluating the manifest's global +
+    /// section `=` expressions. Maps each input name to its evaluated value
+    /// rendered as a Python literal (`repr(value)` — the same form
+    /// `PersonalizationEvaluator` emits for notebook substitution). The worker
+    /// materializes these into `_ck_inputs.py` in the grading workspace so
+    /// pattern-family scripts that reference per-student args / expected can
+    /// load them. Nil when the assignment declares no expressions or no seed
+    /// is available — generated scripts that need a value then fail closed
+    /// with a clear message.
+    public let personalizedInputs: [String: String]?
+
     public init(
         submissionID: String,
         testSetupID: String,
@@ -37,7 +49,8 @@ public struct Job: Codable, Sendable {
         testSetupURL: URL,
         manifest: TestProperties,
         submissionFilename: String? = nil,
-        assignmentSeed: String? = nil
+        assignmentSeed: String? = nil,
+        personalizedInputs: [String: String]? = nil
     ) {
         self.submissionID = submissionID
         self.testSetupID = testSetupID
@@ -47,5 +60,6 @@ public struct Job: Codable, Sendable {
         self.manifest = manifest
         self.submissionFilename = submissionFilename
         self.assignmentSeed = assignmentSeed
+        self.personalizedInputs = personalizedInputs
     }
 }

--- a/Sources/Core/Models/PatternFamily.swift
+++ b/Sources/Core/Models/PatternFamily.swift
@@ -126,6 +126,13 @@ public struct PatternCase: Codable, Equatable, Sendable {
     public let argVarRefs: [String?]
     /// Value compared with `==` against the function's return.
     public let expected: JSONValue
+    /// When non-nil, the expected value is resolved per-student at grading
+    /// time from the personalization input named here (a global or section
+    /// `=` expression row), instead of the literal `expected`.  The renderer
+    /// emits `expected = <name>` — a bare identifier defined by the
+    /// per-student `_ck_inputs` preamble — rather than baking a literal.  nil
+    /// preserves the pre-personalization behaviour (literal `expected`).
+    public let expectedVarRef: String?
     /// Per-case hint shown at the end of every failure message.  When nil,
     /// the family's `defaults.hint` is used instead.
     public let hint: String?
@@ -139,6 +146,7 @@ public struct PatternCase: Codable, Equatable, Sendable {
     public init(
         key: String, label: String, args: [JSONValue], expected: JSONValue,
         argsProvided: [Bool] = [], argVarRefs: [String?] = [],
+        expectedVarRef: String? = nil,
         hint: String? = nil, tier: TestTier? = nil, points: Int? = nil,
         enabled: Bool = true
     ) {
@@ -148,6 +156,7 @@ public struct PatternCase: Codable, Equatable, Sendable {
         self.argsProvided = argsProvided.count == args.count ? argsProvided : []
         self.argVarRefs = argVarRefs.count == args.count ? argVarRefs : []
         self.expected = expected
+        self.expectedVarRef = expectedVarRef
         self.hint = hint
         self.tier = tier
         self.points = points
@@ -164,6 +173,7 @@ public struct PatternCase: Codable, Equatable, Sendable {
         let decodedVarRefs = try c.decodeIfPresent([String?].self, forKey: .argVarRefs) ?? []
         argVarRefs = decodedVarRefs.count == args.count ? decodedVarRefs : []
         expected = try c.decode(JSONValue.self, forKey: .expected)
+        expectedVarRef = try c.decodeIfPresent(String.self, forKey: .expectedVarRef)
         hint = try c.decodeIfPresent(String.self, forKey: .hint)
         tier = try c.decodeIfPresent(TestTier.self, forKey: .tier)
         points = try c.decodeIfPresent(Int.self, forKey: .points)

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -549,6 +549,28 @@ extension WorkerDaemon {
             scriptEnv["CHICKADEE_ASSIGNMENT_SEED"] = seed
         }
 
+        // Materialize per-student personalization inputs (issue #461) into the
+        // grading workspace as `_ck_inputs.py`, so generated pattern-family
+        // scripts that reference per-student args / expected can load them by
+        // path. Each value is already a Python literal (`repr`) resolved
+        // server-side. The filename is reserved (excluded from student-module
+        // candidates in test_runtime), so it can't be mistaken for the
+        // submission.
+        if let inputs = job.personalizedInputs, !inputs.isEmpty {
+            var lines = [
+                "# Auto-generated per-student grading inputs (issue #461). Do not edit.",
+                "_ck = {",
+            ]
+            for key in inputs.keys.sorted() {
+                lines.append("    \"\(key)\": \(inputs[key] ?? "None"),")
+            }
+            lines.append("}")
+            let source = lines.joined(separator: "\n") + "\n"
+            try? source.write(
+                to: testSetupDir.appendingPathComponent("_ck_inputs.py"),
+                atomically: true, encoding: .utf8)
+        }
+
         let executor = NativeScriptExecutor(runner: runner, workDir: testSetupDir, env: scriptEnv)
         let items = manifest.testSuites.map { entry in
             SuiteItem(

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -101,7 +101,7 @@ let testRuntimePy = """
         files: List[Path] = []
         for p in cwd.glob("*.py"):
             name = p.name
-            if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py"}:
+            if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py", "_ck_inputs.py"}:
                 continue
             lower = name.lower()
             if lower.startswith("publictest") or lower.startswith("secrettest") or lower.startswith("releasetest"):

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -438,4 +438,85 @@ import Vapor
         try validatePatternFamilies([], testSuites: [])
     }
 
+    // MARK: - Personalization (per-student inputs, #461)
+
+    private func perStudentBoundaryFamily() -> PatternFamily {
+        let c = PatternCase(
+            key: "01", label: "Adults", args: [.null], expected: .null,
+            argVarRefs: ["patients"], expectedVarRef: "adults_expected")
+        return PatternFamily(
+            id: "adults", name: "Adults", kind: .boundaryEquality,
+            functionName: "countAdults", paramNames: ["patients"], cases: [c])
+    }
+
+    @Test func rendererEmitsPerStudentPreambleAndExpectedRef() throws {
+        let scripts = renderPatternFamily(
+            perStudentBoundaryFamily(), perStudentNames: ["patients", "adults_expected"])
+        let src = try #require(scripts.first).source
+        // The full generated script (preamble + body) must be valid Python.
+        try pfAssertValidPythonSyntax(src, label: "adults_01")
+        // Loads per-student inputs by path from the reserved file.
+        #expect(src.contains("_ck_inputs.py"))
+        #expect(src.contains("spec_from_file_location"))
+        // Binds both referenced per-student names from _ck.
+        #expect(src.contains(#"patients = _ck["patients"]"#))
+        #expect(src.contains(#"adults_expected = _ck["adults_expected"]"#))
+        // Fails closed when a value is missing (no seed).
+        #expect(src.contains("Personalization input"))
+        // Expected is the bare per-student ref, not a baked literal.
+        #expect(src.contains("expected = adults_expected"))
+        #expect(!src.contains("expected = None"))
+        // The arg is passed from the bound name and the function is called.
+        #expect(src.contains("patients = patients"))
+        #expect(src.contains("student_module.countAdults(patients)"))
+    }
+
+    @Test func rendererOmitsPreambleWhenNoPerStudentRefs() throws {
+        // A normal family renders unchanged even when the assignment declares
+        // per-student names the family doesn't reference.
+        let scripts = renderPatternFamily(pfBMIFamily(), perStudentNames: ["patients"])
+        let src = try #require(scripts.first).source
+        #expect(!src.contains("_ck_inputs.py"))
+        #expect(!src.contains("Personalization input"))
+        #expect(src.contains("expected = \"underweight\""))
+    }
+
+    @Test func validation_acceptsPerStudentArgAndExpectedRefs() throws {
+        try validatePatternFamilies(
+            [perStudentBoundaryFamily()], testSuites: [],
+            perStudentExpressionNames: ["patients", "adults_expected"])
+    }
+
+    @Test func validation_rejectsUnknownExpectedRef() throws {
+        let c = PatternCase(
+            key: "01", label: "Adults", args: [.int(1)], expected: .null,
+            expectedVarRef: "not_declared")
+        let family = PatternFamily(
+            id: "adults", name: "Adults", kind: .boundaryEquality,
+            functionName: "countAdults", paramNames: ["x"], cases: [c])
+        #expect {
+            try validatePatternFamilies(
+                [family], testSuites: [], perStudentExpressionNames: ["patients"])
+        } throws: { error in
+            #expect("\(error)".contains("must name a per-student input"))
+            return true
+        }
+    }
+
+    @Test func validation_rejectsPerStudentRefOnNonBoundaryKind() throws {
+        let c = PatternCase(
+            key: "01", label: "X", args: [.null], expected: .double(1.0),
+            argVarRefs: ["patients"])
+        let family = PatternFamily(
+            id: "approx", name: "Approx", kind: .approximateEquality,
+            functionName: "f", paramNames: ["patients"], cases: [c])
+        #expect {
+            try validatePatternFamilies(
+                [family], testSuites: [], perStudentExpressionNames: ["patients"])
+        } throws: { error in
+            #expect("\(error)".contains("only supported in boundary_equality"))
+            return true
+        }
+    }
+
 }

--- a/Tests/CoreTests/CoreCodableTests.swift
+++ b/Tests/CoreTests/CoreCodableTests.swift
@@ -228,6 +228,50 @@ struct CoreCodableTests {
         #expect(decoded.submissionFilename == nil)
     }
 
+    @Test func jobPersonalizedInputsRoundTrip() throws {
+        let manifest = try decoder.decode(
+            TestProperties.self,
+            from: Data(#"{ "schemaVersion": 1, "testSuites": [], "timeLimitSeconds": 5 }"#.utf8))
+        let job = Job(
+            submissionID: "s", testSetupID: "t", attemptNumber: 1,
+            submissionURL: testURL("http://localhost/a"),
+            testSetupURL: testURL("http://localhost/b"),
+            manifest: manifest,
+            assignmentSeed: "deadbeef",
+            personalizedInputs: ["patients": "[{'mrn': '1'}]", "adults_expected": "2"])
+        let decoded = try decoder.decode(Job.self, from: encoder.encode(job))
+        #expect(decoded.personalizedInputs?["patients"] == "[{'mrn': '1'}]")
+        #expect(decoded.personalizedInputs?["adults_expected"] == "2")
+        #expect(decoded.assignmentSeed == "deadbeef")
+    }
+
+    @Test func jobWithoutPersonalizedInputsDecodesNil() throws {
+        // Back-compat: a payload from an older server omits the new fields.
+        let json = #"""
+            { "submissionID": "s", "testSetupID": "t", "attemptNumber": 1,
+              "submissionURL": "http://localhost/a", "testSetupURL": "http://localhost/b",
+              "manifest": { "schemaVersion": 1, "testSuites": [], "timeLimitSeconds": 5 } }
+            """#
+        let decoded = try decoder.decode(Job.self, from: Data(json.utf8))
+        #expect(decoded.personalizedInputs == nil)
+        #expect(decoded.assignmentSeed == nil)
+    }
+
+    @Test func patternCaseExpectedVarRefRoundTrip() throws {
+        let c = PatternCase(
+            key: "01", label: "Adults", args: [.null], expected: .null,
+            argVarRefs: ["patients"], expectedVarRef: "adults_expected")
+        let decoded = try decoder.decode(PatternCase.self, from: encoder.encode(c))
+        #expect(decoded.expectedVarRef == "adults_expected")
+        #expect(decoded.argVarRefs == ["patients"])
+    }
+
+    @Test func patternCaseWithoutExpectedVarRefDecodesNil() throws {
+        let json = #"{ "key": "01", "label": "L", "args": [1], "expected": 2 }"#
+        let decoded = try decoder.decode(PatternCase.self, from: Data(json.utf8))
+        #expect(decoded.expectedVarRef == nil)
+    }
+
     @Test func runnerSanitizedStripsPatternFamilies() throws {
         let family = PatternFamily(
             id: "bmi",

--- a/Tools/runner-support/test_runtime.py
+++ b/Tools/runner-support/test_runtime.py
@@ -95,7 +95,7 @@ def _candidate_student_files() -> List[Path]:
     files: List[Path] = []
     for p in cwd.glob("*.py"):
         name = p.name
-        if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py"}:
+        if name in {"test_runtime.py", "sitecustomize.py", "nb_to_py.py", "_ck_inputs.py"}:
             continue
         lower = name.lower()
         if lower.startswith("publictest") or lower.startswith("secrettest") or lower.startswith("releasetest"):

--- a/changelog.d/personalized-pattern-families-slice-a.md
+++ b/changelog.d/personalized-pattern-families-slice-a.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Per-student pattern families — grading path (issue #461, slice A).** A
+  `.boundaryEquality` pattern-family case may now resolve per-student values at
+  grading time: its expected value (`PatternCase.expectedVarRef`) and `$name`
+  arg references can point at global/section `=` expression inputs. The server
+  resolves them per submission seed (reusing `PersonalizationEvaluator`) into a
+  new `Job.personalizedInputs`; the worker materializes them as `_ck_inputs.py`
+  in the grading workspace, and generated scripts load them by path and fail
+  closed when a value is missing. This is the foundation (native worker path) —
+  the browser runner and editor UI follow in later slices. Design:
+  `docs/personalization-pattern-families.md`.


### PR DESCRIPTION
Slice A of #814 (design: `docs/personalization-pattern-families.md`). Lets a pattern family grade each student against their own per-student data — the deferred "test-script substitution" slice — on the **native worker path**.

## What changed

- **Core.** `PatternCase.expectedVarRef` (per-student expected) and `Job.personalizedInputs` (resolved values shipped to the worker). Both optional + back-compatible (older payloads decode with them nil).
- **Renderer.** A `.boundaryEquality` case whose `$name` arg refs / `expectedVarRef` point at a global/section `=` expression now emits a preamble that loads `_ck_inputs.py` *by path* (no `sys.path` reliance), binds each referenced name, and **fails closed** with a clear message if a value is missing. Non-personalized families render byte-identically, so `spec_hash` / `TestSetupCache` keys are unchanged.
- **Validator.** Accepts arg/expected refs to per-student expressions; scoped to `boundary_equality` for now (the only kind that emits the preamble).
- **Dispatch.** `WorkerJobRoutes` resolves the assignment's expressions for the submission seed (reusing `PersonalizationEvaluator` — env allowlist, `solution.py`/support-file imports) into `Job.personalizedInputs` (expression values only; literals stay inlined at save time).
- **Worker.** Writes `_ck_inputs.py` into the grading workspace before running scripts. The filename is **reserved** in `test_runtime`'s student-module selector so it can't be mistaken for the submission (it would otherwise sort first and hijack `student_module`).

## How `expected` works
The expected value is an instructor-supplied per-student expression (e.g. `= dbgen.ref_count_adults(patients)` — the `dbgen` answer-key pattern, now declarative). Because resolution is server-side, the expression may also call `solution.<fn>(...)` on the worker path without leaking the solution. Browser support (where the solution can't ship) is a later slice.

## Tests
- Renderer: emits the preamble + `_ck["…"]` bindings + bare `expected` ref; full generated script ast-parses as valid Python; non-personalized families omit the preamble.
- Validator: accepts per-student arg+expected refs; rejects unknown expected refs and per-student refs on non-boundary kinds.
- Core: `Job.personalizedInputs` / `PatternCase.expectedVarRef` round-trip + decode-nil back-compat.
- Local end-to-end: generated preamble + a sample `_ck_inputs.py` grade pass/fail correctly and fail closed when absent.

## Verification
`swift build` clean; 158/158 pattern-family + manifest + Core tests pass; swift-format clean; SwiftLint `--strict` 0 violations.

## Scope / safety
Inert until authoring is exposed (no editor/MCP field sets `expectedVarRef` yet) — nothing grades differently today. Slices B (browser), C (auto-derive `expected` from `solution.py`), and D (editor UI) follow.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_