### PR TITLE
refactor: share test-suite section CRUD across published and draft routes

### DIFF
--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+Sections.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+Sections.swift
@@ -37,20 +37,7 @@ extension DraftAssignmentRoutes {
 
         let setup = try await loadDraftSetup(req)
         let body = try req.content.decode(Body.self)
-        let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty else {
-            throw WebAssignmentError.invalidParameter(name: "name", reason: "Section name must not be empty.")
-        }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            var sections = (dict["sections"] as? [[String: Any]]) ?? []
-            sections.append([
-                "id": UUID().uuidString,
-                "name": name,
-            ])
-            dict["sections"] = sections
-        }
-
+        try await createSuiteSectionCore(setup: setup, name: body.name, on: req.db)
         return redirectToDraft(req: req, setup: setup)
     }
 
@@ -65,22 +52,7 @@ extension DraftAssignmentRoutes {
             throw WebAssignmentError.notFound(resource: "Section")
         }
         let body = try req.content.decode(Body.self)
-        let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty else {
-            throw WebAssignmentError.invalidParameter(name: "name", reason: "Section name must not be empty.")
-        }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            guard var sections = dict["sections"] as? [[String: Any]] else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            guard let idx = sections.firstIndex(where: { ($0["id"] as? String) == sectionID }) else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            sections[idx]["name"] = name
-            dict["sections"] = sections
-        }
-
+        try await renameSuiteSectionCore(setup: setup, sectionID: sectionID, name: body.name, on: req.db)
         return redirectToDraft(req: req, setup: setup)
     }
 
@@ -92,79 +64,49 @@ extension DraftAssignmentRoutes {
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            // Drop the section from the list.
-            if var sections = dict["sections"] as? [[String: Any]] {
-                sections.removeAll { ($0["id"] as? String) == sectionID }
-                dict["sections"] = sections
-            }
-            // Clear matching entries' sectionID so the affected items flow
-            // into the trailing Ungrouped block — same semantics as the
-            // assignment-scoped variant.
-            if var testSuites = dict["testSuites"] as? [[String: Any]] {
-                for i in testSuites.indices where (testSuites[i]["sectionID"] as? String) == sectionID {
-                    testSuites[i].removeValue(forKey: "sectionID")
-                }
-                dict["testSuites"] = testSuites
-            }
-        }
-
+        try await deleteSuiteSectionCore(setup: setup, sectionID: sectionID, on: req.db)
         return redirectToDraft(req: req, setup: setup)
     }
 
     // MARK: - POST /instructor/new/draft/suite-sections/:sectionID/variables
     //
-    // Replaces the section's variables list atomically.  Shape matches
-    // the assignment-scoped endpoint: JSON body with `variables:
-    // [FamilyVariable]`; identical Python-identifier + uniqueness
-    // validation.  Returns 303 on the form-encoded path; the auto-save
-    // JS sends `redirect: 'manual'` so it doesn't follow the redirect
-    // back to the create page.
+    // Replaces the section's variables (and per-student expressions) list
+    // atomically, through the same `SectionInputsService.apply` path the
+    // published endpoint uses — so a draft gets the identical validation
+    // (Python-identifier, reserved-`seed`, cross-scope clash) AND expression
+    // support. The save-time expression eval no-ops here: a draft has no
+    // assignment seed yet (`assignmentID: nil`), so expressions are persisted
+    // and first evaluated when the assignment is published. Returns 303 on the
+    // form-encoded path; the auto-save JS sends `redirect: 'manual'` so it
+    // doesn't follow the redirect back to the create page.
 
     @Sendable
     func updateDraftSuiteSectionVariables(req: Request) async throws -> Response {
-        struct Body: Content { var variables: [FamilyVariable] }
+        struct Body: Content {
+            var variables: [FamilyVariable]
+            /// Per-student expressions in section scope (optional so older
+            /// editor builds sending only `variables` keep working).
+            var expressions: [PersonalizationExpression]?
+        }
 
         let setup = try await loadDraftSetup(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
         let body = try req.content.decode(Body.self)
+        let actingUserID = (try? req.auth.require(APIUser.self))?.id
 
-        var seenNames: Set<String> = []
-        for v in body.variables {
-            guard isValidPythonIdentifier(v.name) else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Section variable name '\(v.name)' is not a valid Python identifier.")
-            }
-            guard seenNames.insert(v.name).inserted else {
-                throw WebAssignmentError.unprocessable(
-                    reason: "Duplicate section variable name '\(v.name)'.")
-            }
-        }
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let varData = try encoder.encode(body.variables)
-        guard let parsed = try JSONSerialization.jsonObject(with: varData) as? [Any] else {
-            throw WebAssignmentError.internalFailure(reason: "Failed to re-serialise section variables.")
-        }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            guard var sections = dict["sections"] as? [[String: Any]] else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            guard let idx = sections.firstIndex(where: { ($0["id"] as? String) == sectionID }) else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            if parsed.isEmpty {
-                sections[idx].removeValue(forKey: "variables")
-            } else {
-                sections[idx]["variables"] = parsed
-            }
-            dict["sections"] = sections
-        }
+        try await SectionInputsService.apply(
+            setup: setup,
+            sectionID: sectionID,
+            inputs: .init(variables: body.variables, expressions: body.expressions ?? []),
+            seed: .init(
+                actingUserID: actingUserID,
+                assignmentID: nil,
+                testSetupID: setup.id ?? "",
+                testSetupsDirectory: req.application.testSetupsDirectory),
+            on: req.db
+        )
 
         return redirectToDraft(req: req, setup: setup)
     }
