### PR TITLE
feat(achievements): authorable individual badges (Phase 4)

### DIFF
--- a/Public/badges-editor.js
+++ b/Public/badges-editor.js
@@ -1,0 +1,157 @@
+// Public/badges-editor.js
+//
+// Wires the "Badges" card on the assignment edit page. Each row authors an
+// individual (per-student) badge: a caption, an emoji, and the condition that
+// earns it — either a score threshold ("Score ≥ 90%") or a specific test
+// passing. Loads via GET and saves the whole list via PUT
+// /instructor/:id/badges. Evaluation + display are server-side; authoring only.
+
+(function () {
+    'use strict';
+
+    function csrf() {
+        var m = document.querySelector('meta[name="csrf-token"]');
+        return m ? m.getAttribute('content') : '';
+    }
+
+    function escapeAttr(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;');
+    }
+
+    // The Value cell means different things per kind: a percent for a score
+    // threshold, a test filename for a test-pass badge.
+    function valueFor(badge) {
+        if (badge.kind === 'testBadge') return badge.testName == null ? '' : badge.testName;
+        return badge.thresholdPercent == null ? '' : badge.thresholdPercent;
+    }
+
+    function placeholderFor(kind) {
+        return kind === 'testBadge' ? 'secrettest_x.py' : '90';
+    }
+
+    function rowHTML(badge) {
+        badge = badge || {};
+        var kind = badge.kind === 'testBadge' ? 'testBadge' : 'thresholdBadge';
+        function opt(v, label) {
+            return '<option value="' + v + '"' + (kind === v ? ' selected' : '') + '>' + label + '</option>';
+        }
+        return ''
+            + '<td><input type="text" class="form-input b-name" value="' + escapeAttr(badge.name) + '" placeholder="e.g. Sharpshooter"></td>'
+            + '<td><input type="text" class="form-input b-icon" value="' + escapeAttr(badge.icon) + '" placeholder="🌟"></td>'
+            + '<td><select class="form-input b-kind">'
+            +     opt('thresholdBadge', 'Score ≥ (%)')
+            +     opt('testBadge', 'Test passes')
+            + '</select></td>'
+            + '<td><input type="text" class="form-input b-value" value="' + escapeAttr(valueFor(badge)) + '" placeholder="' + placeholderFor(kind) + '"></td>'
+            + '<td class="time"><button type="button" class="btn action-btn action-danger b-remove" title="Remove badge" aria-label="Remove badge">✕</button></td>';
+    }
+
+    function addRow(tbody, badge) {
+        var tr = document.createElement('tr');
+        tr.className = 'b-row';
+        tr.innerHTML = rowHTML(badge);
+        tbody.appendChild(tr);
+        return tr;
+    }
+
+    function buildPayload(tbody) {
+        var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr.b-row'));
+        var badges = [];
+        rows.forEach(function (tr) {
+            var name = (tr.querySelector('.b-name').value || '').trim();
+            if (!name) return;  // skip blank rows
+            var kind = tr.querySelector('.b-kind').value;
+            var icon = (tr.querySelector('.b-icon').value || '').trim();
+            var rawValue = (tr.querySelector('.b-value').value || '').trim();
+            var badge = { name: name, kind: kind, icon: icon || null };
+            if (kind === 'testBadge') {
+                badge.testName = rawValue;
+            } else {
+                badge.thresholdPercent = Number(rawValue || 0);
+            }
+            badges.push(badge);
+        });
+        return { badges: badges };
+    }
+
+    function init() {
+        var block = document.getElementById('badges-block');
+        if (!block) return;
+        var tbody = block.querySelector('tbody.badges-body');
+        var addBtn = document.getElementById('badge-add');
+        var saveBtn = document.getElementById('badges-save');
+        var status = document.getElementById('badges-status');
+        var assignmentID = block.getAttribute('data-assignment-id') || '';
+        if (!tbody || !assignmentID) return;
+        var url = '/instructor/' + encodeURIComponent(assignmentID) + '/badges';
+
+        function setStatus(text, kind) {
+            if (!status) return;
+            status.textContent = text || '';
+            status.style.color = kind === 'error'
+                ? 'var(--red)'
+                : (kind === 'ok' ? 'var(--green)' : 'var(--gray-500)');
+        }
+
+        fetch(url, { headers: { 'x-csrf-token': csrf() } })
+            .then(function (r) { return r.ok ? r.json() : { badges: [] }; })
+            .then(function (body) {
+                (body && body.badges ? body.badges : []).forEach(function (b) { addRow(tbody, b); });
+            })
+            .catch(function () { /* leave empty on load failure */ });
+
+        if (addBtn) {
+            addBtn.addEventListener('click', function () {
+                var tr = addRow(tbody, {});
+                var input = tr.querySelector('.b-name');
+                if (input) input.focus();
+            });
+        }
+
+        // Keep the Value placeholder in step with the selected kind.
+        block.addEventListener('change', function (e) {
+            if (e.target && e.target.classList.contains('b-kind')) {
+                var tr = e.target.closest('tr.b-row');
+                var value = tr && tr.querySelector('.b-value');
+                if (value) value.placeholder = placeholderFor(e.target.value);
+            }
+        });
+
+        block.addEventListener('click', function (e) {
+            var btn = e.target.closest && e.target.closest('.b-remove');
+            if (btn && block.contains(btn)) {
+                var tr = btn.closest('tr.b-row');
+                if (tr) tr.remove();
+            }
+        });
+
+        if (saveBtn) {
+            saveBtn.addEventListener('click', function () {
+                setStatus('Saving…', null);
+                fetch(url, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrf() },
+                    body: JSON.stringify(buildPayload(tbody))
+                }).then(function (r) {
+                    if (r.ok) { setStatus('Saved.', 'ok'); return; }
+                    return r.text().then(function (t) {
+                        var msg = t || ('HTTP ' + r.status);
+                        try { var p = JSON.parse(t); if (p && p.reason) msg = p.reason; } catch (_) { /* text */ }
+                        setStatus('Save failed: ' + msg.slice(0, 240), 'error');
+                    });
+                }).catch(function (err) {
+                    setStatus('Save failed: ' + (err && err.message ? err.message : err), 'error');
+                });
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -212,6 +212,32 @@
     <p class="class-goals-hint">When at least the chosen share of the class reaches the grade threshold, everyone who submitted earns the bonus as extra credit (capped at 100%), scaled by how far the class gets — students see it as a live progress bar.</p>
 </section>
 
+<section id="badges-block"
+         data-assignment-id="#(assignmentID)"
+         class="editor-block">
+    <div class="editor-block-head">
+        <h2>Badges</h2>
+        <div class="toolbar toolbar--end">
+            <button type="button" class="btn action-btn" id="badge-add">+ Add Badge</button>
+            <button type="button" class="btn action-btn" id="badges-save">Save Badges</button>
+            <span id="badges-status" class="upload-status-inline"></span>
+        </div>
+    </div>
+    <table class="results-table" id="badges-table">
+        <thead>
+            <tr>
+                <th>Badge</th>
+                <th>Icon</th>
+                <th>Earned when</th>
+                <th>Value</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody class="badges-body"></tbody>
+    </table>
+    <p class="class-goals-hint">Individual badges appear on a student's submission when they earn it — either a score threshold ("Score ≥ 90%") or a specific (even secret) test passing. Cosmetic; no grade effect.</p>
+</section>
+
 #if(brightspaceSyncEnabled):
 <!-- ── BrightSpace grade sync ─────────────────────────── -->
 <div class="editor-block">
@@ -566,6 +592,7 @@ function checkUWDates(dateTimeValue, warningEl) {
 
 <script src="/global-inputs-editor.js?v=#appVersion()"></script>
 <script src="/class-goals-editor.js?v=#appVersion()"></script>
+<script src="/badges-editor.js?v=#appVersion()"></script>
 
 <!-- ── Unified Test Editor modal (shell + renderers) ────────────────────────
      The "+ Add Test" button opens one modal; picking a type morphs the body

--- a/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
+++ b/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
@@ -45,6 +45,28 @@ func earnedIndividualBadges(
     }
 }
 
+/// The individual badges to show for a submission's display result: decodes the
+/// stored collection (reusing the handler's date-aware decoder) and evaluates
+/// the authored individual badges.  Returns [] when there is no result.  Lifted
+/// out of the submission handler to keep that function within its length budget.
+func earnedIndividualBadgesForDisplay(
+    displayResult: APIResult?,
+    submission: APISubmission,
+    gradePercent: Int,
+    decoder: JSONDecoder,
+    on db: Database
+) async throws -> [AchievementBadge] {
+    guard let result = displayResult,
+        let collection = try? decoder.decode(
+            TestOutcomeCollection.self, from: Data(result.collectionJSON.utf8))
+    else { return [] }
+    return try await earnedIndividualBadges(
+        testSetupID: submission.testSetupID,
+        gradePercent: gradePercent,
+        outcomes: collection.outcomes,
+        on: db)
+}
+
 private func individualBadgeEarned(
     _ a: Achievement, gradePercent: Int, outcomes: [TestOutcome]
 ) -> Bool {

--- a/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
+++ b/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
@@ -1,0 +1,60 @@
+// APIServer/Helpers/AchievementBadgeEvaluation.swift
+//
+// Per-student evaluation of the instructor-authorable individual badges
+// (`thresholdBadge` / `testBadge`).  Unlike class goals (a periodic class
+// sweep), an individual badge is decided entirely by one student's own result,
+// so it's evaluated at submission-display time.  Reads every tier's outcomes so
+// a badge keyed to a *secret* test still works — the badge is shown to the
+// student while the test itself stays hidden.
+
+import Core
+import Fluent
+import Foundation
+
+/// True for the instructor-authorable individual-badge kinds: a per-student
+/// threshold or test-pass with a cosmetic badge reward.  Excludes the
+/// still-hardcoded `firstTryPerfect` (which isn't authored into the manifest).
+func isAuthorableIndividualBadge(_ a: Achievement) -> Bool {
+    a.scope == .individual && a.reward.type == .badge
+        && (a.kind == .thresholdBadge || a.kind == .testBadge)
+}
+
+/// The individual badges this submission earned, as display badges.  Returns []
+/// when the assignment authors none (the common case).
+func earnedIndividualBadges(
+    testSetupID: String,
+    gradePercent: Int,
+    outcomes: [TestOutcome],
+    on db: Database
+) async throws -> [AchievementBadge] {
+    guard let setup = try await APITestSetup.find(testSetupID, on: db),
+        let props = setup.decodedManifest()
+    else { return [] }
+    let authored = props.achievements.filter(isAuthorableIndividualBadge)
+    guard !authored.isEmpty else { return [] }
+
+    return authored.compactMap { ach in
+        guard individualBadgeEarned(ach, gradePercent: gradePercent, outcomes: outcomes) else {
+            return nil
+        }
+        let icon = ach.reward.icon.map { "\($0) " } ?? ""
+        return AchievementBadge(
+            id: ach.id,
+            label: "\(icon)\(ach.reward.label)",
+            tooltip: ach.detail ?? ach.reward.label)
+    }
+}
+
+private func individualBadgeEarned(
+    _ a: Achievement, gradePercent: Int, outcomes: [TestOutcome]
+) -> Bool {
+    switch a.kind {
+    case .thresholdBadge:
+        return Double(gradePercent) >= (a.threshold ?? 1) * 100
+    case .testBadge:
+        guard let ref = a.target.ref else { return false }
+        return outcomes.contains { $0.testName == ref && $0.status == .pass }
+    default:
+        return false
+    }
+}

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Badges.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Badges.swift
@@ -1,0 +1,123 @@
+// APIServer/Routes/Web/PublishedAssignmentRoutes+Badges.swift
+//
+// Instructor authoring for individual badges — the per-student form of an
+// Achievement (`thresholdBadge` = "score ≥ X%", `testBadge` = "this test
+// passes").  Symmetric to the class-goals endpoint: GET returns the assignment's
+// badges as editable rows; PUT replaces the authorable-badge subset of the
+// manifest's `achievements` array, preserving class goals and anything else.
+// Badges are cosmetic + display-only, so this never retests or re-validates.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension PublishedAssignmentRoutes {
+
+    /// One editable individual-badge row from the editor.
+    struct BadgeInput: Content {
+        var id: String?
+        /// Badge caption shown to the student, e.g. "Sharpshooter".
+        var name: String
+        /// "thresholdBadge" | "testBadge".
+        var kind: String
+        /// Optional emoji, e.g. "🌟".
+        var icon: String?
+        /// `thresholdBadge`: the grade cutoff, 0–100.
+        var thresholdPercent: Double?
+        /// `testBadge`: the script filename that must pass.
+        var testName: String?
+    }
+
+    struct BadgesBody: Content {
+        var badges: [BadgeInput]
+    }
+
+    struct BadgesResponse: Content {
+        var badges: [BadgeInput]
+    }
+
+    // MARK: - GET /instructor/:assignmentID/badges
+
+    @Sendable
+    func getBadges(req: Request) async throws -> BadgesResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        return BadgesResponse(badges: badgeRows(fromManifest: setup.manifest))
+    }
+
+    // MARK: - PUT /instructor/:assignmentID/badges
+
+    @Sendable
+    func putBadges(req: Request) async throws -> BadgesResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let body = try req.content.decode(BadgesBody.self)
+        let newBadges = try body.badges.map { try achievement(fromBadge: $0) }
+
+        let existing =
+            (try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8)))?
+            .achievements ?? []
+        let merged = existing.filter { !isAuthorableIndividualBadge($0) } + newBadges
+
+        try await mutateManifest(setup: setup, on: req.db) { dict in
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            dict["achievements"] = try JSONSerialization.jsonObject(with: encoder.encode(merged))
+        }
+        return BadgesResponse(badges: badgeRows(fromManifest: setup.manifest))
+    }
+
+    // MARK: - Conversions
+
+    private func achievement(fromBadge input: BadgeInput) throws -> Achievement {
+        let trimmed = input.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw WebAssignmentError.invalidParameter(name: "name", reason: "Badge name must not be empty.")
+        }
+        let badgeID: String
+        if let existing = input.id, !existing.isEmpty {
+            badgeID = existing
+        } else {
+            badgeID = "badge_\(UUID().uuidString.prefix(8))"
+        }
+        let trimmedIcon = input.icon?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let reward = AchievementReward(
+            type: .badge, label: trimmed,
+            icon: (trimmedIcon?.isEmpty == false) ? trimmedIcon : nil)
+
+        switch input.kind {
+        case "thresholdBadge":
+            guard let pct = input.thresholdPercent, (0...100).contains(pct) else {
+                throw WebAssignmentError.invalidParameter(
+                    name: "thresholdPercent", reason: "Score threshold must be 0–100.")
+            }
+            return Achievement(
+                id: badgeID, name: trimmed, kind: .thresholdBadge, scope: .individual,
+                reward: reward, target: AchievementTarget(kind: .assignmentGrade),
+                threshold: pct / 100)
+        case "testBadge":
+            let test = (input.testName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !test.isEmpty else {
+                throw WebAssignmentError.invalidParameter(
+                    name: "testName",
+                    reason: "Test-badge rows need the filename of the test that must pass.")
+            }
+            return Achievement(
+                id: badgeID, name: trimmed, kind: .testBadge, scope: .individual,
+                reward: reward, target: AchievementTarget(kind: .testPass, ref: test))
+        default:
+            throw WebAssignmentError.invalidParameter(
+                name: "kind", reason: "Unknown badge kind '\(input.kind)'.")
+        }
+    }
+
+    private func badgeRows(fromManifest manifest: String) -> [BadgeInput] {
+        guard let props = try? JSONDecoder().decode(TestProperties.self, from: Data(manifest.utf8))
+        else { return [] }
+        return props.achievements.filter(isAuthorableIndividualBadge).map { a in
+            BadgeInput(
+                id: a.id, name: a.reward.label, kind: a.kind.rawValue, icon: a.reward.icon,
+                thresholdPercent: a.threshold.map { $0 * 100 },
+                testName: a.target.ref)
+        }
+    }
+}

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
@@ -72,5 +72,9 @@ struct PublishedAssignmentRoutes: RouteCollection {
         // retest/validation on edit.
         r.get(":assignmentID", "achievements", use: getAchievements)
         r.put(":assignmentID", "achievements", use: putAchievements)
+
+        // Assignment-scope individual badges (threshold / test) — display-only.
+        r.get(":assignmentID", "badges", use: getBadges)
+        r.put(":assignmentID", "badges", use: putBadges)
     }
 }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -364,19 +364,11 @@ extension WebRoutes {
             .filter(\.$submissionID == subID)
             .all()
         // Authorable individual badges (threshold / test), earned per-student
-        // from this submission's result. Evaluated here (over all tiers) so a
-        // secret-test badge works without revealing the test.
-        var individualBadges: [AchievementBadge] = []
-        if let result = displayResult,
-            let collection = try? decoder.decode(
-                TestOutcomeCollection.self, from: Data(result.collectionJSON.utf8))
-        {
-            individualBadges = try await earnedIndividualBadges(
-                testSetupID: submission.testSetupID,
-                gradePercent: processed.gradePercent,
-                outcomes: collection.outcomes,
-                on: req.db)
-        }
+        // from this submission's result (evaluated over all tiers so a
+        // secret-test badge works without revealing the test).
+        let individualBadges = try await earnedIndividualBadgesForDisplay(
+            displayResult: displayResult, submission: submission,
+            gradePercent: processed.gradePercent, decoder: decoder, on: req.db)
         let badges =
             processed.badges
             + classAchievements.compactMap { AchievementBadge.forClassAchievement($0.achievementID) }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -363,9 +363,24 @@ extension WebRoutes {
         let classAchievements = try await APIClassAchievement.query(on: req.db)
             .filter(\.$submissionID == subID)
             .all()
+        // Authorable individual badges (threshold / test), earned per-student
+        // from this submission's result. Evaluated here (over all tiers) so a
+        // secret-test badge works without revealing the test.
+        var individualBadges: [AchievementBadge] = []
+        if let result = displayResult,
+            let collection = try? decoder.decode(
+                TestOutcomeCollection.self, from: Data(result.collectionJSON.utf8))
+        {
+            individualBadges = try await earnedIndividualBadges(
+                testSetupID: submission.testSetupID,
+                gradePercent: processed.gradePercent,
+                outcomes: collection.outcomes,
+                on: req.db)
+        }
         let badges =
             processed.badges
             + classAchievements.compactMap { AchievementBadge.forClassAchievement($0.achievementID) }
+            + individualBadges
 
         let sectionedOutcomes = buildSectionedOutcomes(
             outcomes: processed.outcomes,

--- a/Tests/APITests/AchievementBadgeTests.swift
+++ b/Tests/APITests/AchievementBadgeTests.swift
@@ -1,0 +1,136 @@
+// Tests/APITests/AchievementBadgeTests.swift
+//
+// Phase 4: instructor-authorable individual badges (thresholdBadge / testBadge).
+// PUT/GET /instructor/:id/badges round-trips through the manifest, and the
+// per-student evaluation (earnedIndividualBadges) awards a badge from the
+// student's own result — including one keyed to a secret test.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementBadgeTests {
+
+    @Test func putAndGetBadgesRoundTrip() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "badge_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "badge_setup", title: "Badges", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/badges",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.BadgesBody(badges: [
+                            .init(
+                                id: nil, name: "Sharpshooter", kind: "thresholdBadge",
+                                icon: "🌟", thresholdPercent: 90, testName: nil),
+                            .init(
+                                id: nil, name: "Recursion Master", kind: "testBadge",
+                                icon: "🌀", thresholdPercent: nil, testName: "secrettest_rec.py"),
+                        ]), as: .json)
+                },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            let setup = try #require(try await APITestSetup.find("badge_setup", on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+
+            let threshold = try #require(props.achievements.first { $0.kind == .thresholdBadge })
+            #expect(threshold.scope == .individual)
+            #expect(threshold.reward.type == .badge)
+            #expect(threshold.reward.icon == "🌟")
+            #expect(threshold.threshold == 0.9)
+
+            let test = try #require(props.achievements.first { $0.kind == .testBadge })
+            #expect(test.target.kind == .testPass)
+            #expect(test.target.ref == "secrettest_rec.py")
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/badges",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("Sharpshooter"))
+                    #expect(body.contains("secrettest_rec.py"))
+                })
+        }
+    }
+
+    @Test func badgesPutRejectsTestRowWithoutFilename() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "badge_bad_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "badge_bad_setup", title: "Bad Badges", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/badges",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.BadgesBody(badges: [
+                            .init(
+                                id: nil, name: "No Test", kind: "testBadge",
+                                icon: nil, thresholdPercent: nil, testName: "  ")
+                        ]), as: .json)
+                },
+                afterResponse: { res in #expect(res.status != .ok) })
+
+            let setup = try #require(try await APITestSetup.find("badge_bad_setup", on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.achievements.isEmpty, "Invalid badge must not be written")
+        }
+    }
+
+    @Test func earnedIndividualBadgesEvaluatesThresholdAndTest() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let props = TestProperties(achievements: [
+                Achievement(
+                    id: "b_thr", name: "Sharpshooter", kind: .thresholdBadge, scope: .individual,
+                    reward: AchievementReward(type: .badge, label: "Sharpshooter", icon: "🌟"),
+                    target: AchievementTarget(kind: .assignmentGrade), threshold: 0.8),
+                Achievement(
+                    id: "b_test", name: "Recursion Master", kind: .testBadge, scope: .individual,
+                    reward: AchievementReward(type: .badge, label: "Recursion Master", icon: "🌀"),
+                    target: AchievementTarget(kind: .testPass, ref: "secrettest_rec.py")),
+            ])
+            let manifest = try #require(String(bytes: try JSONEncoder().encode(props), encoding: .utf8))
+            let setup = APITestSetup(
+                id: "badge_eval_setup", manifest: manifest,
+                zipPath: app.testSetupsDirectory + "badge_eval_setup.zip", courseID: courseID)
+            try await setup.save(on: app.db)
+
+            let passing = TestOutcome(
+                testName: "secrettest_rec.py", testClass: nil, tier: .secret, status: .pass,
+                shortResult: "passed", longResult: nil, executionTimeMs: 1, memoryUsageBytes: nil,
+                attemptNumber: 1, isFirstPassSuccess: true)
+
+            // 90% + the secret test passing → both badges (the secret test is
+            // readable here even though the student never sees it).
+            let both = try await earnedIndividualBadges(
+                testSetupID: "badge_eval_setup", gradePercent: 90, outcomes: [passing], on: app.db)
+            #expect(Set(both.map(\.label)) == ["🌟 Sharpshooter", "🌀 Recursion Master"])
+
+            // 70% + the test failing → neither.
+            let failing = TestOutcome(
+                testName: "secrettest_rec.py", testClass: nil, tier: .secret, status: .fail,
+                shortResult: "failed", longResult: nil, executionTimeMs: 1, memoryUsageBytes: nil,
+                attemptNumber: 1, isFirstPassSuccess: false)
+            let none = try await earnedIndividualBadges(
+                testSetupID: "badge_eval_setup", gradePercent: 70, outcomes: [failing], on: app.db)
+            #expect(none.isEmpty)
+        }
+    }
+}

