### PR TITLE
Personalize reference-solution notebooks at validation

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -185,6 +185,22 @@ enum MCPServerInstructions {
         non-graded helper file (e.g. a data generator) that tests and personalization expressions can \
         import by stem. Generated pattern-family / notebook-check scripts are not editable via \
         author_script — edit the family/check instead.
+        - Per-student answers (notebooks). A student's answer can be a module-level VARIABLE \
+        (e.g. `answer = ...`) or a FUNCTION. Watch the notebook extractor's import rule: a code cell's \
+        top-level statement runs at grading-import time ONLY if it is a def/class/import or an \
+        assignment whose right-hand side has NO function call — anything else (e.g. \
+        `x = int(os.environ["CHICKADEE_ASSIGNMENT_SEED"], 16)`) is quarantined into \
+        `if __name__ == "__main__":` and does NOT run at import, so the name is undefined to the \
+        grader. Consequences: (1) a per-student answer that must be COMPUTED at module level can't be \
+        — have the student write the discovered value as a literal, or use a function (function bodies \
+        run at call time and may read CHICKADEE_ASSIGNMENT_SEED). (2) The reference solution must \
+        produce the same per-student value, and a seed-agnostic solution can't compute it as a plain \
+        module-level variable. Two supported ways: write the answer cell with a `{{name}}` placeholder \
+        (declare `name` as a global-inputs expression, e.g. `1 + seed % 25`) — the SOLUTION notebook is \
+        substituted per validation-seed just like the starter, so `shift = {{shift}}` becomes a literal \
+        that survives import — or make the solution answer a function that reads \
+        CHICKADEE_ASSIGNMENT_SEED at call time. Use preview_personalization to confirm what a \
+        placeholder resolves to. Full recipe: docs/personalization-solution-notebooks.md. \
         - Resources: each accessible assignment's raw test.properties.json manifest is also exposed \
         as an MCP resource (resources/list, then resources/read on \
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -45,7 +45,12 @@ struct UpdateSolutionTool: ContentTool {
         + "validate_assignment), closing the assignment if it was open (re-open with update_assignment "
         + "once validation passes). This is instructor-authored content — it never touches student "
         + "submissions, and never the starter notebook (use update_notebook for that). Use get_solution "
-        + "first to fetch the current solution to edit."
+        + "first to fetch the current solution to edit. The solution may use `{{name}}` personalization "
+        + "placeholders just like the starter notebook (declare `name` in global inputs); they are "
+        + "substituted per validation-seed at grading, which is the supported way to give a seed-agnostic "
+        + "answer key a per-student VARIABLE value (a module-level assignment that COMPUTES the value via "
+        + "a function call, e.g. reading CHICKADEE_ASSIGNMENT_SEED, is quarantined at import and won't "
+        + "define the variable — see docs/personalization-solution-notebooks.md)."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([

--- a/Sources/APIServer/Routes/WorkerArtifactRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerArtifactRoutes.swift
@@ -1,4 +1,6 @@
+import Core
 import Fluent
+import Foundation
 import Vapor
 
 /// Worker-only artifact download routes authenticated by X-Worker-Secret.
@@ -16,7 +18,95 @@ struct WorkerArtifactRoutes: RouteCollection {
         else {
             throw Abort(.notFound)
         }
+
+        // A reference-solution (validation) notebook may carry the same
+        // `{{name}}` personalization placeholders as the student starter — e.g.
+        // `fortuneShift = {{fortuneShift}}` so the answer key derives a
+        // per-student value exactly the way a student would. Substitute them
+        // here, at worker download, using the SAME per-(user, assignment) seed
+        // the worker resolves for `_ck_inputs.py`
+        // (`WorkerJobRoutes.buildJobPayload`), so the solution's per-student
+        // values and the grader's expected values agree. The stored file keeps
+        // its `{{...}}` template, so `get_solution` and re-validation by any
+        // user still see the editable source.
+        //
+        // This is gated to validation submissions: student submissions are
+        // already-substituted working copies (substituted at notebook
+        // first-open), so they must not be re-processed here.
+        if submission.kind == APISubmission.Kind.validation,
+            let substituted = try? await substitutedValidationNotebook(req: req, submission: submission)
+        {
+            let response = Response(status: .ok)
+            response.headers.contentType = HTTPMediaType(type: "application", subType: "octet-stream")
+            response.body = .init(data: substituted)
+            return response
+        }
+
         return try await req.fileio.asyncStreamFile(at: submission.zipPath)
+    }
+
+    /// Returns the validation submission's notebook with `{{name}}`
+    /// placeholders substituted for the submission's seed, or `nil` when there
+    /// is nothing to do — not an `.ipynb`, no personalization declared on the
+    /// setup, or no substitutions resolved. On `nil` the caller streams the
+    /// stored file verbatim (the historical behaviour), so an assignment with
+    /// no personalization is completely unaffected.
+    ///
+    /// The seed is resolved with the SAME `AssignmentSeedStore.ensureSeed(user,
+    /// assignment)` the worker uses to build `_ck_inputs.py`, keyed on the
+    /// submission's own `userID`, so the substituted answer key matches the
+    /// grader's per-student expected values for this exact validation run.
+    private func substitutedValidationNotebook(
+        req: Request, submission: APISubmission
+    ) async throws -> Data? {
+        guard (submission.filename ?? "solution.ipynb").lowercased().hasSuffix(".ipynb") else {
+            return nil
+        }
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: submission.zipPath)),
+            !data.isEmpty
+        else { return nil }
+
+        let setupID = submission.testSetupID
+        guard let setup = try await APITestSetup.find(setupID, on: req.db),
+            let manifestData = setup.manifest.data(using: .utf8),
+            let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData)
+        else { return nil }
+
+        // Skip the work entirely unless the setup actually declares
+        // personalization — keeps non-personalized assignments on the original
+        // zero-copy streaming path.
+        let hasPersonalization =
+            !manifest.globalVariables.isEmpty
+            || !manifest.globalExpressions.isEmpty
+            || manifest.sections.contains { !$0.variables.isEmpty || !$0.expressions.isEmpty }
+        guard hasPersonalization else { return nil }
+
+        // Resolve the same per-(user, assignment) seed the worker uses for
+        // `_ck_inputs.py` so the answer key and the grader agree.
+        var seedHex: String?
+        if let userID = submission.userID,
+            let assignment = try await APIAssignment.query(on: req.db)
+                .filter(\.$testSetupID == setupID)
+                .first(),
+            let assignmentID = assignment.id
+        {
+            seedHex = try? await AssignmentSeedStore.ensureSeed(
+                userID: userID, assignmentID: assignmentID, on: req.db)
+        }
+
+        let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+        let resolution = await PersonalizationSubstitution.resolve(
+            manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportDir)
+        guard !resolution.substitutions.isEmpty else { return nil }
+
+        // Soft-fail: the editor's save-time scan is the authoritative gate for
+        // unknown placeholders, so leave any stragglers verbatim rather than
+        // throwing here.
+        return try? NotebookSubstitution.apply(
+            notebookData: data,
+            substitutions: resolution.substitutions,
+            strict: false
+        )
     }
 
     @Sendable

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -620,6 +620,72 @@ import XCTVapor
         }
     }
 
