### PR TITLE
feat(personalization): per-student pattern families — browser grading (#461 slice B)

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -254,14 +254,19 @@ for _module_name in student_module_names_in_load_order():
             // A non-personalized setup (or an older server without the endpoint)
             // yields no seed → leave the env var unset, preserving legacy behaviour.
             let assignmentSeed = null;
+            let personalizedInputs = null;
             try {
                 const seedText = await fetchText(`/api/v1/browser-runner/testsetups/${setupID}/seed`);
                 const parsed = JSON.parse(seedText);
                 if (parsed && typeof parsed.seed === 'string' && parsed.seed) {
                     assignmentSeed = parsed.seed;
                 }
+                if (parsed && parsed.personalizedInputs && typeof parsed.personalizedInputs === 'object') {
+                    personalizedInputs = parsed.personalizedInputs;
+                }
             } catch (_) {
                 assignmentSeed = null;  // grade without a seed rather than failing the run
+                personalizedInputs = null;
             }
             if (assignmentSeed !== null) {
                 try {
@@ -269,6 +274,25 @@ for _module_name in student_module_names_in_load_order():
                         `import os\nos.environ['CHICKADEE_ASSIGNMENT_SEED'] = ${JSON.stringify(assignmentSeed)}`);
                 } catch (e) {
                     throw new Error('Failed to set assignment seed: ' + toMessage(e));
+                }
+            }
+            // Per-student personalization inputs (issue #461, Slice B): mirror the
+            // native worker, which writes _ck_inputs.py into the grading workspace
+            // from Job.personalizedInputs. Each value is already a Python literal
+            // the server resolved for this student's seed (via the same
+            // gradingInputs helper); generated pattern-family scripts load this
+            // file by path. The filename is reserved in test_runtime so it can't
+            // be mistaken for the submission module.
+            if (personalizedInputs && Object.keys(personalizedInputs).length > 0) {
+                let ckSource = '# Auto-generated per-student grading inputs (issue #461). Do not edit.\n_ck = {\n';
+                for (const key of Object.keys(personalizedInputs).sort()) {
+                    ckSource += `    ${JSON.stringify(key)}: ${personalizedInputs[key]},\n`;
+                }
+                ckSource += '}\n';
+                try {
+                    py.FS.writeFile(`${workDir}/_ck_inputs.py`, ckSource);
+                } catch (e) {
+                    throw new Error('Failed to write personalization inputs: ' + toMessage(e));
                 }
             }
 

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -121,12 +121,22 @@ struct BrowserRunnerRoutes: RouteCollection {
                 .first(),
             let assignmentID = assignment.id
         else {
-            return BrowserRunnerSeedResponse(seed: nil)
+            return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil)
         }
 
         let seed = try await AssignmentSeedStore.ensureSeed(
             userID: userID, assignmentID: assignmentID, on: req.db)
-        return BrowserRunnerSeedResponse(seed: seed)
+
+        // Resolve per-student personalization inputs (issue #461) the same way
+        // the worker does — via the shared `gradingInputs` helper — so a
+        // browser-graded submission binds the same values a worker would.
+        var personalizedInputs: [String: String]?
+        if let manifest = setup.decodedManifest() {
+            personalizedInputs = await PersonalizationSubstitution.gradingInputs(
+                manifest: manifest, seedHex: seed,
+                supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setupID)/")
+        }
+        return BrowserRunnerSeedResponse(seed: seed, personalizedInputs: personalizedInputs)
     }
 
 }
@@ -134,4 +144,9 @@ struct BrowserRunnerRoutes: RouteCollection {
 /// JSON body for the browser-runner seed endpoint.
 struct BrowserRunnerSeedResponse: Content {
     let seed: String?
+    /// Per-student personalization input values (Python literals), keyed by
+    /// name — the `=` expressions resolved for this student's seed. The browser
+    /// writes these to `_ck_inputs.py` so generated pattern-family scripts can
+    /// load per-student args / expected. Nil when there are none (issue #461).
+    let personalizedInputs: [String: String]?
 }

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -184,30 +184,13 @@ struct WorkerJobRoutes: RouteCollection {
             throw WorkerJobError.internalInconsistency(reason: "Failed to build worker download URLs from base=\(base)")
         }
 
-        // Resolve per-student personalization inputs (issue #461 — pattern
-        // families with per-student values) for this seed, server-side, so the
-        // worker can bind them in generated scripts via `_ck_inputs.py`. Only
-        // the values of `=` expressions are shipped (literal variables are
-        // inlined into scripts at save time). Best-effort: on evaluation error
-        // the value is simply absent and the generated test fails closed with a
-        // clear message — non-personalized assignments are unaffected.
-        var personalizedInputs: [String: String]?
-        let fullManifest = claimed.manifest
-        let hasExpressions =
-            !fullManifest.globalExpressions.isEmpty
-            || fullManifest.sections.contains { !$0.expressions.isEmpty }
-        if let seed = assignmentSeed, hasExpressions {
-            let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
-            let resolution = await PersonalizationSubstitution.resolve(
-                manifest: fullManifest, seedHex: seed, supportFilesDirectory: supportDir)
-            if let evalError = resolution.evaluationError {
-                req.logger.warning(
-                    "Personalization eval failed for submission \(submissionID): \(evalError)")
-            }
-            let exprNames = Set(resolution.evaluatedExpressionNames)
-            let values = resolution.substitutions.filter { exprNames.contains($0.key) }
-            if !values.isEmpty { personalizedInputs = values }
-        }
+        // Resolve per-student personalization inputs (issue #461) for this seed,
+        // server-side, so the worker can bind them in generated scripts via
+        // `_ck_inputs.py`. Shared with the browser seed endpoint via
+        // `gradingInputs` so the two grading paths resolve identically.
+        let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+        let personalizedInputs = await PersonalizationSubstitution.gradingInputs(
+            manifest: claimed.manifest, seedHex: assignmentSeed, supportFilesDirectory: supportDir)
 
         return Job(
             submissionID: submissionID,

--- a/Sources/APIServer/Services/PersonalizationSubstitution.swift
+++ b/Sources/APIServer/Services/PersonalizationSubstitution.swift
@@ -83,4 +83,29 @@ enum PersonalizationSubstitution {
                 evaluationError: "\(error)")
         }
     }
