### PR TITLE
feat(suite-editor): "+ Add Test" dropdown + inline notebook-check editing (Phase 2a/2b)

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1438,6 +1438,48 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 }
 .popup-anchor { position: relative; }
 
+/* "+ Add Test" type dropdown (built from the Test Editor catalog by
+   test-editor-modal.js).  Reuses the .add-section-popup chrome; this class
+   owns the anchored position + the grouped-menu internal layout. */
+.add-test-menu {
+    position: absolute;
+    z-index: 100;
+    top: 100%;
+    right: 0;
+    margin-top: .25rem;
+    padding: .4rem;
+    min-width: 17rem;
+    max-height: 60vh;
+    overflow-y: auto;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, .15);
+}
+.add-test-details[open] .add-test-menu { display: block; }
+.add-test-group { padding: .15rem 0; }
+.add-test-group + .add-test-group { border-top: 1px solid var(--border); margin-top: .15rem; }
+.add-test-group-label {
+    font-size: .68rem;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+    color: var(--gray-500);
+    padding: .3rem .5rem .15rem;
+}
+.add-test-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    border-radius: .3rem;
+    padding: .35rem .5rem;
+    font-size: .85rem;
+    color: var(--gray-900);
+    cursor: pointer;
+}
+.add-test-item:hover, .add-test-item:focus {
+    background: var(--gray-100);
+    outline: none;
+}
+
 /* A suite section block: header bar, view/edit modes, per-section toolbars. */
 .section-block { margin-bottom: 1.25rem; }
 .section-header {

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1480,6 +1480,25 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     outline: none;
 }
 
+/* Inline test editor (accordion) hosted in a detail row under a suite row. */
+.suite-row-expanded > td { background: var(--gray-100); }
+.suite-detail-row > td {
+    padding: .75rem 1rem 1rem;
+    background: var(--gray-100);
+    border-top: none;
+}
+.suite-detail-host { display: flex; flex-direction: column; gap: .5rem; }
+.suite-detail-actions {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    margin-top: .75rem;
+    padding-top: .6rem;
+    border-top: 1px solid var(--border);
+}
+.suite-detail-status { font-size: .8rem; }
+.suite-detail-status-error { color: var(--red); }
+
 /* A suite section block: header bar, view/edit modes, per-section toolbars. */
 .section-block { margin-bottom: 1.25rem; }
 .section-header {

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -314,8 +314,12 @@
                 +     '<span class="card-meta" style="font-size:.72rem">' + escHtml(kind || 'notebook check') + '</span>'
                 +   '</div>'
                 + '</div></td>'
-                + '<td><span class="card-meta" style="font-size:.8rem">' + escHtml(tier) + '</span></td>'
-                + '<td><span class="card-meta" style="font-size:.8rem">' + points + '</span></td>'
+                + '<td><select class="form-input suite-check-tier" style="padding:.25rem .5rem;font-size:.8rem">'
+                +   ['public','secret','release'].map(function (t) {
+                        return '<option value="' + t + '"' + (t === tier ? ' selected' : '') + '>' + t + '</option>';
+                    }).join('')
+                + '</select></td>'
+                + '<td><input type="number" class="form-input suite-check-points" min="0" max="100" value="' + points + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
                 + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
                 +   '<button class="btn action-btn check-edit-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Edit notebook check" aria-label="Edit notebook check" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>'
                 +   '<button class="btn action-btn action-danger check-delete-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Delete notebook check" aria-label="Delete notebook check" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>'
@@ -360,11 +364,23 @@
             }
         }
 
+        // ── Inline editor (accordion) state ──
+        // Only one inline editor is open at a time (the family/check renderers
+        // are singletons). `renderSuspended` gates renderTree while it's open so
+        // a debounced PUT response can't wipe the open detail row.
+        var expandedDetail = null;   // { rowID, mechanism, renderer, detailRow }
+        var renderSuspended = false;
+        var renderPendingFlag = false;
+
         /// Write rows into every server-rendered tbody.  Items without a
         /// sectionID (or with a stale one) land in the Ungrouped tbody
         /// (data-section-id=""), which the server always renders when any
         /// item is ungrouped.
         function renderTree() {
+            // While an inline editor (accordion) is open, defer re-rendering the
+            // tbodies — an innerHTML rebuild would wipe the open detail row
+            // mid-edit. The deferred render runs when the editor collapses.
+            if (renderSuspended) { renderPendingFlag = true; return; }
             var focusSnap = captureFocus();
             var tbodies = container.querySelectorAll('tbody[data-section-id]');
             var bySection = {};
@@ -402,6 +418,152 @@
             }
             restoreFocus(focusSnap);
         }
