### PR TITLE
mcp: close assignment on content edits; audit doc + consistency fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -849,7 +849,7 @@ model quickly.
   only emitted `enrollmentMode` (never `openEnrollment`) since the
   helper extraction in #501.
 
-### v0.4.171 – v0.4.318 highlights (themed digest)
+### v0.4.171 – v0.4.350 highlights (themed digest)
 
 The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
 
@@ -897,6 +897,29 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
   worked example).  Plus OAuth `no-store` headers, reaper consumed-row cleanup,
   an `oauth_grants.previous_refresh_token_hash` index, a `timedOut`
   output-contract case, and `@unchecked Sendable` justification comments.
+
+- **MCP authoring-surface expansion (v0.4.328+).**  The agent tool catalog grew
+  from twelve to twenty content tools (`MCPToolCatalog.live`): `get_server_info`
+  (version/capability probe), `get_solution` / `update_solution` (read + replace
+  the reference solution, re-validating), `author_script` (create/replace a
+  hand-written test or support file through the same `applySuiteEdit` path the
+  web editor uses), and the personalization tools (`get_global_inputs`,
+  `update_global_inputs`, `update_section_variables`, `preview_personalization`).
+  `get_suite` now returns the full source of truth (script bodies + complete
+  pattern-family/notebook-check specs + on-disk filenames), and pattern-family
+  cases gained a per-student `expectedVarRef` (the worker/browser materialize
+  per-student `_ck_inputs.py` from `Job.personalizedInputs`).  Agent-facing
+  copy lives in two places that must stay in sync with the catalog: each tool's
+  `description`/`inputSchema` and the server-level `MCPServerInstructions.text`
+  (the `initialize` handshake's `instructions`); the tool table in
+  `docs/mcp-authoring-roadmap.md` is the human index.  MCP content edits
+  (suite/family/script/notebook/solution) close a currently-open assignment and
+  re-validate — matching the web Save button (`saveEditedAssignment`), since the
+  student gate keys off `isOpen`, not `validationStatus` — so students can't
+  submit against a not-yet-revalidated suite; each write tool's response reports
+  it as `assignmentClosed`, and the human re-opens with
+  `update_assignment(isOpen:true)` once validation passes
+  (`closeOpenAssignmentForContentEdit`).
 
 **Near-term roadmap:**
 

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -109,12 +109,17 @@ enum MCPServerInstructions {
         update_section_variables (a section's scoped variables/expressions), update_notebook (replace \
         the starter notebook), update_solution (replace the reference solution and re-validate), \
         author_script (create/replace a hand-written test or support file). To create a new \
-        assignment, clone_assignment from a known-good one and then edit the copy.
+        assignment, either clone_assignment from a known-good one and then edit the copy (the safest \
+        path) or create_assignment to start a fresh notebook-based assignment from a starter .ipynb.
 
         Important behaviors:
-        - Any content edit (suite, pattern family, notebook) re-runs validation asynchronously; \
-        re-read get_assignment to see validationStatus settle. Metadata-only edits via \
-        update_assignment never trigger a regrade.
+        - Any content edit (suite, pattern family, notebook, solution) re-runs validation \
+        asynchronously AND closes the assignment if it was open (each write tool's response reports \
+        this as `assignmentClosed`), so students can't submit against a not-yet-revalidated suite. \
+        Call validate_assignment to wait for the terminal status (passed/failed/no-runner, with live \
+        queued -> running -> done progress over an SSE connection), then re-open with \
+        update_assignment(isOpen:true) once it passes (opening is refused until it does). \
+        Metadata-only edits via update_assignment never trigger a regrade or a close.
         - update_notebook replaces only the starter notebook; students keep their in-progress copies \
         and pick up the new notebook when their copy is next reset. Call get_notebook first and edit \
         the returned JSON.

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -50,6 +50,9 @@ struct AuthorScriptTool: ContentTool {
         /// The assignment's validation status; the edit re-kicks validation
         /// asynchronously, so re-read get_assignment to see it settle.
         let validationStatus: String?
+        /// true when this edit closed a previously-open assignment (re-open with
+        /// update_assignment once validation passes).
+        let assignmentClosed: Bool
     }
 
     static let name = "author_script"
@@ -62,7 +65,8 @@ struct AuthorScriptTool: ContentTool {
         + "public test). For test tiers you may also set points, displayName, dependsOn (prerequisite "
         + "script names or family:<id> tokens), and sectionID (an existing section). Cannot edit "
         + "pattern-family or notebook-check generated scripts — edit the family/check instead. Saving "
-        + "re-runs the assignment's validation."
+        + "re-runs the assignment's validation and closes the assignment if it was open (re-open with "
+        + "update_assignment once validation passes)."
 
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
@@ -125,10 +129,11 @@ struct AuthorScriptTool: ContentTool {
             "isTest": .object(["type": .string("boolean")]),
             "created": .object(["type": .string("boolean")]),
             "validationStatus": .object(["type": .string("string")]),
+            "assignmentClosed": .object(["type": .string("boolean")]),
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("filename"), .string("tier"),
-            .string("isTest"), .string("created"),
+            .string("isTest"), .string("created"), .string("assignmentClosed"),
         ]),
     ])
 
@@ -233,8 +238,11 @@ struct AuthorScriptTool: ContentTool {
                 setup: setup, context: context)
         }
 
-        // Re-kick validation against the new manifest/zip (debounced), mirroring
+        // Close a currently-open assignment (matching the web Save button) so
+        // students can't submit against the not-yet-revalidated suite, then
+        // re-kick validation against the new manifest/zip (debounced), mirroring
         // the web suite/script edit handlers.
+        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
         await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
 
         return Output(
@@ -243,7 +251,8 @@ struct AuthorScriptTool: ContentTool {
             tier: resolved.wireValue,
             isTest: resolved.isTest,
             created: !existedInZip,
-            validationStatus: assignment.validationStatus)
+            validationStatus: assignment.validationStatus,
+            assignmentClosed: closed)
     }
 
     // MARK: - Test-script authoring (suite-payload path)

