### PR TITLE
ci: flag duplicated / global-shadowing CSS selectors in the style guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,7 +478,9 @@ the `format-lint` CI job) — keep them green:
 - **Shared styling lives in `Public/styles.css`;** page-unique styling lives
   in a page-local `<style>` block with **role-named** classes (e.g.
   `.section-header`, not `.mt-1`). Don't paste the same rule into multiple
-  templates — hoist it to the global sheet.
+  templates — hoist it to the global sheet. (`scripts/check-styles.sh` fails
+  if a page block re-defines a global selector or the same selector appears
+  in more than one page block; `.main` is an allowlisted page override.)
 - **Every `var(--x)` must resolve.** Declare new custom properties in
   `styles.css` (with a `prefers-color-scheme: dark` value if it's a colour).
   Never reference an undeclared var, and never use a hardcoded colour

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1217,6 +1217,8 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 
 /* Square-ish icon-only action button (edit / upload / reset glyphs). */
 .action-btn-icon { padding: .3rem .45rem; }
+/* Compact action button used in dense submission/roster table rows. */
+.action-btn-tight { padding: .25rem .35rem; }
 
 /* Wrapper form that should not introduce vertical rhythm (inline action).
    display:inline is a no-op for flex-item forms (flex blockifies children),

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -53,7 +53,7 @@
                 #endif
             </td>
             <td>
-                <div class="row-actions">
+                <div class="subm-row-actions">
                     #if(row.hasLatestSubmission):
                         <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.latestSubmissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')" class="form-flush">
                             #csrfFormField()
@@ -112,7 +112,7 @@
 .filter-row {
     margin-bottom: .5rem;
 }
-.row-actions {
+.subm-row-actions {
     display: flex;
     gap: .2rem;
     flex-wrap: wrap;
@@ -120,9 +120,6 @@
 }
 .form-flush {
     margin: 0;
-}
-.action-btn-tight {
-    padding: .25rem .35rem;
 }
 .ext-panel {
     margin-top: .4rem;

--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -87,7 +87,7 @@
                 #endif
             </td>
             <td>
-                <div class="row-actions">
+                <div class="student-row-actions">
                     #if(row.submissionCount > 0):
                     <form method="post" action="#(row.retestPath)" onsubmit="return confirm('Re-test all of this student’s submissions on this assignment?')" class="action-form-flush">
                         #csrfFormField()
@@ -230,7 +230,7 @@
                 #endif
             </td>
             <td>
-                <div class="row-actions">
+                <div class="student-row-actions">
                     #if(row.submissionCount > 0):
                     <form method="post" action="#(row.retestPath)" onsubmit="return confirm('Re-test all of this student’s submissions on this assignment?')" class="action-form-flush">
                         #csrfFormField()
@@ -320,7 +320,7 @@
     font-size: .75rem;
     color: var(--gray-600);
 }
-.row-actions {
+.student-row-actions {
     display: flex;
     gap: .3rem;
     flex-wrap: wrap;
@@ -328,9 +328,6 @@
 }
 .action-form-flush {
     margin: 0;
-}
-.action-btn-tight {
-    padding: .25rem .35rem;
 }
 .action-panel {
     margin-top: .4rem;

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -72,8 +72,73 @@ elif [ "$alert_count" -lt "$ALERT_BASELINE" ]; then
   echo "note: alert() count dropped to ${alert_count}; lower ALERT_BASELINE in scripts/check-styles.sh."
 fi
 
+# ── 4. No duplicated / shadowed selectors in page <style> blocks ─────────────
+# Page-local <style> blocks should only define page-unique classes.  Two
+# regressions the cleanup removed (and that render fine, so no test catches):
+#   A. a page block re-defines a selector that already lives in the global
+#      sheet (e.g. submission.leaf shadowing the global .achievement-badge);
+#   B. the same selector is defined in more than one page block (cross-page
+#      duplication that should be hoisted to styles.css).
+# `.main` is an allowlisted intentional global override (notebook.leaf narrows
+# the page container).  Heuristic extractor: selector = text before each `{`
+# (one selector per line, as authored here), skipping at-rules and comments —
+# errs toward false negatives, never false positives.
+ALLOW_GLOBAL_OVERRIDE="^\.main$"
+
+extract_selectors() {
+  # `|| true` on the greps so no-match (e.g. a file with no <style> block)
+  # doesn't trip pipefail.
+  sed -E 's#/\*.*\*/##g' \
+    | { grep '{' || true; } \
+    | sed -E 's/\{.*//; s/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | { grep -vE '^$|^@|^/\*' || true; }
+}
+
+global_sel="$(extract_selectors < Public/styles.css | sort -u)"
+
+# Build "selector<TAB>file" pairs from every page <style> block.
+pairs="$(
+  for f in "${views[@]}"; do
+    base="$(basename "$f")"
+    sed -n '/<style>/,/<\/style>/p' "$f" | extract_selectors \
+      | while IFS= read -r sel; do [ -n "$sel" ] && printf '%s\t%s\n' "$sel" "$base"; done
+  done | sort -u
+)"
+
+# A. page selector also declared globally (excluding the allowlist).
+shadowed=""
+while IFS=$'\t' read -r sel file; do
+  [ -z "$sel" ] && continue
+  if printf '%s\n' "$sel" | grep -qE "$ALLOW_GLOBAL_OVERRIDE"; then continue; fi
+  if printf '%s\n' "$global_sel" | grep -qxF -- "$sel"; then
+    shadowed+="  ${file}: ${sel}"$'\n'
+  fi
+done <<< "$pairs"
+
+if [ -n "$shadowed" ]; then
+  status=1
+  echo "ERROR: a page <style> block re-defines a selector from the global sheet."
+  echo "       Use the global rule, or rename the page-local class."
+  printf '%s' "$shadowed"
+  echo
+fi
+
+# B. same selector defined in more than one page block.
+cross="$(printf '%s\n' "$pairs" | cut -f1 | sort | uniq -d)"
+if [ -n "$cross" ]; then
+  status=1
+  echo "ERROR: the same selector is defined in more than one page <style> block."
+  echo "       Hoist the shared rule into Public/styles.css (or rename if they differ)."
+  while IFS= read -r sel; do
+    [ -z "$sel" ] && continue
+    files="$(printf '%s\n' "$pairs" | awk -F'\t' -v s="$sel" '$1==s{printf " %s", $2}')"
+    echo "  ${sel} →${files}"
+  done <<< "$cross"
+  echo
+fi
+
 if [ "$status" -eq 0 ]; then
