### PR TITLE
feat(achievements): manifest-driven forSubmission (unification A2)

### DIFF
--- a/Sources/APIServer/Helpers/BuiltInAchievements.swift
+++ b/Sources/APIServer/Helpers/BuiltInAchievements.swift
@@ -140,4 +140,36 @@ enum BuiltInAchievements {
         }
         return map
     }
+
+    /// The kinds evaluated per-submission via `forSubmission`.
+    static let perSubmissionKinds: Set<AchievementKind> = [
+        .firstTryPerfect, .comeback, .persistence, .speedRun,
+    ]
+
+    /// The manifest's authored per-submission achievements, or nil to fall back
+    /// to the registry.  `forSubmission` uses this so seeded / edited
+    /// per-submission badges take effect once a manifest carries any.
+    static func manifestPerSubmission(in setup: APITestSetup?) -> [Achievement]? {
+        let perSub = (setup?.decodedManifest()?.achievements ?? [])
+            .filter { perSubmissionKinds.contains($0.kind) }
+        return perSub.isEmpty ? nil : perSub
+    }
+
+    /// Batch `[setupID: per-submission achievements]` for the multi-assignment
+    /// pages; only setups whose manifest authors per-submission achievements
+    /// appear (others fall back to the registry).
+    static func manifestPerSubmissionBySetup(
+        setupIDs: [String], on db: Database
+    ) async throws -> [String: [Achievement]] {
+        guard !setupIDs.isEmpty else { return [:] }
+        let setups = try await APITestSetup.query(on: db)
+            .filter(\.$id ~~ Set(setupIDs))
+            .all()
+        var map: [String: [Achievement]] = [:]
+        for setup in setups {
+            guard let id = setup.id, let perSub = manifestPerSubmission(in: setup) else { continue }
+            map[id] = perSub
+        }
+        return map
+    }
 }

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -76,6 +76,7 @@ extension StudentCourseRoutes {
         // Honor per-assignment disabled built-in awards across the page (reuses
         // the setups already loaded above, so no extra query).
         let disabledBySetup = setupsByID.mapValues { BuiltInAchievements.disabled(in: $0) }
+        let perSubBySetup = setupsByID.compactMapValues { BuiltInAchievements.manifestPerSubmission(in: $0) }
         let classBadgesBySetupID = classBadgesBySetupIDRaw.reduce(
             into: [String: [AchievementBadge]]()
         ) { acc, entry in
@@ -101,7 +102,8 @@ extension StudentCourseRoutes {
             preferredResultBySubmissionID: preferredResultBySubmissionID,
             student: student,
             fmt: fmt,
-            disabledBySetup: disabledBySetup
+            disabledBySetup: disabledBySetup,
+            perSubBySetup: perSubBySetup
         )
         let rows = sortedAssignments.map { assignment in
             buildStudentAssignmentRow(
@@ -746,6 +748,9 @@ extension StudentCourseRoutes {
         let fmt: DateFormatter
         /// `[setupID: disabled built-in award ids]` — the same map for every row.
         let disabledBySetup: [String: Set<String>]
+        /// `[setupID: manifest per-submission achievements]` — same map every
+        /// row; absent setups fall back to the registry.
+        let perSubBySetup: [String: [Achievement]]
     }
 
     fileprivate func buildStudentAssignmentRow(
@@ -778,7 +783,8 @@ extension StudentCourseRoutes {
         let disabledHere = context.disabledBySetup[assignment.testSetupID] ?? []
         var badges = submissionBadges(
             history: history,
-            preferredResultBySubmissionID: preferredResultBySubmissionID
+            preferredResultBySubmissionID: preferredResultBySubmissionID,
+            achievements: context.perSubBySetup[assignment.testSetupID]
         ).filter { !disabledHere.contains($0.id) }
         badges.append(contentsOf: classBadges)
 
@@ -852,7 +858,8 @@ extension StudentCourseRoutes {
     /// improvement).  Class-wide badges are appended by the caller.
     fileprivate func submissionBadges(
         history: [APISubmission],
-        preferredResultBySubmissionID: [String: APIResult]
+        preferredResultBySubmissionID: [String: APIResult],
+        achievements: [Achievement]?
     ) -> [AchievementBadge] {
         guard let latestSubmission = history.first,
             let latestSubID = latestSubmission.id,
@@ -876,7 +883,8 @@ extension StudentCourseRoutes {
                 gradePercent: gradePct,
                 executionTimeMs: collection.executionTimeMs,
                 priorGradePercent: priorPct
-            )
+            ),
+            achievements: achievements
         )
     }
 }

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -211,11 +211,18 @@ struct AchievementBadge: Encodable {
     /// award *conditions* live here (keyed by kind); each badge's identity —
     /// caption + tooltip — comes from `BuiltInAchievements`.  Class-wide badges
     /// are appended separately after a DB query (see `forClassAchievement`).
+    /// Per-submission badges earned for `ctx`.  Source precedence: the explicit
+    /// `achievements` list (the manifest's authored per-submission achievements,
+    /// once seeded) → otherwise the built-in registry minus `disabled`.  Keeping
+    /// `achievements` optional means existing callers stay on the registry path
+    /// unchanged; manifest-sourced callers pass the list.
     static func forSubmission(
-        _ ctx: BadgeContext, disabled: Set<String> = []
+        _ ctx: BadgeContext, achievements: [Achievement]? = nil, disabled: Set<String> = []
     ) -> [AchievementBadge] {
-        BuiltInAchievements.perSubmission
-            .filter { !disabled.contains($0.id) && perSubmissionEarned($0, ctx: ctx) }
+        let source = achievements ?? BuiltInAchievements.perSubmission.filter { !disabled.contains($0.id) }
+        return
+            source
+            .filter { BuiltInAchievements.perSubmissionKinds.contains($0.kind) && perSubmissionEarned($0, ctx: ctx) }
             .map(AchievementBadge.init(from:))
     }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -95,6 +95,24 @@ func groupOutcomesBySection(
     return result
 }
 
+/// The built-in badges (per-submission + class records) for one submission,
+/// sourced from the manifest when seeded, else the registry minus any disabled.
+/// Lifted out of `submissionPage` to keep that handler within its length budget.
+func builtInBadgesForSubmission(
+    submission: APISubmission, badgeContext: BadgeContext,
+    classAchievements: [APIClassAchievement], on db: Database
+) async throws -> [AchievementBadge] {
+    let setup = try? await APITestSetup.find(submission.testSetupID, on: db)
+    let disabled = setup.map { BuiltInAchievements.disabled(in: $0) } ?? []
+    return AchievementBadge.forSubmission(
+        badgeContext,
+        achievements: BuiltInAchievements.manifestPerSubmission(in: setup),
+        disabled: disabled)
+        + classAchievements.compactMap {
+            AchievementBadge.forClassAchievement($0.achievementID, disabled: disabled)
+        }
+}
+
 extension WebRoutes {
 
     // MARK: - GET /testsetups/:id/submit
@@ -403,14 +421,10 @@ extension WebRoutes {
         let individualBadges = try await earnedIndividualBadgesForDisplay(
             displayResult: displayResult, submission: submission,
             gradePercent: processed.gradePercent, decoder: decoder, on: req.db)
-        let disabledAwards =
-            (try? await APITestSetup.find(submission.testSetupID, on: req.db))
-            .map { BuiltInAchievements.disabled(in: $0) } ?? []
         let badges =
-            processed.badges.filter { !disabledAwards.contains($0.id) }
-            + classAchievements.compactMap {
-                AchievementBadge.forClassAchievement($0.achievementID, disabled: disabledAwards)
-            }
+            try await builtInBadgesForSubmission(
+                submission: submission, badgeContext: processed.badgeContext,
+                classAchievements: classAchievements, on: req.db)
             + individualBadges
 
         let sectionedOutcomes = buildSectionedOutcomes(
@@ -602,13 +616,12 @@ extension WebRoutes {
             collection.totalPoints > 0
             ? Int((collection.earnedPoints / Double(collection.totalPoints) * 100).rounded())
             : 0
-        processed.badges = AchievementBadge.forSubmission(
-            BadgeContext(
-                attemptNumber: submission.attemptNumber ?? 1,
-                gradePercent: processed.gradePercent,
-                executionTimeMs: collection.executionTimeMs,
-                priorGradePercent: priorAttempt.gradePercent
-            ))
+        processed.badgeContext = BadgeContext(
+            attemptNumber: submission.attemptNumber ?? 1,
+            gradePercent: processed.gradePercent,
+            executionTimeMs: collection.executionTimeMs,
+            priorGradePercent: priorAttempt.gradePercent
+        )
         let weighted = collection.totalPoints != collection.totalTests
         let itemized = collection.filtering(tiers: viewer.itemizedTiers)
         processed.outcomes = itemized.outcomes.map { outcome in
@@ -876,7 +889,9 @@ private struct ProcessedCollection {
     var rawEarnedPoints: Double
     var executionTimeMs: Int
     var gradePercent: Int
-    var badges: [AchievementBadge]
+    /// Inputs for the per-submission badges; the badges themselves are resolved
+    /// at the call site (manifest-sourced when seeded, else the registry).
+    var badgeContext: BadgeContext
     /// Secret-tier outcomes (students only) in collection order; aggregated
     /// into per-section summaries by `buildSectionedOutcomes`.  Empty for
     /// instructors, who see secret tests itemized as ordinary rows.
@@ -895,7 +910,8 @@ private struct ProcessedCollection {
         rawEarnedPoints: 0,
         executionTimeMs: 0,
         gradePercent: 0,
-        badges: [],
+        badgeContext: BadgeContext(
+            attemptNumber: 1, gradePercent: 0, executionTimeMs: 0, priorGradePercent: nil),
         secretOutcomes: []
     )
 }

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -260,6 +260,8 @@ struct WebRoutes: RouteCollection {
 
                     let disabledBySetup = try await BuiltInAchievements.disabledBySetup(
                         setupIDs: Array(setupIDs), on: req.db)
+                    let perSubBySetup = try await BuiltInAchievements.manifestPerSubmissionBySetup(
+                        setupIDs: Array(setupIDs), on: req.db)
                     for (setupID, latest) in latestSubmissionBySetupID {
                         guard let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
                             let result = preferredResultBySubmissionID[latest.submissionID],
@@ -282,7 +284,9 @@ struct WebRoutes: RouteCollection {
                                 gradePercent: gradePercent,
                                 executionTimeMs: collection.executionTimeMs,
                                 priorGradePercent: priorGradePercent
-                            ), disabled: disabledBySetup[setupID] ?? [])
+                            ),
+                            achievements: perSubBySetup[setupID],
+                            disabled: disabledBySetup[setupID] ?? [])
                     }
 
                     // Batch-query class-wide badges this user currently holds across all setups.

--- a/Tests/APITests/AchievementManifestSourcingTests.swift
+++ b/Tests/APITests/AchievementManifestSourcingTests.swift
@@ -1,0 +1,58 @@
+// Tests/APITests/AchievementManifestSourcingTests.swift
+//
+// Unification A2: forSubmission sources per-submission badges from the manifest
+// when provided (and honors the parameterized thresholds), else falls back to
+// the registry.
+
+import Core
+import Testing
+
+@testable import APIServer
+
+@Suite struct AchievementManifestSourcingTests {
+
+    @Test func forSubmissionSourcesFromManifestAndRespectsThresholds() {
+        // First-try 100% in 1500 ms.
+        let ctx = BadgeContext(
+            attemptNumber: 1, gradePercent: 100, executionTimeMs: 1_500, priorGradePercent: nil)
+
+        // No list → registry fallback: Ace (first-try) + Swift (1500 < 2000 default).
+        #expect(
+            Set(AchievementBadge.forSubmission(ctx).map(\.id)) == ["first_try_perfect", "speed_demon"])
+
+        // A manifest "speed" badge with a tighter 500 ms cutoff is NOT earned at 1500 ms,
+        // and the registry defaults no longer apply (manifest is authoritative).
+        let tight = [
+            Achievement(
+                id: "lightning", name: "Lightning", kind: .speedRun, scope: .individual,
+                reward: AchievementReward(type: .badge, label: "Lightning"),
+                threshold: 1.0, timeThresholdMs: 500)
+        ]
+        #expect(AchievementBadge.forSubmission(ctx, achievements: tight).isEmpty)
+
+        // A looser 3000 ms cutoff IS earned — and only the manifest badge shows.
+        let loose = [
+            Achievement(
+                id: "cruise", name: "Cruise", kind: .speedRun, scope: .individual,
+                reward: AchievementReward(type: .badge, label: "Cruise"),
+                threshold: 1.0, timeThresholdMs: 3_000)
+        ]
+        #expect(AchievementBadge.forSubmission(ctx, achievements: loose).map(\.id) == ["cruise"])
+    }
+
+    @Test func forSubmissionCustomAttemptAndJumpThresholds() {
+        // A "persistence" badge tuned to ≥ 3 attempts fires on attempt 3.
+        let persistent = [
+            Achievement(
+                id: "grit", name: "Grit", kind: .persistence, scope: .individual,
+                reward: AchievementReward(type: .badge, label: "Grit"),
+                threshold: 1.0, attemptThreshold: 3)
+        ]
+        let onThird = BadgeContext(
+            attemptNumber: 3, gradePercent: 100, executionTimeMs: 9_000, priorGradePercent: 100)
+        #expect(AchievementBadge.forSubmission(onThird, achievements: persistent).map(\.id) == ["grit"])
+        let onSecond = BadgeContext(
+            attemptNumber: 2, gradePercent: 100, executionTimeMs: 9_000, priorGradePercent: 100)
+        #expect(AchievementBadge.forSubmission(onSecond, achievements: persistent).isEmpty)
+    }
+}

--- a/changelog.d/achievements-unify-a2.md
+++ b/changelog.d/achievements-unify-a2.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Achievements unification (A2): per-submission badges are manifest-driven.**
+  `forSubmission` now sources the per-submission badges (Ace / Rally / Tenacious
+  / Swift) from the assignment manifest's authored achievements when present,
+  falling back to the built-in registry otherwise — wired at all three display
+  sites (submission page, course history, student dashboard). Behavior-identical
+  until a manifest carries per-submission achievements (the editor + seeding land
+  later in the rollout); the parameterized thresholds then take effect.


### PR DESCRIPTION
## Achievements unification — A2 (manifest-driven `forSubmission`)

Second slice. Makes the per-submission badges (Ace / Rally / Tenacious / Swift) read from the **manifest's authored achievements** when present, so the parameterized thresholds and (later) seeded/edited rows take effect. **Behavior-identical** — registry fallback until a manifest carries any.

### How
- `forSubmission` gains an **optional** `achievements: [Achievement]?` source (defaults to the registry minus `disabled`), so existing callers + the 8 parity tests are untouched.
- Wired at all three display sites:
  - **submission page** — `ProcessedCollection` now carries the `BadgeContext`; the combination point resolves `manifestPerSubmission(in: setup)` (extracted to `builtInBadgesForSubmission` to keep `submissionPage` under the 100-line budget);
  - **history** — a per-setup map threaded via `StudentAssignmentRowContext` (reuses the already-loaded setups, no extra query);
  - **dashboard** — a batch `manifestPerSubmissionBySetup`.

### Tests
New `AchievementManifestSourcingTests` proves custom thresholds + manifest sourcing (a 500 ms "speed" badge doesn't fire at 1500 ms; a ≥3-attempt "persistence" badge fires on attempt 3 not 2). The 37 existing badge/submission/history tests stay green (registry fallback = identical). Build + `swift-format` + SwiftLint `--strict` clean.

### Rollout
A ✅ → **A2 (this)** → A3 (class-record award manifest-driven) → B (unified endpoint) → C (editor table) → D (seed migration + cleanup).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_