### PR TITLE
Add instructor-hint authoring to MCP pattern-family tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -923,7 +923,16 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
   `get_suite` now returns the full source of truth (script bodies + complete
   pattern-family/notebook-check specs + on-disk filenames), and pattern-family
   cases gained a per-student `expectedVarRef` (the worker/browser materialize
-  per-student `_ck_inputs.py` from `Job.personalizedInputs`).  Agent-facing
+  per-student `_ck_inputs.py` from `Job.personalizedInputs`).  Pattern-family
+  authoring also sets instructor **hints**: `create_pattern_family` /
+  `update_pattern_family` take a family-wide `defaultHint` and a per-case `hint`
+  (on update an empty string clears it, nil leaves it untouched), and `get_suite`
+  returns both in the `family` spec.  A hint surfaces to the student as a
+  "💡 Hint" only on a *failing* case — `buildHintByFilename` joins each case's
+  `resolvedHint(defaults:)` (per-case overriding the family default) by generated
+  filename at results-display time, so nothing is baked into the test script.
+  `PatternCase.hint` / `PatternDefaults.hint` have been manifest-authorable since
+  v0.4.94 but had no agent surface until now.  Agent-facing
   copy lives in two places that must stay in sync with the catalog: each tool's
   `description`/`inputSchema` and the server-level `MCPServerInstructions.text`
   (the `initialize` handshake's `instructions`); the tool table in

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -78,11 +78,12 @@ enum MCPServerInstructions {
         (ISO 8601), and an open/closed state.
         - Test suite — the ordered checks that grade an assignment. Each item is a hand-written \
         script, a generated pattern family, or a notebook check, and carries a tier \
-        (public/release/secret/student), points, an optional section, and prerequisites (dependsOn). \
+        (public/release/secret/student), points, an optional section, prerequisites (dependsOn), and \
+        an optional "💡 Hint" shown to the student only when that test fails. \
         get_suite returns the full definition of every item, not just its metadata: each \
         hand-written script's raw body, each pattern family's complete spec (function, paramNames, \
-        defaults, and every case's args/expected), and each notebook check's spec — so you can read \
-        exactly what a test checks (e.g. to explain why a submission lost points).
+        defaults, and every case's args/expected/hint), and each notebook check's spec — so you can \
+        read exactly what a test checks (e.g. to explain why a submission lost points).
         - Starter notebook — the .ipynb a student opens, stored as Jupyter JSON.
         - Solution — the instructor's reference answer key (.ipynb), validated against the suite. It \
         is instructor-authored content, never a student submission. Read with get_solution, replace \
@@ -127,7 +128,9 @@ enum MCPServerInstructions {
         is regraded; validate and open it with update_assignment when ready.
         - get_suite returns the full source of truth for reading: hand-written script bodies, \
         complete pattern-family specs, and notebook-check specs. For authoring, update_pattern_family \
-        edits a generated case's args/expected (validated on save), and author_script writes a single \
+        edits a generated case's args/expected and its hint — per-case `hint` or the family-wide \
+        `defaultHint` (create_pattern_family takes the same), validated on save — and author_script \
+        writes a single \
         hand-written file into the test setup. A test tier (public/release/secret/student) creates or \
         replaces the script AND its suite entry — set points/displayName/dependsOn/sectionID alongside \
         the body; the runner reads the per-student seed from the CHICKADEE_ASSIGNMENT_SEED env var, so \

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -40,9 +40,30 @@ struct CreatePatternFamilyTool: ContentTool {
         /// Per-student expected: name of a global/section `=` expression resolved
         /// for the student's seed at grading time (validator enforces eligible kinds).
         let expectedVarRef: String?
+        /// Per-case "💡 Hint" shown to the student only when this case fails;
+        /// overrides the family-wide `defaultHint`. Omitted/empty = no per-case hint.
+        let hint: String?
         let points: Int?
         let tier: String?
         let enabled: Bool?
+
+        init(
+            key: String, label: String? = nil, args: [JSONValue]? = nil, expected: JSONValue? = nil,
+            argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil, expectedVarRef: String? = nil,
+            hint: String? = nil, points: Int? = nil, tier: String? = nil, enabled: Bool? = nil
+        ) {
+            self.key = key
+            self.label = label
+            self.args = args
+            self.expected = expected
+            self.argVarRefs = argVarRefs
+            self.argsProvided = argsProvided
+            self.expectedVarRef = expectedVarRef
+            self.hint = hint
+            self.points = points
+            self.tier = tier
+            self.enabled = enabled
+        }
     }
 
     struct VariableInput: Decodable, Sendable {
@@ -64,12 +85,37 @@ struct CreatePatternFamilyTool: ContentTool {
         let paramNames: [String]?
         let defaultTier: String?
         let defaultPoints: Int?
+        /// Family-wide "💡 Hint" applied to any case that has no per-case `hint`.
+        let defaultHint: String?
         let tolerance: Double?
         /// Existing section id to place the family in; nil = ungrouped.
         let sectionID: String?
         let dependsOn: [String]?
         let variables: [VariableInput]?
         let cases: [CaseInput]
+
+        init(
+            assignmentPublicID: String, id: String, name: String, kind: String,
+            function: String? = nil, paramNames: [String]? = nil,
+            defaultTier: String? = nil, defaultPoints: Int? = nil, defaultHint: String? = nil,
+            tolerance: Double? = nil, sectionID: String? = nil, dependsOn: [String]? = nil,
+            variables: [VariableInput]? = nil, cases: [CaseInput]
+        ) {
+            self.assignmentPublicID = assignmentPublicID
+            self.id = id
+            self.name = name
+            self.kind = kind
+            self.function = function
+            self.paramNames = paramNames
+            self.defaultTier = defaultTier
+            self.defaultPoints = defaultPoints
+            self.defaultHint = defaultHint
+            self.tolerance = tolerance
+            self.sectionID = sectionID
+            self.dependsOn = dependsOn
+            self.variables = variables
+            self.cases = cases
+        }
     }
 
     struct Output: Encodable, Sendable {
@@ -88,6 +134,8 @@ struct CreatePatternFamilyTool: ContentTool {
         + "stdout_equality), the `function` it tests, `paramNames`, and a non-empty `cases` list — each "
         + "case a { key, args, expected } with raw-JSON args (in parameter order) and expected return. "
         + "Cases may personalize via argVarRefs / expectedVarRef (names of global/section = expressions). "
+        + "Set a `defaultHint` (family-wide) and/or per-case `hint` to give the student a \"💡 Hint\" "
+        + "shown only when that test fails (per-case overrides the family default). "
         + "Saving renders the family's scripts and runs validation synchronously, rejecting a wrong arg "
         + "count, an expected of the wrong shape for the kind, an unknown $ref, or a duplicate id. To "
         + "edit a family afterwards use update_pattern_family."
@@ -129,6 +177,12 @@ struct CreatePatternFamilyTool: ContentTool {
                 ]),
             ]),
             "defaultPoints": .object(["type": .string("integer")]),
+            "defaultHint": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Family-wide \"💡 Hint\" shown to the student on any failing case that has no "
+                        + "per-case hint."),
+            ]),
             "tolerance": .object([
                 "type": .string("number"),
                 "description": .string("Float tolerance for approximate_equality (default 1e-6)."),
@@ -183,6 +237,11 @@ struct CreatePatternFamilyTool: ContentTool {
                         "expectedVarRef": .object([
                             "type": .string("string"),
                             "description": .string("Per-student expected: name of a = expression."),
+                        ]),
+                        "hint": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Per-case \"💡 Hint\" shown when this case fails (overrides defaultHint)."),
                         ]),
                         "points": .object(["type": .string("integer")]),
                         "tier": .object([
@@ -304,7 +363,7 @@ struct CreatePatternFamilyTool: ContentTool {
         let defaults = PatternDefaults(
             tier: try parseTier(input.defaultTier) ?? .pub,
             points: input.defaultPoints ?? 1,
-            hint: nil,
+            hint: normalizedHint(input.defaultHint),
             tolerance: input.tolerance)
         let cases = try input.cases.map { c -> PatternCase in
             let args = c.args ?? []
@@ -318,7 +377,8 @@ struct CreatePatternFamilyTool: ContentTool {
             return PatternCase(
                 key: c.key, label: c.label ?? c.key, args: args, expected: c.expected ?? .null,
                 argsProvided: provided, argVarRefs: refs, expectedVarRef: ref,
-                hint: nil, tier: try parseTier(c.tier), points: c.points, enabled: c.enabled ?? true)
+                hint: normalizedHint(c.hint), tier: try parseTier(c.tier), points: c.points,
+                enabled: c.enabled ?? true)
         }
         return PatternFamily(
             id: id, name: input.name, kind: kind, functionName: input.function ?? "",
@@ -364,5 +424,13 @@ struct CreatePatternFamilyTool: ContentTool {
                 tool: name, detail: "tier must be one of: public, release, secret, student.")
         }
         return tier
+    }
+
+    /// Trims an empty hint to nil so an omitted/blank cell doesn't store an
+    /// empty "💡 Hint" callout.  Matches the empty-string handling used for
+    /// per-student refs.
+    private static func normalizedHint(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return raw
     }
 }

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -62,10 +62,11 @@ struct GetSuiteTool: ContentTool {
             let content: String?
             /// Instructor hint for a hand-written script (`kind == "script"`).
             let hint: String?
-            /// Full pattern-family spec — function, kind, paramNames, defaults,
-            /// variables, and every case's args/expected — for `kind ==
-            /// "family"` items. This is the source of truth the grader renders
-            /// into Python, so it reveals the exact values each case checks.
+            /// Full pattern-family spec — function, kind, paramNames, defaults
+            /// (including the family `hint`), variables, and every case's
+            /// args/expected/hint — for `kind == "family"` items. This is the
+            /// source of truth the grader renders into Python, so it reveals the
+            /// exact values each case checks and the hints students see on failure.
             let family: PatternFamily?
             /// Full notebook-check spec, for `kind == "check"` items.
             let check: NotebookCheck?
@@ -160,8 +161,9 @@ struct GetSuiteTool: ContentTool {
                             "type": .string("object"),
                             "description": .string(
                                 "Full pattern-family spec (kind == \"family\"): function, kind, "
-                                    + "paramNames, defaults, variables, and every case's "
-                                    + "args/expected — the exact values each case checks."),
+                                    + "paramNames, defaults (incl. family hint), variables, and every "
+                                    + "case's args/expected/hint — the exact values each case checks "
+                                    + "and the hints students see on failure."),
                         ]),
                         "check": .object([
                             "type": .string("object"),

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -42,11 +42,15 @@ struct UpdatePatternFamilyTool: ContentTool {
         /// `boundary_equality` only. An empty string clears it; setting
         /// `expected` (a literal) also clears it.
         let expectedVarRef: String?
+        /// Per-case "💡 Hint" shown when this case fails (overrides the family
+        /// `defaultHint`). nil leaves the existing hint untouched; an empty
+        /// string clears it.
+        let hint: String?
 
         init(
             key: String, args: [JSONValue]? = nil, expected: JSONValue? = nil,
             argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil,
-            expectedVarRef: String? = nil
+            expectedVarRef: String? = nil, hint: String? = nil
         ) {
             self.key = key
             self.args = args
@@ -54,6 +58,7 @@ struct UpdatePatternFamilyTool: ContentTool {
             self.argVarRefs = argVarRefs
             self.argsProvided = argsProvided
             self.expectedVarRef = expectedVarRef
+            self.hint = hint
         }
     }
 
@@ -62,6 +67,9 @@ struct UpdatePatternFamilyTool: ContentTool {
         let familyID: String
         let defaultTier: String?
         let defaultPoints: Int?
+        /// Family-wide "💡 Hint" applied to cases without their own hint. nil
+        /// leaves it untouched; an empty string clears it.
+        let defaultHint: String?
         let enableCases: [String]?
         let disableCases: [String]?
         /// Per-case `args` / `expected` edits (the test logic).
@@ -69,13 +77,14 @@ struct UpdatePatternFamilyTool: ContentTool {
 
         init(
             assignmentPublicID: String, familyID: String, defaultTier: String? = nil,
-            defaultPoints: Int? = nil, enableCases: [String]? = nil, disableCases: [String]? = nil,
-            cases: [CaseEdit]? = nil
+            defaultPoints: Int? = nil, defaultHint: String? = nil, enableCases: [String]? = nil,
+            disableCases: [String]? = nil, cases: [CaseEdit]? = nil
         ) {
             self.assignmentPublicID = assignmentPublicID
             self.familyID = familyID
             self.defaultTier = defaultTier
             self.defaultPoints = defaultPoints
+            self.defaultHint = defaultHint
             self.enableCases = enableCases
             self.disableCases = disableCases
             self.cases = cases
@@ -100,7 +109,9 @@ struct UpdatePatternFamilyTool: ContentTool {
     static let description =
         "Edit a pattern family for an assignment, by assignment public ID + family id. Set the "
         + "family's default tier (public/release/secret/student) and/or points, enable/disable cases "
-        + "by key (enableCases / disableCases), and/or edit individual cases' test logic via `cases` "
+        + "by key (enableCases / disableCases), set the family-wide `defaultHint` and/or per-case "
+        + "`hint` (the \"💡 Hint\" shown to the student only when that test fails; empty string clears "
+        + "it), and/or edit individual cases' test logic via `cases` "
         + "(each { key, args?, expected? }). args/expected are raw JSON values (a list of args in "
         + "parameter order, and the expected return). Saving regenerates the family's scripts and "
         + "re-runs validation, which rejects a wrong arg count or an expected value of the wrong shape "
@@ -124,6 +135,12 @@ struct UpdatePatternFamilyTool: ContentTool {
                 ]),
             ]),
             "defaultPoints": .object(["type": .string("integer")]),
+            "defaultHint": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Family-wide \"💡 Hint\" shown on a failing case that has no per-case hint. "
+                        + "Empty string clears it."),
+            ]),
             "enableCases": .object([
                 "type": .string("array"), "items": .object(["type": .string("string")]),
                 "description": .string("Case keys to enable."),
@@ -162,6 +179,12 @@ struct UpdatePatternFamilyTool: ContentTool {
                             "description": .string(
                                 "Per-student expected: name of a global/section = expression resolved for the "
                                     + "student's seed (boundary_equality only). Empty string clears it."),
+                        ]),
+                        "hint": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Per-case \"💡 Hint\" shown when this case fails (overrides defaultHint). "
+                                    + "Empty string clears it."),
                         ]),
                     ]),
                     "required": .array([.string("key")]),
