### PR TITLE
refactor: consolidate duplicated MCP, base64url, and notebook helpers

### DIFF
--- a/Sources/APIServer/MCP/Auth/MCPTokenAuthority.swift
+++ b/Sources/APIServer/MCP/Auth/MCPTokenAuthority.swift
@@ -99,18 +99,11 @@ actor MCPTokenAuthority {
             "use": "sig",
             "alg": "ES256",
             "kid": keyID.string,
-            "x": Self.base64url(parameters.x),
-            "y": Self.base64url(parameters.y),
+            "x": parameters.x.base64ToBase64URL(),
+            "y": parameters.y.base64ToBase64URL(),
         ]
     }
 
-    /// Converts standard base64 to unpadded base64url (RFC 4648 §5).
-    private static func base64url(_ standardBase64: String) -> String {
-        standardBase64
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
 }
 
 // MARK: - Application storage

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -600,7 +600,7 @@ struct MCPOAuthRoutes: Sendable {
     }
 
     private static func pkceMatches(verifier: String, challenge: String) -> Bool {
-        base64url(Data(SHA256.hash(data: Data(verifier.utf8)))) == challenge
+        Data(SHA256.hash(data: Data(verifier.utf8))).base64URLEncodedString() == challenge
     }
 
     /// Atomically flips a single-use `consumed` flag from false→true for the row
@@ -639,15 +639,9 @@ struct MCPOAuthRoutes: Sendable {
     private static func randomToken() -> String {
         var rng = SystemRandomNumberGenerator()
         let bytes = (0..<32).map { _ in UInt8.random(in: 0...255, using: &rng) }
-        return base64url(Data(bytes))
+        return Data(bytes).base64URLEncodedString()
     }
 
-    private static func base64url(_ data: Data) -> String {
-        data.base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
 }
 
 // MARK: - Request / response shapes

--- a/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
@@ -294,15 +294,8 @@ struct AuthorNotebookCheckTool: ContentTool {
         let tier = try Self.parseTier(input.tier)
         let columnMatch = try Self.parseColumnMatch(input.columnMatch)
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
         let existingIndex = payload.items.firstIndex { $0.kind == "check" && $0.check?.id == checkID }
@@ -334,18 +327,10 @@ struct AuthorNotebookCheckTool: ContentTool {
             created = true
         }
 
-        do {
-            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        } catch let error as WebAssignmentError {
-            throw MCPToolError.from(error, tool: Self.name)
-        } catch let error as any AbortError {
-            throw MCPToolError.from(error, tool: Self.name)
-        }
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        // Re-grade existing submissions against the edited suite (gated on a real
-        // manifest change), the automatic equivalent of the "Retest all" button.
-        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        try await applySuiteEditMapped(setup: setup, body: payload, tool: Self.name, on: context.db)
+        // Close, re-grade, and re-validate (matching the web Save button).
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
 
         return Output(
             assignmentPublicID: assignment.publicID,

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -191,15 +191,8 @@ struct AuthorScriptTool: ContentTool {
                 detail: "filename must be a bare filename with no path separators (got \"\(input.filename)\").")
         }
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         // Never clobber a pattern-family / notebook-check generated script —
         // those are owned by the family/check, mirroring the web 409.
@@ -247,15 +240,9 @@ struct AuthorScriptTool: ContentTool {
                 setup: setup, context: context)
         }
 
-        // Close a currently-open assignment (matching the web Save button) so
-        // students can't submit against the not-yet-revalidated suite, then
-        // re-kick validation against the new manifest/zip (debounced), mirroring
-        // the web suite/script edit handlers.
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        // Re-grade existing submissions against the edited suite (gated on a real
-        // manifest change), the automatic equivalent of the "Retest all" button.
-        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        // Close, re-grade, and re-validate (matching the web Save button).
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
 
         return Output(
             assignmentPublicID: assignment.publicID,
@@ -308,13 +295,7 @@ struct AuthorScriptTool: ContentTool {
             }
         }
 
-        do {
-            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        } catch let error as WebAssignmentError {
-            throw MCPToolError.from(error, tool: Self.name)
-        } catch let error as any AbortError {
-            throw MCPToolError.from(error, tool: Self.name)
-        }
+        try await applySuiteEditMapped(setup: setup, body: payload, tool: Self.name, on: context.db)
     }
 
     // MARK: - Support-file authoring (direct zip write)

--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -92,15 +92,8 @@ struct CloneAssignmentTool: ContentTool {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "newTitle must not be empty.")
         }
 
