### PR TITLE
Keep student submission row actions on one line

### DIFF
--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -323,14 +323,20 @@
 .student-row-actions {
     display: flex;
     gap: .3rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
 }
 .action-form-flush {
     margin: 0;
 }
+.ext-details {
+    position: relative;
+}
 .action-panel {
-    margin-top: .4rem;
+    position: absolute;
+    top: calc(100% + .3rem);
+    left: 0;
+    z-index: 10;
     display: flex;
     flex-direction: column;
     gap: .3rem;
@@ -338,6 +344,7 @@
     background: var(--gray-50);
     border: 1px solid var(--gray-300);
     border-radius: .25rem;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, .15);
 }
 .action-panel-label {
     font-size: .78rem;


### PR DESCRIPTION
On the per-course student submissions page (`/:courseCode/students/:id/submissions`), the row of per-student action controls — retest, extension, grade override, reset — wrapped onto multiple rows.

This pins them to a single row:

- `.student-row-actions` switched from `flex-wrap: wrap` to `flex-wrap: nowrap`.
- The extension / grade-override dropdown panels (`.action-panel`) now render as absolutely-positioned overlays anchored to their `<details>` toggle, so an open panel drops *below* the button rather than expanding inline and pushing sibling buttons onto a second line.

`scripts/check-styles.sh` and `scripts/check-css-vars.sh` both pass.

https://claude.ai/code/session_01VLhQe3wRQcKBpAocQZUwWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLhQe3wRQcKBpAocQZUwWS)_