@@ -204,12 +227,14 @@ struct UpdatePatternFamilyTool: ContentTool {
         let disable = Set(input.disableCases ?? [])
         let caseEdits = input.cases ?? []
         guard
-            newTier != nil || input.defaultPoints != nil || !enable.isEmpty || !disable.isEmpty
-                || !caseEdits.isEmpty
+            newTier != nil || input.defaultPoints != nil || input.defaultHint != nil
+                || !enable.isEmpty || !disable.isEmpty || !caseEdits.isEmpty
         else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
-                detail: "Specify at least one of: defaultTier, defaultPoints, enableCases, disableCases, cases.")
+                detail:
+                    "Specify at least one of: defaultTier, defaultPoints, defaultHint, enableCases, "
+                    + "disableCases, cases.")
         }
         guard enable.isDisjoint(with: disable) else {
             throw MCPToolError.invalidArguments(
@@ -246,9 +271,13 @@ struct UpdatePatternFamilyTool: ContentTool {
                 detail: "Unknown case key(s): \(unknown.sorted().joined(separator: ", ")).")
         }
 
+        let newDefaults = PatternDefaults(
+            tier: newTier ?? family.defaults.tier,
+            points: input.defaultPoints ?? family.defaults.points,
+            hint: Self.resolveHintEdit(input.defaultHint, existing: family.defaults.hint),
+            tolerance: family.defaults.tolerance)
         let updatedFamily = try Self.rebuild(
-            family, newTier: newTier, newPoints: input.defaultPoints,
-            enable: enable, disable: disable, edits: editsByKey)
+            family, defaults: newDefaults, enable: enable, disable: disable, edits: editsByKey)
         payload.items[idx].family = updatedFamily
 
         // applySuiteEdit -> applyPatternFamilies -> validatePatternFamilies runs