--- a/changelog.d/achievements-badges.md
+++ b/changelog.d/achievements-badges.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Authorable individual badges (achievements Phase 4).** Instructors can now
+  author per-student badges on the assignment edit page — a "Badges" card where
+  each row is a caption, an emoji, and the condition that earns it: a score
+  threshold ("Score ≥ 90% → Sharpshooter") or a specific test passing ("a secret
+  test passes → Recursion Master"). Earned badges show on the student's
+  submission. Cosmetic (no grade effect), evaluated per-student from their own
+  result — and the evaluation reads every tier, so a badge keyed to a *secret*
+  test works without revealing the test. Persisted via `PUT /instructor/:id/badges`.


### PR DESCRIPTION
## Phase 4 — authorable individual badges

Extends the achievement system so **instructors author per-student badges**, serving your *"instructors build what they need"* direction. This is **additive** — the existing hardcoded First-Try-Perfect / class-record badges are untouched (I looked: subsuming those is a 6-site refactor of working code for no new value; this delivers the value instead).

### What an instructor can author
A new **"Badges" card** on the assignment edit page. Each row: a caption, an emoji, and the condition that earns it —
- **Score threshold** — "Score ≥ 90% → 🌟 Sharpshooter" (`thresholdBadge`, reads the assignment grade), or
- **Test passes** — "a secret test passes → 🌀 Recursion Master" (`testBadge`, reads one named test).

### How it works
- **`GET` / `PUT /instructor/:assignmentID/badges`** (`PublishedAssignmentRoutes+Badges`) — converts rows to `thresholdBadge` / `testBadge` Achievements with a `.badge` reward, replaces just the authorable-badge subset of the manifest's `achievements` (class goals and everything else preserved). Display-only → no retest/validation.
- **`earnedIndividualBadges`** (`AchievementBadgeEvaluation`) — evaluated per-student from the submission's **own** result, and crucially over **all tiers**, so a badge keyed to a *secret* test works **without revealing the test**. Wired into the submission page next to the existing badges.
- **`badges-editor.js`** — kind select + value interpretation (percent vs. test filename), GET-load / Add / Remove / Save.

### Tests
PUT/GET round-trip, invalid-test-row rejection, and an evaluation test covering both kinds incl. the secret-test case (90% + secret pass → both badges; 70% + fail → neither). Build + `check-styles` + `swift-format` + SwiftLint `--strict` clean. Rebased on main (post-3b); 3b's bonus tests still green on the combined code.

### Where the achievements system stands
- **Class goals** (collaborative): author → evaluate → display → grade ✅ (#859/#860/#862/#863/#864)
- **Individual badges** (this PR): author → evaluate → display ✅
- One unified `Achievement` model now backs both. The legacy hardcoded badges still run as-is; folding them in is a no-value follow-up I'd only do on request.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_