### PR TITLE
feat(grades): grade-override control on the per-assignment roster

### DIFF
--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -65,6 +65,29 @@
                             </button>
                         </form>
                     #endif
+                    <details class="ext-details" style="margin:0">
+                        <summary class="btn action-btn ext-summary#if(row.gradeIsOverridden): grade-override-active#endif" title="#if(row.gradeIsOverridden):Edit this student’s grade override#else:Override this student’s grade#endif" aria-label="#if(row.gradeIsOverridden):Edit grade override#else:Override grade#endif" style="padding:.25rem .35rem">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="5" x2="5" y2="19"/><circle cx="6.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="17.5" r="2.5"/></svg>
+                        </summary>
+                        <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/grade-override" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                            #csrfFormField()
+                            <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Override grade (%)
+                                <input type="number" name="overridePercent" min="0" max="100" step="1" value="#(row.gradeOverridePercent)" required style="width:100%;margin-top:.2rem">
+                            </label>
+                            <label style="font-size:.78rem;color:var(--gray-700)">
+                                Note (optional)
+                                <input type="text" name="note" placeholder="Reason for override" style="width:100%;margin-top:.2rem">
+                            </label>
+                            <div style="display:flex;gap:.3rem">
+                                <button class="btn action-btn" type="submit">Save</button>
+                                #if(row.gradeIsOverridden):
+                                <button class="btn action-btn" type="submit" formaction="/instructor/#(assignmentID)/students/#(row.studentUUID)/grade-override/delete" formnovalidate onclick="return confirm('Clear this student’s grade override and revert to the auto-graded result?')">Clear</button>
+                                #endif
+                            </div>
+                        </form>
+                    </details>
                     <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/reset-notebook" onsubmit="return confirm('Reset this student’s working-copy notebook back to the original assignment starter? Past submissions are not affected. The student will see the fresh starter automatically on their next visit.')" style="margin:0">
                         #csrfFormField()
                         <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
@@ -123,6 +146,11 @@
 #assignment-submissions-table th[data-sort-key].sort-desc::after {
     content: "  ↓";
 }
