### PR TITLE
feat(mcp): steer agents toward native check types, raw scripts as escape hatch

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -117,19 +117,39 @@ enum MCPServerInstructions {
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \
-        update_suite (script metadata), update_pattern_family (edit a family's defaults/cases) / \
-        create_pattern_family (add a new family), update_global_inputs (personalization \
-        variables/expressions), update_section_variables (a section's scoped variables/expressions), \
-        create_suite_section / rename_suite_section / delete_suite_section (manage the named display groups), \
-        move_suite_item (place a script, family, or check into a section, or ungroup it), \
-        delete_suite_item (remove a script, family, or check), update_notebook (replace the starter \
-        notebook), update_solution (replace the reference solution and re-validate), author_script \
-        (create/replace a hand-written test or support file), and author_notebook_check \
-        (create/replace a notebook check). To create a new assignment, either clone_assignment from a \
-        known-good one and then edit the copy (the safest path) or create_assignment to start a fresh \
-        notebook-based assignment from a starter .ipynb.
+        update_suite (script metadata). To add or change a GRADED test, prefer Chickadee's native \
+        check types — update_pattern_family (edit a family's defaults/cases) / create_pattern_family \
+        (add a new family) and author_notebook_check (create/replace a notebook check) — over a \
+        hand-written script (see "Prefer native check types" below). Personalization and grouping: \
+        update_global_inputs (personalization variables/expressions), update_section_variables (a \
+        section's scoped variables/expressions), create_suite_section / rename_suite_section / \
+        delete_suite_section (manage the named display groups), move_suite_item (place a script, \
+        family, or check into a section, or ungroup it), delete_suite_item (remove a script, family, \
+        or check). Notebook/solution: update_notebook (replace the starter notebook), update_solution \
+        (replace the reference solution and re-validate). Escape hatch: author_script (create/replace \
+        a hand-written test — only when no native kind fits — or a non-graded support/helper file). \
+        To create a new assignment, either clone_assignment from a known-good one and then edit the \
+        copy (the safest path) or create_assignment to start a fresh notebook-based assignment from a \
+        starter .ipynb.
 
         Important behaviors:
+        - Prefer native check types over hand-written scripts. To author a graded test, first check \
+        whether a pattern family or a notebook check expresses the assertion, and use that instead of \
+        a raw script. Pattern-family kinds (create_pattern_family / update_pattern_family): \
+        boundary_equality and approximate_equality (a function's return equals / is within tolerance \
+        of an expected value), variable_equality (a module-level variable equals a value), \
+        return_type_check, exception_expected, performance_threshold, and stdout_equality. \
+        Notebook-check kinds (author_notebook_check): data_frame_shape, data_frame_columns, \
+        data_frame_equality, series_equality, numeric_array_close, figure_count, cell_contains, \
+        function_exists, variable_exists, and ast_structure. Native checks are validated structurally \
+        when you save (arg count, the expected's shape for the kind, $ref resolution), they \
+        personalize per student ($name / expectedVarRef), and get_suite returns their full spec so a \
+        later reader can see exactly what they assert. author_script is the escape hatch: it writes \
+        the file verbatim, so the only safety net is the asynchronous validation run and the body is \
+        opaque to anything reading the suite back. Use a graded tier of author_script only when the \
+        assertion genuinely cannot be expressed as any pattern kind or notebook check — and when you \
+        do, say why no native construct fit. (Writing a non-graded support/helper file with the \
+        support tier is a normal, primary use of author_script, not a fallback.)
         - Any content edit (suite, pattern family, check, script, notebook, solution) re-runs \
         validation asynchronously AND closes the assignment if it was open (each write tool's response \
         reports this as `assignmentClosed`), so students can't submit against a not-yet-revalidated \

--- a/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
@@ -123,7 +123,10 @@ struct AuthorNotebookCheckTool: ContentTool {
 
     static let name = "author_notebook_check"
     static let description =
-        "Create or replace a notebook check on an assignment, by public ID — a single-shot assertion "
+        "Author a graded check about a student's notebook — preferred over a hand-written "
+        + "author_script whenever the assertion is about a DataFrame/Series/array, a figure count, a "
+        + "defined function or variable, or the notebook source. "
+        + "Create or replace a notebook check on an assignment, by public ID — a single-shot assertion "
         + "about a student's notebook (e.g. is `df` a (rows, cols) DataFrame, did the notebook produce "
         + ">= N figures, does the source use a list comprehension). Provide a stable `id` (reusing an "
         + "existing id replaces that check), a `kind` (data_frame_shape / data_frame_columns / "

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -57,7 +57,16 @@ struct AuthorScriptTool: ContentTool {
 
     static let name = "author_script"
     static let description =
-        "Create or replace a single hand-written test or support file in an assignment's test "
+        "Escape hatch for a hand-written test, plus the normal way to add a non-graded support/helper "
+        + "file. For a GRADED test, prefer Chickadee's native check types first: create_pattern_family "
+        + "/ update_pattern_family (a function's return value equals / is close to an expected, names a "
+        + "type, raises, meets a performance bound, prints expected stdout, or a module variable equals "
+        + "a value) and author_notebook_check (DataFrame / Series / array / figure / source-AST / "
+        + "variable assertions). Native checks are validated on save, personalize per student, and can "
+        + "be read back via get_suite; a raw script is written verbatim (only the async validation run "
+        + "catches errors in it) and is opaque to readers. Use a graded tier here only when no pattern "
+        + "kind or notebook check fits. "
+        + "Create or replace a single hand-written test or support file in an assignment's test "
         + "setup, by its public ID. Provide filename (a bare name, no path separators) and content "
         + "(the full script body). tier is public/release/secret/student for a graded test, or "
         + "\"support\" for a helper file that tests or personalization expressions can import but that "

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -130,7 +130,10 @@ struct CreatePatternFamilyTool: ContentTool {
 
     static let name = "create_pattern_family"
     static let description =
-        "Create a NEW pattern family on an assignment, by public ID. Provide the family `id` "
+        "Author a graded test as a pattern family — preferred over a hand-written author_script "
+        + "whenever the check is a function-call assertion (equality, float tolerance, return type, "
+        + "expected exception, performance bound, or stdout). "
+        + "Create a NEW pattern family on an assignment, by public ID. Provide the family `id` "
         + "(unique; not an existing family), `name`, `kind` (boundary_equality / approximate_equality "
         + "/ variable_equality / return_type_check / exception_expected / performance_threshold / "
         + "stdout_equality), the `function` it tests, `paramNames`, and a non-empty `cases` list — each "

--- a/Tests/APITests/MCP/AuthorScriptToolTests.swift
+++ b/Tests/APITests/MCP/AuthorScriptToolTests.swift
@@ -10,6 +10,17 @@ import Vapor
 @testable import APIServer
 
 @Suite struct AuthorScriptToolTests {
+    /// The tool description must frame author_script as an escape hatch and
+    /// point at the native check types, so an agent reaches for pattern families
+    /// / notebook checks first for graded tests (regression guard for the
+    /// "prefer native" steering).
+    @Test func descriptionFramesItAsAnEscapeHatchPreferringNativeChecks() {
+        let description = AuthorScriptTool.description
+        #expect(description.contains("Escape hatch"))
+        #expect(description.contains("create_pattern_family"))
+        #expect(description.contains("author_notebook_check"))
+    }
+
     private func context(_ app: Application) -> ToolContext {
         ToolContext(
             request: Request(application: app, on: app.eventLoopGroup.any()),

--- a/Tests/APITests/MCP/MCPDispatcherTests.swift
+++ b/Tests/APITests/MCP/MCPDispatcherTests.swift
@@ -43,6 +43,11 @@ import Testing
         let instructions = try #require(result["instructions"]?.stringValue)
         #expect(instructions.contains("list_courses"))
         #expect(instructions.contains("validation"))
+        // The instructions steer agents toward native check types and frame
+        // author_script as a last-resort escape hatch (regression guard for the
+        // "prefer native" steering).
+        #expect(instructions.contains("Prefer native check types"))
+        #expect(instructions.contains("escape hatch"))
     }
 
     @Test func pingReturnsEmptyObject() async throws {

--- a/changelog.d/mcp-prefer-native-checks.md
+++ b/changelog.d/mcp-prefer-native-checks.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **MCP authoring steers agents toward native check types.** The server
+  `initialize` instructions, the `author_script` tool description, and the
+  `create_pattern_family` / `author_notebook_check` descriptions now frame
+  hand-written scripts as a last-resort escape hatch and point agents at pattern
+  families and notebook checks — which are validated structurally on save,
+  personalize per student, and can be read back via `get_suite` — for graded
+  tests. Guidance copy only; no behaviour or schema change.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -48,7 +48,7 @@ course-scoped:
 | `update_pattern_family` | `content:write` | Family defaults (tier/points/`defaultHint`) + per-case args/expected/hint (incl. per-student `$ref`s), enable/disable |
 | `delete_suite_item` | `content:write` | Remove a script, family (+ its cases), or notebook check from the suite |
 | `author_notebook_check` | `content:write` | Create/replace a notebook check (DataFrame shape/columns/equality, figures, AST, …) |
-| `author_script` | `content:write` | Create/replace a hand-written test or support file |
+| `author_script` | `content:write` | Escape hatch: create/replace a hand-written test (prefer a pattern family / notebook check) or a non-graded support file |
 | `update_notebook` | `content:write` | Replace the starter notebook |
 | `update_solution` | `content:write` | Replace the reference solution and re-validate |
 | `create_course_section` | `content:write` | Create a course section (assignment group) with a default grading mode |


### PR DESCRIPTION
## Problem

The MCP authoring surface was **preference-neutral**: `author_script` (the raw-script escape hatch) was presented to the model as a peer of `create_pattern_family` and `author_notebook_check`, with no signal that it's the fallback. An LLM facing 7 pattern kinds, 10 notebook-check kinds, and one fully-general "write any script" tool tends to reach for the general one — it's the surest way to satisfy an arbitrary request, which is the wrong default.

The two surfaces a connected agent actually reads are the server `initialize` **instructions** and each tool's **description**. Neither expressed a preference. The escape-hatch framing existed only in a code comment (`AuthorScriptTool.swift`), invisible to the model.

## Change (guidance copy only — no behaviour or schema change)

- **Server `initialize` instructions** (`InitializeTypes.swift`): reordered the "Edit" workflow step to lead with native authoring, and added a **"Prefer native check types over hand-written scripts"** rule that enumerates the pattern-family kinds (`boundary_equality`, `approximate_equality`, `variable_equality`, `return_type_check`, `exception_expected`, `performance_threshold`, `stdout_equality`) and notebook-check kinds (`data_frame_shape` … `ast_structure`), gives the rationale (validated structurally on save, per-student personalizable, readable back via `get_suite`), and carves out the `support` tier as a legitimate *primary* use of `author_script`, not a fallback.
- **`author_script` description**: leads with the escape-hatch framing and points at the native tools first; existing detail preserved.
- **`create_pattern_family` / `author_notebook_check` descriptions**: a short lead noting they are preferred over a hand-written script (reinforcement at tool-selection time).
- **`docs/mcp-authoring-roadmap.md`**: `author_script` row updated to match (the human index).

The enumerated kinds match exactly what `create_pattern_family`'s schema accepts (the 7 currently exposed via MCP), so the instructions never advertise a kind the tool would reject. `author_script` itself stays fully available — the escape hatch is deliberate; this is soft steering, not a block.

## Tests

- `MCPDispatcherTests.initializeReturnsProtocolVersionAndServerInfo` now asserts the instructions contain `"Prefer native check types"` and `"escape hatch"`.
- New `AuthorScriptToolTests.descriptionFramesItAsAnEscapeHatchPreferringNativeChecks` asserts the description contains `Escape hatch`, `create_pattern_family`, and `author_notebook_check`.

Both pass; package builds with tests; `scripts/format.sh` and `scripts/swiftlint.sh --strict` clean (0 violations). Changelog fragment added under `changelog.d/`.

https://claude.ai/code/session_01H3RJk5XKu8CcenesonMm9h

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3RJk5XKu8CcenesonMm9h)_