+
+    /// Per-student grading inputs for a submission: each `=` expression's
+    /// evaluated value (a Python literal), keyed by name, for `seedHex`.
+    /// Literal variables are excluded — those are inlined into scripts at save
+    /// time; only expression values need to travel to grading time. Returns nil
+    /// when there's no seed, the manifest declares no expressions, or nothing
+    /// evaluated (e.g. an expression raised) — callers then ship no
+    /// `_ck_inputs.py` and generated scripts that need a value fail closed.
+    ///
+    /// Shared by the worker job payload (`WorkerJobRoutes`) and the browser
+    /// seed endpoint (`BrowserRunnerRoutes`) so both grade identically.
+    static func gradingInputs(
+        manifest: TestProperties, seedHex: String?, supportFilesDirectory: String?
+    ) async -> [String: String]? {
+        guard let seedHex, !seedHex.isEmpty else { return nil }
+        let hasExpressions =
+            !manifest.globalExpressions.isEmpty
+            || manifest.sections.contains { !$0.expressions.isEmpty }
+        guard hasExpressions else { return nil }
+        let resolution = await resolve(
+            manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportFilesDirectory)
+        let exprNames = Set(resolution.evaluatedExpressionNames)
+        let values = resolution.substitutions.filter { exprNames.contains($0.key) }
+        return values.isEmpty ? nil : values
+    }
 }

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -358,6 +358,37 @@ import XCTVapor
         }
     }
 
+    /// Slice B of #461: the seed endpoint resolves the assignment's `=`
+    /// expressions for this student and returns them as `personalizedInputs`
+    /// (Python literals), which the browser writes to `_ck_inputs.py` so
+    /// generated pattern-family scripts can bind per-student args / expected.
+    @Test func seedResponseIncludesPersonalizedInputs() async throws {
+        try await withApp(app) { _ in
+            let manifest = """
+                {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,\
+                "globalExpressions":[{"name":"answer","expression":"7 * 6"}]}
+                """
+            let setupID = try await insertSetup(manifest: manifest)
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            let cookie = try await loginAsStudent()
+
+            try await app.asyncTest(
+                .GET, "/api/v1/browser-runner/testsetups/\(setupID)/seed",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let json =
+                        try JSONSerialization.jsonObject(
+                            with: Data(res.body.readableBytesView)) as? [String: Any]
+                    #expect(json?["seed"] is String, "personalized setup must return a seed")
+                    let inputs = try #require(
+                        json?["personalizedInputs"] as? [String: String],
+                        "seed endpoint must resolve = expressions into personalizedInputs")
+                    #expect(inputs["answer"] == "42", "value must be the expression's repr literal")
+                })
+        }
+    }
+
     // MARK: - Full round-trip: dependency-skipped outcomes stored correctly
 
     /// Regression for #105: when the browser runner skips a test because its

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -422,7 +422,10 @@ async function loadRunnerHarness(options = {}) {
       return {
         ok: true,
         async text() {
-          return JSON.stringify({ seed: options.assignmentSeed ?? null });
+          return JSON.stringify({
+            seed: options.assignmentSeed ?? null,
+            personalizedInputs: options.personalizedInputs ?? null,
+          });
         },
       };
     }
@@ -993,6 +996,62 @@ test('omits CHICKADEE_ASSIGNMENT_SEED when the assignment is not personalized (n
   );
 
   assert.equal(harness.py.state.assignmentSeedEnv, null);