+/* Render the override <summary> as a clean icon button (no disclosure
+   triangle) aligned with the Retest / Reset icon buttons in the same row. */
+.ext-summary { margin-top: 0; list-style: none; }
+.ext-summary::-webkit-details-marker { display: none; }
+.ext-details[open] > .ext-summary { background: var(--gray-100); }
 </style>
 <script>
 (function () {

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -168,6 +168,9 @@ struct AssignmentStudentRow: Encodable {
     /// True when `gradeText` is an instructor override rather than the
     /// runner-computed best grade.
     let gradeIsOverridden: Bool
+    /// Prefill for the inline override form: the active override percent when
+    /// one is set, else the runner-computed best grade, else 0.
+    let gradeOverridePercent: Int
     let submissionCount: Int
     let hasLatestSubmission: Bool
     let latestSubmissionID: String

--- a/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
+++ b/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
@@ -57,3 +57,96 @@ func gradeOverridePoints(percent: Int, setup: APITestSetup) -> Double? {
     guard total > 0 else { return nil }
     return Double(percent) / 100.0 * Double(total)
 }
+
+// MARK: - Mutating helpers (shared by every override-setting site)
+//
+// One student's override is the same row no matter which instructor page set
+// it.  Centralising the upsert / clear keeps the per-student grouped view and
+// the per-assignment roster from drifting on the side effects that have to
+// accompany every change — most importantly re-flagging the student's results
+// for BrightSpace sync so the next sweep re-pushes the new effective grade.
+// Audit logging stays at the route layer (it needs the `Request`).
+
+/// Upserts the (setup, user) override to `percent`, storing the note and
+/// granting instructor, then re-flags the student's results for BrightSpace
+/// sync so the next sweep pushes the new effective grade.
+func applyGradeOverride(
+    testSetupID: String,
+    studentUserID: UUID,
+    percent: Int,
+    note: String?,
+    grantedByUserID: UUID?,
+    on db: Database
+) async throws {
+    let existing = try await APIGradeOverride.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$userID == studentUserID)
+        .first()
+    if let existing {
+        existing.overridePercent = percent
+        existing.note = note
+        existing.grantedByUserID = grantedByUserID
+        try await existing.save(on: db)
+    } else {
+        let row = APIGradeOverride(
+            testSetupID: testSetupID,
+            userID: studentUserID,
+            overridePercent: percent,
+            note: note,
+            grantedByUserID: grantedByUserID
+        )
+        try await row.save(on: db)
+    }
+    try await flagGradeResultsPendingSync(
+        testSetupID: testSetupID, studentUserID: studentUserID, on: db)
+}
+
+/// Clears any (setup, user) override and re-flags the student's results for
+/// BrightSpace sync so the next sweep reverts to the runner-computed grade.
+/// Returns `true` when a row existed and was removed (the caller uses this to
+/// gate the audit-log entry).
+@discardableResult
+func clearGradeOverride(
+    testSetupID: String,
+    studentUserID: UUID,
+    on db: Database
+) async throws -> Bool {
+    guard
+        let existing = try await APIGradeOverride.query(on: db)
+            .filter(\.$testSetupID == testSetupID)
+            .filter(\.$userID == studentUserID)
+            .first()
+    else {
+        return false
+    }
+    try await existing.delete(on: db)
+    try await flagGradeResultsPendingSync(
+        testSetupID: testSetupID, studentUserID: studentUserID, on: db)
+    return true
+}
+
+/// Marks every result on one student's submissions for a test setup as pending
+/// BrightSpace sync, so the debounced sweep re-pushes the grade after an
+/// override is set or cleared.
+func flagGradeResultsPendingSync(
+    testSetupID: String, studentUserID: UUID, on db: Database
+) async throws {
+    let submissionIDs = try await APISubmission.query(on: db)
+        .filter(\.$userID == studentUserID)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .all()
+        .compactMap(\.id)
+    guard !submissionIDs.isEmpty else { return }
+    let results = try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ submissionIDs)
+        .all()
+    let now = Date()
+    for result in results {
+        result.brightspaceSyncPending = true
+        if result.brightspacePendingSince == nil {
+            result.brightspacePendingSince = now
+        }
+        try await result.save(on: db)
+    }
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -356,6 +356,7 @@ extension InstructorDashboardRoutes {
             givenNames: inferredName.givenNames,
             gradeText: bestGradePercent.map { "\($0)%" } ?? "—",
             gradeIsOverridden: override != nil,
+            gradeOverridePercent: override ?? runnerBestGradePercent ?? 0,
             submissionCount: history.count,
             hasLatestSubmission: latest != nil,
             latestSubmissionID: latest?.id ?? "",
@@ -651,6 +652,135 @@ extension InstructorDashboardRoutes {
             fallbackPath: fallbackPath
         )
         return req.redirect(to: redirectPath)
+    }
+
+    // MARK: - POST /instructor/:assignmentID/students/:studentID/grade-override
+    //
+    // Per-assignment-roster twin of the grouped per-student page's grade
+    // override.  Both resolve to the same (test_setup, user) row and share
+    // `applyGradeOverride` / `clearGradeOverride`, so an override set from
+    // either page is identical and replaces the runner-computed grade
+    // everywhere (roster median, grades CSV, BrightSpace sync, submission
+    // view).  Student identity here is the UUID path segment, matching the
+    // sibling `reset-notebook` action on this same page.
+
+    @Sendable
+    func saveStudentGradeOverride(req: Request) async throws -> Response {
+        struct OverrideBody: Content {
+            var overridePercent: Int?
+            var note: String?
+            var returnTo: String?
+        }
+
+        let actor = try req.auth.require(APIUser.self)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db) else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+        let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
+        guard let studentUUID = student.id else {
+            throw WebAssignmentError.notFound(resource: "Student")
+        }
+
+        let body = try req.content.decode(OverrideBody.self)
+        guard let percent = body.overridePercent, (0...100).contains(percent) else {
+            throw WebAssignmentError.invalidParameter(
+                name: "overridePercent",
+                reason: "Provide a whole-number percent between 0 and 100."
+            )
+        }
+        let trimmedNote = body.note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let note = (trimmedNote?.isEmpty == false) ? trimmedNote : nil
+
+        try await applyGradeOverride(
+            testSetupID: assignment.testSetupID,
+            studentUserID: studentUUID,
+            percent: percent,
+            note: note,
+            grantedByUserID: actor.id,
+            on: req.db
+        )
+
+        await AuditLogger.record(
+            action: .gradeOverrideSet,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: [
+                "assignment": assignmentIDRaw,
+                "student_username": student.username,
+                "override_percent": String(percent),
+            ],
+            on: req
+        )
+
+        let fallbackPath = "/instructor/\(assignmentIDRaw)/submissions"
+        let redirectPath = sanitizedAssignmentReturnPath(
+            body.returnTo, assignmentIDRaw: assignmentIDRaw, fallbackPath: fallbackPath)
+        return req.redirect(to: redirectPath)
+    }
+
+    // MARK: - POST /instructor/:assignmentID/students/:studentID/grade-override/delete
+
+    @Sendable
+    func deleteStudentGradeOverride(req: Request) async throws -> Response {
+        struct DeleteBody: Content { var returnTo: String? }
+
+        _ = try req.auth.require(APIUser.self)
+        let assignmentIDRaw = try assignmentPublicIDParameter(from: req)
+        guard let assignment = try await assignmentByPublicID(assignmentIDRaw, on: req.db) else {
+            throw WebAssignmentError.notFound(resource: "Assignment '\(assignmentIDRaw)'")
+        }
+        let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
+        guard let studentUUID = student.id else {
+            throw WebAssignmentError.notFound(resource: "Student")
+        }
+
+        if try await clearGradeOverride(
+            testSetupID: assignment.testSetupID, studentUserID: studentUUID, on: req.db)
+        {
+            await AuditLogger.record(
+                action: .gradeOverrideCleared,
+                targetType: .assignment,
+                targetID: assignment.id?.uuidString,
+                metadata: [
+                    "assignment": assignmentIDRaw,
+                    "student_username": student.username,
+                ],
+                on: req
+            )
+        }
+
+        let body = try? req.content.decode(DeleteBody.self)
+        let fallbackPath = "/instructor/\(assignmentIDRaw)/submissions"
+        let redirectPath = sanitizedAssignmentReturnPath(
+            body?.returnTo, assignmentIDRaw: assignmentIDRaw, fallbackPath: fallbackPath)
+        return req.redirect(to: redirectPath)
+    }
+
+    /// Resolves the `:studentID` UUID parameter to a `role == "student"` user
+    /// enrolled in the assignment's course.  Throws `notFound` when the
+    /// parameter is missing/invalid, the user doesn't exist or isn't a
+    /// student, or the user isn't enrolled — the same gate `resetStudentNotebook`
+    /// applies, so per-student instructor actions stay scoped to the roster.
+    private func resolveEnrolledStudent(
+        req: Request, assignment: APIAssignment
+    ) async throws -> APIUser {
+        guard let studentIDRaw = req.parameters.get("studentID"),
+            let studentID = UUID(uuidString: studentIDRaw),
+            let student = try await APIUser.find(studentID, on: req.db),
+            student.role == "student"
+        else {
+            throw WebAssignmentError.notFound(resource: "Student")
+        }
+        let isEnrolled =
+            try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == assignment.courseID)
+            .filter(\.$userID == studentID)
+            .count() > 0
+        guard isEnrolled else {
+            throw WebAssignmentError.notFound(resource: "Enrolled student")
+        }
+        return student
     }
 }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -52,6 +52,10 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post(":assignmentID", "submissions", ":submissionID", "retest", use: retestSubmission)
         r.post(":assignmentID", "retest", use: retestAllSubmissions)
         r.post(":assignmentID", "students", ":studentID", "reset-notebook", use: resetStudentNotebook)
