### PR TITLE
Personalization audit: strip section expressions from runner payload; fix stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -882,6 +882,21 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
   Docs: `docs/inputs.md`, `docs/personalization-phase1.md`.  Remaining UI work
   tracked in #664.  This is the "first personalized assignments" path.
 
+- **Per-student pattern families (issue #461, v0.4.343–347).**  Pattern-family
+  cases can now personalize: a case's `$name` arg (`argVarRefs`) or its Expected
+  (`expectedVarRef`) may point at a per-student `=` expression instead of a
+  baked literal.  The expression is resolved **server-side** for the
+  submission's seed (`PersonalizationSubstitution.gradingInputs`, shared by the
+  worker job payload and the browser seed endpoint) and delivered to grading as
+  a `_ck_inputs.py` preamble the generated script loads — so a per-student
+  `expected = solution.foo(...)` stays server-side on the worker path.  The
+  generated script is byte-identical across students (cache + `spec_hash`
+  unchanged); only the resolved-values map differs.  Authorable via the browser
+  editor (type `$name` in an arg/Expected cell) and MCP (`update_pattern_family`
+  `expectedVarRef`); `preview_personalization` audits the refs.  Restricted to
+  `boundary_equality` families for now.  Doc:
+  `docs/personalization-pattern-families.md`.
+
 - **Notebook checks, BrightSpace grade sync, AppScan/security hardening,
   assignment-revision retest loop, sections** — see the per-version `CHANGELOG.md`.
 
@@ -904,11 +919,13 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
   cycle-detection false positive blocking `assignment-{new,edit}.leaf`
   decomposition is upstream and only fixed in the LeafKit 2 line.
 - **Feature backlog:** continued personalization / notebook-check
-  expansion; pattern kinds beyond
-  `.boundaryEquality` / `.approximateEquality` / `.variableEquality`
-  (e.g. exception-expected, type-check); multi-provider SSO testing
-  beyond UWaterloo DUO; refresh-token handling; gamification
-  expansion (leaderboards, more badges beyond First-Try Perfect).
+  expansion (e.g. per-student refs in pattern kinds beyond
+  `boundary_equality`); pattern kinds beyond the seven shipped
+  (`boundaryEquality` / `approximateEquality` / `variableEquality` /
+  `returnTypeCheck` / `exceptionExpected` / `performanceThreshold` /
+  `stdoutEquality`); multi-provider SSO testing beyond UWaterloo DUO;
+  refresh-token handling; gamification expansion (leaderboards, more
+  badges beyond First-Try Perfect).
 
 ---
 
@@ -929,6 +946,9 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
 - `docs/operational-diagnostics.md` — observability tables, structured log events, metrics endpoint, ops runbook
 - `docs/runner-capability-profiles.md` — runner capability matching, assignment requirements, rollout rules
 - `docs/runner-wasm-migration.md` — plan to share one Swift grading core (RunnerCore) between the worker + browser runner via SwiftWasm; staging, the ScriptExecutor protocol, type-hoist
