### PR TITLE
refactor(achievements): fold the legacy awards into the unified model

### DIFF
--- a/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
+++ b/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
@@ -34,14 +34,8 @@ func earnedIndividualBadges(
     guard !authored.isEmpty else { return [] }
 
     return authored.compactMap { ach in
-        guard individualBadgeEarned(ach, gradePercent: gradePercent, outcomes: outcomes) else {
-            return nil
-        }
-        let icon = ach.reward.icon.map { "\($0) " } ?? ""
-        return AchievementBadge(
-            id: ach.id,
-            label: "\(icon)\(ach.reward.label)",
-            tooltip: ach.detail ?? ach.reward.label)
+        individualBadgeEarned(ach, gradePercent: gradePercent, outcomes: outcomes)
+            ? AchievementBadge(from: ach) : nil
     }
 }
 

--- a/Sources/APIServer/Helpers/BuiltInAchievements.swift
+++ b/Sources/APIServer/Helpers/BuiltInAchievements.swift
@@ -1,0 +1,110 @@
+// APIServer/Helpers/BuiltInAchievements.swift
+//
+// The canonical definition of Chickadee's built-in awards, expressed in the
+// unified `Achievement` model.  These used to live as hardcoded
+// `AchievementBadge` literals + a string switch (the "legacy" badges); folding
+// them in here makes the `Achievement` model the single registry for every
+// award — built-in or instructor-authored — and the display badge is derived
+// from these definitions (`AchievementBadge(from:)`).
+//
+// Behaviour is unchanged: the per-submission award *conditions* still live in
+// `AchievementBadge.forSubmission` (keyed by kind), and the class-record award
+// logic still lives in `ClassAchievements`.  This registry owns only each
+// award's identity — id, caption, tooltip, kind, and (for records) ranking
+// dimension — so there is exactly one place that defines what "Ace" or
+// "Trailblazer" is.
+
+import Core
+
+enum BuiltInAchievements {
+
+    // MARK: Per-submission (individual) awards
+
+    /// 100% on the very first attempt.
+    static let ace = Achievement(
+        id: "first_try_perfect",
+        name: "Ace",
+        detail: "Scored 100% on your very first submission — no warm-up needed.",
+        kind: .firstTryPerfect,
+        scope: .individual,
+        reward: AchievementReward(type: .badge, label: "Ace"))
+
+    /// Jumped ≥50 percentage points in one submission.
+    static let rally = Achievement(
+        id: "comeback_kid",
+        name: "Rally",
+        detail: "Jumped 50 or more percentage points in a single submission.",
+        kind: .comeback,
+        scope: .individual,
+        reward: AchievementReward(type: .badge, label: "Rally"))
+
+    /// 100% after ≥5 attempts.
+    static let tenacious = Achievement(
+        id: "tenacious",
+        name: "Tenacious",
+        detail: "Reached 100% after 5 or more attempts — persistence pays off.",
+        kind: .persistence,
+        scope: .individual,
+        reward: AchievementReward(type: .badge, label: "Tenacious"))
+
+    /// 100% with total execution under 2 s.
+    static let swift = Achievement(
+        id: "speed_demon",
+        name: "Swift",
+        detail: "Scored 100% with every test completing in under 2 seconds total.",
+        kind: .speedRun,
+        scope: .individual,
+        reward: AchievementReward(type: .badge, label: "Swift"))
+
+    /// In display order — `forSubmission` walks this list.
+    static let perSubmission = [ace, rally, tenacious, swift]
+
+    // MARK: Class-wide (competitive) records
+
+    static let pathfinder = Achievement(
+        id: "pathfinder",
+        name: "Pathfinder",
+        detail: "Submitted before anyone else in the class.",
+        kind: .classRecord,
+        scope: .classWide,
+        reward: AchievementReward(type: .title, label: "Pathfinder"),
+        recordDimension: .firstToSolve)
+
+    static let trailblazer = Achievement(
+        id: "trailblazer",
+        name: "Trailblazer",
+        detail: "First student in the class to reach 100% on this assignment.",
+        kind: .classRecord,
+        scope: .classWide,
+        reward: AchievementReward(type: .title, label: "Trailblazer"),
+        recordDimension: .firstToSolve)
+
+    static let speedChampion = Achievement(
+        id: "speed_champion",
+        name: "Fastest",
+        detail: "Holds the class record for fastest 100% execution time.",
+        kind: .classRecord,
+        scope: .classWide,
+        reward: AchievementReward(type: .title, label: "Fastest"),
+        recordDimension: .fastest)
+
+    static let minimalist = Achievement(
+        id: "minimalist",
+        name: "Minimalist",
+        detail: "Reached 100% in fewer attempts than any other student in the class.",
+        kind: .classRecord,
+        scope: .classWide,
+        reward: AchievementReward(type: .title, label: "Minimalist"),
+        recordDimension: .shortest)
+
+    /// The class records, keyed by `APIClassAchievement.achievementID`.
+    static let classRecords = [pathfinder, trailblazer, speedChampion, minimalist]
+
+    /// Every built-in award.
+    static let all = perSubmission + classRecords
+
+    /// The built-in award with this id, if any.
+    static func byID(_ id: String) -> Achievement? {
+        all.first { $0.id == id }
+    }
+}

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -180,82 +180,60 @@ struct AchievementBadge: Encodable {
     let label: String
     let tooltip: String
 
-    // MARK: Per-submission badges
+    /// Derives the display badge from an `Achievement` — the single place a
+    /// badge's caption + tooltip come from, whether the award is built-in
+    /// (`BuiltInAchievements`) or instructor-authored.  An emoji icon, when the
+    /// reward carries one, is prefixed to the caption.
+    init(from achievement: Achievement) {
+        let icon = achievement.reward.icon.map { "\($0) " } ?? ""
+        id = achievement.id
+        label = "\(icon)\(achievement.reward.label)"
+        tooltip = achievement.detail ?? achievement.reward.label
+    }
 
-    static let firstTryPerfect = AchievementBadge(
-        id: "first_try_perfect",
-        label: "Ace",
-        tooltip: "Scored 100% on your very first submission — no warm-up needed."
-    )
-    static let comebackKid = AchievementBadge(
-        id: "comeback_kid",
-        label: "Rally",
-        tooltip: "Jumped 50 or more percentage points in a single submission."
-    )
-    static let tenacious = AchievementBadge(
-        id: "tenacious",
-        label: "Tenacious",
-        tooltip: "Reached 100% after 5 or more attempts — persistence pays off."
-    )
-    static let speedDemon = AchievementBadge(
-        id: "speed_demon",
-        label: "Swift",
-        tooltip: "Scored 100% with every test completing in under 2 seconds total."
-    )
-
-    // MARK: Class-wide badges
-
-    static let pathfinder = AchievementBadge(
-        id: "pathfinder",
-        label: "Pathfinder",
-        tooltip: "Submitted before anyone else in the class."
-    )
-    static let trailblazer = AchievementBadge(
-        id: "trailblazer",
-        label: "Trailblazer",
-        tooltip: "First student in the class to reach 100% on this assignment."
-    )
-    static let speedChampion = AchievementBadge(
-        id: "speed_champion",
-        label: "Fastest",
-        tooltip: "Holds the class record for fastest 100% execution time."
-    )
-    static let minimalist = AchievementBadge(
-        id: "minimalist",
-        label: "Minimalist",
-        tooltip: "Reached 100% in fewer attempts than any other student in the class."
-    )
+    /// Direct memberwise init, retained for tests and any non-Achievement caller.
+    init(id: String, label: String, tooltip: String) {
+        self.id = id
+        self.label = label
+        self.tooltip = tooltip
+    }
 
     // MARK: Computation
 
-    /// Returns all per-submission badges earned for the given context.
-    /// Class-wide badges are appended separately after a DB query.
+    /// All per-submission built-in badges earned for the given context.  The
+    /// award *conditions* live here (keyed by kind); each badge's identity —
+    /// caption + tooltip — comes from `BuiltInAchievements`.  Class-wide badges
+    /// are appended separately after a DB query (see `forClassAchievement`).
     static func forSubmission(_ ctx: BadgeContext) -> [AchievementBadge] {
-        var badges: [AchievementBadge] = []
-        if ctx.attemptNumber == 1, ctx.gradePercent == 100 {
-            badges.append(.firstTryPerfect)
+        BuiltInAchievements.perSubmission
+            .filter { perSubmissionEarned($0.kind, ctx: ctx) }
+            .map(AchievementBadge.init(from:))
+    }
+
+    /// Whether a built-in per-submission award's condition is met for `ctx`.
+    /// These thresholds (50 points, 5 attempts, 2 s) match the legacy badges
+    /// exactly — the fold-in changed where identity lives, not the conditions.
+    private static func perSubmissionEarned(_ kind: AchievementKind, ctx: BadgeContext) -> Bool {
+        switch kind {
+        case .firstTryPerfect:
+            return ctx.attemptNumber == 1 && ctx.gradePercent == 100
+        case .comeback:
+            guard let prior = ctx.priorGradePercent else { return false }
+            return ctx.gradePercent - prior >= 50
+        case .persistence:
+            return ctx.attemptNumber >= 5 && ctx.gradePercent == 100
+        case .speedRun:
+            return ctx.gradePercent == 100 && ctx.executionTimeMs < 2_000
+        default:
+            return false
         }
-        if let prior = ctx.priorGradePercent, ctx.gradePercent - prior >= 50 {
-            badges.append(.comebackKid)
-        }
-        if ctx.attemptNumber >= 5, ctx.gradePercent == 100 {
-            badges.append(.tenacious)
-        }
-        if ctx.gradePercent == 100, ctx.executionTimeMs < 2_000 {
-            badges.append(.speedDemon)
-        }
-        return badges
     }
 
     /// Maps a class-achievement ID string to its badge, returning nil for unknown IDs.
     static func forClassAchievement(_ achievementID: String) -> AchievementBadge? {
-        switch achievementID {
-        case "pathfinder": return .pathfinder
-        case "trailblazer": return .trailblazer
-        case "speed_champion": return .speedChampion
-        case "minimalist": return .minimalist
-        default: return nil
-        }
+        BuiltInAchievements.classRecords
+            .first { $0.id == achievementID }
+            .map(AchievementBadge.init(from:))
     }
 }
 

--- a/Sources/Core/Achievement.swift
+++ b/Sources/Core/Achievement.swift
@@ -80,8 +80,17 @@ public enum AchievementKind: String, Codable, Sendable {
     /// logic lives in the instructor's test; this just maps the pass to a badge.
     case testBadge
     /// Individual: 100% on the first attempt.  Subsumes the legacy First-Try
-    /// Perfect badge.
+    /// Perfect ("Ace") badge.
     case firstTryPerfect
+    /// Individual: jumped a large margin (≥50 percentage points) between
+    /// submissions.  Subsumes the legacy "Rally" comeback badge.
+    case comeback
+    /// Individual: reached 100% only after several attempts (≥5).  Subsumes the
+    /// legacy "Tenacious" persistence badge.
+    case persistence
+    /// Individual: scored 100% with a fast total execution (<2 s).  Subsumes
+    /// the legacy "Swift" speed badge.
+    case speedRun
     /// Competitive, one holder per assignment, ranked on `recordDimension`.
     /// Subsumes the legacy pathfinder / speed-champion / minimalist records.
     /// Kept for back-compat; new assignments lean on the collaborative kinds.

--- a/Tests/APITests/BuiltInAchievementsTests.swift
+++ b/Tests/APITests/BuiltInAchievementsTests.swift
@@ -1,0 +1,80 @@
+// Tests/APITests/BuiltInAchievementsTests.swift
+//
+// Pins the legacy-award fold-in: the built-in awards are now Achievement
+// instances (BuiltInAchievements), the display badge is derived from the model
+// (AchievementBadge(from:)), and forSubmission / forClassAchievement preserve
+// the exact legacy conditions + id→record mapping.
+
+import Core
+import Testing
+
+@testable import APIServer
+
+@Suite struct BuiltInAchievementsTests {
+
+    private func badgeIDs(_ ctx: BadgeContext) -> [String] {
+        AchievementBadge.forSubmission(ctx).map(\.id)
+    }
+
+    @Test func registryCoversEveryLegacyAward() {
+        #expect(
+            Set(BuiltInAchievements.all.map(\.id)) == [
+                "first_try_perfect", "comeback_kid", "tenacious", "speed_demon",
+                "pathfinder", "trailblazer", "speed_champion", "minimalist",
+            ])
+        #expect(BuiltInAchievements.perSubmission.allSatisfy { $0.scope == .individual })
+        #expect(
+            BuiltInAchievements.classRecords.allSatisfy {
+                $0.scope == .classWide && $0.kind == .classRecord && $0.recordDimension != nil
+            })
+    }
+
+    @Test func badgeDerivesIdentityFromTheAchievement() {
+        let ace = AchievementBadge(from: BuiltInAchievements.ace)
+        #expect(ace.id == "first_try_perfect")
+        #expect(ace.label == "Ace")  // no icon → bare caption, exactly as before
+        #expect(ace.tooltip == "Scored 100% on your very first submission — no warm-up needed.")
+
+        // An icon-bearing reward (the authored-badge style) prefixes the emoji.
+        let iconned = AchievementBadge(
+            from: Achievement(
+                id: "x", name: "Sharpshooter", kind: .thresholdBadge, scope: .individual,
+                reward: AchievementReward(type: .badge, label: "Sharpshooter", icon: "🌟")))
+        #expect(iconned.label == "🌟 Sharpshooter")
+    }
+
+    @Test func forSubmissionPreservesLegacyConditionsAndOrder() {
+        // First attempt, 100%, slow → Ace only.
+        #expect(
+            badgeIDs(.init(attemptNumber: 1, gradePercent: 100, executionTimeMs: 5_000, priorGradePercent: nil))
+                == ["first_try_perfect"])
+        // Big jump → Rally only.
+        #expect(
+            badgeIDs(.init(attemptNumber: 2, gradePercent: 100, executionTimeMs: 5_000, priorGradePercent: 40))
+                == ["comeback_kid"])
+        // 100% after many attempts → Tenacious only.
+        #expect(
+            badgeIDs(.init(attemptNumber: 5, gradePercent: 100, executionTimeMs: 5_000, priorGradePercent: 100))
+                == ["tenacious"])
+        // Fast 100% → Swift only.
+        #expect(
+            badgeIDs(.init(attemptNumber: 3, gradePercent: 100, executionTimeMs: 1_000, priorGradePercent: 100))
+                == ["speed_demon"])
+        // Multiple at once keep registry order (Ace before Swift).
+        #expect(
+            badgeIDs(.init(attemptNumber: 1, gradePercent: 100, executionTimeMs: 1_000, priorGradePercent: nil))
+                == ["first_try_perfect", "speed_demon"])
+        // Nothing earned.
+        #expect(
+            badgeIDs(.init(attemptNumber: 2, gradePercent: 80, executionTimeMs: 5_000, priorGradePercent: 80))
+                .isEmpty)
+    }
+
+    @Test func forClassAchievementMapsRecordsAndRejectsUnknown() {
+        #expect(AchievementBadge.forClassAchievement("trailblazer")?.label == "Trailblazer")
+        #expect(AchievementBadge.forClassAchievement("speed_champion")?.label == "Fastest")
+        #expect(AchievementBadge.forClassAchievement("minimalist")?.label == "Minimalist")
+        #expect(AchievementBadge.forClassAchievement("pathfinder")?.label == "Pathfinder")
+        #expect(AchievementBadge.forClassAchievement("not_a_record") == nil)
+    }
+}

