### PR TITLE
MCP: surface gradingMode in get_assignment

### DIFF
--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -23,13 +23,18 @@ struct GetAssignmentTool: ContentTool {
         let startsAt: String?
         let validationStatus: String?
         let deadlineOverrideActive: Bool
+        /// How submissions are graded: "worker" (native runner) or "browser"
+        /// (in-browser Pyodide). Read from the test setup's manifest
+        /// (`TestProperties.gradingMode`, default "worker").
+        let gradingMode: String
     }
 
     static let name = "get_assignment"
     static let description =
         "Get an assignment's details by its public ID: title, course code, slug, "
         + "open/closed state, due date (ISO 8601), scheduled open date (ISO 8601, if any), "
-        + "and runner validation status."
+        + "runner validation status, and gradingMode (\"worker\" = graded by the native runner, "
+        + "\"browser\" = graded in-browser via Pyodide)."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -53,10 +58,11 @@ struct GetAssignmentTool: ContentTool {
             "startsAt": .object(["type": .string("string")]),
             "validationStatus": .object(["type": .string("string")]),
             "deadlineOverrideActive": .object(["type": .string("boolean")]),
+            "gradingMode": .object(["type": .string("string")]),
         ]),
         "required": .array([
             .string("publicID"), .string("title"), .string("slug"), .string("courseCode"),
-            .string("isOpen"), .string("deadlineOverrideActive"),
+            .string("isOpen"), .string("deadlineOverrideActive"), .string("gradingMode"),
         ]),
     ])
     static let requiredScopes: Set<ContentScope> = [.read]
@@ -71,6 +77,12 @@ struct GetAssignmentTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "The assignment's course could not be found.")
         }
+        // Grading mode lives in the test setup's manifest; default to "worker"
+        // (TestProperties' own default) when the setup or manifest is missing.
+        let gradingMode =
+            (try await APITestSetup.find(assignment.testSetupID, on: context.db))?
+            .decodedManifest()?.gradingMode.rawValue ?? "worker"
+
         let formatter = ISO8601DateFormatter()
         return Output(
             publicID: assignment.publicID,
@@ -81,7 +93,8 @@ struct GetAssignmentTool: ContentTool {
             dueAt: assignment.dueAt.map { formatter.string(from: $0) },
             startsAt: assignment.startsAt.map { formatter.string(from: $0) },
             validationStatus: assignment.validationStatus,
-            deadlineOverrideActive: assignment.deadlineOverrideActive ?? false
+            deadlineOverrideActive: assignment.deadlineOverrideActive ?? false,
+            gradingMode: gradingMode
         )
     }
 }

--- a/Tests/APITests/MCP/GetAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/GetAssignmentToolTests.swift
@@ -32,6 +32,29 @@ import Vapor
             #expect(output.title == "Tasks")
             #expect(output.courseCode == "CS246")
             #expect(output.isOpen == false)
+            // The default fixture manifest is browser-graded.
+            #expect(output.gradingMode == "browser")
+        }
+    }
+
+    @Test func reportsWorkerGradingMode() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(
+                on: app, id: "setup_w", courseID: courseID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#
+            )
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_w", courseID: courseID, title: "Tasks")
+
+            let output = try await GetAssignmentTool().execute(
+                GetAssignmentTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            #expect(output.gradingMode == "worker")
         }
     }
 

--- a/changelog.d/mcp-get-assignment-grading-mode.md
+++ b/changelog.d/mcp-get-assignment-grading-mode.md
@@ -1,0 +1,7 @@
+### Added
+
+- **MCP `get_assignment` now reports `gradingMode`.** Its output includes
+  whether an assignment is graded by the native runner (`"worker"`) or
+  in-browser via Pyodide (`"browser"`), read from the test setup's manifest
+  (`TestProperties.gradingMode`). Previously no MCP tool surfaced the grading
+  mode, so an agent had to guess it.


### PR DESCRIPTION
## Why

No MCP tool reported **how** an assignment is graded — worker (native runner) vs
browser (in-browser Pyodide). The value lives in the test-setup manifest
(`TestProperties.gradingMode`, default `worker`) but wasn't surfaced anywhere, so
an agent had to *guess* — which is exactly how I recently mis-assumed an
assignment was browser-graded when it was worker-graded.

## What

- **`get_assignment` output gains `gradingMode`** (`"worker"` / `"browser"`),
  read from the assignment's test-setup manifest, defaulting to `"worker"` when
  the setup/manifest is absent (matching `TestProperties`' own default). The
  tool description and `outputSchema` are updated to match.
- Single extra `APITestSetup` lookup in the handler; no other behavior changes.

## Tests
- `returnsDetailForEnrolledSubject` now asserts `gradingMode == "browser"` (the
  default test fixture uses a browser manifest).
- New `reportsWorkerGradingMode` builds a worker-manifest setup and asserts
  `gradingMode == "worker"`.
- Full build green; `GetAssignmentToolTests` 4/4 pass; swift-format clean;
  SwiftLint `--strict` 0 violations.

https://claude.ai/code/session_012TnxNG5L6oyfKKQ1mH2FBf

---
_Generated by [Claude Code](https://claude.ai/code/session_012TnxNG5L6oyfKKQ1mH2FBf)_