### PR TITLE
feat(pattern-families): auto-existence guards (test-suite rework, Phase 1)

### DIFF
--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -235,7 +235,11 @@ private func testSuiteEntryToDict(_ entry: ConfiguredSuiteEntry) -> [String: Any
     if !entry.dependsOn.isEmpty {
         dict["dependsOn"] = entry.dependsOn
     }
-    if entry.points > 1 {
+    // Emit any non-default points value — including 0.  The decoder
+    // defaults a missing key to 1, so a 0-point entry (e.g. an existence
+    // guard, which gates rather than grades) must be written explicitly or
+    // it round-trips back to 1 and starts counting toward the score.
+    if entry.points != 1 {
         dict["points"] = entry.points
     }
     if let fid = entry.generatedBy, !fid.isEmpty {

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -468,11 +468,20 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
 
     var renderedByFilename: [String: GeneratedScript] = [:]
     for family in nextFamilies {
+        let sv = sectionVars(forFamily: family.id)
         for generated in renderPatternFamily(
-            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables,
+            family, sectionVariables: sv, globalVariables: resolvedGlobalVariables,
             perStudentNames: perStudentExpressionNames)
         {
             renderedByFilename[generated.filename] = generated
+        }
+        // Auto-existence guard (function-calling kinds): one extra generated
+        // file per family that every case depends on.  nil for
+        // `.variableEquality` / no-enabled-cases families.
+        if let guardScript = existenceGuard(
+            for: family, sectionVariables: sv, globalVariables: resolvedGlobalVariables)
+        {
+            renderedByFilename[guardScript.filename] = guardScript
         }
     }
     // Render notebook checks alongside pattern families so a single zip
@@ -607,6 +616,65 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     var emittedFamilyIDs: Set<String> = []
     var emittedCheckIDs: Set<String> = []
 
+    /// Emits a family's generated entries: the existence guard first (for
+    /// function-calling kinds), then one entry per enabled case wired to
+    /// `dependsOn` the guard — so a missing function fails once on the guard
+    /// and the cases auto-skip through the runner's dependency gate.  Shared
+    /// by the authored-order loop and the defensive pass below so the two
+    /// can't drift on the guard wiring.
+    func appendFamilyConfigured(_ family: PatternFamily, familySection: String?) {
+        let inherited = expandDeps(family.dependsOn)
+        let sv = sectionVars(forFamily: family.id)
+        var guardFilename: String?
+        if let guardScript = existenceGuard(
+            for: family, sectionVariables: sv, globalVariables: resolvedGlobalVariables)
+        {
+            order += 1
+            guardFilename = guardScript.filename
+            // The guard inherits the family's own prerequisites; the cases
+            // chain off the guard, so prereqs → guard → cases.
+            newConfigured.append(
+                ConfiguredSuiteEntry(
+                    script: guardScript.filename,
+                    tier: guardScript.tier.rawValue,
+                    order: order,
+                    dependsOn: inherited,
+                    points: guardScript.points,
+                    displayName: guardScript.displayName,
+                    generatedBy: guardScript.familyID,
+                    sectionID: familySection
+                ))
+        }
+        for generated in renderPatternFamily(
+            family, sectionVariables: sv, globalVariables: resolvedGlobalVariables,
+            perStudentNames: perStudentExpressionNames)
+        {
+            order += 1
+            let prior = oldEntryByScript[generated.filename]
+            let perCase = expandDeps(prior?.dependsOn ?? [])
+            var combined: [String] = []
+            var seen = Set<String>()
+            // Guard first so a missing function reports the guard as the
+            // unmet prerequisite; inherited family deps and any preserved
+            // per-case deps follow (deduped).
+            for d in (guardFilename.map { [$0] } ?? []) + inherited + perCase {
+                guard seen.insert(d).inserted else { continue }
+                combined.append(d)
+            }
+            newConfigured.append(
+                ConfiguredSuiteEntry(
+                    script: generated.filename,
+                    tier: generated.tier.rawValue,
+                    order: order,
+                    dependsOn: combined,
+                    points: generated.points,
+                    displayName: generated.displayName,
+                    generatedBy: generated.familyID,
+                    sectionID: familySection
+                ))
+        }
+    }
+
     for item in itemsForOrdering {
         switch item {
         case .script(let s):
@@ -627,32 +695,7 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         case .family(let fid, let familySection):
             guard let family = familyByID[fid], !emittedFamilyIDs.contains(fid) else { continue }
             emittedFamilyIDs.insert(fid)
-            let inherited = expandDeps(family.dependsOn)
-            for generated in renderPatternFamily(
-                family, sectionVariables: sectionVars(forFamily: fid), globalVariables: resolvedGlobalVariables,
-                perStudentNames: perStudentExpressionNames)
-            {
-                order += 1
-                let prior = oldEntryByScript[generated.filename]
-                let perCase = expandDeps(prior?.dependsOn ?? [])
-                var combined: [String] = []
-                var seen = Set<String>()
-                for d in inherited + perCase {
-                    guard seen.insert(d).inserted else { continue }
-                    combined.append(d)
-                }
-                newConfigured.append(
-                    ConfiguredSuiteEntry(
-                        script: generated.filename,
-                        tier: generated.tier.rawValue,
-                        order: order,
-                        dependsOn: combined,
-                        points: generated.points,
-                        displayName: generated.displayName,
-                        generatedBy: generated.familyID,
-                        sectionID: familySection
-                    ))
-            }
+            appendFamilyConfigured(family, familySection: familySection)
 
         case .check(let cid, let checkSection):
             guard let check = checkByID[cid],
@@ -681,32 +724,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
     // `authoredItems` still needs its generated scripts emitted (e.g. if
     // the caller forgot to include a newly added family).
     for family in nextFamilies where !emittedFamilyIDs.contains(family.id) {
-        let inherited = expandDeps(family.dependsOn)
-        for generated in renderPatternFamily(
-            family, sectionVariables: sectionVars(forFamily: family.id), globalVariables: resolvedGlobalVariables,
-            perStudentNames: perStudentExpressionNames)
-        {
-            order += 1
-            let prior = oldEntryByScript[generated.filename]
-            let perCase = expandDeps(prior?.dependsOn ?? [])
-            var combined: [String] = []
-            var seen = Set<String>()
-            for d in inherited + perCase {
-                guard seen.insert(d).inserted else { continue }
-                combined.append(d)
-            }
-            newConfigured.append(
-                ConfiguredSuiteEntry(
-                    script: generated.filename,
-                    tier: generated.tier.rawValue,
-                    order: order,
-                    dependsOn: combined,
-                    points: generated.points,
-                    displayName: generated.displayName,
-                    generatedBy: generated.familyID,
-                    sectionID: nil
-                ))
-        }
+        emittedFamilyIDs.insert(family.id)
+        appendFamilyConfigured(family, familySection: nil)
     }
 
     // Same defensive pass for checks: any check not referenced by

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
@@ -60,13 +60,92 @@ func renderPatternFamily(
 /// Used when diffing old/new specs so we can detect stale files that need
 /// deleting, even for cases that were previously disabled.
 func patternFamilyAllGeneratedFilenames(_ family: PatternFamily) -> [String] {
-    family.cases.map { c in
+    var names = family.cases.map { c in
         generatedScriptFilename(
             familyID: family.id,
             caseKey: c.key,
             tier: c.resolvedTier(defaults: family.defaults)
         )
     }
+    // The auto-existence guard isn't a `case`, but its file is generated for
+    // function-calling kinds — list it here so the diff in
+    // `applyPatternFamilies` deletes a stale guard when the family's default
+    // tier changes, the kind switches to one that doesn't call a function, or
+    // the family is removed, and so the filename-collision checks see it.
+    if patternKindHandler(for: family.kind).requiresFunctionName {
+        names.append(
+            generatedScriptFilename(
+                familyID: family.id,
+                caseKey: patternExistenceGuardCaseKey,
+                tier: family.defaults.tier
+            ))
+    }
+    return names
+}
+
+// MARK: - Existence guard
+
+/// Reserved case key for a family's auto-generated existence guard.  A real
+/// case may not use this key for a function-calling kind (the validator
+/// rejects it), so the guard's deterministic filename
+/// (`{tier}test_{familyID}_exists.py`) can never collide with a case file.
+let patternExistenceGuardCaseKey = "exists"
+
+/// The existence-guard script for `family`, or nil when the family doesn't
+/// call a function (`.variableEquality` already self-guards each case's
+/// variable) or has no enabled cases (nothing to gate).
+///
+/// The guard is a 0-point test that checks the target function is defined and
+/// callable.  Every generated case `dependsOn` it (wired in
+/// `applyPatternFamilies`), so a missing/!callable function produces one clear
+/// "`fn` is not defined" failure and the cases auto-skip through the runner's
+/// dependency gate — instead of N opaque AttributeError tracebacks.  Its tier
+/// follows the family default so the failure is visible at the same level as
+/// the cases it protects.
+func existenceGuard(
+    for family: PatternFamily,
+    sectionVariables: [FamilyVariable] = [],
+    globalVariables: [FamilyVariable] = []
+) -> GeneratedScript? {
+    guard patternKindHandler(for: family.kind).requiresFunctionName,
+        family.cases.contains(where: \.enabled)
+    else { return nil }
+    let hash = patternFamilySpecHash(
+        family, sectionVariables: sectionVariables, globalVariables: globalVariables)
+    let tier = family.defaults.tier
+    let label = "\(family.functionName) is defined"
+    let nameLiteral = "\"" + escapeForPythonStringLiteral(family.functionName) + "\""
+    // Mirrors the `getattr(..., _MISSING)` sentinel that `variableEquality`
+    // (and the function_exists notebook check) already use — `_MISSING`
+    // distinguishes "not defined" from "defined as None"; `callable` catches a
+    // student who shadowed the name with a non-function value.
+    let source = """
+        # Test: \(label)
+        # Generated from pattern family \"\(escapeForPythonStringLiteral(family.name))\" [\(family.id)] spec_hash=\(hash) — edit the family, not this file.
+        # Existence guard: the family's cases depend on this test, so a missing
+        # or non-callable target fails once here and the cases skip instead of
+        # raising N AttributeErrors.
+
+        function_name = \(nameLiteral)
+
+        _MISSING = object()
+        target = getattr(student_module, function_name, _MISSING)
+        if target is _MISSING:
+            failed(f"`{function_name}` is not defined — define a function named `{function_name}` in your submission.")
+        if not callable(target):
+            failed(f"`{function_name}` is defined but is not a function (got {type(target).__name__}).")
+        passed(f"`{function_name}` is defined")
+        """
+    return GeneratedScript(
+        filename: generatedScriptFilename(
+            familyID: family.id, caseKey: patternExistenceGuardCaseKey, tier: tier),
+        source: source,
+        tier: tier,
+        points: 0,
+        displayName: label,
+        caseKey: patternExistenceGuardCaseKey,
+        familyID: family.id
+    )
 }
 
 /// Stable filename for one case.  Format: `{tier}test_{familyID}_{caseKey}.py`.

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -21,6 +21,18 @@ private func validatePatternCaseHeader(
                 "Pattern family '\(family.id)': case key '\(c.key)' must contain only letters, digits, and underscore"
         )
     }
+    // A function-calling family auto-generates an existence guard whose
+    // filename uses `patternExistenceGuardCaseKey`; forbid a real case from
+    // claiming that key so the two can never produce the same filename.
+    if patternKindHandler(for: family.kind).requiresFunctionName,
+        c.key == patternExistenceGuardCaseKey
+    {
+        throw Abort(
+            .unprocessableEntity,
+            reason:
+                "Pattern family '\(family.id)': case key '\(c.key)' is reserved for the auto-generated existence guard; choose a different key."
+        )
+    }
     guard seenCaseKeys.insert(c.key).inserted else {
         throw Abort(
             .unprocessableEntity,

--- a/Tests/APITests/PatternFamilyApplyTests.swift
+++ b/Tests/APITests/PatternFamilyApplyTests.swift
@@ -38,6 +38,9 @@ import Vapor
                     "publictest_bmi_category_01.py",
                     "publictest_bmi_category_02.py",
                     "publictest_bmi_category_03.py",
+                    // Auto-existence guard (Phase 1): one extra generated file
+                    // per function-calling family, that the cases depend on.
+                    "publictest_bmi_category_exists.py",
                 ])
             #expect(result.deletedFiles.isEmpty)
 
@@ -51,10 +54,17 @@ import Vapor
             let props = try pfDecodeManifest(fixture.setup.manifest)
             #expect(props.patternFamilies.count == 1)
             #expect(props.patternFamilies[0].id == "bmi_category")
+            // 3 cases + 1 existence guard, all tagged generatedBy the family.
             let generatedEntries = props.testSuites.filter { $0.generatedBy != nil }
-            #expect(generatedEntries.count == 3)
+            #expect(generatedEntries.count == 4)
             for entry in generatedEntries {
                 #expect(entry.generatedBy == "bmi_category")
+            }
+            // The guard is 0 points and the cases each depend on it.
+            let guardEntry = try #require(generatedEntries.first { $0.script == pfGuardFilename("bmi_category") })
+            #expect(guardEntry.points == 0)
+            for entry in generatedEntries where entry.script != guardEntry.script {
+                #expect(entry.dependsOn.contains(guardEntry.script))
             }
 
         }
@@ -131,8 +141,10 @@ import Vapor
             let props = try pfDecodeManifest(fixture.setup.manifest)
             #expect(props.patternFamilies.count == 1)
             #expect(props.patternFamilies[0].id == "bmi_category")
+            // 3 cases + the existence guard, restored by applyPatternFamilies.
             let generatedEntries = props.testSuites.filter { $0.generatedBy != nil }
-            #expect(generatedEntries.count == 3)
+            #expect(generatedEntries.count == 4)
+            #expect(afterEntries.contains(pfGuardFilename("bmi_category")), "Existence guard restored")
             // Each generated entry's display name must carry the case label so
             // the student result view shows distinct, labelled test rows.
             let names = Set(generatedEntries.compactMap(\.name))
@@ -176,7 +188,9 @@ import Vapor
 
             let result = try await applyPatternFamilies(
                 to: fixture.setup, nextFamilies: [], on: fixture.app.db)
-            #expect(result.deletedFiles.count == 3)
+            // 3 cases + the existence guard all removed.
+            #expect(result.deletedFiles.count == 4)
+            #expect(result.deletedFiles.contains(pfGuardFilename("bmi_category")))
 
             let props = try pfDecodeManifest(fixture.setup.manifest)
             #expect(props.patternFamilies.isEmpty)
@@ -333,10 +347,19 @@ import Vapor
 
             let props = try pfDecodeManifest(fixture.setup.manifest)
             let generated = props.testSuites.filter { $0.generatedBy != nil }
-            #expect(generated.count == 3)
-            for g in generated {
+            // 3 cases + the existence guard.
+            #expect(generated.count == 4)
+            // The guard inherits the family-level dep directly…
+            let guardName = pfGuardFilename("bmi_category")
+            let guardEntry = try #require(generated.first { $0.script == guardName })
+            #expect(
+                guardEntry.dependsOn == ["publictest_prereq.py"],
+                "The existence guard inherits the family-level dependency")
+            // …and every case depends on the guard, then inherits the dep.
+            for g in generated where g.script != guardName {
                 #expect(
-                    g.dependsOn == ["publictest_prereq.py"], "Every generated case must inherit the family-level dep")
+                    g.dependsOn == [guardName, "publictest_prereq.py"],
+                    "Every generated case gates on the guard, then inherits the family-level dep")
             }
 
         }
@@ -523,10 +546,14 @@ import Vapor
                 to: fixture.setup, nextFamilies: [family], on: fixture.app.db)
             let props = try pfDecodeManifest(fixture.setup.manifest)
             let generated = props.testSuites.filter { $0.generatedBy != nil }
-            #expect(generated.count == 3)
-            for entry in generated {
-                #expect(entry.points == 5, "family.defaults.points=5 must propagate to every generated entry")
+            #expect(generated.count == 4)  // 3 cases + existence guard
+            let guardName = pfGuardFilename("bmi_category")
+            for entry in generated where entry.script != guardName {
+                #expect(entry.points == 5, "family.defaults.points=5 must propagate to every generated case")
             }
+            // The guard gates rather than grades — always 0 points, regardless
+            // of the family's points default.
+            #expect(generated.first { $0.script == guardName }?.points == 0)
 
         }
     }