@@ -177,24 +119,7 @@ extension DraftAssignmentRoutes {
 
         let setup = try await loadDraftSetup(req)
         let body = try req.content.decode(Body.self)
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            let existing = (dict["sections"] as? [[String: Any]]) ?? []
-            let byID = Dictionary(
-                uniqueKeysWithValues: existing.compactMap { s -> (String, [String: Any])? in
-                    guard let id = s["id"] as? String else { return nil }
-                    return (id, s)
-                }
-            )
-            guard Set(body.sectionIDs) == Set(byID.keys),
-                body.sectionIDs.count == existing.count
-            else {
-                throw WebAssignmentError.invalidParameter(
-                    name: "sectionIDs", reason: "Section set mismatch in reorder payload.")
-            }
-            dict["sections"] = body.sectionIDs.compactMap { byID[$0] }
-        }
-
+        try await reorderSuiteSectionsCore(setup: setup, sectionIDs: body.sectionIDs, on: req.db)
         return .ok
     }
 

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SuiteSections.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SuiteSections.swift
@@ -36,20 +36,7 @@ extension PublishedAssignmentRoutes {
 
         let (_, setup) = try await loadAssignmentAndSetup(req)
         let body = try req.content.decode(Body.self)
-        let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty else {
-            throw WebAssignmentError.invalidParameter(name: "name", reason: "Section name must not be empty.")
-        }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            var sections = (dict["sections"] as? [[String: Any]]) ?? []
-            sections.append([
-                "id": UUID().uuidString,
-                "name": name,
-            ])
-            dict["sections"] = sections
-        }
-
+        try await createSuiteSectionCore(setup: setup, name: body.name, on: req.db)
         return redirectToEdit(req: req)
     }
 
@@ -64,22 +51,7 @@ extension PublishedAssignmentRoutes {
             throw WebAssignmentError.notFound(resource: "Section")
         }
         let body = try req.content.decode(Body.self)
-        let name = body.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty else {
-            throw WebAssignmentError.invalidParameter(name: "name", reason: "Section name must not be empty.")
-        }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            guard var sections = dict["sections"] as? [[String: Any]] else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            guard let idx = sections.firstIndex(where: { ($0["id"] as? String) == sectionID }) else {
-                throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
-            }
-            sections[idx]["name"] = name
-            dict["sections"] = sections
-        }
-
+        try await renameSuiteSectionCore(setup: setup, sectionID: sectionID, name: body.name, on: req.db)
         return redirectToEdit(req: req)
     }
 
@@ -91,24 +63,7 @@ extension PublishedAssignmentRoutes {
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            // Drop the section from the list.
-            if var sections = dict["sections"] as? [[String: Any]] {
-                sections.removeAll { ($0["id"] as? String) == sectionID }
-                dict["sections"] = sections
-            }
-            // Clear matching entries' sectionID so the affected items flow
-            // into the trailing Ungrouped block — same semantics as the
-            // dashboard's onDelete: .setNull on course_sections.
-            if var testSuites = dict["testSuites"] as? [[String: Any]] {
-                for i in testSuites.indices where (testSuites[i]["sectionID"] as? String) == sectionID {
-                    testSuites[i].removeValue(forKey: "sectionID")
-                }
-                dict["testSuites"] = testSuites
-            }
-        }
-
+        try await deleteSuiteSectionCore(setup: setup, sectionID: sectionID, on: req.db)
         return redirectToEdit(req: req)
     }
 