-  echo "check-styles: OK (no disallowed inline styles; alert()s within baseline)"
+  echo "check-styles: OK (no disallowed inline styles; alert()s within baseline; no duplicated selectors)"
 fi
 
 exit "$status"


### PR DESCRIPTION
Follow-up to #846 — the cheap, zero-dependency duplicate-selector check we discussed (instead of adding a Node/`stylelint` toolchain).

## What it adds
A section in `scripts/check-styles.sh` (pure grep/sed) that fails CI if:
- **A page `<style>` block re-defines a selector from the global sheet** — the `submission.leaf`-shadows-`.achievement-badge` regression class.
- **The same selector appears in more than one page block** — cross-page duplication that should be hoisted to `styles.css`.

`.main` is allowlisted (notebook.leaf intentionally narrows the page container). The extractor is heuristic (selector = text before each `{`) and errs toward false negatives, never false positives.

## It immediately caught leftover dup (fixed, no visual change)
From the parallel-agent work in #845:
- `.action-btn-tight` was defined **identically** in `assignment-submissions.leaf` and `course-student-submissions.leaf` → hoisted to `styles.css`.
- `.row-actions` was defined in both with **different** gaps (`.2` vs `.3rem`) → a real name collision; renamed to `.subm-row-actions` / `.student-row-actions` so each page keeps its spacing.

## Verified
- Guard passes on the tree, and **fails** on an injected violation (confirmed both branches: global-shadow + cross-page dup), green again after cleanup.
- The two edited pages still render (70 Assignment/Course render tests green).
- `CLAUDE.md` updated to document the rule.

https://claude.ai/code/session_01ScnxEuwphdFsn8GF2trQJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScnxEuwphdFsn8GF2trQJc)_