@@ -568,6 +595,8 @@ import Vapor
             #expect(
                 props.testSuites.map(\.script) == [
                     "publictest_a.py",
+                    // Existence guard sorts in just ahead of the cases it gates.
+                    "publictest_bmi_category_exists.py",
                     "publictest_bmi_category_01.py",
                     "publictest_bmi_category_02.py",
                     "publictest_bmi_category_03.py",
@@ -628,6 +657,9 @@ import Vapor
             #expect(
                 props.testSuites.map(\.script) == [
                     "publictest_prereq.py",
+                    // prereq → guard → cases: the guard sits between the
+                    // family's prerequisite and its cases.
+                    "publictest_bmi_category_exists.py",
                     "publictest_bmi_category_01.py",
                     "publictest_bmi_category_02.py",
                     "publictest_bmi_category_03.py",
@@ -699,6 +731,7 @@ import Vapor
             #expect(
                 props.testSuites.map(\.script) == [
                     "publictest_a.py",
+                    "publictest_bmi_category_exists.py",
                     "publictest_bmi_category_01.py",
                     "publictest_bmi_category_02.py",
                     "publictest_bmi_category_03.py",
@@ -780,6 +813,7 @@ import Vapor
             #expect(
                 props.testSuites.map(\.script) == [
                     "publictest_a.py",
+                    "publictest_bmi_category_exists.py",
                     "publictest_bmi_category_01.py",
                     "publictest_bmi_category_02.py",
                     "publictest_bmi_category_03.py",

--- a/Tests/APITests/PatternFamilyExistenceGuardTests.swift
+++ b/Tests/APITests/PatternFamilyExistenceGuardTests.swift
@@ -1,0 +1,172 @@
+// Tests/APITests/PatternFamilyExistenceGuardTests.swift
+//
+// Phase 1: every function-calling pattern family auto-generates one
+// existence guard (`{tier}test_{id}_exists.py`, 0 points) that its cases
+// `dependsOn`.  A missing/non-callable target fails once on the guard and
+// the cases auto-skip through the runner's dependency gate, instead of N
+// opaque AttributeError tracebacks.  `.variableEquality` keeps self-guarding
+// each case, so it gets no guard.
+
+import Core
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct PatternFamilyExistenceGuardTests {
+
+    // MARK: - existenceGuard(for:) shape
+
+    @Test func existenceGuard_isNilForVariableEqualityAndEmptyFamilies() throws {
+        // variableEquality self-guards each case; no separate guard.
+        #expect(existenceGuard(for: pfNotebookVariablesFamily()) == nil)
+
+        // No enabled cases → nothing to gate → nil.
+        let allDisabled = PatternFamily(
+            id: "d", name: "D", kind: .boundaryEquality,
+            functionName: "f", paramNames: ["x"],
+            cases: [
+                PatternCase(
+                    key: "01", label: "a", args: [.int(1)], expected: .int(1), enabled: false)
+            ]
+        )
+        #expect(existenceGuard(for: allDisabled) == nil)
+    }
+
+    @Test func existenceGuard_isZeroPointAndCarriesFamilyDefaultTier() throws {
+        let g = try #require(existenceGuard(for: pfBMIFamily()))
+        #expect(g.points == 0, "the guard gates, it doesn't grade")
+        #expect(g.caseKey == patternExistenceGuardCaseKey)
+        #expect(g.tier == .pub)
+        #expect(g.displayName == "bmi_category is defined")
+        #expect(g.filename == "publictest_bmi_category_exists.py")
+        // First comment line is the student-facing label (test_runtime label picker).
+        #expect(g.source.hasPrefix("# Test: bmi_category is defined\n"))
+        #expect(g.source.contains("spec_hash="))
+    }
+
+    @Test func existenceGuard_followsFamilyDefaultTierIntoFilename() throws {
+        let secretFamily = pfBMIFamily(tier: .secret)
+        let g = try #require(existenceGuard(for: secretFamily))
+        #expect(g.tier == .secret)
+        #expect(g.filename == "secrettest_bmi_category_exists.py")
+    }
+
+    // MARK: - Generated guard actually grades
+
+    @Test func existenceGuard_sourceIsValidPython() throws {
+        let g = try #require(existenceGuard(for: pfBMIFamily()))
+        try pfAssertValidPythonSyntax(g.source, label: "existence guard")
+    }
+
+    @Test func existenceGuard_passesWhenDefinedFailsOtherwise() throws {
+        let body = try #require(existenceGuard(for: pfBMIFamily())).source
+        // Defined + callable → pass.
+        #expect(
+            try pfRunGeneratedCase(
+                body: body, ckInputs: nil,
+                student: "def bmi_category(x):\n    return 'underweight'\n") == .pass)
+        // Not defined → fail (the one clear message; cases would skip).
+        #expect(
+            try pfRunGeneratedCase(
+                body: body, ckInputs: nil, student: "answer = 1\n") == .fail)
+        // Defined but not callable (shadowed by a value) → fail.
+        #expect(
+            try pfRunGeneratedCase(
+                body: body, ckInputs: nil, student: "bmi_category = 42\n") == .fail)
+    }
+
+    // MARK: - Validator reserves the guard case key
+
+    @Test func validator_rejectsReservedCaseKeyForFunctionCallingKind() throws {
+        let fam = PatternFamily(
+            id: "f", name: "F", kind: .boundaryEquality,
+            functionName: "f", paramNames: ["x"],
+            cases: [
+                PatternCase(
+                    key: patternExistenceGuardCaseKey, label: "clash",
+                    args: [.int(1)], expected: .int(1))
+            ]
+        )
+        do {
+            try validatePatternFamilies([fam], testSuites: [])
+            Issue.record("Expected the reserved guard case key to be rejected")
+        } catch let abort as AbortError {
+            #expect("\(abort.reason)".contains("reserved"))
+        }
+    }
+
+    @Test func validator_allowsReservedKeyForVariableEquality() throws {
+        // variableEquality has no guard, so the key isn't reserved there.
+        let fam = PatternFamily(
+            id: "v", name: "V", kind: .variableEquality,
+            functionName: "_", paramNames: ["variable"],
+            cases: [
+                PatternCase(
+                    key: patternExistenceGuardCaseKey, label: "exists var",
+                    args: [.string("answer")], expected: .int(42))
+            ]
+        )
+        try validatePatternFamilies([fam], testSuites: [])
+    }
+
+    // MARK: - Apply wiring
+
+    // These apply-path assertions read the call's own return value
+    // (`result.manifestAfter` / `.writtenFiles`) rather than re-reading
+    // `fixture.setup.manifest`, so they're immune to the shared in-memory
+    // SQLite identity-map contamination that can cross-pollinate the setup
+    // object under heavy parallel local runs (CI uses per-schema Postgres).
+
+    @Test func apply_variableEqualityFamilyHasNoGuardEntry() async throws {
+        try await withPatternFamilyFixture { fixture in
+            let result = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfNotebookVariablesFamily()], on: fixture.app.db)
+            let props = try pfDecodeManifest(result.manifestAfter)
+            let generated = props.testSuites.filter { $0.generatedBy != nil }
+            #expect(generated.count == 2, "variableEquality self-guards; no extra guard entry")
+            #expect(generated.allSatisfy { !$0.script.hasSuffix("_exists.py") })
+        }
+    }
+
+    @Test func apply_approximateEqualityFamilyGetsGuard() async throws {
+        try await withPatternFamilyFixture { fixture in
+            let result = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfApproxFamily()], on: fixture.app.db)
+            let guardName = pfGuardFilename("bmi_kg_m2")
+            // Guard file written to the zip.
+            #expect(result.writtenFiles.contains(guardName))
+            let props = try pfDecodeManifest(result.manifestAfter)
+            let guardEntry = try #require(props.testSuites.first { $0.script == guardName })
+            #expect(guardEntry.generatedBy == "bmi_kg_m2")
+            #expect(guardEntry.points == 0)
+            // Both cases depend on the guard.
+            let cases = props.testSuites.filter { $0.generatedBy == "bmi_kg_m2" && $0.script != guardName }
+            #expect(cases.count == 2)
+            #expect(cases.allSatisfy { $0.dependsOn.contains(guardName) })
+        }
+    }
+
+    // MARK: - Author-view round-trip (guard stays invisible)
+
+    /// The guard is a generated entry tagged `generatedBy` the family, so
+    /// `buildSuitePayload` collapses it into the single family row — it must
+    /// never surface as its own editor row, and the family row's `dependsOn`
+    /// stays the authored family-level list (no internal guard edge).
+    @Test func buildSuitePayload_collapsesGuardIntoFamilyRow() async throws {
+        try await withPatternFamilyFixture { fixture in
+            let result = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfBMIFamily()], on: fixture.app.db)
+
+            let payload = buildSuitePayload(fromManifest: result.manifestAfter)
+            #expect(payload.items.count == 1, "guard collapses into the family row — no extra item")
+            let family = try #require(payload.items.first)
+            #expect(family.kind == "family")
+            #expect(family.family?.id == "bmi_category")
+            #expect((family.dependsOn ?? []).isEmpty, "family row keeps the authored (empty) deps, not the guard edge")
+            // The guard never leaks as a script row.
+            #expect(payload.items.allSatisfy { $0.script?.script != pfGuardFilename("bmi_category") })
+        }
+    }
+}

