### PR TITLE
Report all-tier grade from the results API

### DIFF
--- a/Sources/APIServer/Helpers/TierFilter.swift
+++ b/Sources/APIServer/Helpers/TierFilter.swift
@@ -43,6 +43,34 @@ extension TestOutcomeCollection {
             timestamp: timestamp
         )
     }
+
+    /// Returns a copy with `outcomes` swapped out but every aggregate field
+    /// (counts, points, build status, metadata) left intact.  Used by the
+    /// results API so the response carries the real all-tier grade while
+    /// listing only the caller-visible outcomes — the aggregates therefore may
+    /// not sum to `outcomes`, by design.
+    func replacingOutcomes(with newOutcomes: [TestOutcome]) -> TestOutcomeCollection {
+        TestOutcomeCollection(
+            submissionID: submissionID,
+            testSetupID: testSetupID,
+            attemptNumber: attemptNumber,
+            buildStatus: buildStatus,
+            compilerOutput: compilerOutput,
+            outcomes: newOutcomes,
+            totalTests: totalTests,
+            passCount: passCount,
+            failCount: failCount,
+            errorCount: errorCount,
+            timeoutCount: timeoutCount,
+            executionTimeMs: executionTimeMs,
+            totalPoints: totalPoints,
+            earnedPoints: earnedPoints,
+            warnings: warnings,
+            jobStartedAt: jobStartedAt,
+            runnerVersion: runnerVersion,
+            timestamp: timestamp
+        )
+    }
 }
 
 // MARK: - Tier visibility policy

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -86,27 +86,39 @@ struct SubmissionQueryRoutes: RouteCollection {
         decoder.dateDecodingStrategy = .iso8601
         guard
             let data = result.collectionJSON.data(using: .utf8),
-            var collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+            let fullCollection = try? decoder.decode(TestOutcomeCollection.self, from: data)
         else {
             throw AppError.internalFailure(reason: "Stored result is corrupt")
         }
 
-        // Enforce deadline-based tier visibility first, then honour any ?tiers= filter.
+        // `fullCollection` carries the real grade across every tier.  The caller
+        // may only *inspect* certain outcomes: secret never, release after the
+        // deadline (instructors see all tiers).
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == submission.testSetupID)
             .first()
-        collection = collection.filtering(tiers: visibleTiers(for: caller, assignment: assignment))
+        let visible = fullCollection.filtering(tiers: visibleTiers(for: caller, assignment: assignment))
 
-        // Optional additional tier filter: ?tiers=public,release
+        let responseCollection: TestOutcomeCollection
         if let tiersParam = req.query[String.self, at: "tiers"] {
+            // Explicit tier slice (?tiers=public,release): return a
+            // self-consistent sub-collection — aggregates recomputed over the
+            // requested ∩ visible tiers.
             let requested = Set(tiersParam.split(separator: ",").map(String.init))
-            collection = collection.filtering(tiers: requested)
+            responseCollection = visible.filtering(tiers: requested)
+        } else {
+            // Default: aggregates report the full all-tier grade (matching the
+            // dashboard and submission page), while `outcomes` lists only the
+            // results the caller may inspect.  The counts can exceed
+            // `outcomes.count` — the intended "real grade, partial detail" shape,
+            // identical to the web view.
+            responseCollection = fullCollection.replacingOutcomes(with: visible.outcomes)
         }
 
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = .sortedKeys
-        let responseData = try encoder.encode(collection)
+        let responseData = try encoder.encode(responseCollection)
 
         return Response(
             status: .ok,

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -689,4 +689,88 @@ import XCTVapor
 
         }
     }
