### PR TITLE
Fix Preview visibility: behave as Open for staff, Closed for students

### DIFF
--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -144,7 +144,7 @@
                                 style="font-size:.8rem;padding:.25rem .45rem;min-width:5.5rem"
                                 onchange="this.form.submit()">
                             <option value="open" #if(row.status == "open"):selected#endif>open</option>
-                            <option value="preview" #if(row.status == "preview"):selected#endif>preview (staff only)</option>
+                            <option value="preview" #if(row.status == "preview"):selected#endif>staff only</option>
                             <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
                         </select>
                     </form>
@@ -190,7 +190,7 @@
                 </td>
                 <td>
                     #if(row.status == "unpublished"):
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                     <details class="publish-details">
                         <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
                         <form class="publish-form" method="post" action="/instructor">
@@ -222,7 +222,7 @@
                     </form>
                     </div>
                     #elseif(row.status == "closed"):
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                         <button class="btn action-btn" type="button"
                                 title="Copy student link" aria-label="Copy student link"
                                 style="padding:.25rem .35rem"
@@ -254,7 +254,7 @@
                         </form>
                     </div>
                     #elseif(row.status == "open"):
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                         <button class="btn action-btn" type="button"
                                 title="Copy student link" aria-label="Copy student link"
                                 style="padding:.25rem .35rem"
@@ -286,7 +286,7 @@
                         </form>
                     </div>
                     #else:
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                         <a class="btn btn-primary" href="/instructor/#(row.assignmentID)/validate">Validate &amp; open →</a>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
@@ -357,7 +357,7 @@
                                 style="font-size:.8rem;padding:.25rem .45rem;min-width:5.5rem"
                                 onchange="this.form.submit()">
                             <option value="open" #if(row.status == "open"):selected#endif>open</option>
-                            <option value="preview" #if(row.status == "preview"):selected#endif>preview (staff only)</option>
+                            <option value="preview" #if(row.status == "preview"):selected#endif>staff only</option>
                             <option value="closed" #if(row.status == "closed"):selected#endif>closed</option>
                         </select>
                     </form>
@@ -403,7 +403,7 @@
                 </td>
                 <td>
                     #if(row.status == "unpublished"):
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                     <details class="publish-details">
                         <summary class="btn action-btn" style="cursor:pointer;list-style:none">Publish…</summary>
                         <form class="publish-form" method="post" action="/instructor">
@@ -435,7 +435,7 @@
                     </form>
                     </div>
                     #elseif(row.status == "closed"):
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                         <button class="btn action-btn" type="button"
                                 title="Copy student link" aria-label="Copy student link"
                                 style="padding:.25rem .35rem"
@@ -457,7 +457,7 @@
                         </form>
                     </div>
                     #elseif(row.status == "open"):
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                         <button class="btn action-btn" type="button"
                                 title="Copy student link" aria-label="Copy student link"
                                 style="padding:.25rem .35rem"
@@ -479,7 +479,7 @@
                         </form>
                     </div>
                     #else:
-                    <div style="display:flex;gap:.2rem;flex-wrap:wrap;align-items:center">
+                    <div style="display:flex;gap:.2rem;flex-wrap:nowrap;align-items:center;white-space:nowrap">
                         <a class="btn btn-primary" href="/instructor/#(row.assignmentID)/validate">Validate &amp; open →</a>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -57,10 +57,10 @@
             <td>
                 <span class="tier
                     #if(setup.status == "open"):tier-open
-                    #elseif(setup.status == "preview"):tier-preview
                     #elseif(setup.status == "closed"):tier-closed
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
+                #if(setup.staffOnly):<span class="tier tier-preview staff-only-tag" title="Visible to course staff only — students can't see this assignment yet.">staff only</span>#endif
             </td>
             <td class="due-col">
                 #if(setup.opensAtText):
@@ -176,10 +176,10 @@
             <td>
                 <span class="tier
                     #if(setup.status == "open"):tier-open
