### PR TITLE
feat(achievements): parameterize built-in trigger thresholds (unification Phase A)

### DIFF
--- a/Sources/APIServer/Helpers/BuiltInAchievements.swift
+++ b/Sources/APIServer/Helpers/BuiltInAchievements.swift
@@ -28,7 +28,9 @@ enum BuiltInAchievements {
         detail: "Scored 100% on your very first submission — no warm-up needed.",
         kind: .firstTryPerfect,
         scope: .individual,
-        reward: AchievementReward(type: .badge, label: "Ace"))
+        reward: AchievementReward(type: .badge, label: "Ace"),
+        threshold: 1.0,
+        attemptThreshold: 1)
 
     /// Jumped ≥50 percentage points in one submission.
     static let rally = Achievement(
@@ -37,7 +39,8 @@ enum BuiltInAchievements {
         detail: "Jumped 50 or more percentage points in a single submission.",
         kind: .comeback,
         scope: .individual,
-        reward: AchievementReward(type: .badge, label: "Rally"))
+        reward: AchievementReward(type: .badge, label: "Rally"),
+        jumpThresholdPercent: 50)
 
     /// 100% after ≥5 attempts.
     static let tenacious = Achievement(
@@ -46,7 +49,9 @@ enum BuiltInAchievements {
         detail: "Reached 100% after 5 or more attempts — persistence pays off.",
         kind: .persistence,
         scope: .individual,
-        reward: AchievementReward(type: .badge, label: "Tenacious"))
+        reward: AchievementReward(type: .badge, label: "Tenacious"),
+        threshold: 1.0,
+        attemptThreshold: 5)
 
     /// 100% with total execution under 2 s.
     static let swift = Achievement(
@@ -55,7 +60,9 @@ enum BuiltInAchievements {
         detail: "Scored 100% with every test completing in under 2 seconds total.",
         kind: .speedRun,
         scope: .individual,
-        reward: AchievementReward(type: .badge, label: "Swift"))
+        reward: AchievementReward(type: .badge, label: "Swift"),
+        threshold: 1.0,
+        timeThresholdMs: 2000)
 
     /// In display order — `forSubmission` walks this list.
     static let perSubmission = [ace, rally, tenacious, swift]

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -215,24 +215,28 @@ struct AchievementBadge: Encodable {
         _ ctx: BadgeContext, disabled: Set<String> = []
     ) -> [AchievementBadge] {
         BuiltInAchievements.perSubmission
-            .filter { !disabled.contains($0.id) && perSubmissionEarned($0.kind, ctx: ctx) }
+            .filter { !disabled.contains($0.id) && perSubmissionEarned($0, ctx: ctx) }
             .map(AchievementBadge.init(from:))
     }
 
