### PR TITLE
Responsive design: foundation + summary pages

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -197,9 +197,14 @@ a { color: var(--blue); }
 /* ── Main container ──────────────────────────────────── */
 
 .main {
-    max-width: 900px;
+    /* min(900px, 100%) is identical to a flat 900px at any viewport wide
+       enough to reach the cap, so desktop is unchanged; on a phone it simply
+       tracks the viewport instead of needing a media query to "relax".  The
+       fluid padding clamps to the same 1.5rem on desktop and only tightens
+       below ~600px. */
+    max-width: min(900px, 100%);
     margin: 2rem auto;
-    padding: 0 1.5rem;
+    padding: 0 clamp(1rem, 4vw, 1.5rem);
 }
 
 h1 { font-size: 1.4rem; margin-bottom: 1.25rem; }
@@ -295,7 +300,7 @@ h2 { font-size: 1rem;   margin-bottom: .4rem; }
     display: flex;
     flex-direction: column;
     gap: 1.1rem;
-    max-width: 620px;
+    max-width: min(620px, 100%);
 }
 
 .form--wide {
@@ -782,7 +787,7 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 /* ── Auth pages ──────────────────────────────────────── */
 
 .auth-box {
-    max-width: 420px;
+    max-width: min(420px, 100%);
     margin: 3rem auto;
 }
 
@@ -1030,3 +1035,44 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     vertical-align: middle;
 }
 .grade-override-active { border-color: var(--gray-500); background: var(--gray-100); }
+
+/* ════════════════════════════════════════════════════════════════════
+   Responsive design  —  see docs/responsive-design-plan.md
+   --------------------------------------------------------------------
+   Hard constraint: the desktop (>1024px) rendering is unchanged.  Every
+   rule below is either width-agnostic intrinsic CSS that is identical at
+   desktop by construction (see .main / .form / .auth-box above), or lives
+   inside a (max-width) media query so it can only take effect on smaller
+   screens.
+   Breakpoints:   phone ≤640px      tablet ≤1024px      desktop >1024px
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Column-hiding utilities for tables.  Tag a <th> and the matching <td>s in
+   every row with one of these to drop that column on small screens.  Outside
+   the media queries the classes carry no rule, so applying them in markup can
+   never change the desktop layout. */
+@media (max-width: 1024px) { .col-hide-tablet { display: none; } }
+@media (max-width: 640px)  { .col-hide-phone  { display: none; } }
+
+/* Filter/search inputs keep their authored desktop width via the
+   --filter-width custom property (so desktop is unchanged) and span the full
+   row on phones. */
+.filter-input { width: var(--filter-width, 16rem); max-width: 100%; }
+
+@media (max-width: 640px) {
+    /* Let the top nav wrap onto multiple lines instead of overflowing the
+       viewport; the account/username link sits inline rather than being
+       pushed to the far right. */
+    .nav { flex-wrap: wrap; row-gap: .35rem; column-gap: 1.1rem; }
+    .nav-username { margin-left: 0; }
+
+    /* Allow long assignment titles to wrap inside their flex cell rather than
+       forcing the table (and page) wider than the screen. */
+    .assignment-title-cell { min-width: 0; }
+
+    /* Comfortable tap targets for the icon/action buttons. */
+    .action-btn { min-height: 2.4rem; }
+
+    /* Filter/search inputs span the row. */
+    .filter-input { width: 100%; }
+}

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1054,6 +1054,12 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 @media (max-width: 1024px) { .col-hide-tablet { display: none; } }
 @media (max-width: 640px)  { .col-hide-phone  { display: none; } }
 
+/* Horizontal-scroll wrapper for dense, desktop-first tables (admin runner /
+   audit log).  Width-agnostic: no scrollbar at desktop when the table fits;
+   on a narrow screen it confines the overflow to the table instead of letting
+   it push the whole page wider. */
+.table-scroll { overflow-x: auto; }
+
 /* Filter/search inputs keep their authored desktop width via the
    --filter-width custom property (so desktop is unchanged) and span the full
    row on phones. */

--- a/Resources/Views/admin-audit.leaf
+++ b/Resources/Views/admin-audit.leaf
@@ -51,7 +51,7 @@ Audit Log
     <p style="color:var(--muted);font-size:.85rem;margin-top:0">
         Showing #count(rows) of #(matchCount) matching #if(matchCount == 1):entry#else:entries#endif.
     </p>
-    <table class="results-table">
+    <div class="table-scroll"><table class="results-table">
         <thead>
             <tr>
                 <th style="width:11rem">Time</th>
@@ -76,7 +76,7 @@ Audit Log
             </tr>
             #endfor
         </tbody>
-    </table>
+    </table></div>
     #endif
 </section>
 #endexport

--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -48,7 +48,7 @@ Runner #(runner.workerID)
     #if(recentJobs.isEmpty):
     <p class="empty">No recorded jobs for this runner yet.</p>
     #else:
-    <table class="results-table sortable-table">
+    <div class="table-scroll"><table class="results-table sortable-table">
         <thead>
             <tr>
                 <th data-sort-type="text"><button class="sort-header" type="button">Submission</button></th>
@@ -77,7 +77,7 @@ Runner #(runner.workerID)
             </tr>
         #endfor
         </tbody>
-    </table>
+    </table></div>
     #endif
 </section>
 
@@ -86,7 +86,7 @@ Runner #(runner.workerID)
     #if(snapshots.isEmpty):
     <p class="empty">No heartbeat or poll snapshots recorded yet.</p>
     #else:
-    <table class="results-table sortable-table">
+    <div class="table-scroll"><table class="results-table sortable-table">
         <thead>
             <tr>
                 <th class="time" data-sort-type="date"><button class="sort-header" type="button">Recorded</button></th>
@@ -107,7 +107,7 @@ Runner #(runner.workerID)
             </tr>
         #endfor
         </tbody>
-    </table>
+    </table></div>
     #endif
 </section>
 

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -15,9 +15,9 @@ Users
 </nav>
 <section class="admin-section">
     <div style="display:flex;align-items:center;justify-content:flex-end;flex-wrap:wrap;gap:.5rem;margin-bottom:1rem">
-        <input id="users-filter" class="form-input" type="search" autocomplete="off"
+        <input id="users-filter" class="form-input filter-input" type="search" autocomplete="off"
                placeholder="Filter by name, username or role…"
-               style="width:280px" aria-label="Filter users"
+               style="--filter-width:280px" aria-label="Filter users"
                readonly onfocus="this.removeAttribute('readonly')">
     </div>
     <table class="results-table" id="users-table">

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -26,8 +26,8 @@ Users
                 <th data-sort-key="name" data-sort-type="text" tabindex="0" aria-sort="none">Name</th>
                 <th data-sort-key="username" data-sort-type="text" tabindex="0" aria-sort="none">Username</th>
                 <th data-sort-key="role" data-sort-type="text" tabindex="0" aria-sort="none">Role</th>