@@ -291,17 +320,13 @@ struct UpdatePatternFamilyTool: ContentTool {
         return byKey
     }
 
-    /// Reconstructs the family with new defaults, per-case enabled flags, and
-    /// per-case arg/expected edits; every other field is copied verbatim.
+    /// Reconstructs the family with the resolved `defaults`, per-case enabled
+    /// flags, and per-case arg/expected/hint edits; every other field is copied
+    /// verbatim.
     private static func rebuild(
-        _ family: PatternFamily, newTier: TestTier?, newPoints: Int?,
+        _ family: PatternFamily, defaults: PatternDefaults,
         enable: Set<String>, disable: Set<String>, edits: [String: CaseEdit]
     ) throws -> PatternFamily {
-        let defaults = PatternDefaults(
-            tier: newTier ?? family.defaults.tier,
-            points: newPoints ?? family.defaults.points,
-            hint: family.defaults.hint,
-            tolerance: family.defaults.tolerance)
         let cases = try family.cases.map { caseSpec -> PatternCase in
             let enabled =
                 enable.contains(caseSpec.key)
@@ -346,7 +371,16 @@ struct UpdatePatternFamilyTool: ContentTool {
         return PatternCase(
             key: caseSpec.key, label: caseSpec.label, args: finalArgs, expected: finalExpected,
             argsProvided: finalProvided, argVarRefs: finalVarRefs, expectedVarRef: finalExpectedVarRef,
-            hint: caseSpec.hint, tier: caseSpec.tier, points: caseSpec.points, enabled: enabled)
+            hint: resolveHintEdit(edit.hint, existing: caseSpec.hint),
+            tier: caseSpec.tier, points: caseSpec.points, enabled: enabled)
+    }
+
+    /// Resolves a hint edit against the existing value, matching the
+    /// `expectedVarRef` convention: nil (omitted) preserves the existing hint,
+    /// an empty string clears it, and any other string sets it.
+    private static func resolveHintEdit(_ edit: String?, existing: String?) -> String? {
+        guard let edit else { return existing }
+        return edit.isEmpty ? nil : edit
     }
 
     /// Resolves a parallel array (argVarRefs / argsProvided) for an edited case:

--- a/Tests/APITests/MCP/CreatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/CreatePatternFamilyToolTests.swift
@@ -102,6 +102,57 @@ import Vapor
         }
     }
 
