### PR TITLE
feat(personalization): author per-student pattern families via MCP (#461, slice C)

### DIFF
--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -36,16 +36,24 @@ struct UpdatePatternFamilyTool: ContentTool {
         /// Parallel to `args`: false at a position omits that argument so
         /// Python's own parameter default applies.
         let argsProvided: [Bool]?
+        /// Per-student expected (issue #461): the name of a global/section `=`
+        /// expression whose value, resolved for the student's seed at grading
+        /// time, is the expected return — instead of the literal `expected`.
+        /// `boundary_equality` only. An empty string clears it; setting
+        /// `expected` (a literal) also clears it.
+        let expectedVarRef: String?
 
         init(
             key: String, args: [JSONValue]? = nil, expected: JSONValue? = nil,
-            argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil
+            argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil,
+            expectedVarRef: String? = nil
         ) {
             self.key = key
             self.args = args
             self.expected = expected
             self.argVarRefs = argVarRefs
             self.argsProvided = argsProvided
+            self.expectedVarRef = expectedVarRef
         }
     }
 
@@ -144,6 +152,12 @@ struct UpdatePatternFamilyTool: ContentTool {
                         "argsProvided": .object([
                             "type": .string("array"),
                             "description": .string("Parallel to args: false omits the arg (use Python default)."),
+                        ]),
+                        "expectedVarRef": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Per-student expected: name of a global/section = expression resolved for the "
+                                    + "student's seed (boundary_equality only). Empty string clears it."),
                         ]),
                     ]),
                     "required": .array([.string("key")]),
@@ -307,10 +321,21 @@ struct UpdatePatternFamilyTool: ContentTool {
             explicit: edit.argsProvided, argsReplaced: edit.args != nil,
             existing: caseSpec.argsProvided, argCount: finalArgs.count,
             field: "argsProvided", caseKey: caseSpec.key)
+        // Per-student expected ref: an explicit edit wins (empty string clears);
+        // switching to a literal `expected` clears any stale ref; otherwise the
+        // existing ref carries over.
+        let finalExpectedVarRef: String?
+        if let ref = edit.expectedVarRef {
+            finalExpectedVarRef = ref.isEmpty ? nil : ref
+        } else if edit.expected != nil {
+            finalExpectedVarRef = nil
+        } else {
+            finalExpectedVarRef = caseSpec.expectedVarRef
+        }
         return PatternCase(
             key: caseSpec.key, label: caseSpec.label, args: finalArgs, expected: finalExpected,
-            argsProvided: finalProvided, argVarRefs: finalVarRefs, hint: caseSpec.hint,
-            tier: caseSpec.tier, points: caseSpec.points, enabled: enabled)
+            argsProvided: finalProvided, argVarRefs: finalVarRefs, expectedVarRef: finalExpectedVarRef,
+            hint: caseSpec.hint, tier: caseSpec.tier, points: caseSpec.points, enabled: enabled)
     }
 
     /// Resolves a parallel array (argVarRefs / argsProvided) for an edited case:
@@ -349,7 +374,7 @@ extension PatternCase {
     fileprivate func with(enabled: Bool) -> PatternCase {
         PatternCase(
             key: key, label: label, args: args, expected: expected,
-            argsProvided: argsProvided, argVarRefs: argVarRefs, hint: hint,
-            tier: tier, points: points, enabled: enabled)
+            argsProvided: argsProvided, argVarRefs: argVarRefs, expectedVarRef: expectedVarRef,
+            hint: hint, tier: tier, points: points, enabled: enabled)
     }
 }

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -117,6 +117,61 @@ import Vapor
         }
     }
 
