### PR TITLE
feat(achievements): class-goal grade bonus, extra credit capped at 100% (Phase 3b)

### DIFF
--- a/Sources/APIServer/Helpers/ClassGoalBonus.swift
+++ b/Sources/APIServer/Helpers/ClassGoalBonus.swift
@@ -1,0 +1,53 @@
+// APIServer/Helpers/ClassGoalBonus.swift
+//
+// The positive grade bonus a class goal awards.  Class goals are a class-wide
+// reward: when (at least the configured share of) the class reaches the
+// threshold, every student who submitted earns the same bonus, scaled by how
+// far the class got (`APIAchievementResult.progress`).  The bonus is applied as
+// **extra credit, capped at 100%** (the user-chosen semantic) at each
+// grade-of-record site — the submission page, the BrightSpace push, and the
+// grades CSV — so it never reduces anyone's grade and never exceeds full marks.
+//
+// 0 when the assignment defines no points-rewarded class goals (the common
+// case), so this is a no-op for ordinary assignments.
+
+import Core
+import Fluent
+import Foundation
+
+/// Total class-goal bonus points for an assignment: Σ over its points-rewarded
+/// class goals of `reward.points × current class progress`.
+func classGoalBonusPoints(testSetupID: String, on db: Database) async throws -> Double {
+    guard let setup = try await APITestSetup.find(testSetupID, on: db),
+        let props = setup.decodedManifest()
+    else { return 0 }
+    let goals = props.achievements.filter { $0.kind == .classGoal && $0.reward.type == .points }
+    guard !goals.isEmpty else { return 0 }
+
+    let rows = try await APIAchievementResult.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .all()
+    var progressByID: [String: Double] = [:]
+    for row in rows { progressByID[row.achievementID] = row.progress }
+
+    return goals.reduce(0.0) { sum, goal in
+        sum + Double(goal.reward.points ?? 0) * (progressByID[goal.id] ?? 0)
+    }
+}
+
+/// Adds a class-goal bonus to an earned-points grade as extra credit, capped at
+/// the suite total so the percentage never exceeds 100%.  A 0 bonus or a
+/// non-positive total leaves the grade untouched.
+func earnedWithClassGoalBonus(earned: Double, total: Double, bonus: Double) -> Double {
+    guard total > 0, bonus > 0 else { return earned }
+    return min(total, earned + bonus)
+}
+
+/// The suite's total possible points (sum of test-suite item weights) for a
+/// loaded setup, or nil when the manifest is missing/malformed or sums to zero.
+/// Used as the 100% cap for the class-goal bonus on the points-based exports.
+func suiteTotalPoints(setup: APITestSetup) -> Double? {
+    guard let props = setup.decodedManifest() else { return nil }
+    let total = props.testSuites.map(\.points).reduce(0, +)
+    return total > 0 ? Double(total) : nil
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -52,12 +52,29 @@ extension InstructorDashboardRoutes {
         // map rather than filtering within it. The override percent is
         // converted to points against the setup's total possible points.
         let overrideMap = try await loadGradeOverridePercents(setupIDs: setupIDs, on: req.db)
+        var overrideKeys: Set<String> = []
         for (key, pct) in overrideMap {
             guard let setup = setupByID[key.setupID],
                 let points = gradeOverridePoints(percent: pct, setup: setup)
             else { continue }
             let mapKey = "\(key.userID.uuidString.lowercased())::\(key.setupID)"
             bestPointsByUserAndSetup[mapKey] = points
+            overrideKeys.insert(mapKey)
+        }
+
+        // Class-goal bonus: extra credit (capped at 100%) for every graded
+        // submission on a setup with class goals.  Overrides are authoritative,
+        // so a key an override already set is left untouched.
+        for setupID in setupIDs {
+            let bonus = try await classGoalBonusPoints(testSetupID: setupID, on: req.db)
+            guard bonus > 0, let setup = setupByID[setupID],
+                let total = suiteTotalPoints(setup: setup)
+            else { continue }
+            let suffix = "::\(setupID)"
+            for (mapKey, points) in bestPointsByUserAndSetup
+            where mapKey.hasSuffix(suffix) && !overrideKeys.contains(mapKey) {
+                bestPointsByUserAndSetup[mapKey] = min(total, points + bonus)
+            }
         }
 
         let csv = renderGradesCSV(

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -343,6 +343,22 @@ extension WebRoutes {
             )
         }
 
+        // Class-goal bonus: extra credit on the autograded grade, capped at 100%
+        // (no-op unless the assignment has a points-rewarded class goal).
+        if processed.totalPoints > 0 {
+            let bonus = try await classGoalBonusPoints(
+                testSetupID: submission.testSetupID, on: req.db)
+            if bonus > 0 {
+                let bonused = earnedWithClassGoalBonus(
+                    earned: processed.rawEarnedPoints,
+                    total: Double(processed.totalPoints),
+                    bonus: bonus)
+                processed.gradePercent = Int(
+                    (bonused / Double(processed.totalPoints) * 100).rounded())
+                processed.earnedPoints = formatPoints(bonused)
+            }
+        }
+
         // Append class-wide achievement badges held by this specific submission.
         let classAchievements = try await APIClassAchievement.query(on: req.db)
             .filter(\.$submissionID == subID)
@@ -534,6 +550,7 @@ extension WebRoutes {
         processed.totalTests = collection.totalTests
         processed.executionTimeMs = collection.executionTimeMs
         processed.totalPoints = collection.totalPoints
+        processed.rawEarnedPoints = collection.earnedPoints
         processed.earnedPoints = formatPoints(collection.earnedPoints)
         processed.gradePercent =
             collection.totalPoints > 0
@@ -794,6 +811,9 @@ private struct ProcessedCollection {
     var totalTests: Int
     var totalPoints: Int
     var earnedPoints: String
+    /// Raw earned points before display formatting and before any class-goal
+    /// bonus — used to recompute the grade when a bonus applies.
+    var rawEarnedPoints: Double
     var executionTimeMs: Int
     var gradePercent: Int
     var badges: [AchievementBadge]
@@ -809,6 +829,7 @@ private struct ProcessedCollection {
         totalTests: 0,
         totalPoints: 0,
         earnedPoints: "0",
+        rawEarnedPoints: 0,
         executionTimeMs: 0,
         gradePercent: 0,
         badges: [],

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -236,6 +236,11 @@ private func bestPointsForStudent(
     else {
         throw BrightSpaceSyncError.missingPoints
     }
+    // Class-goal bonus: extra credit, capped at the suite total (100%).
+    let bonus = try await classGoalBonusPoints(testSetupID: testSetupID, on: db)
+    if bonus > 0, let total = try await suiteTotalPoints(testSetupID: testSetupID, db: db) {
+        return min(total, points + bonus)
+    }
     return points
 }
 

--- a/Tests/APITests/AchievementBonusTests.swift
+++ b/Tests/APITests/AchievementBonusTests.swift
@@ -1,0 +1,77 @@
+// Tests/APITests/AchievementBonusTests.swift
+//
+// Phase 3b: the class-goal grade bonus — extra credit, capped at 100% — applied
+// at the grade-of-record sites. The pure cap is unit-tested; the grades CSV
+// (an official export) is exercised end-to-end. The submission page and the
+// BrightSpace push apply the same `classGoalBonusPoints` + `earnedWithClassGoalBonus`.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementBonusTests {
+
+    @Test func earnedWithClassGoalBonusCapsAtTotal() {
+        #expect(earnedWithClassGoalBonus(earned: 18, total: 20, bonus: 5) == 20)  // capped at 100%
+        #expect(earnedWithClassGoalBonus(earned: 10, total: 20, bonus: 5) == 15)  // under the cap
+        #expect(earnedWithClassGoalBonus(earned: 18, total: 20, bonus: 0) == 18)  // no bonus
+        #expect(earnedWithClassGoalBonus(earned: 18, total: 0, bonus: 5) == 18)  // no total → untouched
+    }
+
+    @Test func gradesCSVIncludesCappedClassGoalBonus() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+
+            // Suite worth 20 points + a class goal awarding +5.
+            let testSuites = try JSONDecoder().decode(
+                [TestSuiteEntry].self,
+                from: Data(#"[{"tier":"public","script":"t.sh","points":20}]"#.utf8))
+            let props = TestProperties(
+                testSuites: testSuites,
+                achievements: [
+                    Achievement(
+                        id: "g_csv", name: "Mastery", kind: .classGoal, scope: .classWide,
+                        reward: AchievementReward(type: .points, label: "Mastery", points: 5),
+                        threshold: 0.8, classFraction: 0.8)
+                ])
+            let manifest = try #require(String(bytes: try JSONEncoder().encode(props), encoding: .utf8))
+            let setup = APITestSetup(
+                id: "csv_bonus_setup", manifest: manifest,
+                zipPath: app.testSetupsDirectory + "csv_bonus_setup.zip", courseID: courseID)
+            try await setup.save(on: app.db)
+            _ = try await arInsertAssignment(
+                testSetupID: "csv_bonus_setup", title: "Bonus CSV", isOpen: true, on: app)
+
+            let student = try await arInsertStudent(username: "csv_bonus_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            _ = try await arInsertSubmission(
+                id: "csv_bonus_sub", testSetupID: "csv_bonus_setup",
+                userID: try student.requireID(), on: app)
+            // Earned 18/20; the class reached the goal (progress 1.0) → +5 bonus.
+            try await APIResult(
+                id: "csv_bonus_res", submissionID: "csv_bonus_sub",
+                collectionJSON: #"{"earnedPoints":18,"totalPoints":20,"passCount":18,"totalTests":20}"#
+            ).save(on: app.db)
+            try await APIAchievementResult(
+                testSetupID: "csv_bonus_setup", achievementID: "g_csv",
+                studentsMeeting: 8, denominator: 10, progress: 1.0, locked: false,
+                evaluatedAt: Date()
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/instructor/grades.csv",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("20.0"), "18/20 + 5 bonus capped at 20 must export as 20.0")
+                    #expect(!body.contains("18.0"), "Raw 18 must be replaced by the bonused 20")
+                })
+        }
+    }
+}

--- a/changelog.d/achievements-bonus.md
+++ b/changelog.d/achievements-bonus.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Class-goal grade bonus (achievements Phase 3b).** When the class reaches a
+  goal, every student who submitted earns the goal's points as **extra credit,
+  capped at 100%**, scaled by how far the class got — applied at the
+  grade-of-record sites: the submission page, the BrightSpace grade push, and
+  the grades CSV. Purely positive (never lowers a grade); an instructor grade
+  override still wins; a no-op for assignments without a points-rewarded class
+  goal. This completes the class-goals feature: author → evaluate → display →
+  grade.


### PR DESCRIPTION
## Phase 3b — the class-goal grade bonus (the last functional piece)

When the class reaches a goal, every student who submitted earns the goal's points as **extra credit, capped at 100%** (the semantic you chose), scaled by how far the class got. This completes the feature: **author → evaluate → display → grade.**

### How it works
A shared helper pair in `ClassGoalBonus.swift`:
- `classGoalBonusPoints(testSetupID:)` = Σ over the assignment's points-rewarded class goals of `reward.points × snapshot.progress`.
- `earnedWithClassGoalBonus(earned:total:bonus:)` = `min(total, earned + bonus)` — extra credit, capped so the percentage never exceeds 100%.

Applied at the **three grade-of-record sites**:
- **submission page** — the autograded grade the student sees,
- **BrightSpace push** (`bestPointsForStudent`),
- **grades CSV** (a per-setup overlay on `bestPointsByUserAndSetup`).

### Safety
- **Purely positive** — never lowers a grade.
- An **instructor override is authoritative** and is left untouched (no bonus stacked on an override).
- **No-op** when the assignment has no points-rewarded class goal — so zero effect on every existing assignment (the feature stays dormant until a goal is authored).

### Honest scope note
The instructor **dashboard / roster *summary* grades** (the at-a-glance assignment list + the median metric) still show the *pre-bonus* autograded grade — a small documented follow-up. It's harmless until a goal is authored, and the grade-of-record surfaces (what the student sees + the official exports) are covered here.

### Tests
A pure cap unit test + a grades-CSV integration test (18/20 + 5 bonus → capped **20.0**, raw 18 replaced). Build + `check-styles` + `swift-format` + SwiftLint `--strict` clean.

### Feature status
With this, the class-goals feature is **functionally complete**. Only the optional **Phase 4 (subsume legacy badges)** remains — a refactor with regression risk and no new value; I'll check with you before doing it.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_