+    @Test func createsFamilyWithDefaultAndPerCaseHints() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await CreatePatternFamilyTool().execute(
+                CreatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, id: "hinted", name: "Hinted",
+                    kind: "boundary_equality", function: "f", paramNames: ["x"],
+                    defaultTier: "release", defaultPoints: 1, defaultHint: "mind the boundary",
+                    cases: [
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "01", label: "edge", args: [.int(1)], expected: .string("one"),
+                            hint: "1 is the lower edge"),
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "02", label: "plain", args: [.int(2)], expected: .string("two")),
+                    ]),
+                context(app))
+
+            let family = try await reloadFamily(assignment, id: "hinted", on: app.db)
+            #expect(family.defaults.hint == "mind the boundary")
+            let c1 = try #require(family.cases.first { $0.key == "01" })
+            #expect(c1.hint == "1 is the lower edge")
+            #expect(c1.resolvedHint(defaults: family.defaults) == "1 is the lower edge")
+            // Case 02 has no per-case hint; it inherits the family default.
+            let c2 = try #require(family.cases.first { $0.key == "02" })
+            #expect(c2.hint == nil)
+            #expect(c2.resolvedHint(defaults: family.defaults) == "mind the boundary")
+        }
+    }
+
+    @Test func blankPerCaseHintIsStoredAsNil() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await CreatePatternFamilyTool().execute(
+                CreatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, id: "blank", name: "Blank",
+                    kind: "boundary_equality", function: "f", paramNames: ["x"],
+                    defaultHint: "",
+                    cases: [
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "01", args: [.int(1)], expected: .string("one"), hint: "")
+                    ]),
+                context(app))
+            let family = try await reloadFamily(assignment, id: "blank", on: app.db)
+            // An empty hint normalizes to nil rather than a blank "💡 Hint".
+            #expect(family.defaults.hint == nil)
+            #expect(family.cases.first?.hint == nil)
+        }
+    }
+
     @Test func rejectsDuplicateFamilyID() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -117,6 +117,56 @@ import Vapor
         }
     }
 