+        r.post(":assignmentID", "students", ":studentID", "grade-override", use: saveStudentGradeOverride)
+        r.post(
+            ":assignmentID", "students", ":studentID", "grade-override", "delete",
+            use: deleteStudentGradeOverride)
         // Draft-assignment authoring (create page, save, publish, draft
         // suite / family / check / script / suite-section CRUD) lives on
         // `DraftAssignmentRoutes` (registered in routes.swift).

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -603,31 +603,14 @@ extension StudentCourseRoutes {
         let trimmedNote = body.note?.trimmingCharacters(in: .whitespacesAndNewlines)
         let note = (trimmedNote?.isEmpty == false) ? trimmedNote : nil
 
-        let existing = try await APIGradeOverride.query(on: req.db)
-            .filter(\.$testSetupID == testSetupID)
-            .filter(\.$userID == studentUUID)
-            .first()
-
-        if let existing {
-            existing.overridePercent = percent
-            existing.note = note
-            existing.grantedByUserID = actor.id
-            try await existing.save(on: req.db)
-        } else {
-            let row = APIGradeOverride(
-                testSetupID: testSetupID,
-                userID: studentUUID,
-                overridePercent: percent,
-                note: note,
-                grantedByUserID: actor.id
-            )
-            try await row.save(on: req.db)
-        }
-
-        // The override changes what BrightSpace should receive; re-flag the
-        // student's results so the next sweep re-pushes the new grade.
-        try await flagResultsPendingSync(
-            testSetupID: testSetupID, studentUserID: studentUUID, on: req.db)
+        try await applyGradeOverride(
+            testSetupID: testSetupID,
+            studentUserID: studentUUID,
+            percent: percent,
+            note: note,
+            grantedByUserID: actor.id,
+            on: req.db
+        )
 
         await AuditLogger.record(
             action: .gradeOverrideSet,
@@ -668,16 +651,9 @@ extension StudentCourseRoutes {
         }
         let testSetupID = assignment.testSetupID
 
-        let existing = try await APIGradeOverride.query(on: req.db)
-            .filter(\.$testSetupID == testSetupID)
-            .filter(\.$userID == studentUUID)
-            .first()
-        if let existing {
-            try await existing.delete(on: req.db)
-            // Clearing reverts BrightSpace to the runner-computed grade; re-flag
-            // the student's results so the next sweep re-pushes it.
-            try await flagResultsPendingSync(
-                testSetupID: testSetupID, studentUserID: studentUUID, on: req.db)
+        if try await clearGradeOverride(
+            testSetupID: testSetupID, studentUserID: studentUUID, on: req.db)
+        {
             await AuditLogger.record(
                 action: .gradeOverrideCleared,
                 targetType: .assignment,
@@ -696,32 +672,6 @@ extension StudentCourseRoutes {
                 urlToken: try student.requireURLToken()
             )
         )
-    }
-
-    /// Marks every result on one student's submissions for a test setup as
-    /// pending BrightSpace sync, so the debounced sweep re-pushes the grade
-    /// after an override is set or cleared.
-    fileprivate func flagResultsPendingSync(
-        testSetupID: String, studentUserID: UUID, on db: Database
-    ) async throws {
-        let submissionIDs = try await APISubmission.query(on: db)
-            .filter(\.$userID == studentUserID)
-            .filter(\.$testSetupID == testSetupID)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .all()
-            .compactMap(\.id)
-        guard !submissionIDs.isEmpty else { return }
-        let results = try await APIResult.query(on: db)
-            .filter(\.$submissionID ~~ submissionIDs)
-            .all()
-        let now = Date()
-        for result in results {
-            result.brightspaceSyncPending = true
-            if result.brightspacePendingSince == nil {
-                result.brightspacePendingSince = now
-            }
-            try await result.save(on: db)
-        }
     }
 }
 

--- a/Tests/APITests/GradeOverridesTests.swift
+++ b/Tests/APITests/GradeOverridesTests.swift
@@ -1,7 +1,8 @@
 // Tests/APITests/GradeOverridesTests.swift
 //
-// Coverage for the per-student grade override feature surfaced on the
-// grouped /:courseCode/students/:urlToken/submissions page.
+// Coverage for the per-student grade override feature, surfaced on both the
+// grouped /:courseCode/students/:urlToken/submissions page and the
+// per-assignment /instructor/:assignmentID/submissions roster.
 //
 //  * Override upsert (POST grade-override)        → one row, percent stored.
 //  * Override upsert (overwrite)                  → row updated, no duplicate.
@@ -9,6 +10,8 @@
 //  * Out-of-range percent is rejected            → no row written.
 //  * Setting an override re-flags the student's results for BrightSpace sync.
 //  * Grouped page renders the override value + "overridden" tag.
+//  * Instructor roster: set / update / delete via the UUID-keyed endpoint,
+//    out-of-range + unenrolled-student rejection, control rendered in-page.
 
 import Core
 import Fluent
@@ -374,6 +377,203 @@ import XCTVapor
                     #expect(body.contains("55%"), "Override grade must headline the submission page")
                     #expect(body.contains("overridden"), "Override must carry the tag")
                     #expect(body.contains("Autograded:"), "Autograde breakdown must be labelled")
+                }
+            )
+        }
+    }
+
+    // MARK: - Instructor per-assignment roster: set / clear control
+    //
+    // The same (test_setup, user) override, now reachable from the
+    // /instructor/:assignmentID/submissions roster keyed by the student's
+    // UUID (mirrors the sibling reset-notebook action), in addition to the
+    // grouped per-student page exercised above.
+
+    @Test func rosterOverridePostCreatesAndUpdatesRow() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "roster_ovr_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "roster_ovr_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "roster_ovr_setup", title: "Roster Override", isOpen: true, on: app
+            )
+            let studentUUID = try student.requireID()
+
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignment.publicID)/students/\(studentUUID.uuidString)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": csrf, "overridePercent": "88", "note": "Manual regrade"],
+                        as: .urlEncodedForm
+                    )
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(
+                        res.headers.first(name: .location)
+                            == "/instructor/\(assignment.publicID)/submissions",
+                        "Default redirect lands back on the roster"
+                    )
+                }
+            )
+
+            let saved = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "roster_ovr_setup")
+                .filter(\.$userID == studentUUID)
+                .all()
+            #expect(saved.count == 1, "Upsert must create exactly one row")
+            #expect(saved.first?.overridePercent == 88)
+            #expect(saved.first?.note == "Manual regrade")
+
+            // Second POST updates the same row in place.
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignment.publicID)/students/\(studentUUID.uuidString)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf, "overridePercent": "60"], as: .urlEncodedForm)
+                },
+                afterResponse: { _ in }
+            )
+            let updated = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "roster_ovr_setup")
+                .filter(\.$userID == studentUUID)
+                .all()
+            #expect(updated.count == 1, "Second POST must not create a duplicate")
+            #expect(updated.first?.overridePercent == 60)
+        }
+    }
+
+    @Test func rosterOverrideDeleteRemovesRow() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "roster_ovr_del", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "roster_ovr_del_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "roster_ovr_del_setup", title: "Roster Removable", isOpen: true, on: app
+            )
+            let studentUUID = try student.requireID()
+            try await APIGradeOverride(
+                testSetupID: "roster_ovr_del_setup", userID: studentUUID, overridePercent: 70
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignment.publicID)/students/\(studentUUID.uuidString)/grade-override/delete",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                }
+            )
+
+            let remaining = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "roster_ovr_del_setup")
+                .count()
+            #expect(remaining == 0, "Delete must remove the row")
+        }
+    }
+
+    @Test func rosterOverrideRejectsOutOfRangePercent() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let student = try await arInsertStudent(username: "roster_ovr_bad", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "roster_ovr_bad_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "roster_ovr_bad_setup", title: "Roster Bad", isOpen: true, on: app
+            )
+            let studentUUID = try student.requireID()
+
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignment.publicID)/students/\(studentUUID.uuidString)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf, "overridePercent": "150"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status != .seeOther, "Out-of-range percent must not succeed")
+                }
+            )
+            let count = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "roster_ovr_bad_setup")
+                .count()
+            #expect(count == 0, "Rejected override must not write a row")
+        }
+    }
+
+    @Test func rosterOverrideRejectsUnenrolledStudent() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            // Real user, deliberately NOT enrolled in TEST101 — exercises the
+            // enrollment gate rather than the "user missing" branch.
+            let stranger = try await arInsertStudent(username: "roster_ovr_stranger", on: app)
+            try await arInsertSetup(id: "roster_ovr_stranger_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "roster_ovr_stranger_setup", title: "Roster Stranger", isOpen: true, on: app
+            )
+            let strangerUUID = try stranger.requireID()
+
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignment.publicID)/students/\(strangerUUID.uuidString)/grade-override",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf, "overridePercent": "80"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .notFound)
+                }
+            )
+            let count = try await APIGradeOverride.query(on: app.db)
+                .filter(\.$testSetupID == "roster_ovr_stranger_setup")
+                .count()
+            #expect(count == 0, "Override for an unenrolled student must not be written")
+        }
+    }
+
+    @Test func rosterRendersOverrideControl() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            let student = try await arInsertStudent(username: "roster_ctrl_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "roster_ctrl_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "roster_ctrl_setup", title: "Roster Ctrl", isOpen: true, on: app
+            )
+            let studentUUID = try student.requireID()
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/submissions",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(
+                        body.contains(
+                            "/instructor/\(assignment.publicID)/students/\(studentUUID.uuidString)/grade-override"
+                        ),
+                        "Roster must render the per-student override form action"
+                    )
+                    #expect(body.contains("Override grade (%)"), "Override form must be present")
                 }
             )
         }