+- `docs/personalization-phase1.md` — per-(student, assignment) seed contract (`CHICKADEE_ASSIGNMENT_SEED`), worked hand-written example
+- `docs/inputs.md` — Global + section inputs: literal variables, per-student `=` expressions, `$name` references, save-time inlining vs. notebook substitution
+- `docs/personalization-pattern-families.md` — per-student pattern families: `$name`/`expectedVarRef` → server-resolved values delivered via `_ck_inputs.py` (worker) / browser seed endpoint
 - `docs/ci-followups.md` — historical CI reshaping notes from v0.4.6 (WorkerTests are back in the per-PR gate as of the 2026 cleanup)
 - `reference/` — original Java source for behavioural reference only
 - `CHANGELOG.md` — release history

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -115,9 +115,11 @@ public struct TestSuiteSection: Codable, Equatable, Sendable {
     /// Slice 4 of #461 — per-student expressions in section scope.
     /// Evaluated per-student at notebook first-open alongside global
     /// expressions; results substitute into `{{name}}` placeholders.
-    /// Stays literal-only for pattern-family `$name` references and
-    /// raw-script inlining (matches Slice 2's notebooks-only constraint
-    /// for personalization expressions).
+    /// Like `globalExpressions`, a section expression is never inlined
+    /// into a raw test script, but it MAY back a pattern-family
+    /// per-student reference (`$name` arg / `expectedVarRef`), whose
+    /// value is delivered to grading at dispatch time via
+    /// `Job.personalizedInputs` / the browser seed endpoint.
     public let expressions: [PersonalizationExpression]
 
     public init(
@@ -231,12 +233,16 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// values substitute into starter-notebook `{{name}}` placeholders
     /// alongside literal `globalVariables`.
     ///
-    /// Slice 2 scope: notebooks only.  Expression results are NOT
-    /// inlined into raw test scripts (those use the v0.4.156 env-var
-    /// seed contract for any per-student logic) and are NOT used for
-    /// pattern-family `$name` references (case args want save-time
-    /// literals).  Names cannot clash with any `globalVariables`,
-    /// `sections[].variables`, or the reserved name `seed`.
+    /// Expression results are NOT inlined into raw test scripts (those use
+    /// the v0.4.156 env-var seed contract for any per-student logic) and are
+    /// NOT substituted into them at save time.  They ARE, however, available
+    /// to pattern-family per-student references: a case's `$name` arg or
+    /// `expectedVarRef` may point at an expression row, and the resolved
+    /// value is delivered to grading at dispatch time via
+    /// `Job.personalizedInputs` / the browser seed endpoint (see
+    /// `docs/personalization-pattern-families.md`).  Names cannot clash with
+    /// any `globalVariables`, `sections[].variables`, or the reserved name
+    /// `seed`.
     public let globalExpressions: [PersonalizationExpression]
 
     public init(
@@ -361,12 +367,22 @@ public struct TestProperties: Codable, Equatable, Sendable {
             starterNotebook: starterNotebook,
             patternFamilies: [],
             notebookChecks: [],
-            sections: sections,
+            // Expressions are a server-side authoring concern — both global
+            // AND section scope.  Their source is evaluated server-side per
+            // student; only the resolved values travel to grading (worker via
+            // `Job.personalizedInputs`, browser via the seed endpoint), and
+            // the runner reads neither `globalExpressions` nor
+            // `sections[].expressions`.  Strip every `PersonalizationExpression`
+            // from the runner-facing manifest so reference-solution source
+            // (e.g. `= solution.countAdults(...)`) never ships in the Job
+            // payload.  Section *variables* (literals) are kept for parity
+            // with `globalVariables`.
+            sections: sections.map { section in
+                TestSuiteSection(
+                    id: section.id, name: section.name,
+                    variables: section.variables, expressions: [])
+            },
             globalVariables: globalVariables,
-            // Slice 2: expressions are a server-side authoring concern.
-            // They never reach the runner — values are evaluated at
-            // notebook first-open and substituted into the student
-            // working copy before the runner ever sees the assignment.
             globalExpressions: []
         )
     }

--- a/Tests/APITests/PatternFamilyFixtures.swift
+++ b/Tests/APITests/PatternFamilyFixtures.swift
@@ -200,3 +200,67 @@ func pfAssertValidPythonSyntax(_ source: String, label: String) throws {
         Issue.record("Generated source for \(label) is not valid Python:\n\(err)\n--- source ---\n\(source)")
     }
 }
+
+/// Runtime outcome of executing a generated pattern-family case body.
+enum PFGeneratedOutcome: Equatable { case pass, fail, error }
+
+/// Executes a generated case `body` the way the runner would: in a workspace
+/// holding an optional `_ck_inputs.py` (exactly what
+/// `RunnerDaemon+JobProcessing` / `browser-runner.js` write from the resolved
+/// per-student values) and a `student_module` exposing `student`'s functions,
+/// with test_runtime's `passed()` / `failed()` stubbed to sentinels and cwd
+/// set to the workspace (so the preamble's relative `_ck_inputs.py` load
+/// resolves).  Returns whether the case passed, failed, or errored — letting a
+/// test assert the per-student preamble actually *grades*, not merely parses.
+func pfRunGeneratedCase(
+    body: String, ckInputs: String?, student: String
+) throws -> PFGeneratedOutcome {
+    let fm = FileManager.default
+    let dir = fm.temporaryDirectory.appendingPathComponent("pf_run_\(UUID().uuidString)", isDirectory: true)
+    try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+    defer { try? fm.removeItem(at: dir) }
+
+    if let ckInputs {
+        try ckInputs.write(to: dir.appendingPathComponent("_ck_inputs.py"), atomically: true, encoding: .utf8)
+    }
+    try student.write(to: dir.appendingPathComponent("_student.py"), atomically: true, encoding: .utf8)
+    try body.write(to: dir.appendingPathComponent("_case.py"), atomically: true, encoding: .utf8)
+
+    // Mirrors test_runtime's pass/fail dispatch with sentinels we can catch,
+    // and binds `student_module` the way the runner's bootstrap does.
+    let driver = """
+        import types
+        class _P(Exception): pass
+        class _F(Exception): pass
+        def passed(msg=""):
+            print("OUTCOME:PASS"); raise _P()
+        def failed(msg=""):
+            print("OUTCOME:FAIL"); raise _F()
+        student_module = types.ModuleType("student_module")
+        with open("_student.py") as _f:
+            exec(_f.read(), student_module.__dict__)
+        try:
+            with open("_case.py") as _f:
+                exec(_f.read())
+        except (_P, _F):
+            pass
+        """
+
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    p.arguments = ["python3", "-c", driver]
+    p.currentDirectoryURL = dir
+    let out = Pipe()
+    let err = Pipe()
+    p.standardOutput = out
+    p.standardError = err
+    try p.run()
+    p.waitUntilExit()
+    let stdout = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    if stdout.contains("OUTCOME:PASS") { return .pass }
+    if stdout.contains("OUTCOME:FAIL") { return .fail }
+    let stderrText = String(data: err.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    Issue.record(
+        "Generated case neither passed nor failed:\nstdout=\(stdout)\nstderr=\(stderrText)\n--- body ---\n\(body)")
+    return .error
+}

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -471,6 +471,38 @@ import Vapor
         #expect(src.contains("student_module.countAdults(patients)"))
     }
 
+    /// Runtime contract (not just ast.parse): the generated preamble must
+    /// actually load `_ck_inputs.py`, bind the referenced per-student names,
+    /// and grade against them — passing when the student's result matches the
+    /// resolved expected, failing when it doesn't, and failing *closed* (no
+    /// crash) when the seed (hence `_ck_inputs.py`) is absent.  Exercises the
+    /// exact file the worker / browser write, so a renderer/runtime contract
+    /// drift on either side is caught here.
+    @Test func perStudentScriptGradesAgainstCkInputsAtRuntime() throws {
+        let scripts = renderPatternFamily(
+            perStudentBoundaryFamily(), perStudentNames: ["patients", "adults_expected"])
+        let body = try #require(scripts.first).source
+
+        // Byte-for-byte the shape `RunnerDaemon+JobProcessing` emits: a `_ck`
+        // dict of Python literals (here a list of dicts + an int).
+        let ckInputs = """
+            # Auto-generated per-student grading inputs (issue #461). Do not edit.
+            _ck = {
+                "adults_expected": 2,
+                "patients": [{'age': 40}, {'age': 17}, {'age': 65}],
+            }
+            """
+        let correct = "def countAdults(patients):\n    return sum(1 for p in patients if p['age'] >= 18)"
+        let buggy = "def countAdults(patients):\n    return len(patients)"
+
+        // Correct student matches the resolved expected (2 adults) → pass.
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: ckInputs, student: correct) == .pass)
+        // Buggy student returns 3 → fail.
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: ckInputs, student: buggy) == .fail)
+        // No `_ck_inputs.py` (no seed resolved) → fail closed, not crash.
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: correct) == .fail)
+    }
+
     @Test func rendererOmitsPreambleWhenNoPerStudentRefs() throws {
         // A normal family renders unchanged even when the assignment declares
         // per-student names the family doesn't reference.

--- a/Tests/APITests/SectionInputsTests.swift
+++ b/Tests/APITests/SectionInputsTests.swift
@@ -55,19 +55,28 @@ import Testing
         #expect(decoded.sections[0].expressions[0].name == "shift")
     }
 
