### PR TITLE
feat(mcp): add delete_suite_item tool (#461)

### DIFF
--- a/Sources/APIServer/MCP/Tools/DeleteSuiteItemTool.swift
+++ b/Sources/APIServer/MCP/Tools/DeleteSuiteItemTool.swift
@@ -1,0 +1,158 @@
+// APIServer/MCP/Tools/DeleteSuiteItemTool.swift
+//
+// Write tool: remove one item from an assignment's test suite — a hand-written
+// script, a pattern family (and all its generated cases), or a notebook check.
+// content:write, course-scoped.  Complements author_script / create_pattern_family
+// (which add or replace): until this tool existed there was no MCP way to delete
+// a suite item — only the browser editor could, via its full-payload PUT /suite.
+//
+// Read-modify-write through the same buildSuitePayload / applySuiteEdit path the
+// editor uses: loads the authored suite, drops the matching row, and re-saves —
+// which rebuilds the manifest (the dropped item is no longer graded), prunes a
+// removed family's generated scripts from the zip, and re-runs validation
+// (rejecting, e.g., a dangling dependsOn left by the removal).
+//
+// Targets exactly one item, identified by one of: `script` (hand-written
+// filename), `familyID` (pattern family id), or `check` (notebook-check id).
+// A generated family case is NOT a `script` row — to remove those, delete the
+// family.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+struct DeleteSuiteItemTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// Hand-written script filename to remove (kind == "script").
+        let script: String?
+        /// Pattern family id to remove (kind == "family"); also removes the
+        /// family's generated case scripts.
+        let familyID: String?
+        /// Notebook-check id to remove (kind == "check").
+        let check: String?
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        /// "script", "family", or "check".
+        let kind: String
+        /// The identifier of the removed item (filename / family id / check id).
+        let removed: String
+        let remainingItemCount: Int
+        let validationStatus: String?
+    }
+
+    static let name = "delete_suite_item"
+    static let description =
+        "Remove one item from an assignment's test suite, by public ID. Specify exactly one of: "
+        + "`script` (a hand-written script filename), `familyID` (a pattern family id — also removes "
+        + "its generated cases), or `check` (a notebook-check id). A generated family case is not a "
+        + "`script`; to remove those delete the family. Saving rebuilds the manifest (the item is no "
+        + "longer graded) and re-runs validation, which rejects the removal if it would leave a "
+        + "dangling dependsOn. Ids and filenames come from get_suite."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "script": .object([
+                "type": .string("string"),
+                "description": .string("Hand-written script filename to remove."),
+            ]),
+            "familyID": .object([
+                "type": .string("string"),
+                "description": .string("Pattern family id to remove (with its generated cases)."),
+            ]),
+            "check": .object([
+                "type": .string("string"),
+                "description": .string("Notebook-check id to remove."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "kind": .object(["type": .string("string")]),
+            "removed": .object(["type": .string("string")]),
+            "remainingItemCount": .object(["type": .string("integer")]),
+            "validationStatus": .object(["type": .string("string")]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("kind"), .string("removed"),
+            .string("remainingItemCount"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: true, idempotentHint: false)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let target = try Self.resolveTarget(input)
+
+        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
+        }
+        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "The assignment's test setup could not be found.")
+        }
+
+        var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
+        guard let idx = payload.items.firstIndex(where: { Self.matches($0, target) }) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "No \(target.kind) \"\(target.id)\" found in the suite (see get_suite).")
+        }
+        payload.items.remove(at: idx)
+
+        do {
+            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
+        } catch let error as WebAssignmentError {
+            throw MCPToolError.from(error, tool: Self.name)
+        } catch let error as any AbortError {
+            throw MCPToolError.from(error, tool: Self.name)
+        }
+        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            kind: target.kind,
+            removed: target.id,
+            remainingItemCount: payload.items.count,
+            validationStatus: assignment.validationStatus)
+    }
+
+    private struct Target { let kind: String; let id: String }
+
+    /// Validates that exactly one of script / familyID / check is set and
+    /// returns the (kind, id) to remove.
+    private static func resolveTarget(_ input: Input) throws -> Target {
+        var targets: [Target] = []
+        if let s = input.script, !s.isEmpty { targets.append(Target(kind: "script", id: s)) }
+        if let f = input.familyID, !f.isEmpty { targets.append(Target(kind: "family", id: f)) }
+        if let c = input.check, !c.isEmpty { targets.append(Target(kind: "check", id: c)) }
+        guard targets.count == 1 else {
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "Specify exactly one of: script, familyID, check.")
+        }
+        return targets[0]
+    }
+
+    private static func matches(_ item: SuiteItemDTO, _ target: Target) -> Bool {
+        switch target.kind {
+        case "script": return item.kind == "script" && item.script?.script == target.id
+        case "family": return item.kind == "family" && item.family?.id == target.id
+        case "check": return item.kind == "check" && item.check?.id == target.id
+        default: return false
+        }
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -32,6 +32,7 @@ enum MCPToolCatalog {
             UpdateSectionVariablesTool().erased(),
             UpdatePatternFamilyTool().erased(),
             CreatePatternFamilyTool().erased(),
+            DeleteSuiteItemTool().erased(),
             UpdateNotebookTool().erased(),
             UpdateSolutionTool().erased(),
             AuthorScriptTool().erased(),

--- a/Tests/APITests/MCP/DeleteSuiteItemToolTests.swift
+++ b/Tests/APITests/MCP/DeleteSuiteItemToolTests.swift
@@ -1,0 +1,160 @@
+// Tests for DeleteSuiteItemTool (removing a script / family / check from a
+// suite), backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct DeleteSuiteItemToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let emptyManifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+
+    /// Course + enrolled instructor + setup + assignment.  When `seedFamily` is
+    /// true the BMI family is applied; `seedScript` adds a hand-written script.
+    private func fixture(
+        on app: Application, seedFamily: Bool = false, seedScript: String? = nil
+    ) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        let setup = try await makeTestSetup(
+            on: app, id: "setup_del", courseID: courseID, manifest: emptyManifest)
+        try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_del.zip")
+        var families: [PatternFamily] = []
+        var authored: [AuthoredSuiteItem] = []
+        if seedFamily {
+            families.append(pfBMIFamily())
+            authored.append(.family(id: "bmi_category", sectionID: nil))
+        }
+        if let name = seedScript {
+            authored.append(
+                .script(
+                    AuthoredRawScript(
+                        script: name, tier: .pub, points: 1, displayName: nil,
+                        dependsOn: [], sectionID: nil,
+                        content: "#!/usr/bin/env python3\nprint('ok')", hint: nil)))
+        }
+        if !authored.isEmpty {
+            try await applyPatternFamilies(
+                to: setup, nextFamilies: families, authoredItems: authored, on: app.db)
+        }
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_del", courseID: courseID, title: "Lab")
+    }
+
+    private func reloadItems(_ assignment: APIAssignment, on db: Database) async throws -> [SuiteItemDTO] {
+        let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: db))
+        return buildSuitePayload(fromManifest: reloaded.manifest).items
+    }
+
+    @Test func deletesAHandWrittenScript() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, seedScript: "extra_test.py")
+            #expect(try await reloadItems(assignment, on: app.db).contains { $0.script?.script == "extra_test.py" })
+
+            let output = try await DeleteSuiteItemTool().execute(
+                DeleteSuiteItemTool.Input(
+                    assignmentPublicID: assignment.publicID, script: "extra_test.py",
+                    familyID: nil, check: nil),
+                context(app))
+            #expect(output.kind == "script")
+            #expect(output.removed == "extra_test.py")
+
+            let items = try await reloadItems(assignment, on: app.db)
+            #expect(!items.contains { $0.script?.script == "extra_test.py" })
+        }
+    }
+
+    @Test func deletesAFamily() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, seedFamily: true)
+            let output = try await DeleteSuiteItemTool().execute(
+                DeleteSuiteItemTool.Input(
+                    assignmentPublicID: assignment.publicID, script: nil,
+                    familyID: "bmi_category", check: nil),
+                context(app))
+            #expect(output.kind == "family")
+            #expect(output.removed == "bmi_category")
+
+            let items = try await reloadItems(assignment, on: app.db)
+            #expect(!items.contains { $0.family?.id == "bmi_category" })
+        }
+    }
+
+    @Test func unknownScriptThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await DeleteSuiteItemTool().execute(
+                    DeleteSuiteItemTool.Input(
+                        assignmentPublicID: assignment.publicID, script: "nope.py",
+                        familyID: nil, check: nil),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func noTargetThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await DeleteSuiteItemTool().execute(
+                    DeleteSuiteItemTool.Input(
+                        assignmentPublicID: assignment.publicID, script: nil,
+                        familyID: nil, check: nil),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func multipleTargetsThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, seedScript: "extra_test.py")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await DeleteSuiteItemTool().execute(
+                    DeleteSuiteItemTool.Input(
+                        assignmentPublicID: assignment.publicID, script: "extra_test.py",
+                        familyID: "bmi_category", check: nil),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            _ = try await makeTestSetup(
+                on: app, id: "setup_del", courseID: courseID, manifest: emptyManifest)
+            try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_del.zip")
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_del", courseID: courseID, title: "Lab")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await DeleteSuiteItemTool().execute(
+                    DeleteSuiteItemTool.Input(
+                        assignmentPublicID: assignment.publicID, script: "x.py",
+                        familyID: nil, check: nil),
+                    context(app))
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-delete-suite-item.md
+++ b/changelog.d/mcp-delete-suite-item.md
@@ -1,0 +1,10 @@
+### Added
+
+- **MCP `delete_suite_item` tool (issue #461).** Removes one item from an
+  assignment's test suite — a hand-written `script`, a pattern `familyID` (with
+  its generated cases), or a notebook `check` — through the same
+  buildSuitePayload / applySuiteEdit path the editor uses, so the manifest is
+  rebuilt (the item is no longer graded) and validation re-runs (rejecting a
+  removal that would leave a dangling dependsOn). Completes the MCP authoring
+  surface (create / edit / delete) needed to migrate hand-written tests to
+  declarative families end-to-end.


### PR DESCRIPTION
**Slice H** — the delete capability you asked me to batch in, so the MCP authoring surface is complete (create / edit / delete) and the Assignment 3 conversion can run end-to-end over MCP with no manual editor step.

## What
New `delete_suite_item` MCP tool (`content:write`, course-scoped). Removes one suite item — a hand-written `script`, a pattern `familyID` (with its generated cases), or a notebook `check` — identified by exactly one of those three. It loads the authored suite (`buildSuitePayload`), drops the row, and re-saves via `applySuiteEdit` (the same path the editor's delete uses), so the manifest is rebuilt (the item is no longer graded), a removed family's generated scripts are pruned, and validation re-runs — rejecting a removal that would leave a dangling `dependsOn`. Marked `destructiveHint: true`.

A generated family case isn't a `script` row, so it can't be targeted that way — to remove those, delete the family (documented in the tool description).

## Verification
`swift build` clean; `DeleteSuiteItemToolTests` 6/6 (delete script, delete family, unknown-target error, no-target error, multiple-targets error, enrollment denial); swift-format clean; SwiftLint `--strict` 0 violations.

## After this merges
All four capabilities are in (G create-family, E approximate-personalization, F unordered-equality, H delete). Redeploy the live server once to include #826/#827/#828/this, and I'll convert all 8 of Assignment 3's hand-written `dbgen` tests to declarative families — creating the families + per-student expected expressions and removing the old scripts — entirely over MCP.

https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6

---
_Generated by [Claude Code](https://claude.ai/code/session_014fwUvy4URn8XeDqX6WSyS6)_