### PR TITLE
Unify student grade across dashboard and submission page

### DIFF
--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -132,23 +132,14 @@ Submission #(submissionID)
 </section>
 #endfor
 
-#if(releaseSummary || secretSummary):
+#if(secretSummary):
 <div class="hidden-tiers-summary">
-    <h3 class="hidden-tiers-heading">Additional Tests</h3>
-    #if(releaseSummary):
-    <div class="tier-summary-row tier-summary-release">
-        <span class="tier tier-release-badge">release</span>
-        <span class="tier-summary-counts">#(releaseSummary.passCount) passed, #(releaseSummary.failCount) failed#if(releaseSummary.errorCount): , #(releaseSummary.errorCount) error(s)#endif</span>
-        <span class="tier-summary-note">— details available after the deadline</span>
-    </div>
-    #endif
-    #if(secretSummary):
+    <h3 class="hidden-tiers-heading">Secret tests</h3>
     <div class="tier-summary-row tier-summary-secret">
         <span class="tier tier-secret-badge">secret</span>
-        <span class="tier-summary-counts">#(secretSummary.total) test#if(secretSummary.total != 1):s#endif</span>
-        <span class="tier-summary-note">— results not shown</span>
+        <span class="tier-summary-counts">#(secretSummary.passCount) passed, #(secretSummary.failCount) failed#if(secretSummary.errorCount): , #(secretSummary.errorCount) error(s)#endif</span>
+        <span class="tier-summary-note">— these count toward your grade; individual tests aren't shown</span>
     </div>
-    #endif
 </div>
 #endif
 

--- a/Sources/APIServer/Helpers/TierFilter.swift
+++ b/Sources/APIServer/Helpers/TierFilter.swift
@@ -2,11 +2,15 @@
 //
 // Tier-visibility helpers shared between the web UI and the JSON API.
 //
-// Visibility rules:
-//   public   — always visible to students and instructors
-//   release  — visible to students only after the assignment deadline passes
-//              (or immediately when the assignment has no deadline)
-//   secret   — never visible to students; always visible to instructors/admins
+// The grade is always computed over every tier, so the percentage is identical
+// on the dashboard and the submission page and does not jump at the deadline.
+// What the deadline (and tier) gate is *presentation*:
+//   public   — listed by name with full output, always
+//   release  — listed by name always (so a student knows which hidden tests
+//              they're failing), but the per-test output is hidden until the
+//              deadline passes (or immediately when there is no deadline)
+//   secret   — never itemized; shown to students only as an aggregate pass/fail
+//              count.  Always fully visible to instructors/admins.
 
 import Core
 import Foundation