--- a/changelog.d/grade-override-roster.md
+++ b/changelog.d/grade-override-roster.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Grade override on the per-assignment roster.** The instructor's
+  `/instructor/:assignmentID/submissions` page now carries the same set/clear
+  grade-override control that the per-student page already had — an inline
+  pencil-icon form per student row (override percent + optional note, with a
+  Clear button once one is set). The roster already displayed overrides and
+  folded them into the median; it can now edit them too. Both sites resolve to
+  the same `(test_setup, user)` row through shared `applyGradeOverride` /
+  `clearGradeOverride` helpers, so an override set from either page is identical
+  and continues to replace the runner-computed grade everywhere (roster median,
+  grades CSV, BrightSpace sync, submission view).


### PR DESCRIPTION
## What & why

The grade-override feature was reachable from only one place — the grouped
per-student page (`/:courseCode/students/:urlToken/submissions`). The
instructor's per-assignment roster (`/instructor/:assignmentID/submissions`)
**displayed** an override (the "overridden" tag) and folded it into the median,
but had no way to **set or clear** one. This adds that control for consistency.

Scope was confirmed with the requester as **roster only** — the submission
detail page (`/submissions/:id`) stays display-only.

## What changed

- **Shared helpers (`GradeOverrideHelpers.swift`).** Extracted `applyGradeOverride`,
  `clearGradeOverride`, and `flagGradeResultsPendingSync` as free functions so
  every override-setting site mutates the same `(test_setup, user)` row with the
  same side effects (most importantly re-flagging the student's results for
  BrightSpace re-sync). The existing per-student handlers in
  `StudentCourseRoutes+History.swift` now call these instead of inline logic
  (its `fileprivate flagResultsPendingSync` is removed) — no behaviour change.