-        guard
-            let source = try await assignmentByPublicID(
-                input.sourceAssignmentPublicID, on: context.db)
-        else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "No assignment found with public ID \"\(input.sourceAssignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(source.courseID, tool: Self.name)
+        let source = try await context.authorizedAssignment(
+            publicID: input.sourceAssignmentPublicID, tool: Self.name)
 
         guard let sourceSetup = try await APITestSetup.find(source.testSetupID, on: context.db) else {
             throw MCPToolError.invalidArguments(

--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -21,6 +21,7 @@
 
 import Core
 import Fluent
+import Vapor
 
 /// Closes `assignment` if it is currently open, persisting the change, and
 /// reports whether it did. A no-op returning `false` when not open, so a tool
@@ -54,4 +55,41 @@ func retestSubmissionsAfterContentEdit(setup: APITestSetup, context: ToolContext
         context.logger.warning("retestSubmissionsAfterContentEdit failed: \(error)")
         return 0
     }
+}
+
+/// Runs `applySuiteEdit` and maps web-layer failures (`WebAssignmentError`,
+/// `AbortError`) to `MCPToolError` so the agent sees a structured, actionable
+/// error rather than an opaque protocol-level internal error.
+func applySuiteEditMapped(
+    setup: APITestSetup, body: SuitePayload, tool: String, on db: any Database
+) async throws {
+    do {
+        try await applySuiteEdit(setup: setup, body: body, on: db)
+    } catch let error as WebAssignmentError {
+        throw MCPToolError.from(error, tool: tool)
+    } catch let error as any AbortError {
+        throw MCPToolError.from(error, tool: tool)
+    }
+}
+
+/// The standard finalize step shared by content-edit tools: close a
+/// currently-open assignment (so students can't submit against a
+/// not-yet-revalidated suite), optionally re-grade existing submissions, then
+/// re-kick (debounced) validation. Returns whether the assignment was closed.
+///
+/// `retest: true` for edits that can change a grade (scripts, families, checks,
+/// solution); `retest: false` for placement/metadata-only edits (e.g.
+/// `move_suite_item`) that only reorder or re-tag and never change an outcome.
+/// The close→retest→revalidate ordering is the invariant documented on
+/// `closeOpenAssignmentForContentEdit` / `retestSubmissionsAfterContentEdit`.
+@discardableResult
+func finalizeContentEdit(
+    assignment: APIAssignment, setup: APITestSetup, context: ToolContext, retest: Bool
+) async throws -> Bool {
+    let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
+    if retest {
+        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
+    }
+    await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+    return closed
 }

--- a/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
@@ -244,11 +244,8 @@ struct SetAssignmentCourseSectionTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         // Resolve + validate the target section against this assignment's course.
         // A non-empty id that doesn't resolve is rejected rather than silently

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -87,7 +87,7 @@ struct CreateAssignmentTool: ContentTool {
         guard !title.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "title must not be empty.")
         }
-        try Self.validateNotebookShape(input.notebook)
+        try validateNotebookShape(input.notebook, tool: Self.name)
 
         let code = input.courseCode.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
@@ -125,25 +125,8 @@ struct CreateAssignmentTool: ContentTool {
             title: created.assignment.title,
             slug: created.assignment.slug,
             courseCode: course.code,
-            cellCount: Self.cellCount(of: input.notebook),
+            cellCount: notebookCellCount(input.notebook),
             isOpen: created.assignment.isOpen)
     }
 
-    private static func validateNotebookShape(_ notebook: JSONValue) throws {
-        guard case .object(let root) = notebook else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "notebook must be a JSON object.")
-        }
-        guard case .array? = root["cells"] else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "notebook must contain a \"cells\" array.")
-        }
-    }
-
-    private static func cellCount(of notebook: JSONValue) -> Int {
-        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
-            return 0
-        }
-        return cells.count
-    }
 }

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -305,15 +305,8 @@ struct CreatePatternFamilyTool: ContentTool {
         }
         try Self.assertUniqueCaseKeys(input.cases)
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
         guard
