### PR TITLE
fix(personalization): materialize validation grading at enqueue, off the worker download hot path

### DIFF
--- a/Sources/APIServer/Migrations/AddSubmissionMaterialization.swift
+++ b/Sources/APIServer/Migrations/AddSubmissionMaterialization.swift
@@ -1,0 +1,28 @@
+// APIServer/Migrations/AddSubmissionMaterialization.swift
+//
+// Adds the optional `materialization_json` column to the submissions table:
+// the cached, once-resolved personalization for a validation submission (see
+// `SubmissionMaterialization`). It lets the worker poll + download paths read
+// pre-resolved values instead of running the personalization evaluator on a
+// hot path the runner times out against.
+//
+// Standalone Add* migration because production has already applied
+// CreateSubmissions without this column and would never pick it up from a body
+// change. Fresh deploys run CreateSubmissions then this; existing prod runs
+// only this one. Additive + nullable, so existing rows are unaffected.
+
+import Fluent
+
+struct AddSubmissionMaterialization: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("submissions")
+            .field("materialization_json", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("submissions")
+            .deleteField("materialization_json")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APISubmission.swift
+++ b/Sources/APIServer/Models/APISubmission.swift
@@ -63,6 +63,13 @@ final class APISubmission: Model, Content, @unchecked Sendable {
     @Field(key: "kind")
     var kind: String
 
+    /// Cached per-student personalization for a validation submission, resolved
+    /// once at enqueue (`materializeValidationGrading`) so the worker poll +
+    /// download paths stay eval-free. JSON-encoded `SubmissionMaterialization`;
+    /// nil for student submissions, non-personalized assignments, and pre-fix rows.
+    @OptionalField(key: "materialization_json")
+    var materializationJSON: String?
+
     init() {}
 
     init(

--- a/Sources/APIServer/Models/SubmissionMaterialization.swift
+++ b/Sources/APIServer/Models/SubmissionMaterialization.swift
@@ -1,0 +1,48 @@
+// APIServer/Models/SubmissionMaterialization.swift
+//
+// Cached, per-validation-submission personalization, resolved ONCE at enqueue
+// (`materializeValidationGrading`) so the two worker-facing routes stay pure
+// I/O and never run `python3`:
+//
+//   * `inputs` — the resolved `=` expression values (Python literals). Read by
+//     `WorkerJobRoutes.buildJobPayload` and handed to the runner as
+//     `Job.personalizedInputs` (→ `_ck_inputs.py`), instead of re-evaluating on
+//     the poll path.
+//   * The substituted solution notebook is written alongside as a
+//     `<zipPath>.grading` sidecar and streamed verbatim by
+//     `WorkerArtifactRoutes.downloadSubmission` — no manifest decode, no seed
+//     lookup, no subprocess. This is what fixes the runner's 5 s download
+//     timeout (the `#869` regression that ran the evaluator in the download
+//     handler).
+//
+// `seedHex` pins the one seed every cached value was resolved against, so the
+// answer-key notebook, `_ck_inputs.py`, and `CHICKADEE_ASSIGNMENT_SEED` all
+// agree. The stored `zipPath` keeps the `{{...}}` template, so `get_solution`,
+// the editor, and re-validation by another user are unaffected.
+
+import Foundation
+
+struct SubmissionMaterialization: Codable, Sendable {
+    /// `sha256(seedHex | manifest)` — a staleness guard. Per-submission
+    /// materialization can't normally go stale (a manifest edit enqueues a
+    /// fresh validation submission), so this is belt-and-suspenders for edge
+    /// cases (a seed reset, or a manifest mutation that didn't re-enqueue).
+    let key: String
+    /// The seed every cached value was resolved against; nil for a
+    /// literal-only assignment that declares no per-student expressions.
+    let seedHex: String?
+    /// Resolved `=` expression values (Python literals), keyed by name — the
+    /// same map `PersonalizationSubstitution.gradingInputs` produces. Empty for
+    /// a literal-only assignment.
+    let inputs: [String: String]
+}
+
+extension APISubmission {
+    /// Decodes the cached personalization materialization, or nil when the
+    /// submission was never materialized (student submissions, non-personalized
+    /// assignments, or rows written before this fix).
+    func decodedMaterialization() -> SubmissionMaterialization? {
+        guard let json = materializationJSON, let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(SubmissionMaterialization.self, from: data)
+    }
+}

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -60,7 +60,109 @@ func enqueueRunnerValidationSubmission(
         kind: APISubmission.Kind.validation
     )
     try await submission.save(on: req.db)
+
+    // Resolve personalization ONCE here (at enqueue — an instructor save, which
+    // is latency-tolerant) and cache it, so the worker poll + download paths
+    // never run the personalization evaluator. See `materializeValidationGrading`.
+    await materializeValidationGrading(
+        submission: submission,
+        setupID: setupID,
+        templateNotebookData: solutionNotebookData,
+        testSetupsDirectory: req.application.testSetupsDirectory,
+        on: req.db)
+
     return subID
+}
+
+/// Resolve a validation submission's personalization ONCE and persist it, so
+/// the worker poll + download paths never run `python3` (which the runner times
+/// out against on its 5 s artifact download — the `#869` regression). Writes:
+///
+///   * `submission.materializationJSON` — the resolved `=` expression value map
+///     plus the seed everything was resolved against. `buildJobPayload` reads
+///     this instead of re-evaluating; the values become `_ck_inputs.py`.
+///   * `<submission.zipPath>.grading` — the solution notebook with `{{name}}`
+///     placeholders substituted. `WorkerArtifactRoutes.downloadSubmission`
+///     streams it verbatim (pure I/O).
+///
+/// The stored `zipPath` keeps its `{{...}}` template, so `get_solution`, the
+/// editor, and re-validation by another user are unaffected.
+///
+/// Best-effort: never throws out. On any failure the submission is left
+/// un-materialized — the download route then streams the template (grading
+/// fails clearly, but the worker never times out), and `buildJobPayload` falls
+/// back to live resolution.
+func materializeValidationGrading(
+    submission: APISubmission,
+    setupID: String,
+    templateNotebookData: Data,
+    testSetupsDirectory: String,
+    on db: any Database
+) async {
+    do {
+        guard let setup = try await APITestSetup.find(setupID, on: db),
+            let manifestData = setup.manifest.data(using: .utf8),
+            let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData)
+        else { return }
+
+        // Non-personalized assignments: nothing to resolve or cache — the
+        // download route streams the stored zip exactly as before.
+        let hasPersonalization =
+            !manifest.globalVariables.isEmpty
+            || !manifest.globalExpressions.isEmpty
+            || manifest.sections.contains { !$0.variables.isEmpty || !$0.expressions.isEmpty }
+        guard hasPersonalization else { return }
+
+        // Resolve the per-(user, assignment) seed when we can. Literal variables
+        // substitute without a seed; only `=` expressions need one.
+        var seedHex: String?
+        if let userID = submission.userID,
+            let assignment = try await APIAssignment.query(on: db)
+                .filter(\.$testSetupID == setupID)
+                .first(),
+            let assignmentID = assignment.id
+        {
+            seedHex = try? await AssignmentSeedStore.ensureSeed(
+                userID: userID, assignmentID: assignmentID, on: db)
+        }
+
+        let supportDir = testSetupsDirectory + "shared/\(setupID)/"
+        let resolution = await PersonalizationSubstitution.resolve(
+            manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportDir)
+
+        // Expression-only value map (identical to `gradingInputs`) → _ck_inputs.py.
+        let exprNames = Set(resolution.evaluatedExpressionNames)
+        let inputs = resolution.substitutions.filter { exprNames.contains($0.key) }
+
+        // Substitute the solution notebook once and write the grading sidecar.
+        // Soft-fail substitution: the editor's save-time scan is the
+        // authoritative gate for unknown placeholders.
+        let filename = submission.filename ?? "solution.ipynb"
+        if filename.lowercased().hasSuffix(".ipynb"),
+            !resolution.substitutions.isEmpty,
+            !templateNotebookData.isEmpty,
+            let substituted = try? NotebookSubstitution.apply(
+                notebookData: templateNotebookData,
+                substitutions: resolution.substitutions,
+                strict: false)
+        {
+            try? substituted.write(to: URL(fileURLWithPath: submission.zipPath + ".grading"))
+        }
+
+        let materialization = SubmissionMaterialization(
+            key: manifestHash((seedHex ?? "") + "|" + setup.manifest),
+            seedHex: seedHex,
+            inputs: inputs)
+        if let encoded = try? JSONEncoder().encode(materialization),
+            let json = String(data: encoded, encoding: .utf8)
+        {
+            submission.materializationJSON = json
+            try await submission.save(on: db)
+        }
+    } catch {
+        // Best-effort: leave the submission un-materialized; the download route
+        // falls back to streaming the template and buildJobPayload to live eval.
+    }
 }
 
 /// Schedule a validation submission after a suite edit, best-effort.

--- a/Sources/APIServer/Routes/WorkerArtifactRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerArtifactRoutes.swift
@@ -1,4 +1,3 @@
-import Core
 import Fluent
 import Foundation
 import Vapor
@@ -19,94 +18,26 @@ struct WorkerArtifactRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        // A reference-solution (validation) notebook may carry the same
-        // `{{name}}` personalization placeholders as the student starter — e.g.
-        // `fortuneShift = {{fortuneShift}}` so the answer key derives a
-        // per-student value exactly the way a student would. Substitute them
-        // here, at worker download, using the SAME per-(user, assignment) seed
-        // the worker resolves for `_ck_inputs.py`
-        // (`WorkerJobRoutes.buildJobPayload`), so the solution's per-student
-        // values and the grader's expected values agree. The stored file keeps
-        // its `{{...}}` template, so `get_solution` and re-validation by any
-        // user still see the editable source.
+        // A validation (reference-solution) notebook carrying `{{name}}`
+        // personalization placeholders is substituted ONCE at enqueue
+        // (`materializeValidationGrading`) into a `<zipPath>.grading` sidecar.
+        // Stream that pre-substituted copy when present, so this route stays
+        // pure I/O — no manifest decode, no seed lookup, no `python3`. That's
+        // what keeps it under the runner's tight download timeout (the `#869`
+        // regression ran the evaluator here and tripped a 5 s `-1001`).
         //
-        // This is gated to validation submissions: student submissions are
-        // already-substituted working copies (substituted at notebook
-        // first-open), so they must not be re-processed here.
-        if submission.kind == APISubmission.Kind.validation,
-            let substituted = try? await substitutedValidationNotebook(req: req, submission: submission)
-        {
-            let response = Response(status: .ok)
-            response.headers.contentType = HTTPMediaType(type: "application", subType: "octet-stream")
-            response.body = .init(data: substituted)
-            return response
+        // The stored `zipPath` keeps its `{{...}}` template, so `get_solution`,
+        // the editor, and re-validation by another user still see the source.
+        // When no sidecar exists (non-personalized assignment, or materialization
+        // didn't run) we stream the stored file verbatim, exactly as before.
+        if submission.kind == APISubmission.Kind.validation {
+            let gradingCopy = submission.zipPath + ".grading"
+            if FileManager.default.fileExists(atPath: gradingCopy) {
+                return try await req.fileio.asyncStreamFile(at: gradingCopy)
+            }
         }
 
         return try await req.fileio.asyncStreamFile(at: submission.zipPath)
-    }
-
-    /// Returns the validation submission's notebook with `{{name}}`
-    /// placeholders substituted for the submission's seed, or `nil` when there
-    /// is nothing to do — not an `.ipynb`, no personalization declared on the
-    /// setup, or no substitutions resolved. On `nil` the caller streams the
-    /// stored file verbatim (the historical behaviour), so an assignment with
-    /// no personalization is completely unaffected.
-    ///
-    /// The seed is resolved with the SAME `AssignmentSeedStore.ensureSeed(user,
-    /// assignment)` the worker uses to build `_ck_inputs.py`, keyed on the
-    /// submission's own `userID`, so the substituted answer key matches the
-    /// grader's per-student expected values for this exact validation run.
-    private func substitutedValidationNotebook(
-        req: Request, submission: APISubmission
-    ) async throws -> Data? {
-        guard (submission.filename ?? "solution.ipynb").lowercased().hasSuffix(".ipynb") else {
-            return nil
-        }
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: submission.zipPath)),
-            !data.isEmpty
-        else { return nil }
-
-        let setupID = submission.testSetupID
-        guard let setup = try await APITestSetup.find(setupID, on: req.db),
-            let manifestData = setup.manifest.data(using: .utf8),
-            let manifest = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData)
-        else { return nil }
-
-        // Skip the work entirely unless the setup actually declares
-        // personalization — keeps non-personalized assignments on the original
-        // zero-copy streaming path.
-        let hasPersonalization =
-            !manifest.globalVariables.isEmpty
-            || !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.variables.isEmpty || !$0.expressions.isEmpty }
-        guard hasPersonalization else { return nil }
-
-        // Resolve the same per-(user, assignment) seed the worker uses for
-        // `_ck_inputs.py` so the answer key and the grader agree.
-        var seedHex: String?
-        if let userID = submission.userID,
-            let assignment = try await APIAssignment.query(on: req.db)
-                .filter(\.$testSetupID == setupID)
-                .first(),
-            let assignmentID = assignment.id
-        {
-            seedHex = try? await AssignmentSeedStore.ensureSeed(
-                userID: userID, assignmentID: assignmentID, on: req.db)
-        }
-
-        let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
-        let resolution = await PersonalizationSubstitution.resolve(
-            manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportDir)
-        guard !resolution.substitutions.isEmpty else { return nil }
-
-        // Soft-fail: the editor's save-time scan is the authoritative gate for
-        // unknown placeholders, so leave any stragglers verbatim rather than
-        // throwing here.
-        return try? NotebookSubstitution.apply(
-            notebookData: data,
-            substitutions: resolution.substitutions,
-            strict: false
-        )
     }
 
     @Sendable

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -154,12 +154,22 @@ struct WorkerJobRoutes: RouteCollection {
         let setup = claimed.setup
         let base = resolvedWorkerBaseURL(req: req)
 
+        // Validation submissions are pre-materialized at enqueue
+        // (`materializeValidationGrading`): the seed + resolved expression values
+        // are cached on the row, so we read them here instead of re-running the
+        // personalization evaluator on this hot (poll) path — and the answer-key
+        // notebook, `_ck_inputs.py`, and `CHICKADEE_ASSIGNMENT_SEED` all derive
+        // from one seed. Student submissions have no cache and resolve live.
+        let materialization = submission.decodedMaterialization()
+
         // Per-(student, assignment) seed for personalized inputs (issue #461, Phase 1).
         // Generated lazily on first grading attempt; stable for the lifetime of the
         // (user, assignment) pair. Nil when the submission has no associated user
         // (legacy / unauthenticated path) or no assignment row was matched.
         var assignmentSeed: String?
-        if let userID = submission.userID, let resolvedAssignmentID = claimed.assignmentID {
+        if let materialization {
+            assignmentSeed = materialization.seedHex
+        } else if let userID = submission.userID, let resolvedAssignmentID = claimed.assignmentID {
             do {
                 assignmentSeed = try await AssignmentSeedStore.ensureSeed(
                     userID: userID,
@@ -187,10 +197,17 @@ struct WorkerJobRoutes: RouteCollection {
         // Resolve per-student personalization inputs (issue #461) for this seed,
         // server-side, so the worker can bind them in generated scripts via
         // `_ck_inputs.py`. Shared with the browser seed endpoint via
-        // `gradingInputs` so the two grading paths resolve identically.
-        let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
-        let personalizedInputs = await PersonalizationSubstitution.gradingInputs(
-            manifest: claimed.manifest, seedHex: assignmentSeed, supportFilesDirectory: supportDir)
+        // `gradingInputs` so the two grading paths resolve identically. For a
+        // pre-materialized validation submission we use the cached values
+        // (no re-eval on this hot path); otherwise we resolve live.
+        let personalizedInputs: [String: String]?
+        if let materialization {
+            personalizedInputs = materialization.inputs.isEmpty ? nil : materialization.inputs
+        } else {
+            let supportDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+            personalizedInputs = await PersonalizationSubstitution.gradingInputs(
+                manifest: claimed.manifest, seedHex: assignmentSeed, supportFilesDirectory: supportDir)
+        }
 
         return Job(
             submissionID: submissionID,

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -243,4 +243,9 @@ func registerMigrations(on app: Application) {
     // Replaces assignments.is_open (bool) with assignments.visibility (enum
     // string). Runs after CreateAssignments on every deploy.
     app.migrations.add(ChangeAssignmentIsOpenToVisibility())
+
+    // Adds submissions.materialization_json — cached once-at-enqueue
+    // personalization for validation submissions, so worker poll + download
+    // stay eval-free.
+    app.migrations.add(AddSubmissionMaterialization())
 }

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -621,15 +621,18 @@ import XCTVapor
     }
 
     // A reference-solution (validation) notebook carrying `{{name}}`
-    // personalization placeholders is substituted at worker download, so the
-    // answer key can derive per-student values the same way the student does.
+    // personalization placeholders is substituted ONCE at enqueue
+    // (`materializeValidationGrading`) into a `<zipPath>.grading` sidecar; the
+    // download route then streams that sidecar verbatim (no eval on the hot
+    // path). These tests drive `materializeValidationGrading` directly and
+    // assert the download route is pure I/O.
     private let substManifestJSON = """
         {"schemaVersion":1,"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,\
         "globalVariables":[{"name":"answer","value":"ck_subst_marker"}]}
         """
 
     private func makeNotebookSubmission(
-        id: String, setupID: String, kind: String, source: String
+        id: String, setupID: String, kind: String, source: String, userID: UUID? = nil
     ) async throws -> APISubmission {
         let nbURL = URL(fileURLWithPath: app.submissionsDirectory)
             .appendingPathComponent("\(id).ipynb")
@@ -642,26 +645,57 @@ import XCTVapor
         let sub = APISubmission(
             id: id, testSetupID: setupID, zipPath: nbURL.path,
             attemptNumber: 1, status: "pending",
-            filename: "solution.ipynb", userID: nil, kind: kind)
+            filename: "solution.ipynb", userID: userID, kind: kind)
         try await sub.save(on: app.db)
         return sub
     }
 
-    @Test func downloadSubmission_validationNotebook_substitutesPlaceholders() async throws {
+    @Test func materializeValidation_writesSidecar_andDownloadStreamsIt() async throws {
         try await withApp(app) { _ in
             let setup = try await makeTestSetup(id: "subst_setup_01", manifest: substManifestJSON)
-            _ = try await makeNotebookSubmission(
-                id: "subst_val_01", setupID: (try setup.requireID()),
+            let setupID = try setup.requireID()
+            let sub = try await self.makeNotebookSubmission(
+                id: "subst_val_01", setupID: setupID,
                 kind: APISubmission.Kind.validation, source: "x = {{answer}}")
 
+            // Substitution happens at enqueue, NOT on the download hot path.
+            let template = try Data(contentsOf: URL(fileURLWithPath: sub.zipPath))
+            await materializeValidationGrading(
+                submission: sub, setupID: setupID, templateNotebookData: template,
+                testSetupsDirectory: self.app.testSetupsDirectory, on: self.app.db)
+
+            // The cache record is stamped on the row.
+            #expect(sub.materializationJSON != nil)
+
             let path = "/api/v1/worker/submissions/subst_val_01/download"
-            try await app.asyncTest(
+            try await self.app.asyncTest(
                 .GET, path,
-                beforeRequest: { req in req.headers = workerHeaders(method: .GET, path: path) },
+                beforeRequest: { req in req.headers = self.workerHeaders(method: .GET, path: path) },
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     #expect(res.body.string.contains("ck_subst_marker"))
                     #expect(!res.body.string.contains("{{answer}}"))
+                })
+        }
+    }
+
+    @Test func downloadValidation_noSidecar_streamsTemplateVerbatim() async throws {
+        // Without materialization there is no sidecar, so the download route
+        // streams the stored template verbatim — pure I/O, never substituting
+        // on this path (so it can't trip the runner's download timeout).
+        try await withApp(app) { _ in
+            let setup = try await makeTestSetup(id: "subst_setup_03", manifest: substManifestJSON)
+            _ = try await self.makeNotebookSubmission(
+                id: "subst_val_03", setupID: (try setup.requireID()),
+                kind: APISubmission.Kind.validation, source: "x = {{answer}}")
+
+            let path = "/api/v1/worker/submissions/subst_val_03/download"
+            try await self.app.asyncTest(
+                .GET, path,
+                beforeRequest: { req in req.headers = self.workerHeaders(method: .GET, path: path) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("{{answer}}"))
                 })
         }
     }
@@ -671,18 +705,62 @@ import XCTVapor
         // download path must NOT re-process them.
         try await withApp(app) { _ in
             let setup = try await makeTestSetup(id: "subst_setup_02", manifest: substManifestJSON)
-            _ = try await makeNotebookSubmission(
+            _ = try await self.makeNotebookSubmission(
                 id: "subst_stu_01", setupID: (try setup.requireID()),
                 kind: APISubmission.Kind.student, source: "x = {{answer}}")
 
             let path = "/api/v1/worker/submissions/subst_stu_01/download"
-            try await app.asyncTest(
+            try await self.app.asyncTest(
                 .GET, path,
-                beforeRequest: { req in req.headers = workerHeaders(method: .GET, path: path) },
+                beforeRequest: { req in req.headers = self.workerHeaders(method: .GET, path: path) },
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     #expect(res.body.string.contains("{{answer}}"))
                 })
+        }
+    }
+
+    // The gap #869 missed: a per-student `=` EXPRESSION in the solution (not a
+    // literal) must resolve at enqueue and land in the grading sidecar — with
+    // the same seed feeding `_ck_inputs.py`. Requires a real seed (→ user +
+    // assignment) and `python3`.
+    @Test func materializeValidation_resolvesExpressionForSeed() async throws {
+        let python3Paths = ["/usr/bin/python3", "/usr/local/bin/python3", "/opt/homebrew/bin/python3"]
+        guard python3Paths.contains(where: { FileManager.default.fileExists(atPath: $0) }) else {
+            return  // python3 unavailable on this platform — skip
+        }
+        try await withApp(app) { _ in
+            let manifest = """
+                {"schemaVersion":1,"testSuites":[{"tier":"public","script":"test.sh"}],\
+                "timeLimitSeconds":10,\
+                "globalExpressions":[{"name":"shift","expression":"1 + seed % 25"}]}
+                """
+            let setup = try await makeTestSetup(id: "subst_setup_expr", manifest: manifest)
+            let setupID = try setup.requireID()
+            _ = try await self.makeAssignment(setupID: setupID)
+            let user = APIUser(username: "ck_val_user", passwordHash: "x", role: "student")
+            try await user.save(on: self.app.db)
+
+            let sub = try await self.makeNotebookSubmission(
+                id: "subst_val_expr", setupID: setupID,
+                kind: APISubmission.Kind.validation, source: "shift = {{shift}}",
+                userID: try user.requireID())
+
+            let template = try Data(contentsOf: URL(fileURLWithPath: sub.zipPath))
+            await materializeValidationGrading(
+                submission: sub, setupID: setupID, templateNotebookData: template,
+                testSetupsDirectory: self.app.testSetupsDirectory, on: self.app.db)
+
+            // Sidecar carries the resolved int, not the raw placeholder.
+            let sidecar = sub.zipPath + ".grading"
+            let body = try String(contentsOf: URL(fileURLWithPath: sidecar), encoding: .utf8)
+            #expect(!body.contains("{{shift}}"))
+            #expect(body.range(of: #"shift = \d+"#, options: .regularExpression) != nil)
+
+            // The same value is cached for _ck_inputs.py, keyed to one seed.
+            let materialization = try #require(sub.decodedMaterialization())
+            #expect(materialization.seedHex != nil)
+            #expect(materialization.inputs["shift"] != nil)
         }
     }
 

--- a/changelog.d/validation-grading-materialization.md
+++ b/changelog.d/validation-grading-materialization.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Reference-solution personalization no longer times out the runner.** A
+  validation submission's `{{name}}` placeholders and `=` expressions are now
+  resolved **once at enqueue** and cached — the substituted answer-key notebook
+  to a `<submission>.grading` sidecar, the expression values onto the submission
+  row — so the worker poll and artifact-download routes stay pure I/O. Previously
+  (v0.4.388, #869) the download handler ran a `python3` subprocess inline, which
+  the runner's 5 s download timeout tripped (`NSURLErrorTimedOut` / `-1001`),
+  surfacing as a spurious "Build failed" on any personalized assignment graded
+  via the worker (including browser-graded assignments validated through the
+  worker backstop). The answer-key notebook, `_ck_inputs.py`, and
+  `CHICKADEE_ASSIGNMENT_SEED` now all derive from one seed.


### PR DESCRIPTION
## Problem

Personalized assignments graded via the worker were failing validation with a spurious **"Build failed"** carrying `Error Domain=NSURLErrorDomain Code=-1001` (`NSURLErrorTimedOut`).

Root cause: #869 (v0.4.388) added a **blocking `python3` subprocess** (`PersonalizationEvaluator`, via `proc.waitUntilExit()`) directly inside the worker **artifact-download HTTP handler** to substitute `{{name}}` placeholders in the reference-solution notebook. The runner downloads artifacts with a **hard 5 s request timeout** (`RunnerDaemon.downloadSession`), so a route that must respond in <5 s now sometimes took ~5 s → `-1001` → the job was reported as build-failed before any test ran. This hit every personalized assignment graded by the worker, including browser-graded ones validated through the v0.4.56 worker backstop.

## Fix — resolve once at enqueue, keep the worker routes pure I/O

Personalization for a validation submission is now resolved **exactly once, at enqueue time** (an instructor save — latency-tolerant) and cached:

- **`submissions.materialization_json`** (new nullable column) holds the resolved `=` expression value map + the seed it was resolved against. `WorkerJobRoutes.buildJobPayload` reads it instead of re-evaluating on the poll path; the values become `_ck_inputs.py`.
- **`<submission.zipPath>.grading`** sidecar holds the substituted solution notebook. `WorkerArtifactRoutes.downloadSubmission` streams it verbatim.

Both worker-facing routes (poll + download) are now **pure I/O** — no manifest decode, no seed lookup, no subprocess — so the runner's tight timeout can't trip on them.

### Properties
- The stored `zipPath` keeps its `{{...}}` template → `get_solution`, the editor, and re-validation by another user are unaffected.
- The answer-key notebook, `_ck_inputs.py`, and `CHICKADEE_ASSIGNMENT_SEED` now all derive from **one** seed (closes the two-resolution mismatch #869 had).
- Non-personalized assignments stay on the zero-cost verbatim-stream path (`hasPersonalization` short-circuit).
- Best-effort materialization: on failure the submission is left un-materialized and the download streams the template (grading fails clearly, but the worker never times out).

## Changes
- `SubmissionMaterialization` type + `materialization_json` column + `AddSubmissionMaterialization` migration.
- `materializeValidationGrading(...)` wired into `enqueueRunnerValidationSubmission` (covers all five enqueue callers: MCP `update_solution`, web save, new-assignment, Marmoset import, suite-edit reschedule).
- `WorkerArtifactRoutes.downloadSubmission` → pure read of the sidecar (removed the in-handler eval).
- `WorkerJobRoutes.buildJobPayload` → prefers the cached materialization for validation submissions; students resolve live as before.

## Tests
- `materializeValidation_writesSidecar_andDownloadStreamsIt` — enqueue→sidecar→download streams substituted bytes.
- `downloadValidation_noSidecar_streamsTemplateVerbatim` — pure-I/O fallback.
- `downloadSubmission_studentNotebook_leavesPlaceholdersVerbatim` — student path unchanged.
- `materializeValidation_resolvesExpressionForSeed` — the gap #869's test missed: a per-student **expression** (not a literal) resolves at enqueue and lands in the sidecar, with the same seed feeding `_ck_inputs.py` (python3-guarded).

Local: `swift build` ✓, WorkerRoutesTests (23) ✓, AssignmentRoutesPublish/Retest + CoreCodable (86) ✓, `scripts/lint.sh` ✓, `scripts/swiftlint.sh --strict` (0 violations) ✓.

A follow-up PR will address the cross-cutting `PersonalizationEvaluator` hardening (non-blocking wait + concurrent pipe drain) so the remaining eval sites are robust too.

https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3

---
_Generated by [Claude Code](https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3)_