### PR TITLE
feat(core): achievements model — generalized, instructor-authorable rewards (Phase 1)

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -109,15 +109,17 @@ jobs:
       # the type) keep their old source mtime, so `git restore-mtime` marks
       # them "fresh" and llbuild reuses stale object files compiled against the
       # old symbol → "undefined reference" link errors. Bumping the salt forces
-      # one clean rebuild for everyone.  (v2: TestItem struct→enum, v0.4.228.)
+      # one clean rebuild for everyone.  (v2: TestItem struct→enum, v0.4.228;
+      # v3: TestProperties gained the `achievements` field — its init's mangled
+      # signature changed, so stale transitive objects fail to link.)
       - name: Cache build artifacts
         id: build-cache
         uses: actions/cache@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v3-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
           restore-keys: |
-            ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-
+            ${{ runner.os }}-build-v3-${{ steps.toolchain.outputs.key }}-
 
       # Exact cache hit: artifacts already match this tree, skip even the
       # near-no-op build.  Restore-keys partial hit (cache-hit is false): the
@@ -147,7 +149,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v3-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Run CoreTests
         run: |
@@ -177,7 +179,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v3-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
         run: |
@@ -246,7 +248,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v3-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
         run: |
@@ -314,7 +316,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .build
-          key: ${{ runner.os }}-build-v2-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          key: ${{ runner.os }}-build-v3-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install worker test dependencies
         # `file` backs SubmissionNormalizer's MIME detection; `python3` runs the