@@ -163,25 +118,7 @@ extension PublishedAssignmentRoutes {
 
         let (_, setup) = try await loadAssignmentAndSetup(req)
         let body = try req.content.decode(Body.self)
-
-        try await mutateManifest(setup: setup, on: req.db) { dict in
-            let existing = (dict["sections"] as? [[String: Any]]) ?? []
-            let byID = Dictionary(
-                uniqueKeysWithValues: existing.compactMap { s -> (String, [String: Any])? in
-                    guard let id = s["id"] as? String else { return nil }
-                    return (id, s)
-                }
-            )
-            // Validate the set of ids matches exactly.
-            guard Set(body.sectionIDs) == Set(byID.keys),
-                body.sectionIDs.count == existing.count
-            else {
-                throw WebAssignmentError.invalidParameter(
-                    name: "sectionIDs", reason: "Section set mismatch in reorder payload.")
-            }
-            dict["sections"] = body.sectionIDs.compactMap { byID[$0] }
-        }
-
+        try await reorderSuiteSectionsCore(setup: setup, sectionIDs: body.sectionIDs, on: req.db)
         return .ok
     }
 

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -212,3 +212,83 @@ func mutateManifest(
     setup.manifest = json
     try await setup.save(on: db)
 }
+
+// MARK: - Suite-section manifest mutations
+//
+// Shared cores for the test-suite Sections CRUD, used by both the published
+// (`PublishedAssignmentRoutes+SuiteSections`) and draft
+// (`DraftAssignmentRoutes+Sections`) handlers. The handlers differ only in how
+// they resolve the setup and where they redirect afterward; the manifest
+// mutations are identical, so they live here once. (Section variables are
+// handled by `SectionInputsService`, which both paths call directly.)
+
+/// Appends a new, uniquely-identified section with the given display name.
+func createSuiteSectionCore(setup: APITestSetup, name: String, on db: any Database) async throws {
+    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        throw WebAssignmentError.invalidParameter(name: "name", reason: "Section name must not be empty.")
+    }
+    try await mutateManifest(setup: setup, on: db) { dict in
+        var sections = (dict["sections"] as? [[String: Any]]) ?? []
+        sections.append(["id": UUID().uuidString, "name": trimmed])
+        dict["sections"] = sections
+    }
+}
+
+/// Renames the section with `sectionID`, throwing `notFound` if it is absent.
+func renameSuiteSectionCore(
+    setup: APITestSetup, sectionID: String, name: String, on db: any Database
+) async throws {
+    let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+        throw WebAssignmentError.invalidParameter(name: "name", reason: "Section name must not be empty.")
+    }
+    try await mutateManifest(setup: setup, on: db) { dict in
+        guard var sections = dict["sections"] as? [[String: Any]],
+            let idx = sections.firstIndex(where: { ($0["id"] as? String) == sectionID })
+        else {
+            throw WebAssignmentError.notFound(resource: "Section '\(sectionID)'")
+        }
+        sections[idx]["name"] = trimmed
+        dict["sections"] = sections
+    }
+}
+
+/// Removes the section and clears the `sectionID` of any test-suite entries
+/// that referenced it, so they flow into the trailing Ungrouped block (same
+/// semantics as `onDelete: .setNull` on course_sections).
+func deleteSuiteSectionCore(setup: APITestSetup, sectionID: String, on db: any Database) async throws {
+    try await mutateManifest(setup: setup, on: db) { dict in
+        if var sections = dict["sections"] as? [[String: Any]] {
+            sections.removeAll { ($0["id"] as? String) == sectionID }
+            dict["sections"] = sections
+        }
+        if var testSuites = dict["testSuites"] as? [[String: Any]] {
+            for i in testSuites.indices where (testSuites[i]["sectionID"] as? String) == sectionID {
+                testSuites[i].removeValue(forKey: "sectionID")
+            }
+            dict["testSuites"] = testSuites
+        }
+    }
+}
+
+/// Reorders the section list to match `sectionIDs`, which must be a permutation
+/// of the existing ids.
+func reorderSuiteSectionsCore(
+    setup: APITestSetup, sectionIDs: [String], on db: any Database
+) async throws {
+    try await mutateManifest(setup: setup, on: db) { dict in
+        let existing = (dict["sections"] as? [[String: Any]]) ?? []
+        let byID = Dictionary(
+            uniqueKeysWithValues: existing.compactMap { s -> (String, [String: Any])? in
+                guard let id = s["id"] as? String else { return nil }
+                return (id, s)
+            }
+        )
+        guard Set(sectionIDs) == Set(byID.keys), sectionIDs.count == existing.count else {
+            throw WebAssignmentError.invalidParameter(
+                name: "sectionIDs", reason: "Section set mismatch in reorder payload.")
+        }
+        dict["sections"] = sectionIDs.compactMap { byID[$0] }
+    }
+}