--- a/Tests/APITests/PatternFamilyFixtures.swift
+++ b/Tests/APITests/PatternFamilyFixtures.swift
@@ -182,6 +182,14 @@ func pfDecodeManifest(_ json: String) throws -> TestProperties {
     try JSONDecoder().decode(TestProperties.self, from: Data(json.utf8))
 }
 
+/// Deterministic filename of a function-calling family's auto-existence
+/// guard (Phase 1).  Mirrors `existenceGuard` / `generatedScriptFilename`,
+/// so order/diff assertions can reference the guard without hard-coding the
+/// `_exists` convention in every test.
+func pfGuardFilename(_ familyID: String, tier: TestTier = .pub) -> String {
+    generatedScriptFilename(familyID: familyID, caseKey: patternExistenceGuardCaseKey, tier: tier)
+}
+
 func pfAssertValidPythonSyntax(_ source: String, label: String) throws {
     let p = Process()
     p.executableURL = URL(fileURLWithPath: "/usr/bin/env")

--- a/Tests/APITests/PatternFamilySectionsTests.swift
+++ b/Tests/APITests/PatternFamilySectionsTests.swift
@@ -192,13 +192,13 @@ import Vapor
 
             // Per-entry sectionID survives:
             //   - publictest_a.py was authored in the section
-            //   - bmi_category's three generated entries were too
+            //   - bmi_category's existence guard + three generated entries were too
             //   - df_shape's generated entry was too
             //   - publictest_b.py was authored ungrouped → sectionID nil
             let bySection = Dictionary(grouping: props.testSuites, by: { $0.sectionID })
             #expect(
-                bySection[sectionID]?.count ?? 0 == 5,
-                "Five entries must keep sectionID=\(sectionID): publictest_a.py + 3 generated bmi_category + 1 generated df_shape; got: \(props.testSuites.map { "\($0.script)→\($0.sectionID ?? "nil")" })"
+                bySection[sectionID]?.count ?? 0 == 6,
+                "Six entries must keep sectionID=\(sectionID): publictest_a.py + bmi_category guard + 3 generated bmi_category + 1 generated df_shape; got: \(props.testSuites.map { "\($0.script)→\($0.sectionID ?? "nil")" })"
             )
             #expect(
                 bySection[nil]?.map(\.script) == ["publictest_b.py"],

