### PR TITLE
fix(security): gate browser-runner endpoints on assignment visibility

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -138,7 +138,8 @@ enum MCPServerInstructions {
         a raw script. Pattern-family kinds (create_pattern_family / update_pattern_family): \
         boundary_equality and approximate_equality (a function's return equals / is within tolerance \
         of an expected value), variable_equality (a module-level variable equals a value), \
-        return_type_check, exception_expected, performance_threshold, and stdout_equality. \
+        return_type_check, exception_expected, performance_threshold, stdout_equality, and \
+        unordered_equality (a function's return equals an expected collection ignoring order). \
         Notebook-check kinds (author_notebook_check): data_frame_shape, data_frame_columns, \
         data_frame_equality, series_equality, numeric_array_close, figure_count, cell_contains, \
         function_exists, variable_exists, and ast_structure. Native checks are validated structurally \

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -136,7 +136,8 @@ struct CreatePatternFamilyTool: ContentTool {
         + "Create a NEW pattern family on an assignment, by public ID. Provide the family `id` "
         + "(unique; not an existing family), `name`, `kind` (boundary_equality / approximate_equality "
         + "/ variable_equality / return_type_check / exception_expected / performance_threshold / "
-        + "stdout_equality), the `function` it tests, `paramNames`, and a non-empty `cases` list — each "
+        + "stdout_equality / unordered_equality), the `function` it tests, `paramNames`, and a "
+        + "non-empty `cases` list — each "
         + "case a { key, args, expected } with raw-JSON args (in parameter order) and expected return. "
         + "Cases may personalize via argVarRefs / expectedVarRef (names of global/section = expressions). "
         + "Set a `defaultHint` (family-wide) and/or per-case `hint` to give the student a \"💡 Hint\" "
@@ -165,7 +166,7 @@ struct CreatePatternFamilyTool: ContentTool {
                     .string("boundary_equality"), .string("approximate_equality"),
                     .string("variable_equality"), .string("return_type_check"),
                     .string("exception_expected"), .string("performance_threshold"),
-                    .string("stdout_equality"),
+                    .string("stdout_equality"), .string("unordered_equality"),
                 ]),
             ]),
             "function": .object([

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -49,7 +49,16 @@ struct BrowserRunnerRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        // Gate on effective-open (enrollment + open/visible), not enrollment
+        // alone: a student must not be able to pull the test scripts of a
+        // closed, not-yet-opened, or staff-only (preview) assignment by guessing
+        // its testSetupID. requireOpenStudentAssignment throws .closed (403) for a
+        // gated student and bypasses for staff. It returns nil only when no
+        // assignment owns the setup — then there is no hidden assignment to
+        // protect, so fall back to the plain enrollment check.
+        if try await requireOpenStudentAssignment(for: setupID, user: caller, on: req) == nil {
+            try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        }
         return try await req.fileio.asyncStreamFile(at: setup.zipPath)
     }
 
@@ -73,7 +82,11 @@ struct BrowserRunnerRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        // Effective-open gate (see downloadTestSetup): the manifest carries the
+        // full testSuites list, so the same hidden-assignment leak applies.
+        if try await requireOpenStudentAssignment(for: setupID, user: caller, on: req) == nil {
+            try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        }
 
         var headers = HTTPHeaders()
         headers.add(name: .contentType, value: "application/json; charset=utf-8")
@@ -110,17 +123,20 @@ struct BrowserRunnerRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
-
-        // A test setup belongs to a single assignment (1:1 via test_setup_id),
-        // matching how the worker resolves the assignment for a claimed job.
-        guard
-            let userID = caller.id,
-            let assignment = try await APIAssignment.query(on: req.db)
-                .filter(\.$testSetupID == setupID)
-                .first(),
-            let assignmentID = assignment.id
+        // Effective-open gate (enrollment + open/visible): prevents a student
+        // from fetching the per-student resolved personalization values — which
+        // can encode solution-derived expected answers — for a closed,
+        // not-yet-opened, or preview assignment. requireOpenStudentAssignment
+        // throws .closed (403) for a gated student and bypasses for staff; it
+        // returns nil only when no assignment owns the setup, in which case there
+        // is nothing personalized to resolve — fall back to the enrollment check
+        // and return the empty seed (mirroring the worker leaving it unset).
+        guard let assignment = try await requireOpenStudentAssignment(for: setupID, user: caller, on: req)
         else {
+            try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+            return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil)
+        }
+        guard let userID = caller.id, let assignmentID = assignment.id else {
             return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil)
         }
 

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -389,6 +389,65 @@ import XCTVapor
         }
     }
 