-                <th class="time" data-sort-key="last-seen" data-sort-type="date" tabindex="0" aria-sort="none">Last Seen</th>
-                <th class="time" data-sort-key="joined" data-sort-type="date" tabindex="0" aria-sort="none">Joined</th>
+                <th class="time col-hide-phone" data-sort-key="last-seen" data-sort-type="date" tabindex="0" aria-sort="none">Last Seen</th>
+                <th class="time col-hide-phone" data-sort-key="joined" data-sort-type="date" tabindex="0" aria-sort="none">Joined</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -55,14 +55,14 @@ Users
                         <button class="btn action-btn" type="submit">Save</button>
                     </form>
                 </td>
-                <td class="time js-relative-time" data-iso="#(user.lastSeenAt)">
+                <td class="time js-relative-time col-hide-phone" data-iso="#(user.lastSeenAt)">
                     #if(user.lastSeenAt):
                         #(user.lastSeenAt)
                     #else:
                         —
                     #endif
                 </td>
-                <td class="time js-relative-time" data-iso="#(user.createdAt)">#(user.createdAt)</td>
+                <td class="time js-relative-time col-hide-phone" data-iso="#(user.createdAt)">#(user.createdAt)</td>
                 <td>
                     <div style="display:flex;align-items:center;gap:.35rem">
                         <a href="/admin/users/#(user.id)"
@@ -285,8 +285,8 @@ Users
                     + '<button class="btn action-btn" type="submit">Save</button>'
                 + '</form>'
             + '</td>'
-            + '<td class="time js-relative-time" data-iso="' + lastSeen + '">' + (user.lastSeenAt ? lastSeen : '—') + '</td>'
-            + '<td class="time js-relative-time" data-iso="' + created + '">' + created + '</td>'
+            + '<td class="time js-relative-time col-hide-phone" data-iso="' + lastSeen + '">' + (user.lastSeenAt ? lastSeen : '—') + '</td>'
+            + '<td class="time js-relative-time col-hide-phone" data-iso="' + created + '">' + created + '</td>'
             + '<td>'
                 + '<div style="display:flex;align-items:center;gap:.35rem">'
                     + '<a href="/admin/users/' + id + '" class="btn action-btn" title="Manage user" aria-label="Manage user" style="padding:.3rem .45rem">' + editIcon + '</a>'

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -25,9 +25,9 @@
         <tr>
             <th data-sort-key="surname" data-sort-type="text" tabindex="0" aria-sort="none">Surname</th>
             <th data-sort-key="given_names" data-sort-type="text" tabindex="0" aria-sort="none">Given Names</th>
-            <th data-sort-key="student_id" data-sort-type="text" tabindex="0" aria-sort="none">Student ID</th>
+            <th class="col-hide-phone" data-sort-key="student_id" data-sort-type="text" tabindex="0" aria-sort="none">Student ID</th>
             <th data-sort-key="grade" data-sort-type="number" tabindex="0" aria-sort="none">Grade</th>
-            <th data-sort-key="history" data-sort-type="datetime" tabindex="0" aria-sort="none">History</th>
+            <th class="col-hide-phone" data-sort-key="history" data-sort-type="datetime" tabindex="0" aria-sort="none">History</th>
             <th>Action</th>
         </tr>
     </thead>
@@ -36,9 +36,9 @@
         <tr>
             <td>#(row.surname)</td>
             <td>#(row.givenNames)</td>
-            <td><strong>#(row.studentID)</strong></td>
+            <td class="col-hide-phone"><strong>#(row.studentID)</strong></td>
             <td>#(row.gradeText)#if(row.gradeIsOverridden):<span class="grade-override-tag" title="Grade manually overridden by an instructor">overridden</span>#endif</td>
-            <td data-ts="#(row.latestSubmittedAtEpoch)">
+            <td class="col-hide-phone" data-ts="#(row.latestSubmittedAtEpoch)">
                 #if(row.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(row.hasLatestSubmission):
@@ -69,7 +69,7 @@
                         <summary class="btn action-btn ext-summary#if(row.gradeIsOverridden): grade-override-active#endif" title="#if(row.gradeIsOverridden):Edit this student’s grade override#else:Override this student’s grade#endif" aria-label="#if(row.gradeIsOverridden):Edit grade override#else:Override grade#endif" style="padding:.25rem .35rem">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="5" x2="5" y2="19"/><circle cx="6.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="17.5" r="2.5"/></svg>
                         </summary>
-                        <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/grade-override" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                        <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/grade-override" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
                             #csrfFormField()
                             <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
                             <label style="font-size:.78rem;color:var(--gray-700)">
@@ -151,6 +151,11 @@
 .ext-summary { margin-top: 0; list-style: none; }
 .ext-summary::-webkit-details-marker { display: none; }
 .ext-details[open] > .ext-summary { background: var(--gray-100); }
