### PR TITLE
fix(assignments): let staff test a preview that has a scheduled open date

### DIFF
--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -385,19 +385,15 @@ struct WebRoutes: RouteCollection {
             }()
             let isOpenForThisUser: Bool = {
                 guard let assignment else { return false }
-                // Preview is open for staff, closed for students.
-                let treatAsOpen: Bool
-                switch assignment.visibility {
-                case .open: treatAsOpen = true
-                case .closed: treatAsOpen = false
-                case .preview: treatAsOpen = user.isInstructor
-                }
+                // Preview is open for staff, closed for students; staff testing a
+                // preview also bypass the future-open-date gate (see submissionGate).
+                let gate = assignment.visibility.submissionGate(isStaff: user.isInstructor)
                 return isAssignmentOpenForUser(
-                    isOpen: treatAsOpen,
+                    isOpen: gate.treatAsOpen,
                     overrideActive: assignment.deadlineOverrideActive ?? false,
                     baselineDueAt: baselineDueAt,
                     effectiveDueAt: effectiveDueAt,
-                    startsAt: assignment.startsAt
+                    startsAt: gate.honorsStartDate ? assignment.startsAt : nil
                 )
             }()
             let canEdit = isOpenForThisUser || previouslyOpenedSetupIDs.contains(setupID)

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -105,20 +105,16 @@ func isAssignmentEffectivelyOpen(
 ) async throws -> Bool {
     // Preview is a staff-only "open": course staff see and use it exactly like an
     // open assignment, while students are held out as if it were closed. For
-    // .open / .closed the stored visibility applies to everyone.
-    let treatAsOpen: Bool
-    switch assignment.visibility {
-    case .open: treatAsOpen = true
-    case .closed: treatAsOpen = false
-    case .preview: treatAsOpen = user.isInstructor
-    }
+    // .open / .closed the stored visibility applies to everyone. Staff testing a
+    // preview also bypass the future-open-date gate — see `submissionGate`.
+    let gate = assignment.visibility.submissionGate(isStaff: user.isInstructor)
     let effective = try await effectiveDueAt(for: assignment, user: user, on: db)
     return isAssignmentOpenForUser(
-        isOpen: treatAsOpen,
+        isOpen: gate.treatAsOpen,
         overrideActive: assignmentDeadlineOverrideIsActive(assignment),
         baselineDueAt: assignment.dueAt,
         effectiveDueAt: effective,
-        startsAt: assignment.startsAt,
+        startsAt: gate.honorsStartDate ? assignment.startsAt : nil,
         now: now
     )
 }

--- a/Sources/Core/AssignmentVisibility.swift
+++ b/Sources/Core/AssignmentVisibility.swift
@@ -34,4 +34,28 @@ public enum AssignmentVisibility: String, Codable, Sendable, CaseIterable {
     public init(legacyIsOpen: Bool) {
         self = legacyIsOpen ? .open : .closed
     }
+
+    /// How this visibility maps onto the per-viewer submission / access gate.
+    ///
+    /// - `treatAsOpen`: whether the assignment behaves as "open" for this viewer.
+    ///   `.preview` is open only for staff; `.closed` is closed for everyone.
+    /// - `honorsStartDate`: whether a future open date (`startsAt`) should hold
+    ///   the assignment closed for this viewer.
+    ///
+    /// Staff testing a `.preview` assignment deliberately *bypass* the start-date
+    /// gate: the open date governs when the assignment auto-publishes to
+    /// *students*, not whether staff may exercise the grading path before then.
+    /// Without this, a `.preview` assignment that also carries a scheduled open
+    /// date is unreachable by the very staff who put it in preview to test it —
+    /// the front gate in `isAssignmentOpenForUser` would hold it closed for
+    /// everyone. (`.preview` is the only state where this matters: `.open`
+    /// consumes `startsAt`, and `.closed`/`.preview`-for-students are already
+    /// held closed by `treatAsOpen == false`.)
+    public func submissionGate(isStaff: Bool) -> (treatAsOpen: Bool, honorsStartDate: Bool) {
+        switch self {
+        case .open: return (treatAsOpen: true, honorsStartDate: true)
+        case .closed: return (treatAsOpen: false, honorsStartDate: true)
+        case .preview: return (treatAsOpen: isStaff, honorsStartDate: !isStaff)
+        }
+    }
 }

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -448,6 +448,42 @@ import XCTVapor
         }
     }
 
+    /// Regression: a `.preview` assignment that *also* carries a future open
+    /// date (`startsAt`) must still be testable by staff. The open date is when
+    /// the assignment auto-publishes to students; it must not hold the preview
+    /// closed for the very staff who put it in preview to exercise grading.
+    /// Students stay blocked (preview is staff-only regardless of the date).
+    @Test func previewWithFutureOpenDateStillReachableByStaff() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            let assignment = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            assignment.visibility = .preview
+            assignment.startsAt = Date().addingTimeInterval(7 * 24 * 3_600)  // a week out
+            try await assignment.save(on: app.db)
+
+            let studentCookie = try await loginAsStudent()
+            try await app.asyncTest(
+                .GET, "/api/v1/browser-runner/testsetups/\(setupID)/manifest",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentCookie) },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "student must not reach a preview assignment, even before its open date")
+                })
+
+            let staffCookie = try await loginUser(
+                username: "prof1", password: "pass", role: "instructor", on: app)
+            try await app.asyncTest(
+                .GET, "/api/v1/browser-runner/testsetups/\(setupID)/manifest",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffCookie) },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .ok,
+                        "staff must reach a preview assignment to test it before its scheduled open date")
+                })
+        }
+    }
+
     // MARK: - Full round-trip: dependency-skipped outcomes stored correctly
 
     /// Regression for #105: when the browser runner skips a test because its

