### PR TITLE
feat(achievements): author class goals in the assignment editor (Phase 5)

### DIFF
--- a/Public/class-goals-editor.js
+++ b/Public/class-goals-editor.js
@@ -1,0 +1,129 @@
+// Public/class-goals-editor.js
+//
+// Wires the "Class Goals" card on the assignment edit page.  Each row is one
+// class-wide goal: a name, a per-student grade threshold (%), the share of the
+// class that must reach it (%), and the bonus points everyone who submitted
+// earns once the class gets there.  Loads the current goals via GET and saves
+// the whole list via PUT /instructor/:id/achievements.  Evaluation + display of
+// these goals are server-side; this module is authoring only.
+
+(function () {
+    'use strict';
+
+    function csrf() {
+        var m = document.querySelector('meta[name="csrf-token"]');
+        return m ? m.getAttribute('content') : '';
+    }
+
+    function escapeAttr(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;');
+    }
+
+    function rowHTML(goal) {
+        goal = goal || {};
+        function v(x) { return x == null ? '' : String(x); }
+        return ''
+            + '<td><input type="text" class="form-input cg-name" value="' + escapeAttr(goal.name) + '" placeholder="e.g. 80% Mastery"></td>'
+            + '<td><input type="number" class="form-input cg-threshold" min="0" max="100" value="' + escapeAttr(v(goal.thresholdPercent)) + '"></td>'
+            + '<td><input type="number" class="form-input cg-class" min="0" max="100" value="' + escapeAttr(v(goal.classPercent)) + '"></td>'
+            + '<td><input type="number" class="form-input cg-bonus" min="0" value="' + escapeAttr(v(goal.bonusPoints)) + '"></td>'
+            + '<td class="time"><button type="button" class="btn action-btn action-danger cg-remove" title="Remove goal" aria-label="Remove goal">✕</button></td>';
+    }
+
+    function addRow(tbody, goal) {
+        var tr = document.createElement('tr');
+        tr.className = 'cg-row';
+        tr.innerHTML = rowHTML(goal);
+        tbody.appendChild(tr);
+        return tr;
+    }
+
+    function buildPayload(tbody) {
+        var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr.cg-row'));
+        var goals = [];
+        rows.forEach(function (tr) {
+            var name = (tr.querySelector('.cg-name').value || '').trim();
+            if (!name) return;  // skip blank rows
+            goals.push({
+                name: name,
+                thresholdPercent: Number(tr.querySelector('.cg-threshold').value || 0),
+                classPercent: Number(tr.querySelector('.cg-class').value || 0),
+                bonusPoints: Math.max(0, parseInt(tr.querySelector('.cg-bonus').value || 0, 10) || 0)
+            });
+        });
+        return { goals: goals };
+    }
+
+    function init() {
+        var block = document.getElementById('class-goals-block');
+        if (!block) return;
+        var tbody = block.querySelector('tbody.class-goals-body');
+        var addBtn = document.getElementById('class-goal-add');
+        var saveBtn = document.getElementById('class-goals-save');
+        var status = document.getElementById('class-goals-status');
+        var assignmentID = block.getAttribute('data-assignment-id') || '';
+        if (!tbody || !assignmentID) return;
+        var url = '/instructor/' + encodeURIComponent(assignmentID) + '/achievements';
+
+        function setStatus(text, kind) {
+            if (!status) return;
+            status.textContent = text || '';
+            status.style.color = kind === 'error'
+                ? 'var(--red)'
+                : (kind === 'ok' ? 'var(--green)' : 'var(--gray-500)');
+        }
+
+        // Load the current goals into rows.
+        fetch(url, { headers: { 'x-csrf-token': csrf() } })
+            .then(function (r) { return r.ok ? r.json() : { goals: [] }; })
+            .then(function (body) {
+                (body && body.goals ? body.goals : []).forEach(function (g) { addRow(tbody, g); });
+            })
+            .catch(function () { /* leave empty on load failure */ });
+
+        if (addBtn) {
+            addBtn.addEventListener('click', function () {
+                var tr = addRow(tbody, {});
+                var input = tr.querySelector('.cg-name');
+                if (input) input.focus();
+            });
+        }
+
+        block.addEventListener('click', function (e) {
+            var btn = e.target.closest && e.target.closest('.cg-remove');
+            if (btn && block.contains(btn)) {
+                var tr = btn.closest('tr.cg-row');
+                if (tr) tr.remove();
+            }
+        });
+
+        if (saveBtn) {
+            saveBtn.addEventListener('click', function () {
+                setStatus('Saving…', null);
+                fetch(url, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrf() },
+                    body: JSON.stringify(buildPayload(tbody))
+                }).then(function (r) {
+                    if (r.ok) { setStatus('Saved.', 'ok'); return; }
+                    return r.text().then(function (t) {
+                        var msg = t || ('HTTP ' + r.status);
+                        try { var p = JSON.parse(t); if (p && p.reason) msg = p.reason; } catch (_) { /* text */ }
+                        setStatus('Save failed: ' + msg.slice(0, 240), 'error');
+                    });
+                }).catch(function (err) {
+                    setStatus('Save failed: ' + (err && err.message ? err.message : err), 'error');
+                });
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -186,6 +186,32 @@
     </table>
 </section>
 
+<section id="class-goals-block"
+         data-assignment-id="#(assignmentID)"
+         class="editor-block">
+    <div class="editor-block-head">
+        <h2>Class Goals</h2>
+        <div class="toolbar toolbar--end">
+            <button type="button" class="btn action-btn" id="class-goal-add">+ Add Goal</button>
+            <button type="button" class="btn action-btn" id="class-goals-save">Save Goals</button>
+            <span id="class-goals-status" class="upload-status-inline"></span>
+        </div>
+    </div>
+    <table class="results-table" id="class-goals-table">
+        <thead>
+            <tr>
+                <th>Goal</th>
+                <th>Grade ≥ (%)</th>
+                <th>Class ≥ (%)</th>
+                <th>Bonus (pts)</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody class="class-goals-body"></tbody>
+    </table>
+    <p class="class-goals-hint">When at least the chosen share of the class reaches the grade threshold, everyone who submitted earns the bonus as extra credit (capped at 100%), scaled by how far the class gets — students see it as a live progress bar.</p>
+</section>
+
 #if(brightspaceSyncEnabled):
 <!-- ── BrightSpace grade sync ─────────────────────────── -->
 <div class="editor-block">
@@ -539,6 +565,7 @@ function checkUWDates(dateTimeValue, warningEl) {
 </script>
 
 <script src="/global-inputs-editor.js?v=#appVersion()"></script>
+<script src="/class-goals-editor.js?v=#appVersion()"></script>
 
 <!-- ── Unified Test Editor modal (shell + renderers) ────────────────────────
      The "+ Add Test" button opens one modal; picking a type morphs the body

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
@@ -1,0 +1,114 @@
+// APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
+//
+// Instructor authoring for class-wide goals (a kind of Achievement).
+//
+// GET returns the assignment's current class goals as editable rows; PUT
+// replaces the class-goal set in the manifest.  Class goals are
+// server-evaluated and display-only — they never change what the suite grades —
+// so, unlike suite edits, this path does NOT retest submissions, reschedule
+// validation, or close the assignment.  It just rewrites the manifest's
+// `achievements` array (preserving any non-class-goal achievements).
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension PublishedAssignmentRoutes {
+
+    /// One editable class-goal row from the editor.
+    struct ClassGoalInput: Content {
+        var id: String?
+        var name: String
+        /// Per-student grade threshold, 0–100 (% of the assignment grade).
+        var thresholdPercent: Double
+        /// Share of the class that must reach the threshold, 0–100.
+        var classPercent: Double
+        /// Positive bonus points (extra credit, capped at 100% at grading time).
+        var bonusPoints: Int
+    }
+
+    struct AchievementsBody: Content {
+        var goals: [ClassGoalInput]
+    }
+
+    struct AchievementsResponse: Content {
+        var goals: [ClassGoalInput]
+    }
+
+    // MARK: - GET /instructor/:assignmentID/achievements
+
+    @Sendable
+    func getAchievements(req: Request) async throws -> AchievementsResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        return AchievementsResponse(goals: classGoalRows(fromManifest: setup.manifest))
+    }
+
+    // MARK: - PUT /instructor/:assignmentID/achievements
+
+    @Sendable
+    func putAchievements(req: Request) async throws -> AchievementsResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let body = try req.content.decode(AchievementsBody.self)
+
+        let newGoals = try body.goals.map { try achievement(from: $0) }
+
+        // Preserve any non-class-goal achievements; replace the class-goal set.
+        let existing =
+            (try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8)))?
+            .achievements ?? []
+        let merged = existing.filter { $0.kind != .classGoal } + newGoals
+
+        try await mutateManifest(setup: setup, on: req.db) { dict in
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            dict["achievements"] = try JSONSerialization.jsonObject(with: encoder.encode(merged))
+        }
+        return AchievementsResponse(goals: classGoalRows(fromManifest: setup.manifest))
+    }
+
+    // MARK: - Conversions
+
+    private func achievement(from input: ClassGoalInput) throws -> Achievement {
+        let trimmed = input.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw WebAssignmentError.invalidParameter(name: "name", reason: "Goal name must not be empty.")
+        }
+        guard (0...100).contains(input.thresholdPercent),
+            (0...100).contains(input.classPercent),
+            input.bonusPoints >= 0
+        else {
+            throw WebAssignmentError.invalidParameter(
+                name: "goal",
+                reason: "Threshold and class share must be 0–100; bonus points must be ≥ 0.")
+        }
+        let goalID: String
+        if let existing = input.id, !existing.isEmpty {
+            goalID = existing
+        } else {
+            goalID = "goal_\(UUID().uuidString.prefix(8))"
+        }
+        return Achievement(
+            id: goalID,
+            name: trimmed,
+            kind: .classGoal,
+            scope: .classWide,
+            reward: AchievementReward(type: .points, label: trimmed, points: input.bonusPoints),
+            target: AchievementTarget(kind: .assignmentGrade),
+            threshold: input.thresholdPercent / 100,
+            classFraction: input.classPercent / 100)
+    }
+
+    private func classGoalRows(fromManifest manifest: String) -> [ClassGoalInput] {
+        guard let props = try? JSONDecoder().decode(TestProperties.self, from: Data(manifest.utf8))
+        else { return [] }
+        return props.achievements.filter { $0.kind == .classGoal }.map { a in
+            ClassGoalInput(
+                id: a.id,
+                name: a.name,
+                thresholdPercent: (a.threshold ?? 0) * 100,
+                classPercent: (a.classFraction ?? 0) * 100,
+                bonusPoints: a.reward.points ?? 0)
+        }
+    }
+}

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
@@ -67,5 +67,10 @@ struct PublishedAssignmentRoutes: RouteCollection {
         // Assignment-scope global variables.
         r.get(":assignmentID", "global-variables", use: getGlobalVariables)
         r.put(":assignmentID", "global-variables", use: putGlobalVariables)
+
+        // Assignment-scope class goals (achievements) — display-only, so no
+        // retest/validation on edit.
+        r.get(":assignmentID", "achievements", use: getAchievements)
+        r.put(":assignmentID", "achievements", use: putAchievements)
     }
 }