--- a/Sources/Core/Achievement.swift
+++ b/Sources/Core/Achievement.swift
@@ -1,0 +1,157 @@
+// Core/Achievement.swift
+
+/// An instructor-authored reward attached to one assignment — the generalized,
+/// per-assignment form of Chickadee's previously-hardcoded badge and
+/// class-achievement system.
+///
+/// Achievements are **server-evaluated and display-only**: they never run as a
+/// per-submission test, and `TestProperties.runnerSanitized()` strips them from
+/// the runner-facing manifest so a runner never has to decode an
+/// `AchievementKind` case it doesn't know (the same rationale as
+/// `patternFamilies` / `notebookChecks`).
+///
+/// One `Achievement` expresses both the legacy hardcoded rewards (First-Try
+/// Perfect; the pathfinder / speed-champion / minimalist class records) and the
+/// new collaborative class goal, distinguished by `kind`.  Per-kind parameters
+/// live in the optional fields (`threshold`, `classFraction`,
+/// `recordDimension`) — the same idiom `PatternFamily` and `NotebookCheck` use.
+public struct Achievement: Codable, Equatable, Sendable {
+    public let id: String
+    /// Student-facing label, e.g. "Class Goal: 80% reach mastery".
+    public let name: String
+    /// Optional longer description shown to students ("how to earn this").
+    public let detail: String?
+    public let kind: AchievementKind
+    public let scope: AchievementScope
+    public let reward: AchievementReward
+    /// Which graded signal the condition reads (a specific test, a section, or
+    /// the whole-assignment grade).
+    public let target: AchievementTarget
+    /// Per-student metric cutoff in `0...1` (fraction of the `target` earned).
+    /// Used by `classGoal` and `thresholdBadge`.
+    public let threshold: Double?
+    /// Proportion of the class (`0...1`) that must reach `threshold` for a
+    /// `classGoal` to be fully met.
+    public let classFraction: Double?
+    /// Which dimension a `classRecord` ranks students on.
+    public let recordDimension: RecordDimension?
+    /// Suite section this achievement renders under; nil = the trailing
+    /// "Achievements" block.
+    public let sectionID: String?
+
+    public init(
+        id: String,
+        name: String,
+        detail: String? = nil,
+        kind: AchievementKind,
+        scope: AchievementScope,
+        reward: AchievementReward,
+        target: AchievementTarget = AchievementTarget(kind: .assignmentGrade),
+        threshold: Double? = nil,
+        classFraction: Double? = nil,
+        recordDimension: RecordDimension? = nil,
+        sectionID: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.detail = detail
+        self.kind = kind
+        self.scope = scope
+        self.reward = reward
+        self.target = target
+        self.threshold = threshold
+        self.classFraction = classFraction
+        self.recordDimension = recordDimension
+        self.sectionID = sectionID
+    }
+}
+
+/// The variety of achievement — the discriminator that says which optional
+/// parameters apply and how it is evaluated.
+public enum AchievementKind: String, Codable, Sendable {
+    /// Collaborative: at least `classFraction` of the class reaches `threshold`
+    /// on `target`.  Awards a positive, fractional `points` bonus to everyone
+    /// who submitted, scaled by class progress.  Evaluated by the periodic
+    /// class sweep; locks at the deadline.
+    case classGoal
+    /// Individual: this student's best `target` value is ≥ `threshold`.
+    case thresholdBadge
+    /// Individual: a referenced (often secret) test passes — content-specific
+    /// logic lives in the instructor's test; this just maps the pass to a badge.
+    case testBadge
+    /// Individual: 100% on the first attempt.  Subsumes the legacy First-Try
+    /// Perfect badge.
+    case firstTryPerfect
+    /// Competitive, one holder per assignment, ranked on `recordDimension`.
+    /// Subsumes the legacy pathfinder / speed-champion / minimalist records.
+    /// Kept for back-compat; new assignments lean on the collaborative kinds.
+    case classRecord
+}
+
+/// Whether an achievement is earned per-student or computed across the class.
+public enum AchievementScope: String, Codable, Sendable {
+    case individual
+    case classWide
+}
+
+/// What graded signal an achievement condition reads.
+public struct AchievementTarget: Codable, Equatable, Sendable {
+    public let kind: TargetKind
+    /// The script filename (`suiteItem` / `testPass`) or section id (`section`)
+    /// the target refers to; nil for `assignmentGrade`.
+    public let ref: String?
+
+    public init(kind: TargetKind, ref: String? = nil) {
+        self.kind = kind
+        self.ref = ref
+    }
+}
+
+public enum TargetKind: String, Codable, Sendable {
+    /// The whole-assignment grade percent (earnedPoints / totalPoints).
+    case assignmentGrade
+    /// One suite item's fractional `score` (the partial-credit metric).
+    case suiteItem
+    /// The aggregate score of one suite section.
+    case section
+    /// Pass/fail of one referenced test (for `testBadge`).
+    case testPass
+}
+
+/// What a student gets for earning an achievement.
+public struct AchievementReward: Codable, Equatable, Sendable {
+    public let type: RewardType
+    /// Display text — the badge caption or record title.
+    public let label: String
+    /// Emoji / icon for `badge` rewards (e.g. "🌟"); nil otherwise.
+    public let icon: String?
+    /// Graded bonus points for `points` rewards (the "pinned grade").  Awarded
+    /// positively only; nil for cosmetic rewards.
+    public let points: Int?
+
+    public init(type: RewardType, label: String, icon: String? = nil, points: Int? = nil) {
+        self.type = type
+        self.label = label
+        self.icon = icon
+        self.points = points
+    }
+}
+
+public enum RewardType: String, Codable, Sendable {
+    /// A cosmetic badge shown on the student's submission.
+    case badge
+    /// A one-holder record title (class records).
+    case title
+    /// A positive grade bonus.
+    case points
+}
+
+/// The dimension a `classRecord` ranks students on.
+public enum RecordDimension: String, Codable, Sendable {
+    /// Earliest correct submission.
+    case firstToSolve
+    /// Fastest execution time.
+    case fastest
+    /// Shortest solution.
+    case shortest
+}

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -245,6 +245,13 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// `seed`.
     public let globalExpressions: [PersonalizationExpression]
 
+    /// Instructor-authored achievements / goals / awards for this assignment —
+    /// the generalized form of the hardcoded badge + class-achievement system.
+    /// Server-evaluated and display-only; `runnerSanitized()` strips them so a
+    /// runner never decodes an `AchievementKind` it doesn't know (same rationale
+    /// as `patternFamilies` / `notebookChecks`).
+    public let achievements: [Achievement]
+
     public init(
         schemaVersion: Int = 1,
         gradingMode: GradingMode = .worker,
@@ -258,6 +265,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         sections: [TestSuiteSection] = [],
         globalVariables: [FamilyVariable] = [],
         globalExpressions: [PersonalizationExpression] = [],
+        achievements: [Achievement] = [],
         testItems: [TestItem]? = nil
     ) {
         self.schemaVersion = schemaVersion
@@ -277,6 +285,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         self.sections = sections
         self.globalVariables = globalVariables
         self.globalExpressions = globalExpressions
+        self.achievements = achievements
     }
 
     public init(from decoder: Decoder) throws {
@@ -307,6 +316,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
             try c.decodeIfPresent(
                 [PersonalizationExpression].self,
                 forKey: .globalExpressions) ?? []
+        achievements = try c.decodeIfPresent([Achievement].self, forKey: .achievements) ?? []
     }
 
     // `patternFamilies` / `notebookChecks` are computed (derived from