-                    #elseif(setup.status == "preview"):tier-preview
                     #elseif(setup.status == "closed"):tier-closed
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
+                #if(setup.staffOnly):<span class="tier tier-preview staff-only-tag" title="Visible to course staff only — students can't see this assignment yet.">staff only</span>#endif
             </td>
             <td class="due-col">
                 #if(setup.opensAtText):
@@ -295,10 +295,10 @@
             <td>
                 <span class="tier
                     #if(setup.status == "open"):tier-open
-                    #elseif(setup.status == "preview"):tier-preview
                     #elseif(setup.status == "closed"):tier-closed
                     #elseif(setup.status == "unpublished"):tier-unpublished
                     #endif">#(setup.status)</span>
+                #if(setup.staffOnly):<span class="tier tier-preview staff-only-tag" title="Visible to course staff only — students can't see this assignment yet.">staff only</span>#endif
             </td>
             <td class="due-col">
                 #if(setup.opensAtText):

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -102,10 +102,11 @@ enum MCPServerInstructions {
         with update_global_inputs. Sections can also carry their own scoped variables/expressions \
         (same shape); get_suite returns them per section and update_section_variables replaces them.
         - Visibility — an assignment is closed, preview, or open (set via update_assignment `visibility`, \
-        or the legacy `isOpen` boolean for open/closed). `preview` is a staff-only beta state: only \
-        course staff can see it and they may test-submit to it, while students still can't see it. The \
-        lifecycle is one-way (closed → preview → open); moving an already-open assignment to preview is \
-        refused. Both preview and open require the suite's runner validation to have passed.
+        or the legacy `isOpen` boolean for open/closed). `preview` is a staff-only state: course staff \
+        see and use it exactly like an open assignment (its bundled solution and tests, normal grading), \
+        while students see it as closed. Switching to preview is a pure visibility change with no side \
+        effects — it neither re-validates nor closes anything. Only opening to students requires the \
+        suite's runner validation to have passed.
 
         Recommended workflow:
         1. Discover: list_courses, then list_assignments for a course. get_server_info reports the \

--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -140,7 +140,7 @@ struct CloneAssignmentTool: ContentTool {
             case .setupCopyFailed(let reason):
                 throw MCPToolError.executionFailed(
                     tool: Self.name, detail: "Could not copy the source test setup: \(reason)")
-            case .validationNotPassed, .cannotPreviewOpenAssignment:
+            case .validationNotPassed:
                 throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
             }
         }

--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -5,15 +5,14 @@
 // A content edit (suite metadata, pattern family, raw script, starter notebook,
 // or reference solution) can change what the suite grades, so it re-runs
 // validation — and, matching the web "Save" button (`saveEditedAssignment`,
-// which closes on every save), it returns the assignment to `.closed`. The
+// which closes on every save), it CLOSES a currently-open assignment. The
 // student submission gate keys off visibility (`.open`), not `validationStatus`,
 // so leaving an edited assignment open would let students submit against a
-// not-yet-revalidated — possibly broken — suite. A `.preview` assignment is
-// closed too: its staff test-submit path is gated on validation, which the edit
-// has just invalidated, so it must drop out of the staff-only beta state and be
-// re-validated. Closing holds everyone out until the instructor re-opens (or
-// re-previews) with `update_assignment`, which is itself refused until
-// validation passes.
+// not-yet-revalidated — possibly broken — suite. Closing holds them out until
+// the instructor re-opens with `update_assignment`, which is itself refused
+// until validation passes. (A `.preview` assignment is staff-only and already
+// hidden from students, so it is left as-is — editing it is not a student-facing
+// risk and must not silently kick it out of preview.)
 //
 // This is persisted as its own save rather than folded into
 // `scheduleValidationAfterSuiteEdit`: that helper is debounced and skips its own
@@ -23,15 +22,14 @@
 import Core
 import Fluent
 
