### PR TITLE
Group secret-test counts per section on the submission page

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -607,31 +607,14 @@ th.sort-desc .sort-header::after { content: "↓"; }
     font-weight: 500;
 }
 
-/* Hidden-tier summary (release before deadline, secret always) */
-.hidden-tiers-summary {
-    margin-top: 1.25rem;
-    border: 1px solid var(--gray-100);
-    border-radius: .5rem;
-    padding: .75rem 1rem;
-    background: var(--gray-100);
-}
-
-.hidden-tiers-heading {
-    font-size: .8rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: .05em;
-    color: var(--gray-600);
-    margin: 0 0 .5rem;
-}
-
+/* Per-section secret-tier aggregate (never itemized for students) */
 .tier-summary-row {
     display: flex;
     align-items: center;
     gap: .6rem;
     border-left: 3px solid var(--gray-400);
     padding: .35rem 0 .35rem .6rem;
-    margin-bottom: .3rem;
+    margin: .25rem 0 .3rem;
     font-size: .9rem;
 }
 

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -101,6 +101,7 @@ Submission #(submissionID)
     #if(sec.sectionName):
     <h3 class="submission-section-heading">#(sec.sectionName)</h3>
     #endif
+    #if(!sec.outcomes.isEmpty):
     <table class="results-table">
         <thead>
             <tr>
@@ -157,19 +158,16 @@ Submission #(submissionID)
         #endfor
         </tbody>
     </table>
-</section>
-#endfor
-
-#if(secretSummary):
-<div class="hidden-tiers-summary">
-    <h3 class="hidden-tiers-heading">Secret tests</h3>
+    #endif
+    #if(sec.secretSummary):
     <div class="tier-summary-row tier-summary-secret">
         <span class="tier tier-secret-badge">secret</span>
-        <span class="tier-summary-counts">#(secretSummary.passCount) passed, #(secretSummary.failCount) failed#if(secretSummary.errorCount): , #(secretSummary.errorCount) error(s)#endif</span>
-        <span class="tier-summary-note">— these count toward your grade; individual tests aren't shown</span>
+        <span class="tier-summary-counts">#(sec.secretSummary.passCount) passed, #(sec.secretSummary.failCount) failed#if(sec.secretSummary.errorCount): , #(sec.secretSummary.errorCount) error(s)#endif</span>
+        <span class="tier-summary-note">— hidden tests in this section; they count toward your grade, but individual tests aren't shown</span>
     </div>
