### PR TITLE
fix: auto-close assignments at deadline even with active extensions

### DIFF
--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -134,18 +134,17 @@ func closeAssignmentIfExpired(
     guard assignmentDeadlineHasPassed(assignment, now: now) else { return false }
     guard !assignmentDeadlineOverrideIsActive(assignment) else { return false }
 
-    // A still-active per-student extension keeps the assignment-wide window
-    // open so the extended student can still see and submit to it; per-user
-    // gating (`isAssignmentOpenForUser`) keeps everyone else out.  Once the
-    // last extension lapses, a later sweep closes the assignment normally.
-    if let assignmentID = assignment.id {
-        let activeExtensions = try await APIAssignmentExtension.query(on: db)
-            .filter(\.$assignmentID == assignmentID)
-            .filter(\.$extendedDueAt > now)
-            .count()
-        if activeExtensions > 0 { return false }
-    }
-
+    // The assignment-wide visibility closes at the deadline even when some
+    // students hold an active extension.  Per-student access after the close is
+    // handled downstream, not by keeping the whole assignment open: the
+    // submission gate (`isAssignmentOpenForUser`) treats a close *at/after* the
+    // deadline as the automatic sweep and keeps submitting open for a student
+    // whose `effectiveDueAt` is still in the future, and the student dashboard
+    // re-includes setups where the viewer holds an active extension.  Leaving
+    // the assignment-wide flag `.open` instead would make it read as "open" to
+    // everyone (instructor dashboard + every student's list) long past the
+    // deadline — the assignment would appear never to close whenever any
+    // accommodation extension exists.
     assignment.visibility = .closed
     try await assignment.save(on: db)
     logger.info("Auto-closed assignment '\(assignment.title)' (\(assignment.publicID)) at deadline")

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -140,24 +140,24 @@ import XCTVapor
         }
     }
 
-    @Test func closeExpiredAssignmentsKeepsAssignmentsWithActiveExtensionsOpen() async throws {
+    @Test func closeExpiredAssignmentsClosesAtDeadlineEvenWithActiveExtension() async throws {
         try await withAssignmentRoutesApp { app in
-            _ = try await arInsertSetup(id: "setup_ext_keepopen", on: app)
+            _ = try await arInsertSetup(id: "setup_ext_close", on: app)
             let extended = try await arInsertAssignment(
-                testSetupID: "setup_ext_keepopen",
+                testSetupID: "setup_ext_close",
                 title: "Extended overdue",
                 isOpen: true,
                 dueAt: Date().addingTimeInterval(-60), on: app
             )
-            let student = try await arInsertStudent(username: "keepopen_student", on: app)
-            try await arEnrollStudentInTestCourse(student, on: app)
+            let extendedStudent = try await arInsertStudent(username: "extended_student", on: app)
+            try await arEnrollStudentInTestCourse(extendedStudent, on: app)
             try await APIAssignmentExtension(
                 assignmentID: try extended.requireID(),
-                userID: try student.requireID(),
+                userID: try extendedStudent.requireID(),
                 extendedDueAt: Date().addingTimeInterval(86_400)
             ).save(on: app.db)
 
-            // A second overdue assignment with no extension must still close.
+            // A second overdue assignment with no extension also closes.
             _ = try await arInsertSetup(id: "setup_noext_close", on: app)
             let plain = try await arInsertAssignment(
                 testSetupID: "setup_noext_close",
@@ -165,14 +165,31 @@ import XCTVapor
                 isOpen: true,
                 dueAt: Date().addingTimeInterval(-60), on: app
             )
+            let regularStudent = try await arInsertStudent(username: "regular_student", on: app)
+            try await arEnrollStudentInTestCourse(regularStudent, on: app)
 
+            // Both assignments must auto-close at the deadline: an active
+            // per-student extension does NOT hold the assignment-wide window
+            // open (that's what made assignments appear never to close).
             let closedCount = try await closeExpiredAssignments(on: app.db, logger: app.logger)
-            #expect(closedCount == 1, "Only the assignment without an active extension should close")
+            #expect(closedCount == 2, "Both expired assignments close, extension or not")
 
             let extendedReloaded = try #require(try await APIAssignment.find(extended.id, on: app.db))
-            #expect(extendedReloaded.isOpen, "Assignment with an active extension must stay open")
+            #expect(
+                extendedReloaded.isOpen == false,
+                "Assignment auto-closes at its deadline even with an active extension")
             let plainReloaded = try #require(try await APIAssignment.find(plain.id, on: app.db))
-            #expect(plainReloaded.isOpen == false, "Assignment with no extension must auto-close")
+            #expect(plainReloaded.isOpen == false, "Assignment with no extension auto-closes")
+
+            // After the close, per-student gating still grants the extended
+            // student access (their effectiveDueAt is in the future) while the
+            // non-extended student is held out.
+            let extendedStillOpen = try await isAssignmentEffectivelyOpen(
+                extendedReloaded, for: extendedStudent, on: app.db)
+            #expect(extendedStillOpen, "Extended student can still submit after the auto-close")
+            let regularBlocked = try await isAssignmentEffectivelyOpen(
+                extendedReloaded, for: regularStudent, on: app.db)
+            #expect(regularBlocked == false, "Non-extended student is blocked once the deadline passes")
         }
     }
 