--- a/changelog.d/achievements-subsume.md
+++ b/changelog.d/achievements-subsume.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **Folded the legacy awards into the unified Achievement model.** The
+  previously-hardcoded badges — the per-submission Ace / Rally / Tenacious /
+  Swift and the Pathfinder / Trailblazer / Fastest / Minimalist class records —
+  are now defined as `Achievement` instances in one registry
+  (`BuiltInAchievements`), and the display badge is derived from the model
+  (`AchievementBadge(from:)`, shared with the authored individual badges). New
+  `comeback` / `persistence` / `speedRun` achievement kinds give the three
+  per-submission badges a model home alongside `firstTryPerfect`. Behaviour is
+  unchanged — the award conditions and the class-record award logic are
+  identical; only the source of each award's identity moved into the model, so
+  there is now exactly one place that defines what "Ace" or "Trailblazer" is.


### PR DESCRIPTION
## Fold the legacy awards into the unified Achievement model

Per your request — the previously-hardcoded badges are now expressed *as* `Achievement` instances, so there's one model and one registry behind every award. **No behavioral or visual change**; the 36 existing badge/submission tests stay green as the regression guard.

### What moved
The hardcoded `AchievementBadge` literals + string `switch` are replaced by a single **`BuiltInAchievements`** registry of `Achievement` values:

