### PR TITLE
feat(achievements): class-goal evaluation engine (Phase 2)

### DIFF
--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -22,6 +22,7 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
     app.lifecycle.use(ObservabilityLifecycleHandler())
     app.lifecycle.use(AssignmentDeadlineLifecycleHandler())
     app.lifecycle.use(StuckSubmissionReaperLifecycleHandler())
+    app.lifecycle.use(AchievementEvaluationLifecycleHandler())
     app.lifecycle.use(SessionReaperLifecycleHandler())
     app.lifecycle.use(
         AuditLogReaperLifecycleHandler(

--- a/Sources/APIServer/Migrations/CreateAchievementResults.swift
+++ b/Sources/APIServer/Migrations/CreateAchievementResults.swift
@@ -1,0 +1,24 @@
+// APIServer/Migrations/CreateAchievementResults.swift
+
+import Fluent
+
+struct CreateAchievementResults: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("achievement_results")
+            .id()
+            .field("test_setup_id", .string, .required)
+            .field("achievement_id", .string, .required)
+            .field("students_meeting", .int, .required)
+            .field("denominator", .int, .required)
+            .field("progress", .double, .required)
+            .field("locked", .bool, .required)
+            .field("evaluated_at", .datetime, .required)
+            // One snapshot per achievement per assignment.
+            .unique(on: "test_setup_id", "achievement_id")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("achievement_results").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAchievementResult.swift
+++ b/Sources/APIServer/Models/APIAchievementResult.swift
@@ -1,0 +1,72 @@
+// APIServer/Models/APIAchievementResult.swift
+//
+// A computed snapshot of a class-wide achievement's progress for one
+// assignment — one row per (testSetupID, achievementID).  Written by the
+// periodic `evaluateClassGoalAchievements` sweep and read at grade / display
+// time.
+//
+// `APIResult` rows are immutable, so the class aggregate can't live on them;
+// it gets its own table, the same "computed result lives beside the immutable
+// runner result" pattern as `APIGradeOverride` and `APIClassAchievement`.
+
+import Fluent
+import Vapor
+
+final class APIAchievementResult: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within the evaluation sweep, never
+    // across concurrent tasks (one sweep runs at a time).
+    static let schema = "achievement_results"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    /// The assignment (test setup) this snapshot is scoped to.
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    /// The `Achievement.id` within that assignment's manifest.
+    @Field(key: "achievement_id")
+    var achievementID: String
+
+    /// How many enrolled students currently meet the goal's threshold.
+    @Field(key: "students_meeting")
+    var studentsMeeting: Int
+
+    /// Enrolled-student count used as the denominator (the class size).
+    @Field(key: "denominator")
+    var denominator: Int
+
+    /// Fraction of the goal reached, `0...1`: the share of the class meeting the
+    /// threshold, scaled by the goal's target share.  `1.0` once the target
+    /// share (or more) has reached it.  Drives the bonus and the progress bar.
+    @Field(key: "progress")
+    var progress: Double
+
+    /// True once the assignment deadline has passed; a locked snapshot is frozen
+    /// (the sweep stops recomputing it).
+    @Field(key: "locked")
+    var locked: Bool
+
+    @Field(key: "evaluated_at")
+    var evaluatedAt: Date
+
+    init() {}
+
+    init(
+        testSetupID: String,
+        achievementID: String,
+        studentsMeeting: Int,
+        denominator: Int,
+        progress: Double,
+        locked: Bool,
+        evaluatedAt: Date
+    ) {
+        self.testSetupID = testSetupID
+        self.achievementID = achievementID
+        self.studentsMeeting = studentsMeeting
+        self.denominator = denominator
+        self.progress = progress
+        self.locked = locked
+        self.evaluatedAt = evaluatedAt
+    }
+}

--- a/Sources/APIServer/Services/AchievementEvaluationService.swift
+++ b/Sources/APIServer/Services/AchievementEvaluationService.swift
@@ -1,0 +1,203 @@
+// APIServer/Services/AchievementEvaluationService.swift
+//
+// Periodic evaluation of class-wide (`classGoal`) achievements.  For each
+// assignment whose manifest carries a class goal, the sweep computes how much
+// of the class has reached the goal's threshold and upserts an
+// `APIAchievementResult` snapshot per (setup, achievement).  The snapshot drives
+// the student progress bar (Phase 3 display) and the positive grade bonus
+// (Phase 3 grading).
+//
+// Modeled on `StuckSubmissionReaperService` / `AssignmentDeadlineService`:
+// a pure sweep function + a Task-based monitor + a LifecycleHandler (startup
+// sweep + periodic timer) registered in `AppServices`.
+//
+// Individual achievement kinds (badges, records) are evaluated elsewhere and
+// land in later phases; this sweep is class-aggregate only.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+private let achievementSweepInterval: TimeInterval = 60
+
+/// Fraction of a class goal reached, `0...1`: the share of the roster meeting
+/// the threshold, scaled by the goal's target share.  Returns `1.0` once
+/// `classFraction` of the class (or more) has reached it, and `0` for an empty
+/// roster.  Pure — unit-tested without a database.
+func classGoalProgress(studentsMeeting: Int, denominator: Int, classFraction: Double) -> Double {
+    guard denominator > 0 else { return 0 }
+    let reached = Double(studentsMeeting) / Double(denominator)
+    let target = max(classFraction, 0.0001)
+    return min(1, reached / target)
+}
+
+/// Evaluates every assignment's `classGoal` achievements and upserts one
+/// `APIAchievementResult` snapshot per (setup, achievement).  A snapshot whose
+/// assignment deadline has passed is locked and then frozen — later sweeps skip
+/// it.  Returns the number of snapshots written.
+@discardableResult
+func evaluateClassGoalAchievements(
+    on db: Database,
+    logger: Logger,
+    now: Date = Date()
+) async throws -> Int {
+    let assignments = try await APIAssignment.query(on: db).all()
+    var written = 0
+
+    for assignment in assignments {
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: db),
+            let setupID = setup.id,
+            let props = try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+        else { continue }
+
+        let goals = props.achievements.filter { $0.kind == .classGoal }
+        guard !goals.isEmpty else { continue }
+
+        let existing = try await APIAchievementResult.query(on: db)
+            .filter(\.$testSetupID == setupID)
+            .all()
+        var rowByAchievement: [String: APIAchievementResult] = [:]
+        for row in existing { rowByAchievement[row.achievementID] = row }
+
+        // Every goal here already frozen → nothing to recompute for this setup.
+        if goals.allSatisfy({ rowByAchievement[$0.id]?.locked == true }) { continue }
+
+        let denominator = try await enrolledStudentCount(forCourse: assignment.courseID, on: db)
+        let locked = assignment.dueAt.map { $0 <= now } ?? false
+        let bestByStudent = try await bestAssignmentGradeByStudent(testSetupID: setupID, on: db)
+
+        for goal in goals {
+            if rowByAchievement[goal.id]?.locked == true { continue }  // frozen at the deadline
+
+            let threshold = goal.threshold ?? 1
+            let studentsMeeting = bestByStudent.values.filter { $0 >= threshold }.count
+            let progress = classGoalProgress(
+                studentsMeeting: studentsMeeting,
+                denominator: denominator,
+                classFraction: goal.classFraction ?? 1)
+
+            if let row = rowByAchievement[goal.id] {
+                row.studentsMeeting = studentsMeeting
+                row.denominator = denominator
+                row.progress = progress
+                row.locked = locked
+                row.evaluatedAt = now
+                try await row.save(on: db)
+            } else {
+                try await APIAchievementResult(
+                    testSetupID: setupID,
+                    achievementID: goal.id,
+                    studentsMeeting: studentsMeeting,
+                    denominator: denominator,
+                    progress: progress,
+                    locked: locked,
+                    evaluatedAt: now
+                ).save(on: db)
+            }
+            written += 1
+        }
+    }
+
+    if written > 0 {
+        logger.debug("Class-goal achievement sweep wrote \(written) snapshot(s)")
+    }
+    return written
+}
+
+/// Per-student best whole-assignment grade (`0...1`) for a setup, from
+/// worker-authoritative results (browser previews lose to a worker result).
+///
+/// `classGoal` currently grades on the whole-assignment metric; per-item /
+/// per-section targets are a follow-up (there is no way to author one until the
+/// Phase 5 editor, so this covers every goal that can exist today).
+func bestAssignmentGradeByStudent(testSetupID: String, on db: Database) async throws -> [UUID: Double] {
+    let submissions = try await APISubmission.query(on: db)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .filter(\.$testSetupID == testSetupID)
+        .all()
+    let identified = submissions.compactMap { sub -> (id: String, userID: UUID)? in
+        guard let id = sub.id, let userID = sub.userID else { return nil }
+        return (id, userID)
+    }
+    let preferred = try await preferredResultsBySubmissionID(for: identified.map(\.id), on: db)
+
+    var best: [UUID: Double] = [:]
+    for sub in identified {
+        guard let result = preferred[sub.id],
+            let percent = gradePercentFromCollectionJSON(result.collectionJSON)
+        else { continue }
+        let value = Double(percent) / 100
+        if value > (best[sub.userID] ?? -1) { best[sub.userID] = value }
+    }
+    return best
+}
+
+// MARK: - Monitor + lifecycle (same shape as StuckSubmissionReaperMonitor)
+
+final class AchievementEvaluationMonitor: @unchecked Sendable {
+    // @unchecked Sendable: `task` is touched only from start()/stop() on the
+    // app lifecycle (didBoot/shutdown), never concurrently.
+    private var task: Task<Void, Never>?
+    private let intervalNanoseconds: UInt64
+
+    init(interval: TimeInterval = achievementSweepInterval) {
+        intervalNanoseconds = UInt64(max(interval, 1) * 1_000_000_000)
+    }
+
+    func start(application: Application) {
+        guard task == nil else { return }
+        task = Task {
+            while !Task.isCancelled {
+                do {
+                    _ = try await evaluateClassGoalAchievements(
+                        on: application.db, logger: application.logger)
+                } catch {
+                    application.logger.error(
+                        "Class-goal achievement sweep failed: \(error.localizedDescription)")
+                }
+                do { try await Task.sleep(nanoseconds: intervalNanoseconds) } catch { break }
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+}
+
+struct AchievementEvaluationMonitorKey: StorageKey {
+    typealias Value = AchievementEvaluationMonitor
+}
+
+struct AchievementEvaluationLifecycleHandler: LifecycleHandler {
+    func didBoot(_ application: Application) throws {
+        Task {
+            do {
+                _ = try await evaluateClassGoalAchievements(
+                    on: application.db, logger: application.logger)
+            } catch {
+                application.logger.error(
+                    "Initial class-goal achievement sweep failed: \(error.localizedDescription)")
+            }
+        }
+        application.achievementEvaluationMonitor.start(application: application)
+    }
+
+    func shutdown(_ application: Application) {
+        application.achievementEvaluationMonitor.stop()
+    }
+}
+
+extension Application {
+    var achievementEvaluationMonitor: AchievementEvaluationMonitor {
+        get {
+            if let existing = storage[AchievementEvaluationMonitorKey.self] { return existing }
+            let created = AchievementEvaluationMonitor()
+            storage[AchievementEvaluationMonitorKey.self] = created
+            return created
+        }
+        set { storage[AchievementEvaluationMonitorKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -212,6 +212,7 @@ func registerMigrations(on app: Application) {
     app.migrations.add(CreateRunnerProfiles())
     app.migrations.add(CreateAssignmentRequirements())
     app.migrations.add(CreateClassAchievements())
+    app.migrations.add(CreateAchievementResults())
     app.migrations.add(CreatePreEnrollments())
     app.migrations.add(SessionRecord.migration)
     app.migrations.add(CreateClientDiagnostics())

--- a/Tests/APITests/AchievementEvaluationTests.swift
+++ b/Tests/APITests/AchievementEvaluationTests.swift
@@ -1,0 +1,134 @@
+// Tests/APITests/AchievementEvaluationTests.swift
+//
+// Phase 2 engine: the class-goal evaluation sweep computes one
+// `APIAchievementResult` snapshot per (setup, achievement) from the per-student
+// grades, over the enrolled roster, locking (and then freezing) at the deadline.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementEvaluationTests {
+
+    // MARK: - Pure progress math (no DB)
+
+    @Test func classGoalProgressScalesAndClamps() {
+        // Share of the class meeting the threshold, scaled by the target share.
+        #expect(classGoalProgress(studentsMeeting: 0, denominator: 10, classFraction: 0.8) == 0)
+        #expect(classGoalProgress(studentsMeeting: 4, denominator: 10, classFraction: 0.8) == 0.5)  // 0.4 / 0.8
+        #expect(classGoalProgress(studentsMeeting: 8, denominator: 10, classFraction: 0.8) == 1.0)  // exactly met
+        #expect(classGoalProgress(studentsMeeting: 10, denominator: 10, classFraction: 0.8) == 1.0)  // clamped
+        #expect(classGoalProgress(studentsMeeting: 5, denominator: 0, classFraction: 0.8) == 0)  // empty roster
+    }
+
+    // MARK: - Full sweep (DB-backed)
+
+    private func makeClassGoalManifest(
+        id: String, threshold: Double, classFraction: Double
+    ) throws -> String {
+        let props = TestProperties(
+            achievements: [
+                Achievement(
+                    id: id, name: "Class Goal", kind: .classGoal, scope: .classWide,
+                    reward: AchievementReward(type: .points, label: "Class Goal Met", points: 5),
+                    threshold: threshold, classFraction: classFraction)
+            ])
+        let data = try JSONEncoder().encode(props)
+        return try #require(String(bytes: data, encoding: .utf8))
+    }
+
+    @Test func sweepComputesClassGoalSnapshot() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let setup = APITestSetup(
+                id: "ag_setup",
+                manifest: try makeClassGoalManifest(id: "goal1", threshold: 0.8, classFraction: 0.5),
+                zipPath: app.testSetupsDirectory + "ag_setup.zip",
+                courseID: courseID)
+            try await setup.save(on: app.db)
+            _ = try await arInsertAssignment(
+                testSetupID: "ag_setup", title: "Goals Lab", isOpen: true, on: app)
+
+            // Two enrolled students: A at 100% (meets 0.8), B at 50% (doesn't).
+            let a = try await arInsertStudent(username: "ag_a", on: app)
+            try await arEnrollStudentInTestCourse(a, on: app)
+            let b = try await arInsertStudent(username: "ag_b", on: app)
+            try await arEnrollStudentInTestCourse(b, on: app)
+            _ = try await arInsertSubmission(
+                id: "ag_sub_a", testSetupID: "ag_setup", userID: try a.requireID(), on: app)
+            try await APIResult(
+                id: "ag_res_a", submissionID: "ag_sub_a",
+                collectionJSON: #"{"earnedPoints":4,"totalPoints":4}"#
+            ).save(on: app.db)
+            _ = try await arInsertSubmission(
+                id: "ag_sub_b", testSetupID: "ag_setup", userID: try b.requireID(), on: app)
+            try await APIResult(
+                id: "ag_res_b", submissionID: "ag_sub_b",
+                collectionJSON: #"{"earnedPoints":2,"totalPoints":4}"#
+            ).save(on: app.db)
+
+            let written = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+            #expect(written >= 1)
+
+            let snapshot = try #require(
+                try await APIAchievementResult.query(on: app.db)
+                    .filter(\.$testSetupID == "ag_setup").first())
+            #expect(snapshot.achievementID == "goal1")
+            #expect(snapshot.studentsMeeting == 1)
+            #expect(snapshot.denominator == 2)
+            #expect(snapshot.progress == 1.0)  // (1/2) reached / 0.5 target = 1.0
+            #expect(snapshot.locked == false)  // no deadline → never locked
+        }
+    }
+
+    @Test func frozenSnapshotIsNotRecomputed() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let setup = APITestSetup(
+                id: "frz_setup",
+                manifest: try makeClassGoalManifest(id: "goalF", threshold: 0.8, classFraction: 0.5),
+                zipPath: app.testSetupsDirectory + "frz_setup.zip",
+                courseID: courseID)
+            try await setup.save(on: app.db)
+            _ = try await arInsertAssignment(
+                testSetupID: "frz_setup", title: "Frozen Lab", isOpen: true, on: app)
+
+            let a = try await arInsertStudent(username: "frz_a", on: app)
+            try await arEnrollStudentInTestCourse(a, on: app)
+            _ = try await arInsertSubmission(
+                id: "frz_sub_a", testSetupID: "frz_setup", userID: try a.requireID(), on: app)
+            try await APIResult(
+                id: "frz_res_a", submissionID: "frz_sub_a",
+                collectionJSON: #"{"earnedPoints":4,"totalPoints":4}"#
+            ).save(on: app.db)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+            let row = try #require(
+                try await APIAchievementResult.query(on: app.db)
+                    .filter(\.$testSetupID == "frz_setup").first())
+            #expect(row.studentsMeeting == 1)
+
+            // Freeze it, then add another qualifying student and re-sweep.
+            row.locked = true
+            try await row.save(on: app.db)
+            let b = try await arInsertStudent(username: "frz_b", on: app)
+            try await arEnrollStudentInTestCourse(b, on: app)
+            _ = try await arInsertSubmission(
+                id: "frz_sub_b", testSetupID: "frz_setup", userID: try b.requireID(), on: app)
+            try await APIResult(
+                id: "frz_res_b", submissionID: "frz_sub_b",
+                collectionJSON: #"{"earnedPoints":4,"totalPoints":4}"#
+            ).save(on: app.db)
+
+            _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
+            let after = try #require(
+                try await APIAchievementResult.query(on: app.db)
+                    .filter(\.$testSetupID == "frz_setup").first())
+            #expect(after.studentsMeeting == 1, "A locked snapshot must not be recomputed")
+        }
+    }
+}