+
+    /// Default response: the grade aggregates span EVERY tier (the real grade,
+    /// matching the dashboard / submission page), while `outcomes` lists only
+    /// the results the student may inspect.  The counts intentionally exceed
+    /// `outcomes.count` — this is the fix for the API re-introducing the
+    /// visible-only-grade drift.
+    @Test func getResultsGradeSpansAllTiersWhileHidingOutcomes() async throws {
+        try await withApp(app) { _ in
+            let setupID = "setup_alltier_grade"
+            let username = "student_atg"
+            let cookie = try await loginAsStudent(username: username)
+            let student = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == username).first())
+            try await ensureAssignment(setupID: setupID, dueAt: Date().addingTimeInterval(3600))  // future
+            try await insertSubmission(id: "sub_atg", testSetupID: setupID, userID: student.id)
+            let collection = makeCollection(
+                submissionID: "sub_atg",
+                outcomes: [
+                    makeOutcome(name: "test_pub", tier: .pub, status: .pass),
+                    makeOutcome(name: "test_release", tier: .release, status: .fail),
+                    makeOutcome(name: "test_secret", tier: .secret, status: .fail),
+                ]
+            )
+            try await insertResult(submissionID: "sub_atg", collection: collection)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_atg/results",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try self.decodeCollection(from: res.body)
+                    // Grade aggregates span every tier (the real grade).
+                    #expect(body.totalTests == 3)
+                    #expect(body.passCount == 1)
+                    #expect(body.failCount == 2)
+                    #expect(body.totalPoints == 3)
+                    #expect(body.earnedPoints == 1)
+                    // …but only the public outcome is listed (release hidden
+                    // before the deadline, secret never).
+                    #expect(body.outcomes.count == 1)
+                    #expect(body.outcomes[0].testName == "test_pub")
+                    #expect(body.outcomes.contains { $0.tier == .release } == false)
+                    #expect(body.outcomes.contains { $0.tier == .secret } == false)
+                })
+
+        }
+    }
+
+    /// An explicit `?tiers=` slice still returns a self-consistent
+    /// sub-collection (aggregates recomputed over the requested ∩ visible
+    /// tiers), so power-user slicing is unaffected by the all-tier default.
+    @Test func getResultsExplicitTierSliceIsSelfConsistent() async throws {
+        try await withApp(app) { _ in
+            let setupID = "setup_slice"
+            let username = "student_slice"
+            let cookie = try await loginAsStudent(username: username)
+            let student = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == username).first())
+            try await ensureAssignment(setupID: setupID, dueAt: Date().addingTimeInterval(3600))
+            try await insertSubmission(id: "sub_slice", testSetupID: setupID, userID: student.id)
+            let collection = makeCollection(
+                submissionID: "sub_slice",
+                outcomes: [
+                    makeOutcome(name: "test_pub", tier: .pub, status: .pass),
+                    makeOutcome(name: "test_release", tier: .release, status: .fail),
+                    makeOutcome(name: "test_secret", tier: .secret, status: .fail),
+                ]
+            )
+            try await insertResult(submissionID: "sub_slice", collection: collection)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_slice/results?tiers=public",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try self.decodeCollection(from: res.body)
+                    #expect(body.outcomes.count == 1)
+                    #expect(body.totalTests == 1)
+                    #expect(body.passCount == 1)
+                    #expect(body.failCount == 0)
+                })
+
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #821 (the dashboard/submission grade-consistency fix), as flagged in that PR.

## Problem

`GET /api/v1/submissions/:id/results` recomputed its aggregate counts/points over the *caller-visible* tiers (via `filtering(tiers: visibleTiers(...))`), so a student fetching results over the API saw a **visible-only grade** — re-introducing at the API layer the exact dashboard-vs-submission drift #821 fixed for the web.

## Fix

The **default** response now reports the real **all-tier grade** in the aggregate fields (`totalTests`, `passCount`, `failCount`, `errorCount`, `timeoutCount`, `totalPoints`, `earnedPoints`), while `outcomes` still lists only the results the caller may inspect (secret never; release after the deadline; instructors see all). The counts can exceed `outcomes.count` **by design** — the API analog of the web view's "all-tier headline grade + partial rows + secret aggregate".

An explicit **`?tiers=` slice** is unchanged: it still returns a self-consistent sub-collection (aggregates recomputed over the requested ∩ visible tiers), so power-user tier slicing keeps working exactly as before.

### Changes
- `TierFilter.swift` — new `replacingOutcomes(with:)` helper (swap the outcomes array, keep the aggregates).
- `SubmissionQueryRoutes.swift` — default path returns all-tier aggregates + visible outcomes; `?tiers=` path returns a self-consistent slice.

## Tests
- New: `getResultsGradeSpansAllTiersWhileHidingOutcomes` (student pre-deadline sees the all-tier grade in the aggregates but only the public outcome in `outcomes`) and `getResultsExplicitTierSliceIsSelfConsistent` (the `?tiers=` slice stays self-consistent).
- All 19 existing `SubmissionQueryRoutes` tests pass unchanged — the `?tiers=` behavior they pin is preserved.
- `swift-format`, SwiftLint `--strict` (0 violations), build, and the suite all pass locally against the current `main`.

https://claude.ai/code/session_01Y1H2h4TnYWyjHpiFTUqsue

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1H2h4TnYWyjHpiFTUqsue)_