@@ -333,21 +326,10 @@ struct CreatePatternFamilyTool: ContentTool {
         // applySuiteEdit -> applyPatternFamilies -> validatePatternFamilies runs
         // the structural + per-kind checks synchronously; surface those as clean
         // MCP errors rather than opaque protocol failures.
-        do {
-            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        } catch let error as WebAssignmentError {
-            throw MCPToolError.from(error, tool: Self.name)
-        } catch let error as any AbortError {
-            throw MCPToolError.from(error, tool: Self.name)
-        }
-        // A new family adds graded cases, so close a currently-open assignment
-        // (matching update_pattern_family and the web Save button) before the
-        // debounced re-validation.
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        // Re-grade existing submissions against the edited suite (gated on a real
-        // manifest change), the automatic equivalent of the "Retest all" button.
-        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        try await applySuiteEditMapped(setup: setup, body: payload, tool: Self.name, on: context.db)
+        // Close, re-grade, and re-validate (matching the web Save button).
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
 
         return Output(
             assignmentPublicID: assignment.publicID,
@@ -377,7 +359,7 @@ struct CreatePatternFamilyTool: ContentTool {
     /// that runs inside applySuiteEdit.
     private static func buildFamily(_ input: Input, id: String, kind: PatternKind) throws -> PatternFamily {
         let defaults = PatternDefaults(
-            tier: try parseTier(input.defaultTier) ?? .pub,
+            tier: try parseOptionalTier(input.defaultTier, tool: Self.name) ?? .pub,
             points: input.defaultPoints ?? 1,
             hint: normalizedHint(input.defaultHint),
             tolerance: input.tolerance)
@@ -393,7 +375,8 @@ struct CreatePatternFamilyTool: ContentTool {
             return PatternCase(
                 key: c.key, label: c.label ?? c.key, args: args, expected: c.expected ?? .null,
                 argsProvided: provided, argVarRefs: refs, expectedVarRef: ref,
-                hint: normalizedHint(c.hint), tier: try parseTier(c.tier), points: c.points,
+                hint: normalizedHint(c.hint), tier: try parseOptionalTier(c.tier, tool: Self.name),
+                points: c.points,
                 enabled: c.enabled ?? true)
         }
         return PatternFamily(
@@ -431,15 +414,6 @@ struct CreatePatternFamilyTool: ContentTool {
             result.append(row)
         }
         return result
-    }
-
-    private static func parseTier(_ raw: String?) throws -> TestTier? {
-        guard let raw else { return nil }
-        guard let tier = TestTier(rawValue: raw) else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "tier must be one of: public, release, secret, student.")
-        }
-        return tier
     }
 
     /// Trims an empty hint to nil so an omitted/blank cell doesn't store an

--- a/Sources/APIServer/MCP/Tools/DeleteSuiteItemTool.swift
+++ b/Sources/APIServer/MCP/Tools/DeleteSuiteItemTool.swift
@@ -100,15 +100,8 @@ struct DeleteSuiteItemTool: ContentTool {
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         let target = try Self.resolveTarget(input)
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
         guard let idx = payload.items.firstIndex(where: { Self.matches($0, target) }) else {
@@ -118,21 +111,10 @@ struct DeleteSuiteItemTool: ContentTool {
         }
         payload.items.remove(at: idx)
 
-        do {
-            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        } catch let error as WebAssignmentError {
-            throw MCPToolError.from(error, tool: Self.name)
-        } catch let error as any AbortError {
-            throw MCPToolError.from(error, tool: Self.name)
-        }
-        // Removing a graded item changes what the suite grades, so close a
-        // currently-open assignment (matching every other content-edit tool and
-        // the web Save button) before the debounced re-validation.
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        // Re-grade existing submissions against the edited suite (gated on a real
-        // manifest change), the automatic equivalent of the "Retest all" button.
-        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        try await applySuiteEditMapped(setup: setup, body: payload, tool: Self.name, on: context.db)
+        // Close, re-grade, and re-validate (matching the web Save button).
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
 
         return Output(
             assignmentPublicID: assignment.publicID,

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -84,11 +84,8 @@ struct GetAssignmentTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
         guard let course = try await APICourse.find(assignment.courseID, on: context.db) else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "The assignment's course could not be found.")

--- a/Sources/APIServer/MCP/Tools/GetGlobalInputsTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetGlobalInputsTool.swift
@@ -75,15 +75,8 @@ struct GetGlobalInputsTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         let result = try GlobalInputsService.current(setup: setup)
         return Output(

--- a/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetNotebookTool.swift
@@ -59,18 +59,8 @@ struct GetNotebookTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
-        else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         let data: Data
         do {
@@ -90,15 +80,7 @@ struct GetNotebookTool: ContentTool {
 
         return Output(
             assignmentPublicID: assignment.publicID,
-            cellCount: Self.cellCount(of: notebook),
+            cellCount: notebookCellCount(notebook),
             notebook: notebook)
-    }
-
-    /// Number of cells in the notebook, or 0 if the `cells` array is absent.
-    private static func cellCount(of notebook: JSONValue) -> Int {
-        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
-            return 0
-        }
-        return cells.count
     }
 }

--- a/Sources/APIServer/MCP/Tools/GetSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSolutionTool.swift
@@ -65,13 +65,8 @@ struct GetSolutionTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
-        else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         guard let solution = try await loadExistingSolution(assignment: assignment, on: context.db)
         else {
@@ -94,15 +89,7 @@ struct GetSolutionTool: ContentTool {
         return Output(
             assignmentPublicID: assignment.publicID,
             filename: solution.filename,
-            cellCount: Self.cellCount(of: notebook),
+            cellCount: notebookCellCount(notebook),
             notebook: notebook)
-    }
-
-    /// Number of cells in the notebook, or 0 if the `cells` array is absent.
-    private static func cellCount(of notebook: JSONValue) -> Int {
-        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
-            return 0
-        }
-        return cells.count
     }
 }

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -184,15 +184,8 @@ struct GetSuiteTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         // Pass the zip path so raw hand-written script bodies are filled in
         // (generated family/check files are derived from their specs and need

--- a/Sources/APIServer/MCP/Tools/MCPNotebookShape.swift
+++ b/Sources/APIServer/MCP/Tools/MCPNotebookShape.swift
@@ -1,0 +1,29 @@
+// APIServer/MCP/Tools/MCPNotebookShape.swift
+//
+// Shared notebook-JSON shape helpers for the MCP tools that accept or return a
+// notebook (`create_assignment`, `update_notebook`, `get_notebook`,
+// `get_solution`, `update_solution`). Each tool previously carried byte-identical
+// private copies of these.
+
+import Core
+
+/// Number of cells in a notebook JSON object (0 if it isn't the expected shape).
+func notebookCellCount(_ notebook: JSONValue) -> Int {
+    guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
+        return 0
+    }
+    return cells.count
+}
+
+/// Validates the minimal shape every Jupyter notebook has: a JSON object with a
+/// `cells` array. Stricter nbformat checks are left to the runner, matching the
+/// web save path's lenient JSON-only validation.
+func validateNotebookShape(_ notebook: JSONValue, tool: String) throws {
+    guard case .object(let root) = notebook else {
+        throw MCPToolError.invalidArguments(tool: tool, detail: "notebook must be a JSON object.")
+    }
+    guard case .array? = root["cells"] else {
+        throw MCPToolError.invalidArguments(
+            tool: tool, detail: "notebook must contain a \"cells\" array.")
+    }
+}

--- a/Sources/APIServer/MCP/Tools/MCPTierParsing.swift
+++ b/Sources/APIServer/MCP/Tools/MCPTierParsing.swift
@@ -1,0 +1,20 @@
+// APIServer/MCP/Tools/MCPTierParsing.swift
+//
+// Shared tier parsing for the suite/pattern-family MCP tools, which each
+// carried an identical `String? -> TestTier?` helper differing only in the
+// argument name reported on failure.
+
+import Core
+
+/// Parses an optional tier string into a `TestTier`, returning nil for a nil
+/// input and throwing `invalidArguments` for an unrecognized value. `field`
+/// names the offending argument in the error message (e.g. "tier",
+/// "defaultTier").
+func parseOptionalTier(_ raw: String?, tool: String, field: String = "tier") throws -> TestTier? {
+    guard let raw else { return nil }
+    guard let tier = TestTier(rawValue: raw) else {
+        throw MCPToolError.invalidArguments(
+            tool: tool, detail: "\(field) must be one of: public, release, secret, student.")
+    }
+    return tier
+}

--- a/Sources/APIServer/MCP/Tools/MoveSuiteItemTool.swift
+++ b/Sources/APIServer/MCP/Tools/MoveSuiteItemTool.swift
@@ -108,8 +108,8 @@ struct MoveSuiteItemTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let resolved = try await resolveSetupForSectionEdit(
-            assignmentPublicID: input.assignmentPublicID, tool: Self.name, context: context)
+        let resolved = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: resolved.setup.manifest, zipPath: resolved.setup.zipPath)
 
@@ -150,16 +150,12 @@ struct MoveSuiteItemTool: ContentTool {
             payload.items.append(moved)
         }
 
-        do {
-            try await applySuiteEdit(setup: resolved.setup, body: payload, on: context.db)
-        } catch let error as WebAssignmentError {
-            throw MCPToolError.from(error, tool: Self.name)
-        } catch let error as any AbortError {
-            throw MCPToolError.from(error, tool: Self.name)
-        }
-
-        let closed = try await closeOpenAssignmentForContentEdit(resolved.assignment, on: context.db)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: resolved.assignment)
+        try await applySuiteEditMapped(
+            setup: resolved.setup, body: payload, tool: Self.name, on: context.db)
+        // Placement-only edit: close + re-validate, but no regrade (move can't
+        // change an outcome).
+        let closed = try await finalizeContentEdit(
+            assignment: resolved.assignment, setup: resolved.setup, context: context, retest: false)
 
         return Output(
             assignmentPublicID: resolved.assignment.publicID,

--- a/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+++ b/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
@@ -113,15 +113,8 @@ struct PreviewPersonalizationTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.read]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
         guard let manifest = setup.decodedManifest() else {
             throw MCPToolError.executionFailed(tool: Self.name, detail: "Manifest is not valid JSON.")
         }