+    @Test func setsPerStudentExpectedVarRefAndClearsOnLiteralEdit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Seed the family AND a global `=` expression the case can reference.
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            let setup = try await makeTestSetup(
+                on: app, id: "setup_pf", courseID: courseID, manifest: emptyManifest)
+            try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_pf.zip")
+            try await applyPatternFamilies(
+                to: setup, nextFamilies: [pfBMIFamily()],
+                authoredItems: [.family(id: "bmi_category", sectionID: nil)],
+                globalExpressions: [PersonalizationExpression(name: "exp_val", expression: "seed % 5")],
+                on: app.db)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_pf", courseID: courseID, title: "Lab")
+
+            // Point case 01's expected at the per-student expression.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", expectedVarRef: "exp_val")]),
+                context(app))
+            var family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.cases.first { $0.key == "01" }?.expectedVarRef == "exp_val")
+
+            // Editing to a literal expected clears the per-student ref.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", expected: .string("normal"))]),
+                context(app))
+            family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.cases.first { $0.key == "01" }?.expectedVarRef == nil)
+            #expect(family.cases.first { $0.key == "01" }?.expected == .string("normal"))
+        }
+    }
+
+    @Test func rejectsExpectedVarRefToUndeclaredExpression() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Fixture has no global expressions, so "nope" resolves to nothing.
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", expectedVarRef: "nope")]),
+                    context(app))
+            }
+        }
+    }
+
     @Test func wrongArgCountThrows() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/changelog.d/personalized-pattern-families-authoring.md