--- a/changelog.d/deadline-close-with-extension.md
+++ b/changelog.d/deadline-close-with-extension.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Assignments now auto-close at their deadline even when a student has an
+  active extension.** The deadline sweep was refusing to close the
+  assignment-wide window whenever any per-student extension (e.g. an
+  AccessAbility accommodation) was still active, so an assignment with any
+  extension appeared never to close — it kept reading as "open" on the
+  instructor dashboard and in every student's list past its deadline. The
+  assignment-wide visibility now always closes at the deadline; per-student
+  access is preserved downstream as designed — the submission gate
+  (`isAssignmentOpenForUser`) keeps submitting open for a student whose
+  extension is still in the future, and the student dashboard re-includes
+  setups where the viewer holds an active extension.


### PR DESCRIPTION
## The bug

For the second time in a row, an assignment failed to close on its set deadline.

The root cause is in `closeAssignmentIfExpired` (`AssignmentDeadlineService.swift`). The deadline sweep refused to close an assignment's class-wide window whenever **any** student held an active per-student extension:

```swift
// (removed) — bailed out of the close when any extension was still active
if let assignmentID = assignment.id {
    let activeExtensions = try await APIAssignmentExtension.query(on: db)
        .filter(\.$assignmentID == assignmentID)
        .filter(\.$extendedDueAt > now)
        .count()
    if activeExtensions > 0 { return false }
}
```

Per-student extensions (AccessAbility accommodations) are routine, so in practice an assignment with any extension would **appear never to close** — it kept reading as "open" on the instructor dashboard and in every student's assignment list well past the deadline.

## Why removing the guard is correct

The rest of the system is built on the premise that *the sweep closes the assignment* and per-student access is handled separately — and both pieces explicitly document the auto-closed state as expected:

- **`isAssignmentOpenForUser`** keeps submitting open for a student whose `effectiveDueAt` (their extension) is still in the future, distinguishing the automatic sweep (close *at/after* the deadline) from a deliberate manual close (before the deadline). Its doc: *"a close at/after the deadline is the automatic sweep, so an active per-student extension … keeps submission open for that one student."*
- **The student dashboard** (`WebRoutes.swift`) already re-includes setups where the viewer holds an active extension: *"an assignment that the automatic sweep closed at its deadline stays visible to a student who was granted more time."*

So the assignment should always close at its deadline; students with extensions keep access until their extension is over. The guard was the lone piece of code violating that design.

## The fix

`closeAssignmentIfExpired` now always closes the assignment-wide visibility at the deadline (subject to the existing `.open` / deadline-passed / manual-override guards). Extended students retain access via the unchanged per-user gate until their extension lapses.

## Tests

- Rewrote the dashboard test (`closeExpiredAssignmentsClosesAtDeadlineEvenWithActiveExtension`): both expired assignments now close even with an active extension, the extended student stays effectively-open, and a non-extended peer is blocked.
- Existing `effectiveOpenHonorsExtensionAfterAutoClose` and `effectiveDueAtUsesExtensionWhenLater` (which model the post-close per-user gate) continue to pass.
- `AssignmentRoutesDashboardTests` + `AssignmentExtensionsTests` (19 tests) green; `swift-format` and SwiftLint `--strict` clean.

https://claude.ai/code/session_01GZkZohpJqYSfrsEVp5YVg5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZkZohpJqYSfrsEVp5YVg5)_