--- a/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
@@ -70,15 +70,8 @@ struct SetGradingModeTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "gradingMode must be \"browser\" or \"worker\".")
         }
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
         let effective = try await setManifestGradingMode(setup: setup, to: mode, on: context.db)
         return Output(assignmentPublicID: assignment.publicID, gradingMode: effective)
     }

--- a/Sources/APIServer/MCP/Tools/SuiteSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/SuiteSectionTools.swift
@@ -81,8 +81,8 @@ struct CreateSuiteSectionTool: ContentTool {
         guard !name.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "Section name must not be empty.")
         }
-        let resolved = try await resolveSetupForSectionEdit(
-            assignmentPublicID: input.assignmentPublicID, tool: Self.name, context: context)
+        let resolved = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
         let newID = UUID().uuidString
         do {
             try await mutateManifest(setup: resolved.setup, on: context.db) { dict in
@@ -161,8 +161,8 @@ struct RenameSuiteSectionTool: ContentTool {
         guard !input.sectionID.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "sectionID must not be empty.")
         }
-        let resolved = try await resolveSetupForSectionEdit(
-            assignmentPublicID: input.assignmentPublicID, tool: Self.name, context: context)
+        let resolved = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
         do {
             try await mutateManifest(setup: resolved.setup, on: context.db) { dict in
                 guard var sections = dict["sections"] as? [[String: Any]],
@@ -241,8 +241,8 @@ struct DeleteSuiteSectionTool: ContentTool {
         guard !input.sectionID.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "sectionID must not be empty.")
         }
-        let resolved = try await resolveSetupForSectionEdit(
-            assignmentPublicID: input.assignmentPublicID, tool: Self.name, context: context)
+        let resolved = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
         // Captured inside the mutation closure so the response reflects what
         // actually changed.
         var removed = false
@@ -275,24 +275,4 @@ struct DeleteSuiteSectionTool: ContentTool {
             removed: removed,
             ungroupedItemCount: ungrouped)
     }
-}
-
-// MARK: - Shared resolution
-
-/// Resolves the (assignment, setup) pair for a section-edit tool, enforcing
-/// course access.  Factored out so the three section-CRUD tools share one
-/// lookup + authorization path.
-func resolveSetupForSectionEdit(
-    assignmentPublicID: String, tool: String, context: ToolContext
-) async throws -> (assignment: APIAssignment, setup: APITestSetup) {
-    guard let assignment = try await assignmentByPublicID(assignmentPublicID, on: context.db) else {
-        throw MCPToolError.invalidArguments(
-            tool: tool, detail: "No assignment found with public ID \"\(assignmentPublicID)\".")
-    }
-    try await context.authorizeCourseAccess(assignment.courseID, tool: tool)
-    guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-        throw MCPToolError.invalidArguments(
-            tool: tool, detail: "The assignment's test setup could not be found.")
-    }
-    return (assignment, setup)
 }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -80,4 +80,42 @@ struct ToolContext {
                 detail: "The MCP account is not enrolled in the target course.")
         }
     }
