### PR TITLE
UI tweaks: dashboard single-line rows, autofill suppression, editor layout

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -46,6 +46,24 @@ if (dropZone && fileInput) {
     });
 }
 
+// ── Site-wide credential-autofill suppression ──────────────────────────────
+// Browsers heuristically offer username/password autofill on any text field —
+// e.g. an admin filter named "actor" with placeholder "username" — which is
+// noise on the many non-credential forms across the app. HTML has no global
+// "default off" switch, so set autocomplete="off" at the form level for every
+// form that hasn't opted in. Real credential forms (login, register, the admin
+// worker-secret field) opt their inputs into autocomplete explicitly; an
+// input-level autocomplete overrides this form-level default per the HTML spec,
+// so they keep working. We also skip any form that already carries a password
+// field or an annotated control, out of caution.
+(function suppressSpuriousAutofill() {
+    const forms = document.querySelectorAll('form:not([autocomplete])');
+    forms.forEach((form) => {
+        if (form.querySelector('input[type="password"], [autocomplete]')) return;
+        form.setAttribute('autocomplete', 'off');
+    });
+})();
+
 // Results page: poll until the submission reaches its final state.
 //
 // Statuses that require polling:

--- a/Public/global-inputs-editor.js
+++ b/Public/global-inputs-editor.js
@@ -146,21 +146,15 @@
         var tr = document.createElement('tr');
         tr.className = 'global-input-row';
         tr.innerHTML =
-            '<td><strong>Global input</strong></td>'
-          + '<td style="width:14rem;white-space:nowrap">'
+            '<td style="width:14rem;white-space:nowrap">'
           +   '<span class="global-input-row-valid" style="display:inline-block;width:1rem;color:var(--green);font-size:.95rem;text-align:center"></span>'
           +   '<input type="text" class="form-input global-input-name" value="" placeholder="Input Name" style="width:calc(100% - 1.5rem);padding:.2rem .4rem;font-family:monospace">'
           + '</td>'
           + '<td><input type="text" class="form-input global-input-value" value="" placeholder=\'12, "hello", [1, 2, 3], or = seed % 26\' style="width:100%;padding:.2rem .4rem;font-family:monospace"></td>'
           + '<td class="time"><button type="button" class="btn action-btn action-danger global-input-remove" title="Remove input" aria-label="Remove input"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg></button></td>';
-        // Insert before the trailing "Add input" row so the button stays at the bottom.
-        var addRow = document.getElementById('global-input-add');
-        var anchor = addRow ? addRow.closest('tr') : null;
-        if (anchor && anchor.parentNode === tbody) {
-            tbody.insertBefore(tr, anchor);
-        } else {
-            tbody.appendChild(tr);
-        }
+        // The "+ Add Input" button now lives in the panel header (not a
+        // trailing table row), so new rows simply append to the end.
+        tbody.appendChild(tr);
         refreshRow(tr, tbody);
         var input = tr.querySelector('.global-input-name');
         if (input) input.focus();

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1415,7 +1415,10 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 .input-sm { font-size: .875rem; padding: .25rem .5rem; }
 
 /* Suite editor header row + the "+ Section" pop-out menu. */