--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -1,0 +1,34 @@
+// APIServer/MCP/Tools/ContentEditClose.swift
+//
+// Shared post-edit step for the MCP content-authoring write tools.
+//
+// A content edit (suite metadata, pattern family, raw script, starter notebook,
+// or reference solution) can change what the suite grades, so it re-runs
+// validation — and, matching the web "Save" button (`saveEditedAssignment`,
+// which sets `isOpen = false` on every save), it CLOSES a currently-open
+// assignment. The student submission gate (`isAssignmentOpenForUser`) keys off
+// `isOpen`, not `validationStatus`, so leaving an edited assignment open would
+// let students submit against a not-yet-revalidated — possibly broken — suite.
+// Closing holds them out until the instructor re-opens with
+// `update_assignment(isOpen: true)`, which is itself refused until validation
+// passes.
+//
+// This is persisted as its own save rather than folded into
+// `scheduleValidationAfterSuiteEdit`: that helper is debounced and skips its own
+// save when a validation is already pending, and it is *also* the web suite
+// editor's path, where the live-edit UX deliberately does not close.
+
+import Fluent
+
+/// Closes `assignment` if it is currently open, persisting the change, and
+/// reports whether it did. A no-op returning `false` when already closed, so a
+/// tool can surface "did this edit close the assignment" to the agent.
+@discardableResult
+func closeOpenAssignmentForContentEdit(
+    _ assignment: APIAssignment, on db: any Database
+) async throws -> Bool {
+    guard assignment.isOpen else { return false }
+    assignment.isOpen = false
+    try await assignment.save(on: db)
+    return true
+}