+
+    // MARK: - Assignment resolution
+
+    /// Resolves the assignment referenced by a tool's `assignmentPublicID`,
+    /// throwing the standard `invalidArguments` error if none matches. Does
+    /// not check authorization — prefer `authorizedAssignment` unless the
+    /// caller authorizes by other means.
+    func requireAssignment(publicID: String, tool: String) async throws -> APIAssignment {
+        guard let assignment = try await assignmentByPublicID(publicID, on: db) else {
+            throw MCPToolError.invalidArguments(
+                tool: tool, detail: "No assignment found with public ID \"\(publicID)\".")
+        }
+        return assignment
+    }
+
+    /// Resolves the assignment and authorizes the acting subject for its course
+    /// (`authorizeCourseAccess`). The standard entry point for a tool acting on
+    /// a single assignment.
+    func authorizedAssignment(publicID: String, tool: String) async throws -> APIAssignment {
+        let assignment = try await requireAssignment(publicID: publicID, tool: tool)
+        try await authorizeCourseAccess(assignment.courseID, tool: tool)
+        return assignment
+    }
+
+    /// Resolves and authorizes the assignment, then loads its test setup,
+    /// throwing the standard `invalidArguments` error if the setup is missing.
+    func authorizedAssignmentAndSetup(
+        publicID: String, tool: String
+    ) async throws
+        -> (assignment: APIAssignment, setup: APITestSetup)
+    {
+        let assignment = try await authorizedAssignment(publicID: publicID, tool: tool)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: db) else {
+            throw MCPToolError.invalidArguments(
+                tool: tool, detail: "The assignment's test setup could not be found.")
+        }
+        return (assignment, setup)
+    }
 }

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -133,11 +133,8 @@ struct UpdateAssignmentTool: ContentTool {
                 tool: Self.name, detail: "Specify at least one of: title, dueAt, startsAt, isOpen, visibility.")
         }
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
         do {
             // Title/date metadata first. The legacy `isOpen` is applied here only
             // when `visibility` was not given (visibility is the richer form and

--- a/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
@@ -110,15 +110,8 @@ struct UpdateGlobalInputsTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         // The save-time expression eval runs against the acting account's own
         // seed — same as the instructor's seed on the web path.

--- a/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
@@ -77,20 +77,10 @@ struct UpdateNotebookTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        try Self.validateNotebookShape(input.notebook)
+        try validateNotebookShape(input.notebook, tool: Self.name)
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
-        else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         let data: Data
         do {
@@ -112,37 +102,15 @@ struct UpdateNotebookTool: ContentTool {
             throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
         }
 
-        // Close a currently-open assignment (matching the web Save button) so
-        // students can't submit against the not-yet-revalidated suite, then
-        // re-kick validation (debounced).
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        // Starter-notebook edit: close + re-validate, no regrade of submissions.
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: false)
 
         return Output(
             assignmentPublicID: assignment.publicID,
-            cellCount: Self.cellCount(of: input.notebook),
+            cellCount: notebookCellCount(input.notebook),
             validationStatus: assignment.validationStatus,
             assignmentClosed: closed)
     }
 
-    /// A notebook must be a JSON object carrying a `cells` array — the minimal
-    /// shape every Jupyter notebook has. Stricter nbformat checks are left to
-    /// the runner, matching the web save path's lenient JSON-only validation.
-    private static func validateNotebookShape(_ notebook: JSONValue) throws {
-        guard case .object(let root) = notebook else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "notebook must be a JSON object.")
-        }
-        guard case .array? = root["cells"] else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "notebook must contain a \"cells\" array.")
-        }
-    }
-
-    private static func cellCount(of notebook: JSONValue) -> Int {
-        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
-            return 0
-        }
-        return cells.count
-    }
 }

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -222,7 +222,7 @@ struct UpdatePatternFamilyTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let newTier = try Self.parseTier(input.defaultTier)
+        let newTier = try parseOptionalTier(input.defaultTier, tool: Self.name, field: "defaultTier")
         let enable = Set(input.enableCases ?? [])
         let disable = Set(input.disableCases ?? [])
         let caseEdits = input.cases ?? []