+    @Test func setsAndClearsDefaultAndPerCaseHints() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Set a family-wide default hint and a per-case hint on case 01.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultHint: "watch the category boundaries",
+                    cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", hint: "18.5 rounds up to normal")]),
+                context(app))
+            var family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.defaults.hint == "watch the category boundaries")
+            #expect(family.cases.first { $0.key == "01" }?.hint == "18.5 rounds up to normal")
+            // Case 02 keeps no per-case hint and inherits the family default.
+            let c2 = try #require(family.cases.first { $0.key == "02" })
+            #expect(c2.hint == nil)
+            #expect(c2.resolvedHint(defaults: family.defaults) == "watch the category boundaries")
+            // Args/expected are untouched by a hint-only edit.
+            #expect(family.cases.first { $0.key == "01" }?.expected == .string("underweight"))
+
+            // An empty string clears each hint; everything else is preserved.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultHint: "",
+                    cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", hint: "")]),
+                context(app))
+            family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.defaults.hint == nil)
+            #expect(family.cases.first { $0.key == "01" }?.hint == nil)
+            #expect(family.cases.first { $0.key == "01" }?.expected == .string("underweight"))
+        }
+    }
+
+    @Test func defaultHintOnlyIsAValidChangeSet() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // defaultHint alone (no tier/points/case edits) must be accepted.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultHint: "re-read the spec's edge cases"),
+                context(app))
+            let family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.defaults.hint == "re-read the spec's edge cases")
+        }
+    }
+
     @Test func setsPerStudentExpectedVarRefAndClearsOnLiteralEdit() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/changelog.d/mcp-pattern-family-hints.md