--- a/Tests/APITests/AchievementAuthoringTests.swift
+++ b/Tests/APITests/AchievementAuthoringTests.swift
@@ -1,0 +1,97 @@
+// Tests/APITests/AchievementAuthoringTests.swift
+//
+// Phase 5 authoring: the instructor edit page's "Class Goals" card persists
+// class goals into the assignment manifest via PUT /instructor/:id/achievements
+// (and reads them back via GET). Display-only, so the save does not retest or
+// re-validate.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementAuthoringTests {
+
+    @Test func putAndGetClassGoalsRoundTrip() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "cga_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "cga_setup", title: "Goals", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.AchievementsBody(goals: [
+                            .init(
+                                id: nil, name: "80% Mastery",
+                                thresholdPercent: 80, classPercent: 80, bonusPoints: 5)
+                        ]), as: .json)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                })
+
+            // The manifest now carries the class goal, encoded as an Achievement.
+            let setup = try #require(try await APITestSetup.find("cga_setup", on: app.db))
+            let props = try JSONDecoder().decode(
+                TestProperties.self, from: Data(setup.manifest.utf8))
+            let goal = try #require(props.achievements.first { $0.kind == .classGoal })
+            #expect(goal.name == "80% Mastery")
+            #expect(goal.scope == .classWide)
+            #expect(goal.threshold == 0.8)
+            #expect(goal.classFraction == 0.8)
+            #expect(goal.reward.type == .points)
+            #expect(goal.reward.points == 5)
+
+            // GET returns it as an editable row (percent units back out).
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("80% Mastery"))
+                    #expect(body.contains("\"thresholdPercent\":80"))
+                })
+        }
+    }
+
+    @Test func putRejectsOutOfRangeThreshold() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "cga_bad_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "cga_bad_setup", title: "Bad Goals", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.AchievementsBody(goals: [
+                            .init(
+                                id: nil, name: "Impossible",
+                                thresholdPercent: 150, classPercent: 80, bonusPoints: 5)
+                        ]), as: .json)
+                },
+                afterResponse: { res in
+                    #expect(res.status != .ok, "Out-of-range threshold must be rejected")
+                })
+
+            let setup = try #require(try await APITestSetup.find("cga_bad_setup", on: app.db))
+            let props = try JSONDecoder().decode(
+                TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.achievements.isEmpty, "Rejected goal must not be written")
+        }
+    }
+}

