### PR TITLE
fix(personalization): write validation grading sidecar before the submission is claimable

### DIFF
--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -59,11 +59,16 @@ func enqueueRunnerValidationSubmission(
         userID: resolvedSubmitterID,
         kind: APISubmission.Kind.validation
     )
-    try await submission.save(on: req.db)
 
-    // Resolve personalization ONCE here (at enqueue — an instructor save, which
-    // is latency-tolerant) and cache it, so the worker poll + download paths
-    // never run the personalization evaluator. See `materializeValidationGrading`.
+    // Resolve personalization and write the grading sidecar BEFORE the
+    // submission is saved. Saving makes it `pending` — a polling worker can
+    // claim and download it immediately — so the substituted `.grading` sidecar
+    // and the cached `materializationJSON` MUST already be in place, or the
+    // worker races in and grades the un-substituted template. Materialize first,
+    // then a single save flips the row to claimable with everything ready.
+    // (This resolves personalization once, at enqueue — an instructor save,
+    // which is latency-tolerant — so the worker poll + download paths never run
+    // the personalization evaluator. See `materializeValidationGrading`.)
     await materializeValidationGrading(
         submission: submission,
         setupID: setupID,
@@ -71,19 +76,27 @@ func enqueueRunnerValidationSubmission(
         testSetupsDirectory: req.application.testSetupsDirectory,
         on: req.db)
 
+    try await submission.save(on: req.db)
     return subID
 }
 
-/// Resolve a validation submission's personalization ONCE and persist it, so
-/// the worker poll + download paths never run `python3` (which the runner times
-/// out against on its 5 s artifact download — the `#869` regression). Writes:
+/// Resolve a validation submission's personalization ONCE, so the worker poll +
+/// download paths never run `python3` (which the runner times out against on its
+/// 5 s artifact download — the `#869` regression). Produces:
 ///
-///   * `submission.materializationJSON` — the resolved `=` expression value map
-///     plus the seed everything was resolved against. `buildJobPayload` reads
-///     this instead of re-evaluating; the values become `_ck_inputs.py`.
 ///   * `<submission.zipPath>.grading` — the solution notebook with `{{name}}`
-///     placeholders substituted. `WorkerArtifactRoutes.downloadSubmission`
+///     placeholders substituted, written to disk. `WorkerArtifactRoutes`
 ///     streams it verbatim (pure I/O).
+///   * `submission.materializationJSON` set **in memory** — the resolved `=`
+///     expression value map plus the seed everything was resolved against.
+///     `buildJobPayload` reads it instead of re-evaluating; the values become
+///     `_ck_inputs.py`.
+///
+/// IMPORTANT — call this BEFORE saving the submission. It deliberately does NOT
+/// save: the caller persists the row exactly once afterwards, so the submission
+/// only becomes `pending` (claimable by a polling worker) once the sidecar and
+/// cache are already in place. Saving first opens a race where the worker
+/// downloads the un-substituted template before this finishes.
 ///
 /// The stored `zipPath` keeps its `{{...}}` template, so `get_solution`, the
 /// editor, and re-validation by another user are unaffected.
@@ -156,8 +169,10 @@ func materializeValidationGrading(
         if let encoded = try? JSONEncoder().encode(materialization),
             let json = String(data: encoded, encoding: .utf8)
         {
+            // Set in-memory only; the caller saves the submission exactly once,
+            // AFTER this returns, so the row never becomes claimable before the
+            // sidecar + cache are ready.
             submission.materializationJSON = json
-            try await submission.save(on: db)
         }
     } catch {
         // Best-effort: leave the submission un-materialized; the download route

--- a/changelog.d/validation-materialize-race.md
+++ b/changelog.d/validation-materialize-race.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Validation grading no longer races the worker.** The substituted
+  reference-solution notebook (and its cached personalization values) is now
+  written *before* the validation submission is saved as `pending`, so a
+  fast-polling worker can't claim and download the un-substituted `{{...}}`
+  template in the window before materialization finishes. Previously a
+  personalized assignment could intermittently fail its own answer-key checks
+  ("variable not defined") even though the timeout regression was fixed.


### PR DESCRIPTION
## Problem

After #870 deployed (v0.4.389), Lab 5 validation still failed Q3 — but **not** with the `-1001` timeout (that regression is fixed; grading now completes end-to-end). Instead the answer key failed its own check: *"These variables are not defined yet: fortuneShift, fortuneBlockSize."*

Root cause is a **race in #870's enqueue ordering**:

```
submission.save(on: req.db)            // saved as "pending" → immediately claimable
await materializeValidationGrading(...) // writes the .grading sidecar ~1s later (python3 eval)
```

A fast, idle worker (observed: `Sparrow`, empty queue) claims and downloads the submission inside the ~1s window **before** the sidecar exists. The download handler finds no sidecar, streams the un-substituted `{{...}}` template, and the notebook extractor drops the now-invalid `fortuneShift = {{fortuneShift}}` cell → the variable is undefined → the answer key fails. (The runner being a version behind is irrelevant; substitution is server-side.)

The unit tests passed precisely because there's no competing worker in a test — the race only manifests against a live polling runner.

## Fix

Reorder so the sidecar + cached values are in place **before** the row becomes claimable:

```
await materializeValidationGrading(...) // write sidecar + set materializationJSON (in memory)
try await submission.save(on: req.db)   // single save → claimable, everything ready
```

`materializeValidationGrading` no longer saves the submission — the caller owns the one save, after materialization — and its doc spells out the ordering requirement. Applies to every enqueue caller (MCP `update_solution`, web save, new-assignment, Marmoset import, suite-edit reschedule).

## Tests
Existing `WorkerRoutesTests` (23) pass, including the materialize + download and expression-resolution cases. The race itself isn't unit-testable without a live worker, so the guarantee is structural (materialize strictly precedes the only save) and documented.

Local: `swift build` ✓, WorkerRoutesTests ✓, `scripts/lint.sh` ✓, `scripts/swiftlint.sh --strict` (0 violations) ✓.

https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3

---
_Generated by [Claude Code](https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3)_