+++ b/changelog.d/mcp-pattern-family-hints.md
@@ -1,0 +1,11 @@
+### Added
+
+- **MCP pattern families can now set instructor hints.** `create_pattern_family`
+  and `update_pattern_family` accept a family-wide `defaultHint` and a per-case
+  `hint` (per-case overrides the family default; on update an empty string clears
+  a hint and nil leaves it untouched). The hint surfaces to the student as a
+  "💡 Hint" only on a failing case via the existing display-time
+  `resolvedHint(defaults:)` join — nothing is baked into the generated script.
+  `get_suite` already returns these in the `family` spec. Previously the fields
+  were manifest-authorable (since v0.4.94) but had no agent surface, so hints
+  authored through MCP were silently dropped.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -39,7 +39,8 @@ tools, all `content:read` / `content:write` scoped and course-scoped:
 | `update_suite` | `content:write` | Script metadata: tier, points, displayName, dependsOn, section |
 | `update_global_inputs` | `content:write` | Replace the assignment's global personalization variables/expressions |
 | `update_section_variables` | `content:write` | Replace a section's scoped variables/expressions |
-| `update_pattern_family` | `content:write` | Family defaults + per-case args/expected (incl. per-student `$ref`s), enable/disable |
+| `create_pattern_family` | `content:write` | Create a new pattern family: kind, function, cases (args/expected/hint), defaults (tier/points/`defaultHint`) |
+| `update_pattern_family` | `content:write` | Family defaults (tier/points/`defaultHint`) + per-case args/expected/hint (incl. per-student `$ref`s), enable/disable |
 | `update_notebook` | `content:write` | Replace the starter notebook |
 | `update_solution` | `content:write` | Replace the reference solution and re-validate |
 | `author_script` | `content:write` | Create/replace a hand-written test or support file |


### PR DESCRIPTION
## What

`create_pattern_family` and `update_pattern_family` (MCP) now accept instructor **hints**:
- a family-wide `defaultHint`, and
- a per-case `hint` (overrides the family default).

This exposes the existing `PatternDefaults.hint` / `PatternCase.hint` fields, which have been manifest-authorable since v0.4.94 but had **no MCP surface** — so hints an agent authored through these tools were silently dropped.

## Why

While adding pattern-family tests to an assignment via MCP, the per-family Hint specified in the task couldn't be applied: neither tool exposed the field. The storage, rendering, and display layers already support hints end-to-end; only the agent-facing surface was missing.

## How hints reach the student

Nothing is baked into the generated test script. A hint surfaces as a "💡 Hint" **only on a failing case**, via the existing display-time join (`buildHintByFilename` → `PatternCase.resolvedHint(defaults:)`), per-case overriding the family default. Generated-script bytes are therefore unchanged (`spec_hash` / cache keys stable).

## Semantics

- **Create:** `defaultHint` + per-case `hint`; an empty string normalizes to `nil` (a blank cell never stores an empty callout).
- **Update:** `defaultHint` + per-case `hint` with **nil-preserves / empty-string-clears** semantics, matching the existing `expectedVarRef` convention. A hint-only edit is a valid change set.

## Changes

- `CreatePatternFamilyTool` / `UpdatePatternFamilyTool` — new inputs, schema, descriptions, wiring. `rebuild` takes the resolved `PatternDefaults` (keeps it within the 6-param SwiftLint limit).
- `GetSuiteTool` — doc/schema note that the `family` spec carries hints (already serialized; round-trips for read-back).
- `MCPServerInstructions` — hint mention in the suite concept + authoring note.
- `CLAUDE.md`, `docs/mcp-authoring-roadmap.md` (also adds the previously-missing `create_pattern_family` row).
- `changelog.d/` fragment.

## Verification

- `swift build` (APIServer) clean
- `swift-format --strict` clean
- `scripts/swiftlint.sh` (`--strict`) — 0 violations
- 26 tests pass across both suites, incl. 4 new: hint set/inherit/blank→nil (create); set/clear + default-only change set (update)

https://claude.ai/code/session_01AVnrxvE5q9y5E2ARVEgLWY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVnrxvE5q9y5E2ARVEgLWY)_