| Award | id | kind |
|---|---|---|
| Ace | `first_try_perfect` | `firstTryPerfect` |
| Rally | `comeback_kid` | `comeback` *(new kind)* |
| Tenacious | `tenacious` | `persistence` *(new kind)* |
| Swift | `speed_demon` | `speedRun` *(new kind)* |
| Pathfinder / Trailblazer / Fastest / Minimalist | (same ids) | `classRecord` + `recordDimension` |

- **`AchievementBadge.init(from: Achievement)`** derives the display badge (caption + tooltip, with an optional emoji prefix) from the model — and Phase 4's `earnedIndividualBadges` now uses it too, so **built-in and authored badges render through one path**.
- **`forSubmission`** iterates `BuiltInAchievements.perSubmission` and evaluates each by kind — the exact legacy conditions (attempt 1 + 100%; ≥50-point jump; ≥5 attempts; <2 s) and order.
- **`forClassAchievement`** maps the `APIClassAchievement` id to the registry record. The class-record *award* logic (`ClassAchievements`) is untouched.
- Three new Core kinds (`comeback` / `persistence` / `speedRun`) give the per-submission "fun" badges a model home next to `firstTryPerfect`.

### Why this is safe
- The call sites (submission page, history) don't change — only the *internals* of the two functions derive from the model.
- Behaviour is identical: same captions, same tooltips, same conditions, same id→record mapping.
- **Guard:** `WebRoutesBadgeTests` + `WebRoutesSubmissionPageTests` (36 tests, incl. `pathfinderAwardedToFirstStudentEvenAfterAdminSubmits`) stay green. New `BuiltInAchievementsTests` pins the registry coverage, the `init(from:)` derivation, and the `forSubmission`/`forClassAchievement` mapping per legacy condition.

Build + `swift-format` + SwiftLint `--strict` clean.

### Net result
One `Achievement` model now backs **everything**: collaborative class goals, instructor-authored individual badges, *and* the built-in awards — exactly one place defines what "Ace" or "Trailblazer" is.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_