+/* Desktop keeps the comfortable 14rem override form; on a phone it fills the
+   available width instead of forcing the submissions table wider than the
+   screen. */
+.ext-details form { min-width: 14rem; }
+@media (max-width: 640px) { .ext-details form { min-width: 0; } }
 </style>
 <script>
 (function () {

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -15,9 +15,9 @@
 <p class="empty">No student users found.</p>
 #else:
 <div style="margin-bottom:.5rem">
-    <input id="submissions-filter" class="form-input" type="search" autocomplete="off"
+    <input id="submissions-filter" class="form-input filter-input" type="search" autocomplete="off"
            placeholder="Filter by name or ID…"
-           style="width:220px" aria-label="Filter students"
+           style="--filter-width:220px" aria-label="Filter students"
            readonly onfocus="this.removeAttribute('readonly')">
 </div>
 <table class="results-table" id="assignment-submissions-table">

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -101,8 +101,8 @@
                 <th>Name</th>
                 <th>Status</th>
                 <th>Validation</th>
-                <th class="due-col">Due</th>
-                <th>Submissions</th>
+                <th class="due-col col-hide-phone">Due</th>
+                <th class="col-hide-phone">Submissions</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -182,8 +182,8 @@
                     <span class="tier">—</span>
                     #endif
                 </td>
-                <td class="due-col">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
-                <td style="white-space:nowrap">
+                <td class="due-col col-hide-phone">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
+                <td class="col-hide-phone" style="white-space:nowrap">
                     #if(row.assignmentID):
                     <span title="#(row.submittedStudentCount) / #(enrolledStudentCount) students submitted">#(row.submittedStudentCount) / #(enrolledStudentCount)</span>
                     #else:—#endif
@@ -340,8 +340,8 @@
                 <th>Name</th>
                 <th>Status</th>
                 <th>Validation</th>
-                <th class="due-col">Due</th>
-                <th>Submissions</th>
+                <th class="due-col col-hide-phone">Due</th>
+                <th class="col-hide-phone">Submissions</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -414,8 +414,8 @@
                     <span class="tier">—</span>
                     #endif
                 </td>
-                <td class="due-col">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
-                <td style="white-space:nowrap">
+                <td class="due-col col-hide-phone">#if(row.dueAt):#(row.dueAt)#else:—#endif</td>
+                <td class="col-hide-phone" style="white-space:nowrap">
                     #if(row.assignmentID):
                     <span title="#(row.submittedStudentCount) / #(enrolledStudentCount) students submitted">#(row.submittedStudentCount) / #(enrolledStudentCount)</span>
                     #else:—#endif

--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -26,9 +26,9 @@
         <tr>
             <th>Name</th>
             <th>Status</th>
-            <th class="due-col">Due</th>
+            <th class="due-col col-hide-phone">Due</th>
             <th>Grade</th>
-            <th>History</th>
+            <th class="col-hide-phone">History</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -53,7 +53,7 @@
                     #elseif(row.status == "closed"):tier-closed
                     #endif">#(row.status)</span>
             </td>
-            <td class="due-col">
+            <td class="due-col col-hide-phone">
                 #if(row.effectiveDueAtText):
                     <span title="Assignment-wide due date: #if(row.dueAtText):#(row.dueAtText)#else:none#endif">#(row.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">+ extension</span></span>
                 #elseif(row.dueAtText):
@@ -72,7 +72,7 @@
                     <span class="empty">—</span>
                 #endif
             </td>
-            <td>
+            <td class="col-hide-phone">
                 #if(row.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(row.hasLatestSubmission):
@@ -104,7 +104,7 @@
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
                             #endif
                         </summary>
-                        <form method="post" action="#(row.extensionSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                        <form method="post" action="#(row.extensionSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
                             #csrfFormField()
                             <label style="font-size:.78rem;color:var(--gray-700)">
                                 New deadline for this student
@@ -126,7 +126,7 @@
                         <summary class="btn action-btn ext-summary#if(row.gradeIsOverridden): grade-override-active#endif" title="#if(row.gradeIsOverridden):Edit this student’s grade override#else:Override this student’s grade#endif" aria-label="#if(row.gradeIsOverridden):Edit grade override#else:Override grade#endif" style="padding:.25rem .35rem">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="5" x2="5" y2="19"/><circle cx="6.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="17.5" r="2.5"/></svg>
                         </summary>
-                        <form method="post" action="#(row.gradeOverrideSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                        <form method="post" action="#(row.gradeOverrideSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
                             #csrfFormField()
                             <label style="font-size:.78rem;color:var(--gray-700)">
                                 Override grade (%)
@@ -169,9 +169,9 @@
         <tr>
             <th>Name</th>
             <th>Status</th>
-            <th class="due-col">Due</th>
+            <th class="due-col col-hide-phone">Due</th>
             <th>Grade</th>
-            <th>History</th>
+            <th class="col-hide-phone">History</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -196,7 +196,7 @@
                     #elseif(row.status == "closed"):tier-closed
                     #endif">#(row.status)</span>
             </td>
-            <td class="due-col">
+            <td class="due-col col-hide-phone">
                 #if(row.effectiveDueAtText):
                     <span title="Assignment-wide due date: #if(row.dueAtText):#(row.dueAtText)#else:none#endif">#(row.effectiveDueAtText)<br><span style="font-size:.75rem;color:var(--gray-600)">+ extension</span></span>
                 #elseif(row.dueAtText):
@@ -215,7 +215,7 @@
                     <span class="empty">—</span>
                 #endif
             </td>
-            <td>
+            <td class="col-hide-phone">
                 #if(row.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(row.hasLatestSubmission):
@@ -247,7 +247,7 @@
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
                             #endif
                         </summary>
-                        <form method="post" action="#(row.extensionSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                        <form method="post" action="#(row.extensionSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
                             #csrfFormField()
                             <label style="font-size:.78rem;color:var(--gray-700)">
                                 New deadline for this student
@@ -269,7 +269,7 @@
                         <summary class="btn action-btn ext-summary#if(row.gradeIsOverridden): grade-override-active#endif" title="#if(row.gradeIsOverridden):Edit this student’s grade override#else:Override this student’s grade#endif" aria-label="#if(row.gradeIsOverridden):Edit grade override#else:Override grade#endif" style="padding:.25rem .35rem">
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="19" y1="5" x2="5" y2="19"/><circle cx="6.5" cy="6.5" r="2.5"/><circle cx="17.5" cy="17.5" r="2.5"/></svg>
                         </summary>
-                        <form method="post" action="#(row.gradeOverrideSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;min-width:14rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
+                        <form method="post" action="#(row.gradeOverrideSavePath)" style="margin-top:.4rem;display:flex;flex-direction:column;gap:.3rem;padding:.5rem;background:var(--gray-50);border:1px solid var(--gray-300);border-radius:.25rem">
                             #csrfFormField()
                             <label style="font-size:.78rem;color:var(--gray-700)">
                                 Override grade (%)
@@ -309,6 +309,10 @@
 .ext-summary { margin-top: 0; list-style: none; }
 .ext-summary::-webkit-details-marker { display: none; }
 .ext-details[open] > .ext-summary { background: var(--gray-100); }
+/* Desktop keeps the comfortable 14rem extension/override forms; on a phone
+   they fill the available width instead of forcing the table wider. */
+.ext-details form { min-width: 14rem; }
+@media (max-width: 640px) { .ext-details form { min-width: 0; } }
 </style>
 #endexport
 #endextend

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -29,9 +29,9 @@
         <tr>
             <th>Name</th>
             <th>Status</th>
-            <th class="due-col">Due</th>
+            <th class="due-col col-hide-phone">Due</th>
             <th>Grade</th>
-            <th>History</th>
+            <th class="col-hide-phone">History</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -65,7 +65,7 @@
                     #endif">#(setup.status)</span>
                 #endif
             </td>
-            <td class="due-col">
+            <td class="due-col col-hide-phone">
                 #if(setup.opensAtText):
                     <span title="This assignment opens automatically at this time.">Opens #(setup.opensAtText)</span>
                 #elseif(setup.hasActiveExtension):
@@ -86,7 +86,7 @@
                     <span class="empty">—</span>
                 #endif
             </td>
-            <td>
+            <td class="col-hide-phone">
                 #if(setup.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(setup.hasLatestSubmission):
@@ -151,9 +151,9 @@
         <tr>
             <th>Name</th>
             <th>Status</th>
-            <th class="due-col">Due</th>
+            <th class="due-col col-hide-phone">Due</th>
             <th>Grade</th>
-            <th>History</th>
+            <th class="col-hide-phone">History</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -187,7 +187,7 @@
                     #endif">#(setup.status)</span>
                 #endif
             </td>
-            <td class="due-col">
+            <td class="due-col col-hide-phone">
                 #if(setup.opensAtText):
                     <span title="This assignment opens automatically at this time.">Opens #(setup.opensAtText)</span>
                 #elseif(setup.hasActiveExtension):
@@ -208,7 +208,7 @@
                     <span class="empty">—</span>
                 #endif
             </td>
-            <td>
+            <td class="col-hide-phone">
                 #if(setup.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(setup.hasLatestSubmission):
@@ -273,9 +273,9 @@
         <tr>
             <th>Name</th>
             <th>Status</th>
-            <th class="due-col">Due</th>
+            <th class="due-col col-hide-phone">Due</th>
             <th>Grade</th>
-            <th>History</th>
+            <th class="col-hide-phone">History</th>
             <th>Actions</th>
         </tr>
     </thead>
@@ -309,7 +309,7 @@
                     #endif">#(setup.status)</span>
                 #endif
             </td>
-            <td class="due-col">
+            <td class="due-col col-hide-phone">
                 #if(setup.opensAtText):
                     <span title="This assignment opens automatically at this time.">Opens #(setup.opensAtText)</span>
                 #elseif(setup.hasActiveExtension):
@@ -330,7 +330,7 @@
                     <span class="empty">—</span>
                 #endif
             </td>
-            <td>
+            <td class="col-hide-phone">
                 #if(setup.submissionCount > 0):
                     <div style="display:flex;flex-direction:column;gap:.2rem">
                         #if(setup.hasLatestSubmission):

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -6,6 +6,27 @@ Notebook
 <style>
 /* Override the 900px max-width for this page only */
 .main { max-width: 100%; padding: 0 1rem; }
+
+/* The JupyterLite editor needs room and a pointer; it is unusable on a phone.
+   Below 640px we hide the editor surface and show a notice instead.  Tablets
+   (641px+) keep the full editor. */
+.nb-smallscreen-notice { display: none; }
+@media (max-width: 640px) {
+    .notebook-header,
+    #jl-frame,
+    #nb-fallback,
+    #nb-results,
+    #browser-runner-status { display: none; }
+    .nb-smallscreen-notice {
+        display: block;
+        margin: 2rem auto;
+        max-width: 32rem;
+        padding: 1.25rem 1.5rem;
+        border: 1px solid var(--gray-200);
+        border-radius: .5rem;
+        background: var(--surface);
+    }
+}
 </style>
 <div class="notebook-header">
     <div class="notebook-toolbar">
@@ -23,6 +44,13 @@ Notebook
             #endif
         </div>
     </div>
+</div>
+<div class="nb-smallscreen-notice" role="note">
+    <h2 style="margin:.2rem 0 .5rem">Open on a larger screen</h2>
+    <p style="margin:0;color:var(--gray-700)">
+        The notebook editor needs a tablet or computer. Please reopen this
+        assignment on a larger screen to edit and submit your notebook.
+    </p>
 </div>
 <iframe
     id="jl-frame"

--- a/Resources/Views/submission-history.leaf
+++ b/Resources/Views/submission-history.leaf
@@ -10,7 +10,7 @@ Submission History
 <table class="results-table">
     <thead>
         <tr>
-            <th>Attempt</th>
+            <th class="col-hide-phone">Attempt</th>
             <th>Submitted</th>
             <th>Status</th>
             <th>Grade</th>
@@ -20,7 +20,7 @@ Submission History
     <tbody>
     #for(row in rows):
         <tr>
-            <td>#(row.attemptNumber)</td>
+            <td class="col-hide-phone">#(row.attemptNumber)</td>
             <td>#(row.submittedAt)</td>
             <td>#(row.status)</td>
             <td>#(row.gradeText)</td>

--- a/changelog.d/responsive-design.md
+++ b/changelog.d/responsive-design.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Responsive web UI for phones and tablets.** Summary/list pages (student and
+  instructor dashboards, submission history) hide non-essential columns on small
+  screens; the per-student extension / grade-override flow is usable on a phone;
+  dense admin tables (runner, audit) scroll horizontally; and the notebook editor
+  is gated to tablet-and-up with an "open on a larger screen" notice on phones.
+  Built intrinsic-first (`min()` / `clamp()` containers, viewport breakpoints only
+  where needed) so the desktop layout is unchanged. See
+  `docs/responsive-design-plan.md`.

--- a/docs/responsive-design-plan.md
+++ b/docs/responsive-design-plan.md
@@ -48,6 +48,29 @@ The three real problems:
    screens; per-row action buttons and `.action-btn` icon buttons
    (`styles.css:276`, ~0.8rem) are below comfortable tap-target size (44px).
 
+## Hard constraint: zero desktop changes
+
+**Nothing about the desktop (>1024px) rendering may change — visually or in the
+cascade.** This is the governing rule and overrides convenience anywhere it
+conflicts:
+
+- **Every new rule lives inside an `@media (max-width: …)` block.** No new
+  selector or property is added to the default (unguarded) cascade. If a change
+  can't be expressed inside a media query, it doesn't ship in this effort.
+- **No global property additions** (e.g. a bare `min-width: 0` on a shared flex
+  container) — those leak into desktop. Such guards go *inside* the phone/tablet
+  media blocks only.
+- **Markup refactors must be visually inert at desktop.** Where an inline
+  `style="width:220px"` is moved to a class so a media query can override it,
+  the class reproduces the exact desktop value (`width: 220px`), so desktop
+  renders identically; only the phone block changes it.
+- **Structural wrappers must be inert at desktop.** `.table-wrap` uses
+  `overflow-x: auto`, which shows a scrollbar *only when content overflows* —
+  desktop tables fit within `.main` today, so no scrollbar and no visual change.
+- **Enforcement:** the 1440px (and 1280px) row of the test matrix is a
+  regression gate, checked against `main` — desktop must be pixel-identical. Any
+  diff at desktop width is a bug in the change, not an accepted trade-off.
+
 ## Approach decisions (locked)
 
 - **Table strategy: hide non-essential columns** below the breakpoint (chosen
@@ -93,9 +116,12 @@ unconditional width traps. Nothing should change at >1024px.
       `admin-users.leaf`, `style="width:280px"` in `assignment-submissions.leaf`)
       with a `.filter-input` class that is a fixed width on desktop and
       `width: 100%` on phone. (Keeps markup honest; avoids `!important`.)
-- [ ] Add `min-width: 0` to flex containers that hold long text (nav username,
-      `.assignment-title-cell`, `.submission-header-row`) so long names/emails
-      wrap instead of forcing horizontal overflow.
+- [ ] **Inside the phone/tablet blocks only**, add `min-width: 0` to flex
+      containers that hold long text (nav username, `.assignment-title-cell`,
+      `.submission-header-row`) so long names/emails wrap instead of forcing
+      horizontal overflow. This must **not** be added to the default cascade —
+      a global `min-width: 0` would change desktop wrap behavior for long
+      strings.
 - [ ] Wrap every `.results-table` in a `.table-wrap { overflow-x: auto; }` —
       this is the **safety net** so that even before per-table column hiding
       lands, no table can blow out the viewport. (The column-hiding work in
@@ -203,7 +229,13 @@ Manual, devtools-based (no automated visual regression in this pass):
 | 414px | larger phone | Same |
 | 768px | iPad portrait | Notebook editor usable; tables comfortable |
 | 1024px | iPad landscape | Boundary — should look near-desktop |
-| 1440px | desktop | **Pixel-identical to today** (regression guard) |
+| 1280px | small desktop | **Pixel-identical to `main`** (regression gate) |
+| 1440px | desktop | **Pixel-identical to `main`** (regression gate) |
+
+The two desktop rows are the enforcement mechanism for the
+[zero-desktop-changes constraint](#hard-constraint-zero-desktop-changes):
+diff each touched page against `main` at these widths; any visual difference
+means a rule escaped its media query and must be fixed before merge.
 
 Each phase's PR description should include before/after screenshots at 375px and
 1440px for the pages it touches.

--- a/docs/responsive-design-plan.md
+++ b/docs/responsive-design-plan.md
@@ -1,0 +1,238 @@
+# Responsive Design Plan
+
+Status: **proposed** (planning only — no CSS/markup changes yet)
+
+## Goal
+
+Make Chickadee's web UI usable on phones and tablets without a framework
+migration or a redesign. The bar is **viewing and light data-entry**, not full
+authoring:
+
+- **Phones (≤640px):** view summary/list pages (student dashboard, instructor
+  dashboard, submissions, account, history) and perform small interactive tasks
+  — most importantly **granting a student an extension** (the per-student grade
+  override / due-date form on the submissions page).
+- **Tablets (641–1024px):** everything phones can do, plus the notebook editor
+  (JupyterLite needs room but works with touch).
+- **Desktop (>1024px):** unchanged — current layout is the baseline.
+
+Explicit non-goals: making the JupyterLite notebook editor work on a phone, and
+making the dense admin tables (runner dashboard, audit log) comfortable on a
+phone beyond "readable, no horizontal blowout."
+
+## Why the codebase is ready
+
+The front end is in a good state for additive responsive work:
+
+- **One hand-rolled stylesheet** — [`Public/styles.css`](../Public/styles.css)
+  (~26KB), CSS custom properties, `rem`-based sizing throughout. No
+  Bootstrap/Tailwind to migrate.
+- **One shared layout** — every page extends
+  [`Resources/Views/base.leaf`](../Resources/Views/base.leaf), which already
+  ships `<meta name="viewport" content="width=device-width, initial-scale=1">`
+  (line 5). One change propagates everywhere.
+- **The only existing media query is `prefers-color-scheme: dark`**
+  (`styles.css:44`). No breakpoint logic to untangle — we are adding the first.
+- Flexbox/grid with `flex-wrap: wrap` and `gap` are already the norm.
+
+The three real problems:
+
+1. **Fixed-width containers never relax.** `.main` is `max-width: 900px`
+   (`styles.css:199`), `.form` is `620px` (`styles.css:294`), `.auth-box` is
+   `420px` (`styles.css:784`), plus inline `style="width:220px"` /
+   `style="width:280px"` filter inputs. All applied unconditionally.
+2. **Tables have no small-screen strategy.** `.results-table`
+   (`styles.css:483`) is `width: 100%` with no overflow handling; the app is
+   table-heavy and some admin tables run 7–8 columns with hardcoded widths.
+3. **Nav + dense action cells.** The top nav (`base.leaf:22`) crowds on small
+   screens; per-row action buttons and `.action-btn` icon buttons
+   (`styles.css:276`, ~0.8rem) are below comfortable tap-target size (44px).
+
+## Approach decisions (locked)
+
+- **Table strategy: hide non-essential columns** below the breakpoint (chosen
+  over horizontal-scroll and card/stack). Each table gets a per-column priority;
+  low-priority columns are `display: none` on phones. Essentials stay; the row's
+  detail link still leads to the full record. See
+  [Column priorities](#table-column-priorities) below.
+- **Mobile-first additive, not a rewrite.** Desktop rules stay as the default;
+  we add `@media (max-width: …)` blocks that override. No existing selector is
+  deleted.
+- **No JS framework, no nav JS yet.** First pass makes the nav *wrap* cleanly
+  rather than introducing a hamburger menu. Revisit a hamburger only if wrapping
+  proves insufficient (see Phase 1 exit check).
+
+## Breakpoints
+
+Two breakpoints, defined once as a comment-documented convention (CSS custom
+properties can't be used inside `@media` conditions, so these are literal but
+centralized in one block at the top of the stylesheet):
+
+| Name    | Range            | Media query                  |
+|---------|------------------|------------------------------|
+| phone   | ≤ 640px          | `@media (max-width: 640px)`  |
+| tablet  | 641px – 1024px   | `@media (max-width: 1024px)` |
+| desktop | > 1024px         | (default, no query)          |
+
+`max-width` (desktop-first overrides) is chosen because the existing CSS *is*
+the desktop layout — we layer reductions on top rather than rebuilding up.
+
+## Phases
+
+### Phase 0 — Foundation (no visible desktop change)
+
+A single PR that establishes the breakpoint scaffolding and fixes the
+unconditional width traps. Nothing should change at >1024px.
+
+- [ ] Add a documented "Responsive breakpoints" banner comment + the two
+      `@media` blocks (initially near-empty) at the end of `styles.css`.
+- [ ] In the phone block: `.main { max-width: 100%; padding: 0 1rem; margin: 1rem auto; }`.
+- [ ] In the tablet block: relax `.form { max-width: 100%; }` and
+      `.form--wide` already has none.
+- [ ] Replace inline fixed-width filter inputs (`style="width:220px"` in
+      `admin-users.leaf`, `style="width:280px"` in `assignment-submissions.leaf`)
+      with a `.filter-input` class that is a fixed width on desktop and
+      `width: 100%` on phone. (Keeps markup honest; avoids `!important`.)
+- [ ] Add `min-width: 0` to flex containers that hold long text (nav username,
+      `.assignment-title-cell`, `.submission-header-row`) so long names/emails
+      wrap instead of forcing horizontal overflow.
+- [ ] Wrap every `.results-table` in a `.table-wrap { overflow-x: auto; }` —
+      this is the **safety net** so that even before per-table column hiding
+      lands, no table can blow out the viewport. (The column-hiding work in
+      later phases removes the *need* to scroll on the priority pages, but the
+      wrapper stays as a backstop for the dense admin tables.)
+- [ ] Nav: in the phone block, allow `.nav { flex-wrap: wrap; row-gap: .25rem; }`
+      and drop `margin-left: auto` on `.nav-username` so items wrap left-aligned.
+
+**Exit check:** Chrome devtools at 375 / 768 / 1024 / 1440 — every page renders
+with no horizontal scrollbar on the `<body>`; desktop pixel-identical to today.
+
+### Phase 1 — Summary / read pages (priority)
+
+Pages: `index.leaf` (student dashboard), `assignments.leaf` (instructor
+dashboard), `account.leaf`, `submission-history.leaf`,
+`course-student-submissions.leaf`, `submission.leaf` (single result view).
+
+- [ ] Apply [column priorities](#table-column-priorities) — add
+      `data-priority` / utility classes (`.col-hide-phone`) to non-essential
+      `<th>`/`<td>` and hide them in the phone block.
+- [ ] Stack `.submission-header-row` (`styles.css:411`) vertically on phone
+      (already `flex-wrap: wrap`; ensure the score/badges don't get cramped).
+- [ ] Ensure action button groups wrap and meet a min tap target: in the phone
+      block, bump `.action-btn { min-height: 2.4rem; }` and ensure ≥6px gaps.
+- [ ] `.course-tabs` already `overflow-x: auto` (`styles.css:825`) — verify it
+      scrolls cleanly with many courses; no change expected.
+
+**Exit check:** On a real phone (or 375px emulation) a student can read their
+dashboard, open an assignment, and read results top-to-bottom with no
+sideways scrolling. If the nav wrapping looks bad here, open a follow-up for a
+hamburger — do **not** scope-creep it into this phase.
+
+### Phase 2 — The extension / grade-override workflow
+
+The one *interactive* mobile flow called out by the user. Lives on
+`assignment-submissions.leaf` — the per-student list whose Actions column holds
+the grade-override / extension form, currently an inline `<details>` /
+`position: absolute` popup that will overflow a phone viewport.
+
+- [ ] Audit the popup's positioning (look for `position: absolute; right: 0`
+      style popups like `.add-section-popup`, `.publish-form` at
+      `styles.css:972`). On phone, switch the override form to **static flow**
+      (full-width block under the row) instead of an absolutely-positioned
+      overlay, so it can't clip off-screen.
+- [ ] Form fields full-width; date/number inputs use native mobile pickers
+      (`type="date"` / `type="number"` already give good mobile keyboards —
+      verify the markup uses them).
+- [ ] Submit/cancel buttons full-width-stacked on phone, min 44px tall.
+
+**Exit check:** Grant an extension end-to-end on a 375px viewport without
+zooming or horizontal scrolling.
+
+### Phase 3 — Dense admin tables (lowest priority)
+
+Pages: `admin-runner.leaf` (8-col jobs + snapshots), `admin-audit.leaf` (7 cols
+with hardcoded `width:` on `<th>`), `admin-users.leaf`.
+
+- [ ] Keep the `.table-wrap` horizontal-scroll backstop from Phase 0.
+- [ ] Apply aggressive column hiding (these are desktop-first admin tools): on
+      phone keep only the 2–3 identifying columns + the primary metric; hide the
+      rest. The full record stays reachable on desktop.
+- [ ] Remove/scope the hardcoded `<th style="width:…">` widths in
+      `admin-audit.leaf` so they don't force overflow on phone (move to a class
+      that only applies the width ≥1024px).
+
+**Exit check:** Admin pages are *readable* on a phone (no body-level overflow);
+full comfort is explicitly not required.
+
+### Phase 4 — Tablet-only editor gating
+
+`notebook.leaf` already overrides `.main` to full width and sizes the iframe
+`calc(100vh - 9rem)` (`styles.css:766`). JupyterLite is unusable on a phone.
+
+- [ ] In the phone block only, replace the iframe with a friendly notice:
+      "The notebook editor needs a larger screen — please open this on a tablet
+      or computer." (Show via a `.notebook-smallscreen-notice` block that is
+      `display: none` above phone and `display: block` / iframe hidden at phone.)
+- [ ] Verify the editor *renders and is touch-usable* at 768px (tablet). No
+      layout change expected beyond confirming the toolbar wraps.
+
+## Table column priorities
+
+For the hide-non-essential-columns strategy. "Keep (phone)" columns stay
+visible ≤640px; the rest get `.col-hide-phone`.
+
+| Page / table | Keep (phone) | Hide (phone) |
+|---|---|---|
+| `index.leaf` — assignments | Name, Status/Grade, Actions | Due, History |
+| `assignments.leaf` — instructor assignments | Name, Status, Actions | Due, counts |
+| `assignment-submissions.leaf` — submissions | Name, Grade, Actions (extension) | Student ID, History |
+| `account.leaf` — enrollments | Code/Name, Action | (few cols; likely keep all) |
+| `admin-users.leaf` | Name/Username, Role, Actions | Last Seen, Joined |
+| `admin-runner.leaf` — jobs | Submission, Status | User, all timing metrics, Peak Disk, Completed |
+| `admin-audit.leaf` | Time, Action | Actor, Category, Target, Remote, Metadata |
+
+These are starting points; tune during implementation against real content.
+
+## Testing matrix
+
+Manual, devtools-based (no automated visual regression in this pass):
+
+| Viewport | Device proxy | What to check |
+|---|---|---|
+| 375px | iPhone SE / mini | No body horizontal scroll; nav wraps; tables show kept columns; extension flow works |
+| 414px | larger phone | Same |
+| 768px | iPad portrait | Notebook editor usable; tables comfortable |
+| 1024px | iPad landscape | Boundary — should look near-desktop |
+| 1440px | desktop | **Pixel-identical to today** (regression guard) |
+
+Each phase's PR description should include before/after screenshots at 375px and
+1440px for the pages it touches.
+
+## Risks & notes
+
+- **`document.write` after multipart submit** (`base.leaf:122`) replaces the
+  whole document. Any responsive CSS lives in the linked stylesheet, so the
+  rewritten doc still picks it up — no special handling needed, but worth
+  remembering when testing the upload/extension flows.
+- **Dark mode interaction:** the new `@media (max-width)` blocks are orthogonal
+  to the existing `@media (prefers-color-scheme: dark)` block; they compose
+  fine, but test phone layout in both color schemes once.
+- **LeafKit partial limitation:** the codebase notes LeafKit 1.x false-positive
+  cycle errors prevent some shared partials (e.g. `styles.css:883` comment).
+  This plan adds **zero** new Leaf partials — all changes are CSS plus class
+  attributes on existing markup — so it sidesteps that entirely.
+- **No version bump in PRs.** Per `CLAUDE.md`, add a `changelog.d/` fragment per
+  PR; do not touch `VERSION` / `ChickadeeVersion` / `CHANGELOG.md`.
+- **SwiftLint/swift-format are not triggered** by CSS/Leaf-only changes, but run
+  `scripts/lint.sh` if any Swift is touched (none expected here).
+
+## Suggested PR sequence
+
+1. **Phase 0** — foundation (breakpoints, container relax, `.table-wrap`,
+   nav wrap). Low risk, unblocks everything.
+2. **Phase 1** — summary pages + column priorities.
+3. **Phase 2** — extension/grade-override flow.
+4. **Phase 3** — admin tables.
+5. **Phase 4** — notebook tablet gating.
+
+Each is independently shippable and independently reviewable.

--- a/docs/responsive-design-plan.md
+++ b/docs/responsive-design-plan.md
@@ -13,15 +13,16 @@ student dashboard (`index.leaf`).
   phone) wired into the two search inputs.
 - **Phase 1 — in progress.** `index.leaf` (student dashboard) hides the Due and
   History columns on phones across all three table variants.
-- **Key finding (changes the table mechanism):** the plan preferred
-  `@container` for table column-hiding, but `container-type: inline-size` (and
-  an `overflow` wrapper) establishes a new containing block / clips, which
-  **moves or clips the absolutely-positioned popups** that live inside some
-  tables (grade-override on the submissions page, add-section/publish popups on
-  the instructor dashboard) — a desktop regression. So column-hiding uses
-  plain **viewport `@media` + `.col-hide-phone` utility classes on the `<th>`
-  and matching `<td>`s** (no wrapper, provably desktop-inert). `overflow-x`
-  wrappers are reserved for the popup-free dense admin tables in Phase 3.
+- **Table mechanism: viewport `@media` + `.col-hide-phone` utility classes on
+  the `<th>` and matching `<td>`s.** Chosen because it needs **no wrapper at
+  all** and is therefore provably desktop-inert — the simplest tool that does
+  the job. (`container-type: inline-size` / `overflow` wrappers would also
+  re-anchor or clip the absolutely-positioned popups inside some tables —
+  grade-override on the submissions page, add-section/publish on the instructor
+  dashboard. Per the instructor (2026-06): **popup positioning is explicitly
+  acceptable to revisit/refine later**, so this is no longer a hard blocker —
+  `@container` and `overflow-x` wrappers are fair game in later phases where
+  they're genuinely cleaner, with any popup nudge handled as a follow-up.)
 
 ## Goal
 

--- a/docs/responsive-design-plan.md
+++ b/docs/responsive-design-plan.md
@@ -1,6 +1,27 @@
 # Responsive Design Plan
 
-Status: **proposed** (planning only — no CSS/markup changes yet)
+Status: **in progress** — Phase 0 (foundation) landed; Phase 1 started with the
+student dashboard (`index.leaf`).
+
+## Implementation status
+
+- **Phase 0 (foundation) — done.** Intrinsic containers (`.main` / `.form` /
+  `.auth-box` now use `min(…, 100%)`, `.main` padding fluid via `clamp()`),
+  documented breakpoint block + `.col-hide-phone` / `.col-hide-tablet`
+  utilities, phone nav wrapping, `.action-btn` tap targets, and a
+  `.filter-input` class (authored width via `--filter-width`, full-width on
+  phone) wired into the two search inputs.
+- **Phase 1 — in progress.** `index.leaf` (student dashboard) hides the Due and
+  History columns on phones across all three table variants.
+- **Key finding (changes the table mechanism):** the plan preferred
+  `@container` for table column-hiding, but `container-type: inline-size` (and
+  an `overflow` wrapper) establishes a new containing block / clips, which
+  **moves or clips the absolutely-positioned popups** that live inside some
+  tables (grade-override on the submissions page, add-section/publish popups on
+  the instructor dashboard) — a desktop regression. So column-hiding uses
+  plain **viewport `@media` + `.col-hide-phone` utility classes on the `<th>`
+  and matching `<td>`s** (no wrapper, provably desktop-inert). `overflow-x`
+  wrappers are reserved for the popup-free dense admin tables in Phase 3.
 
 ## Goal
 

--- a/docs/responsive-design-plan.md
+++ b/docs/responsive-design-plan.md
@@ -1,18 +1,38 @@
 # Responsive Design Plan
 
-Status: **in progress** — Phase 0 (foundation) landed; Phase 1 started with the
-student dashboard (`index.leaf`).
+Status: **first pass complete** — all five phases landed; ready to deploy and
+fine-tune column-priority / breakpoint choices against real content.
 
 ## Implementation status
 
 - **Phase 0 (foundation) — done.** Intrinsic containers (`.main` / `.form` /
   `.auth-box` now use `min(…, 100%)`, `.main` padding fluid via `clamp()`),
   documented breakpoint block + `.col-hide-phone` / `.col-hide-tablet`
-  utilities, phone nav wrapping, `.action-btn` tap targets, and a
-  `.filter-input` class (authored width via `--filter-width`, full-width on
-  phone) wired into the two search inputs.
-- **Phase 1 — in progress.** `index.leaf` (student dashboard) hides the Due and
-  History columns on phones across all three table variants.
+  utilities, `.table-scroll` wrapper, phone nav wrapping, `.action-btn` tap
+  targets, and a `.filter-input` class (authored width via `--filter-width`,
+  full-width on phone) wired into the two search inputs.
+- **Phase 1 (summary pages) — done.** Student dashboard (`index.leaf`) and
+  instructor dashboard (`assignments.leaf`) hide Due / History / Submissions on
+  phones; submission history hides Attempt. `account.leaf` and the single
+  submission view (`submission.leaf`) already fit a phone and were left
+  untouched.
+- **Phase 2 (extension / grade-override flow) — done.** `assignment-submissions.leaf`
+  and `course-student-submissions.leaf` hide Student ID / Due / History on
+  phones and the extension/override forms drop their 14rem min-width below the
+  breakpoint (`.ext-details form`) so opening one no longer forces the table
+  wider than the screen.
+- **Phase 3 (dense admin tables) — done.** Runner dashboard (`admin-runner.leaf`)
+  and audit log (`admin-audit.leaf`) tables are wrapped in `.table-scroll`
+  (horizontal scroll, all columns reachable). `admin-users.leaf` hides Last
+  Seen / Joined on phones — applied to both the server-rendered rows and the
+  JS auto-refresh row template so a poll repaint keeps them hidden.
+- **Phase 4 (notebook tablet gating) — done.** Below 640px `notebook.leaf`
+  hides the editor surface and shows an "open on a larger screen" notice;
+  tablets (641px+) keep the full editor.
+  - *Follow-up:* the hidden iframe still loads JupyterLite/Pyodide in the
+    background on phones (CSS can't stop the `src` from fetching). Preventing
+    that load needs a small markup/JS guard — deferred, since it's wasteful
+    rather than broken.
 - **Table mechanism: viewport `@media` + `.col-hide-phone` utility classes on
   the `<th>` and matching `<td>`s.** Chosen because it needs **no wrapper at
   all** and is therefore provably desktop-inert — the simplest tool that does

--- a/docs/responsive-design-plan.md
+++ b/docs/responsive-design-plan.md
@@ -48,36 +48,65 @@ The three real problems:
    screens; per-row action buttons and `.action-btn` icon buttons
    (`styles.css:276`, ~0.8rem) are below comfortable tap-target size (44px).
 
-## Hard constraint: zero desktop changes
+## Hard constraint: desktop renders identically
 
-**Nothing about the desktop (>1024px) rendering may change — visually or in the
-cascade.** This is the governing rule and overrides convenience anywhere it
-conflicts:
+**The desktop (>1024px) rendering must not change — verified by diffing each
+touched page against `main`.** This is an *outcome* guarantee and the governing
+rule. *How* we get there is a means, not the rule — and the means matters for
+long-term maintainability, so prefer them in this order:
 
-- **Every new rule lives inside an `@media (max-width: …)` block.** No new
-  selector or property is added to the default (unguarded) cascade. If a change
-  can't be expressed inside a media query, it doesn't ship in this effort.
-- **No global property additions** (e.g. a bare `min-width: 0` on a shared flex
-  container) — those leak into desktop. Such guards go *inside* the phone/tablet
-  media blocks only.
-- **Markup refactors must be visually inert at desktop.** Where an inline
-  `style="width:220px"` is moved to a class so a media query can override it,
-  the class reproduces the exact desktop value (`width: 220px`), so desktop
-  renders identically; only the phone block changes it.
-- **Structural wrappers must be inert at desktop.** `.table-wrap` uses
-  `overflow-x: auto`, which shows a scrollbar *only when content overflows* —
-  desktop tables fit within `.main` today, so no scrollbar and no visual change.
-- **Enforcement:** the 1440px (and 1280px) row of the test matrix is a
-  regression gate, checked against `main` — desktop must be pixel-identical. Any
+1. **Width-agnostic intrinsic CSS that is identical at desktop by construction**
+   — preferred over `max-width` overrides. e.g. `.main { max-width: min(900px,
+   100%) }` is byte-for-byte the same as `max-width: 900px` at any viewport ≥
+   ~900px, so it satisfies the constraint *without* a media query and *without*
+   an override pile, while also never overflowing a phone. Same idea with
+   `clamp()` for fluid spacing/type and `grid-template-columns: repeat(auto-fit,
+   minmax(…))` for card flows that wrap themselves.
+2. **Container queries (`@container`) for self-contained components** — reach for
+   these when a component should adapt to *its own* available width rather than
+   the viewport. This is the right home for table column-hiding: a table that
+   responds to its container is more reusable than one keyed to the global
+   viewport.
+3. **Viewport `@media` only for genuinely page-level/global concerns** — in
+   practice just the nav collapse. New components may be written mobile-first
+   (`min-width`, additive cascade); the legacy base stays as-is.
+
+Why not "everything is a `max-width` override": a desktop-first override pile
+makes the cascade *subtractive* (every breakpoint undoes desktop rules), invites
+specificity/`!important` creep when overriding inline widths, and freezes mobile
+as a degraded desktop. The intrinsic-first order above avoids all three while
+still guaranteeing desktop is untouched.
+
+Supporting rules (unchanged in intent):
+
+- **No global property additions that alter desktop** (e.g. a bare `min-width:
+  0` on a shared flex container). Where such a guard is only needed below a
+  breakpoint, scope it to that breakpoint/container.
+- **Markup refactors and structural wrappers must be visually inert at
+  desktop.** A `.table-wrap { overflow-x: auto }` shows a scrollbar only when
+  content overflows — desktop tables fit within `.main` today, so no visual
+  change. (Prefer not to need the wrapper at all once container-query column
+  hiding lands; keep it only as a backstop for the dense admin tables.)
+- **Enforcement:** the 1280px and 1440px rows of the test matrix are a
+  regression gate, diffed against `main` — desktop must be pixel-identical. Any
   diff at desktop width is a bug in the change, not an accepted trade-off.
+
+Pragmatism note: this is a CSS layer on an autograding tool, not a design
+system. `min()`/`clamp()` are universally supported and `@container` is in every
+evergreen browser since 2023, so the intrinsic path is low-risk — but introduce
+it incrementally, not as a big-bang refactor.
 
 ## Approach decisions (locked)
 
-- **Table strategy: hide non-essential columns** below the breakpoint (chosen
-  over horizontal-scroll and card/stack). Each table gets a per-column priority;
-  low-priority columns are `display: none` on phones. Essentials stay; the row's
-  detail link still leads to the full record. See
+- **Table strategy: hide non-essential columns** on small screens (chosen over
+  horizontal-scroll and card/stack). Each table gets a per-column priority;
+  low-priority columns are hidden when space is tight. Essentials stay; the
+  row's detail link still leads to the full record. See
   [Column priorities](#table-column-priorities) below.
+  **Mechanism: prefer a container query** (`@container`) on the table's wrapper
+  so the table hides columns based on its *own* width, falling back to a
+  viewport `@media` only if a container context proves awkward. Either way the
+  desktop rendering is unchanged.
 - **Mobile-first additive, not a rewrite.** Desktop rules stay as the default;
   we add `@media (max-width: …)` blocks that override. No existing selector is
   deleted.
@@ -109,9 +138,11 @@ unconditional width traps. Nothing should change at >1024px.
 
 - [ ] Add a documented "Responsive breakpoints" banner comment + the two
       `@media` blocks (initially near-empty) at the end of `styles.css`.
-- [ ] In the phone block: `.main { max-width: 100%; padding: 0 1rem; margin: 1rem auto; }`.
-- [ ] In the tablet block: relax `.form { max-width: 100%; }` and
-      `.form--wide` already has none.
+- [ ] Make containers intrinsically fluid instead of media-query-relaxed:
+      `.main { max-width: min(900px, 100%) }` and `.form { max-width: min(620px,
+      100%) }` — identical at desktop, never overflow on a phone, no breakpoint
+      needed. Optionally tighten `.main` padding with `clamp()`.
+      (`.form--wide` already has no cap.)
 - [ ] Replace inline fixed-width filter inputs (`style="width:220px"` in
       `admin-users.leaf`, `style="width:280px"` in `assignment-submissions.leaf`)
       with a `.filter-input` class that is a fixed width on desktop and


### PR DESCRIPTION
Adds phone/tablet support to the web UI. **Hard constraint: the desktop (>1024px) rendering is unchanged** — every rule is either intrinsic CSS that's identical at desktop by construction (`min()`, `clamp()`) or scoped inside a `max-width` media query. Full design + per-page status in [`docs/responsive-design-plan.md`](docs/responsive-design-plan.md).

### Approach
- **Intrinsic-first**, breakpoints only where needed (phone ≤640px, tablet ≤1024px).
- **Tables hide non-essential columns** via `.col-hide-phone` utilities on `<th>` + matching `<td>`s; dense admin tables use a `.table-scroll` horizontal-scroll wrapper instead.

### All phases complete
- **Phase 0 — foundation:** intrinsic `.main`/`.form`/`.auth-box`, fluid padding, breakpoint block + column-hide utilities + `.table-scroll`, phone nav wrapping, `.action-btn` tap targets, `.filter-input` class.
- **Phase 1 — summary pages:** student + instructor dashboards (hide Due/History/Submissions), submission history (hide Attempt). `account.leaf` and `submission.leaf` already fit; left untouched.
- **Phase 2 — extension/grade-override flow:** submissions + course-student-submissions hide Student ID/Due/History and the extension/override forms shed their 14rem min-width on phones so opening one doesn't widen the table.
- **Phase 3 — admin tables:** runner + audit wrapped in `.table-scroll`; users table hides Last Seen/Joined (server rows **and** the JS auto-refresh template).
- **Phase 4 — notebook:** editor gated to tablet+, "open on a larger screen" notice on phones. *(Follow-up: the hidden iframe still background-loads Pyodide on phones — wasteful, not broken; needs a small JS guard to fully prevent.)*

### Testing
Manual devtools matrix (375/414/768/1024/1280/1440). Desktop rows (1280/1440) are a regression gate — pixel-identical to `main`. Intended to deploy and fine-tune column-priority/breakpoint choices against real content from there.

https://claude.ai/code/session_01H2DLoLPSkTunHPrtXouqdE