@@ -43,12 +47,18 @@ extension TestOutcomeCollection {
 
 // MARK: - Tier visibility policy
 
-/// Returns the set of tier raw-value strings that `user` is permitted to see
-/// for the given assignment (or nil assignment = no deadline context).
+/// Returns the set of tier raw-value strings whose *individual outcomes* a
+/// caller may receive verbatim through the raw results API for the given
+/// assignment.  This is the conservative "may hand back full detail" gate used
+/// by `GET /api/v1/submissions/:id/results`:
 ///
 /// - Instructors and admins always see all three tiers.
 /// - Students see `public` always, `release` after the deadline passes
 ///   (or immediately when there is no deadline), and never `secret`.
+///
+/// The student *web* view is more nuanced — it lists release tests by name
+/// before the deadline but redacts their output — so it uses `itemizedTiers`
+/// and `releaseOutputVisible` instead.
 func visibleTiers(for user: APIUser, assignment: APIAssignment?) -> Set<String> {
     if user.isInstructor {
         return ["public", "release", "secret"]
@@ -58,16 +68,35 @@ func visibleTiers(for user: APIUser, assignment: APIAssignment?) -> Set<String> 
     return releaseVisible ? ["public", "release"] : ["public"]
 }
 
-func visibleCollection(
-    from collectionJSON: String,
-    for user: APIUser,
-    assignment: APIAssignment?
-) -> TestOutcomeCollection? {
+/// Tiers whose individual test rows are itemized (listed by name) in the
+/// student submission view.  Students always see `public` and `release` rows —
+/// release names are shown even before the deadline so a student knows which
+/// hidden tests they are failing — but `secret` is never itemized.  Instructors
+/// see every tier.  The grade is computed over *all* tiers regardless of this
+/// set, so the number is stable across the deadline; only release *output* is
+/// additionally gated (see `releaseOutputVisible`).
+func itemizedTiers(for user: APIUser) -> Set<String> {
+    user.isInstructor ? ["public", "release", "secret"] : ["public", "release"]
+}
+
+/// Whether release-tier *output* (the result message + stderr/traceback panel)
+/// is shown to `user`.  Release rows are always listed by name for students,
+/// but their detailed output stays hidden until the deadline passes so students
+/// can't read the expected/actual values early.  Instructors always see it.
+func releaseOutputVisible(for user: APIUser, assignment: APIAssignment?) -> Bool {
+    if user.isInstructor { return true }
+    return assignment?.dueAt.map { $0 <= Date() } ?? true
+}
+
+/// Decodes a stored collection JSON with no tier filtering — the full,
+/// all-tier collection the runner reported.  Used wherever the *grade* is
+/// needed (it is computed over every tier), as opposed to the tier-filtered
+/// itemized rows.
+func decodedCollection(from collectionJSON: String) -> TestOutcomeCollection? {
     guard let data = collectionJSON.data(using: .utf8) else { return nil }
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
-    guard let collection = try? decoder.decode(TestOutcomeCollection.self, from: data) else { return nil }
-    return collection.filtering(tiers: visibleTiers(for: user, assignment: assignment))
+    return try? decoder.decode(TestOutcomeCollection.self, from: data)
 }
 
 func gradePercent(from collection: TestOutcomeCollection) -> Int? {

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -795,7 +795,6 @@ extension StudentCourseRoutes {
         let courseCode = context.courseCode
         let urlToken = context.urlToken
         let preferredResultBySubmissionID = context.preferredResultBySubmissionID
-        let student = context.student
         let fmt = context.fmt
         let latest = history.first
         let bestGradePercent: Int? = {
@@ -813,10 +812,8 @@ extension StudentCourseRoutes {
         }()
 
         var badges = submissionBadges(
-            assignment: assignment,
             history: history,
-            preferredResultBySubmissionID: preferredResultBySubmissionID,
-            student: student
+            preferredResultBySubmissionID: preferredResultBySubmissionID
         )
         badges.append(contentsOf: classBadges)
 
@@ -888,19 +885,13 @@ extension StudentCourseRoutes {
     /// Achievement badges earned on the latest submission (attempt/speed/
     /// improvement).  Class-wide badges are appended by the caller.
     fileprivate func submissionBadges(
-        assignment: APIAssignment,
         history: [APISubmission],
-        preferredResultBySubmissionID: [String: APIResult],
-        student: APIUser
+        preferredResultBySubmissionID: [String: APIResult]
     ) -> [AchievementBadge] {
         guard let latestSubmission = history.first,
             let latestSubID = latestSubmission.id,
             let result = preferredResultBySubmissionID[latestSubID],
-            let collection = visibleCollection(
-                from: result.collectionJSON,
-                for: student,
-                assignment: assignment
-            ),
+            let collection = decodedCollection(from: result.collectionJSON),
             let gradePct = gradePercent(from: collection)
         else {
             return []

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -251,8 +251,9 @@ struct AchievementBadge: Encodable {
     }
 }
 
-/// Aggregate summary for a hidden test tier (release before deadline, or secret).
-/// No individual test names or output are included — only counts.
+/// Aggregate pass/fail summary for a tier that is never itemized for the
+/// student (currently secret).  No individual test names or output are
+/// included — only counts.
 struct TierSummary: Encodable {
     let total: Int
     let passCount: Int
@@ -306,17 +307,18 @@ struct SubmissionContext: Encodable {
     let executionTimeMs: Int
     /// True when any test has points > 1 (i.e. grade uses weighted points).
     let isWeighted: Bool
-    /// Sum of points for all visible outcomes; equals totalTests when unweighted.
+    /// Sum of points across all tiers; equals totalTests when unweighted.
     let totalPoints: Int
-    /// Sum of points for passing outcomes; equals passCount when unweighted.
+    /// Sum of points for passing tests across all tiers; equals passCount when unweighted.
     let earnedPoints: Int
     /// True when a prior attempt exists and delta data is populated.
     let hasDelta: Bool
     /// E.g. "↑ fixed 2 tests · ↓ broke 1 test since attempt 3"; nil on first attempt.
     let deltaHeaderText: String?
-    /// Non-nil for students when release tests exist but are not yet visible (before deadline).
-    let releaseSummary: TierSummary?
-    /// Non-nil for students when secret tests exist (always hidden).
+    /// Non-nil for students when secret tests exist.  Secret tests count toward
+    /// the grade but are never itemized — only their aggregate pass/fail counts
+    /// are shown.  (Release tests are itemized as ordinary rows, even before the
+    /// deadline, so they no longer need a separate summary.)
     let secretSummary: TierSummary?
     let badges: [AchievementBadge]
     let currentUser: CurrentUserContext?

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -310,11 +310,16 @@ extension WebRoutes {
             }
         }
 
-        // Fetch the assignment for deadline-based tier visibility.
+        // Fetch the assignment for deadline-based output gating.
         let submissionAssignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == submission.testSetupID)
             .first()
-        let allowedTiers = visibleTiers(for: user, assignment: submissionAssignment)
+        // Students see public + release rows itemized (release output is gated
+        // on the deadline); secret is never itemized.  The grade itself spans
+        // every tier — see `processDisplayResult` — so it is stable across the
+        // deadline and matches the dashboard.
+        let itemized = itemizedTiers(for: user)
+        let releaseOutput = releaseOutputVisible(for: user, assignment: submissionAssignment)
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -329,7 +334,8 @@ extension WebRoutes {
         if let result = displayResult {
             processed = processDisplayResult(
                 result: result,
-                viewer: SubmissionViewer(user: user, allowedTiers: allowedTiers),
+                viewer: SubmissionViewer(
+                    user: user, itemizedTiers: itemized, releaseOutputVisible: releaseOutput),
                 submission: submission,
                 priorAttempt: priorAttempt,
                 manifestDisplay: manifestDisplay,
@@ -349,7 +355,7 @@ extension WebRoutes {
             outcomes: processed.outcomes,
             manifestEntries: manifestDisplay.entries,
             manifestSections: manifestDisplay.sections,
-            allowedTiers: allowedTiers
+            allowedTiers: itemized
         )
 
         let currentAttempt = submission.attemptNumber ?? 1
@@ -484,11 +490,12 @@ extension WebRoutes {
             sections: sections, entries: entries)
     }
 
-    /// Decodes the chosen result's `TestOutcomeCollection`, filters by tier,
-    /// computes totals and badges, and renders each visible outcome into an
-    /// `OutcomeRow` for the template.  Hidden-tier summaries (release before
-    /// deadline, secret) are computed for non-instructors only — instructors
-    /// see every tier directly.
+    /// Decodes the chosen result's `TestOutcomeCollection`, computes the
+    /// all-tier grade (so the number matches the dashboard and is stable across
+    /// the deadline), and renders each *itemized* outcome into an `OutcomeRow`.
+    /// Students see public + release rows; release output is redacted until the
+    /// deadline.  Secret never appears as a row — for non-instructors it is
+    /// surfaced as an aggregate pass/fail `TierSummary` instead.
     private func processDisplayResult(
         result: APIResult,
         viewer: SubmissionViewer,
@@ -505,31 +512,28 @@ extension WebRoutes {
             return processed
         }
 
-        // Compute per-tier summaries from the full (unfiltered) collection.
+        // Secret tests count toward the grade but are never itemized for
+        // students; surface them as an aggregate pass/fail summary.
         if !viewer.user.isInstructor {
-            let releaseOutcomes = collection.outcomes.filter { $0.tier == .release }
             let secretOutcomes = collection.outcomes.filter { $0.tier == .secret }
-            let releaseVisible = viewer.allowedTiers.contains("release")
-            if !releaseVisible, !releaseOutcomes.isEmpty {
-                processed.releaseSummary = TierSummary(outcomes: releaseOutcomes, isRelease: true)
-            }
             if !secretOutcomes.isEmpty {
                 processed.secretSummary = TierSummary(outcomes: secretOutcomes, isRelease: false)
             }
         }
 
-        let visible = collection.filtering(tiers: viewer.allowedTiers)
+        // Grade spans every tier (matches `gradePercentFromCollectionJSON` on
+        // the dashboard); only the itemized rows are tier-filtered.
         processed.buildFailed = collection.buildStatus == .failed
         processed.compilerOutput = collection.compilerOutput
         processed.warnings = collection.warnings
-        processed.passCount = visible.passCount
-        processed.totalTests = visible.totalTests
+        processed.passCount = collection.passCount
+        processed.totalTests = collection.totalTests
         processed.executionTimeMs = collection.executionTimeMs
-        processed.totalPoints = visible.totalPoints
-        processed.earnedPoints = visible.earnedPoints
+        processed.totalPoints = collection.totalPoints
+        processed.earnedPoints = collection.earnedPoints
         processed.gradePercent =
-            processed.totalPoints > 0
-            ? Int((Double(processed.earnedPoints) / Double(processed.totalPoints) * 100).rounded())
+            collection.totalPoints > 0
+            ? Int((Double(collection.earnedPoints) / Double(collection.totalPoints) * 100).rounded())
             : 0
         processed.badges = AchievementBadge.forSubmission(
             BadgeContext(
@@ -538,11 +542,16 @@ extension WebRoutes {
                 executionTimeMs: collection.executionTimeMs,
                 priorGradePercent: priorAttempt.gradePercent
             ))
-        let weighted = processed.totalPoints != visible.totalTests
-        processed.outcomes = visible.outcomes.map { outcome in
-            renderOutcomeRow(
+        let weighted = collection.totalPoints != collection.totalTests
+        let itemized = collection.filtering(tiers: viewer.itemizedTiers)
+        processed.outcomes = itemized.outcomes.map { outcome in
+            // Release output stays hidden until the deadline; the row (name,
+            // mark, hint) still renders so the student knows which test failed.
+            let redactOutput = outcome.tier == .release && !viewer.releaseOutputVisible
+            return renderOutcomeRow(
                 outcome: outcome,
                 weighted: weighted,
+                redactOutput: redactOutput,
                 priorOutcomeMap: priorAttempt.outcomeMap,
                 displayNameMap: manifestDisplay.displayNameMap,
                 hintByFilename: manifestDisplay.hintByFilename
@@ -557,20 +566,34 @@ extension WebRoutes {
     private func renderOutcomeRow(
         outcome: TestOutcome,
         weighted: Bool,
+        redactOutput: Bool,
         priorOutcomeMap: [String: TestStatus],
         displayNameMap: [String: String],
         hintByFilename: [String: String]
     ) -> OutcomeRow {
         let skip = parseSkip(shortResult: outcome.shortResult)
-        let shortOutput = formattedShortResult(from: outcome.shortResult, status: outcome.status)
-        let longOutput =
-            outcome.status == .pass
-            ? formattedPassingDetailedOutput(primary: outcome.longResult)
-            : formattedDetailedOutput(
-                primary: outcome.longResult,
-                fallback: outcome.shortResult,
-                status: outcome.status
-            )
+        let shortOutput: String
+        let longOutput: String?
+        if redactOutput {
+            // Release before the deadline: the name, mark, and hint still show
+            // so the student knows which hidden test is failing, but the result
+            // message and output panel (which can leak expected/actual values)
+            // are withheld until the deadline.
+            longOutput = nil
+            shortOutput =
+                (outcome.status == .pass || skip.isSkipped)
+                ? "" : "Detailed feedback is available after the deadline."
+        } else {
+            shortOutput = formattedShortResult(from: outcome.shortResult, status: outcome.status)
+            longOutput =
+                outcome.status == .pass
+                ? formattedPassingDetailedOutput(primary: outcome.longResult)
+                : formattedDetailedOutput(
+                    primary: outcome.longResult,
+                    fallback: outcome.shortResult,
+                    status: outcome.status
+                )
+        }
         let (markLabel, markClass): (String, String) = {
             if skip.isSkipped { return ("—", "skipped") }
             switch outcome.status {
@@ -589,9 +612,13 @@ extension WebRoutes {
         let pointsLabel: String? = weighted && outcome.points > 1 ? "\(outcome.points) pts" : nil
         // Surface the instructor hint only on a genuine failure (not pass, not
         // a skipped/blocked test — there the blocker message is the guidance).
+        // Hints are shown for failing release rows too, even before the deadline.
         let hint: String? =
             (!skip.isSkipped && outcome.status != .pass)
             ? hintByFilename[outcome.testName] : nil
+        // Don't reveal a (possibly hidden-tier) prerequisite name when output
+        // is redacted.
+        let blockerName = redactOutput ? nil : skip.blockerName
         return OutcomeRow(
             testName: displayNameMap[outcome.testName] ?? outcome.testName,
             tier: outcome.tier.rawValue,
@@ -601,7 +628,7 @@ extension WebRoutes {
             markLabel: markLabel,
             markClass: markClass,
             isSkipped: skip.isSkipped,
-            blockerName: skip.blockerName,
+            blockerName: blockerName,
             deltaImproved: deltaImproved,
             deltaRegressed: deltaRegressed,
             pointsLabel: pointsLabel,
@@ -703,7 +730,6 @@ extension WebRoutes {
             earnedPoints: processed.earnedPoints,
             hasDelta: delta.hasDelta,
             deltaHeaderText: delta.headerText,
-            releaseSummary: processed.releaseSummary,
             secretSummary: processed.secretSummary,
             badges: badges,
             currentUser: currentUser
@@ -729,7 +755,6 @@ private struct ProcessedCollection {
     var executionTimeMs: Int
     var gradePercent: Int
     var badges: [AchievementBadge]
-    var releaseSummary: TierSummary?
     var secretSummary: TierSummary?
 
     static let empty = ProcessedCollection(
@@ -745,7 +770,6 @@ private struct ProcessedCollection {
         executionTimeMs: 0,
         gradePercent: 0,
         badges: [],
-        releaseSummary: nil,
         secretSummary: nil
     )
 }
@@ -803,10 +827,16 @@ private struct ManifestDisplayData {
     let entries: [TestSuiteEntry]
 }
 
-/// Viewer-side inputs that gate which tiers and summaries are visible.
+/// Viewer-side inputs that gate which tiers are itemized and whether release
+/// output is shown.  The grade spans every tier regardless of these.
 private struct SubmissionViewer {
     let user: APIUser
-    let allowedTiers: Set<String>
+    /// Tiers rendered as individual rows (public + release for students; all
+    /// tiers for instructors).  Secret is never itemized for students.
+    let itemizedTiers: Set<String>
+    /// Whether release-tier output is shown (true after the deadline / for
+    /// instructors).  Release rows are listed by name either way.
+    let releaseOutputVisible: Bool
 }
 
 /// Banner text shown above the outcomes table comparing this attempt against

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -263,12 +263,7 @@ struct WebRoutes: RouteCollection {
                     for (setupID, latest) in latestSubmissionBySetupID {
                         guard let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
                             let result = preferredResultBySubmissionID[latest.submissionID],
-                            let assignment = assignmentBySetup[setupID],
-                            let collection = visibleCollection(
-                                from: result.collectionJSON,
-                                for: user,
-                                assignment: assignment
-                            ),
+                            let collection = decodedCollection(from: result.collectionJSON),
                             let gradePercent = gradePercent(from: collection)
                         else {
                             continue

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -305,6 +305,52 @@ import XCTVapor
         }
     }
 
+    /// Regression for the dashboard-vs-submission inconsistency: before the
+    /// deadline both surfaces must show the SAME all-tier grade.  Previously the
+    /// dashboard showed the all-tier grade (33%) while the submission page
+    /// showed a public-only 100%.
+    @Test func dashboardAndSubmissionPageAgreeOnAllTierGrade() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_consistency", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_consistency", title: "Consistency", isOpen: true,
+                dueAt: Date().addingTimeInterval(86400 * 30), on: app
+            )
+            try await wrInsertSubmission(
+                id: "sub_consistency", testSetupID: "setup_consistency", userID: userID, on: app)
+            // 1 of 3 across all tiers → 33% everywhere.
+            try await wrInsertResult(
+                submissionID: "sub_consistency",
+                outcomes: [
+                    wrMakeOutcome(name: "pub_ok", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "rel_bad", tier: .release, status: .fail),
+                    wrMakeOutcome(name: "sec_bad", tier: .secret, status: .fail),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("33%"), "Dashboard should show the all-tier grade 33%")
+                })
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_consistency",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.body.string.contains("33%"),
+                        "Submission page should show the SAME all-tier grade as the dashboard")
+                })
+        }
+    }
+
     @Test func indexShowsFirstTryPerfectBadgeForLatestPerfectFirstSubmission() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsStudent(on: app)

--- a/Tests/APITests/WebRoutesSubmissionPageTests.swift
+++ b/Tests/APITests/WebRoutesSubmissionPageTests.swift
@@ -562,13 +562,15 @@ import XCTVapor
 
     // MARK: - Tier visibility
 
-    @Test func studentSeesOnlyPublicTiersBeforeDeadline() async throws {
+    @Test func studentSeesReleaseNamesButNotOutputBeforeDeadline() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsStudent(on: app)
             let user = try await wrStudentUser(on: app)
             let userID = try user.requireID()
             try await wrInsertSetup(id: "setup_tier", on: app)
-            // Due date in the future → release tests are hidden
+            // Due date in the future → release OUTPUT is hidden, but the release
+            // test still appears by name so the student knows what they're
+            // failing.  Secret is never itemized.
             try await wrInsertAssignment(
                 testSetupID: "setup_tier", title: "Tiered", isOpen: true,
                 dueAt: Date().addingTimeInterval(86400 * 30), on: app
@@ -578,7 +580,9 @@ import XCTVapor
                 submissionID: "sub_tier",
                 outcomes: [
                     wrMakeOutcome(name: "pub_test", tier: .pub, status: .pass),
-                    wrMakeOutcome(name: "rel_test", tier: .release, status: .fail),
+                    wrMakeOutcome(
+                        name: "rel_test", tier: .release, status: .fail,
+                        shortResult: "expected 42 got 7", longResult: "secret release traceback"),
                     wrMakeOutcome(name: "sec_test", tier: .secret, status: .pass),
                 ], on: app)
 
@@ -591,8 +595,183 @@ import XCTVapor
                     #expect(res.status == .ok)
                     let html = res.body.string
                     #expect(html.contains("pub_test"), "Public test should be visible")
-                    #expect(html.contains("rel_test") == false, "Release test name should be hidden before deadline")
+                    #expect(html.contains("rel_test"), "Release test name should be shown before the deadline")
+                    #expect(
+                        html.contains("expected 42 got 7") == false,
+                        "Release result message must stay hidden before the deadline")
+                    #expect(
+                        html.contains("secret release traceback") == false,
+                        "Release output must stay hidden before the deadline")
+                    #expect(
+                        html.contains("Detailed feedback is available after the deadline"),
+                        "Release row should note that output unlocks at the deadline")
                     #expect(html.contains("sec_test") == false, "Secret test name should never be shown")
+                })
+
+        }
+    }
+
+    /// The headline grade is computed over EVERY tier (public + release +
+    /// secret), so a student who passes only the public tests does not see a
+    /// misleading 100%.  This is the basis fix behind the dashboard/submission
+    /// inconsistency.
+    @Test func submissionGradeSpansAllTiersIncludingHidden() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrInsertSetup(id: "setup_alltier", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_alltier", title: "All Tier", isOpen: true,
+                dueAt: Date().addingTimeInterval(86400 * 30), on: app
+            )
+            try await wrInsertSubmission(id: "sub_alltier", testSetupID: "setup_alltier", userID: userID, on: app)
+            // 1 of 3 tests pass across all tiers → 33%, NOT 100% (public only).
+            try await wrInsertResult(
+                submissionID: "sub_alltier",
+                outcomes: [
+                    wrMakeOutcome(name: "pub_ok", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "rel_bad", tier: .release, status: .fail),
+                    wrMakeOutcome(name: "sec_bad", tier: .secret, status: .fail),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_alltier",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("33%"), "Grade should reflect all tiers (1/3), not public-only 100%")
+                    #expect(html.contains("1 / 3 tests passed"), "Denominator should be the full all-tier count")
+                })
+
+        }
+    }
+
+    /// Secret tests are never itemized but their aggregate pass/fail counts are
+    /// shown, and they count toward the grade.
+    @Test func studentSeesSecretAggregatePassFailCounts() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrInsertSetup(id: "setup_secret_agg", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_secret_agg", title: "Secret Agg", isOpen: true,
+                dueAt: Date().addingTimeInterval(-3600), on: app  // past deadline: secret still hidden
+            )
+            try await wrInsertSubmission(id: "sub_secret_agg", testSetupID: "setup_secret_agg", userID: userID, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_secret_agg",
+                outcomes: [
+                    wrMakeOutcome(name: "pub_ok", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "secret_alpha", tier: .secret, status: .pass),
+                    wrMakeOutcome(name: "secret_beta", tier: .secret, status: .fail),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_secret_agg",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("1 passed, 1 failed"), "Secret aggregate counts should be shown")
+                    #expect(html.contains("count toward your grade"), "Secret note should say they count")
+                    #expect(html.contains("secret_alpha") == false, "Secret test names must never be shown")
+                    #expect(html.contains("secret_beta") == false, "Secret test names must never be shown")
+                })
+
+        }
+    }
+
+    /// A failing release test shows its instructor hint before the deadline
+    /// (guidance without the answer), while its output stays hidden.
+    @Test func releaseHintShownBeforeDeadlineWithoutOutput() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            let manifest = """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[\
+                {"tier":"public","script":"test.sh"},\
+                {"tier":"release","script":"releasetest_q2.py","hint":"check the negative case"}\
+                ],"timeLimitSeconds":10}
+                """
+            let course = try await wrMakeCourse(on: app)
+            let courseID = try course.requireID()
+            let setup = APITestSetup(
+                id: "setup_rel_hint",
+                manifest: manifest,
+                zipPath: app.testSetupsDirectory + "setup_rel_hint.zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+            try await wrInsertAssignment(
+                testSetupID: "setup_rel_hint", title: "Rel Hint", isOpen: true,
+                dueAt: Date().addingTimeInterval(86400 * 30), on: app
+            )
+            try await wrInsertSubmission(id: "sub_rel_hint", testSetupID: "setup_rel_hint", userID: userID, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_rel_hint",
+                outcomes: [
+                    wrMakeOutcome(name: "test", tier: .pub, status: .pass),
+                    wrMakeOutcome(
+                        name: "releasetest_q2", tier: .release, status: .fail,
+                        shortResult: "AssertionError: expected -1", longResult: "revealing traceback"),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_rel_hint",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("releasetest_q2"), "Release test name should show")
+                    #expect(html.contains("check the negative case"), "Release hint should show before the deadline")
+                    #expect(html.contains("revealing traceback") == false, "Release output must stay hidden")
+                    #expect(html.contains("AssertionError: expected -1") == false, "Release message must stay hidden")
+                })
+
+        }
+    }
+
+    /// First-Try Perfect ("Ace") rides the all-tier grade, so passing only the
+    /// public tests while a hidden secret test fails does NOT earn the badge.
+    @Test func firstTryPerfectBadgeNotAwardedWhenSecretTestFails() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            try await wrInsertSetup(id: "setup_badge_secret", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_badge_secret", title: "Badge Secret", isOpen: true,
+                dueAt: Date().addingTimeInterval(86400 * 30), on: app
+            )
+            try await wrInsertSubmission(
+                id: "sub_badge_secret", testSetupID: "setup_badge_secret", userID: userID, attemptNumber: 1, on: app)
+            try await wrInsertResult(
+                submissionID: "sub_badge_secret",
+                outcomes: [
+                    wrMakeOutcome(name: "pub_ok", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "sec_bad", tier: .secret, status: .fail),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_badge_secret",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("50%"), "All-tier grade is 1/2 = 50%")
+                    #expect(html.contains("Ace") == false, "Ace must not be awarded when a hidden test fails")
                 })
 
         }

--- a/changelog.d/release-secret-grade-presentation.md
+++ b/changelog.d/release-secret-grade-presentation.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Dashboard and submission-page grades now agree.** The submission page used
+  to headline a tier-filtered grade (e.g. 100% from public tests only before a
+  deadline) while the dashboard showed the all-tier grade — two different
+  numbers for the same student. Both now report the same all-tier grade, so the
+  number no longer jumps when the deadline passes.
+
+### Changed
+
+- **Release/secret tests are presented more deliberately to students.** The
+  grade is always computed over every tier (public + release + secret), so it
+  is stable across the deadline. Release tests are now listed by name (with
+  their instructor hint on failures) even before the deadline — only their
+  detailed output is withheld until the deadline. Secret tests are never
+  itemized but their aggregate pass/fail counts are shown and count toward the
+  grade. First-Try Perfect now rides the all-tier grade, so it can't be earned
+  while a hidden test is still failing.


### PR DESCRIPTION
## Problem

Two issues with how grades and hidden test tiers are shown to students:

1. **The dashboard grade and the submission-page grade disagreed.** The dashboard already showed the *all-tier* grade (`gradePercentFromCollectionJSON`), while the submission page headlined a *tier-filtered* grade (public-only before the deadline). A student could see **100%** at the top of a submission and a much lower number on their dashboard for the same work.
2. **Release/secret tests were confusing before the deadline** — students saw they were "failing something" with no idea what.

## Approach

There is now **one grade — the all-tier grade (public + release + secret) — everywhere**, so the number is identical on both surfaces and **stable across the deadline** (the deadline reveals *detail*, never moves the *number*). What's gated is *presentation*, not the math:

| Tier | Itemized rows | Output | Hints | In grade |
|------|---------------|--------|-------|----------|
| **public** | yes | yes | on fail | yes |
| **release** | **yes — name + Pass/Fail + Δ** | **only after deadline** | **on fail (always)** | yes |
| **secret** | never | never | never | yes — shown as aggregate **"X passed, Y failed"** |

This is a **web-display change only** — the runner already stores all-tier `totalPoints`/`earnedPoints`, so RunnerCore / the wasm grader / `output-contract.json` are untouched.

### Key changes
- **`TierFilter.swift`** — split the conflated concern into `itemizedTiers(for:)` (which rows render), `releaseOutputVisible(for:assignment:)` (release output gate), and `decodedCollection(from:)` (all-tier grade). `visibleTiers` is retained unchanged for the conservative raw results API.
- **`WebRoutes+Submission.swift`** — grade computed from the full collection; rows itemized by `itemizedTiers`; release output redacted pre-deadline (name/mark/hint kept); secret surfaced as an aggregate summary. Badges auto-ride the all-tier grade.
- **Dashboard / student-course-history badge paths** — switched from the deadline-gated grade to the all-tier grade so "Ace" can't be earned while a hidden test fails.
- **`submission.leaf`** — the hidden-tiers box is now secret-only with pass/fail counts; release lives in the main table.

### Scope note
The raw JSON API (`GET /api/v1/submissions/:id/results`) keeps its existing conservative tier filter — left out of this pass deliberately (it's a separate contract with its own consumers).

## Tests
- Rewrote the tier-visibility test (release names now show pre-deadline; output stays hidden).
- Added: all-tier grade on the submission page; secret aggregate pass/fail; release hint shown pre-deadline without output; First-Try Perfect not awarded when a secret test fails; **dashboard % == submission % regression test**.
- `swift-format`, SwiftLint (`--strict`, 0 violations), and the affected suites all pass locally.

https://claude.ai/code/session_01Y1H2h4TnYWyjHpiFTUqsue

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1H2h4TnYWyjHpiFTUqsue)_