--- a/changelog.d/section-crud-consolidation.md
+++ b/changelog.d/section-crud-consolidation.md
@@ -1,0 +1,19 @@
+### Changed
+
+- **Test-suite section CRUD shares one implementation across published and
+  draft.** The create / rename / delete / reorder manifest mutations were
+  copy-pasted between `PublishedAssignmentRoutes+SuiteSections` and
+  `DraftAssignmentRoutes+Sections`; they now call shared cores
+  (`createSuiteSectionCore` / `renameSuiteSectionCore` / `deleteSuiteSectionCore`
+  / `reorderSuiteSectionsCore`) in `SuiteEditHelpers`. The handlers keep only
+  their setup resolution and redirect target. No behaviour change.
+
+### Fixed
+
+- **Draft section variables now support per-student expressions.** The draft
+  section-variables endpoint had drifted from its published sibling: it
+  hand-rolled validation and silently dropped any `expressions` the editor sent.
+  It now routes through the same `SectionInputsService.apply` path, gaining
+  expression support plus the shared validation (reserved-`seed` name,
+  cross-scope clash). The save-time expression eval correctly no-ops on a draft
+  (no assignment seed yet) and first runs when the assignment is published.


### PR DESCRIPTION
## What

The "meatier" follow-up to #838. The test-suite **Sections** CRUD was copy-pasted between the published and draft route files; this extracts the shared cores and, in the process, fixes a feature-drift bug the duplication had hidden.

## Why

`PublishedAssignmentRoutes+SuiteSections` and `DraftAssignmentRoutes+Sections` carried byte-identical `create` / `rename` / `delete` / `reorder` manifest mutations — the draft file's own header even says *"Same body shapes, same validation rules, same dictionary-of-Any manifest mutations."* The only real differences are how each resolves the test setup (`loadAssignmentAndSetup` vs `loadDraftSetup`) and where it redirects. Copy-paste like this is exactly how the two paths silently drift apart — which is what had already happened to the variables handler.

## Changes

**Consolidation**
- Four shared cores in `SuiteEditHelpers`: `createSuiteSectionCore`, `renameSuiteSectionCore`, `deleteSuiteSectionCore`, `reorderSuiteSectionsCore`. Each published/draft handler reduces to *resolve setup → core → redirect*. No behaviour change for these four.

**Fixed (feature drift)**
- The **draft** section-variables endpoint had diverged from its published sibling: it hand-rolled `FamilyVariable` validation and its `Body` only decoded `variables`, so any per-student `expressions` the editor sent were **silently dropped**. It now routes through the same `SectionInputsService.apply` path the published endpoint uses, gaining:
  - per-student `expressions` support, and
  - the shared validation (reserved-`seed` name check + cross-scope clash check) it was missing.
- The save-time expression eval correctly **no-ops on a draft** — a draft has no assignment seed yet, so `apply` is called with `assignmentID: nil` (which `evaluateForActingSeed` already guards on) and expressions are first evaluated when the assignment is published. Missing-section and empty-variables behaviour is byte-for-byte identical to the old inline handler (verified against `SectionInputsService.persist`).

## Verification

- `swift build` — clean, 0 warnings
- `scripts/format.sh` applied; `scripts/swiftlint.sh --strict` — 0 violations
- `SuiteSectionRoutesTests`, `DraftSuiteSectionRoutesTests`, `SectionInputs*` — **40 tests pass**

Net **−58 lines**.

## Deliberately out of scope

The published-vs-draft **script** CRUD (`createScript`/`deleteScript` vs `createDraftScript`/`deleteDraftScript`) is a similar duplication, but those paths have genuine divergences (support-file re-extraction, `editURL`) and touch the grading-critical zip-rewrite path — better as its own focused PR. Happy to do it next if you'd like.

https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r)_