--- a/changelog.d/achievements-authoring.md
+++ b/changelog.d/achievements-authoring.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Author class goals from the assignment editor (achievements Phase 5).** A
+  new "Class Goals" card on the instructor assignment edit page lets you add
+  class-wide goals — a name, a per-student grade threshold, the share of the
+  class that must reach it, and the bonus points everyone who submitted earns —
+  persisted to the manifest via `PUT /instructor/:id/achievements`. Class goals
+  are display-only, so saving doesn't retest submissions or re-validate. The
+  student progress bar (Phase 3a) and the grade bonus (Phase 3b) read these.


### PR DESCRIPTION
## Phase 5 — author class goals in the assignment editor

Now an instructor can actually **create** class goals (the feature was inert without this). The agent's seam-mapping confirmed this is *simpler* than pattern-families authoring — class goals are display-only, so the save path skips retest/validation/close entirely.

### What's in it
- **`GET` / `PUT /instructor/:assignmentID/achievements`** (`PublishedAssignmentRoutes+Achievements`). GET returns the assignment's class goals as editable rows; PUT validates (name non-empty; threshold + class share 0–100; bonus ≥ 0), converts each row to a `classGoal` `Achievement` (assignment-grade target, points reward), and rewrites the manifest's `achievements` array via the lightweight **`mutateManifest`** helper — **preserving any non-class-goal achievements**. No retest, no re-validation, no assignment close (display-only).
- **A "Class Goals" card** on the assignment edit page (Global-Inputs-style: section outside the form, table, Add/Remove/Save) + **`class-goals-editor.js`** (loads via GET, adds/removes rows, saves the whole list via PUT). Self-contained client-loaded module — no edit-page context changes, no coupling to the server-authoritative suite editor.

### Tests
`AchievementAuthoringTests`: a PUT→manifest→GET round-trip (asserts the `Achievement` is written with the right threshold/fraction/reward and reads back as percent rows) and an out-of-range rejection (no row written). Build + `check-styles` + `swift-format` + SwiftLint `--strict` clean.

### Where this leaves the feature
End-to-end now: **author** a class goal → the **engine** (Phase 2) computes class progress → students **see** the progress bar (Phase 3a). The only piece left is the **grade bonus (Phase 3b)** — which you chose to be **extra credit, capped at 100%** — landing next.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_