### PR TITLE
refactor: share script create/delete CRUD across published and draft routes

### DIFF
--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
@@ -71,55 +71,8 @@ extension DraftAssignmentRoutes {
     @Sendable
     func createDraftScript(req: Request) async throws -> Response {
         let setup = try await loadDraftSetup(req)
-
-        struct CreateBody: Content {
-            var filename: String
-            var content: String
-            var tier: String?
-            var points: Int?
-            var isTest: Bool?
-        }
-        let body = try req.content.decode(CreateBody.self)
-
-        let cleaned = sanitizeSuiteFilename(body.filename)
-        guard !cleaned.isEmpty, cleaned == body.filename else {
-            throw WebAssignmentError.invalidParameter(name: "filename", reason: "Invalid filename '\(body.filename)'")
-        }
-
-        if listZipEntries(zipPath: setup.zipPath).contains(cleaned) {
-            throw WebAssignmentError.conflict(reason: "A file named '\(cleaned)' already exists in this setup")
-        }
-
-        // Slice 1: prepend assignment-scope variables (section vars get
-        // applied on the next suite-edit save once the new entry's
-        // sectionID is known).
-        let inlinedContent: String = {
-            guard let manifest = setup.decodedManifest()
-
-            else { return body.content }
-            return TestScriptVariablePrepender.applyForRawScript(
-                filename: cleaned,
-                content: body.content,
-                manifest: manifest
-            )
-        }()
-        try updateScriptInZip(zipPath: setup.zipPath, filename: cleaned, content: inlinedContent)
-
-        let tier = normalizeTier(body.tier, isTest: body.isTest)
-        // v0.4.105: allow 0-mark tests for guards (see AssignmentRoutes+Editor).
-        let points = max(0, body.points ?? 1)
-        let shouldTest = tier != "support"
-
-        if shouldTest {
-            let entry = ConfiguredSuiteEntry(
-                script: cleaned, tier: tier, order: 0,
-                dependsOn: [], points: points, displayName: nil
-            )
-            if let updated = updateManifestAddingScript(manifestJSON: setup.manifest, entry: entry) {
-                setup.manifest = updated
-                try await setup.save(on: req.db)
-            }
-        }
+        let body = try req.content.decode(CreateScriptBody.self)
+        let result = try await createScriptInSetup(setup: setup, body: body, on: req.db)
 
         struct CreatedResponse: Content {
             var filename: String
@@ -128,13 +81,14 @@ extension DraftAssignmentRoutes {
             var isTest: Bool
         }
         // Note: no editURL yet — the draft doesn't have a stable assignment
-        // route.  The create page re-renders with the updated suite state
-        // to pick up the new row.
+        // route — and no shared-dir re-extraction (a draft has no students).
+        // The create page re-renders with the updated suite state to pick up
+        // the new row.
         let resp = CreatedResponse(
-            filename: cleaned,
-            tier: tier,
-            points: points,
-            isTest: shouldTest
+            filename: result.filename,
+            tier: result.tier,
+            points: result.points,
+            isTest: result.isTest
         )
         return try await resp.encodeResponse(status: .created, for: req)
     }
@@ -145,35 +99,7 @@ extension DraftAssignmentRoutes {
     func deleteDraftScript(req: Request) async throws -> HTTPStatus {
         let setup = try await loadDraftSetup(req)
         let filename = try safeScriptFilename(from: req)
-
-        guard listZipEntries(zipPath: setup.zipPath).contains(filename) else {
-            throw WebAssignmentError.notFound(resource: "File '\(filename)' in setup zip")
-        }
-
-        if let familyID = generatedByFamilyID(manifestJSON: setup.manifest, filename: filename) {
-            throw WebAssignmentError.conflict(
-                reason: "'\(filename)' is generated from pattern family '\(familyID)'. Remove it via the family editor."
-            )
-        }
-
-        let dependents = manifestDependents(manifestJSON: setup.manifest, filename: filename)
-        guard dependents.isEmpty else {
-            throw WebAssignmentError.conflict(
-                reason:
-                    "Cannot delete '\(filename)': the following scripts depend on it: \(dependents.joined(separator: ", "))"
-            )
-        }
-
-        do {
-            try removeScriptFromZip(zipPath: setup.zipPath, filename: filename)
-        } catch ScriptZipError.zipFailed {
-            throw WebAssignmentError.internalFailure(reason: "Failed to update setup zip")
-        }
-
-        if let updated = updateManifestRemovingScript(manifestJSON: setup.manifest, filename: filename) {
-            setup.manifest = updated
-            try await setup.save(on: req.db)
-        }
+        try await deleteScriptFromSetup(setup: setup, filename: filename, on: req.db)
         return .noContent
     }
 

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+ScriptCRUD.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+ScriptCRUD.swift
@@ -102,75 +102,24 @@ extension PublishedAssignmentRoutes {
     @Sendable
     func createScript(req: Request) async throws -> Response {
         let idStr = try assignmentPublicIDParameter(from: req)
-
-        struct CreateBody: Content {
-            var filename: String
-            var content: String
-            var tier: String?
-            var points: Int?
-            var isTest: Bool?
-        }
-        let body = try req.content.decode(CreateBody.self)
-
-        // Validate filename: must be a simple filename (no path separators).
-        let cleaned = sanitizeSuiteFilename(body.filename)
-        guard !cleaned.isEmpty, cleaned == body.filename else {
-            throw WebAssignmentError.invalidParameter(name: "filename", reason: "Invalid filename '\(body.filename)'")
-        }
+        let body = try req.content.decode(CreateScriptBody.self)
 
         guard
             let assignment = try await assignmentByPublicID(idStr, on: req.db),
             let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
         else { throw WebAssignmentError.notFound(resource: "Assignment '\(idStr)'") }
 
-        // Reject duplicate filenames.
-        if listZipEntries(zipPath: setup.zipPath).contains(cleaned) {
-            throw WebAssignmentError.conflict(reason: "A file named '\(cleaned)' already exists in this setup")
-        }
+        let result = try await createScriptInSetup(setup: setup, body: body, on: req.db)
 
-        // Slice 1: prepend assignment-scope variables.  Section variables
-        // aren't applied here (the suite entry — and thus its sectionID —
-        // is created below); the next applyPatternFamilies / suite-edit
-        // save will re-prepend with the correct section scope.
-        let createInlined: String = {
-            guard let manifest = setup.decodedManifest()
-
-            else { return body.content }
-            return TestScriptVariablePrepender.applyForRawScript(
-                filename: cleaned,
-                content: body.content,
-                manifest: manifest
-            )
-        }()
-        try updateScriptInZip(zipPath: setup.zipPath, filename: cleaned, content: createInlined)
-
-        let tier = normalizeTier(body.tier, isTest: body.isTest)
-        // v0.4.105: allow 0-mark tests (e.g. function-existence guards
-        // that exist purely to short-circuit downstream tests, not to
-        // contribute to the grade).  Negative values still clamp to 0.
-        let points = max(0, body.points ?? 1)
-        let shouldTest = tier != "support"
-
-        if shouldTest {
-            let entry = ConfiguredSuiteEntry(
-                script: cleaned, tier: tier, order: 0,
-                dependsOn: [], points: points, displayName: nil
-            )
-            if let updated = updateManifestAddingScript(manifestJSON: setup.manifest, entry: entry) {
-                setup.manifest = updated
-                try await setup.save(on: req.db)
-            }
-        } else {
+        if !result.isTest {
             // Support files (tier=="support") aren't entries in `testSuites`,
             // but they still need to land in the shared extraction dir so
             // student JupyterLite working copies pick them up via the symlinks
-            // created in `createSupportFileSymlinks`.  v0.4.116+: keep the
+            // created in `createSupportFileSymlinks`. v0.4.116+: keep the
             // shared dir in sync after every POST /scripts upload, not just
             // the bigger /edit/save flow.
             let activeTestSuiteScripts: Set<String> = {
-                guard let props = setup.decodedManifest()
-
-                else { return [] }
+                guard let props = setup.decodedManifest() else { return [] }
                 return Set(props.testSuites.map(\.script))
             }()
             extractSupportFilesToSharedDirectory(
@@ -189,11 +138,11 @@ extension PublishedAssignmentRoutes {
             var editURL: String
         }
         let resp = CreatedResponse(
-            filename: cleaned,
-            tier: tier,
-            points: points,
-            isTest: shouldTest,
-            editURL: "/instructor/\(idStr)/scripts/\(urlEncode(cleaned))"
+            filename: result.filename,
+            tier: result.tier,
+            points: result.points,
+            isTest: result.isTest,
+            editURL: "/instructor/\(idStr)/scripts/\(urlEncode(result.filename))"
         )
         return try await resp.encodeResponse(status: .created, for: req)
     }
@@ -213,35 +162,7 @@ extension PublishedAssignmentRoutes {
             let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
         else { throw WebAssignmentError.notFound(resource: "Assignment '\(idStr)'") }
 
-        guard listZipEntries(zipPath: setup.zipPath).contains(filename) else {
-            throw WebAssignmentError.notFound(resource: "File '\(filename)' in setup zip")
-        }
-
-        if let familyID = generatedByFamilyID(manifestJSON: setup.manifest, filename: filename) {
-            throw WebAssignmentError.conflict(
-                reason:
-                    "'\(filename)' is generated from pattern family '\(familyID)'. Remove it via the family editor (delete the case, or delete the whole family)."
-            )
-        }
-
-        let dependents = manifestDependents(manifestJSON: setup.manifest, filename: filename)
-        guard dependents.isEmpty else {
-            throw WebAssignmentError.conflict(
-                reason:
-                    "Cannot delete '\(filename)': the following scripts depend on it: \(dependents.joined(separator: ", "))"
-            )
-        }
-
-        do {
-            try removeScriptFromZip(zipPath: setup.zipPath, filename: filename)
-        } catch ScriptZipError.zipFailed {
-            throw WebAssignmentError.internalFailure(reason: "Failed to update setup zip")
-        }
-
-        if let updated = updateManifestRemovingScript(manifestJSON: setup.manifest, filename: filename) {
-            setup.manifest = updated
-            try await setup.save(on: req.db)
-        }
+        try await deleteScriptFromSetup(setup: setup, filename: filename, on: req.db)
 
         // Re-extract support files to the shared dir (parallels the
         // create-script path).  Idempotent and cheap; the shared dir

--- a/Sources/APIServer/Routes/Web/ScriptCRUDHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ScriptCRUDHelpers.swift
@@ -1,0 +1,114 @@
+// APIServer/Routes/Web/ScriptCRUDHelpers.swift
+//
+// Shared cores for creating and deleting individual test/support scripts inside
+// a test setup's zip + manifest. Used by both the published
+// (`PublishedAssignmentRoutes+ScriptCRUD`) and draft
+// (`DraftAssignmentRoutes+SuiteEditing`) handlers — which differ only in how
+// they resolve the target setup and what they do afterward (the published path
+// re-extracts support files to the shared student dir and returns an editURL; a
+// draft has no students or stable route yet, so it does neither).
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// Decoded request body for the create-script endpoints (published + draft).
+struct CreateScriptBody: Content {
+    var filename: String
+    var content: String
+    var tier: String?
+    var points: Int?
+    var isTest: Bool?
+}
+
+/// The resolved outcome of a create, used by the caller to shape its response
+/// and decide on support-file re-extraction.
+struct CreatedScript {
+    let filename: String
+    let tier: String
+    let points: Int
+    let isTest: Bool
+}
+
+/// Validates the filename, inlines assignment-scope variables, writes the file
+/// into the setup zip, and — for a graded tier — adds a manifest entry.
+@discardableResult
+func createScriptInSetup(
+    setup: APITestSetup, body: CreateScriptBody, on db: any Database
+) async throws -> CreatedScript {
+    let cleaned = sanitizeSuiteFilename(body.filename)
+    guard !cleaned.isEmpty, cleaned == body.filename else {
+        throw WebAssignmentError.invalidParameter(name: "filename", reason: "Invalid filename '\(body.filename)'")
+    }
+
+    // Reject duplicate filenames.
+    if listZipEntries(zipPath: setup.zipPath).contains(cleaned) {
+        throw WebAssignmentError.conflict(reason: "A file named '\(cleaned)' already exists in this setup")
+    }
+
+    // Slice 1: prepend assignment-scope variables before write so the saved
+    // content matches what the runner sees. Section variables aren't applied
+    // here (the suite entry — and thus its sectionID — is created below); the
+    // next applyPatternFamilies / suite-edit save re-prepends with section
+    // scope. Falls back to raw content for non-.py files or a bad manifest.
+    let inlined: String = {
+        guard let manifest = setup.decodedManifest() else { return body.content }
+        return TestScriptVariablePrepender.applyForRawScript(
+            filename: cleaned, content: body.content, manifest: manifest)
+    }()
+    try updateScriptInZip(zipPath: setup.zipPath, filename: cleaned, content: inlined)
+
+    let tier = normalizeTier(body.tier, isTest: body.isTest)
+    // v0.4.105: allow 0-mark tests (e.g. function-existence guards that only
+    // short-circuit downstream tests). Negative values clamp to 0.
+    let points = max(0, body.points ?? 1)
+    let shouldTest = tier != "support"
+
+    if shouldTest {
+        let entry = ConfiguredSuiteEntry(
+            script: cleaned, tier: tier, order: 0,
+            dependsOn: [], points: points, displayName: nil)
+        if let updated = updateManifestAddingScript(manifestJSON: setup.manifest, entry: entry) {
+            setup.manifest = updated
+            try await setup.save(on: db)
+        }
+    }
+
+    return CreatedScript(filename: cleaned, tier: tier, points: points, isTest: shouldTest)
+}
+
+/// Guards that the file exists and is neither pattern-family-generated nor a
+/// prerequisite of another script, then removes it from the setup zip and drops
+/// its manifest entry.
+func deleteScriptFromSetup(setup: APITestSetup, filename: String, on db: any Database) async throws {
+    guard listZipEntries(zipPath: setup.zipPath).contains(filename) else {
+        throw WebAssignmentError.notFound(resource: "File '\(filename)' in setup zip")
+    }
+
+    if let familyID = generatedByFamilyID(manifestJSON: setup.manifest, filename: filename) {
+        throw WebAssignmentError.conflict(
+            reason:
+                "'\(filename)' is generated from pattern family '\(familyID)'. Remove it via the family editor (delete the case, or delete the whole family)."
+        )
+    }
+
+    let dependents = manifestDependents(manifestJSON: setup.manifest, filename: filename)
+    guard dependents.isEmpty else {
+        throw WebAssignmentError.conflict(
+            reason:
+                "Cannot delete '\(filename)': the following scripts depend on it: \(dependents.joined(separator: ", "))"
+        )
+    }
+
+    do {
+        try removeScriptFromZip(zipPath: setup.zipPath, filename: filename)
+    } catch ScriptZipError.zipFailed {
+        throw WebAssignmentError.internalFailure(reason: "Failed to update setup zip")
+    }
+
+    if let updated = updateManifestRemovingScript(manifestJSON: setup.manifest, filename: filename) {
+        setup.manifest = updated
+        try await setup.save(on: db)
+    }
+}

--- a/changelog.d/script-crud-consolidation.md
+++ b/changelog.d/script-crud-consolidation.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Script create/delete CRUD shared across published and draft routes.** The
+  per-file create and delete logic — filename sanitization, duplicate-name and
+  pattern-family guards, variable inlining, zip write/remove, and manifest
+  update — was copy-pasted between `PublishedAssignmentRoutes+ScriptCRUD` and
+  `DraftAssignmentRoutes+SuiteEditing`. It now lives in shared cores
+  (`createScriptInSetup` / `deleteScriptFromSetup` in `ScriptCRUDHelpers`), with
+  a shared `CreateScriptBody`. The published handlers keep their support-file
+  re-extraction and `editURL`; the draft handlers, which have neither students
+  nor a stable route yet, keep neither. No behaviour change (net ~130 fewer
+  lines in the handlers).


### PR DESCRIPTION
## What

Third and final consolidation in this streamlining series (after #838, #839). The per-file **script create/delete** CRUD was copy-pasted between the published and draft route handlers; this extracts the shared cores.

## Why

`PublishedAssignmentRoutes+ScriptCRUD.createScript`/`deleteScript` and `DraftAssignmentRoutes+SuiteEditing.createDraftScript`/`deleteDraftScript` duplicated all their substance — filename sanitization, the duplicate-name conflict, the pattern-family-generated and dependent-script guards, assignment-scope variable inlining, the zip write/remove, and the manifest add/remove. Same copy-paste pattern that had already let the section handlers (#839) silently drift.

## Changes

- New `ScriptCRUDHelpers.swift` with two cores:
  - `createScriptInSetup(setup:body:on:)` → validates, inlines variables, writes the file, adds the manifest entry, returns a `CreatedScript`.
  - `deleteScriptFromSetup(setup:filename:on:)` → existence + generated-family + dependent guards, zip removal, manifest update.
- Shared `CreateScriptBody` decode struct replaces the two identical local `CreateBody` definitions.
- The published handlers keep their two genuine extras — support-file re-extraction to the shared student dir, and the `editURL` in the response. The draft handlers keep neither (a draft has no students and no stable assignment route yet). That divergence is now **explicit at the call site** instead of buried in two near-identical 90-line copies.

One incidental consistency tweak: the draft delete's "generated from pattern family" error now uses the same fuller wording as the published one ("…delete the case, or delete the whole family"). No test asserted the old shorter text.

## Verification

- `swift build` — clean; `scripts/format.sh` applied; `scripts/swiftlint.sh --strict` — 0 violations
- Script/suite route suites — **135 tests pass** (`ScriptEditRoutesTests`, `SuiteRouteTests`, `DraftSuiteSectionRoutesTests`, `AuthorScriptToolTests`, …)

Net ~130 fewer lines in the handlers. This PR's files are disjoint from #839's, so it merged cleanly onto the post-#839 `main`.

https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r)_