--- a/changelog.d/achievements-engine.md
+++ b/changelog.d/achievements-engine.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Class-goal evaluation engine (achievements Phase 2).** A periodic server-side
+  sweep (`evaluateClassGoalAchievements`, lifecycle-registered alongside the
+  other monitors) computes, for each assignment carrying a `classGoal`
+  achievement, how much of the enrolled class has reached the goal's threshold,
+  and upserts a snapshot per (assignment, goal) into a new `achievement_results`
+  table. It reads worker-authoritative results over the canonical
+  enrolled-student roster, and locks — then freezes — each snapshot once the
+  deadline passes. Not yet surfaced: the student progress bar and the positive
+  grade bonus that read these snapshots land in Phase 3.


### PR DESCRIPTION
## Phase 2 of the achievements layer — the class-goal evaluation engine

Builds on the Phase 1 model (#859). This computes class-wide goal progress server-side and persists it; **no grade or display impact yet** (those read these snapshots in Phase 3), so it's low-risk.

### Why a new table
`APIResult` rows are immutable and grades are read from them, so the class aggregate can't live there — it gets its own `achievement_results` table, the same pattern as `APIGradeOverride`/`APIClassAchievement`.

### What's in it
- **`APIAchievementResult`** + **`CreateAchievementResults`** migration — one snapshot per `(test_setup, achievement)`, unique-keyed: `studentsMeeting`, `denominator`, `progress` (0–1), `locked`, `evaluatedAt`.
- **`evaluateClassGoalAchievements`** — for each assignment whose manifest carries a `classGoal`: compute each student's best whole-assignment grade from **worker-authoritative** results (`preferredResultsBySubmissionID`), count those meeting the threshold over the **canonical enrolled roster** (`enrolledStudentCount`), and upsert `progress = min(1, reached/target)`. **Locks at the deadline**, and a locked snapshot is then **frozen** (the sweep skips it).
- **`AchievementEvaluationMonitor` + lifecycle handler** — startup sweep + 60 s periodic, registered in `AppServices`, cloned from `StuckSubmissionReaperService`.

### Scope notes
- `classGoal` currently grades on the **whole-assignment metric** (the default target). Per-item / per-section targets are a follow-up — there's no way to author one until the Phase 5 editor, so this covers every goal that can exist today.
- Individual badges and class records (the other `kind`s) are evaluated in Phase 4's subsume pass.

### Tests
`AchievementEvaluationTests`: pure progress-math (scaling + clamp + empty roster); a DB integration test seeding a course + two students at different grades, asserting the snapshot (`studentsMeeting=1, denominator=2, progress=1.0, locked=false`); and a freeze test (a locked snapshot isn't recomputed). Builds clean, `swift-format` + SwiftLint `--strict` clean.

### Roadmap
3. **payoff** — read-time positive bonus (submission / BrightSpace / CSV) + student "Achievements" section with the live progress bar.
4. **subsume** — re-express First-Try-Perfect + the class records as built-in kinds.
5. **authoring** — editor section + MCP tools.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_