### PR TITLE
docs: personalization eval-runtime decision (0.5) + MCP validation-access plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1042,6 +1042,8 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
 - `docs/personalization-phase1.md` — per-(student, assignment) seed contract (`CHICKADEE_ASSIGNMENT_SEED`), worked hand-written example
 - `docs/inputs.md` — Global + section inputs: literal variables, per-student `=` expressions, `$name` references, save-time inlining vs. notebook substitution
 - `docs/personalization-pattern-families.md` — per-student pattern families: `$name`/`expectedVarRef` → server-resolved values delivered via `_ck_inputs.py` (worker) / browser seed endpoint
+- `docs/personalization-eval-runtime.md` — design note + deferred 0.5+ future work: where/in-what-language personalization expressions are evaluated; why the server runs `python3` today, the trilemma, and the direction to move eval to the runner/browser per-language
+- `docs/mcp-validation-access.md` — planned MCP read tool for validation-run results only (per-test outcomes, never student data)
 - `docs/ci-followups.md` — historical CI reshaping notes from v0.4.6 (WorkerTests are back in the per-PR gate as of the 2026 cleanup)
 - `reference/` — original Java source for behavioural reference only
 - `CHANGELOG.md` — release history

--- a/docs/mcp-validation-access.md
+++ b/docs/mcp-validation-access.md
@@ -1,0 +1,95 @@
+# MCP read access to validation runs (planned)
+
+**Status:** planned feature, not yet implemented. Captured here so the design
+is settled before we build it.
+
+## Motivation
+
+An MCP agent can already author content and *trigger* validation
+(`update_solution`, `update_suite`, `validate_assignment`), but it can only learn
+the **outcome** of a validation run as a single word: `passed` / `failed` /
+`no-runner`. When a validation fails, the agent can't see *which* test failed or
+*why* — so diagnosing (e.g. "Q3's answer key reports `fortuneShift` undefined")
+requires a human to copy the per-test result out of the web UI.
+
+Giving the agent read access to **validation-run results** closes that loop, so
+it can diagnose and fix a failing suite on the instructor's behalf without a
+human relaying the grid.
+
+## Hard guardrails
+
+This is **validation runs only** — never student data. Concretely:
+
+- **Scope:** `content:read`.
+- **Only `kind == .validation` submissions.** The tool must refuse anything
+  `kind == .student`. It never accepts a raw submission id; it resolves the
+  validation submission from the assignment.
+- **Authorization:** same course-scoping as every other content tool — the
+  account must be enrolled in the course that owns the assignment (admin = all).
+- **No student identities, no student submissions, no grades, no rosters.** The
+  response carries only the instructor's own reference-solution run.
+
+Validation submissions are instructor-authored (the reference solution graded
+against the suite), so this is the same trust tier the agent already reads via
+`get_solution` / `get_suite` — no new data class is exposed.
+
+## Proposed surface
+
+`get_validation_result(assignmentPublicID)` → the latest validation run for the
+assignment:
+
+```jsonc
+{
+  "assignmentPublicID": "G9mx8H",
+  "validationStatus": "failed",          // passed | failed | no-runner | pending
+  "ranAt": "2026-06-09T15:49:14Z",
+  "buildStatus": "passed",               // passed | failed
+  "compilerOutput": null,
+  "outcomes": [
+    { "testName": "fortune key defined", "tier": "public",
+      "status": "fail",
+      "shortResult": "These variables are not defined yet: fortuneShift, fortuneBlockSize.",
+      "longResult": "…" },
+    { "testName": "Decoded fortune matches", "tier": "secret",
+      "status": "skip-equivalent", "shortResult": "Skipped: prerequisite … did not pass" }
+  ],
+  "counts": { "total": 10, "pass": 8, "fail": 1, "error": 0, "timeout": 0 }
+}
+```
+
+Optionally, later: `list_validation_runs(assignmentPublicID)` → recent attempts
+(`{ ranAt, validationStatus, pass/total }`) for trend/debugging.
+
+## Implementation sketch
+
+- Resolve the assignment with the existing `authorizedAssignment` /
+  `authorizedAssignmentAndSetup` helper (course-scoped auth, no new path).
+- Resolve the validation submission: prefer `assignment.validationSubmissionID`,
+  else the most recent `kind == .validation` submission for the setup — exactly
+  the resolver `loadExistingSolution` already uses, **filtered to
+  `kind == .validation`**.
+- Load its `APIResult` (`collectionJSON` → `TestOutcomeCollection`), decode, and
+  map to a DTO that includes per-test outcomes + counts and **excludes any user
+  field** (`submissionID`/`userID` are dropped from the DTO).
+- Return all tiers (public/release/secret/student): validation is instructor
+  content, and the agent needs the secret-tier outcomes to debug the suite.
+- A `pending` / missing-result state returns `validationStatus` with empty
+  `outcomes` (mirrors `validate_assignment`).
+
+## Open questions
+
+- **Personalized expected values.** A failing pattern-family case's resolved
+  per-student `expected` (from `_ck_inputs`) could appear in `longResult`. That's
+  solution-derived, but it's the *instructor's own* assignment that the agent
+  already authors — so surfacing it to the authorized instructor account is fine.
+  Worth a conscious confirm when implementing.
+- **`get_suite` overlap.** `get_suite` already returns the suite definition; this
+  tool is strictly the *run outcome*. Keep them separate.
+- Whether to fold `list_validation_runs` in now or defer until there's a need.
+
+## Catalog/doc sync reminder
+
+When implemented, update the two agent-facing copies that must stay in lockstep
+with the tool catalog (per the MCP design notes in `CLAUDE.md`): the tool's
+`description`/`inputSchema`, and `MCPServerInstructions.text` (the `initialize`
+handshake), plus the human index in `docs/mcp-authoring-roadmap.md`.

