### PR TITLE
feat(achievements): student class-goal progress display (Phase 3a)

### DIFF
--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -3,6 +3,17 @@
 Submission #(submissionID)
 #endexport
 #export("content"):
+<style>
+.class-goals-block { margin: 1rem 0; }
+.class-goals-heading { font-size: 1.1rem; margin: 0 0 0.5rem; }
+.class-goal { margin: 0.5rem 0; }
+.class-goal-row { display: flex; justify-content: space-between; align-items: baseline; gap: 0.5rem; }
+.class-goal-name { font-weight: 600; }
+.class-goal-reward { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.class-goal-progress { width: 100%; height: 0.6rem; }
+.class-goal-status { font-size: 0.85rem; margin-top: 0.15rem; }
+.class-goal-detail { font-size: 0.85rem; margin: 0.15rem 0 0; }
+</style>
 <div id="submission-root"
      data-submission-id="#(submissionID)"
      data-pending="#(isPending)">
@@ -39,6 +50,23 @@ Submission #(submissionID)
     #endif
     #endif
 </div>
+
+#if(!classGoals.isEmpty):
+<section class="class-goals-block">
+    <h2 class="class-goals-heading">Class goals</h2>
+    #for(goal in classGoals):
+    <div class="class-goal">
+        <div class="class-goal-row">
+            <span class="class-goal-name">#(goal.name)</span>
+            <span class="class-goal-reward">#(goal.rewardLabel)</span>
+        </div>
+        <progress class="class-goal-progress" max="100" value="#(goal.progressPercent)">#(goal.progressPercent)%</progress>
+        <div class="class-goal-status">#if(goal.met):✅ Reached!#else:#(goal.progressPercent)% of the way#endif · #(goal.studentsMeeting) / #(goal.denominator) students#if(goal.locked): · final#endif</div>
+        #if(goal.detail):<p class="class-goal-detail">#(goal.detail)</p>#endif
+    </div>
+    #endfor
+</section>
+#endif
 
 #if(isPending):
 <div class="pending-box">

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -331,4 +331,24 @@ struct SubmissionContext: Encodable {
     let secretSummary: TierSummary?
     let badges: [AchievementBadge]
     let currentUser: CurrentUserContext?
+    /// Class-wide goals for this assignment with their current progress, shown
+    /// as an "Achievements" section.  Empty when the assignment has no class
+    /// goals (or the sweep hasn't produced a snapshot yet).
+    let classGoals: [ClassGoalView]
+}
+
+/// One class-goal achievement's display state for the submission page.
+struct ClassGoalView: Encodable {
+    let name: String
+    let detail: String?
+    /// e.g. "+5 pts", or the reward label for non-points rewards.
+    let rewardLabel: String
+    /// 0–100 — the share of the goal reached (the progress-bar fill).
+    let progressPercent: Int
+    let studentsMeeting: Int
+    let denominator: Int
+    /// True once the class has fully reached the goal.
+    let met: Bool
+    /// True once the deadline has passed and the snapshot is final.
+    let locked: Bool
 }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -374,6 +374,9 @@ extension WebRoutes {
                 setupID: submission.testSetupID, userID: submissionUserID, on: req.db)
         }
 
+        let classGoals = try await loadClassGoalViews(
+            testSetupID: submission.testSetupID, on: req.db)
+
         let ctx = buildSubmissionContext(
             subID: subID,
             submission: submission,
@@ -382,7 +385,8 @@ extension WebRoutes {
             decorations: SubmissionDecorations(
                 badges: badges,
                 currentUser: req.currentUserContext,
-                overrideGradePercent: overrideGradePercent
+                overrideGradePercent: overrideGradePercent,
+                classGoals: classGoals
             ),
             delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText)
         )
@@ -732,8 +736,46 @@ extension WebRoutes {
             deltaHeaderText: delta.headerText,
             secretSummary: processed.secretSummary,
             badges: badges,
-            currentUser: currentUser
+            currentUser: currentUser,
+            classGoals: decorations.classGoals
         )
+    }
+}
+
+/// Loads an assignment's class-goal achievements joined with their latest
+/// `APIAchievementResult` snapshot, for the student-facing "Achievements"
+/// section.  Returns `[]` when the manifest carries no class goals.
+func loadClassGoalViews(testSetupID: String, on db: Database) async throws -> [ClassGoalView] {
+    guard let setup = try await APITestSetup.find(testSetupID, on: db),
+        let props = try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+    else { return [] }
+    let goals = props.achievements.filter { $0.kind == .classGoal }
+    guard !goals.isEmpty else { return [] }
+
+    let rows = try await APIAchievementResult.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .all()
+    var rowByAchievement: [String: APIAchievementResult] = [:]
+    for row in rows { rowByAchievement[row.achievementID] = row }
+
+    return goals.map { goal in
+        let row = rowByAchievement[goal.id]
+        let progress = row?.progress ?? 0
+        let rewardLabel: String
+        if goal.reward.type == .points, let points = goal.reward.points {
+            rewardLabel = "+\(points) pts"
+        } else {
+            rewardLabel = goal.reward.label
+        }
+        return ClassGoalView(
+            name: goal.name,
+            detail: goal.detail,
+            rewardLabel: rewardLabel,
+            progressPercent: Int((progress * 100).rounded()),
+            studentsMeeting: row?.studentsMeeting ?? 0,
+            denominator: row?.denominator ?? 0,
+            met: progress >= 1,
+            locked: row?.locked ?? false)
     }
 }
 