+    // A reference-solution (validation) notebook carrying `{{name}}`
+    // personalization placeholders is substituted at worker download, so the
+    // answer key can derive per-student values the same way the student does.
+    private let substManifestJSON = """
+        {"schemaVersion":1,"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,\
+        "globalVariables":[{"name":"answer","value":"ck_subst_marker"}]}
+        """
+
+    private func makeNotebookSubmission(
+        id: String, setupID: String, kind: String, source: String
+    ) async throws -> APISubmission {
+        let nbURL = URL(fileURLWithPath: app.submissionsDirectory)
+            .appendingPathComponent("\(id).ipynb")
+        let notebook = """
+            {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[\
+            {"cell_type":"code","metadata":{},"execution_count":null,"outputs":[],"source":\(
+                String(data: try JSONEncoder().encode(source), encoding: .utf8) ?? "\"\"")}]}
+            """
+        try Data(notebook.utf8).write(to: nbURL)
+        let sub = APISubmission(
+            id: id, testSetupID: setupID, zipPath: nbURL.path,
+            attemptNumber: 1, status: "pending",
+            filename: "solution.ipynb", userID: nil, kind: kind)
+        try await sub.save(on: app.db)
+        return sub
+    }
+
+    @Test func downloadSubmission_validationNotebook_substitutesPlaceholders() async throws {
+        try await withApp(app) { _ in
+            let setup = try await makeTestSetup(id: "subst_setup_01", manifest: substManifestJSON)
+            _ = try await makeNotebookSubmission(
+                id: "subst_val_01", setupID: (try setup.requireID()),
+                kind: APISubmission.Kind.validation, source: "x = {{answer}}")
+
+            let path = "/api/v1/worker/submissions/subst_val_01/download"
+            try await app.asyncTest(
+                .GET, path,
+                beforeRequest: { req in req.headers = workerHeaders(method: .GET, path: path) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("ck_subst_marker"))
+                    #expect(!res.body.string.contains("{{answer}}"))
+                })
+        }
+    }
+
+    @Test func downloadSubmission_studentNotebook_leavesPlaceholdersVerbatim() async throws {
+        // Student submissions are already-substituted working copies, so the
+        // download path must NOT re-process them.
+        try await withApp(app) { _ in
+            let setup = try await makeTestSetup(id: "subst_setup_02", manifest: substManifestJSON)
+            _ = try await makeNotebookSubmission(
+                id: "subst_stu_01", setupID: (try setup.requireID()),
+                kind: APISubmission.Kind.student, source: "x = {{answer}}")
+
+            let path = "/api/v1/worker/submissions/subst_stu_01/download"
+            try await app.asyncTest(
+                .GET, path,
+                beforeRequest: { req in req.headers = workerHeaders(method: .GET, path: path) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("{{answer}}"))
+                })
+        }
+    }
+
     // MARK: - GET /api/v1/worker/testsetups/:id/download
 
     @Test func downloadTestSetup_existingFile_returns200() async throws {

--- a/changelog.d/solution-notebook-personalization.md
+++ b/changelog.d/solution-notebook-personalization.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Reference-solution notebooks are now personalized like the starter.** A
+  validation (solution) notebook's `{{name}}` placeholders are substituted at
+  worker download using the same per-(student, assignment) seed the worker uses
+  for `_ck_inputs.py`, so the answer key resolves the same per-student values the
+  grader expects. This makes a per-student **variable** answer (e.g.
+  `shift = {{shift}}`) a first-class, validatable pattern — previously only a
+  seed-reading *function* could survive the notebook extractor's import-time
+  quarantine. The stored solution keeps its `{{…}}` template, so `get_solution`
+  and re-validation by any user still work. New doc:
+  `docs/personalization-solution-notebooks.md`; the MCP `initialize`
+  instructions and `update_solution` description now spell out the quarantine
+  rule and the two supported ways a solution produces a per-student value.

--- a/docs/personalization-solution-notebooks.md
+++ b/docs/personalization-solution-notebooks.md
@@ -1,0 +1,133 @@
+# Per-student answers in notebooks (and their reference solutions)
+
+This page captures a rule that is easy to rediscover the hard way: **how a
+per-student answer can be expressed in a notebook, and how the reference
+solution produces the matching per-student value so validation passes.**
+
+It complements:
+
+- [personalization-phase1.md](personalization-phase1.md) — the per-(student,
+  assignment) seed contract (`CHICKADEE_ASSIGNMENT_SEED`).
+- [inputs.md](inputs.md) — global/section inputs, literal `variables` vs
+  per-student `expressions`, `{{name}}` starter-notebook substitution.
+- [personalization-pattern-families.md](personalization-pattern-families.md) —
+  per-student pattern families via `$name` / `expectedVarRef` and `_ck_inputs.py`.
+
+## The one rule that bites: the notebook-extractor import quarantine
+
+When a notebook is graded, the runner extracts each code cell into a Python
+module and **imports** it (`RunnerCore.extractPython` →
+`sanitizeCellForModule`). A top-level statement runs at import **only** if it is
+"safe":
+
+- a `def` / `class` / `import` / `from … import` / decorator, **or**
+- an assignment whose right-hand side contains **no function call**
+  (`x = 5`, `x = "abc"`, `x = a + b`, `x = data[0]` all qualify).
+
+Anything else — a bare call, control flow, or an assignment whose RHS calls a
+function — is **quarantined** into an `if __name__ == "__main__":` block so it
+does not run at import (this keeps side effects and one broken cell from taking
+down the rest of the module). At grading time the module is imported, so
+`__name__` is the module name, **not** `"__main__"`, and the quarantined code
+never runs.
+
+Concretely, this does **not** define `seed` for the grader:
+
+```python
+import os
+seed = int(os.environ["CHICKADEE_ASSIGNMENT_SEED"], 16)   # RHS has int(...) → quarantined
+fortuneShift = 1 + seed % 25                                # NameError at import → whole cell dropped
+```
+
+while this **does** (no call on the RHS):
+
+```python
+fortuneShift = 7        # literal → runs at import → readable by the grader
+```
+
+and so does a function (its body runs at *call* time, not import):
+
+```python
+import os
+def fortune_shift():
+    return 1 + int(os.environ["CHICKADEE_ASSIGNMENT_SEED"], 16) % 25
+```
+
+## Choosing the answer shape for a student
+
+| Answer kind | How the student writes it | Graded by |
+|---|---|---|
+| Fixed value | `answer = "..."` (a literal) | `variable_equality` pattern family, or a notebook check |
+| **Per-student** value | the student **discovers** it and writes it as a **literal** (`shift = 7`), since a computed module-level value would be quarantined | hand-written secret script (reads `CHICKADEE_ASSIGNMENT_SEED` or `_ck_inputs.py`), or a pattern family |
+| Function | `def f(...): ...` | any function-calling pattern family |
+
+A per-student **variable** answer is fine for students: they brute-force / read
+off the value and type the literal in. The grader re-derives the expected value
+from the seed (a test script may read `CHICKADEE_ASSIGNMENT_SEED`; pattern
+families and `_ck_inputs.py` carry resolved per-student values).
+
+## The catch: the reference solution must also produce the per-student value
+
+The reference solution is graded exactly like a submission (same extractor, same
+quarantine), but unlike a student it must be **seed-agnostic** — one notebook
+that validates for whatever seed the validation run uses. So it cannot hard-code
+a literal, and (per the rule above) it cannot compute a per-student value into a
+plain module-level variable either.
+
+Two supported ways to give the solution a per-student value:
+
+### 1. `{{name}}` placeholder in the solution (preferred for variable answers)
+
+The **solution notebook is personalized just like the starter** — its
+`{{name}}` placeholders are substituted with the validation run's seed values
+(`WorkerArtifactRoutes.downloadSubmission` substitutes validation-submission
+notebooks at worker download, using the same `AssignmentSeedStore.ensureSeed`
+the worker uses for `_ck_inputs.py`, so the answer key and the grader agree).
+Declare the value as a global-inputs **expression** and reference it:
+
+```text
+Global inputs (update_global_inputs):
+  expressions:
+    fortuneShift     = 1 + seed % 25
+    fortuneBlockSize = 2 + seed % 5
+
+Solution notebook cell:
+  fortuneShift = {{fortuneShift}}          # → e.g. `fortuneShift = 7` at validation
+  fortuneBlockSize = {{fortuneBlockSize}}
+```
+
+After substitution the cell holds literals, which survive import. The **stored**
+solution keeps the `{{...}}` template, so `get_solution` and re-validation by any
+user still work. (The starter notebook only needs the placeholders the *student*
+should see — it does not reference the answer expressions.)
+
+### 2. A function that reads the seed at call time
+
+If the student's answer is a function anyway, the solution's function can read
+`CHICKADEE_ASSIGNMENT_SEED` itself:
+
+```python
+import os
+def decode_fortune(ciphertext: str) -> str:
+    seed = int(os.environ.get("CHICKADEE_ASSIGNMENT_SEED", "0"), 16)
+    return decomposite(ciphertext, 1 + seed % 25, 2 + seed % 5)
+```
+
+This is why a per-student exercise historically used a function: it was the only
+shape whose seed-dependent value survived import. With option 1, a per-student
+**variable** answer is now equally supported.
+
+## Authoring checklist (MCP or web)
+
+1. Decide the answer shape (table above). For a per-student value, the student
+   writes a literal; don't ask them to compute it at module level.
+2. `update_global_inputs`: add the per-student `expressions` the answer derives
+   from the seed.
+3. Grader: a hand-written secret script (reads `CHICKADEE_ASSIGNMENT_SEED` or
+   loads `_ck_inputs.py`) or a pattern family. `_ck_inputs.py` carries every
+   evaluated expression as a Python literal — load it with
+   `importlib.util.spec_from_file_location("_ck_inputs", "_ck_inputs.py")`.
+4. Solution: use `{{name}}` placeholders (option 1) or a seed-reading function
+   (option 2). Never a computed module-level variable.
+5. `validate_assignment` and confirm `passed`. Use `preview_personalization`
+   to see exactly what a seed resolves each `{{name}}` to.


### PR DESCRIPTION
## Why

While reworking HLTH 230 **Lab 5** to use per-student **variable** answers (instead of functions), validation kept failing for the per-student question — and it turned out to be a real platform gap, not a one-off:

1. The notebook extractor (`RunnerCore.sanitizeCellForModule`) quarantines any module-level statement whose RHS contains a **function call** into `if __name__ == "__main__":`, so it never runs at grading-import. A solution that derives a per-student value at module level (e.g. `seed = int(os.environ["CHICKADEE_ASSIGNMENT_SEED"], 16); shift = 1 + seed % 25`) leaves `shift` **undefined** for the grader.
2. The **starter** notebook gets `{{name}}` substitution, but the **solution** notebook was stored and graded verbatim — so `shift = {{shift}}` wouldn't resolve either.

Net effect: a per-student answer had **no** seed-agnostic validating reference solution unless it was a *function* (whose body reads the seed at call time). That's why these exercises were historically functions, and why "just make it a variable" was quietly impossible.

## What

Substitute `{{name}}` placeholders in **validation (solution) submissions** at worker download (`WorkerArtifactRoutes.downloadSubmission`), using the **same** `AssignmentSeedStore.ensureSeed(user, assignment)` the worker uses to build `_ck_inputs.py` — so the answer key and the grader resolve identical per-student values.

- **Gated to validation submissions.** Student submissions are already-substituted working copies and stream verbatim, unchanged.
- **Template preserved.** The stored solution keeps its `{{…}}` source, so `get_solution` and re-validation by any user still work (substitution happens per download, per seed).
- **Backward compatible.** Assignments with no personalization take the original zero-copy streaming path; existing solutions have no `{{…}}`, so nothing changes for them.

This makes a per-student **variable** answer a first-class, validatable pattern: declare `shift = 1 + seed % 25` as a global-inputs expression and write `shift = {{shift}}` in the solution.

## Make it discoverable (the "document these abilities" ask)

- New doc: **`docs/personalization-solution-notebooks.md`** — the import-quarantine rule, the answer-shape decision table, and the two supported ways a solution produces a per-student value.
- MCP `initialize` instructions (`MCPServerInstructions`) gain a "Per-student answers (notebooks)" section spelling out the quarantine rule and the placeholder/function options.
- `update_solution` tool description now notes solutions support `{{name}}` substitution and why a computed module-level variable won't work.

## Tests

- `downloadSubmission_validationNotebook_substitutesPlaceholders` — a validation `.ipynb` with `{{answer}}` comes back substituted.
- `downloadSubmission_studentNotebook_leavesPlaceholdersVerbatim` — student submissions are **not** re-processed.

Both pass; `swift-format lint` clean on all changed files.

## Follow-up

Once this deploys to `chickadee.uwaterloo.ca`, HLTH 230 Lab 5 Q3 can use `fortuneShift = {{fortuneShift}}` / `fortuneBlockSize = {{fortuneBlockSize}}` in the solution and validate green (the assignment is wired for it). Until deploy, that lab's per-student question validates only with a seed-reading function.

https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3

---
_Generated by [Claude Code](https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3)_