--- a/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
@@ -29,15 +29,20 @@ struct UpdateNotebookTool: ContentTool {
         let assignmentPublicID: String
         let cellCount: Int
         let validationStatus: String?
+        /// true when this edit closed a previously-open assignment (re-open with
+        /// update_assignment once validation passes).
+        let assignmentClosed: Bool
     }
 
     static let name = "update_notebook"
     static let description =
         "Replace an assignment's starter notebook (the notebook students open) with new .ipynb JSON, "
         + "by assignment public ID. Supply the full notebook as a JSON object with a \"cells\" array; "
-        + "the server normalizes it for the in-browser kernel and re-runs validation. Only the starter "
-        + "notebook changes — existing students keep their in-progress work and pick up the new notebook "
-        + "when their copy is next reset. Use get_notebook first to fetch the current notebook to edit."
+        + "the server normalizes it for the in-browser kernel and re-runs validation, closing the "
+        + "assignment if it was open (re-open with update_assignment once validation passes). Only the "
+        + "starter notebook changes — existing students keep their in-progress work and pick up the new "
+        + "notebook when their copy is next reset. Use get_notebook first to fetch the current notebook "
+        + "to edit."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -61,8 +66,11 @@ struct UpdateNotebookTool: ContentTool {
             "assignmentPublicID": .object(["type": .string("string")]),
             "cellCount": .object(["type": .string("integer")]),
             "validationStatus": .object(["type": .string("string")]),
+            "assignmentClosed": .object(["type": .string("boolean")]),
         ]),
-        "required": .array([.string("assignmentPublicID"), .string("cellCount")]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("cellCount"), .string("assignmentClosed"),
+        ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: true, idempotentHint: true)
@@ -104,12 +112,17 @@ struct UpdateNotebookTool: ContentTool {
             throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
         }
 
+        // Close a currently-open assignment (matching the web Save button) so
+        // students can't submit against the not-yet-revalidated suite, then
+        // re-kick validation (debounced).
+        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
         await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
 
         return Output(
             assignmentPublicID: assignment.publicID,
             cellCount: Self.cellCount(of: input.notebook),
-            validationStatus: assignment.validationStatus)
+            validationStatus: assignment.validationStatus,
+            assignmentClosed: closed)
     }
 
     /// A notebook must be a JSON object carrying a `cells` array — the minimal

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -91,6 +91,9 @@ struct UpdatePatternFamilyTool: ContentTool {
         /// Keys of cases whose args/expected were edited by this call.
         let editedCaseKeys: [String]
         let validationStatus: String?
+        /// true when this edit closed a previously-open assignment (re-open with
+        /// update_assignment once validation passes).
+        let assignmentClosed: Bool
     }
 
     static let name = "update_pattern_family"
@@ -101,7 +104,8 @@ struct UpdatePatternFamilyTool: ContentTool {
         + "(each { key, args?, expected? }). args/expected are raw JSON values (a list of args in "
         + "parameter order, and the expected return). Saving regenerates the family's scripts and "
         + "re-runs validation, which rejects a wrong arg count or an expected value of the wrong shape "
-        + "for the family's kind. Family ids and case keys come from get_suite."
+        + "for the family's kind. Saving also closes the assignment if it was open (re-open with "
+        + "update_assignment once validation passes). Family ids and case keys come from get_suite."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -182,10 +186,12 @@ struct UpdatePatternFamilyTool: ContentTool {
                 "type": .string("array"), "items": .object(["type": .string("string")]),
             ]),
             "validationStatus": .object(["type": .string("string")]),
+            "assignmentClosed": .object(["type": .string("boolean")]),
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("familyID"), .string("defaultTier"),
             .string("defaultPoints"), .string("enabledCaseKeys"), .string("editedCaseKeys"),
+            .string("assignmentClosed"),
         ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
@@ -255,6 +261,10 @@ struct UpdatePatternFamilyTool: ContentTool {
         } catch let error as any AbortError {
             throw MCPToolError.from(error, tool: Self.name)
         }