@@ -854,6 +896,8 @@ private struct SubmissionDecorations {
     /// Instructor override percent for this student × assignment, nil when
     /// none.  The effective grade shown above the autograded breakdown.
     let overrideGradePercent: Int?
+    /// Class-goal progress views for the "Achievements" section.
+    let classGoals: [ClassGoalView]
 }
 
 // `SubmitFormBody` and the submission-output formatting helpers live in

--- a/Tests/APITests/AchievementDisplayTests.swift
+++ b/Tests/APITests/AchievementDisplayTests.swift
@@ -1,0 +1,66 @@
+// Tests/APITests/AchievementDisplayTests.swift
+//
+// Phase 3a display: the student submission page renders an "Achievements"
+// section with a live progress bar for each class goal, reading the manifest
+// spec joined with the latest `APIAchievementResult` snapshot.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementDisplayTests {
+
+    @Test func submissionPageShowsClassGoalProgress() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            try await wrEnrollUser(student, on: app)
+            try await wrInsertSetup(id: "cg_setup", on: app)
+
+            // Replace the default manifest with one carrying a class goal.
+            let props = TestProperties(
+                achievements: [
+                    Achievement(
+                        id: "goalX", name: "Mastery Goal", kind: .classGoal, scope: .classWide,
+                        reward: AchievementReward(type: .points, label: "Mastery", points: 5),
+                        threshold: 0.8, classFraction: 0.8)
+                ])
+            let setup = try #require(try await APITestSetup.find("cg_setup", on: app.db))
+            let data = try JSONEncoder().encode(props)
+            setup.manifest = try #require(String(bytes: data, encoding: .utf8))
+            try await setup.save(on: app.db)
+
+            // The sweep's snapshot: 41 of 64 students, 80% of the goal.
+            try await APIAchievementResult(
+                testSetupID: "cg_setup", achievementID: "goalX",
+                studentsMeeting: 41, denominator: 64, progress: 0.8, locked: false,
+                evaluatedAt: Date()
+            ).save(on: app.db)
+
+            _ = try await wrInsertAssignment(
+                testSetupID: "cg_setup", title: "Goals", isOpen: true, on: app)
+            _ = try await wrInsertSubmission(
+                id: "cg_sub", testSetupID: "cg_setup", userID: try student.requireID(), on: app)
+            _ = try await wrInsertResult(
+                submissionID: "cg_sub", outcomes: [wrMakeOutcome(name: "t1", status: .pass)], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/cg_sub",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("Class goals"))
+                    #expect(body.contains("Mastery Goal"))
+                    #expect(body.contains("80% of the way"))
+                    #expect(body.contains("41 / 64 students"))
+                    #expect(body.contains("+5 pts"))
+                    #expect(body.contains(#"<progress class="class-goal-progress" max="100" value="80">"#))
+                })
+        }
+    }
+}

--- a/changelog.d/achievements-display.md
+++ b/changelog.d/achievements-display.md
@@ -1,0 +1,7 @@
+### Added
+
+- **Class goals shown to students (achievements Phase 3a).** The submission page
+  now renders an "Achievements" section with a live progress bar for each class
+  goal — e.g. "80% of the way · 41 / 64 students", the reward, and a "Reached!" /
+  "final" state — read from the Phase 2 snapshots. Display only; the positive
+  grade bonus these goals award lands in Phase 3b.


### PR DESCRIPTION
## Phase 3a — class goals become visible to students

Builds on Phase 2 (#860). This is the first **visible** payoff: the submission page now shows the class goals and their live progress. **Display only — no grade change** (the positive bonus is Phase 3b), so it's low-risk.

### What's in it
- **`loadClassGoalViews`** — joins each `classGoal` in the assignment manifest with its latest `APIAchievementResult` snapshot into a `ClassGoalView` (name, reward label, `progressPercent`, students-meeting / denominator, `met`, `locked`), surfaced through `SubmissionDecorations`.
- **`submission.leaf`** — a new **"Class goals"** section: per goal, a native `<progress>` bar plus *"80% of the way · 41 / 64 students"*, the reward (e.g. `+5 pts`), and a `✅ Reached!` / `final` state. Page-local **layout-only** CSS (no new custom properties), so `check-styles` + `check-css-vars` stay clean. Native `<progress>` keeps it accessible.

### Notes
- Equity by design: shows counts/percent only — never names who has or hasn't reached it.
- Renders whether or not this attempt is pending/failed (it's a class-wide signal, not this submission's result).

### Tests
`AchievementDisplayTests` seeds a class goal + a snapshot (41/64, 80%) and asserts the section, the `<progress value="80">`, the student count, and the reward render. Build + test + `check-styles` + `swift-format` + SwiftLint `--strict` all clean.

### Roadmap
3b. **grade bonus** — apply the positive class-goal bonus at the three grade-read sites (submission grade, BrightSpace, CSV).
4. **subsume** legacy badges. 5. **authoring** (editor + MCP).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_