--- a/Tests/APITests/SuiteRouteTests.swift
+++ b/Tests/APITests/SuiteRouteTests.swift
@@ -470,10 +470,13 @@ import XCTVapor
             let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
             let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
             let generated = props.testSuites.filter { $0.generatedBy != nil }
-            #expect(generated.count == 2)
-            for entry in generated {
+            // 2 cases + the auto-existence guard.
+            #expect(generated.count == 3)
+            // family.defaults.points applies to each case; the guard gates at 0.
+            for entry in generated where !entry.script.hasSuffix("_exists.py") {
                 #expect(entry.points == 3)
             }
+            #expect(generated.first { $0.script.hasSuffix("_exists.py") }?.points == 0)
 
         }
     }

--- a/changelog.d/pattern-family-existence-guards.md
+++ b/changelog.d/pattern-family-existence-guards.md
@@ -1,0 +1,21 @@
+### Added
+
+- **Automatic existence guards for pattern families.** Every function-calling
+  pattern family (`boundary_equality`, `approximate_equality`,
+  `return_type_check`, `exception_expected`, `performance_threshold`,
+  `stdout_equality`, `unordered_equality`) now auto-generates one 0-point
+  `… is defined` guard test; its cases `dependsOn` the guard, so a missing or
+  non-callable target produces a single clear "`fn` is not defined" failure and
+  the cases auto-skip through the runner's dependency gate — instead of N opaque
+  `AttributeError` tracebacks. `variable_equality` is unchanged (it already
+  self-guards each case). The guard is internal: it collapses into the family
+  row in the suite editor and is reserved against the case key `exists`. No
+  runner changes — the guard is an ordinary generated test and the gating reuses
+  the existing `dependsOn` machinery.
+
+### Fixed
+
+- **0-point test entries now round-trip.** `makeWorkerManifestJSON` only
+  serialized `points` when greater than 1, so a 0-point entry decoded back to
+  the default of 1 and silently started counting toward the score. Any non-1
+  value (including 0) is now written explicitly.


