### PR TITLE
Convert submission-history tables to icon action buttons

### DIFF
--- a/Resources/Views/assignment-student-history.leaf
+++ b/Resources/Views/assignment-student-history.leaf
@@ -30,12 +30,18 @@
             <td><span class="tier">#(row.status)</span></td>
             <td>#(row.submittedAt)</td>
             <td><strong>#(row.gradeText)</strong></td>
-            <td><a href="/submissions/#(row.submissionID)">Open</a></td>
             <td>
-                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
+                <a class="btn action-btn action-btn-icon" href="/submissions/#(row.submissionID)" title="View results" aria-label="View results">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                </a>
+            </td>
+            <td>
+                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')" class="inline-form">
                     #csrfFormField()
                     <input type="hidden" name="returnTo" value="#(historyPath)">
-                    <button class="btn action-btn" type="submit">Re-test</button>
+                    <button class="btn action-btn action-btn-icon" type="submit" title="Re-test submission" aria-label="Re-test submission">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 0 1-15.364 6.364L3 16m0 0v5m0-5h5"/><path d="M3 12a9 9 0 0 1 15.364-6.364L21 8m0 0V3m0 5h-5"/></svg>
+                    </button>
                 </form>
             </td>
         </tr>

--- a/Resources/Views/student-assignment-history.leaf
+++ b/Resources/Views/student-assignment-history.leaf
@@ -34,12 +34,18 @@
             <td><span class="tier">#(row.status)</span></td>
             <td>#(row.submittedAt)</td>
             <td><strong>#(row.gradeText)</strong></td>
-            <td><a href="/submissions/#(row.submissionID)">Open</a></td>
             <td>
-                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')">
+                <a class="btn action-btn action-btn-icon" href="/submissions/#(row.submissionID)" title="View results" aria-label="View results">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                </a>
+            </td>
+            <td>
+                <form method="post" action="/instructor/#(assignmentID)/submissions/#(row.submissionID)/retest" onsubmit="return confirm('Send this submission back to the testing queue?')" class="inline-form">
                     #csrfFormField()
                     <input type="hidden" name="returnTo" value="#(historyPath)">
-                    <button class="btn action-btn" type="submit">Re-test</button>
+                    <button class="btn action-btn action-btn-icon" type="submit" title="Re-test submission" aria-label="Re-test submission">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12a9 9 0 0 1-15.364 6.364L3 16m0 0v5m0-5h5"/><path d="M3 12a9 9 0 0 1 15.364-6.364L21 8m0 0V3m0 5h-5"/></svg>
+                    </button>
                 </form>
             </td>
         </tr>

--- a/Resources/Views/submission-history.leaf
+++ b/Resources/Views/submission-history.leaf
@@ -25,16 +25,32 @@ Submission History
             <td>#(row.status)</td>
             <td>#(row.gradeText)</td>
             <td>
-                <a class="btn action-btn" href="/submissions/#(row.submissionID)">View results</a>
-                <a class="btn action-btn" href="/api/v1/submissions/#(row.submissionID)/download">Download</a>
-                #if(row.canOpenInNotebook):
-                <a class="btn action-btn" href="#(row.openInNotebookURL)">Open</a>
-                #endif
+                <div class="history-actions">
+                    <a class="btn action-btn action-btn-icon" href="/submissions/#(row.submissionID)" title="View results" aria-label="View results">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/></svg>
+                    </a>
+                    <a class="btn action-btn action-btn-icon" href="/api/v1/submissions/#(row.submissionID)/download" title="Download submission" aria-label="Download submission">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                    </a>
+                    #if(row.canOpenInNotebook):
+                    <a class="btn action-btn action-btn-icon" href="#(row.openInNotebookURL)" title="Open in notebook" aria-label="Open in notebook">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+                    </a>
+                    #endif
+                </div>
             </td>
         </tr>
     #endfor
     </tbody>
 </table>
 #endif
+<style>
+.history-actions {
+    display: flex;
+    gap: .4rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+</style>
 #endexport
 #endextend

--- a/changelog.d/icon-history-actions.md
+++ b/changelog.d/icon-history-actions.md
@@ -1,0 +1,7 @@
+### Changed
+
+- UI consistency: the three submission-history tables now use icon action
+  buttons (view-results / download / open-in-notebook for students; view /
+  re-test for the instructor per-student drilldowns), matching the assignment
+  list, roster, and student-dashboard rows that were already iconified. Each
+  glyph keeps a `title` + `aria-label` for accessibility.


### PR DESCRIPTION
## UI consistency audit: iconic row actions

The three submission-history tables still rendered text action buttons while their sibling tables — the assignment list (`assignments.leaf`), the per-assignment roster (`assignment-submissions.leaf`), the per-student course view (`course-student-submissions.leaf`), and the student dashboard rows (`_assignment-row.leaf`) — had already moved to icon buttons. This brings them in line.

### Changed

- **`submission-history.leaf`** (a student's own per-assignment history, e.g. `/testsetups/:id/history` — the page that prompted this audit): `View results` / `Download` / `Open` → **eye** / **download** / **book-open** icon buttons.
- **`assignment-student-history.leaf`** and **`student-assignment-history.leaf`** (instructor per-student drilldowns): the `Open` details link → **eye** (view results), and the `Re-test` button → **circular-arrows** retest icon (the same glyph already used on the roster).

Every glyph reuses the existing Feather-style icon vocabulary (24×24 viewBox, stroke-width 2.5, rendered 13×13) and the established `action-btn action-btn-icon` classes, and carries both `title` and `aria-label` for accessibility.

### Scope / deliberate keeps

The rest of the audit confirmed the remaining text `action-btn`s are appropriately labeled and were left alone:

- **Standalone labeled page actions** — `Back to …`, `Export Grades CSV`, `Enrol from CSV`, `Import from Marmoset`.
- **Panel / modal form buttons** — `Save` / `Clear` / `Remove` (grade-override & extension panels), `Enroll`, `Mint token`, `Test connection`, `Retry failed`.
- **Notebook editor controls** — the `Edit` / `Upload` buttons on the assignment new/edit pages, `Publish…` dropdowns.
- **`admin-course.leaf`'s lone per-row `Submissions` link** — single, descriptive, ample space; a bare icon would *lose* clarity, so kept as text.

### Verification

- `scripts/check-styles.sh` and `scripts/check-css-vars.sh` both pass.
- No tests assert the old button text (the history render test only checks the page title), so nothing was broken. Column counts are unchanged.

https://claude.ai/code/session_01TraDC26HewMuMCFADLPPi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01TraDC26HewMuMCFADLPPi8)_