+        // Close a currently-open assignment (matching the web Save button) so
+        // students can't submit against the not-yet-revalidated suite, then
+        // re-kick validation (debounced).
+        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
         await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
 
         return Output(
@@ -264,7 +274,8 @@ struct UpdatePatternFamilyTool: ContentTool {
             defaultPoints: updatedFamily.defaults.points,
             enabledCaseKeys: updatedFamily.cases.filter(\.enabled).map(\.key),
             editedCaseKeys: editsByKey.keys.sorted(),
-            validationStatus: assignment.validationStatus)
+            validationStatus: assignment.validationStatus,
+            assignmentClosed: closed)
     }
 
     /// Indexes case edits by key, rejecting duplicates so the last-write-wins

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -31,6 +31,9 @@ struct UpdateSolutionTool: ContentTool {
         let assignmentPublicID: String
         let cellCount: Int
         let validationStatus: String?
+        /// true when this edit closed a previously-open assignment (re-open with
+        /// update_assignment once validation passes).
+        let assignmentClosed: Bool
     }
 
     static let name = "update_solution"
@@ -39,7 +42,8 @@ struct UpdateSolutionTool: ContentTool {
         + "validate the test suite) with new .ipynb JSON, by assignment public ID. Supply the full "
         + "notebook as a JSON object with a \"cells\" array; the server stores it as a new validation "
         + "submission and re-runs validation against the current suite (watch the result with "
-        + "validate_assignment). This is instructor-authored content — it never touches student "
+        + "validate_assignment), closing the assignment if it was open (re-open with update_assignment "
+        + "once validation passes). This is instructor-authored content — it never touches student "
         + "submissions, and never the starter notebook (use update_notebook for that). Use get_solution "
         + "first to fetch the current solution to edit."
     static let inputSchema: JSONValue = .object([
@@ -65,8 +69,11 @@ struct UpdateSolutionTool: ContentTool {
             "assignmentPublicID": .object(["type": .string("string")]),
             "cellCount": .object(["type": .string("integer")]),
             "validationStatus": .object(["type": .string("string")]),
+            "assignmentClosed": .object(["type": .string("boolean")]),
         ]),
-        "required": .array([.string("assignmentPublicID"), .string("cellCount")]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("cellCount"), .string("assignmentClosed"),
+        ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: true, idempotentHint: true)
@@ -108,6 +115,11 @@ struct UpdateSolutionTool: ContentTool {
                 tool: Self.name, detail: "Could not store the solution for validation: \(error)")
         }
 
+        // Close a currently-open assignment (matching the web Save button) so
+        // students can't submit against the not-yet-revalidated solution/suite;
+        // folded into the same save as the validation-status flip.
+        let closed = assignment.isOpen
+        assignment.isOpen = false
         assignment.validationSubmissionID = validationSubmissionID
         assignment.validationStatus = "pending"
         try await assignment.save(on: context.db)
@@ -115,7 +127,8 @@ struct UpdateSolutionTool: ContentTool {
         return Output(
             assignmentPublicID: assignment.publicID,
             cellCount: Self.cellCount(of: input.notebook),
-            validationStatus: assignment.validationStatus)
+            validationStatus: assignment.validationStatus,
+            assignmentClosed: closed)
     }
 
     /// A notebook must be a JSON object carrying a `cells` array — the minimal

--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -38,6 +38,9 @@ struct UpdateSuiteTool: ContentTool {
         let updatedScripts: [String]
         /// The assignment's validation status after the edit re-kicks validation.
         let validationStatus: String?
+        /// true when this edit closed a previously-open assignment (re-open with
+        /// update_assignment once validation passes).
+        let assignmentClosed: Bool
     }
 
     static let name = "update_suite"