### PR DESCRIPTION
## What & why

Phase 1 of the test-suite UI rework. Today a function-calling pattern family that targets a function the student never defined produces **N opaque `AttributeError` tracebacks** — one per case. This makes every such family auto-guard the target's existence, so a missing/non-callable function fails **once** with a clear message and the cases auto-skip.

Decisions confirmed with @JimWallace before implementing:
- **One result, rest skip** — a single existence guard per target; dependents skip via the existing dependency gate.
- (Phases 2–3, not in this PR: hoist the type-picker onto a "+ Add Test" dropdown; inline accordion editing of family/check params; MCP doc sync + polish.)

## How it works

- Every function-calling kind (`boundary_equality`, `approximate_equality`, `return_type_check`, `exception_expected`, `performance_threshold`, `stdout_equality`, `unordered_equality`) gets one generated **`<fn> is defined`** guard — `{tier}test_{id}_exists.py`, **0 points**, family-default tier — and each case `dependsOn` it.
- `variable_equality` is unchanged; it already self-guards each case with the same `getattr(_MISSING)` sentinel this guard reuses.
- When the target is missing the student sees **one** `` `fn` is not defined `` failure and the cases render as *skipped* (`"Skipped: prerequisite '…' did not pass"`), via the gate in `RunnerCore/SuiteExecution.swift`.