@@ -242,15 +242,8 @@ struct UpdatePatternFamilyTool: ContentTool {
         }
         let editsByKey = try Self.indexCaseEdits(caseEdits)
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
         guard
@@ -283,21 +276,10 @@ struct UpdatePatternFamilyTool: ContentTool {
         // applySuiteEdit -> applyPatternFamilies -> validatePatternFamilies runs
         // the structural + per-kind case checks synchronously; surface those as
         // clean MCP errors rather than opaque protocol failures.
-        do {
-            try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        } catch let error as WebAssignmentError {
-            throw MCPToolError.from(error, tool: Self.name)
-        } catch let error as any AbortError {
-            throw MCPToolError.from(error, tool: Self.name)
-        }
-        // Close a currently-open assignment (matching the web Save button) so
-        // students can't submit against the not-yet-revalidated suite, then
-        // re-kick validation (debounced).
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        // Re-grade existing submissions against the edited suite (gated on a real
-        // manifest change), the automatic equivalent of the "Retest all" button.
-        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        try await applySuiteEditMapped(setup: setup, body: payload, tool: Self.name, on: context.db)
+        // Close, re-grade, and re-validate (matching the web Save button).
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
 
         return Output(
             assignmentPublicID: assignment.publicID,
@@ -407,14 +389,6 @@ struct UpdatePatternFamilyTool: ContentTool {
         return argsReplaced ? [] : existing
     }
 
-    private static func parseTier(_ raw: String?) throws -> TestTier? {
-        guard let raw else { return nil }
-        guard let tier = TestTier(rawValue: raw) else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "defaultTier must be one of: public, release, secret, student.")
-        }
-        return tier
-    }
 }
 
 extension PatternCase {

--- a/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
@@ -112,15 +112,8 @@ struct UpdateSectionVariablesTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         let actingUser = try await context.requireEligibleSubject(tool: Self.name)
 

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -80,15 +80,10 @@ struct UpdateSolutionTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        try Self.validateNotebookShape(input.notebook)
+        try validateNotebookShape(input.notebook, tool: Self.name)
 
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
-        else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
         // The bearer context has no `Request.auth` APIUser; resolve the subject
         // so the validation submission is attributed to the acting account.
         let subject = try await context.requireEligibleSubject(tool: Self.name)
@@ -129,29 +124,9 @@ struct UpdateSolutionTool: ContentTool {
 
         return Output(
             assignmentPublicID: assignment.publicID,
-            cellCount: Self.cellCount(of: input.notebook),
+            cellCount: notebookCellCount(input.notebook),
             validationStatus: assignment.validationStatus,
             assignmentClosed: closed)
     }
 
-    /// A notebook must be a JSON object carrying a `cells` array — the minimal
-    /// shape every Jupyter notebook has. Matches update_notebook's lenient,
-    /// JSON-only validation; stricter nbformat checks are left to the runner.
-    private static func validateNotebookShape(_ notebook: JSONValue) throws {
-        guard case .object(let root) = notebook else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "notebook must be a JSON object.")
-        }
-        guard case .array? = root["cells"] else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "notebook must contain a \"cells\" array.")
-        }
-    }
-
-    private static func cellCount(of notebook: JSONValue) -> Int {
-        guard case .object(let root) = notebook, case .array(let cells)? = root["cells"] else {
-            return 0
-        }
-        return cells.count
-    }
 }