@@ -45,7 +48,8 @@ struct UpdateSuiteTool: ContentTool {
         "Edit test-suite script metadata for an assignment, by its public ID. For each named "
         + "script provide any of: tier (public/release/secret/student), points, displayName, "
         + "dependsOn (prerequisite script names), and sectionID (\"\" to ungroup). Does NOT change "
-        + "script content or pattern families. Saving re-runs the assignment's validation."
+        + "script content or pattern families. Saving re-runs the assignment's validation and closes "
+        + "the assignment if it was open (re-open with update_assignment once validation passes)."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -95,8 +99,11 @@ struct UpdateSuiteTool: ContentTool {
                 "type": .string("array"), "items": .object(["type": .string("string")]),
             ]),
             "validationStatus": .object(["type": .string("string")]),
+            "assignmentClosed": .object(["type": .string("boolean")]),
         ]),
-        "required": .array([.string("assignmentPublicID"), .string("updatedScripts")]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("updatedScripts"), .string("assignmentClosed"),
+        ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
         readOnlyHint: false, destructiveHint: false, idempotentHint: true)
@@ -142,14 +149,17 @@ struct UpdateSuiteTool: ContentTool {
         }
 
         try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        // Re-kick validation against the edited manifest (debounced), mirroring
-        // the web PUT /suite handler.
+        // Close a currently-open assignment (matching the web Save button) so
+        // students can't submit against the not-yet-revalidated suite, then
+        // re-kick validation against the edited manifest (debounced).
+        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
         await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
 
         return Output(
             assignmentPublicID: assignment.publicID,
             updatedScripts: updated,
-            validationStatus: assignment.validationStatus)
+            validationStatus: assignment.validationStatus,
+            assignmentClosed: closed)
     }
 
     private static func parseTier(_ raw: String?) throws -> TestTier? {

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -553,16 +553,20 @@ extension WorkerDaemon {
         // grading workspace as `_ck_inputs.py`, so generated pattern-family
         // scripts that reference per-student args / expected can load them by
         // path. Each value is already a Python literal (`repr`) resolved
-        // server-side. The filename is reserved (excluded from student-module
-        // candidates in test_runtime), so it can't be mistaken for the
-        // submission.
+        // server-side; keys are emitted as escaped Python string literals via
+        // `JSONValue.string(_:).pythonLiteral` — the same canonical escaping the
+        // renderer's reader and the browser path (`JSON.stringify`) use, so the
+        // three stay byte-for-byte consistent (input names are validated
+        // identifiers today, so this is defense in depth). The filename is
+        // reserved (excluded from student-module candidates in test_runtime), so
+        // it can't be mistaken for the submission.
         if let inputs = job.personalizedInputs, !inputs.isEmpty {
             var lines = [
                 "# Auto-generated per-student grading inputs (issue #461). Do not edit.",
                 "_ck = {",
             ]
             for key in inputs.keys.sorted() {
-                lines.append("    \"\(key)\": \(inputs[key] ?? "None"),")
+                lines.append("    \(JSONValue.string(key).pythonLiteral): \(inputs[key] ?? "None"),")
             }
             lines.append("}")
             let source = lines.joined(separator: "\n") + "\n"

--- a/Tests/APITests/MCP/UpdateSolutionToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSolutionToolTests.swift
@@ -75,6 +75,37 @@ import Vapor
         }
     }
 
+    @Test func closesOpenAssignmentOnEdit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)  // makeTestAssignment defaults isOpen: true
+            #expect(assignment.isOpen)
+            let output = try await UpdateSolutionTool().execute(
+                UpdateSolutionTool.Input(
+                    assignmentPublicID: assignment.publicID, notebook: try json(twoCellSolution)),
+                context(app))
+            #expect(output.assignmentClosed)
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(!reloaded.isOpen)
+        }
+    }
+
+    @Test func leavesClosedAssignmentClosed() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            assignment.isOpen = false
+            try await assignment.save(on: app.db)
+            let output = try await UpdateSolutionTool().execute(
+                UpdateSolutionTool.Input(
+                    assignmentPublicID: assignment.publicID, notebook: try json(twoCellSolution)),
+                context(app))
+            #expect(!output.assignmentClosed)
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(!reloaded.isOpen)
+        }
+    }
+
     @Test func roundTripsWithGetSolution() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/UpdateSuiteToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSuiteToolTests.swift