+++ b/changelog.d/personalized-pattern-families-authoring.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Author per-student pattern families via MCP (issue #461).** The
+  `update_pattern_family` tool now accepts a per-case `expectedVarRef` — the name
+  of a global/section `=` expression whose value, resolved for each student's
+  seed at grading time, becomes the expected return (instead of the literal
+  `expected`). With the existing `$name` `argVarRefs`, this completes the JSON
+  authoring path for personalized `boundary_equality` families. Slice C of the
+  design ("auto-derive expected from the solution") is folded in: an instructor
+  writes the case's expected as a `= solution.<fn>(...)` expression and points
+  `expectedVarRef` at it. See `docs/personalization-pattern-families.md`.

--- a/docs/personalization-pattern-families.md
+++ b/docs/personalization-pattern-families.md
@@ -1,6 +1,8 @@
 # Personalization — Pattern families with per-student values (design)
 
-Status: **proposed** (design only; not yet implemented).
+Status: **in progress** — slices A (#816) + B (#817) shipped; authorable via the
+MCP `update_pattern_family` tool. Slice C is folded into the expected-expression
+pattern (below); the editor UI (D) is the remaining piece.
 Tracking: next slice of [issue #461](https://github.com/JimWallace/Chickadee/issues/461).
 Builds on: [personalization-phase1.md](personalization-phase1.md) (per-student
 `CHICKADEE_ASSIGNMENT_SEED`) and [inputs.md](inputs.md) (global/section inputs,
@@ -158,18 +160,41 @@ So the feature's strongest wins are for **worker-graded** assignments and for
 
 ## Incremental scope
 
-- **A — worker-only MVP.** Manifest support for per-student args/`expected`
-  expressions on `.boundaryEquality`; renderer emits `_ck_inputs[...]` refs;
-  dispatch-time `PersonalizationEvaluator` run → `Job.personalizedInputs`; worker
-  injects `_ck_inputs`. Authored via MCP/JSON (no editor UI yet). Validate
-  end-to-end against the solution.
-- **B — browser.** Seed + per-student values endpoint + runner injection (rides
-  on the in-flight browser-seed work).
-- **C — auto-derive `expected` from `solution.py`** (worker; documented as
-  unavailable on the browser).
-- **D — editor UX.** Per-case "personalized" toggle, expression cells, `spec_hash`
-  + preview integration, and extend the `preview_personalization` placeholder
-  audit (now reading the right notebook after #811) to cover test scripts.
+- **A — worker-only MVP** ✅ (#816). A `.boundaryEquality` case's `argVarRefs` /
+  new `expectedVarRef` may point at a global/section `=` expression; the renderer
+  emits a `_ck_inputs.py` preamble (loaded by path, fails closed if missing);
+  dispatch resolves `Job.personalizedInputs`; the worker writes `_ck_inputs.py`
+  into the grading workspace (the filename is reserved in `test_runtime`).
+- **B — browser** ✅ (#817). The browser seed endpoint returns
+  `personalizedInputs` and `browser-runner.js` writes `_ck_inputs.py` into the
+  Pyodide workspace. A shared `PersonalizationSubstitution.gradingInputs` helper
+  backs both the worker job payload and the browser endpoint, so they resolve
+  identically.
+- **Authoring (MCP)** ✅. `update_pattern_family` accepts a per-case
+  `expectedVarRef` (and already accepts `$name` `argVarRefs`), so an agent can
+  author a personalized family from JSON. Browser-side validation note: a
+  browser-graded family gives per-student *variety* but not secrecy (§"The
+  `expected` value splits by grading mode").
+- **C — auto-derive `expected` from `solution.py`** — *folded into the
+  expected-expression pattern.* Because the resolver auto-imports `solution.py`
+  (and any uploaded helper, e.g. `dbgen.py`), an instructor writes a case's
+  expected as a per-student expression and points `expectedVarRef` at it:
+
+  ```text
+  Global / section inputs:
+    patients        = = dbgen.generate_patients(seed)
+    adults_expected = = solution.countAdults(patients)   # worker: stays server-side
+                      # …or = dbgen.ref_count_adults(patients) for a browser-safe answer key
+
+  Family case:  args: ["$patients"], expectedVarRef: "adults_expected"
+  ```
+
+  No separate auto-derive mechanism is needed; on the worker path the
+  `solution.<fn>(...)` form keeps the answer server-side.
+- **D — editor UX** (remaining). Per-case "personalized" toggle, expression
+  cells, `spec_hash` + preview integration, and extend the
+  `preview_personalization` placeholder audit (now reading the right notebook
+  after #811) to cover test scripts.
 
 ## Open questions
 


### PR DESCRIPTION
Completes the **JSON/MCP authoring path** for per-student pattern families (the engine landed in #816 + #817), and records the Slice C decision. Part of #814.

## The unlock
The MCP `update_pattern_family` tool already accepted `$name` `argVarRefs` (per-student *args*) but not a per-student *expected* — so a personalized family couldn't be fully authored. This adds a per-case **`expectedVarRef`**: the name of a global/section `=` expression whose value, resolved for the student's seed at grading time, becomes the expected return.

- `CaseEdit` + the tool's input schema gain `expectedVarRef`.
- `applyCaseEdit` threads it: an explicit edit wins, empty string clears it, setting a literal `expected` clears a stale ref, otherwise it's preserved. **Bug fix:** `applyCaseEdit` *and* `with(enabled:)` previously reconstructed `PatternCase` without `expectedVarRef`, so any edit/enable-toggle silently dropped it.

## Slice C, resolved
"Auto-derive `expected` from `solution.py`" is **folded into the expected-expression pattern** rather than built as a separate mechanism. Because the resolver auto-imports `solution.py` (and uploaded helpers like `dbgen.py`), an instructor writes the case's expected as a per-student expression and points `expectedVarRef` at it:

```text
adults_expected = = solution.countAdults(patients)   # worker: stays server-side
Family case:  args: ["$patients"], expectedVarRef: "adults_expected"
```

No new code path needed; on the worker the `solution.<fn>(...)` form keeps the answer server-side. Documented in `docs/personalization-pattern-families.md` (now marks A/B/MCP shipped).

## Tests
`UpdatePatternFamilyToolTests`: setting `expectedVarRef` persists and clears on a literal edit; an `expectedVarRef` to an undeclared expression is rejected by validation (real eval path).

## Verification
`swift build` clean; UpdatePatternFamilyToolTests 15/15; swift-format clean; SwiftLint `--strict` 0 violations.

The remaining slice is **D — the editor UI** (per-case "personalized" toggle + expression cells in the browser). After this lands, the feature is fully authorable via MCP/JSON; D adds the instructor-facing browser authoring.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_