### PR TITLE
feat(achievements): per-assignment built-in award toggles (+ fix achievements wiped on suite edit)

### DIFF
--- a/Public/builtin-awards-editor.js
+++ b/Public/builtin-awards-editor.js
@@ -1,0 +1,118 @@
+// Public/builtin-awards-editor.js
+//
+// Wires the "Built-in Awards" card on the assignment edit page.  Lists the
+// built-in awards (the per-submission Ace/Rally/Tenacious/Swift and the
+// competitive Pathfinder/Trailblazer/Fastest/Minimalist class records) with an
+// on/off checkbox each.  Loads via GET and saves the DISABLED set via PUT
+// /instructor/:id/built-in-awards.  An instructor can, e.g., turn the
+// competitive records off for a collaborative course.
+
+(function () {
+    'use strict';
+
+    function csrf() {
+        var m = document.querySelector('meta[name="csrf-token"]');
+        return m ? m.getAttribute('content') : '';
+    }
+
+    function escapeHTML(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    var GROUP_LABEL = {
+        perSubmission: 'Per-submission badges',
+        classRecord: 'Class records (competitive)'
+    };
+
+    function renderRows(tbody, awards) {
+        tbody.innerHTML = '';
+        var lastGroup = null;
+        awards.forEach(function (award) {
+            if (award.group !== lastGroup) {
+                lastGroup = award.group;
+                var head = document.createElement('tr');
+                head.className = 'builtin-awards-group';
+                head.innerHTML = '<td colspan="3"><strong>'
+                    + escapeHTML(GROUP_LABEL[award.group] || award.group) + '</strong></td>';
+                tbody.appendChild(head);
+            }
+            var tr = document.createElement('tr');
+            tr.className = 'builtin-award-row';
+            tr.setAttribute('data-award-id', award.id);
+            tr.innerHTML = ''
+                + '<td><strong>' + escapeHTML(award.name) + '</strong></td>'
+                + '<td>' + escapeHTML(award.detail) + '</td>'
+                + '<td class="time"><input type="checkbox" class="ba-enabled"'
+                + (award.enabled ? ' checked' : '') + '></td>';
+            tbody.appendChild(tr);
+        });
+    }
+
+    function disabledIDs(tbody) {
+        var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr.builtin-award-row'));
+        var disabled = [];
+        rows.forEach(function (tr) {
+            var box = tr.querySelector('.ba-enabled');
+            if (box && !box.checked) disabled.push(tr.getAttribute('data-award-id'));
+        });
+        return disabled;
+    }
+
+    function init() {
+        var block = document.getElementById('builtin-awards-block');
+        if (!block) return;
+        var tbody = block.querySelector('tbody.builtin-awards-body');
+        var saveBtn = document.getElementById('builtin-awards-save');
+        var status = document.getElementById('builtin-awards-status');
+        var assignmentID = block.getAttribute('data-assignment-id') || '';
+        if (!tbody || !assignmentID) return;
+        var url = '/instructor/' + encodeURIComponent(assignmentID) + '/built-in-awards';
+
+        function setStatus(text, kind) {
+            if (!status) return;
+            status.textContent = text || '';
+            status.style.color = kind === 'error'
+                ? 'var(--red)'
+                : (kind === 'ok' ? 'var(--green)' : 'var(--gray-500)');
+        }
+
+        fetch(url, { headers: { 'x-csrf-token': csrf() } })
+            .then(function (r) { return r.ok ? r.json() : { awards: [] }; })
+            .then(function (body) { renderRows(tbody, (body && body.awards) || []); })
+            .catch(function () { /* leave empty on load failure */ });
+
+        if (saveBtn) {
+            saveBtn.addEventListener('click', function () {
+                setStatus('Saving…', null);
+                fetch(url, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrf() },
+                    body: JSON.stringify({ disabled: disabledIDs(tbody) })
+                }).then(function (r) {
+                    if (r.ok) {
+                        return r.json().then(function (body) {
+                            renderRows(tbody, (body && body.awards) || []);
+                            setStatus('Saved.', 'ok');
+                        }).catch(function () { setStatus('Saved.', 'ok'); });
+                    }
+                    return r.text().then(function (t) {
+                        var msg = t || ('HTTP ' + r.status);
+                        try { var p = JSON.parse(t); if (p && p.reason) msg = p.reason; } catch (_) { /* text */ }
+                        setStatus('Save failed: ' + msg.slice(0, 240), 'error');
+                    });
+                }).catch(function (err) {
+                    setStatus('Save failed: ' + (err && err.message ? err.message : err), 'error');
+                });
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -236,6 +236,28 @@
     </table>
 </section>
 
+<section id="builtin-awards-block"
+         data-assignment-id="#(assignmentID)"
+         class="editor-block">
+    <div class="editor-block-head">
+        <h2>Built-in Awards</h2>
+        <div class="toolbar toolbar--end">
+            <button type="button" class="btn action-btn" id="builtin-awards-save">Save</button>
+            <span id="builtin-awards-status" class="upload-status-inline"></span>
+        </div>
+    </div>
+    <table class="results-table" id="builtin-awards-table">
+        <thead>
+            <tr>
+                <th>Award</th>
+                <th>Earned for</th>
+                <th class="time">Active</th>
+            </tr>
+        </thead>
+        <tbody class="builtin-awards-body"></tbody>
+    </table>
+</section>
+
 #if(brightspaceSyncEnabled):
 <!-- ── BrightSpace grade sync ─────────────────────────── -->
 <div class="editor-block">
@@ -591,6 +613,7 @@ function checkUWDates(dateTimeValue, warningEl) {
 <script src="/global-inputs-editor.js?v=#appVersion()"></script>
 <script src="/class-goals-editor.js?v=#appVersion()"></script>
 <script src="/badges-editor.js?v=#appVersion()"></script>
+<script src="/builtin-awards-editor.js?v=#appVersion()"></script>
 
 <!-- ── Unified Test Editor modal (shell + renderers) ────────────────────────
      The "+ Add Test" button opens one modal; picking a type morphs the body

--- a/Sources/APIServer/Helpers/BuiltInAchievements.swift
+++ b/Sources/APIServer/Helpers/BuiltInAchievements.swift
@@ -15,6 +15,7 @@
 // "Trailblazer" is.
 
 import Core
+import Fluent
 
 enum BuiltInAchievements {
 
@@ -106,5 +107,30 @@ enum BuiltInAchievements {
     /// The built-in award with this id, if any.
     static func byID(_ id: String) -> Achievement? {
         all.first { $0.id == id }
+    }
+
+    /// The set of built-in award ids this assignment has disabled (empty when
+    /// the manifest can't be decoded or disables nothing — the common case).
+    static func disabled(in setup: APITestSetup) -> Set<String> {
+        Set(setup.decodedManifest()?.disabledBuiltInAwardIDs ?? [])
+    }
+
+    /// Batch `[setupID: disabled-ids]` for several setups in one query; only
+    /// setups that disable something appear.  For the multi-assignment pages
+    /// (dashboard) that don't already have the setups loaded.
+    static func disabledBySetup(
+        setupIDs: [String], on db: Database
+    ) async throws -> [String: Set<String>] {
+        guard !setupIDs.isEmpty else { return [:] }
+        let setups = try await APITestSetup.query(on: db)
+            .filter(\.$id ~~ Set(setupIDs))
+            .all()
+        var map: [String: Set<String>] = [:]
+        for setup in setups {
+            guard let id = setup.id else { continue }
+            let d = disabled(in: setup)
+            if !d.isEmpty { map[id] = d }
+        }
+        return map
     }
 }

--- a/Sources/APIServer/Helpers/ClassAchievements.swift
+++ b/Sources/APIServer/Helpers/ClassAchievements.swift
@@ -20,24 +20,31 @@ func awardClassBadgesFor100Percent(
     submissionID: String,
     executionTimeMs: Int,
     attemptNumber: Int,
+    disabled: Set<String> = [],
     on db: Database
 ) async throws {
     guard let user = try await APIUser.find(userID, on: db),
         user.role == "student"
     else { return }
 
-    async let trail: Void = awardImmutableBadge(
-        achievementID: "trailblazer",
-        testSetupID: testSetupID, userID: userID, submissionID: submissionID, on: db)
-    async let speed: Void = updateRecordBadge(
-        achievementID: "speed_champion",
-        testSetupID: testSetupID, userID: userID, submissionID: submissionID,
-        newValue: Double(executionTimeMs), on: db)
-    async let mini: Void = updateRecordBadge(
-        achievementID: "minimalist",
-        testSetupID: testSetupID, userID: userID, submissionID: submissionID,
-        newValue: Double(attemptNumber), on: db)
-    _ = try await (trail, speed, mini)
+    // Skip any record the instructor disabled for this assignment.
+    if !disabled.contains("trailblazer") {
+        try await awardImmutableBadge(
+            achievementID: "trailblazer",
+            testSetupID: testSetupID, userID: userID, submissionID: submissionID, on: db)
+    }
+    if !disabled.contains("speed_champion") {
+        try await updateRecordBadge(
+            achievementID: "speed_champion",
+            testSetupID: testSetupID, userID: userID, submissionID: submissionID,
+            newValue: Double(executionTimeMs), on: db)
+    }
+    if !disabled.contains("minimalist") {
+        try await updateRecordBadge(
+            achievementID: "minimalist",
+            testSetupID: testSetupID, userID: userID, submissionID: submissionID,
+            newValue: Double(attemptNumber), on: db)
+    }
 }
 
 /// Inserts the badge record only if no holder exists yet (first-to wins).

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -81,12 +81,16 @@ struct ResultRoutes: RouteCollection {
             {
                 let grade = gradePercent(from: collection) ?? 0
                 if grade == 100 {
+                    let disabled =
+                        (try? await APITestSetup.find(submission.testSetupID, on: req.db))
+                        .map { BuiltInAchievements.disabled(in: $0) } ?? []
                     try await awardClassBadgesFor100Percent(
                         testSetupID: submission.testSetupID,
                         userID: userID,
                         submissionID: subID,
                         executionTimeMs: collection.executionTimeMs,
                         attemptNumber: submission.attemptNumber ?? 1,
+                        disabled: disabled,
                         on: req.db
                     )
                 }

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -153,7 +153,9 @@ func makeWorkerManifestJSON(
     notebookChecks: [NotebookCheck] = [],
     sections: [TestSuiteSection] = [],
     globalVariables: [FamilyVariable] = [],
-    globalExpressions: [PersonalizationExpression] = []
+    globalExpressions: [PersonalizationExpression] = [],
+    achievements: [Achievement] = [],
+    disabledBuiltInAwardIDs: [String] = []
 ) throws -> String {
     // Topologically sort so the runner can process dependencies with a single
     // linear pass (parents always appear before children in the array).
@@ -193,6 +195,14 @@ func makeWorkerManifestJSON(
     // Slice 2 — assignment-scope expressions (notebook only). Each
     // entry is `{ name, expression }`.
     try spliceEncodedArray(into: &manifest, key: "globalExpressions", values: globalExpressions)
+    // Display/award-only fields (server-side; `runnerSanitized()` strips them).
+    // Spliced here so a suite rebuild doesn't wipe authored achievements or the
+    // instructor's built-in-award toggles — `makeWorkerManifestJSON` builds a
+    // fresh dict, so anything absent here is lost on the next suite edit.
+    try spliceEncodedArray(into: &manifest, key: "achievements", values: achievements)
+    if !disabledBuiltInAwardIDs.isEmpty {
+        manifest["disabledBuiltInAwardIDs"] = disabledBuiltInAwardIDs
+    }
 
     let data = try JSONSerialization.data(withJSONObject: manifest)
     return String(data: data, encoding: .utf8) ?? "{}"

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+BuiltInAwards.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+BuiltInAwards.swift
@@ -1,0 +1,80 @@
+// APIServer/Routes/Web/PublishedAssignmentRoutes+BuiltInAwards.swift
+//
+// Per-assignment on/off toggles for the built-in awards (BuiltInAchievements):
+// the per-submission badges (Ace / Rally / Tenacious / Swift) and the
+// competitive class records (Pathfinder / Trailblazer / Fastest / Minimalist).
+//
+// GET lists all built-ins with their current enabled state for this assignment;
+// PUT stores the DISABLED-id set in the manifest (`disabledBuiltInAwardIDs`).
+// The award + display paths honor it (skip awarding/showing disabled ones), so
+// an instructor can, e.g., turn the competitive records off for a collaborative
+// course.  Metadata-only — no retest/validation needed.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension PublishedAssignmentRoutes {
+
+    struct BuiltInAwardRow: Content {
+        var id: String
+        var name: String
+        var detail: String
+        /// "perSubmission" | "classRecord" — for grouping in the editor.
+        var group: String
+        var enabled: Bool
+    }
+
+    struct BuiltInAwardsBody: Content {
+        /// The ids the instructor has disabled for this assignment.
+        var disabled: [String]
+    }
+
+    struct BuiltInAwardsResponse: Content {
+        var awards: [BuiltInAwardRow]
+    }
+
+    // MARK: - GET /instructor/:assignmentID/built-in-awards
+
+    @Sendable
+    func getBuiltInAwards(req: Request) async throws -> BuiltInAwardsResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        return BuiltInAwardsResponse(
+            awards: builtInAwardRows(disabled: BuiltInAchievements.disabled(in: setup)))
+    }
+
+    // MARK: - PUT /instructor/:assignmentID/built-in-awards
+
+    @Sendable
+    func putBuiltInAwards(req: Request) async throws -> BuiltInAwardsResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let body = try req.content.decode(BuiltInAwardsBody.self)
+
+        // Keep only ids that are real built-in awards; de-dupe + sort for a
+        // stable manifest (so cosmetic re-saves don't churn the bytes).
+        let validIDs = Set(BuiltInAchievements.all.map(\.id))
+        let disabled = Set(body.disabled).intersection(validIDs).sorted()
+
+        try await mutateManifest(setup: setup, on: req.db) { dict in
+            if disabled.isEmpty {
+                dict.removeValue(forKey: "disabledBuiltInAwardIDs")
+            } else {
+                dict["disabledBuiltInAwardIDs"] = disabled
+            }
+        }
+        return BuiltInAwardsResponse(awards: builtInAwardRows(disabled: Set(disabled)))
+    }
+
+    private func builtInAwardRows(disabled: Set<String>) -> [BuiltInAwardRow] {
+        let perSubmissionIDs = Set(BuiltInAchievements.perSubmission.map(\.id))
+        return BuiltInAchievements.all.map { award in
+            BuiltInAwardRow(
+                id: award.id,
+                name: award.reward.label,
+                detail: award.detail ?? "",
+                group: perSubmissionIDs.contains(award.id) ? "perSubmission" : "classRecord",
+                enabled: !disabled.contains(award.id))
+        }
+    }
+}

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
@@ -76,5 +76,9 @@ struct PublishedAssignmentRoutes: RouteCollection {
         // Assignment-scope individual badges (threshold / test) — display-only.
         r.get(":assignmentID", "badges", use: getBadges)
         r.put(":assignmentID", "badges", use: putBadges)
+
+        // Per-assignment built-in award on/off toggles — metadata-only.
+        r.get(":assignmentID", "built-in-awards", use: getBuiltInAwards)
+        r.put(":assignmentID", "built-in-awards", use: putBuiltInAwards)
     }
 }

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -70,8 +70,19 @@ extension StudentCourseRoutes {
         let setupsByID = try await setupsByIDFuture
         let submissions = try await submissionsFuture
         let extensionByAssignmentID = try await extensionByAssignmentIDFuture
-        let classBadgesBySetupID = try await classBadgesBySetupIDFuture
+        let classBadgesBySetupIDRaw = try await classBadgesBySetupIDFuture
         let overrideBySetupID = try await overrideBySetupIDFuture
+
+        // Honor per-assignment disabled built-in awards across the page (reuses
+        // the setups already loaded above, so no extra query).
+        let disabledBySetup = setupsByID.mapValues { BuiltInAchievements.disabled(in: $0) }
+        let classBadgesBySetupID = classBadgesBySetupIDRaw.reduce(
+            into: [String: [AchievementBadge]]()
+        ) { acc, entry in
+            let disabled = disabledBySetup[entry.key] ?? []
+            let kept = disabled.isEmpty ? entry.value : entry.value.filter { !disabled.contains($0.id) }
+            if !kept.isEmpty { acc[entry.key] = kept }
+        }
 
         let submissionsBySetupID = submissionsGroupedBySetupID(submissions)
         // preferredResults must wait until submissions resolves (it needs
@@ -89,7 +100,8 @@ extension StudentCourseRoutes {
             urlToken: try student.requireURLToken(),
             preferredResultBySubmissionID: preferredResultBySubmissionID,
             student: student,
-            fmt: fmt
+            fmt: fmt,
+            disabledBySetup: disabledBySetup
         )
         let rows = sortedAssignments.map { assignment in
             buildStudentAssignmentRow(
@@ -732,6 +744,8 @@ extension StudentCourseRoutes {
         let preferredResultBySubmissionID: [String: APIResult]
         let student: APIUser
         let fmt: DateFormatter
+        /// `[setupID: disabled built-in award ids]` — the same map for every row.
+        let disabledBySetup: [String: Set<String>]
     }
 
     fileprivate func buildStudentAssignmentRow(
@@ -761,10 +775,11 @@ extension StudentCourseRoutes {
             return best >= 0 ? best : nil
         }()
 
+        let disabledHere = context.disabledBySetup[assignment.testSetupID] ?? []
         var badges = submissionBadges(
             history: history,
             preferredResultBySubmissionID: preferredResultBySubmissionID
-        )
+        ).filter { !disabledHere.contains($0.id) }
         badges.append(contentsOf: classBadges)
 
         let dueAtText = assignment.dueAt.map { fmt.string(from: $0) }

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -211,9 +211,11 @@ struct AchievementBadge: Encodable {
     /// award *conditions* live here (keyed by kind); each badge's identity —
     /// caption + tooltip — comes from `BuiltInAchievements`.  Class-wide badges
     /// are appended separately after a DB query (see `forClassAchievement`).
-    static func forSubmission(_ ctx: BadgeContext) -> [AchievementBadge] {
+    static func forSubmission(
+        _ ctx: BadgeContext, disabled: Set<String> = []
+    ) -> [AchievementBadge] {
         BuiltInAchievements.perSubmission
-            .filter { perSubmissionEarned($0.kind, ctx: ctx) }
+            .filter { !disabled.contains($0.id) && perSubmissionEarned($0.kind, ctx: ctx) }
             .map(AchievementBadge.init(from:))
     }
 
@@ -237,8 +239,11 @@ struct AchievementBadge: Encodable {
     }
 
     /// Maps a class-achievement ID string to its badge, returning nil for unknown IDs.
-    static func forClassAchievement(_ achievementID: String) -> AchievementBadge? {
-        BuiltInAchievements.classRecords
+    static func forClassAchievement(
+        _ achievementID: String, disabled: Set<String> = []
+    ) -> AchievementBadge? {
+        guard !disabled.contains(achievementID) else { return nil }
+        return BuiltInAchievements.classRecords
             .first { $0.id == achievementID }
             .map(AchievementBadge.init(from:))
     }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -215,7 +215,9 @@ extension WebRoutes {
         // checks the submitter's role and uses the existence of a
         // pathfinder row directly (the unique constraint on
         // (test_setup_id, achievement_id) makes this the natural query).
-        if user.role == "student", let uid = user.id {
+        if user.role == "student", let uid = user.id,
+            !BuiltInAchievements.disabled(in: setup).contains("pathfinder")
+        {
             let pathfinderExists =
                 try await APIClassAchievement.query(on: req.db)
                 .filter(\.$testSetupID == setupID)
@@ -401,9 +403,14 @@ extension WebRoutes {
         let individualBadges = try await earnedIndividualBadgesForDisplay(
             displayResult: displayResult, submission: submission,
             gradePercent: processed.gradePercent, decoder: decoder, on: req.db)
+        let disabledAwards =
+            (try? await APITestSetup.find(submission.testSetupID, on: req.db))
+            .map { BuiltInAchievements.disabled(in: $0) } ?? []
         let badges =
-            processed.badges
-            + classAchievements.compactMap { AchievementBadge.forClassAchievement($0.achievementID) }
+            processed.badges.filter { !disabledAwards.contains($0.id) }
+            + classAchievements.compactMap {
+                AchievementBadge.forClassAchievement($0.achievementID, disabled: disabledAwards)
+            }
             + individualBadges
 
         let sectionedOutcomes = buildSectionedOutcomes(

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -258,6 +258,8 @@ struct WebRoutes: RouteCollection {
                         }
                     }
 
+                    let disabledBySetup = try await BuiltInAchievements.disabledBySetup(
+                        setupIDs: Array(setupIDs), on: req.db)
                     for (setupID, latest) in latestSubmissionBySetupID {
                         guard let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
                             let result = preferredResultBySubmissionID[latest.submissionID],
@@ -280,7 +282,7 @@ struct WebRoutes: RouteCollection {
                                 gradePercent: gradePercent,
                                 executionTimeMs: collection.executionTimeMs,
                                 priorGradePercent: priorGradePercent
-                            ))
+                            ), disabled: disabledBySetup[setupID] ?? [])
                     }
 
                     // Batch-query class-wide badges this user currently holds across all setups.
@@ -289,7 +291,9 @@ struct WebRoutes: RouteCollection {
                         .filter(\.$testSetupID ~~ setupIDs)
                         .all()
                     for ach in classAchievements {
-                        if let badge = AchievementBadge.forClassAchievement(ach.achievementID) {
+                        if let badge = AchievementBadge.forClassAchievement(
+                            ach.achievementID, disabled: disabledBySetup[ach.testSetupID] ?? [])
+                        {
                             latestBadgesBySetupID[ach.testSetupID, default: []].append(badge)
                         }
                     }

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -757,7 +757,9 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         notebookChecks: resolvedChecks,
         sections: resolvedSections,
         globalVariables: resolvedGlobalVariables,
-        globalExpressions: resolvedGlobalExpressions
+        globalExpressions: resolvedGlobalExpressions,
+        achievements: props.achievements,
+        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs
     )
 
     // Belt-and-suspenders: the post-expansion manifest is the one the runner

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -252,6 +252,12 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// as `patternFamilies` / `notebookChecks`).
     public let achievements: [Achievement]
 
+    /// IDs of built-in awards (`BuiltInAchievements`) the instructor has disabled
+    /// for this assignment.  Empty = all built-ins active (the default).  The
+    /// award + display paths skip any id listed here.  Stripped from the
+    /// runner-facing manifest (awards are server-side) via the memberwise default.
+    public let disabledBuiltInAwardIDs: [String]
+
     public init(
         schemaVersion: Int = 1,
         gradingMode: GradingMode = .worker,
@@ -266,6 +272,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         globalVariables: [FamilyVariable] = [],
         globalExpressions: [PersonalizationExpression] = [],
         achievements: [Achievement] = [],
+        disabledBuiltInAwardIDs: [String] = [],
         testItems: [TestItem]? = nil
     ) {
         self.schemaVersion = schemaVersion
@@ -286,6 +293,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         self.globalVariables = globalVariables
         self.globalExpressions = globalExpressions
         self.achievements = achievements
+        self.disabledBuiltInAwardIDs = disabledBuiltInAwardIDs
     }
 
     public init(from decoder: Decoder) throws {
@@ -317,6 +325,8 @@ public struct TestProperties: Codable, Equatable, Sendable {
                 [PersonalizationExpression].self,
                 forKey: .globalExpressions) ?? []
         achievements = try c.decodeIfPresent([Achievement].self, forKey: .achievements) ?? []
+        disabledBuiltInAwardIDs =
+            try c.decodeIfPresent([String].self, forKey: .disabledBuiltInAwardIDs) ?? []
     }
 
     // `patternFamilies` / `notebookChecks` are computed (derived from
@@ -338,6 +348,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         case globalVariables
         case globalExpressions
         case achievements
+        case disabledBuiltInAwardIDs
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -358,6 +369,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         try c.encode(globalVariables, forKey: .globalVariables)
         try c.encode(globalExpressions, forKey: .globalExpressions)
         try c.encode(achievements, forKey: .achievements)
+        try c.encode(disabledBuiltInAwardIDs, forKey: .disabledBuiltInAwardIDs)
     }
 
     /// Manifest view shipped to runners.  Pattern families and notebook

--- a/Tests/APITests/BuiltInAwardTogglesTests.swift
+++ b/Tests/APITests/BuiltInAwardTogglesTests.swift
@@ -1,0 +1,107 @@
+// Tests/APITests/BuiltInAwardTogglesTests.swift
+//
+// Per-assignment built-in award on/off toggles: the editor endpoint round-trips
+// the disabled set into the manifest; the award + display paths honor it; and a
+// suite rebuild preserves both the toggles and authored achievements (the
+// previously-latent wipe-on-suite-edit bug).
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct BuiltInAwardTogglesTests {
+
+    @Test func forSubmissionAndClassRecordsHonorDisabled() {
+        let ctx = BadgeContext(
+            attemptNumber: 1, gradePercent: 100, executionTimeMs: 1_000, priorGradePercent: nil)
+        // First-try perfect + fast → Ace + Swift.
+        #expect(Set(AchievementBadge.forSubmission(ctx).map(\.id)) == ["first_try_perfect", "speed_demon"])
+        // Disabling Ace leaves only Swift.
+        #expect(
+            AchievementBadge.forSubmission(ctx, disabled: ["first_try_perfect"]).map(\.id)
+                == ["speed_demon"])
+        // Class records honor the disabled set.
+        #expect(AchievementBadge.forClassAchievement("trailblazer") != nil)
+        #expect(AchievementBadge.forClassAchievement("trailblazer", disabled: ["trailblazer"]) == nil)
+    }
+
+    @Test func suiteRebuildPreservesAchievementsAndToggles() throws {
+        // Regression: makeWorkerManifestJSON builds a fresh dict, so before the
+        // fix a suite edit wiped authored achievements (and would wipe toggles).
+        let goal = Achievement(
+            id: "g1", name: "Goal", kind: .classGoal, scope: .classWide,
+            reward: AchievementReward(type: .points, label: "Goal", points: 5),
+            threshold: 0.8, classFraction: 0.8)
+        let json = try makeWorkerManifestJSON(
+            testSuites: [], includeMakefile: false,
+            achievements: [goal], disabledBuiltInAwardIDs: ["trailblazer", "speed_champion"])
+        let props = try JSONDecoder().decode(TestProperties.self, from: Data(json.utf8))
+        #expect(props.achievements.map(\.id) == ["g1"])
+        #expect(Set(props.disabledBuiltInAwardIDs) == ["trailblazer", "speed_champion"])
+    }
+
+    @Test func putAndGetBuiltInAwardToggles() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "ba_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ba_setup", title: "BA", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/built-in-awards",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(PublishedAssignmentRoutes.BuiltInAwardsResponse.self)
+                    #expect(body.awards.count == 8)
+                    #expect(body.awards.allSatisfy { $0.enabled }, "All enabled by default")
+                })
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/built-in-awards",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.BuiltInAwardsBody(
+                            disabled: ["trailblazer", "speed_champion", "minimalist", "pathfinder"]),
+                        as: .json)
+                },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            let setup = try #require(try await APITestSetup.find("ba_setup", on: app.db))
+            #expect(
+                BuiltInAchievements.disabled(in: setup)
+                    == ["trailblazer", "speed_champion", "minimalist", "pathfinder"])
+        }
+    }
+
+    @Test func awardClassBadgesSkipsDisabledRecords() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let setup = APITestSetup(
+                id: "ba_award_setup", manifest: #"{"schemaVersion":1}"#,
+                zipPath: app.testSetupsDirectory + "ba_award_setup.zip", courseID: courseID)
+            try await setup.save(on: app.db)
+            let student = try await arInsertStudent(username: "ba_student", on: app)
+            let uid = try student.requireID()
+            _ = try await arInsertSubmission(
+                id: "ba_award_sub", testSetupID: "ba_award_setup", userID: uid, on: app)
+
+            try await awardClassBadgesFor100Percent(
+                testSetupID: "ba_award_setup", userID: uid, submissionID: "ba_award_sub",
+                executionTimeMs: 100, attemptNumber: 1,
+                disabled: ["trailblazer", "speed_champion", "minimalist"], on: app.db)
+
+            let rows = try await APIClassAchievement.query(on: app.db)
+                .filter(\.$testSetupID == "ba_award_setup")
+                .all()
+            #expect(rows.isEmpty, "Every class record disabled → none awarded")
+        }
+    }
+}

--- a/changelog.d/builtin-award-toggles.md
+++ b/changelog.d/builtin-award-toggles.md
@@ -1,0 +1,17 @@
+### Added
+
+- **Per-assignment built-in award toggles.** A "Built-in Awards" card on the
+  assignment edit page lists Chickadee's built-in awards — the per-submission
+  Ace / Rally / Tenacious / Swift and the competitive Pathfinder / Trailblazer /
+  Fastest / Minimalist class records — with an on/off switch each. Disabling one
+  (e.g. turning the competitive class records off for a collaborative course)
+  stops it being awarded and hides it on the submission page, history, and
+  dashboard. Persisted in the manifest as `disabledBuiltInAwardIDs`.
+
+### Fixed
+
+- **Authored achievements no longer survive only until the next suite edit.**
+  The suite-rebuild path (`makeWorkerManifestJSON`) built a fresh manifest that
+  dropped the `achievements` array, so authoring a class goal or badge and then
+  editing the test suite silently wiped it. The rebuild now preserves
+  achievements (and the new built-in-award toggles).


### PR DESCRIPTION
## Per-assignment built-in award toggles

Surfaces the built-in awards in the editor and lets an instructor **enable/disable each per assignment** — the flavor you chose. Directly serves "collaborative by default, competitive is holding space": disable the Pathfinder/Trailblazer/Fastest/Minimalist class records for a collaborative course and they stop being awarded and shown.

### What an instructor sees
A new **"Built-in Awards"** card on the assignment edit page, listing all 8 built-ins with an on/off switch, grouped:
- **Per-submission badges** — Ace, Rally, Tenacious, Swift
- **Class records (competitive)** — Pathfinder, Trailblazer, Fastest, Minimalist

### How it's honored
- **`GET`/`PUT /instructor/:id/built-in-awards`** stores the disabled-id set in the manifest (`disabledBuiltInAwardIDs`, new `TestProperties` field, stripped from the runner manifest).
- **Display** filtered everywhere a badge renders: the submission page, the per-course history, and the student dashboard (`forSubmission`/`forClassAchievement` take a `disabled` set, default empty → today's behavior).
- **Award** skipped at both award sites: `awardClassBadgesFor100Percent` (100% records) and the Pathfinder award on first submission. So a disabled record is never created, not just hidden.

### Bug fix bundled in (it had to be)
While wiring persistence I found that **`makeWorkerManifestJSON` builds a fresh manifest dict that omitted `achievements`** — so authoring a class goal/badge and then editing the test suite (reorder, add a test, edit a family) **silently wiped it**, since `applyPatternFamilies` rebuilds through that path. The rebuild now preserves `achievements` *and* the new toggles. This repairs the shipped class-goals/badges authoring, not just my feature.

### Tests
`BuiltInAwardTogglesTests`: endpoint round-trip; `forSubmission`/`forClassAchievement` honor the disabled set; `awardClassBadgesFor100Percent` skips disabled records; and a **suite-rebuild-preserves-achievements-and-toggles** regression. The existing `WebRoutesBadgeTests` (incl. `pathfinderAwardedToFirstStudentEvenAfterAdminSubmits`) + `BuiltInAchievementsTests` stay green. Build + `check-styles` + `swift-format` + SwiftLint `--strict` clean.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_