--- a/docs/personalization-eval-runtime.md
+++ b/docs/personalization-eval-runtime.md
@@ -1,0 +1,134 @@
+# Personalization evaluation runtime
+
+**Status:** design note + deferred future work (targeting 0.5+). No action for
+now — the current Python-on-the-server implementation is intentionally kept.
+
+This records a design discussion about *where* and *in what language* per-student
+personalization expressions are evaluated, so we don't relitigate it from scratch
+later.
+
+## What runs today
+
+Per-student personalization lets an instructor write an `=` expression that is
+evaluated per `(student, assignment)` seed — e.g.
+
+```python
+fortuneShift = 1 + seed % 25
+expected     = solution.classify_bmi(weight, height)   # may import solution.py
+```
+
+These expressions are **instructor-authored Python**. They are evaluated by
+`PersonalizationEvaluator` (`Sources/APIServer/Services/`), which spawns
+`python3` **on the Vapor server** (`chickadee-server`). The resolved values feed
+three consumers:
+
+- `_ck_inputs.py` for worker/browser grading (pattern-family `$name` /
+  `expectedVarRef`);
+- `{{name}}` substitution in the student starter notebook at first open;
+- `{{name}}` substitution in the **reference-solution** notebook at validation
+  (so the answer key derives the same per-student value a student would).
+
+## The architectural tension
+
+Chickadee's stated rule is *"Swift never imports a language runtime; everything
+goes through `Process` + sandbox,"* and that sandbox boundary lives at the
+**runner** (`chickadee-runner`), not the web server. The personalization
+evaluator is the one place the **Vapor server itself** spawns a language runtime
+— and it does so **unsandboxed** (only an env-var allowlist), next to secrets
+(`RUNNER_SHARED_SECRET`, DB creds, OIDC/BrightSpace keys).
+
+So the smell isn't "Python exists" — the *graded content* (student code, test
+scripts, Pyodide) is Python by definition and always will be. The smell is that
+Python execution leaked from the runner tier into the server tier.
+
+## Why it can't just be Swift
+
+For the simple cases you *could* evaluate in Swift — but faithfully, not
+trivially. `seed` is a 64-hex-char value, so `int(seed, 16)` is a **256-bit
+integer**; even `1 + seed % 25` needs arbitrary-precision integers (no stdlib
+BigInt in Swift), plus Python's floored modulo, int/float division, slicing,
+comprehensions, and `repr()` formatting. The whole point of computing the value
+is that it **matches what Python grades against**, so any semantic divergence
+silently mis-grades students. Reimplementing Python semantics in Swift is a
+parity-risk minefield.
+
+For the headline case it's outright impossible: `expected = solution.foo(...)`
+runs the instructor's arbitrary `solution.py`. "Converting that to Swift" means
+auto-transpiling an arbitrary Python module — not a thing. The feature *is*
+"run the instructor's solution to get the canonical answer," which is, by
+definition, running their Python.
+
+## The trilemma
+
+For a **worker-graded, personalized** assignment you can have at most two of:
+
+1. **Server spawns zero Python** (a genuinely Swift-only server).
+2. **Expression source + `solution.py` never reach the runner** — today's
+   deliberate property (`TestProperties.runnerSanitized()` strips
+   `globalExpressions` / `sections[].expressions` precisely so solution-derived
+   source like `= solution.countAdults(...)` never ships in the Job payload).
+3. **Support `= solution.foo(...)` expressions** (the strongest feature).
+
+- Today picks **2 + 3** (server evaluates; nothing leaks to runners).
+- "Move eval to the runner" picks **1 + 3** (server is Swift-only, but
+  expression source + the reference solution must ship to the trusted runner).
+- "Restrict to a Swift-evaluable DSL" picks **1 + 2** (loses `= solution.foo()`).
+
+A worker-graded assignment has no browser at submit time, so the value must be
+computed on the server or the runner — there is no fourth corner.
+
+## Decision (this pass)
+
+**Defer.** Keep Python on the server for now. Rationale:
+
+- Every assignment today is Python; Python is the most accessible language for
+  the audience; the current code works.
+- The right long-term answer only becomes forced when a **second language**
+  (R, etc.) lands — at which point "what language is personalization in?" stops
+  being "Python vs Swift" and becomes **"the assignment's own language."**
+
+## Future direction (0.5+)
+
+When multi-language support is on the table, evaluate personalization **in the
+assignment's language, at the tier where that language already runs**:
+
+- native **runner** (`python3`, `Rscript`, … inside its sandbox), and/or
+- the **browser** (Pyodide / WebR) for first-open substitution and browser-graded
+  submissions.
+
+Swift stays the **engine/orchestrator** — it ships `{ seed, expression specs }`
+and consumes resolved values — and **never the evaluator**. Net effects:
+
+- `chickadee-server` spawns zero language runtimes.
+- All language execution is consolidated behind one sandbox boundary (a security
+  win — instructor expressions stop running unsandboxed next to server secrets).
+- Parity is automatic: the evaluator and the grader are the same runtime in the
+  same place.
+
+This is the generalized form of "move eval to the runner." It is a deliberate,
+runner-redeploy change and **requires accepting that expression source +
+`solution.py` ship to the (trusted, HMAC-authed) runner** — i.e. relaxing
+property **2** above. That trade is reasonable: the runner already receives the
+full test suite, which typically encodes solution behavior anyway.
+
+### Interim hardening (optional, independent of the language question)
+
+If the server keeps evaluating in the meantime, `PersonalizationEvaluator`
+should be hardened regardless: drain stdout/stderr **concurrently** with process
+exit (today it reads pipes only after `waitUntilExit()`, risking a pipe-buffer
+deadlock on large output) and avoid blocking a cooperative-pool thread, and run
+the subprocess under the same `sandbox-exec` / `unshare` profile the runner uses.
+
+## Related fixes that surfaced this
+
+- **#869** first moved solution-notebook substitution into the worker *download*
+  handler, which ran `python3` synchronously on a route the runner times out
+  against (5 s) → `-1001` "Build failed".
+- **#870** resolved personalization **once at enqueue** and cached it (value map
+  on the submission row, substituted notebook in a `<zipPath>.grading` sidecar),
+  making the worker poll + download routes pure I/O.
+- The follow-up race fix ensured the sidecar is written **before** the
+  submission becomes claimable.
+
+All three keep eval on the server; this note is the record of the decision to
+*leave* it there for now and the direction to move it later.


### PR DESCRIPTION
Docs-only. Records the design discussion from this session so we don't relitigate it.

- **`docs/personalization-eval-runtime.md`** — why `chickadee-server` runs `python3` for personalization today, why it can't simply be Swift (256-bit seed needs BigInt; Python semantics parity; `= solution.foo()` requires running arbitrary instructor Python), the **trilemma** (server-runs-no-Python / expression-source-never-reaches-runner / support `= solution.foo()` — pick two), the **decision to keep Python on the server for now** (Python is the default; all assignments are Python), and the **0.5+ direction**: evaluate personalization in the *assignment's own language* at the runner/browser tier, with Swift as engine-not-evaluator. Also notes the optional interim hardening of the evaluator.
- **`docs/mcp-validation-access.md`** — planned MCP read tool for **validation-run results only** (per-test outcomes + counts), with hard guardrails: `content:read`, `kind == .validation` only, course-scoped auth, **never** student data/submissions/grades. Includes a proposed `get_validation_result(assignmentPublicID)` shape and an implementation sketch reusing the existing solution resolver.
- Indexes both in `CLAUDE.md` Reference Material.

No code changes.

https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3

---
_Generated by [Claude Code](https://claude.ai/code/session_0145aVDWxAN7KdQubaF36NM3)_