--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -113,21 +113,14 @@ struct UpdateSuiteTool: ContentTool {
         guard !input.edits.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "Provide at least one edit.")
         }
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "The assignment's test setup could not be found.")
-        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         // Load the full authored suite with script bodies preserved from the zip.
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)
         var updated: [String] = []
         for edit in input.edits {
-            let tier = try Self.parseTier(edit.tier)
+            let tier = try parseOptionalTier(edit.tier, tool: Self.name)
             guard
                 let idx = payload.items.firstIndex(where: {
                     $0.kind == "script" && $0.script?.script == edit.script
@@ -148,15 +141,10 @@ struct UpdateSuiteTool: ContentTool {
             updated.append(edit.script)
         }
 
-        try await applySuiteEdit(setup: setup, body: payload, on: context.db)
-        // Close a currently-open assignment (matching the web Save button) so
-        // students can't submit against the not-yet-revalidated suite, then
-        // re-kick validation against the edited manifest (debounced).
-        let closed = try await closeOpenAssignmentForContentEdit(assignment, on: context.db)
-        // Re-grade existing submissions against the edited suite (gated on a real
-        // manifest change), the automatic equivalent of the "Retest all" button.
-        await retestSubmissionsAfterContentEdit(setup: setup, context: context)
-        await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+        try await applySuiteEditMapped(setup: setup, body: payload, tool: Self.name, on: context.db)
+        // Close, re-grade, and re-validate (matching the web Save button).
+        let closed = try await finalizeContentEdit(
+            assignment: assignment, setup: setup, context: context, retest: true)
 
         return Output(
             assignmentPublicID: assignment.publicID,
@@ -165,12 +153,4 @@ struct UpdateSuiteTool: ContentTool {
             assignmentClosed: closed)
     }
 
-    private static func parseTier(_ raw: String?) throws -> TestTier? {
-        guard let raw else { return nil }
-        guard let tier = TestTier(rawValue: raw) else {
-            throw MCPToolError.invalidArguments(
-                tool: name, detail: "tier must be one of: public, release, secret, student.")
-        }
-        return tier
-    }
 }

--- a/Sources/APIServer/MCP/Tools/ValidateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/ValidateAssignmentTool.swift
@@ -79,13 +79,8 @@ struct ValidateAssignmentTool: ContentTool {
     }
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard let assignment = try await assignmentByPublicID(input.assignmentPublicID, on: context.db)
-        else {
-            throw MCPToolError.invalidArguments(
-                tool: Self.name,
-                detail: "No assignment found with public ID \"\(input.assignmentPublicID)\".")
-        }
-        try await context.authorizeCourseAccess(assignment.courseID, tool: Self.name)
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
 
         let timeout = Self.clampTimeout(input.timeoutSeconds)
         let outcome = try await watchValidation(

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -742,22 +742,11 @@ extension DraftAssignmentRoutes {
             return req.redirect(to: "/instructor")
         }
 
-        let due: Date?
-        if let raw = body.dueAt, !raw.isEmpty {
-            // datetime-local sends "2026-04-01T14:00" — try ISO8601 with and without seconds.
-            let iso = ISO8601DateFormatter()
-            if let d = iso.date(from: raw) {
-                due = d
-            } else {
-                // Try without timezone (datetime-local format)
-                let fmt = DateFormatter()
-                fmt.locale = Locale(identifier: "en_US_POSIX")
-                fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
-                due = fmt.date(from: raw)
-            }
-        } else {
-            due = nil
-        }
+        // datetime-local sends Toronto wall-clock ("2026-04-01T14:00"); parseDueDate
+        // interprets a no-timezone value in America/Toronto, matching the edit
+        // form's save path (previously this inline parser used the server's
+        // default zone, shifting the due date by the UTC offset on publish).
+        let due = parseDueDate(body.dueAt)
 
         guard let courseID = courseState.activeCourseUUID else {
             throw WebAssignmentError.noActiveCourse(action: "publishing an assignment")

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -40,12 +40,12 @@ struct SSOAuthRoutes: RouteCollection {
         // PKCE: generate random 32-byte code_verifier, then SHA-256 → base64url code_challenge
         var rng = SystemRandomNumberGenerator()
         let codeVerifierBytes = (0..<32).map { _ in UInt8.random(in: 0...255, using: &rng) }
-        let codeVerifier = Data(codeVerifierBytes).base64URLEncoded()
-        let codeChallenge = Data(SHA256.hash(data: Data(codeVerifier.utf8))).base64URLEncoded()
+        let codeVerifier = Data(codeVerifierBytes).base64URLEncodedString()
+        let codeChallenge = Data(SHA256.hash(data: Data(codeVerifier.utf8))).base64URLEncodedString()
 
         // State token for CSRF protection
         let stateBytes = (0..<32).map { _ in UInt8.random(in: 0...255, using: &rng) }
-        let state = Data(stateBytes).base64URLEncoded()
+        let state = Data(stateBytes).base64URLEncodedString()
 
         // Persist in session so callback can validate
         req.session.data["oidc_state"] = state
@@ -461,15 +461,5 @@ private extension String {
 
     func normalizedIdentityKey() -> String? {
         nilIfBlank()?.lowercased()
-    }
-}
-
-private extension Data {
-    /// Base64url encoding (RFC 4648 §5): replaces +/→-_, strips padding.
-    func base64URLEncoded() -> String {
-        base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -392,7 +392,7 @@ func createRunnerSetupZip(
     )
 
     if storedNameByIndex.isEmpty {
-        try writeEmptyZip(to: zipPath)
+        try writeEmptyZip(at: zipPath)
     } else {
         // Rebuilding an existing setup zip must start from a clean archive.
         // `zip -r existing.zip .` updates/adds entries but does not remove files
@@ -410,18 +410,6 @@ func createRunnerSetupZip(
         return n == "makefile" || n == "gnumakefile"
     }
     return RunnerSetupPackage(testSuites: testSuites, hasMakefile: hasMakefile)
-}
-
-private func writeEmptyZip(to path: String) throws {
-    let emptyZip = Data([
-        0x50, 0x4b, 0x05, 0x06,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00,
-    ])
-    try emptyZip.write(to: URL(fileURLWithPath: path))
 }
 
 // MARK: - Support file extraction

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -151,10 +151,7 @@ actor BrightSpaceAPIClient {
     private func hmacSHA256Base64URL(key: String, message: String) -> String {
         let symmetricKey = SymmetricKey(data: Data(key.utf8))
         let mac = HMAC<SHA256>.authenticationCode(for: Data(message.utf8), using: symmetricKey)
-        return Data(mac).base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
+        return Data(mac).base64URLEncodedString()
     }
 
     // MARK: - Push grade

--- a/Sources/APIServer/Utilities/Base64URL.swift
+++ b/Sources/APIServer/Utilities/Base64URL.swift
@@ -1,0 +1,25 @@
+// APIServer/Utilities/Base64URL.swift
+//
+// Shared base64url (RFC 4648 §5) encoding used by the OAuth/PKCE flows, the
+// ES256 JWT minting in MCPTokenAuthority, and the BrightSpace HMAC signing.
+// Previously each site reimplemented the same `+`→`-`, `/`→`_`, strip-`=`
+// transform; this is the single source so they cannot drift.
+
+import Foundation
+
+extension Data {
+    /// Base64url encoding: standard base64 with `+`→`-`, `/`→`_`, and padding
+    /// (`=`) removed.
+    func base64URLEncodedString() -> String {
+        base64EncodedString().base64ToBase64URL()
+    }
+}
+
+extension String {
+    /// Converts a standard base64 string to unpadded base64url.
+    func base64ToBase64URL() -> String {
+        replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/changelog.d/codebase-audit-streamline.md
+++ b/changelog.d/codebase-audit-streamline.md
@@ -1,0 +1,22 @@
+### Changed
+
+- **MCP tool layer consolidation.** Extracted the assignment-resolution
+  prologue (`requireAssignment` / `authorizedAssignment` /
+  `authorizedAssignmentAndSetup` on `ToolContext`) and the post-edit finalize
+  sequence (`applySuiteEditMapped` / `finalizeContentEdit` in
+  `ContentEditClose`) that ~20 MCP content tools had copy-pasted. The
+  close→retest→revalidate ordering and the per-tool error strings now live in
+  one place each instead of being a copy-paste convention. No behaviour change
+  (net ~290 fewer lines).
+- **Shared base64url + notebook-shape helpers.** The four hand-rolled base64url
+  encoders (SSO/PKCE, OAuth, ES256 JWT, BrightSpace HMAC) now share
+  `Data.base64URLEncodedString()` / `String.base64ToBase64URL()`, and the
+  notebook `cellCount` / `validateNotebookShape` helpers duplicated across five
+  MCP tools are now shared. Identical output.
+
+### Fixed
+
+- **New-assignment publish due date now uses the Waterloo timezone.** The draft
+  publish path parsed a no-seconds `datetime-local` value in the server's
+  default zone instead of `America/Toronto`, shifting the due date by the UTC
+  offset; it now reuses the shared `parseDueDate` parser like the edit form.


### PR DESCRIPTION
## What

A codebase-streamlining pass: removes copy-pasted boilerplate in the MCP tool layer and a few cross-cutting helpers, replacing it with shared, idiomatic Swift abstractions. **Net ~290 fewer lines**, no behaviour change except one timezone bug fix.

## Why

Audit of `Sources/` (corroborated by three independent exploration passes) found the largest remaining duplication concentrated in the 34-tool MCP catalog — every content tool hand-rolled the same assignment-resolution prologue, post-edit finalize sequence, and error mapping — plus four hand-rolled base64url encoders and several copy-pasted notebook/tier helpers. The grading core, route helpers, and pattern/check dispatch are already well-factored and were left alone.

## Changes

**MCP tool layer**
- `ToolContext.requireAssignment` / `authorizedAssignment` / `authorizedAssignmentAndSetup` collapse the *resolve-assignment → authorize-course → load-setup* prologue duplicated across ~20 tools (including the two repeated error strings). The pre-existing local `resolveSetupForSectionEdit` is folded into the shared method.
- `applySuiteEditMapped` + `finalizeContentEdit` (in `ContentEditClose`) centralize the `applySuiteEdit` error mapping and the `close → retest → revalidate` sequence — the ordering and "which edits regrade" policy are now a single function rather than a copy-paste convention. `update_suite` now maps suite-edit errors like its sibling tools.
- Shared `notebookCellCount` / `validateNotebookShape` (`MCPNotebookShape`) replace 5 identical private copies; shared `parseOptionalTier` (`MCPTierParsing`) replaces 3.

**Cross-cutting**
- One base64url implementation (`Data.base64URLEncodedString()` / `String.base64ToBase64URL()`) replaces four hand-rolled copies in the SSO/PKCE, OAuth, ES256 JWT, and BrightSpace HMAC paths. Byte-identical output.
- The two identical `writeEmptyZip` functions in `TestSetupZipHelpers` collapse to one (the variant that clears any existing file first).

**Fixed**
- New-assignment **publish** parsed a no-seconds `datetime-local` due date in the server's default timezone instead of `America/Toronto`, shifting the due date by the UTC offset. It now reuses the shared `parseDueDate`, matching the edit form (consistent with the v0.4.82 timezone work).

## Verification

- `swift build` — clean, 0 warnings
- `scripts/format.sh` (swift-format) applied
- `scripts/swiftlint.sh` (`--strict`) — 0 violations
- Targeted test run: **578 tests / 76 suites pass** (MCP tools, SSO, notebook, pattern-family, suite, token authority, assignment publish)

Genuinely safe, mechanical consolidations; the only observable change is the timezone fix.

https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r)_