-/// Closes `assignment` if students could currently see it as open or staff are
-/// previewing it (visibility != `.closed`), persisting the change, and reports
-/// whether it did. A no-op returning `false` when already closed, so a tool can
-/// surface "did this edit close the assignment" to the agent.
+/// Closes `assignment` if it is currently open, persisting the change, and
+/// reports whether it did. A no-op returning `false` when not open, so a tool
+/// can surface "did this edit close the assignment" to the agent.
 @discardableResult
 func closeOpenAssignmentForContentEdit(
     _ assignment: APIAssignment, on db: any Database
 ) async throws -> Bool {
-    guard assignment.visibility != .closed else { return false }
+    guard assignment.visibility == .open else { return false }
     assignment.visibility = .closed
     try await assignment.save(on: db)
     return true

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -53,9 +53,9 @@ struct UpdateAssignmentTool: ContentTool {
         + "open for submissions now — refused until runner validation passes, and clears any pending "
         + "open date — or false to close), and/or visibility (\"closed\", \"preview\", or \"open\"). "
         + "visibility is the three-state form of isOpen and wins if both are given: \"preview\" is a "
-        + "staff-only beta state where only course staff can see the assignment and test-submit to it "
-        + "(refused until validation passes); the lifecycle is one-way (closed → preview → open), so "
-        + "moving an already-open assignment to preview is refused — close it first. Does not change "
+        + "staff-only state where course staff see and use the assignment exactly like open while "
+        + "students see it as closed. Switching to preview is a pure visibility change (no validation, "
+        + "no close); only opening to students is refused until validation passes. Does not change "
         + "test content, so it never triggers a regrade."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
@@ -152,11 +152,7 @@ struct UpdateAssignmentTool: ContentTool {
         } catch AssignmentAuthoringError.validationNotPassed {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
-                detail: "The assignment cannot be opened or previewed until its runner validation has passed.")
-        } catch AssignmentAuthoringError.cannotPreviewOpenAssignment {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "open → preview is not allowed; close the assignment before moving it to preview.")
+                detail: "The assignment cannot be opened until its runner validation has passed.")
         }
 
         let formatter = ISO8601DateFormatter()

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -117,9 +117,12 @@ struct UpdateSolutionTool: ContentTool {
 
         // Close a currently-open assignment (matching the web Save button) so
         // students can't submit against the not-yet-revalidated solution/suite;
-        // folded into the same save as the validation-status flip.
-        let closed = assignment.visibility != .closed
-        assignment.visibility = .closed
+        // folded into the same save as the validation-status flip. A staff-only
+        // Preview assignment is left as-is (already hidden from students).
+        let closed = assignment.visibility == .open
+        if closed {
+            assignment.visibility = .closed
+        }
         assignment.validationSubmissionID = validationSubmissionID
         assignment.validationStatus = "pending"
         try await assignment.save(on: context.db)

--- a/Sources/APIServer/Models/APISubmission.swift
+++ b/Sources/APIServer/Models/APISubmission.swift
@@ -11,14 +11,6 @@ final class APISubmission: Model, Content, @unchecked Sendable {
     enum Kind {
         static let student = "student"
         static let validation = "validation"
-        /// A course-staff test submission, made while an assignment is in the
-        /// Preview (or open) state to exercise the real grading path before
-        /// publishing. Graded exactly like a student submission — the worker
-        /// claims it and results are stored normally — but excluded from every
-        /// student-facing aggregate (all class-stat queries filter to
-        /// `.student`), so staff test runs never pollute class data, grades,
-        /// or badges.
-        static let preview = "preview"
     }
 
     @ID(custom: "id", generatedBy: .user)

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -90,8 +90,7 @@ struct BrowserResultRoutes: RouteCollection {
             status: "complete",
             filename: "\(subID).ipynb",
             userID: caller.id,
-            // Course-staff submissions are test/preview runs, never class data.
-            kind: caller.isInstructor ? APISubmission.Kind.preview : APISubmission.Kind.student
+            kind: APISubmission.Kind.student
         )
         try await submission.save(on: req.db)
 
@@ -192,8 +191,7 @@ struct BrowserResultRoutes: RouteCollection {
             status: "pending",
             filename: submittedFilename,
             userID: caller.id,
-            // Course-staff submissions are test/preview runs, never class data.
-            kind: caller.isInstructor ? APISubmission.Kind.preview : APISubmission.Kind.student
+            kind: APISubmission.Kind.student
         )
         try await submission.save(on: req.db)
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -284,12 +284,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             try await AssignmentAuthoringService.setVisibility(assignment, visibility, on: req.db)
         } catch AssignmentAuthoringError.validationNotPassed {
             throw WebAssignmentError.validationRequired(
-                reason: "Assignment cannot be opened or previewed until runner validation passes."
-            )
-        } catch AssignmentAuthoringError.cannotPreviewOpenAssignment {
-            throw WebAssignmentError.invalidParameter(
-                name: "status",
-                reason: "Close the assignment before moving it to Preview."
+                reason: "Assignment cannot be opened until runner validation passes."
             )
         }
         return req.redirect(to: "/instructor")

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -778,7 +778,8 @@ extension StudentCourseRoutes {
         return StudentAssignmentRow(
             assignmentID: assignment.publicID,
             title: assignment.title,
-            status: assignment.visibility.rawValue,
+            // Student-facing: Preview is indistinguishable from closed.
+            status: assignment.visibility == .preview ? "closed" : assignment.visibility.rawValue,
             isOpen: assignment.isOpen,
             dueAtText: dueAtText,
             effectiveDueAtText: effectiveDueAtText,

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -27,7 +27,11 @@ struct TestSetupRow: Encodable {
     /// in the future. Drives the "Opens …" hint in the Due column; nil once
     /// the assignment has opened or when no open date is set.
     let opensAtText: String?
-    let status: String  // "unpublished" | "open" | "closed"
+    let status: String  // "unpublished" | "open" | "closed" (per viewer; preview resolves here)
+    /// True only for course staff viewing a Preview assignment: it functions as
+    /// open for them but carries a subtle "staff-only" marker so they can tell
+    /// at a glance it isn't visible to students yet. Always false for students.
+    let staffOnly: Bool
     let isOpen: Bool
     /// True when the Edit link should be shown: the assignment is open for
     /// this user, OR it is closed but the student has previously opened it

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -49,15 +49,10 @@ extension WebRoutes {
         // are unaffected.
         let isClosed: Bool
         if let assignment {
-            let effectivelyOpen = try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db)
-            // Course staff get an editable notebook on a Preview assignment so
-            // they can test-submit it (matching the submission gate's preview
-            // bypass); students see Preview read-only, exactly as for a closed
-            // assignment.
-            let staffPreview =
-                user.isInstructor && assignment.visibility == .preview
-                && (assignment.validationStatus == nil || assignment.validationStatus == "passed")
-            isClosed = !(effectivelyOpen || staffPreview)
+            // Preview counts as open for staff and closed for students — handled
+            // inside isAssignmentEffectivelyOpen — so staff get an editable
+            // notebook on a Preview assignment and students see it read-only.
+            isClosed = !(try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db))
         } else {
             isClosed = false
         }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -168,8 +168,7 @@ extension WebRoutes {
             attemptNumber: priorCount + 1,
             filename: fallbackFilename,
             userID: user.id,
-            // Course-staff submissions are test/preview runs, never class data.
-            kind: user.isInstructor ? APISubmission.Kind.preview : APISubmission.Kind.student
+            kind: APISubmission.Kind.student
         )
         try await submission.save(on: req.db)
         await req.application.diagnostics.recordSubmissionCreated(

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -330,11 +330,26 @@ struct WebRoutes: RouteCollection {
                 guard let assignment, let startsAt = assignment.startsAt else { return false }
                 return Date() < startsAt
             }()
+            // Preview is staff-only: staff see it functioning as "open" with a
+            // subtle staff-only marker, while to students it is indistinguishable
+            // from "closed". So the displayed status is resolved per viewer.
             let status: String
+            let staffOnly: Bool
             if let assignment {
-                status = assignment.visibility.rawValue  // "closed" | "preview" | "open"
+                switch assignment.visibility {
+                case .open:
+                    status = "open"
+                    staffOnly = false
+                case .closed:
+                    status = "closed"
+                    staffOnly = false
+                case .preview:
+                    status = user.isInstructor ? "open" : "closed"
+                    staffOnly = user.isInstructor
+                }
             } else {
                 status = "unpublished"
+                staffOnly = false
             }
             let hasNotebook: Bool = {
                 // True when the setup has a flat notebook file on disk, or the zip
@@ -372,8 +387,15 @@ struct WebRoutes: RouteCollection {
             }()
             let isOpenForThisUser: Bool = {
                 guard let assignment else { return false }
+                // Preview is open for staff, closed for students.
+                let treatAsOpen: Bool
+                switch assignment.visibility {
+                case .open: treatAsOpen = true
+                case .closed: treatAsOpen = false
+                case .preview: treatAsOpen = user.isInstructor
+                }
                 return isAssignmentOpenForUser(
-                    isOpen: assignment.isOpen,
+                    isOpen: treatAsOpen,
                     overrideActive: assignment.deadlineOverrideActive ?? false,
                     baselineDueAt: baselineDueAt,
                     effectiveDueAt: effectiveDueAt,
@@ -392,6 +414,7 @@ struct WebRoutes: RouteCollection {
                 dueAt: assignment?.dueAt.map { fmt.string(from: $0) },
                 opensAtText: notYetOpen ? assignment?.startsAt.map { fmt.string(from: $0) } : nil,
                 status: status,
+                staffOnly: staffOnly,
                 isOpen: isOpenForThisUser,
                 canEdit: canEdit,
                 gradingMode: props?.gradingMode.rawValue ?? GradingMode.worker.rawValue,

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -285,12 +285,9 @@ private struct BlockedCandidate {
 private func collectClaimCandidates(
     on db: Database
 ) async throws -> [(APISubmission, APITestSetup, TestProperties)] {
-    // Course-staff "preview" submissions grade through the same worker path as
-    // student work (so staff can test a Preview assignment); they're excluded
-    // from student analytics by kind elsewhere, not here.
     let studentSubmissions = try await APISubmission.query(on: db)
         .filter(\.$status == "pending")
-        .filter(\.$kind ~~ [APISubmission.Kind.student, APISubmission.Kind.preview])
+        .filter(\.$kind == APISubmission.Kind.student)
         .sort(\.$submittedAt, .ascending)
         .all()
         .sorted { lhs, rhs in

--- a/Sources/APIServer/Services/AssignmentAuthoringService.swift
+++ b/Sources/APIServer/Services/AssignmentAuthoringService.swift
@@ -14,13 +14,8 @@ import Vapor
 /// Domain errors from assignment-authoring operations, mapped to transport
 /// errors by callers (`WebAssignmentError` on the web, `MCPToolError` over MCP).
 enum AssignmentAuthoringError: Error, Sendable, Equatable {
-    /// Opening (or entering preview) was refused because runner validation has
-    /// not passed.
+    /// Opening was refused because runner validation has not passed.
     case validationNotPassed
-    /// Refused to move an already-open assignment into the staff-only Preview
-    /// state: that would retract it from students who already saw it. The
-    /// lifecycle is a one-way street (closed → preview → open); close it first.
-    case cannotPreviewOpenAssignment
     /// The source assignment's test setup files (zip) could not be copied.
     case setupCopyFailed(reason: String)
 }
@@ -262,9 +257,8 @@ enum AssignmentAuthoringService {
 
     /// Sets an assignment's three-state visibility (closed / preview / open) and
     /// saves. Metadata-only — never touches the manifest, so it does not trigger
-    /// a regrade. Throws `validationNotPassed` if opening or previewing before
-    /// validation has passed, and `cannotPreviewOpenAssignment` for the one
-    /// forbidden transition (open → preview).
+    /// a regrade. Only opening requires validation to have passed; switching to
+    /// preview or closed is unconditional.
     static func setVisibility(
         _ assignment: APIAssignment,
         _ visibility: AssignmentVisibility,
@@ -283,33 +277,28 @@ enum AssignmentAuthoringService {
 
     /// Mutates visibility in memory (no save).
     ///
-    /// - Opening and entering **preview** both require validation to have passed
-    ///   (or no suite to validate): preview is a staff beta state where staff
-    ///   test-submit, so the content must be gradeable.
-    /// - **open** additionally consumes any pending scheduled open date and
-    ///   re-derives the deadline override from the (possibly past) due date —
-    ///   otherwise the student gate would keep blocking, or the auto-open sweep
-    ///   could re-open after a manual close.
-    /// - **open → preview** is refused (`cannotPreviewOpenAssignment`): the
-    ///   lifecycle is one-way and pulling a live assignment back into the
-    ///   staff-only state would retract it from students who already saw it.
+    /// - **open** requires validation to have passed (or no suite to validate),
+    ///   consumes any pending scheduled open date, and re-derives the deadline
+    ///   override from the (possibly past) due date — otherwise the student gate
+    ///   would keep blocking, or the auto-open sweep could re-open after a close.
+    /// - **preview** is a pure visibility flip with no side effects: it makes an
+    ///   already-validated assignment visible to staff (as open) while staying
+    ///   hidden from students, so it neither re-validates nor closes anything.
+    /// - **closed** simply hides it from everyone.
     private static func applyVisibility(
         _ assignment: APIAssignment, _ visibility: AssignmentVisibility, now: Date
     ) throws {
         switch visibility {
-        case .open, .preview:
+        case .open:
             guard assignment.validationStatus == nil || assignment.validationStatus == "passed" else {
                 throw AssignmentAuthoringError.validationNotPassed
             }
-            if visibility == .preview, assignment.visibility == .open {
-                throw AssignmentAuthoringError.cannotPreviewOpenAssignment
-            }
-            assignment.visibility = visibility
-            if visibility == .open {
-                assignment.startsAt = nil
-                assignment.deadlineOverrideActive = deadlineOverrideValueForInstructorOpen(
-                    dueAt: assignment.dueAt, now: now)
-            }
+            assignment.visibility = .open
+            assignment.startsAt = nil
+            assignment.deadlineOverrideActive = deadlineOverrideValueForInstructorOpen(
+                dueAt: assignment.dueAt, now: now)
+        case .preview:
+            assignment.visibility = .preview
         case .closed:
             assignment.visibility = .closed
         }

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -103,9 +103,18 @@ func isAssignmentEffectivelyOpen(
     on db: Database,
     now: Date = Date()
 ) async throws -> Bool {
+    // Preview is a staff-only "open": course staff see and use it exactly like an
+    // open assignment, while students are held out as if it were closed. For
+    // .open / .closed the stored visibility applies to everyone.
+    let treatAsOpen: Bool
+    switch assignment.visibility {
+    case .open: treatAsOpen = true
+    case .closed: treatAsOpen = false
+    case .preview: treatAsOpen = user.isInstructor
+    }
     let effective = try await effectiveDueAt(for: assignment, user: user, on: db)
     return isAssignmentOpenForUser(
-        isOpen: assignment.isOpen,
+        isOpen: treatAsOpen,
         overrideActive: assignmentDeadlineOverrideIsActive(assignment),
         baselineDueAt: assignment.dueAt,
         effectiveDueAt: effective,
@@ -240,19 +249,9 @@ func requireOpenStudentAssignment(
 
     _ = try await closeAssignmentIfExpired(assignment, on: req.db, logger: req.logger, now: now)
 
-    // Course staff may test-submit to a Preview assignment to exercise the
-    // real grading path before publishing it to students. Gated on validation
-    // having passed (the same guard as opening), so staff can only submit to
-    // content a student could actually be graded against. Students fall through
-    // to the normal gate below and are held out exactly as for a closed
-    // assignment. (The submission itself is stamped `kind = preview` at the
-    // call site so it stays out of student-facing analytics.)
-    if user.isInstructor, assignment.visibility == .preview,
-        assignment.validationStatus == nil || assignment.validationStatus == "passed"
-    {
-        return assignment
-    }
-
+    // Preview is open for course staff and closed for students — handled
+    // uniformly by isAssignmentEffectivelyOpen, so staff use it via the normal
+    // open path (bundled solution/tests, normal submission) with no special case.
     let open = try await isAssignmentEffectivelyOpen(assignment, for: user, on: req.db, now: now)
     guard open else {
         throw AssignmentSubmissionGateError.closed

--- a/Tests/APITests/AssignmentAuthoringServiceTests.swift
+++ b/Tests/APITests/AssignmentAuthoringServiceTests.swift
@@ -125,26 +125,28 @@ import Vapor
 
     // MARK: - Three-state visibility (Preview)
 
-    @Test func previewRequiresValidation() async throws {
+    @Test func previewNeedsNoValidation() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
+            // Switching to preview is a pure visibility flip — it must not be
+            // gated on validation the way opening to students is.
             let assignment = try await makeAssignment(on: app, validationStatus: "pending")
-            await #expect(throws: AssignmentAuthoringError.validationNotPassed) {
-                try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
-            }
-            let reloaded = try await assignmentByPublicID(assignment.publicID, on: app.db)
-            #expect(reloaded?.visibility == .closed)
+            try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
+            #expect(assignment.visibility == .preview)
+            // It is not open to students (the derived flag stays false).
+            #expect(assignment.isOpen == false)
         }
     }
 
-    @Test func previewAllowedWhenValidationPassedAndHidesFromStudents() async throws {
+    @Test func previewIsOpenForStaffAndClosedForStudents() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let assignment = try await makeAssignment(on: app, validationStatus: "passed")
             try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
-            #expect(assignment.visibility == .preview)
-            // Preview is not open to students (the derived flag stays false).
-            #expect(assignment.isOpen == false)
+            let staff = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            let student = try await makeTestUser(on: app, username: "stu", role: "student")
+            #expect(try await isAssignmentEffectivelyOpen(assignment, for: staff, on: app.db))
+            #expect(!(try await isAssignmentEffectivelyOpen(assignment, for: student, on: app.db)))
         }
     }
 
@@ -158,17 +160,15 @@ import Vapor
         }
     }
 
-    @Test func openToPreviewIsRefused() async throws {
+    @Test func openToPreviewIsAllowed() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
+            // No one-way restriction: an instructor can pull a live assignment
+            // back to staff-only (it just becomes hidden from students again).
             let assignment = try await makeAssignment(on: app, validationStatus: "passed")
             try await AssignmentAuthoringService.setVisibility(assignment, .open, on: app.db)
-            await #expect(throws: AssignmentAuthoringError.cannotPreviewOpenAssignment) {
-                try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
-            }
-            // The one-way-street guard leaves the assignment open.
-            let reloaded = try await assignmentByPublicID(assignment.publicID, on: app.db)
-            #expect(reloaded?.visibility == .open)
+            try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
+            #expect(assignment.visibility == .preview)
         }
     }
 
@@ -178,7 +178,7 @@ import Vapor
             let assignment = try await makeAssignment(on: app, validationStatus: "passed")
             try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
             // A past open date auto-opens a *closed* assignment, but a Preview
-            // assignment must stay in its staff-only beta state.
+            // assignment must stay in its staff-only state.
             assignment.startsAt = Date().addingTimeInterval(-3600)
             try await assignment.save(on: app.db)
             let opened = try await openScheduledAssignment(assignment, on: app.db, logger: app.logger)

--- a/Tests/APITests/MCP/UpdateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/UpdateAssignmentToolTests.swift
@@ -74,11 +74,12 @@ import Vapor
         }
     }
 
-    @Test func setsPreviewVisibility() async throws {
+    @Test func setsPreviewVisibilityWithoutRequiringValidation() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
+            // Preview is a pure visibility flip: no validation gate.
             let assignment = try await enrolledAssignment(
-                on: app, validationStatus: "passed", isOpen: false)
+                on: app, validationStatus: "pending", isOpen: false)
             let output = try await UpdateAssignmentTool().execute(
                 UpdateAssignmentTool.Input(
                     assignmentPublicID: assignment.publicID, visibility: "preview"),
@@ -90,19 +91,19 @@ import Vapor
         }
     }
 
-    @Test func refusesPreviewOnOpenAssignment() async throws {
+    @Test func allowsPreviewOnOpenAssignment() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
+            // No one-way restriction: open → preview is allowed.
             let assignment = try await enrolledAssignment(
                 on: app, validationStatus: "passed", isOpen: true)
-            await #expect(throws: MCPToolError.self) {
-                _ = try await UpdateAssignmentTool().execute(
-                    UpdateAssignmentTool.Input(
-                        assignmentPublicID: assignment.publicID, visibility: "preview"),
-                    context(app))
-            }
+            let output = try await UpdateAssignmentTool().execute(
+                UpdateAssignmentTool.Input(
+                    assignmentPublicID: assignment.publicID, visibility: "preview"),
+                context(app))
+            #expect(output.visibility == "preview")
             let reloaded = try await assignmentByPublicID(assignment.publicID, on: app.db)
-            #expect(reloaded?.visibility == .open)
+            #expect(reloaded?.visibility == .preview)
         }
     }
 

--- a/changelog.d/preview-visibility-staff-open.md
+++ b/changelog.d/preview-visibility-staff-open.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Preview assignment visibility simplified to "Open, but staff-only."** A
+  Preview assignment now behaves exactly like an Open one for course
+  staff/admins (bundled solution and tests, normal grading, editable notebook,
+  normal submissions) while appearing **Closed** to students. Switching an
+  already-validated assignment to Preview is a pure visibility change — it no
+  longer re-validates, asks for a reference-solution upload, or closes the
+  assignment, and it can be set to/from any state. Staff see a subtle
+  "staff-only" marker on the dashboard; students see no Preview badge. Removed
+  the separate `preview` submission kind (staff submissions behave like any
+  other), so no behaviour of Open assignments changed.


### PR DESCRIPTION
## What

Corrects the over-built Preview implementation from #832 so it does exactly one thing, as intended: **a Preview assignment behaves identically to Open for course staff/admins, and identically to Closed for students.** The enum + migration from #832 (already on `main`) are kept; this strips the scope creep.

This addresses the feedback that Preview shouldn't ask to re-validate, shouldn't require uploading a reference solution, shouldn't show a "preview" badge to students, and shouldn't have added new UI/flows.

## Behaviour now
- **Gate:** `isAssignmentEffectivelyOpen` treats `preview` as open for `isInstructor`, closed for everyone else. Staff get the full Open experience — bundled solution + tests, editable notebook, normal submit/grade — via the *normal* open path (no special case). Students are held out exactly as for closed.
- **Switching to preview is a pure visibility flip:** no validation gate, no close-on-edit, no reference-solution upload, and it can be set to/from any state.
- **Display:** students never see a "preview" badge (it shows as **closed**); staff see it functioning as **open** with a subtle **"staff-only"** marker.

## Reverted scope creep
- Removed the `preview` **submission kind**, the worker-claim change, and stamping instructor submissions as preview → **Open assignments are unchanged**.
- `ContentEditClose` / `UpdateSolution` close only genuinely-open assignments again.
- Removed the validation gate on entering preview and the one-way transition guard (and the dead `cannotPreviewOpenAssignment` error).

## Instructor dashboard UI fixes
- Status dropdown option relabelled **"staff only"** (no longer widens the status column).
- Actions cell no longer wraps — all four buttons stay on one row.

## Testing
- `swift build`, `swift-format` (`scripts/lint.sh`), SwiftLint `--strict` — all clean.
- Tests updated: preview no longer requires validation, `open → preview` is allowed, preview is open-for-staff / closed-for-students, auto-open still skips preview. Affected suites pass in isolation.

🤖 Draft — opened for CI + your verification. I will **not** auto-merge this one; I'll get CI green and hand it back for you to confirm the behaviour before merging.

https://claude.ai/code/session_012zsmz2kwrqEVngL8LuXNGF

---
_Generated by [Claude Code](https://claude.ai/code/session_012zsmz2kwrqEVngL8LuXNGF)_