-    @Test func testProperties_runnerSanitizedKeepsSectionExpressions() {
-        // Section expressions are kept on the runner-facing manifest
-        // because the runner doesn't choke on them (FamilyVariable +
-        // PersonalizationExpression are stable Codable types).  This
-        // mirrors the kept-vs-stripped policy for globalVariables.
+    @Test func testProperties_runnerSanitizedStripsSectionExpressions() {
+        // Section expressions are a server-side authoring concern, exactly
+        // like globalExpressions: their source is evaluated server-side per
+        // student and only the resolved value travels to grading (via
+        // Job.personalizedInputs / the browser seed endpoint).  The
+        // runner-facing manifest must not carry the expression source (which
+        // can be reference-solution code like `= solution.foo(...)`), so
+        // runnerSanitized() strips them.  The section's literal *variables*
+        // and its id/name are kept for parity with globalVariables.
         let section = TestSuiteSection(
             id: "s1", name: "Q1",
+            variables: [FamilyVariable(name: "lo", value: .int(1))],
             expressions: [PersonalizationExpression(name: "x", expression: "seed % 2")]
         )
         let props = TestProperties(sections: [section])
         let sanitized = props.runnerSanitized()
         #expect(sanitized.sections.count == 1)
-        #expect(sanitized.sections[0].expressions.count == 1)
+        #expect(sanitized.sections[0].id == "s1")
+        #expect(sanitized.sections[0].variables.count == 1)
+        #expect(
+            sanitized.sections[0].expressions.isEmpty,
+            "Section expressions are server-side only; the runner shouldn't see them.")
     }
 
     // MARK: - End-to-end evaluator integration