+    // MARK: - Effective-open gate (hidden-assignment leak)
+
+    /// Security regression: an enrolled student must NOT be able to fetch a
+    /// closed (or not-yet-opened / preview) assignment's test scripts, manifest,
+    /// or per-student seed by guessing its testSetupID. The seed in particular
+    /// can encode solution-derived `expected` answers, so all three
+    /// browser-runner GETs are gated on effective-open for students.
+    @Test func closedAssignmentHidesBrowserEndpointsFromStudents() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: false)
+            // loginAsStudent auto-enrolls in the .auto course, so a 403 here is
+            // the effective-open gate firing, not a missing-enrollment 403.
+            let cookie = try await loginAsStudent()
+
+            for endpoint in ["manifest", "download", "seed"] {
+                try await app.asyncTest(
+                    .GET, "/api/v1/browser-runner/testsetups/\(setupID)/\(endpoint)",
+                    beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                    afterResponse: { res in
+                        #expect(
+                            res.status == .forbidden,
+                            "enrolled student must be blocked from \(endpoint) of a closed assignment, got \(res.status)"
+                        )
+                    })
+            }
+        }
+    }
+
+    /// A `.preview` (staff-only) assignment is the sharp case: hidden from
+    /// students but usable by staff. The student must be blocked from the
+    /// manifest while the instructor — who bypasses the effective-open gate for
+    /// preview — gets it.
+    @Test func previewAssignmentVisibleToStaffHiddenFromStudents() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            let assignment = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            assignment.visibility = .preview
+            try await assignment.save(on: app.db)
+
+            let studentCookie = try await loginAsStudent()
+            try await app.asyncTest(
+                .GET, "/api/v1/browser-runner/testsetups/\(setupID)/manifest",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentCookie) },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden, "student must not see a preview assignment's manifest")
+                })
+
+            let staffCookie = try await loginUser(
+                username: "prof1", password: "pass", role: "instructor", on: app)
+            try await app.asyncTest(
+                .GET, "/api/v1/browser-runner/testsetups/\(setupID)/manifest",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffCookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "staff must still access a preview assignment's manifest")
+                })
+        }
+    }
+
     // MARK: - Full round-trip: dependency-skipped outcomes stored correctly
 
     /// Regression for #105: when the browser runner skips a test because its

--- a/changelog.d/audit-followup-fixes.md
+++ b/changelog.d/audit-followup-fixes.md
@@ -1,0 +1,19 @@
+### Security
+
+- **Browser-runner endpoints gated on assignment visibility, not just
+  enrollment.** `GET /api/v1/browser-runner/testsetups/:id/{download,manifest,seed}`
+  previously checked only course enrollment, so an enrolled student who supplied
+  a `testSetupID` could pull a closed, not-yet-opened, or staff-only (preview)
+  assignment's test scripts and — via the seed endpoint — its per-student
+  resolved personalization values, which can encode solution-derived expected
+  answers. All three now require the assignment to be effectively open for the
+  caller (staff bypass), falling back to the enrollment check only when no
+  assignment owns the setup. Regression tests cover the closed-student-blocked
+  and preview-staff-visible cases.
+
+### Fixed
+
+- **`create_pattern_family` (MCP) advertises `unordered_equality`.** The tool's
+  input-schema `kind` enum, its description, and the `initialize` server
+  instructions omitted the `unordered_equality` kind, so an agent validating
+  against the schema couldn't author one even though the handler accepted it.


### PR DESCRIPTION
## What

Fixes from the correctness/security audit of recent feature work (Preview visibility, pattern-family kinds, grade overrides). Of everything reviewed, these are the two findings worth acting on; the rest were clean or by-design (see below).

## 🔴 Fix 1 — Browser-runner endpoints leaked hidden-assignment content

`GET /api/v1/browser-runner/testsetups/:id/{download,manifest,seed}` gated on **course enrollment only**, never on whether the assignment was open/visible to the caller. So an enrolled student who supplied a `testSetupID` could pull a **closed, not-yet-opened, or staff-only (preview)** assignment's:
- test scripts (download/manifest — including secret/release-tier), and
- via the **seed** endpoint, the per-student *resolved* personalization values — which, with `expected = solution.foo(...)` refs, **encode solution-derived answers**.

All three now go through `requireOpenStudentAssignment` (enrollment **+** effective-open, staff bypass), falling back to the plain enrollment check only when no assignment owns the setup (nothing hidden to protect — preserves the existing orphan-setup behavior). `AssignmentSubmissionGateError.closed` already maps to a clean **403**, and these endpoints are only called by `browser-runner.js` at submit time, so result-viewing is unaffected.

Provenance: pre-existing (the browser personalization path, ~#817), **not** a regression from the recent Preview work — `.preview` was exactly as exposed as `.closed` here, which is how tracing the (otherwise-clean) Preview gates surfaced it.

New regression tests:
- enrolled student → **403** on a closed assignment's `manifest`/`download`/`seed`;
- `.preview` assignment → student **403**, instructor **200** (staff bypass).

## 🟡 Fix 2 — `create_pattern_family` (MCP) didn't advertise `unordered_equality`

The tool's input-schema `kind` enum, its description, and the `initialize` server instructions listed only the original 7 kinds, so a schema-validating agent couldn't author an `unordered_equality` family even though the handler accepted the raw value (#828 shipped the kind but missed the agent-facing surface). Added it to all three.

## Reviewed and deliberately *not* changed

- **Pattern-family injection / `unordered_equality` semantics / per-student `approximate_equality` refs (#827/#828):** clean — every interpolation is escaped (`pythonLiteral`/`escapeForPythonStringLiteral`) or a validated identifier; malformed `expected` fails cleanly via try/except; the per-student-ref allowlist + validator were correctly extended. The `default=str` canonicalization looseness and an approx/boundary block-order nit are documented/cosmetic, and changing them would shift generated-script bytes (`spec_hash`/cache churn) — left alone.
- **Grade overrides (#822) + all-tier results API (#823):** clean — override endpoints are instructor-gated + CSRF + enrolled-student-validated; `outcomes` are still tier-filtered by deadline; the all-tier aggregate was already exposed in the student web view (#823 just brings the JSON API to parity per the "grade doesn't jump at the deadline" policy). Two minor non-security notes (results API doesn't apply overrides; non-atomic override upsert) left as-is.
- **Preview visibility (#832/#836):** invariant holds across every student gate, the migration, and the bundle round-trip — no fix needed.

## Verification

`swift build` clean; `scripts/format.sh` applied; `scripts/swiftlint.sh --strict` 0 violations; `BrowserRunnerRoutesTests` (19, incl. the 2 new) + `CreatePatternFamilyToolTests` pass.

https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnKiKLCA9Xvjr4abHUGG9r)_