@@ -327,6 +337,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         case sections
         case globalVariables
         case globalExpressions
+        case achievements
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -346,6 +357,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         try c.encode(sections, forKey: .sections)
         try c.encode(globalVariables, forKey: .globalVariables)
         try c.encode(globalExpressions, forKey: .globalExpressions)
+        try c.encode(achievements, forKey: .achievements)
     }
 
     /// Manifest view shipped to runners.  Pattern families and notebook
@@ -383,7 +395,8 @@ public struct TestProperties: Codable, Equatable, Sendable {
                     variables: section.variables, expressions: [])
             },
             globalVariables: globalVariables,
-            globalExpressions: []
+            globalExpressions: [],
+            achievements: []
         )
     }
 }

--- a/Tests/CoreTests/AchievementTests.swift
+++ b/Tests/CoreTests/AchievementTests.swift
@@ -1,0 +1,93 @@
+// Tests/CoreTests/AchievementTests.swift
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct AchievementTests {
+
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    @Test func classGoalAchievementRoundTrips() throws {
+        let goal = Achievement(
+            id: "ach_classgoal",
+            name: "Class Goal: 80% reach mastery",
+            detail: "When 80% of the class hits 80%, everyone earns the bonus.",
+            kind: .classGoal,
+            scope: .classWide,
+            reward: AchievementReward(type: .points, label: "Class Goal Met", points: 5),
+            target: AchievementTarget(kind: .suiteItem, ref: "test_accuracy.py"),
+            threshold: 0.8,
+            classFraction: 0.8)
+        let decoded = try decoder.decode(Achievement.self, from: encoder.encode(goal))
+        #expect(decoded == goal)
+        #expect(decoded.kind == .classGoal)
+        #expect(decoded.reward.points == 5)
+        #expect(decoded.target.ref == "test_accuracy.py")
+    }
+
+    @Test func firstTryPerfectBadgeRoundTrips() throws {
+        let badge = Achievement(
+            id: "ach_ftp",
+            name: "First-Try Perfect",
+            kind: .firstTryPerfect,
+            scope: .individual,
+            reward: AchievementReward(type: .badge, label: "First-Try Perfect", icon: "🌟"))
+        let decoded = try decoder.decode(Achievement.self, from: encoder.encode(badge))
+        #expect(decoded == badge)
+        #expect(decoded.reward.icon == "🌟")
+        #expect(decoded.threshold == nil)
+        #expect(decoded.target.kind == .assignmentGrade)  // defaulted
+    }
+
+    @Test func classRecordRoundTrips() throws {
+        let record = Achievement(
+            id: "ach_speed",
+            name: "Speed Champion",
+            kind: .classRecord,
+            scope: .classWide,
+            reward: AchievementReward(type: .title, label: "Speed Champion"),
+            recordDimension: .fastest)
+        let decoded = try decoder.decode(Achievement.self, from: encoder.encode(record))
+        #expect(decoded == record)
+        #expect(decoded.recordDimension == .fastest)
+        #expect(decoded.reward.type == .title)
+    }
+
+    @Test func testPropertiesCarriesAchievementsThroughRoundTrip() throws {
+        let props = TestProperties(
+            testSuites: [],
+            achievements: [
+                Achievement(
+                    id: "g1", name: "Goal", kind: .classGoal, scope: .classWide,
+                    reward: AchievementReward(type: .points, label: "Goal", points: 3),
+                    threshold: 0.8, classFraction: 0.8)
+            ])
+        let decoded = try decoder.decode(TestProperties.self, from: encoder.encode(props))
+        #expect(decoded.achievements.count == 1)
+        #expect(decoded.achievements.first?.id == "g1")
+        #expect(decoded.achievements.first?.classFraction == 0.8)
+    }
+
+    @Test func runnerSanitizedStripsAchievements() throws {
+        let props = TestProperties(
+            achievements: [
+                Achievement(
+                    id: "g1", name: "Goal", kind: .classGoal, scope: .classWide,
+                    reward: AchievementReward(type: .points, label: "Goal", points: 3))
+            ])
+        #expect(props.achievements.count == 1)
+        // Stripped from the runner-facing manifest so older runners never decode
+        // an AchievementKind they don't know.
+        #expect(props.runnerSanitized().achievements.isEmpty)
+    }
+
+    @Test func legacyManifestWithoutAchievementsDecodesToEmpty() throws {
+        // A manifest authored before achievements existed has no `achievements` key.
+        let json = Data(#"{"schemaVersion":1,"testSuites":[],"timeLimitSeconds":10}"#.utf8)
+        let decoded = try decoder.decode(TestProperties.self, from: json)
+        #expect(decoded.achievements.isEmpty)
+    }
+}

--- a/changelog.d/achievements-model.md
+++ b/changelog.d/achievements-model.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Achievements model (foundation).** A per-assignment `achievements: [Achievement]`
+  manifest field (Core) — the generalized, instructor-authorable form of
+  Chickadee's previously-hardcoded badge / class-achievement system. One
+  `Achievement` expresses the collaborative class goal, individual badges
+  (incl. First-Try Perfect), and the legacy one-holder class records, by
+  `kind`. Server-evaluated and display-only; stripped from the runner-facing
+  manifest like pattern families and notebook checks. Groundwork only —
+  evaluation, the class-goal grade bonus, student display, and authoring land
+  in follow-ups.


### PR DESCRIPTION
## What & why

**Phase 1 of the achievements layer** — the generalized, per-assignment, instructor-authorable form of Chickadee's gamification rewards. This is the foundation the rest of the feature builds on; it's pure model + manifest wiring, so **no behavior changes and there's zero regression risk**.

We decided to **subsume** the existing hardcoded rewards rather than add a parallel system: `AchievementBadge` (First-Try Perfect) and `APIClassAchievement` (pathfinder / speed-champion / minimalist) become *kinds* within one `Achievement` type, alongside the new collaborative **class goal**. The competitive "records" kind is kept for back-compat but is legacy holding-space — new assignments lean collaborative.

## What's in this PR

A new `Achievement` Core type family + an `achievements: [Achievement]` field on `TestProperties`. One `Achievement` expresses all the varieties via `kind`:

| kind | scope | reward | subsumes |
|---|---|---|---|
| `classGoal` | class | points (fractional bonus) | — (new, the priority) |
| `thresholdBadge` | individual | badge | — |
| `testBadge` | individual | badge | — (content-defined via a referenced test) |
| `firstTryPerfect` | individual | badge | the hardcoded First-Try Perfect |
| `classRecord` | class | title | pathfinder / speed-champion / minimalist |

Per-kind params (`threshold`, `classFraction`, `recordDimension`, `target`) live in optional fields — the same idiom `PatternFamily` / `NotebookCheck` use. `reward` is a small `badge | title | points` union.

Threaded through `TestProperties`'s custom Codable with `decodeIfPresent ?? []` (back-compat: legacy manifests decode to empty), and **stripped by `runnerSanitized()`** so a runner never decodes an `AchievementKind` it doesn't know — the exact rationale used for pattern families / notebook checks.

## Tests
`AchievementTests`: round-trips for the class goal, an individual badge, and a class record; `TestProperties` carries achievements through a round-trip; `runnerSanitized()` empties them; a legacy manifest with no `achievements` key decodes to `[]`. Core suite green, `swift-format` + SwiftLint `--strict` clean.

## Roadmap (separate PRs)
2. **engine** — `APIAchievementResult` table + evaluation sweep computing the `classGoal` aggregate.
3. **payoff** — read-time positive bonus (submission/BrightSpace/CSV) + student "Achievements" section with the live progress bar.
4. **subsume** — re-express First-Try-Perfect + the class records as built-in kinds, retiring the hardcoded paths.
5. **authoring** — editor "Achievements" section + MCP tools.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_