### PR TITLE
feat(pattern-families): add unordered_equality kind (#461)

### DIFF
--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -38,6 +38,7 @@
             items: [
                 { value: 'boundary_equality',     mechanism: 'family', label: 'Returns the right value' },
                 { value: 'approximate_equality',  mechanism: 'family', label: 'Returns the right value (within tolerance)' },
+                { value: 'unordered_equality',    mechanism: 'family', label: 'Returns the right values (any order)' },
                 { value: 'return_type_check',     mechanism: 'family', label: 'Returns the right type' },
                 { value: 'exception_expected',    mechanism: 'family', label: 'Raises the right error' },
                 { value: 'stdout_equality',       mechanism: 'family', label: 'Prints the right output' },
@@ -76,6 +77,7 @@
     var DESCRIPTIONS = {
         boundary_equality:     'Call the student’s function with a table of inputs and check each return value.',
         approximate_equality:  'Like “Returns the right value”, but compares floats within a tolerance.',
+        unordered_equality:    'Like “Returns the right value”, but compares lists ignoring element order.',
         return_type_check:     'Check that the function returns a value of the expected type.',
         exception_expected:    'Check that the function raises the expected exception for given inputs.',
         stdout_equality:       'Check what the function prints to stdout for given inputs.',

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -416,6 +416,7 @@
                         <option value="exception_expected">Exception expected (function raises a specific class)</option>
                         <option value="performance_threshold">Performance threshold (max milliseconds)</option>
                         <option value="stdout_equality">Stdout equality (compare captured print output)</option>
+                        <option value="unordered_equality">Unordered equality (list compare, ignore order)</option>
                     </select>
                 </label>
                 <label id="family-tolerance-label" style="display:none;font-size:.85rem;flex-direction:column;gap:.2rem">

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -428,6 +428,7 @@ Create Assignment
                         <option value="exception_expected">Exception expected (function raises a specific class)</option>
                         <option value="performance_threshold">Performance threshold (max milliseconds)</option>
                         <option value="stdout_equality">Stdout equality (compare captured print output)</option>
+                        <option value="unordered_equality">Unordered equality (list compare, ignore order)</option>
                     </select>
                 </label>
                 <label id="family-tolerance-label" style="display:none;font-size:.85rem;flex-direction:column;gap:.2rem">

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
@@ -386,6 +386,84 @@ func renderBoundaryEquality(
         """
 }
 
+// MARK: - unorderedEquality
+
+/// Renders an order-insensitive list-equality case.  Same shape as
+/// `renderBoundaryEquality` (header, per-student preamble, input echo, rich
+/// failure messages, per-student `expected`) but the comparison canonicalises
+/// each element (JSON with sorted keys, `str()` fallback) and compares the
+/// sorted multisets, so a correct-but-reordered list still passes.
+func renderUnorderedEquality(
+    family: PatternFamily,
+    case c: PatternCase,
+    sectionVariables: [FamilyVariable],
+    specHash: String,
+    perStudentNames: Set<String> = []
+) -> String {
+    let ctx = callContext(for: family, case: c)
+
+    let variableDecls = combinedVariableDecls(sectionVariables: sectionVariables, family: family)
+    let variableBlock = variableDecls.isEmpty ? "" : variableDecls + "\n\n"
+
+    let preamble = personalizationPreambleForCase(c, perStudentNames: perStudentNames)
+    let preambleBlock = preamble.isEmpty ? "" : preamble + "\n\n"
+    let expectedExpr = expectedExpression(for: c)
+
+    return """
+        \(generatedCaseHeader(family: family, case: c, specHash: specHash))
+
+        \(preambleBlock)\(variableBlock)\(ctx.declLines.isEmpty ? "# (no input arguments)" : ctx.declLines)
+        expected = \(expectedExpr)
+
+        # Order-insensitive comparison: canonicalise each element (JSON with
+        # sorted keys, str() fallback for non-JSON values) and compare the
+        # sorted multisets, so a correct-but-reordered result still passes.
+        import json as _ck_json
+        def _ck_canon(seq):
+            return sorted(_ck_json.dumps(_e, sort_keys=True, default=str) for _e in seq)
+
+        try:
+            result = student_module.\(family.functionName)(\(ctx.callArgs))
+        except Exception as ex:
+            import traceback as _tb
+            _tb_frames = _tb.extract_tb(ex.__traceback__)
+            _tb_src = ""
+            if _tb_frames and _tb_frames[-1].line:
+                _tb_src = f"\\n  source:   {_tb_frames[-1].line.strip()}"
+            failed(
+                "unexpected exception\\n"
+                \(ctx.inputLineLiteral)
+                f"  expected (any order): {expected!r}\\n"
+                f"  error:    {type(ex).__name__}: {ex}" + _tb_src + "\\n"            )
+
+        if not isinstance(result, list):
+            failed(
+                "wrong return type\\n"
+                \(ctx.inputLineLiteral)
+                f"  expected: a list (any order) like {expected!r}\\n"
+                f"  got:      {result!r} (type {type(result).__name__})\\n"            )
+
+        try:
+            _ck_match = _ck_canon(result) == _ck_canon(expected)
+        except Exception as ex:
+            failed(
+                "could not compare result\\n"
+                \(ctx.inputLineLiteral)
+                f"  expected (any order): {expected!r}\\n"
+                f"  got:      {result!r}\\n"
+                f"  error:    {type(ex).__name__}: {ex}\\n"            )
+
+        if not _ck_match:
+            failed(
+                "wrong elements (order doesn't matter)\\n"
+                \(ctx.inputLineLiteral)
+                f"  expected (any order): {expected!r}\\n"
+                f"  got:      {result!r}\\n"            )
+
+        passed(f"Returned the expected {len(result)} element(s) (any order)")
+        """
+}
+
 // MARK: - approximateEquality
 
 /// Default tolerance when the family spec leaves `defaults.tolerance` nil.

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -124,7 +124,7 @@ private func validateFamilyVariablesAndArgRefs(
 /// exhaustive switch — a new `PatternKind` must opt in or out here explicitly.
 private func kindSupportsPerStudentRefs(_ kind: PatternKind) -> Bool {
     switch kind {
-    case .boundaryEquality, .approximateEquality: return true
+    case .boundaryEquality, .approximateEquality, .unorderedEquality: return true
     case .variableEquality, .returnTypeCheck, .exceptionExpected,
         .performanceThreshold, .stdoutEquality:
         return false

--- a/Sources/APIServer/Utilities/PatternKindHandler.swift
+++ b/Sources/APIServer/Utilities/PatternKindHandler.swift
@@ -61,6 +61,7 @@ func patternKindHandler(for kind: PatternKind) -> any PatternKindHandler {
     case .exceptionExpected: return ExceptionExpectedKind()
     case .performanceThreshold: return PerformanceThresholdKind()
     case .stdoutEquality: return StdoutEqualityKind()
+    case .unorderedEquality: return UnorderedEqualityKind()
     }
 }
 
@@ -274,6 +275,36 @@ struct StdoutEqualityKind: PatternKindHandler {
                 reason:
                     "Pattern family '\(family.id)' (stdout_equality): case '\(c.key)' expected must be a string (the captured stdout to match)"
             )
+        }
+    }
+}
+
+// MARK: - unorderedEquality
+
+struct UnorderedEqualityKind: PatternKindHandler {
+    func render(
+        family: PatternFamily, case c: PatternCase,
+        sectionVariables: [FamilyVariable], specHash: String,
+        perStudentNames: Set<String>
+    ) -> String {
+        renderUnorderedEquality(
+            family: family, case: c, sectionVariables: sectionVariables,
+            specHash: specHash, perStudentNames: perStudentNames)
+    }
+
+    func validateCase(family: PatternFamily, case c: PatternCase) throws {
+        try validatePatternArgCount(family: family, case: c, kindLabel: "unordered_equality")
+        // Expected must be a list (the elements to match, in any order) — except
+        // when it's per-student (expectedVarRef), where the list arrives at
+        // grading time and the literal `expected` is unused.
+        if c.expectedVarRef == nil {
+            guard case .array = c.expected else {
+                throw Abort(
+                    .unprocessableEntity,
+                    reason:
+                        "Pattern family '\(family.id)' (unordered_equality): case '\(c.key)' expected must be a list (the elements to match, in any order)"
+                )
+            }
         }
     }
 }

--- a/Sources/Core/Models/PatternFamily.swift
+++ b/Sources/Core/Models/PatternFamily.swift
@@ -60,6 +60,13 @@ public enum PatternKind: String, Codable, Sendable, Equatable {
     /// ignored — instructors who care about both stdout and the
     /// return value should write two families (one of each kind).
     case stdoutEquality = "stdout_equality"
+    /// Calls the function with each case's args and compares the returned
+    /// list to `expected` **ignoring order** — each element is canonicalised
+    /// (JSON with sorted keys) and the two canonical multisets are compared.
+    /// For functions that return a collection where order is not part of the
+    /// contract (e.g. "find all patients with diagnosis X"); a plain
+    /// `boundary_equality` would false-fail on a correct-but-reordered result.
+    case unorderedEquality = "unordered_equality"
 }
 
 /// Shared defaults for a family.  Any case may override `tier`, `points`,

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -614,4 +614,83 @@ import Vapor
         #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: correct) == .fail)
     }
 
+    // MARK: - unorderedEquality (Slice F)
+
+    private func unorderedFamily() -> PatternFamily {
+        let c = PatternCase(
+            key: "01", label: "Pick", args: [.array([.int(3), .int(1), .int(2)])],
+            expected: .array([.int(1), .int(2), .int(3)]))
+        return PatternFamily(
+            id: "pick", name: "Pick", kind: .unorderedEquality,
+            functionName: "pick", paramNames: ["xs"], cases: [c])
+    }
+
+    private func unorderedPerStudentFamily() -> PatternFamily {
+        let c = PatternCase(
+            key: "01", label: "Find", args: [.null], expected: .null,
+            argVarRefs: ["patients"], expectedVarRef: "matches")
+        return PatternFamily(
+            id: "find", name: "Find", kind: .unorderedEquality,
+            functionName: "findByDiag", paramNames: ["patients"], cases: [c])
+    }
+
+    @Test func unorderedRendererEmitsCanonicalComparison() throws {
+        let src = try #require(renderPatternFamily(unorderedFamily(), perStudentNames: []).first).source
+        try pfAssertValidPythonSyntax(src, label: "pick_01")
+        #expect(src.contains("_ck_canon"))
+        #expect(src.contains("sort_keys=True"))
+        #expect(src.contains("student_module.pick("))
+    }
+
+    @Test func unorderedGradesOrderInsensitivelyAtRuntime() throws {
+        let body = try #require(renderPatternFamily(unorderedFamily(), perStudentNames: []).first).source
+        // Same elements, original (different) order → pass: order is ignored.
+        let reordered = "def pick(xs):\n    return list(xs)"
+        let sortedFn = "def pick(xs):\n    return sorted(xs)"
+        let missing = "def pick(xs):\n    return xs[:2]"
+        let notList = "def pick(xs):\n    return 5"
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: reordered) == .pass)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: sortedFn) == .pass)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: missing) == .fail)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: notList) == .fail)
+    }
+
+    @Test func unorderedPerStudentGradesAtRuntime() throws {
+        let scripts = renderPatternFamily(
+            unorderedPerStudentFamily(), perStudentNames: ["patients", "matches"])
+        let body = try #require(scripts.first).source
+        // `matches` lists the two 'A' patients in a different order than the
+        // student's filter will produce — order-insensitive compare → pass.
+        let ckInputs = """
+            _ck = {
+                "patients": [{'mrn': '1', 'dx': 'A'}, {'mrn': '2', 'dx': 'B'}, {'mrn': '3', 'dx': 'A'}],
+                "matches": [{'mrn': '3', 'dx': 'A'}, {'mrn': '1', 'dx': 'A'}],
+            }
+            """
+        let correct = "def findByDiag(patients):\n    return [p for p in patients if p['dx'] == 'A']"
+        let buggy = "def findByDiag(patients):\n    return patients"
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: ckInputs, student: correct) == .pass)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: ckInputs, student: buggy) == .fail)
+        #expect(try pfRunGeneratedCase(body: body, ckInputs: nil, student: correct) == .fail)
+    }
+
+    @Test func validation_unorderedRequiresListExpected() throws {
+        let c = PatternCase(key: "01", label: "x", args: [.int(1)], expected: .int(5))
+        let family = PatternFamily(
+            id: "u", name: "U", kind: .unorderedEquality,
+            functionName: "f", paramNames: ["x"], cases: [c])
+        #expect {
+            try validatePatternFamilies([family], testSuites: [])
+        } throws: { error in
+            #expect("\(error)".contains("must be a list"))
+            return true
+        }
+    }
+
+    @Test func validation_acceptsPerStudentRefsForUnordered() throws {
+        try validatePatternFamilies(
+            [unorderedPerStudentFamily()], testSuites: [],
+            perStudentExpressionNames: ["patients", "matches"])
+    }
+
 }

--- a/changelog.d/pattern-family-unordered-equality.md
+++ b/changelog.d/pattern-family-unordered-equality.md
@@ -1,0 +1,10 @@
+### Added
+
+- **`unordered_equality` pattern-family kind (issue #461).** A new kind for
+  functions that return a list where order isn't part of the contract (e.g.
+  "find all patients with diagnosis X"): each element is canonicalised (JSON with
+  sorted keys, `str()` fallback) and the two multisets are compared, so a
+  correct-but-reordered result passes where `boundary_equality` would false-fail.
+  Supports per-student `argVarRefs` / `expectedVarRef`. Available in the
+  assignment editor's family-kind dropdown, the New-Family modal, and via
+  `create_pattern_family` / `update_pattern_family`.


### PR DESCRIPTION
**Slice F of the "build the missing capabilities" arc** — the last kind gap. Unblocks Assignment 3's `findPatientsByDiagnosis` (and any list-returning function where order isn't part of the contract).

## What
New `unordered_equality` pattern kind. The generated case canonicalises each element (`json.dumps(..., sort_keys=True, default=str)`) and compares the **sorted multisets**, so a correct-but-reordered list passes where `boundary_equality` would false-fail. It keeps the rich failure messages (wrong type / wrong elements / exception) and supports per-student `argVarRefs` / `expectedVarRef` (added to the Slice E allowlist, emitting the same `_ck_inputs` preamble).

Wired through **every** kind-enumeration site so the new kind appears everywhere:
- Core `PatternKind` enum
- `UnorderedEqualityKind` handler + the exhaustive `patternKindHandler` resolver
- `kindSupportsPerStudentRefs` allowlist
- `renderUnorderedEquality`
- both `assignment-edit` / `assignment-new` family-kind dropdowns
- the New-Family modal menu (`test-editor-modal.js`)
- authorable via `create_pattern_family` / `update_pattern_family`

Validation: `expected` must be a list (unless per-student via `expectedVarRef`, where it arrives at grading time).

## Verification
`swift build` clean; 63 tests pass — `PatternFamilyRendererTests` (41, incl. 5 new: canonical-comparison render, **runtime** order-insensitive grading [reordered → pass, missing/extra → fail, non-list → fail], per-student runtime, list-expected validation, per-student acceptance), plus `CreatePatternFamilyToolTests`/`UpdatePatternFamilyToolTests` on the new base; swift-format clean; SwiftLint `--strict` 0 violations.

## After this merges
All three capabilities (G create-family, E approximate-personalization, F unordered-equality) are in. Once the live server is redeployed to include them, I can convert **all 8** of Assignment 3's hand-written `dbgen` tests to declarative families.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_