-</div>
-#endif
+    #endif
+</section>
+#endfor
 
 #endif
 

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -164,6 +164,13 @@ struct OutcomeRow: Encodable {
 struct SectionedOutcomes: Encodable {
     let sectionName: String?
     let outcomes: [OutcomeRow]
+    /// Aggregate pass/fail counts for the secret-tier tests that belong to
+    /// this section (students only; nil when the section has no secret tests
+    /// or the viewer is an instructor, who sees secret tests itemized as
+    /// ordinary rows instead).  Secret tests are never named or itemized for
+    /// students — surfacing the per-section count lets a student see *where*
+    /// hidden tests are failing without revealing which.
+    let secretSummary: TierSummary?
 }
 
 /// Input data used to compute per-submission achievement badges.
@@ -302,11 +309,6 @@ struct SubmissionContext: Encodable {
     let hasDelta: Bool
     /// E.g. "↑ fixed 2 tests · ↓ broke 1 test since attempt 3"; nil on first attempt.
     let deltaHeaderText: String?
-    /// Non-nil for students when secret tests exist.  Secret tests count toward
-    /// the grade but are never itemized — only their aggregate pass/fail counts
-    /// are shown.  (Release tests are itemized as ordinary rows, even before the
-    /// deadline, so they no longer need a separate summary.)
-    let secretSummary: TierSummary?
     let badges: [AchievementBadge]
     let currentUser: CurrentUserContext?
     /// Class-wide goals for this assignment with their current progress, shown

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -23,10 +23,22 @@ import Vapor
 /// share a case label (e.g. both `bmi` and `age` having a "Test 1"
 /// case), and a name-keyed dict silently collapsed them onto the
 /// last-written section (v0.4.105 fix).
+///
+/// `secretOutcomes` / `sectionIDPerSecretOutcome` carry the secret-tier
+/// outcomes (never itemized for students) plus their per-outcome section
+/// ids, correlated the same way.  They are aggregated into a per-section
+/// `secretSummary` so a student can see *where* hidden tests are failing
+/// without revealing which.  A section that contains only secret tests is
+/// still emitted (with empty `outcomes` and a non-nil `secretSummary`) so
+/// the student gets a signal for that question; secret outcomes with no
+/// (or a stale) section fall into the trailing/ungrouped bucket alongside
+/// any ungrouped visible rows.
 func groupOutcomesBySection(
     _ outcomes: [OutcomeRow],
     sections: [TestSuiteSection],
-    sectionIDPerOutcome: [String?]
+    sectionIDPerOutcome: [String?],
+    secretOutcomes: [TestOutcome] = [],
+    sectionIDPerSecretOutcome: [String?] = []
 ) -> [SectionedOutcomes] {
     let knownSectionIDs = Set(sections.map(\.id))
     var bucketsByID: [String: [OutcomeRow]] = [:]
@@ -39,26 +51,46 @@ func groupOutcomesBySection(
             ungrouped.append(row)
         }
     }
-    var result: [SectionedOutcomes] = []
-    for section in sections {
-        if let rows = bucketsByID[section.id], !rows.isEmpty {
-            result.append(SectionedOutcomes(sectionName: section.name, outcomes: rows))
+    // Secret outcomes are counted, never itemized: bucket them by section the
+    // same way, then fold each bucket into an aggregate `TierSummary`.
+    var secretByID: [String: [TestOutcome]] = [:]
+    var secretUngrouped: [TestOutcome] = []
+    for (i, outcome) in secretOutcomes.enumerated() {
+        let sid: String? = (i < sectionIDPerSecretOutcome.count) ? sectionIDPerSecretOutcome[i] : nil
+        if let sid, knownSectionIDs.contains(sid) {
+            secretByID[sid, default: []].append(outcome)
+        } else {
+            secretUngrouped.append(outcome)
         }
     }
-    if !ungrouped.isEmpty {
+    func summary(_ list: [TestOutcome]) -> TierSummary? {
+        list.isEmpty ? nil : TierSummary(outcomes: list, isRelease: false)
+    }
+    var result: [SectionedOutcomes] = []
+    for section in sections {
+        let rows = bucketsByID[section.id] ?? []
+        let secret = secretByID[section.id] ?? []
+        if rows.isEmpty && secret.isEmpty { continue }
+        result.append(
+            SectionedOutcomes(
+                sectionName: section.name, outcomes: rows, secretSummary: summary(secret)))
+    }
+    if !ungrouped.isEmpty || !secretUngrouped.isEmpty {
         // Trailing bucket label: when sections exist, call it "Ungrouped"
         // so students see why this block appears separately.  When no
         // sections exist at all, emit it unlabelled to preserve the
         // legacy single-table look.
         let label: String? = sections.isEmpty ? nil : "Ungrouped"
-        result.append(SectionedOutcomes(sectionName: label, outcomes: ungrouped))
+        result.append(
+            SectionedOutcomes(
+                sectionName: label, outcomes: ungrouped, secretSummary: summary(secretUngrouped)))
     }
     if result.isEmpty {
         // Empty outcome list still needs one bucket so the template's
         // `#for(sec in sectionedOutcomes)` has something to skip over
         // gracefully.  An empty `outcomes` array renders as an empty
         // tbody, just like today.
-        result.append(SectionedOutcomes(sectionName: nil, outcomes: []))
+        result.append(SectionedOutcomes(sectionName: nil, outcomes: [], secretSummary: nil))
     }
     return result
 }
@@ -376,6 +408,7 @@ extension WebRoutes {
 
         let sectionedOutcomes = buildSectionedOutcomes(
             outcomes: processed.outcomes,
+            secretOutcomes: processed.secretOutcomes,
             manifestEntries: manifestDisplay.entries,
             manifestSections: manifestDisplay.sections,
             allowedTiers: itemized
@@ -540,12 +573,11 @@ extension WebRoutes {
         }
 
         // Secret tests count toward the grade but are never itemized for
-        // students; surface them as an aggregate pass/fail summary.
+        // students; they are bucketed into per-section aggregate pass/fail
+        // summaries by `buildSectionedOutcomes`.  Kept in collection order so
+        // the section correlation lines up with the secret manifest entries.
         if !viewer.user.isInstructor {
-            let secretOutcomes = collection.outcomes.filter { $0.tier == .secret }
-            if !secretOutcomes.isEmpty {
-                processed.secretSummary = TierSummary(outcomes: secretOutcomes, isRelease: false)
-            }
+            processed.secretOutcomes = collection.outcomes.filter { $0.tier == .secret }
         }
 
         // Grade spans every tier (matches `gradePercentFromCollectionJSON` on
@@ -674,24 +706,39 @@ extension WebRoutes {
     /// misattributing outcomes.
     private func buildSectionedOutcomes(
         outcomes: [OutcomeRow],
+        secretOutcomes: [TestOutcome],
         manifestEntries: [TestSuiteEntry],
         manifestSections: [TestSuiteSection],
         allowedTiers: Set<String>
     ) -> [SectionedOutcomes] {
         let visibleEntries = manifestEntries.filter { allowedTiers.contains($0.tier.rawValue) }
-        var sectionIDPerOutcome: [String?] = visibleEntries.map { $0.sectionID }
-        if sectionIDPerOutcome.count < outcomes.count {
-            sectionIDPerOutcome.append(
-                contentsOf:
-                    Array(repeating: String?.none, count: outcomes.count - sectionIDPerOutcome.count))
-        } else if sectionIDPerOutcome.count > outcomes.count {
-            sectionIDPerOutcome = Array(sectionIDPerOutcome.prefix(outcomes.count))
-        }
+        let sectionIDPerOutcome = alignSectionIDs(
+            visibleEntries.map { $0.sectionID }, toCount: outcomes.count)
+        // Secret outcomes never appear in `allowedTiers` for students, so they
+        // correlate against the secret-tier manifest entries on their own.
+        let secretEntries = manifestEntries.filter { $0.tier == .secret }
+        let sectionIDPerSecret = alignSectionIDs(
+            secretEntries.map { $0.sectionID }, toCount: secretOutcomes.count)
         return groupOutcomesBySection(
             outcomes,
             sections: manifestSections,
-            sectionIDPerOutcome: sectionIDPerOutcome
+            sectionIDPerOutcome: sectionIDPerOutcome,
+            secretOutcomes: secretOutcomes,
+            sectionIDPerSecretOutcome: sectionIDPerSecret
         )
+    }
+
+    /// Pads with nil / truncates a section-id array so it matches the outcome
+    /// count exactly.  Browser-mode submissions or a manifest churn mid-flight
+    /// can yield a slightly different shape; misaligned entries fall into
+    /// Ungrouped rather than misattributing an outcome to the wrong section.
+    private func alignSectionIDs(_ ids: [String?], toCount count: Int) -> [String?] {
+        if ids.count < count {
+            return ids + Array(repeating: String?.none, count: count - ids.count)
+        } else if ids.count > count {
+            return Array(ids.prefix(count))
+        }
+        return ids
     }
 
     /// Composes the human-readable banner text shown above the outcomes table
@@ -758,7 +805,6 @@ extension WebRoutes {
             earnedPoints: processed.earnedPoints,
             hasDelta: delta.hasDelta,
             deltaHeaderText: delta.headerText,
-            secretSummary: processed.secretSummary,
             badges: badges,
             currentUser: currentUser,
             classGoals: decorations.classGoals
@@ -824,7 +870,10 @@ private struct ProcessedCollection {
     var executionTimeMs: Int
     var gradePercent: Int
     var badges: [AchievementBadge]
-    var secretSummary: TierSummary?
+    /// Secret-tier outcomes (students only) in collection order; aggregated
+    /// into per-section summaries by `buildSectionedOutcomes`.  Empty for
+    /// instructors, who see secret tests itemized as ordinary rows.
+    var secretOutcomes: [TestOutcome]
 
     static let empty = ProcessedCollection(
         resultSource: "",
@@ -840,7 +889,7 @@ private struct ProcessedCollection {
         executionTimeMs: 0,
         gradePercent: 0,
         badges: [],
-        secretSummary: nil
+        secretOutcomes: []
     )
 }
 

--- a/Tests/APITests/SectionsTests.swift
+++ b/Tests/APITests/SectionsTests.swift
@@ -266,4 +266,73 @@ import Testing
         #expect(grouped[1].sectionName == "Warm Up II")
         #expect(grouped[1].outcomes.count == 1)
     }
+
+    // MARK: - groupOutcomesBySection (secret per-section summaries)
+
+    private func secret(_ name: String, _ status: TestStatus) -> TestOutcome {
+        TestOutcome(
+            testName: name, testClass: nil, tier: .secret, status: status,
+            shortResult: status == .pass ? "passed" : "failed", longResult: nil,
+            executionTimeMs: 1, memoryUsageBytes: nil, attemptNumber: 1,
+            isFirstPassSuccess: status == .pass)
+    }
+
+    @Test func secretOutcomesAggregateIntoTheirOwnSection() {
+        let sections = [
+            TestSuiteSection(id: "s1", name: "One"),
+            TestSuiteSection(id: "s2", name: "Two"),
+        ]
+        let outcomes = [row("a.py"), row("b.py")]
+        let perOutcome: [String?] = ["s1", "s2"]
+        // Two secret tests in s1 (1 pass, 1 fail), one in s2 (pass).
+        let secrets = [secret("x", .pass), secret("y", .fail), secret("z", .pass)]
+        let secretSections: [String?] = ["s1", "s1", "s2"]
+        let grouped = groupOutcomesBySection(
+            outcomes, sections: sections, sectionIDPerOutcome: perOutcome,
+            secretOutcomes: secrets, sectionIDPerSecretOutcome: secretSections)
+        #expect(grouped.count == 2)
+        #expect(grouped[0].sectionName == "One")
+        #expect(grouped[0].secretSummary?.passCount == 1)
+        #expect(grouped[0].secretSummary?.failCount == 1)
+        #expect(grouped[0].secretSummary?.total == 2)
+        #expect(grouped[1].sectionName == "Two")
+        #expect(grouped[1].secretSummary?.passCount == 1)
+        #expect(grouped[1].secretSummary?.failCount == 0)
+    }
+
+    @Test func sectionWithOnlySecretTestsIsStillEmitted() {
+        // A section whose only tests are secret still appears (empty visible
+        // table, non-nil summary) so the student sees a signal for it.
+        let sections = [
+            TestSuiteSection(id: "s1", name: "Visible"),
+            TestSuiteSection(id: "s2", name: "Secret Only"),
+        ]
+        let outcomes = [row("a.py")]
+        let perOutcome: [String?] = ["s1"]
+        let secrets = [secret("x", .fail)]
+        let secretSections: [String?] = ["s2"]
+        let grouped = groupOutcomesBySection(
+            outcomes, sections: sections, sectionIDPerOutcome: perOutcome,
+            secretOutcomes: secrets, sectionIDPerSecretOutcome: secretSections)
+        #expect(grouped.count == 2)
+        #expect(grouped[0].sectionName == "Visible")
+        #expect(grouped[0].secretSummary == nil)
+        #expect(grouped[1].sectionName == "Secret Only")
+        #expect(grouped[1].outcomes.isEmpty)
+        #expect(grouped[1].secretSummary?.failCount == 1)
+    }
+
+    @Test func ungroupedSecretOutcomesFallIntoTrailingBucket() {
+        // No sections at all: visible + secret land in the single unlabelled
+        // bucket — the legacy single-table look with a secret count under it.
+        let outcomes = [row("a.py")]
+        let secrets = [secret("x", .pass), secret("y", .pass)]
+        let grouped = groupOutcomesBySection(
+            outcomes, sections: [], sectionIDPerOutcome: [nil],
+            secretOutcomes: secrets, sectionIDPerSecretOutcome: [nil, nil])
+        #expect(grouped.count == 1)
+        #expect(grouped[0].sectionName == nil)
+        #expect(grouped[0].outcomes.count == 1)
+        #expect(grouped[0].secretSummary?.passCount == 2)
+    }
 }

--- a/Tests/APITests/WebRoutesSubmissionPageTests.swift
+++ b/Tests/APITests/WebRoutesSubmissionPageTests.swift
@@ -688,6 +688,77 @@ import XCTVapor
         }
     }
 
+    /// With sections, secret tests are aggregated under the section they
+    /// belong to (one summary per section), not in a single bottom block —
+    /// the student can see which question's hidden tests failed.
+    @Test func studentSeesSecretCountsGroupedBySection() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            let userID = try user.requireID()
+            // Two sections, each with a public test + a secret test. Worker
+            // emits one outcome per testSuites entry, in order.
+            let manifest = """
+                {"schemaVersion":1,"requiredFiles":[],"sections":[\
+                {"id":"q1","name":"Question One"},{"id":"q2","name":"Question Two"}\
+                ],"testSuites":[\
+                {"tier":"public","script":"pub_q1.sh","sectionID":"q1"},\
+                {"tier":"secret","script":"sec_q1.sh","sectionID":"q1"},\
+                {"tier":"public","script":"pub_q2.sh","sectionID":"q2"},\
+                {"tier":"secret","script":"sec_q2.sh","sectionID":"q2"}\
+                ],"timeLimitSeconds":10}
+                """
+            let course = try await wrMakeCourse(on: app)
+            let courseID = try course.requireID()
+            let setup = APITestSetup(
+                id: "setup_secret_sec",
+                manifest: manifest,
+                zipPath: app.testSetupsDirectory + "setup_secret_sec.zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+            try await wrInsertAssignment(
+                testSetupID: "setup_secret_sec", title: "Secret Sections", isOpen: true,
+                dueAt: Date().addingTimeInterval(-3600), on: app
+            )
+            try await wrInsertSubmission(
+                id: "sub_secret_sec", testSetupID: "setup_secret_sec", userID: userID, on: app)
+            // Outcomes in testSuites order: q1 public pass, q1 secret fail,
+            // q2 public pass, q2 secret pass.
+            try await wrInsertResult(
+                submissionID: "sub_secret_sec",
+                outcomes: [
+                    wrMakeOutcome(name: "pub_q1", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "sec_q1", tier: .secret, status: .fail),
+                    wrMakeOutcome(name: "pub_q2", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "sec_q2", tier: .secret, status: .pass),
+                ], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/sub_secret_sec",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("Question One"), "Section headings should render")
+                    #expect(html.contains("Question Two"), "Section headings should render")
+                    // Q1's secret test failed; Q2's passed.
+                    #expect(
+                        html.contains("0 passed, 1 failed"),
+                        "Question One's secret aggregate should show its failure")
+                    #expect(
+                        html.contains("1 passed, 0 failed"),
+                        "Question Two's secret aggregate should show its pass")
+                    #expect(
+                        html.contains("sec_q1") == false && html.contains("sec_q2") == false,
+                        "Secret test names must never be shown")
+                })
+
+        }
+    }
+
     /// A failing release test shows its instructor hint before the deadline
     /// (guidance without the answer), while its output stays hidden.
     @Test func releaseHintShownBeforeDeadlineWithoutOutput() async throws {

--- a/changelog.d/secret-per-section-summary.md
+++ b/changelog.d/secret-per-section-summary.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Secret-test counts are now shown per section on the submission page.**
+  Instead of one aggregate "Secret tests" block at the bottom, each test-suite
+  section shows its own hidden-test pass/fail summary, so a student can see
+  *which question's* secret tests are failing without revealing the tests
+  themselves. Release tests were already itemized in their section; secret
+  tests now follow the same sectioning. Assignments with no sections keep the
+  single summary under the one table.


### PR DESCRIPTION
## What & why

On the student submission page, **release** tests are already itemized within their test-suite section, but **secret** tests were lumped into a single aggregate "Secret tests" block at the bottom of the page. That made it hard for a student to tell *which question's* hidden tests were failing.

This change makes secret tests follow the same sectioning as release tests: each section now shows its own hidden-test pass/fail summary under its table. Individual secret test names/output are still never shown — only the per-section counts.

## How

- `SectionedOutcomes` carries a per-section `secretSummary: TierSummary?`.
- `groupOutcomesBySection` buckets secret outcomes by section using the same **index correlation** already used for visible outcomes (so two families sharing a case label across sections still bucket correctly), and emits a section that contains *only* secret tests so the student still gets a signal for that question.
- `buildSectionedOutcomes` correlates secret outcomes against the secret-tier manifest entries; the pad/truncate alignment logic is factored into a shared `alignSectionIDs` helper.
- The `submission.leaf` template renders each section's secret summary under its table and drops the standalone bottom block. Assignments with **no** sections keep the single summary under the one table (behaviour preserved).
- Instructors are unaffected — they continue to see secret tests itemized as ordinary rows within their sections.

## Tests

- `SectionsTests`: secret outcomes aggregate into their own section; a secret-only section is still emitted; ungrouped secret outcomes fall into the trailing bucket.
- `WebRoutesSubmissionPageTests.studentSeesSecretCountsGroupedBySection`: end-to-end render with two sections, each with a public + secret test, asserts per-section counts and that secret test names never leak.
- Existing `studentSeesSecretAggregatePassFailCounts` (no-sections case) still passes.

`scripts/check-styles.sh`, `scripts/check-css-vars.sh`, `swift-format`, and SwiftLint (`--strict`) all clean.

https://claude.ai/code/session_017oKSxsbhRRMLp6prEDQPE3

---
_Generated by [Claude Code](https://claude.ai/code/session_017oKSxsbhRRMLp6prEDQPE3)_