### PR TITLE
ci(wasm): rebase-and-retry the re-vendor push so it stops losing the release race

### DIFF
--- a/.github/workflows/runner-wasm-vendor.yml
+++ b/.github/workflows/runner-wasm-vendor.yml
@@ -125,4 +125,23 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Public/runner-wasm runner-size-baseline.txt
           git commit -m "chore(wasm): re-vendor RunnerCore browser artifact [skip ci]"
-          git push origin HEAD:main
+          # main can advance between checkout and here: auto-release.yml pushes a
+          # `chore(release)` commit in the same post-merge window, and this job —
+          # the slower of the two (it installs the wasm SDK and rebuilds) — loses
+          # a plain push every time, so the re-vendor silently never lands until
+          # someone re-triggers it by hand. Rebase our artifact-only commit onto
+          # the latest main and retry; the commit touches only Public/runner-wasm
+          # and runner-size-baseline.txt, which nothing else writes, so the
+          # rebase never conflicts (abort + fail loudly if it somehow does rather
+          # than force-push over main).
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              echo "::notice::Pushed re-vendored artifact (attempt $attempt)."
+              exit 0
+            fi
+            echo "::warning::push rejected (attempt $attempt) — rebasing onto origin/main and retrying"
+            git fetch origin main
+            git rebase origin/main || { git rebase --abort; echo "::error::unexpected rebase conflict re-vendoring wasm"; exit 1; }
+          done
+          echo "::error::could not push re-vendored artifact after 5 attempts"
+          exit 1

--- a/changelog.d/wasm-vendor-push-race.md
+++ b/changelog.d/wasm-vendor-push-race.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Browser-wasm re-vendor no longer loses the post-merge push race.** The
+  `runner-wasm-vendor.yml` job rebuilds the in-browser grading wasm whenever
+  RunnerCore changes on `main` and pushes the artifact back — but
+  `auto-release.yml` pushes its `chore(release)` commit to `main` in the same
+  post-merge window, and the slower wasm job lost a plain `git push` on every
+  RunnerCore-touching merge, leaving the re-vendor unpushed until a manual
+  re-trigger. It now rebases its artifact-only commit onto the latest `main`
+  and retries (up to 5×), so the artifact lands on its own.


### PR DESCRIPTION
## What & why

Follow-up to #853. The `runner-wasm-vendor.yml` job rebuilds the in-browser grading wasm whenever RunnerCore changes on `main` and pushes the artifact back. But `auto-release.yml` pushes its `chore(release)` commit to `main` in the **same post-merge window**, and the wasm job is the slower of the two (it installs the Swift + Embedded-wasm SDK and rebuilds). So a plain `git push origin HEAD:main` lost the race and was rejected non-fast-forward on **every RunnerCore-touching merge** — leaving the re-vendor unpushed until someone re-triggered it by hand.

That's exactly what happened right after #853 merged: the wasm built fine but the push was rejected (`! [rejected] HEAD -> main (fetch first)`), and I had to re-dispatch the workflow to land it (v0.4.375's browser artifact).

## The fix

The push now retries up to 5×, rebasing the artifact-only commit onto the latest `main` between attempts:

```bash
for attempt in 1 2 3 4 5; do
  if git push origin HEAD:main; then exit 0; fi
  git fetch origin main
  git rebase origin/main || { git rebase --abort; exit 1; }
done
```

The re-vendor commit touches only `Public/runner-wasm/` and `runner-size-baseline.txt`, which nothing else writes — so the rebase never conflicts in practice. On an unexpected conflict it **aborts and fails loudly** rather than force-pushing over `main`. The commit keeps its `[skip ci]` tag, so the retry can't trigger a release loop.

## Scope / safety

- Single workflow file + a changelog fragment. No app code.
- This workflow only runs on push to `main` / `workflow_dispatch`, so PR CI doesn't execute it; validated locally with `yaml.safe_load` (parses) and `bash -n` (script syntax OK).
- No force-push to `main` is ever introduced — the loop only ever does fast-forward pushes after rebasing.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_