### PR TITLE
feat(mcp): preview_personalization audit covers test-script per-student refs (#461)

### DIFF
--- a/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+++ b/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
@@ -31,9 +31,11 @@ struct PreviewPersonalizationTool: ContentTool {
             let value: String
         }
         struct Placeholders: Encodable, Sendable {
-            /// `{{name}}` markers found in the starter notebook.
+            /// Per-student input names referenced anywhere: `{{name}}` markers in
+            /// the starter notebook AND `$name` refs in pattern-family test-script
+            /// cases (`argVarRefs` / `expectedVarRef`).
             let used: [String]
-            /// Used markers with no matching declared input (would fail at save).
+            /// Used names with no matching declared input (would fail at save).
             let unresolved: [String]
         }
         let assignmentPublicID: String
@@ -131,7 +133,8 @@ struct PreviewPersonalizationTool: ContentTool {
         let resolution = await PersonalizationSubstitution.resolve(
             manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportDir)
 
-        let placeholders = Self.placeholderAudit(setup: setup, resolution: resolution)
+        let placeholders = Self.placeholderAudit(
+            manifest: manifest, setup: setup, resolution: resolution)
         let values = resolution.substitutions
             .map { Output.ResolvedValue(name: $0.key, value: $0.value) }
             .sorted { $0.name < $1.name }
@@ -172,19 +175,33 @@ struct PreviewPersonalizationTool: ContentTool {
     }
 
     private static func placeholderAudit(
-        setup: APITestSetup, resolution: PersonalizationSubstitution.Resolution
+        manifest: TestProperties, setup: APITestSetup,
+        resolution: PersonalizationSubstitution.Resolution
     ) -> Output.Placeholders {
-        // Read the notebook the student actually opens. `notebookData(for:)`
-        // prefers the standalone `notebookPath` blob — what `update_notebook`,
-        // the editor, and the student first-open path all use — and only falls
-        // back to the zip's starter entry. The previous zip-only read missed
-        // markers in notebooks edited via the MCP `update_notebook` path (which
-        // writes `notebookPath`, not the zip entry), so the audit under-reported
-        // `used` even though substitution worked at first-open.
-        guard let notebookData = try? notebookData(for: setup) else {
-            return Output.Placeholders(used: [], unresolved: [])
+        var used = Set<String>()
+
+        // 1. Notebook `{{name}}` placeholders. Read the notebook the student
+        // actually opens: `notebookData(for:)` prefers the standalone
+        // `notebookPath` blob — what `update_notebook`, the editor, and the
+        // student first-open path all use — and only falls back to the zip's
+        // starter entry. (Before #811 this read the zip and missed markers added
+        // via `update_notebook`, which writes `notebookPath`, not the zip entry.)
+        if let notebookData = try? notebookData(for: setup) {
+            used.formUnion(NotebookSubstitution.placeholderNames(in: notebookData))
         }
-        let used = NotebookSubstitution.placeholderNames(in: notebookData)
+
+        // 2. Test-script per-student refs: a pattern-family case may reference a
+        // per-student input via `$name` (argVarRefs) or `expectedVarRef`. Report
+        // those too so the audit covers grading, not just the notebook.
+        for family in manifest.patternFamilies {
+            for c in family.cases {
+                for ref in c.argVarRefs.compactMap({ $0 }) { used.insert(ref) }
+                if let expectedRef = c.expectedVarRef, !expectedRef.isEmpty {
+                    used.insert(expectedRef)
+                }
+            }
+        }
+
         let resolved = Set(resolution.substitutions.keys)
         let unresolved = used.filter { !resolved.contains($0) }
         return Output.Placeholders(used: used.sorted(), unresolved: unresolved.sorted())

--- a/Tests/APITests/MCP/PreviewPersonalizationToolTests.swift
+++ b/Tests/APITests/MCP/PreviewPersonalizationToolTests.swift
@@ -163,6 +163,42 @@ import Vapor
         }
     }
 
+    @Test func auditIncludesPatternFamilyPerStudentRefs() async throws {
+        // The audit covers grading, not just the notebook: a pattern-family
+        // case that references per-student inputs (argVarRefs / expectedVarRef)
+        // shows up in `used`, and resolves when the inputs are declared.
+        let manifest = #"""
+            {"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10,
+            "globalExpressions":[{"name":"patients","expression":"[1, 2, 3]"},
+            {"name":"adults_expected","expression":"2"}]}
+            """#
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await enrolledFixture(
+                on: app, id: "setup_pv", manifest: manifest, withNotebook: false)
+            // Add a personalized family whose case references the per-student inputs.
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_pv.zip")
+            let famCase = PatternCase(
+                key: "01", label: "Adults", args: [.null], expected: .null,
+                argVarRefs: ["patients"], expectedVarRef: "adults_expected")
+            let family = PatternFamily(
+                id: "adults", name: "Adults", kind: .boundaryEquality,
+                functionName: "countAdults", paramNames: ["patients"], cases: [famCase])
+            try await applyPatternFamilies(
+                to: setup, nextFamilies: [family],
+                authoredItems: [.family(id: "adults", sectionID: nil)],
+                on: app.db)
+
+            let output = try await PreviewPersonalizationTool().execute(
+                PreviewPersonalizationTool.Input(assignmentPublicID: assignment.publicID, seedHex: "ff"),
+                context(app))
+            #expect(output.placeholders.used.contains("patients"))
+            #expect(output.placeholders.used.contains("adults_expected"))
+            #expect(output.placeholders.unresolved.isEmpty)
+        }
+    }
+
     @Test func deniesWhenSubjectNotEnrolled() async throws {
         let manifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
         let app = try await makeTestApp()

--- a/changelog.d/personalization-preview-audit-scripts.md
+++ b/changelog.d/personalization-preview-audit-scripts.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **`preview_personalization` audit now covers test scripts (issue #461).** Its
+  `{{placeholder}}` audit also reports the per-student inputs that a pattern
+  family's test-script cases reference (`$name` `argVarRefs` + `expectedVarRef`),
+  not just notebook `{{markers}}` — so `placeholders.used` / `unresolved` reflect
+  grading too. (`get_suite` already surfaces `expectedVarRef` / `argVarRefs` via
+  the Codable family spec, so the read-side round-trip was already complete.)


### PR DESCRIPTION
Personalization follow-ups #1 + #2 (after the A–D feature landed in #816/#817/#818/#819).

## #2 — `preview_personalization` audit covers test scripts
The tool's `{{placeholder}}` audit reported only notebook markers. It now also collects the per-student inputs a **pattern family's test-script cases** reference — `$name` `argVarRefs` and the new `expectedVarRef` — and folds them into `placeholders.used` / `unresolved`. So a preview now reflects what *grading* uses, not just the notebook; an undeclared ref still surfaces as `unresolved`. Reuses the same per-seed resolution.

**Test:** a personalized family whose case references a per-student arg + expected shows both names in the audit's `used`, resolved.

## #1 — `get_suite` read DTO — already complete (no code)
`get_suite` emits each family as a Codable `PatternFamily` (`Output.Item.family`), so `expectedVarRef` / `argVarRefs` are already in the read output, and Slice A's `patternCaseExpectedVarRefRoundTrip` test pins that `expectedVarRef` survives encode/decode. So the read-side round-trip was already there — nothing to add.

## #3 — convert Assignment 3 (separate; needs deploy)
Replacing Assignment 3's hand-written `dbgen` Challenge tests with declarative personalized families is **MCP content work against the live server**, which needs #818/#819 deployed first (the live `update_pattern_family` must accept `expectedVarRef`). I'll do that once the deploy lands — it directly delivers the original "make them work like other tests" goal.

## Verification
`swift build` clean; PreviewPersonalizationToolTests 7/7 (incl. the new audit test, real `python3` eval); swift-format clean; SwiftLint `--strict` 0 violations.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_