+});
+
+test('writes _ck_inputs.py from the seed endpoint personalizedInputs (parity with the worker)', async () => {
+  // The worker writes _ck_inputs.py into the grading workspace from
+  // Job.personalizedInputs; the browser must do the same from the seed
+  // endpoint's personalizedInputs so a generated pattern-family script that
+  // loads per-student args/expected grades identically. Values are verbatim
+  // Python literals (repr) the server resolved for this student's seed.
+  const harness = await loadRunnerHarness({
+    assignmentSeed: 'deadbeefcafe0123',
+    personalizedInputs: { adults_expected: '2', patients: "[{'mrn': '1001'}]" },
+    zipFiles: { 'publictest_x.py': '# x\nJSON_RESULT_PASS\n' },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 5,
+      testSuites: [{ script: 'publictest_x.py', tier: 'public' }],
+    },
+  });
+
+  await harness.window.BrowserRunner.runAndSubmit(
+    new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+    'setup_personalized',
+  );
+
+  // FS.writes is an append-only log, so the record survives workdir cleanup.
+  const write = harness.py.FS.writes.find(w => w.targetPath.endsWith('/_ck_inputs.py'));
+  assert.ok(write, '_ck_inputs.py must be written to the work dir');
+  const src = String(write.value);
+  assert.ok(src.includes('_ck = {'), 'emits a _ck dict');
+  assert.ok(src.includes('"adults_expected": 2,'), 'value inserted verbatim');
+  assert.ok(src.includes(`"patients": [{'mrn': '1001'}],`), 'Python-literal value preserved');
+  // Keys sorted for determinism (adults_expected before patients).
+  assert.ok(src.indexOf('adults_expected') < src.indexOf('patients'));
+});
+
+test('omits _ck_inputs.py when the seed endpoint returns no personalizedInputs', async () => {
+  const harness = await loadRunnerHarness({
+    assignmentSeed: 'deadbeefcafe0123',
+    zipFiles: { 'publictest_x.py': '# x\nJSON_RESULT_PASS\n' },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 5,
+      testSuites: [{ script: 'publictest_x.py', tier: 'public' }],
+    },
+  });
+
+  await harness.window.BrowserRunner.runAndSubmit(
+    new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+    'setup_noinputs',
+  );
+
+  assert.equal(
+    harness.py.FS.writes.find(w => w.targetPath.endsWith('/_ck_inputs.py')),
+    undefined,
+    'no _ck_inputs.py when there are no per-student inputs',
+  );
 });
 
 // ── Section grouping (results displayed per test-suite section) ──────────────

--- a/changelog.d/personalized-pattern-families-slice-b.md
+++ b/changelog.d/personalized-pattern-families-slice-b.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Per-student pattern families — browser grading (issue #461, slice B).**
+  Browser-graded (Pyodide) submissions now resolve per-student pattern-family
+  values too: the browser-runner seed endpoint returns the assignment's `=`
+  expression values (`personalizedInputs`) alongside the seed, and the browser
+  runner writes them to `_ck_inputs.py` in the grading workspace — mirroring the
+  native worker. A shared `PersonalizationSubstitution.gradingInputs` helper
+  backs both grading paths so they resolve identically.


### PR DESCRIPTION
Slice B of #814 — extends per-student pattern families (slice A, #816) to the **browser (Pyodide) grading path**.

Pleasant surprise from the research: the browser **already** has a per-student seed endpoint (`/browser-runner/testsetups/:id/seed`, resolving the same `AssignmentSeedStore.ensureSeed`) and already injects `CHICKADEE_ASSIGNMENT_SEED`. So this slice is small.

## What changed

- **Shared resolver.** New `PersonalizationSubstitution.gradingInputs(manifest:seedHex:supportFilesDirectory:)` — resolves the assignment's `=` expression values (Python literals) for a seed, excluding literals (those inline at save time). `WorkerJobRoutes` is refactored onto it, and the browser seed endpoint now uses it too, so **both grading paths resolve identically**.
- **Server.** `BrowserRunnerSeedResponse` gains `personalizedInputs`; the seed endpoint returns it alongside the seed.
- **Browser.** `browser-runner.js` parses `personalizedInputs` from the seed response and writes `_ck_inputs.py` into the Pyodide work dir (where scripts run) — mirroring the worker. The filename is already reserved in `test_runtime` (slice A), so it can't be mistaken for the submission.

## Secrecy note
Per the design doc: browser grading runs on the student's machine, so the resolved values (incl. `expected`) are visible there. Browser-graded personalization gives per-student **variety**, not secrecy — the ceiling browser grading already has. Worker-graded assignments keep both.

## Tests
- JS harness (`browser-runner.test.mjs`): asserts `_ck_inputs.py` is written from the seed endpoint's `personalizedInputs` (keys sorted, values verbatim Python literals), and omitted when there are none.
- Server (`BrowserRunnerRoutesTests`): the seed endpoint resolves a `=` expression into `personalizedInputs` (real `python3` eval).

## Verification
`swift build` clean; BrowserRunnerRoutesTests 17/17; browser-runner JS tests 18/18; runtime-drift 2/2; swift-format clean; SwiftLint `--strict` 0 violations.

Still inert until authoring is exposed (no field sets `expectedVarRef` yet). Slices C (auto-derive `expected` from `solution.py`) and D (editor UI) follow.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_