### PR TITLE
fix(zip): emit a valid empty archive instead of failing on an empty test setup

### DIFF
--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -24,6 +24,15 @@ enum ScriptZipError: Error {
 /// on any failure — caller decides whether to translate to a higher-level
 /// error.
 func repackZipFromDirectory(zipPath: String, sourceDir: URL) throws {
+    // `/usr/bin/zip -r . ` aborts with "Nothing to do!" (exit 12) when the
+    // source directory holds no files. An empty test setup is a legitimate
+    // state — attaching personalization inputs to a brand-new assignment before
+    // any test script exists, or deleting the last script — so emit a valid
+    // empty archive rather than failing the whole save with a raw zip error.
+    guard directoryContainsFile(sourceDir) else {
+        try writeEmptyZip(at: zipPath)
+        return
+    }
     try withZipProcessLock {
         let zip = Process()
         zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
@@ -35,6 +44,30 @@ func repackZipFromDirectory(zipPath: String, sourceDir: URL) throws {
         zip.waitUntilExit()
         guard zip.terminationStatus == 0 else { throw ScriptZipError.zipFailed }
     }
+}
+
+/// True when `dir` contains at least one regular file (searched recursively).
+/// `zip` has "nothing to do" — and exits non-zero — when this is false.
+private func directoryContainsFile(_ dir: URL) -> Bool {
+    guard
+        let enumerator = FileManager.default.enumerator(
+            at: dir, includingPropertiesForKeys: [.isRegularFileKey])
+    else { return false }
+    for case let url as URL in enumerator
+    where (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile == true {
+        return true
+    }
+    return false
+}
+
+/// Writes a valid, empty zip archive (a bare 22-byte End-Of-Central-Directory
+/// record) to `zipPath`. `zip(1)` refuses to create an empty archive, so we
+/// emit the canonical empty-zip bytes directly; `unzip` / `listZipEntries` read
+/// it back as an archive with zero entries.
+private func writeEmptyZip(at zipPath: String) throws {
+    let endOfCentralDirectory: [UInt8] = [0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18)
+    try? FileManager.default.removeItem(atPath: zipPath)
+    try Data(endOfCentralDirectory).write(to: URL(fileURLWithPath: zipPath))
 }
 
 // MARK: - Zip upload size guard

--- a/Tests/APITests/EmptySuitePersonalizationTests.swift
+++ b/Tests/APITests/EmptySuitePersonalizationTests.swift
@@ -1,0 +1,89 @@
+// Regression tests for the empty-suite zip-repack bug: `repackZipFromDirectory`
+// shelled out to `zip -r .`, which aborts with "Nothing to do!" (exit 12) on an
+// empty source directory. That raw `ScriptZipError` escaped GlobalInputsService
+// (which only maps WebAssignmentError), so adding personalization to a
+// brand-new assignment — whose setup zip has no test files yet — failed with an
+// opaque error. The fix emits a valid empty archive instead.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct EmptySuitePersonalizationTests {
+
+    /// Writes the canonical 22-byte empty zip (End-Of-Central-Directory only) so
+    /// the test reproduces a brand-new setup's truly-empty archive without
+    /// depending on the code under test.
+    private func writeEmptyZipFile(at path: String) throws {
+        let eocd: [UInt8] = [0x50, 0x4B, 0x05, 0x06] + [UInt8](repeating: 0, count: 18)
+        try? FileManager.default.removeItem(atPath: path)
+        try Data(eocd).write(to: URL(fileURLWithPath: path))
+    }
+
+    // MARK: - Unit: repack an empty directory
+
+    @Test func repackEmptyDirectoryProducesUsableEmptyZip() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("empty-src-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+        let zipPath = fm.temporaryDirectory.appendingPathComponent("out-\(UUID().uuidString).zip").path
+        defer { try? fm.removeItem(atPath: zipPath) }
+
+        // Previously threw ScriptZipError.zipFailed (zip "Nothing to do!").
+        try repackZipFromDirectory(zipPath: zipPath, sourceDir: dir)
+
+        #expect(fm.fileExists(atPath: zipPath))
+        #expect(listZipEntries(zipPath: zipPath).isEmpty)
+
+        // The empty archive is still usable: a later add round-trips.
+        try applyScriptChangesToZip(zipPath: zipPath, writes: ["t.sh": "exit 0\n"], deletions: [])
+        #expect(listZipEntries(zipPath: zipPath) == ["t.sh"])
+    }
+
+    // MARK: - Integration: global inputs on an empty suite
+
+    @Test func globalInputsSucceedOnEmptySuite() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            let manifest = #"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#
+            try await makeTestSetup(on: app, id: "setup_empty", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_empty", courseID: courseID, title: "Fresh")
+
+            // Reproduce a brand-new assignment: an empty setup zip (no test files).
+            let setup = try #require(try await APITestSetup.find("setup_empty", on: app.db))
+            try writeEmptyZipFile(at: setup.zipPath)
+
+            // Before the fix this threw ScriptZipError.zipFailed on the empty
+            // repack. `actingUserID: nil` skips the per-seed eval so the test
+            // isolates the zip path. A literal `fortunes` list is the exact
+            // shape the Lab 5 authoring flow hit.
+            let result = try await GlobalInputsService.apply(
+                setup: setup,
+                assignment: assignment,
+                actingUserID: nil,
+                inputs: .init(
+                    variables: [
+                        FamilyVariable(name: "fortunes", value: .array([.string("a"), .string("b")]))
+                    ],
+                    expressions: []),
+                testSetupsDirectory: app.testSetupsDirectory,
+                on: app.db)
+
+            #expect(result.variables.contains { $0.name == "fortunes" })
+
+            // The setup zip is still a valid (empty) archive afterwards.
+            let reloaded = try #require(try await APITestSetup.find("setup_empty", on: app.db))
+            #expect(listZipEntries(zipPath: reloaded.zipPath).isEmpty)
+        }
+    }
+}

--- a/changelog.d/empty-suite-zip-repack.md
+++ b/changelog.d/empty-suite-zip-repack.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Personalization / suite edits on a brand-new assignment no longer fail with
+  an opaque error.** When a test setup had no files yet — e.g. attaching global
+  inputs (a personalized fortune) to a fresh notebook assignment before
+  authoring any test — the save threw an internal error. `repackZipFromDirectory`
+  shelled out to `zip -r .`, which aborts with "Nothing to do!" (exit 12) on an
+  empty directory, and that raw error escaped `update_global_inputs`'s
+  error mapping. It now emits a valid empty archive instead, so an empty test
+  suite is a legitimate state. (Workaround until now: author one test before
+  adding personalization.)


### PR DESCRIPTION
## Summary

Follow-up to #833 (flagged in that PR's notes): fixes the `update_global_inputs` empty-suite failure I hit while authoring Lab 5.

**Bug.** Adding global inputs — or any suite re-render — to an assignment whose test setup has **no files yet** (a brand-new notebook assignment, before any test script is authored) failed with an opaque internal error over MCP.

**Root cause.** `repackZipFromDirectory` shells out to `zip -r . `, which aborts with **"Nothing to do!" (exit 12)** when the source directory is empty, throwing `ScriptZipError.zipFailed`. That raw error escapes `GlobalInputsService` (which only maps `WebAssignmentError`), so it surfaced as a generic `-32603` rather than a clean validation message. An empty test setup is a *legitimate* state — personalization lives in the manifest, not the zip — so failing the save is wrong.

**Fix.** `repackZipFromDirectory` now detects an empty source directory and writes the canonical 22-byte empty zip (End-Of-Central-Directory record) instead of invoking `zip`. `unzip` / `listZipEntries` read it back as a zero-entry archive, and a subsequent add round-trips normally. This also covers deleting the last script in a suite.

## Tests

- **Unit:** `repackZipFromDirectory` on an empty directory yields a usable empty archive (`listZipEntries` → `[]`), and a later `applyScriptChangesToZip` add round-trips.
- **Integration:** `GlobalInputsService.apply` succeeds on an empty-suite setup with an empty zip and persists the literal `fortunes` list — the exact Lab 5 authoring scenario that previously threw.

`swift build`, both new tests, `swift-format`, and SwiftLint (`--strict`) pass locally. A `changelog.d/` fragment is included; no `VERSION`/`CHANGELOG` edits.

## Impact

Removes the "author a test before adding personalization" workaround — instructors (and the MCP agent) can attach personalized inputs to a fresh assignment in any order.

https://claude.ai/code/session_014jMRtHj6MgTTTymB1VFgrN

---
_Generated by [Claude Code](https://claude.ai/code/session_014jMRtHj6MgTTTymB1VFgrN)_