The guard is internal:
- shares the family's `generatedBy` tag, so `buildSuitePayload` collapses it into the single family row (no extra editor row, no leaked dependency edge);
- the case key `exists` is reserved by the validator for function-calling kinds;
- `patternFamilyAllGeneratedFilenames` lists it so stale guards are cleaned up on tier/kind change or family removal.

The two `.family` emit sites (authored-order loop + defensive pass) are deduplicated into a shared `appendFamilyConfigured` helper so they can't drift on the guard wiring.

## No runner changes

The guard is an ordinary generated `.py`; the "skip the rest" behaviour reuses the `dependsOn` gate already pinned by `Tests/Fixtures/dependency-skip-message.json` / `output-contract.json`. `RunnerCore` is untouched, so the vendored wasm and the parity contract don't move. MCP authoring benefits automatically (shared `applyPatternFamilies`).

## Bug fixed along the way

`makeWorkerManifestJSON` only serialized `points` when `> 1`, so a **0-point entry round-tripped back to 1** (the decode default) and started counting toward the score. Any non-1 value (including 0) is now written explicitly — required for the 0-point guard.

## Rollout

Existing assignments gain guards only when their manifest is next re-rendered (any suite save re-runs `applyPatternFamilies`), so there's **no deploy-time mass-retest**. For a student who *did* define the function there's one extra passing `<fn> is defined` row (Phase 3 will auto-hide passing guards). Scores are unaffected (guard = 0 pts; skips already count as `fail`).

## Tests

- New `PatternFamilyExistenceGuardTests`: guard shape (nil for `variable_equality` / empty families, 0 pts, tier→filename), the generated guard **actually grades** via real `python3` (pass / not-defined / non-callable), validator reserves the case key, apply wiring (cases depend on guard; `variable_equality` gets none), and the `buildSuitePayload` collapse round-trip.
- Updated the existing apply/section/suite-route fixtures for the +1 guard entry and the 0-point guard.
- Full `APITests` green (the only failures were pre-existing local-SQLite parallel flakiness, confirmed passing in isolation). `swift-format` + SwiftLint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WzW6mPdV47HcwBjoSMrQr8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzW6mPdV47HcwBjoSMrQr8)_