### PR TITLE
feat(pattern-families): per-student refs for approximate_equality (#461)

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
@@ -404,7 +404,8 @@ func renderApproximateEquality(
     family: PatternFamily,
     case c: PatternCase,
     sectionVariables: [FamilyVariable],
-    specHash: String
+    specHash: String,
+    perStudentNames: Set<String> = []
 ) -> String {
     let ctx = callContext(for: family, case: c)
 
@@ -416,11 +417,19 @@ func renderApproximateEquality(
     let variableDecls = combinedVariableDecls(sectionVariables: sectionVariables, family: family)
     let variableBlock = variableDecls.isEmpty ? "" : variableDecls + "\n\n"
 
+    // Per-student inputs (arg refs + the expected ref that resolve to a
+    // global/section `=` expression) are bound at grading time from
+    // `_ck_inputs.py` — identical mechanism to renderBoundaryEquality.  When the
+    // case has no per-student refs this is "" and `expectedExpression` returns
+    // the baked literal, so non-personalized cases render byte-for-byte as before.
+    let preamble = personalizationPreambleForCase(c, perStudentNames: perStudentNames)
+    let preambleBlock = preamble.isEmpty ? "" : preamble + "\n\n"
+
     return """
         \(generatedCaseHeader(family: family, case: c, specHash: specHash))
 
-        \(variableBlock)\(ctx.declLines.isEmpty ? "# (no input arguments)" : ctx.declLines)
-        expected = \(c.expected.pythonLiteral)
+        \(variableBlock)\(preambleBlock)\(ctx.declLines.isEmpty ? "# (no input arguments)" : ctx.declLines)
+        expected = \(expectedExpression(for: c))
         tolerance = \(toleranceLiteral)
 
         try:

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -87,18 +87,18 @@ private func validateFamilyVariablesAndArgRefs(
                         "Pattern family '\(family.id)': case '\(c.key)' arg '\(paramLabel)' references unknown variable '$\(ref)'"
                 )
             }
-            // Per-student arg refs are bound by the boundary_equality
-            // preamble only (the other kinds don't emit it yet).
-            if isPerStudent, family.kind != .boundaryEquality {
+            // Per-student arg refs are bound by the generated case's
+            // personalization preamble, which only the equality kinds emit.
+            if isPerStudent, !kindSupportsPerStudentRefs(family.kind) {
                 throw Abort(
                     .unprocessableEntity,
                     reason:
-                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in boundary_equality families for now."
+                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in boundary_equality and approximate_equality families for now."
                 )
             }
         }
         // A per-student expected ref must name a declared `=` expression and
-        // is (for now) supported only in boundary_equality families.
+        // is (for now) supported only in the equality kinds (boundary/approximate).
         if let eref = c.expectedVarRef {
             guard perStudentExpressionNames.contains(eref) else {
                 throw Abort(
@@ -107,14 +107,27 @@ private func validateFamilyVariablesAndArgRefs(
                         "Pattern family '\(family.id)': case '\(c.key)' expected reference '$\(eref)' must name a per-student input (a global or section `=` expression)."
                 )
             }
-            guard family.kind == .boundaryEquality else {
+            guard kindSupportsPerStudentRefs(family.kind) else {
                 throw Abort(
                     .unprocessableEntity,
                     reason:
-                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in boundary_equality families for now."
+                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in boundary_equality and approximate_equality families for now."
                 )
             }
         }
+    }
+}
+
+/// Whether a kind's generated cases bind per-student `_ck_inputs` (so `$name`
+/// arg refs and `expectedVarRef` resolve at grading time).  Extend as renderers
+/// gain the personalization preamble (`personalizationPreambleForCase`).  An
+/// exhaustive switch — a new `PatternKind` must opt in or out here explicitly.
+private func kindSupportsPerStudentRefs(_ kind: PatternKind) -> Bool {
+    switch kind {
+    case .boundaryEquality, .approximateEquality: return true
+    case .variableEquality, .returnTypeCheck, .exceptionExpected,
+        .performanceThreshold, .stdoutEquality:
+        return false
     }
 }
 

--- a/Sources/APIServer/Utilities/PatternKindHandler.swift
+++ b/Sources/APIServer/Utilities/PatternKindHandler.swift
@@ -108,7 +108,9 @@ struct ApproximateEqualityKind: PatternKindHandler {
         sectionVariables: [FamilyVariable], specHash: String,
         perStudentNames: Set<String>
     ) -> String {
-        renderApproximateEquality(family: family, case: c, sectionVariables: sectionVariables, specHash: specHash)
+        renderApproximateEquality(
+            family: family, case: c, sectionVariables: sectionVariables,
+            specHash: specHash, perStudentNames: perStudentNames)
     }
 
     func validateFamily(_ family: PatternFamily) throws {

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -535,20 +535,83 @@ import Vapor
         }
     }
 
-    @Test func validation_rejectsPerStudentRefOnNonBoundaryKind() throws {
+    @Test func validation_rejectsPerStudentRefOnUnsupportedKind() throws {
+        // performance_threshold has no personalization preamble, so a per-student
+        // arg ref is still rejected (boundary + approximate are the supported set).
         let c = PatternCase(
-            key: "01", label: "X", args: [.null], expected: .double(1.0),
+            key: "01", label: "X", args: [.null], expected: .double(100.0),
             argVarRefs: ["patients"])
         let family = PatternFamily(
-            id: "approx", name: "Approx", kind: .approximateEquality,
+            id: "perf", name: "Perf", kind: .performanceThreshold,
             functionName: "f", paramNames: ["patients"], cases: [c])
         #expect {
             try validatePatternFamilies(
                 [family], testSuites: [], perStudentExpressionNames: ["patients"])
         } throws: { error in
-            #expect("\(error)".contains("only supported in boundary_equality"))
+            #expect("\(error)".contains("only supported in boundary_equality and approximate_equality"))
             return true
         }
+    }
+
+    // MARK: - Personalization for approximateEquality (Slice E)
+
+    private func perStudentApproxFamily() -> PatternFamily {
+        let c = PatternCase(
+            key: "01", label: "Average", args: [.null], expected: .null,
+            argVarRefs: ["patients"], expectedVarRef: "avg_expected")
+        return PatternFamily(
+            id: "avg", name: "Average Age", kind: .approximateEquality,
+            functionName: "averageAge", paramNames: ["patients"], cases: [c])
+    }
+
+    @Test func validation_acceptsPerStudentRefsForApproximate() throws {
+        try validatePatternFamilies(
+            [perStudentApproxFamily()], testSuites: [],
+            perStudentExpressionNames: ["patients", "avg_expected"])
+    }
+
+    @Test func approximateRendererEmitsPerStudentPreambleAndExpectedRef() throws {
+        let scripts = renderPatternFamily(
+            perStudentApproxFamily(), perStudentNames: ["patients", "avg_expected"])
+        let src = try #require(scripts.first).source
+        try pfAssertValidPythonSyntax(src, label: "avg_01")
+        #expect(src.contains("_ck_inputs.py"))
+        #expect(src.contains(#"patients = _ck["patients"]"#))
+        #expect(src.contains(#"avg_expected = _ck["avg_expected"]"#))
+        // Expected is the bare per-student ref, not a baked literal; tolerance kept.
+        #expect(src.contains("expected = avg_expected"))
+        #expect(src.contains("tolerance ="))
+        #expect(src.contains("student_module.averageAge(patients)"))
+    }
+
+    @Test func approximateRendererOmitsPreambleWhenNoPerStudentRefs() throws {
+        // A normal approximate family with a literal expected renders unchanged
+        // (no preamble) even when the assignment declares per-student names.
+        let c = PatternCase(key: "01", label: "x", args: [.double(2.0)], expected: .double(4.0))
+        let family = PatternFamily(
+            id: "sq", name: "Square", kind: .approximateEquality,
+            functionName: "square", paramNames: ["x"], cases: [c])
+        let src = try #require(renderPatternFamily(family, perStudentNames: ["patients"]).first).source
+        #expect(!src.contains("_ck_inputs.py"))
+        #expect(src.contains("expected = 4.0"))
+    }
+
+    @Test func perStudentApproxGradesAgainstCkInputsAtRuntime() throws {
+        let scripts = renderPatternFamily(
+            perStudentApproxFamily(), perStudentNames: ["patients", "avg_expected"])
+        let body = try #require(scripts.first).source
+        let ckInputs = """
+            # Auto-generated per-student grading inputs (issue #461). Do not edit.
+            _ck = {
+                "avg_expected": 40.0,
+                "patients": [{'age': 40}, {'age': 20}, {'age': 60}],
+            }
+            """
+        let correct = "def averageAge(patients):\n    return sum(p['age'] for p in patients) / len(patients)"
+        let buggy = "def averageAge(patients):\n    return sum(p['age'] for p in patients)"
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: ckInputs, student: correct) == .pass)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: ckInputs, student: buggy) == .fail)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: correct) == .fail)
     }
 
 }

--- a/changelog.d/pattern-family-approx-personalization.md
+++ b/changelog.d/pattern-family-approx-personalization.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Per-student pattern families now support `approximate_equality` (issue #461).**
+  A float-tolerance family case may reference per-student inputs via `$name` arg
+  refs and `expectedVarRef` (e.g. `args: ["$patients"]`,
+  `expectedVarRef: "avg_expected"`), resolved per student at grading time — the
+  same `_ck_inputs` preamble `boundary_equality` already emitted. The supported
+  set is now boundary + approximate (gated by one allowlist in the validator);
+  non-personalized cases render byte-for-byte unchanged, so existing families'
+  `spec_hash` is stable.


### PR DESCRIPTION
**Slice E of the "build the missing capabilities" arc.** Lets float-tolerance families personalize, unblocking Assignment 3's `averageAge` and `bmi` conversions.

## What
Per-student pattern-family refs (`$name` arg refs + `expectedVarRef`, resolved per student at grading time) were restricted to `boundary_equality`. This extends the supported set to **`approximate_equality`**:

- `renderApproximateEquality` now emits the same `_ck_inputs` personalization preamble `boundary_equality` already uses, and takes `expected` from `expectedExpression(for:)` (the per-student ref, or the baked literal when none).
- The validator's two boundary-only gates collapse into one `kindSupportsPerStudentRefs(_:)` allowlist — an **exhaustive switch**, so a new `PatternKind` must opt in or out explicitly (Slice F's `unorderedEquality` will add itself here).

## Safety
Non-personalized approximate cases render **byte-for-byte unchanged** (empty preamble + literal expected via `expectedExpression`), so existing families' `spec_hash` / `TestSetupCache` keys are stable. Verified by a new `approximateRendererOmitsPreambleWhenNoPerStudentRefs` test.

## Verification
`swift build` clean; `PatternFamilyRendererTests` 36/36 incl. 4 new approximate tests — render (preamble + `expected = avg_expected` + tolerance), **runtime** grading against a real `_ck_inputs.py` (correct → pass, buggy → fail, no-seed → fail-closed), validation accepts approximate refs, and an unsupported kind (`performance_threshold`) is still rejected; swift-format clean; SwiftLint `--strict` 0 violations.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_