--- a/Tests/CoreTests/AssignmentVisibilityTests.swift
+++ b/Tests/CoreTests/AssignmentVisibilityTests.swift
@@ -21,4 +21,30 @@ import Testing
         #expect(AssignmentVisibility.preview.rawValue == "preview")
         #expect(AssignmentVisibility.open.rawValue == "open")
     }
+
+    @Test func submissionGateTreatsOpenAndClosedTheSameForBothViewers() {
+        for isStaff in [true, false] {
+            let openGate = AssignmentVisibility.open.submissionGate(isStaff: isStaff)
+            #expect(openGate.treatAsOpen)
+            #expect(openGate.honorsStartDate)
+
+            let closedGate = AssignmentVisibility.closed.submissionGate(isStaff: isStaff)
+            #expect(!closedGate.treatAsOpen)
+            #expect(closedGate.honorsStartDate)
+        }
+    }
+
+    @Test func submissionGatePreviewIsStaffOnlyAndStaffBypassTheStartDate() {
+        // Staff: preview behaves as open, AND the future-open-date gate is
+        // bypassed so they can test before the scheduled open date.
+        let staffGate = AssignmentVisibility.preview.submissionGate(isStaff: true)
+        #expect(staffGate.treatAsOpen)
+        #expect(!staffGate.honorsStartDate)
+
+        // Students: preview is closed, and the start-date gate still applies
+        // (redundant with treatAsOpen == false, but never accidentally open).
+        let studentGate = AssignmentVisibility.preview.submissionGate(isStaff: false)
+        #expect(!studentGate.treatAsOpen)
+        #expect(studentGate.honorsStartDate)
+    }
 }

--- a/changelog.d/preview-future-open-date.md
+++ b/changelog.d/preview-future-open-date.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Preview assignments with a scheduled open date are reachable by staff
+  again.** A `.preview` assignment that also carried a future open date
+  (`startsAt`) was held closed for *everyone* by the front gate in
+  `isAssignmentOpenForUser` — so the instructor who put it in preview to test it
+  couldn't open the notebook or submit (worse for browser-graded labs, where no
+  upload fallback exists, leaving the row with no actions at all). Staff now
+  bypass the future-open-date gate when previewing; the date still governs when
+  the assignment auto-publishes to students, and students remain blocked. The
+  preview/start-date decision is now a single `AssignmentVisibility.submissionGate`
+  helper shared by the submission gate and the dashboard listing.


### PR DESCRIPTION
## Problem

Setting an assignment (e.g. *HLTH 230 Lab 3*) to **Preview** made it *unavailable to the staff who set it* whenever it also carried a scheduled open date.

`.preview` is the staff-only beta state — staff exercise the real grading path before publishing. Flipping to preview is a pure visibility change; it does **not** clear a previously-set open date (`startsAt`). But the front gate in `isAssignmentOpenForUser` held any assignment with a future `startsAt` closed for **everyone**:

```swift
// Front gate: a future open date holds the assignment closed for
// everyone, regardless of `isOpen` or any deadline/extension state.
if let startsAt, now < startsAt { return false }
```

Since `.open` consumes `startsAt`, and `.closed` / preview-for-students are already held closed by `treatAsOpen == false`, **preview-viewed-by-staff was the only case where that front gate ever changed the outcome** — so its sole practical effect was to make a scheduled preview unreachable.

This explains both of the reported hypotheses:
- **Worker-graded** preview + open date → no Upload button (`isOpen` false).
- **Browser-graded** preview + open date → no Edit/notebook button either (`canEdit` false), so the dashboard row showed *no actions at all* — which looked like a distinct browser-grading bug but shares this one root cause.

## Fix

Staff now bypass the future-open-date gate when previewing. The date still governs when the assignment auto-publishes to students, and students remain held out (preview is staff-only regardless of the date — verified by test).

The preview / start-date decision is consolidated into a single `AssignmentVisibility.submissionGate(isStaff:)` helper in `Core`, used by both the server-side submission gate (`isAssignmentEffectivelyOpen`) and the dashboard listing (`WebRoutes`), replacing two duplicated `treatAsOpen` switches.

## Notes / scope

- `isAssignmentOpenForUser`'s contract is unchanged (its existing pure-logic tests stay green); the preview-awareness lives in the new gate helper at the call sites.
- Auto-open behaviour is unchanged: `.preview` is still published to students manually, never by the scheduled-open sweep (documented design). Once staff are done testing they flip it to **Open**, which consumes `startsAt`.

## Tests

- `CoreTests/AssignmentVisibilityTests` — unit coverage for `submissionGate` across all three visibilities × staff/student.
- `BrowserRunnerRoutesTests.previewWithFutureOpenDateStillReachableByStaff` — regression: staff reach a preview's manifest before its open date; student still gets `403`.
- `swift build`, formatter, and SwiftLint (`--strict`, 0 violations) all clean locally.

https://claude.ai/code/session_01L1eazVz6DQaztmUNW6J98a

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1eazVz6DQaztmUNW6J98a)_