--- a/changelog.d/personalization-runner-sanitize-section-expressions.md
+++ b/changelog.d/personalization-runner-sanitize-section-expressions.md
@@ -1,0 +1,23 @@
+### Changed
+
+- **Per-student pattern families: section expressions are now stripped from the
+  runner-facing manifest.** `TestProperties.runnerSanitized()` already dropped
+  `globalExpressions` (a server-side authoring concern — only the resolved
+  values reach grading via `Job.personalizedInputs` / the browser seed
+  endpoint), but it kept each section's identical `PersonalizationExpression`
+  rows. Section expressions are now stripped too, so reference-solution source
+  (e.g. `= solution.countAdults(...)`) never travels in the worker job payload.
+  No grading-behaviour change — the runner reads neither field; per-student
+  values continue to arrive resolved.
+
+### Fixed
+
+- **Stale personalization docs/comments.** `docs/inputs.md` and two
+  `TestProperties` doc-comments still stated that pattern-family `$name`
+  references "can NOT target an expression row" and that test-script
+  personalization "remains a future slice" — both lifted by the per-student
+  pattern-family work. Updated to point at
+  `docs/personalization-pattern-families.md`. Added a runtime regression test
+  that executes a generated per-student case against a real `_ck_inputs.py`
+  (passes when correct, fails closed when the seed is absent), complementing the
+  existing syntax-only check.

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -56,8 +56,14 @@ substitutes into starter-notebook `{{name}}` placeholders.
     testsetups/:id/seed`, resolved by the same `AssignmentSeedStore.ensureSeed`)
     and injects it into `os.environ` before tests run, so a seed-reading
     test grades identically whether it runs on the worker or in the browser.
-  - Pattern-family `$name` references can NOT target an expression row
-    (case args need a save-time literal).
+  - Pattern-family `$name` references targeting an expression row are now
+    supported for **grade-time** use: a case's `$name` arg or its Expected
+    cell (`expectedVarRef`) may point at a per-student `=` expression, whose
+    value is resolved server-side and delivered to grading via
+    `Job.personalizedInputs` (worker) / the browser seed endpoint — see
+    [personalization-pattern-families.md](personalization-pattern-families.md).
+    A `$name` ref that wants a single byte-identical *literal* for every
+    student still targets a literal variable row, inlined at save time.
   - Save-time eval: the server runs every expression once against the
     instructor's own seed when you save the panel.  Broken expressions
     (`= 1/0`, `= unknown_var`, ...) return a 400 with the failure
@@ -199,5 +205,10 @@ Phase 1 test script (unchanged, instructor authors):
 
 Each student sees a different `plaintext` substituted into their
 notebook.  The test script re-derives the expected plaintext from the
-same seed via Phase 1's env-var contract.  Slice 2 doesn't substitute
-into test scripts — test-script substitution remains a future slice.
+same seed via Phase 1's env-var contract.  Slice 2 itself doesn't
+substitute expression values into raw test scripts — that hand-written
+script reads the seed directly.  Per-student values *can* now reach
+**pattern-family** tests, though: a case's `$name` arg / `expectedVarRef`
+resolves an expression server-side and the value is delivered to grading
+via a `_ck_inputs.py` preamble — see
+[personalization-pattern-families.md](personalization-pattern-families.md).


### PR DESCRIPTION
Audit follow-up on the per-student pattern-family work (#816–#820). I swept the personalization subsystem (Core types, renderer, worker + browser dispatch, validator, MCP tools, editor JS, evaluator security boundary) for loose ends left by the rapid development. Most of it checked out clean — the worker/browser parity, the `PersonalizationEvaluator` env allowlist (no parent-env inheritance), the `_ck_inputs.py` reserved-filename handling, and `os.chdir(workDir)` in the browser were all correct. Three loose ends remained.

## 1. `runnerSanitized()` inconsistency (code, low-risk)

`TestProperties.runnerSanitized()` stripped `globalExpressions` from the runner-facing manifest (with the comment *"expressions … never reach the runner"*) but kept each section's **identical** `PersonalizationExpression` rows. Two tests even encoded contradictory rationales for the same type.

Section expressions are now stripped too. Both scopes are a server-side authoring concern: the source is evaluated server-side per student and only the resolved value reaches grading (worker via `Job.personalizedInputs`, browser via the seed endpoint). The runner reads neither field, so this is a **no-op for grading behaviour** — it just keeps reference-solution source (e.g. `= solution.countAdults(...)`) out of the Job payload (defense-in-depth + consistency). Verified the only caller is `WorkerJobRoutes`, the browser uses the full unsanitized manifest, and nothing in `Worker`/`RunnerCore` reads `sections`/`expressions`.

## 2. Stale docs/comments

The per-student feature explicitly **lifted** the "`$name` can't target an expression row" rule, but several places still stated it as current:
- `docs/inputs.md` ("can NOT target an expression row", "test-script substitution remains a future slice")
- two `TestProperties.swift` doc-comments

Updated to reflect the shipped behaviour and cross-link `docs/personalization-pattern-families.md`.

## 3. Test gap

The per-student preamble + `_ck_inputs.py` interop was only **syntax**-checked (`ast.parse`). Added `pfRunGeneratedCase` + `perStudentScriptGradesAgainstCkInputsAtRuntime`, which executes a generated case against a real `_ck_inputs.py` (byte-for-byte what the worker/browser write): **passes** when the student is correct, **fails** when buggy, **fails closed** (no crash) when the seed/`_ck_inputs.py` is absent.

## CLAUDE.md refresh

The themed digest stopped at v0.4.318. Added a per-student-pattern-families entry, listed the three personalization docs in Reference Material (they were absent), and corrected the roadmap line that still listed `exception-expected` / `type-check` as future — the pattern-kind enum now ships seven kinds.

## Verification

- `swift build` clean; `swift format lint --strict` and `scripts/swiftlint.sh --strict` both 0 violations.
- Targeted suites pass: `PatternFamilyRendererTests` (incl. the new runtime test), `SectionInputsTests` (flipped assertion), `PersonalizationEvaluatorTests`, `CoreCodableTests`, `GlobalInputsTests`, `BrowserRunnerRoutesTests`, `PatternFamilySectionsTests`, `PatternFamilyApplyTests`.

https://claude.ai/code/session_01DScwQAYzzK7xr5tyRhsJAM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DScwQAYzzK7xr5tyRhsJAM)_