@@ -113,6 +113,47 @@ import Vapor
         }
     }
 
+    @Test func closesOpenAssignmentOnEdit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)  // makeTestAssignment defaults isOpen: true
+            #expect(assignment.isOpen)
+            let output = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [
+                        UpdateSuiteTool.ScriptEdit(
+                            script: "test_a.sh", tier: "secret", points: nil, displayName: nil,
+                            dependsOn: nil, sectionID: nil)
+                    ]),
+                context(app))
+            #expect(output.assignmentClosed)
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(!reloaded.isOpen)
+        }
+    }
+
+    @Test func leavesClosedAssignmentClosed() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            assignment.isOpen = false
+            try await assignment.save(on: app.db)
+            let output = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [
+                        UpdateSuiteTool.ScriptEdit(
+                            script: "test_a.sh", tier: "secret", points: nil, displayName: nil,
+                            dependsOn: nil, sectionID: nil)
+                    ]),
+                context(app))
+            #expect(!output.assignmentClosed)
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(!reloaded.isOpen)
+        }
+    }
+
     @Test func unknownScriptThrows() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/changelog.d/mcp-content-edit-close.md
+++ b/changelog.d/mcp-content-edit-close.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **MCP content edits now close an open assignment.** Editing an assignment's
+  suite, pattern family, hand-written script (`author_script`), starter notebook,
+  or reference solution through the MCP server now closes a currently-open
+  assignment and re-runs validation — matching the web "Save" button — so
+  students can't submit against a not-yet-revalidated suite. Each write tool's
+  response reports it as `assignmentClosed`; the instructor re-opens with
+  `update_assignment(isOpen: true)` once validation passes. The agent-facing
+  `initialize` instructions and tool descriptions document the behavior, and now
+  also name the `validate_assignment` and `create_assignment` tools.
+
+### Fixed
+
+- **Per-student grading inputs (`_ck_inputs.py`).** The native worker now emits
+  the personalization dict keys as escaped Python string literals (matching the
+  browser runner's `JSON.stringify` and the script renderer), keeping the three
+  materialization paths byte-for-byte consistent.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -20,21 +20,29 @@ added in the `mcp-course-scoping-and-hardening` work, PR #704).
 The original vertical slice (two tools, proving the auth/transport/dispatch
 pipeline) has grown into the full feature. The live tool catalog
 (`MCPToolCatalog.live` in
-`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) now ships twelve
+`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) now ships twenty
 tools, all `content:read` / `content:write` scoped and course-scoped:
 
 | Tool | Scope | Capability |
 |------|-------|------------|
 | `list_courses` | `content:read` | Courses the subject may act on |
+| `get_server_info` | `content:read` | Deployed version + MCP mode/advertised scopes (liveness + capability probe) |
 | `list_assignments` | `content:read` | A course's assignments (id, title, slug, open/closed, due date) |
 | `get_assignment` | `content:read` | One assignment's full detail |
 | `get_suite` | `content:read` | Full test-suite definition: items, tiers, points, deps, sections, plus each script's raw body, each family's full spec (cases' args/expected), and each notebook check's spec |
 | `get_notebook` | `content:read` | The starter notebook (.ipynb JSON) |
+| `get_solution` | `content:read` | The reference solution notebook (.ipynb JSON), resolved from the validation submission |
+| `get_global_inputs` | `content:read` | Assignment personalization: global variables + per-student expressions |
+| `preview_personalization` | `content:read` | Resolve a seed's `name → value` map + a starter-notebook `{{placeholder}}` audit |
 | `validate_assignment` | `content:read` | Watch validation to completion; live SSE progress |
 | `update_assignment` | `content:write` | Metadata: title, due date, open/close |
 | `update_suite` | `content:write` | Script metadata: tier, points, displayName, dependsOn, section |
-| `update_pattern_family` | `content:write` | Family defaults + per-case enable/disable |
+| `update_global_inputs` | `content:write` | Replace the assignment's global personalization variables/expressions |
+| `update_section_variables` | `content:write` | Replace a section's scoped variables/expressions |
+| `update_pattern_family` | `content:write` | Family defaults + per-case args/expected (incl. per-student `$ref`s), enable/disable |
 | `update_notebook` | `content:write` | Replace the starter notebook |
+| `update_solution` | `content:write` | Replace the reference solution and re-validate |
+| `author_script` | `content:write` | Create/replace a hand-written test or support file |
 | `clone_assignment` | `content:write` | Duplicate an assignment (closed, unvalidated) |
 | `create_assignment` | `content:write` | New notebook-based assignment from scratch |
 


### PR DESCRIPTION
## Why

Audit follow-ups for the recent MCP authoring-tool expansion (PRs #795–#820). The recent work is solid — every new tool is registered, `content:*`-scoped, course-scoped, audited, schema'd, and tested — but the audit surfaced a few loose ends, plus one behavioral gap that affects students.

## The behavioral gap (main change)

The web **Save button** (`saveEditedAssignment`) closes an assignment on every save (`isOpen = false`). The web **suite editor** (`PUT /suite`) and **all MCP content tools** did **not** close. Because the student submission gate (`isAssignmentOpenForUser`) keys off `isOpen` — **not** `validationStatus` — an open assignment edited via MCP stayed *submittable during the async re-validation window*: students could submit against a freshly-edited, not-yet-validated (possibly broken) suite.

This PR aligns the MCP content tools with the Save button: **a content edit on an open assignment now closes it and re-runs validation.**

- Tools affected: `update_suite`, `update_pattern_family`, `author_script`, `update_notebook`, `update_solution`.
- New shared helper `closeOpenAssignmentForContentEdit` (persisted independently — `scheduleValidationAfterSuiteEdit` is debounced and skips its own save when a validation is already pending).
- `update_assignment` is unchanged: it's metadata-only and only touches `isOpen` when explicitly asked, so it never closes.
- Each write tool's response now reports `assignmentClosed`; the instructor re-opens with `update_assignment(isOpen: true)` once validation passes (opening is already refused until it does).

## Agent-facing docs

- `MCPServerInstructions.text` (the `initialize` handshake) now documents the close-on-edit behavior **and** names `validate_assignment` and `create_assignment`, which were previously unnamed in the server-level instructions. (The recently-added `get_solution` / `update_solution` / `author_script` / `get_server_info` were already covered; per-tool `description`/`inputSchema` text was already current.)

## Consistency / doc fixes

- **Worker `_ck_inputs.py`**: dict keys are now emitted as escaped Python string literals via `JSONValue.string(_:).pythonLiteral`, matching the browser runner's `JSON.stringify(key)` and the pattern-family renderer. Not exploitable (input names are validated identifiers) — defense-in-depth consistency across the three materialization paths.
- **`docs/mcp-authoring-roadmap.md`**: the tool table was stale (said "twelve tools"; the catalog ships **twenty**) — rebuilt with all 20.
- **`CLAUDE.md`**: digest bumped to v0.4.350 with a bullet for the MCP authoring-surface expansion + the close-on-edit behavior.

## Tests

`closesOpenAssignmentOnEdit` / `leavesClosedAssignmentClosed` for both the helper path (`update_suite`) and the inline-save path (`update_solution`). Full local gate green: `swift build`, the 5 content-tool suites (44 tests), `swift-format lint --strict`, and SwiftLint `--strict` (0 violations / 516 files).

https://claude.ai/code/session_01JttufZG4KF98nAk6M9eZdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01JttufZG4KF98nAk6M9eZdg)_