-.suite-editor-head {
+/* Generic header bar for an editor block: a heading on the left, an
+   action toolbar on the right.  Shared by the Files, Global Inputs, and
+   Test Suite blocks on the assignment new/edit pages. */
+.editor-block-head {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -1505,9 +1508,9 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 .bs-body { margin-top: .75rem; max-width: 520px; }
 .bs-note { margin: .3rem 0 .6rem; }
 
-/* Suite editor container + its header heading. */
+/* Suite editor container + editor-block header headings. */
 .suite-editor-section { margin-top: 1.25rem; }
-.suite-editor-head h2 { margin: 0; }
+.editor-block-head h2 { margin: 0; }
 
 /* "Generate starter tests" panel (display toggled by JS, kept inline). */
 .gen-tests-panel {

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -960,6 +960,9 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     color: var(--gray-600);
 }
 
+/* Staff-only ("preview") badge on the student dashboard stays on one line. */
+.staff-only-tag { white-space: nowrap; }
+
 /* ── Inline publish form (inside <details>) ──────────── */
 
 .publish-details summary::-webkit-details-marker { display: none; }
@@ -1212,7 +1215,8 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 .assignment-actions-cell {
     display: flex;
     gap: .4rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    align-items: center;
 }
 
 /* Square-ish icon-only action button (edit / upload / reset glyphs). */

--- a/Resources/Views/_assignment-row.leaf
+++ b/Resources/Views/_assignment-row.leaf
@@ -25,7 +25,7 @@
     </td>
     <td>
         #if(setup.staffOnly):
-        <span class="tier tier-preview staff-only-tag" title="Visible to course staff only — students can't see this assignment yet.">staff only</span>
+        <span class="tier tier-preview staff-only-tag" title="Visible to course staff only — students can't see this assignment yet.">preview</span>
         #else:
         <span class="tier
             #if(setup.status == "open"):tier-open

--- a/Resources/Views/admin-audit.leaf
+++ b/Resources/Views/admin-audit.leaf
@@ -37,7 +37,7 @@ Audit Log
         </label>
         <label class="audit-filter-field">
             <span class="audit-filter-label">Actor contains</span>
-            <input type="text" name="actor" value="#(filterActor)" placeholder="username" />
+            <input type="text" name="actor" value="#(filterActor)" placeholder="username" autocomplete="off" />
         </label>
         <button type="submit" class="btn">Filter</button>
         #if(filtered):

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -65,6 +65,15 @@
     </div>
 
     <div class="editor-block">
+        <div class="editor-block-head">
+            <h2>Files</h2>
+            <div class="toolbar toolbar--end">
+                <button class="btn action-btn" type="button" id="add-support-file-btn"
+                        title="Upload a data file (CSV, JSON, etc.) bundled with the assignment">+ Add Support File</button>
+                <input type="file" id="support-file-upload-input" hidden multiple>
+                <span id="support-file-upload-status" class="upload-status-inline"></span>
+            </div>
+        </div>
         <table class="results-table" id="notebook-files-table">
             <thead>
                 <tr>
@@ -119,15 +128,6 @@
                     </td>
                 </tr>
                 #endfor
-                <tr>
-                    <td><strong>Add support file</strong></td>
-                    <td colspan="2">
-                        <button class="btn action-btn" type="button" id="add-support-file-btn"
-                                title="Upload a data file (CSV, JSON, etc.) bundled with the assignment">+ Upload file</button>
-                        <input type="file" id="support-file-upload-input" hidden multiple>
-                        <span id="support-file-upload-status" class="upload-status-inline"></span>
-                    </td>
-                </tr>
             </tbody>
         </table>
     </div>
@@ -145,11 +145,17 @@
 <section id="global-inputs-block"
          data-assignment-id="#(assignmentID)"
          class="editor-block">
+    <div class="editor-block-head">
+        <h2>Global Inputs</h2>
+        <div class="toolbar toolbar--end">
+            <button type="button" class="btn action-btn" id="global-input-add">+ Add Input</button>
+            <span id="global-inputs-status" class="upload-status-inline"></span>
+        </div>
+    </div>
     <table class="results-table" id="global-inputs-table">
         <tbody class="global-inputs-body">
             #for(v in globalVariableRows):
             <tr class="global-input-row">
-                <td><strong>Global input</strong></td>
                 <td class="section-var-namecell">
                     <span class="global-input-row-valid section-var-valid"></span>
                     <input type="text" class="form-input global-input-name global-input-name-input"
@@ -176,13 +182,6 @@
                 </td>
             </tr>
             #endfor
-            <tr>
-                <td><strong>Add input</strong></td>
-                <td colspan="3">
-                    <button type="button" class="btn action-btn" id="global-input-add">+ Add Input</button>
-                    <span id="global-inputs-status" class="upload-status-inline"></span>
-                </td>
-            </tr>
         </tbody>
     </table>
 </section>
@@ -226,7 +225,7 @@
 <input class="form-input" id="suite-files-input" type="file" multiple hidden>
 
 <div class="suite-editor-section">
-    <div class="suite-editor-head">
+    <div class="editor-block-head">
         <h2>Test Suite</h2>
         <div class="toolbar toolbar--end">
             <!-- Add Section — form POST + full page reload.  Mirrors the

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -77,6 +77,17 @@ Create Assignment
     <button id="js-clear-solution-notebook"     type="submit" formaction="/instructor/new/draft" name="draftAction" value="clear-solution-notebook"     hidden></button>
 
     <div class="editor-block">
+        <div class="editor-block-head">
+            <h2>Files</h2>
+            #if(draftID):
+            <div class="toolbar toolbar--end">
+                <button class="btn action-btn" type="button" id="add-support-file-btn"
+                        title="Upload a data file (CSV, JSON, etc.) bundled with the assignment">+ Add Support File</button>
+                <input type="file" id="support-file-upload-input" hidden multiple>
+                <span id="support-file-upload-status" class="upload-status-inline"></span>
+            </div>
+            #endif
+        </div>
         <table class="results-table" id="notebook-files-table">
             <thead>
                 <tr>
@@ -156,17 +167,6 @@ Create Assignment
                     </td>
                 </tr>
                 #endfor
-                #if(draftID):
-                <tr>
-                    <td><strong>Add support file</strong></td>
-                    <td colspan="2">
-                        <button class="btn action-btn" type="button" id="add-support-file-btn"
-                                title="Upload a data file (CSV, JSON, etc.) bundled with the assignment">+ Upload file</button>
-                        <input type="file" id="support-file-upload-input" hidden multiple>
-                        <span id="support-file-upload-status" class="upload-status-inline"></span>
-                    </td>
-                </tr>
-                #endif
             </tbody>
         </table>
     </div>
@@ -211,7 +211,7 @@ Create Assignment
 <input class="form-input" id="suite-files-input" type="file" multiple hidden>
 
 <div class="form form--wide suite-editor-section">
-    <div class="suite-editor-head">
+    <div class="editor-block-head">
         <h2>Test Suite</h2>
         <div class="toolbar toolbar--end">
             <!-- Add Section — form POST + full page reload, mirrors the

--- a/changelog.d/dashboard-actions-preview-badge.md
+++ b/changelog.d/dashboard-actions-preview-badge.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Student-dashboard assignment table single-line polish.** The staff-only
+  status badge now reads "preview" and stays on one line instead of wrapping to
+  two, and the Actions cell keeps its icon buttons on a single row (matching the
+  tighter instructor assignments view) rather than wrapping.

--- a/changelog.d/editor-layout-and-autofill.md
+++ b/changelog.d/editor-layout-and-autofill.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Audit-log "Actor" filter no longer offers credential autofill.** The field
+  is now `autocomplete="off"` like the other admin filter inputs. A site-wide
+  default was also added (`app.js`): forms that don't opt into autocomplete and
+  carry no password field now default to `autocomplete="off"`, so stray
+  username/password autofill prompts stop appearing on non-credential forms
+  across the app. Login/register/admin-secret forms opt their fields in
+  explicitly and are unaffected.
+
+### Changed
+
+- **Assignment editor: "Add Support File" and "Add Input" moved above their
+  tables.** Both now sit in a header bar beside a heading ("Files" /
+  "Global Inputs"), mirroring the Test Suite section header, instead of being a
+  trailing table row — which also frees two rows from the table area. The
+  Global Inputs table drops its redundant "Global input" label column so the
+  value field gets that horizontal space.


### PR DESCRIPTION
A batch of small UI follow-ups after the big UI pass, all on
`claude/intelligent-newton-Dastm`. Template/CSS/JS only — no Swift changes.

## 1. Student-dashboard assignment table (the `/` view)

- **Status badge: "staff only" → "preview", single line.** It wrapped to two
  lines in the narrow Status column. Renamed to "preview" (the underlying
  visibility state) and added `.staff-only-tag { white-space: nowrap; }`. The
  descriptive hover tooltip is unchanged.
- **Actions cell on one line.** `.assignment-actions-cell` used
  `flex-wrap: wrap`; switched to `nowrap` + `align-items: center`, matching the
  `.row-actions-tight` layout the instructor (`/instructor`) view already uses.

## 2. Audit log — stray credential autofill

- The `/admin/audit` "Actor contains" filter offered username/password autofill
  (`name="actor"`, placeholder "username"). Added `autocomplete="off"`, matching
  the other admin filter inputs.
- **Site-wide default** (answering "can we make this default somehow?"):
  `app.js` now sets `autocomplete="off"` on every form that hasn't opted in and
  carries no password field. Credential forms (login, register, admin
  worker-secret) opt their inputs in explicitly, and an input-level
  `autocomplete` overrides the form-level default per the HTML spec, so their
  password managers are unaffected.

## 3. Assignment editor (`/instructor/:id/edit`, mirrored to `/new`)

- **"Add Support File" and "Add Input" moved above their tables.** Both now sit
  in a header bar beside a heading ("Files" / "Global Inputs"), mirroring the
  Test Suite section header, instead of being a trailing table row — which frees
  two rows from the table area.
- **Global Inputs drops its redundant "Global input" label column**, giving the
  value field that horizontal space.
- Generalized the `.suite-editor-head` CSS class to `.editor-block-head` (now
  shared by the Files, Global Inputs, and Test Suite headers) and updated the
  global-inputs row-builder JS to match the new columns.

## Verification

- `scripts/check-styles.sh` and `scripts/check-css-vars.sh` pass.
- All 24 browser JS tests pass (`node --test Tests/BrowserRunnerJSTests/*.mjs`).
- No tests assert on the changed markup; render tests assert pages render.

https://claude.ai/code/session_016pkUQqvuYp8FQsCA4KNLP6