- **New instructor endpoints.**
  `POST /instructor/:assignmentID/students/:studentID/grade-override` and
  `.../grade-override/delete`, keyed by the student's UUID like the sibling
  `reset-notebook` action, gated on course enrollment + `role == "student"`,
  with `returnTo` support and audit logging (`gradeOverrideSet` / `Cleared`).
- **Roster UI (`assignment-submissions.leaf`).** An inline pencil-icon
  `<details>` form per row (override % + optional note; Clear button once one is
  set), matching the per-student page. Added the `.ext-summary`/`.ext-details`
  styles locally (they live inline on the per-student page, not in `styles.css`).
- **Context.** `AssignmentStudentRow.gradeOverridePercent` for the form prefill
  (override % → runner best → 0).

Because both sites resolve to the same row, an override set from either page is
identical and continues to replace the runner-computed grade everywhere the
existing helpers already covered: roster median, grades CSV, BrightSpace sync,
and the submission view.

## Tests

`GradeOverridesTests` extended with 5 cases for the roster endpoints (upsert,
update-in-place, delete, out-of-range rejection, unenrolled-student rejection,
in-page control render). Full suite: **13/13 passing**. `swift-format --strict`
and `SwiftLint --strict` both clean; APIServer builds.

## Notes

- No migration — reuses the existing `grade_overrides` table.
- Changelog fragment added under `changelog.d/` (no `VERSION`/`CHANGELOG.md`
  edits, per the release process).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QXAi32zdroeTTuNjvf98bT)_