-    /// Whether a built-in per-submission award's condition is met for `ctx`.
-    /// These thresholds (50 points, 5 attempts, 2 s) match the legacy badges
-    /// exactly — the fold-in changed where identity lives, not the conditions.
-    private static func perSubmissionEarned(_ kind: AchievementKind, ctx: BadgeContext) -> Bool {
-        switch kind {
+    /// Whether a per-submission award's (now parameterized) condition is met for
+    /// `ctx`.  Reads the thresholds off the achievement, defaulting to the
+    /// legacy constants (attempt 1 / +50 pts / 5 attempts / 2 s @ 100%) so the
+    /// built-in defaults behave exactly as before.
+    private static func perSubmissionEarned(_ a: Achievement, ctx: BadgeContext) -> Bool {
+        // `threshold` is a 0…1 grade fraction; default 100%.  gradePercent never
+        // exceeds 100, so `>=` collapses to `==` at the default.
+        let gradeCutoff = Int(((a.threshold ?? 1.0) * 100).rounded())
+        switch a.kind {
         case .firstTryPerfect:
-            return ctx.attemptNumber == 1 && ctx.gradePercent == 100
+            return ctx.attemptNumber <= (a.attemptThreshold ?? 1) && ctx.gradePercent >= gradeCutoff
         case .comeback:
             guard let prior = ctx.priorGradePercent else { return false }
-            return ctx.gradePercent - prior >= 50
+            return ctx.gradePercent - prior >= (a.jumpThresholdPercent ?? 50)
         case .persistence:
-            return ctx.attemptNumber >= 5 && ctx.gradePercent == 100
+            return ctx.attemptNumber >= (a.attemptThreshold ?? 5) && ctx.gradePercent >= gradeCutoff
         case .speedRun:
-            return ctx.gradePercent == 100 && ctx.executionTimeMs < 2_000
+            return ctx.gradePercent >= gradeCutoff && ctx.executionTimeMs < (a.timeThresholdMs ?? 2_000)
         default:
             return false
         }

--- a/Sources/Core/Achievement.swift
+++ b/Sources/Core/Achievement.swift
@@ -35,6 +35,15 @@ public struct Achievement: Codable, Equatable, Sendable {
     public let classFraction: Double?
     /// Which dimension a `classRecord` ranks students on.
     public let recordDimension: RecordDimension?
+    /// Attempt-count cutoff: the *max* attempt for `firstTryPerfect` (def 1)
+    /// and the *min* attempt for `persistence` (def 5).  The ≤/≥ sense is
+    /// intrinsic to the kind.
+    public let attemptThreshold: Int?
+    /// Total-execution cutoff in ms for `speedRun` (def 2000).
+    public let timeThresholdMs: Int?
+    /// Minimum grade jump (percentage points) between submissions for
+    /// `comeback` (def 50).
+    public let jumpThresholdPercent: Int?
     /// Suite section this achievement renders under; nil = the trailing
     /// "Achievements" block.
     public let sectionID: String?
@@ -50,6 +59,9 @@ public struct Achievement: Codable, Equatable, Sendable {
         threshold: Double? = nil,
         classFraction: Double? = nil,
         recordDimension: RecordDimension? = nil,
+        attemptThreshold: Int? = nil,
+        timeThresholdMs: Int? = nil,
+        jumpThresholdPercent: Int? = nil,
         sectionID: String? = nil
     ) {
         self.id = id
@@ -62,6 +74,9 @@ public struct Achievement: Codable, Equatable, Sendable {
         self.threshold = threshold
         self.classFraction = classFraction
         self.recordDimension = recordDimension
+        self.attemptThreshold = attemptThreshold
+        self.timeThresholdMs = timeThresholdMs
+        self.jumpThresholdPercent = jumpThresholdPercent
         self.sectionID = sectionID
     }
 }

--- a/docs/achievements-unification.md
+++ b/docs/achievements-unification.md
@@ -1,0 +1,80 @@
+# Achievements unification
+
+Status: **in progress** (this doc is the plan-of-record). Collapses the three
+separate achievement editors (Class Goals, Badges, Built-in Awards) into one
+**Achievements** table at the bottom of the assignment editor, where every
+achievement — collaborative class goals, individual badges, and the
+(formerly-hardcoded) built-in awards — is a first-class, editable row that any
+instructor can add, rename, retune, or remove.
+
+## Decisions (locked)
+
+1. **Built-ins are seeded as editable defaults.** Every assignment's manifest
+   starts with the eight built-ins as real `Achievement` rows; a one-time
+   migration seeds existing assignments. They are ordinary rows, not a code
+   registry + toggle. (Supersedes the `disabledBuiltInAwardIDs` toggle shipped
+   in #874, which is retired in Phase D.)
+2. **Trigger thresholds are parameterized.** The four per-submission badges
+   carry editable numbers instead of hardcoded constants:
+   | Badge | Trigger (parameterized) |
+   |-------|--------------------------|
+   | Ace (firstTryPerfect) | grade ≥ `threshold` (def 1.0) within `attemptThreshold` attempts (def 1) |
+   | Rally (comeback) | grade jumped ≥ `jumpThresholdPercent` points (def 50) |
+   | Tenacious (persistence) | grade ≥ `threshold` (def 1.0) after ≥ `attemptThreshold` attempts (def 5) |
+   | Swift (speedRun) | grade ≥ `threshold` (def 1.0) with total time ≤ `timeThresholdMs` (def 2000) |
+3. **Reward semantics unchanged.** Class goals grant `points` (the capped grade
+   bonus); badges and class records stay cosmetic. No custom icons — the generic
+   per-kind rendering is used (the `reward.icon` field stays in the model for
+   back-compat but is no longer authored).
+
+## Model changes (Core/Achievement.swift)
+
+New optional fields, all `decodeIfPresent` (back-compat), stripped from the
+runner manifest like the rest of `achievements`:
+
+- `attemptThreshold: Int?` — Ace (max) / Tenacious (min); the ≤/≥ sense is
+  intrinsic to the kind.
+- `timeThresholdMs: Int?` — Swift.
+- `jumpThresholdPercent: Int?` — Rally.
+
+`threshold` (grade fraction 0…1) is reused as the grade gate for Ace / Tenacious
+/ Swift, the same field class goals and threshold badges already use.
+
+## Evaluation: manifest-driven, per kind
+
+The mechanisms stay per-kind; only their **source** moves from the hardcoded
+registry to the manifest's `achievements` array:
+
+| Kind(s) | Mechanism (unchanged) | Source (was → becomes) |
+|---------|------------------------|------------------------|
+| classGoal | periodic sweep → `APIAchievementResult` | manifest (already) |
+| thresholdBadge / testBadge | `earnedIndividualBadges` at display | manifest (already) |
+| firstTryPerfect / comeback / persistence / speedRun | `forSubmission(BadgeContext)` | **`BuiltInAchievements.perSubmission` → manifest** |
+| classRecord | `awardClassBadgesFor100Percent` + pathfinder award | **hardcoded ids → manifest classRecords** |
+
+`BuiltInAchievements` stays as the **seed source** (the default rows) + the
+registry fallback for any un-seeded/malformed manifest.
+
+## Phases (each its own PR)
+
+- **A — manifest-driven + parameterized evaluation** (backend, behavior-identical).
+  Add the model fields; move the trigger constants into the registry defaults;
+  make `forSubmission` and the class-record award logic read the manifest's
+  achievements (registry fallback when none seeded).
+- **B — one unified endpoint.** `GET/PUT /instructor/:id/achievements` round-trips
+  the whole typed list with per-kind validation; retire `/badges` and
+  `/built-in-awards`.
+- **C — the unified editor table (UI).** One "Achievements" section after the
+  Test Suite; one table, kind-appropriate columns, **Add Achievement → pick kind
+  → fill params** (pattern-family-editor style). Drop the icon input. Delete the
+  three old cards + their JS.
+- **D — migration + cleanup.** Seed existing assignments; retire
+  `disabledBuiltInAwardIDs` + the built-in-awards endpoint/JS; finalize this doc.
+
+## Compatibility
+
+- New fields are additive + `decodeIfPresent`; old manifests decode unchanged.
+- Un-seeded assignments fall back to the registry so behavior is identical until
+  migrated; the migration is defensive (skips malformed manifests → fallback).
+- Generated test-script bytes are untouched, so `spec_hash` / `TestSetupCache`
+  keys are stable.


### PR DESCRIPTION
## Achievements unification — Phase A (foundation)

First slice of the unified-Achievements plan ([`docs/achievements-unification.md`](docs/achievements-unification.md), included here as the plan-of-record). **Behavior-identical** — pure foundation.

Per your two decisions: **seed built-ins as editable defaults** and **parameterize the trigger thresholds**. This PR does the parameterization groundwork:

- **Core:** `Achievement` gains `attemptThreshold` / `timeThresholdMs` / `jumpThresholdPercent` (optional, `decodeIfPresent` → old manifests decode unchanged).
- **Registry as data:** the four per-submission badges now carry their legacy constants as fields — Ace (`attempt ≤ 1` @ 100%), Rally (`+50` pts), Tenacious (`attempt ≥ 5` @ 100%), Swift (`< 2000 ms` @ 100%).
- **Evaluator reads them:** `perSubmissionEarned` pulls thresholds off the achievement instead of hardcoding, defaulting to the legacy constants.

**Parity guard:** the existing `forSubmission` tests (`BuiltInAchievementsTests`, `BuiltInAwardTogglesTests` — 8 tests) stay green, proving the defaults behave exactly as before. Build + `swift-format` + SwiftLint `--strict` clean.

### Rollout (this is PR 1 of ~4)
- **A (this) — parameterized eval + plan doc.**
- **B/A2 — manifest-driven sourcing:** `forSubmission` + the class-record award read the manifest's achievements (registry as seed + fallback), so custom-tuned and added achievements take effect.
- **C — unified endpoint** (`GET/PUT /achievements` for the whole typed list; retire `/badges`, `/built-in-awards`).
- **D — the editor table** (one "Achievements" table after the Test Suite; add-any-kind; drop icons; delete the 3 cards) **+ migration/cleanup** (seed existing assignments; retire the toggle).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_