+
+        // ── Inline editor (accordion) open/close ──
+
+        /// ctx handed to a renderer hosted inline. Mirrors the modal's ctx so
+        /// the same family/check renderers work in either host.
+        function inlineCtx(sectionID) {
+            return {
+                csrfToken: csrfToken,
+                getSectionID: function () { return sectionID || null; },
+                setStatus: function () {},
+                extractErrorMessage: extractErrorMessage
+            };
+        }
+
+        /// Tear down the open inline editor: cleanup the renderer, remove the
+        /// detail row, un-suspend renderTree, and flush any deferred render.
+        function collapseInlineEditor() {
+            var d = expandedDetail;
+            if (!d) return;
+            expandedDetail = null;
+            if (d.renderer && typeof d.renderer.cleanup === 'function') {
+                try { d.renderer.cleanup(); } catch (e) { /* ignore */ }
+            }
+            if (d.detailRow && d.detailRow.parentNode) {
+                d.detailRow.parentNode.removeChild(d.detailRow);
+            }
+            if (d.rowID) {
+                var pr = container.querySelector('tr[data-id="' + d.rowID.replace(/"/g, '\\"') + '"]');
+                if (pr) pr.classList.remove('suite-row-expanded');
+            }
+            renderSuspended = false;
+            if (renderPendingFlag) { renderPendingFlag = false; renderTree(); }
+        }
+
+        /// Open an inline editor for a family/check — either editing an existing
+        /// item (opts.editing.item + opts.afterRowID) or authoring a new one
+        /// (opts.kind, appended to the section's tbody). Hosts the singleton
+        /// renderer in a detail row with Save/Cancel; persistence flows through
+        /// the renderer's persistAndSync (the same PUT /suite path the modal
+        /// used). Custom scripts still use the modal.
+        function expandInlineEditor(opts) {
+            opts = opts || {};
+            var renderer = (window.ChickadeeTestRenderers || {})[opts.mechanism];
+            if (!renderer) { alert('This test type is unavailable — reload the page.'); return; }
+
+            // Toggle off when re-clicking the row that's already open.
+            if (opts.afterRowID && expandedDetail && expandedDetail.rowID === opts.afterRowID) {
+                collapseInlineEditor();
+                return;
+            }
+            collapseInlineEditor();
+
+            var tr = document.createElement('tr');
+            tr.className = 'suite-detail-row';
+            var td = document.createElement('td');
+            td.setAttribute('colspan', '4');
+            var host = document.createElement('div');
+            host.className = 'suite-detail-host';
+            var actions = document.createElement('div');
+            actions.className = 'suite-detail-actions';
+            var saveBtn = document.createElement('button');
+            saveBtn.type = 'button';
+            saveBtn.className = 'btn btn-primary btn-compact';
+            saveBtn.textContent = 'Save';
+            var cancelBtn = document.createElement('button');
+            cancelBtn.type = 'button';
+            cancelBtn.className = 'btn btn-compact';
+            cancelBtn.textContent = 'Cancel';
+            var status = document.createElement('span');
+            status.className = 'suite-detail-status card-meta';
+            actions.appendChild(saveBtn);
+            actions.appendChild(cancelBtn);
+            actions.appendChild(status);
+            td.appendChild(host);
+            td.appendChild(actions);
+            tr.appendChild(td);
+
+            var parentRow = opts.afterRowID
+                ? container.querySelector('tr[data-id="' + opts.afterRowID.replace(/"/g, '\\"') + '"]')
+                : null;
+            if (parentRow) {
+                parentRow.parentNode.insertBefore(tr, parentRow.nextSibling);
+                parentRow.classList.add('suite-row-expanded');
+            } else {
+                var sidSel = (opts.sectionID || '').replace(/"/g, '\\"');
+                var tb = container.querySelector('tbody[data-section-id="' + sidSel + '"]')
+                    || container.querySelector('tbody[data-section-id=""]')
+                    || container.querySelector('tbody');
+                if (!tb) { alert('No section to add this test to.'); return; }
+                var rootDrop = tb.querySelector('.suite-root-drop');
+                if (rootDrop) tb.insertBefore(tr, rootDrop); else tb.appendChild(tr);
+            }
+
+            renderSuspended = true;
+            window.__chickadeeTargetSection = opts.sectionID || null;
+            var ctx = inlineCtx(opts.sectionID);
+            expandedDetail = {
+                rowID: opts.afterRowID || null,
+                mechanism: opts.mechanism,
+                renderer: renderer,
+                detailRow: tr
+            };
+
+            try {
+                renderer.mount(host, ctx);
+                if (opts.editing && opts.editing.item) renderer.populate(opts.editing.item, ctx);
+                else renderer.reset(opts.kind, ctx);
+            } catch (e) {
+                status.textContent = 'Could not open editor: ' + ((e && e.message) ? e.message : e);
+            }
+
+            saveBtn.addEventListener('click', function () {
+                var spec;
+                try { spec = renderer.readSpec(); }
+                catch (err) {
+                    status.textContent = (err && err.message) ? err.message : String(err);
+                    status.classList.add('suite-detail-status-error');
+                    return;
+                }
+                status.textContent = 'Saving…';
+                status.classList.remove('suite-detail-status-error');
+                saveBtn.disabled = true;
+                renderer.persistAndSync(spec)
+                    .then(function () { collapseInlineEditor(); })
+                    .catch(function (err) {
+                        status.textContent = 'Save failed — ' + ((err && err.message) ? err.message : err);
+                        status.classList.add('suite-detail-status-error');
+                        saveBtn.disabled = false;
+                    });
+            });
+            cancelBtn.addEventListener('click', collapseInlineEditor);
+
+            if (tr.scrollIntoView) tr.scrollIntoView({ block: 'nearest' });
+        }
+
+        /// Entry point for the "+ Add Test" dropdown to author a NEW inline test
+        /// (no parent row yet). Exposed as a window global so the Test Editor
+        /// modal's dropdown can route family/check picks here.
+        function addInlineTest(mechanism, kind, sectionID) {
+            expandInlineEditor({ mechanism: mechanism, kind: kind, sectionID: sectionID || null, afterRowID: null });
+        }
+        window.chickadeeAddInlineTest = addInlineTest;
+        // Let the modal close any open inline editor before it opens, so the two
+        // hosts never run simultaneously (the renderSuspended guard would
+        // otherwise defer the modal's save render until the inline one closes).
+        window.chickadeeCollapseInlineEditor = collapseInlineEditor;
 
         // ── Persistence (items only; sections go through dedicated endpoints) ──
 
@@ -862,6 +1024,19 @@
                 if (ptsElF)  nextDefaults.points = Math.max(0, parseInt(ptsElF.value) || 0);
                 fitem.family = Object.assign({}, fitem.family, { defaults: nextDefaults });
                 schedulePush();
+                return;
+            }
+            var checkRow = e.target.closest && e.target.closest('tr[data-kind="check"]');
+            if (checkRow) {
+                var citem = findByID(checkRow.getAttribute('data-id'));
+                if (!citem || !citem.check) return;
+                var tierElC = checkRow.querySelector('.suite-check-tier');
+                var ptsElC  = checkRow.querySelector('.suite-check-points');
+                var nextCheck = Object.assign({}, citem.check);
+                if (tierElC) nextCheck.tier = tierElC.value;
+                if (ptsElC)  nextCheck.points = Math.max(0, parseInt(ptsElC.value) || 0);
+                citem.check = nextCheck;
+                schedulePush();
             }
         });
 
@@ -893,9 +1068,13 @@
                 if (!row) return;
                 var cid = row.getAttribute('data-check-id');
                 var item = findByID('check:' + cid);
-                if (!item || !window.__chickadeeTestEditorModal) return;
-                window.__chickadeeTestEditorModal.open(
-                    { editing: { mechanism: 'check', id: cid, item: item.check } });
+                if (!item) return;
+                expandInlineEditor({
+                    mechanism: 'check',
+                    editing: { item: item.check },
+                    sectionID: item.sectionID || null,
+                    afterRowID: item.id
+                });
                 return;
             }
             var delBtn = e.target.closest && e.target.closest('.check-delete-btn');

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -77,7 +77,7 @@
         }
         function tbodyForSection(sid) {
             var selector = sid
-                ? 'tbody[data-section-id="' + sid.replace(/"/g, '\\"') + '"]'
+                ? 'tbody[data-section-id="' + cssAttrEscape(sid) + '"]'
                 : 'tbody[data-section-id=""]';
             return container.querySelector(selector);
         }
@@ -354,7 +354,7 @@
 
         function restoreFocus(snap) {
             if (!snap) return;
-            var row = container.querySelector('tr[data-id="' + snap.dataID.replace(/"/g, '\\"') + '"]');
+            var row = container.querySelector('tr[data-id="' + cssAttrEscape(snap.dataID) + '"]');
             if (!row) return;
             var el = row.querySelector('.' + snap.cls);
             if (!el) return;
@@ -371,6 +371,13 @@
         var expandedDetail = null;   // { rowID, mechanism, renderer, detailRow }
         var renderSuspended = false;
         var renderPendingFlag = false;
+
+        /// Escape a value for safe interpolation inside a double-quoted CSS
+        /// attribute selector — backslash first, then double-quote (closes
+        /// CodeQL js/incomplete-sanitization on the [data-*="…"] lookups).
+        function cssAttrEscape(v) {
+            return String(v == null ? '' : v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        }
 
         /// Write rows into every server-rendered tbody.  Items without a
         /// sectionID (or with a stale one) land in the Ungrouped tbody
@@ -445,7 +452,7 @@
                 d.detailRow.parentNode.removeChild(d.detailRow);
             }
             if (d.rowID) {
-                var pr = container.querySelector('tr[data-id="' + d.rowID.replace(/"/g, '\\"') + '"]');
+                var pr = container.querySelector('tr[data-id="' + cssAttrEscape(d.rowID) + '"]');
                 if (pr) pr.classList.remove('suite-row-expanded');
             }
             renderSuspended = false;
@@ -496,13 +503,13 @@
             tr.appendChild(td);
 
             var parentRow = opts.afterRowID
-                ? container.querySelector('tr[data-id="' + opts.afterRowID.replace(/"/g, '\\"') + '"]')
+                ? container.querySelector('tr[data-id="' + cssAttrEscape(opts.afterRowID) + '"]')
                 : null;
             if (parentRow) {
                 parentRow.parentNode.insertBefore(tr, parentRow.nextSibling);
                 parentRow.classList.add('suite-row-expanded');
             } else {
-                var sidSel = (opts.sectionID || '').replace(/"/g, '\\"');
+                var sidSel = cssAttrEscape(opts.sectionID || '');
                 var tb = container.querySelector('tbody[data-section-id="' + sidSel + '"]')
                     || container.querySelector('tbody[data-section-id=""]')
                     || container.querySelector('tbody');
@@ -882,7 +889,7 @@
                 if (!overBlock) return;
                 var overSid = overBlock.getAttribute('data-section-id');
                 if (!overSid || overSid === dragSectionID) return;
-                var draggedBlock = container.querySelector('.section-block[data-section-id="' + dragSectionID.replace(/"/g, '\\"') + '"]');
+                var draggedBlock = container.querySelector('.section-block[data-section-id="' + cssAttrEscape(dragSectionID) + '"]');
                 if (!draggedBlock) return;
                 var brect = overBlock.getBoundingClientRect();
                 var afterBlock = e.clientY > brect.top + brect.height / 2;

--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -294,14 +294,17 @@
                 || (editingItem && editingItem.item && editingItem.item.kind)
                 || (mechanism === 'script' ? 'script' : typeSelect.value);
 
-            // Editing fixes the type; creating lets the instructor switch it.
-            typeRow.style.display = editingItem ? 'none' : 'flex';
+            // The in-modal type picker is now only a fallback: the "+ Add Test"
+            // dropdown picks the type before opening (`presetType`), and editing
+            // fixes it. Either way the row is hidden so there's no redundant
+            // second picker.
+            typeRow.style.display = (editingItem || opts.presetType) ? 'none' : 'flex';
             setStatus('', 'info');
             if (typeSelect.value !== kind) typeSelect.value = kind;
             refreshDescription();
             enterMode(mechanism, kind);
             overlay.style.display = 'flex';
-            setTimeout(function () { if (!editingItem) typeSelect.focus(); }, 0);
+            setTimeout(function () { if (!editingItem && !opts.presetType) typeSelect.focus(); }, 0);
         }
 
         function close() {
@@ -347,15 +350,71 @@
             if (e.key === 'Escape' && overlay.style.display !== 'none') close();
         });
 
-        // Per-section "+ Add Test" buttons (body-level delegation, same flag
-        // the legacy dispatcher used so downstream placement is unchanged).
+        // ── "+ Add Test" dropdown ──────────────────────────────────────────
+        // Each server-rendered `.section-add-test-btn` is upgraded in place to a
+        // <details> dropdown whose menu is the instructor-facing catalog,
+        // grouped. Picking a type stashes the target section and opens the modal
+        // already in that type (`presetType`) — no redundant picker inside the
+        // modal. (The catalog lives here in JS, so the menu is built client-side
+        // rather than templated; sections are added via full-page reload, so a
+        // one-time upgrade at init covers every button.)
+        function addTestMenuHTML() {
+            return CATALOG.map(function (g) {
+                var items = g.items.map(function (it) {
+                    return '<button type="button" class="add-test-item" data-kind="'
+                        + escAttr(it.value) + '" data-mechanism="' + escAttr(it.mechanism)
+                        + '">' + escHtml(it.label) + '</button>';
+                }).join('');
+                return '<div class="add-test-group"><div class="add-test-group-label">'
+                    + escHtml(g.group) + '</div>' + items + '</div>';
+            }).join('');
+        }
+
+        function enhanceAddTestButtons() {
+            var btns = document.querySelectorAll('.section-add-test-btn');
+            for (var i = 0; i < btns.length; i++) {
+                var btn = btns[i];
+                if (!btn.parentNode) continue;
+                var sid = btn.getAttribute('data-section-id') || '';
+                var details = document.createElement('details');
+                details.className = 'add-section-details popup-anchor add-test-details';
+                var summary = document.createElement('summary');
+                summary.className = 'btn action-btn btn-xs summary-btn';
+                summary.textContent = '+ Add Test';
+                var menu = document.createElement('div');
+                menu.className = 'add-section-popup add-test-menu';
+                menu.setAttribute('data-section-id', sid);
+                menu.innerHTML = addTestMenuHTML();
+                details.appendChild(summary);
+                details.appendChild(menu);
+                btn.parentNode.replaceChild(details, btn);
+            }
+        }
+        enhanceAddTestButtons();
+
+        // Menu item → open the modal in the chosen type, for the menu's section.
         document.body.addEventListener('click', function (e) {
-            var btn = e.target && e.target.closest && e.target.closest('.section-add-test-btn');
-            if (!btn) return;
+            var item = e.target && e.target.closest && e.target.closest('.add-test-item');
+            if (!item) return;
             e.preventDefault();
-            var sid = btn.getAttribute('data-section-id') || '';
+            var menu = item.closest('.add-test-menu');
+            var sid = menu ? (menu.getAttribute('data-section-id') || '') : '';
+            var details = item.closest('details');
+            if (details) details.open = false;
             global.__chickadeeTargetSection = sid || null;
-            open({});
+            open({
+                mechanism: item.getAttribute('data-mechanism'),
+                kind: item.getAttribute('data-kind'),
+                presetType: true
+            });
+        });
+
+        // Dismiss an open "+ Add Test" dropdown on an outside click.
+        document.addEventListener('click', function (e) {
+            var openMenus = document.querySelectorAll('.add-test-details[open]');
+            for (var i = 0; i < openMenus.length; i++) {
+                if (!openMenus[i].contains(e.target)) openMenus[i].open = false;
+            }
         });
 
         var api = { open: open, close: close };

--- a/Public/test-editor-modal.js
+++ b/Public/test-editor-modal.js
@@ -277,6 +277,11 @@
         // ── Open / close ─────────────────────────────────────────────────────
         function open(opts) {
             opts = opts || {};
+            // Close any open inline (accordion) editor first — only one editor
+            // host should be live at a time (the renderers are singletons).
+            if (typeof global.chickadeeCollapseInlineEditor === 'function') {
+                try { global.chickadeeCollapseInlineEditor(); } catch (e) { /* ignore */ }
+            }
             editingItem = opts.editing || null;
             // When editing, the mechanism + kind are authoritative from the
             // edit payload — the type dropdown is hidden and its leftover
@@ -402,11 +407,15 @@
             var details = item.closest('details');
             if (details) details.open = false;
             global.__chickadeeTargetSection = sid || null;
-            open({
-                mechanism: item.getAttribute('data-mechanism'),
-                kind: item.getAttribute('data-kind'),
-                presetType: true
-            });
+            var mechanism = item.getAttribute('data-mechanism');
+            var kind = item.getAttribute('data-kind');
+            // Notebook checks author inline (accordion row); families and custom
+            // scripts still open the modal during the staged rollout.
+            if (mechanism === 'check' && typeof global.chickadeeAddInlineTest === 'function') {
+                global.chickadeeAddInlineTest('check', kind, sid);
+                return;
+            }
+            open({ mechanism: mechanism, kind: kind, presetType: true });
         });
 
         // Dismiss an open "+ Add Test" dropdown on an outside click.

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -474,10 +474,11 @@
     // ── Section inputs JS extracted to Public/section-inputs-editor.js
     //    (loaded above).
     //
-    // Per-section "+ Add Test" buttons (`.section-add-test-btn`) are wired
-    // by the unified Test Editor modal (test-editor-modal.js): a click
-    // stashes `window.__chickadeeTargetSection` and opens the modal, whose
-    // type picker morphs the body to the chosen renderer.
+    // Per-section "+ Add Test" buttons (`.section-add-test-btn`) are upgraded
+    // in place by the unified Test Editor modal (test-editor-modal.js) into a
+    // <details> dropdown of the test-type catalog. Picking a type stashes
+    // `window.__chickadeeTargetSection` and opens the modal already in that
+    // type (no second picker inside the modal).
 })();
 </script>
 <script>

--- a/Resources/Views/assignment-new.leaf
+++ b/Resources/Views/assignment-new.leaf
@@ -633,8 +633,9 @@ Create Assignment
         });
     });
 
-    // Per-section "+ Add Test" buttons (`.section-add-test-btn`) are wired by
-    // the unified Test Editor modal (test-editor-modal.js, loaded below).
+    // Per-section "+ Add Test" buttons (`.section-add-test-btn`) are upgraded
+    // into a test-type dropdown by the unified Test Editor modal
+    // (test-editor-modal.js, loaded below); a pick opens the modal in that type.
 
     // ── Section header view/edit toggle ────────────────────────────────
     document.addEventListener('click', function (e) {


### PR DESCRIPTION
## What & why

Phase 2 of the test-suite UI rework — moving test authoring out of the modal. Two slices on this branch:

### 2a — "+ Add Test" dropdown
The in-modal test-type `<select>` is replaced by a dropdown on each section's **+ Add Test** button (built client-side from the existing catalog; the button is upgraded in place to a `<details>` popup, so **no template structural changes**). Picking a type lands you straight in the right editor.

### 2b — Inline (accordion) editing for notebook checks
Notebook checks now edit **inline** instead of in the modal. Picking a check type from the dropdown, or clicking a check's edit button, expands a detail row beneath it hosting the existing check renderer with **Save/Cancel**. Check rows' **tier/points are now editable inline** too (they were read-only spans, despite the renderer's own note that they're row-edited).

Mechanics (all in `suite-table.js`, reusing the renderer's existing `mount/reset/populate/readSpec/persistAndSync` contract — no renderer changes):
- **Single-open accordion** — one inline editor at a time (the renderers are singletons).
- **`renderSuspended` guard** so `renderTree()` defers tbody rebuilds while an editor is open (a debounced `PUT /suite` response can't wipe it mid-edit); the deferred render runs on collapse / save.
- The check renderer rebuilds on mount and uses no Pyodide, so its detail row is safe to create/destroy per expand.

Routing: the modal collapses any open inline editor before opening (one host at a time). **Families and custom scripts still use the modal** for now.

## What's next (not on this branch)
**2c — families inline.** Deliberately deferred: the family editor *relocates* a singleton `#family-editor-body` element (tearing down its detail row would destroy it) and runs Pyodide for the Expected auto-compute / function scan. It needs body-relocation handling + a browser pass, so I'm holding it until 2a/2b are eyeballed.

## Verification
- `swift build` unaffected (JS/CSS only; Leaf changes are comments). `check-styles` + `check-css-vars` + `node --check` all clean. CI green so far.
- ⚠️ **Browser smoke-test still pending** — no jsdom/browser in this env, and `suite-table.js` is DOM-coupled (can't unit-test the accordion). Please verify on an instructor edit page: **+ Add Test → a check type** opens an inline editor that saves; a check row's **edit** expands/saves inline; **tier/points** edit on the row. This is a behavior change to a working flow, so it wants eyes before merge.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WzW6mPdV47HcwBjoSMrQr8