### PR TITLE
feat(achievements): manifest-driven class-record awards (unification A3)

### DIFF
--- a/Sources/APIServer/Helpers/BuiltInAchievements.swift
+++ b/Sources/APIServer/Helpers/BuiltInAchievements.swift
@@ -76,7 +76,7 @@ enum BuiltInAchievements {
         kind: .classRecord,
         scope: .classWide,
         reward: AchievementReward(type: .title, label: "Pathfinder"),
-        recordDimension: .firstToSolve)
+        recordDimension: .firstToSubmit)
 
     static let trailblazer = Achievement(
         id: "trailblazer",
@@ -171,5 +171,17 @@ enum BuiltInAchievements {
             map[id] = perSub
         }
         return map
+    }
+
+    /// The class records to award for a setup: the manifest's authored
+    /// `classRecord` achievements (or the registry default when none), minus
+    /// any the instructor disabled.  Callers award each by its `recordDimension`.
+    static func classRecordsForAward(
+        in setup: APITestSetup?, disabled: Set<String>
+    ) -> [Achievement] {
+        let manifest = (setup?.decodedManifest()?.achievements ?? [])
+            .filter { $0.kind == .classRecord }
+        let source = manifest.isEmpty ? classRecords : manifest
+        return source.filter { !disabled.contains($0.id) }
     }
 }

--- a/Sources/APIServer/Helpers/ClassAchievements.swift
+++ b/Sources/APIServer/Helpers/ClassAchievements.swift
@@ -3,6 +3,7 @@
 // Logic for awarding class-wide achievement badges when a 100% result arrives.
 // Called from ResultRoutes after the result is persisted.
 
+import Core
 import Fluent
 import Foundation
 
@@ -27,23 +28,29 @@ func awardClassBadgesFor100Percent(
         user.role == "student"
     else { return }
 
-    // Skip any record the instructor disabled for this assignment.
-    if !disabled.contains("trailblazer") {
-        try await awardImmutableBadge(
-            achievementID: "trailblazer",
-            testSetupID: testSetupID, userID: userID, submissionID: submissionID, on: db)
-    }
-    if !disabled.contains("speed_champion") {
-        try await updateRecordBadge(
-            achievementID: "speed_champion",
-            testSetupID: testSetupID, userID: userID, submissionID: submissionID,
-            newValue: Double(executionTimeMs), on: db)
-    }
-    if !disabled.contains("minimalist") {
-        try await updateRecordBadge(
-            achievementID: "minimalist",
-            testSetupID: testSetupID, userID: userID, submissionID: submissionID,
-            newValue: Double(attemptNumber), on: db)
+    // The class records to award — the manifest's authored ones (or the registry
+    // default), minus disabled.  Each is awarded by its dimension; firstToSubmit
+    // (Pathfinder) is awarded at submission time, not on reaching 100%.
+    let setup = try await APITestSetup.find(testSetupID, on: db)
+    for record in BuiltInAchievements.classRecordsForAward(in: setup, disabled: disabled) {
+        switch record.recordDimension {
+        case .firstToSolve:
+            try await awardImmutableBadge(
+                achievementID: record.id,
+                testSetupID: testSetupID, userID: userID, submissionID: submissionID, on: db)
+        case .fastest:
+            try await updateRecordBadge(
+                achievementID: record.id,
+                testSetupID: testSetupID, userID: userID, submissionID: submissionID,
+                newValue: Double(executionTimeMs), on: db)
+        case .shortest:
+            try await updateRecordBadge(
+                achievementID: record.id,
+                testSetupID: testSetupID, userID: userID, submissionID: submissionID,
+                newValue: Double(attemptNumber), on: db)
+        case .firstToSubmit, .none:
+            continue
+        }
     }
 }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -233,19 +233,23 @@ extension WebRoutes {
         // checks the submitter's role and uses the existence of a
         // pathfinder row directly (the unique constraint on
         // (test_setup_id, achievement_id) makes this the natural query).
-        if user.role == "student", let uid = user.id,
-            !BuiltInAchievements.disabled(in: setup).contains("pathfinder")
-        {
-            let pathfinderExists =
-                try await APIClassAchievement.query(on: req.db)
-                .filter(\.$testSetupID == setupID)
-                .filter(\.$achievementID == "pathfinder")
-                .first() != nil
-            if !pathfinderExists {
-                let badge = APIClassAchievement(
-                    testSetupID: setupID, achievementID: "pathfinder",
-                    userID: uid, submissionID: subID)
-                try? await badge.save(on: req.db)
+        if user.role == "student", let uid = user.id {
+            // First-to-submit records (Pathfinder) — the manifest's authored
+            // ones, or the registry default, minus any the instructor disabled.
+            let records = BuiltInAchievements.classRecordsForAward(
+                in: setup, disabled: BuiltInAchievements.disabled(in: setup))
+            for record in records where record.recordDimension == .firstToSubmit {
+                let exists =
+                    try await APIClassAchievement.query(on: req.db)
+                    .filter(\.$testSetupID == setupID)
+                    .filter(\.$achievementID == record.id)
+                    .first() != nil
+                if !exists {
+                    try? await APIClassAchievement(
+                        testSetupID: setupID, achievementID: record.id,
+                        userID: uid, submissionID: subID
+                    ).save(on: req.db)
+                }
             }
         }
 

--- a/Sources/Core/Achievement.swift
+++ b/Sources/Core/Achievement.swift
@@ -172,8 +172,11 @@ public enum RewardType: String, Codable, Sendable {
 
 /// The dimension a `classRecord` ranks students on.
 public enum RecordDimension: String, Codable, Sendable {
-    /// Earliest correct submission.
+    /// Earliest correct (100%) submission — the "Trailblazer" record.
     case firstToSolve
+    /// Earliest submission of any kind — the "Pathfinder" record (awarded at
+    /// submission time, not on reaching 100%).
+    case firstToSubmit
     /// Fastest execution time.
     case fastest
     /// Shortest solution.

--- a/Tests/APITests/ClassRecordManifestTests.swift
+++ b/Tests/APITests/ClassRecordManifestTests.swift
@@ -1,0 +1,50 @@
+// Tests/APITests/ClassRecordManifestTests.swift
+//
+// Unification A3: the class-record award logic (awardClassBadgesFor100Percent)
+// iterates the manifest's authored classRecord achievements by dimension when
+// present, instead of the hardcoded registry ids.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct ClassRecordManifestTests {
+
+    @Test func awardUsesManifestRecordsNotRegistry() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            // Manifest authors a single custom "fastest" record — the registry
+            // defaults (trailblazer / speed_champion / minimalist) must NOT apply.
+            let props = TestProperties(achievements: [
+                Achievement(
+                    id: "custom_speed", name: "Speedy", kind: .classRecord, scope: .classWide,
+                    reward: AchievementReward(type: .title, label: "Speedy"),
+                    recordDimension: .fastest)
+            ])
+            let manifest = try #require(String(bytes: try JSONEncoder().encode(props), encoding: .utf8))
+            let setup = APITestSetup(
+                id: "cr_setup", manifest: manifest,
+                zipPath: app.testSetupsDirectory + "cr_setup.zip", courseID: courseID)
+            try await setup.save(on: app.db)
+            let student = try await arInsertStudent(username: "cr_student", on: app)
+            let uid = try student.requireID()
+            _ = try await arInsertSubmission(
+                id: "cr_sub", testSetupID: "cr_setup", userID: uid, on: app)
+
+            try await awardClassBadgesFor100Percent(
+                testSetupID: "cr_setup", userID: uid, submissionID: "cr_sub",
+                executionTimeMs: 100, attemptNumber: 1, on: app.db)
+
+            let rows = try await APIClassAchievement.query(on: app.db)
+                .filter(\.$testSetupID == "cr_setup")
+                .all()
+            #expect(
+                rows.map(\.achievementID) == ["custom_speed"],
+                "Only the manifest's record is awarded — not the registry defaults")
+        }
+    }
+}

--- a/changelog.d/achievements-unify-a3.md
+++ b/changelog.d/achievements-unify-a3.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Achievements unification (A3): class-record awards are manifest-driven.**
+  `awardClassBadgesFor100Percent` and the Pathfinder award iterate the assignment
+  manifest's authored `classRecord` achievements by `recordDimension`
+  (firstToSolve / fastest / shortest / new firstToSubmit), falling back to the
+  built-in registry. Behavior-identical until a manifest authors class records.
+  The new `firstToSubmit` dimension distinguishes Pathfinder (first to submit)
+  from Trailblazer (first to solve).


### PR DESCRIPTION
## Achievements unification — A3 (manifest-driven class-record awards)

Third slice. The class-record award logic (`awardClassBadgesFor100Percent` + the Pathfinder award) now iterates the manifest's authored `classRecord` achievements **by `recordDimension`** instead of hardcoded ids — so seeded/edited/added class records take effect. **Behavior-identical** via registry fallback.

### How
- `BuiltInAchievements.classRecordsForAward(in: setup, disabled:)` returns the manifest's `classRecord` achievements (or the registry default when none), minus disabled.
- Awarded by dimension:
  | dimension | mechanic | default |
  |---|---|---|
  | `firstToSolve` | immutable, first to 100% | Trailblazer |
  | `fastest` | record on exec ms | Fastest |
  | `shortest` | record on attempts | Minimalist |
  | **`firstToSubmit`** *(new)* | immutable, on submit | Pathfinder |
- New `RecordDimension.firstToSubmit` cleanly separates **Pathfinder** (awarded at submission time) from **Trailblazer** (awarded on reaching 100%) — they previously shared `firstToSolve`. The disabled-skip moves into the helper's filter.

### Tests
The 11 existing award tests stay green (incl. `pathfinderAwardedToFirstStudentEvenAfterAdminSubmits` and `awardClassBadgesSkipsDisabledRecords`) — registry fallback = identical. New `ClassRecordManifestTests` proves a manifest's custom `fastest` record is awarded and the registry defaults are *not*. Build + `swift-format` + SwiftLint `--strict` clean.

### Rollout
A ✅ → A2 ✅ → **A3 (this)** → B (unified `/achievements` endpoint) → C (the editor table) → D (seed migration + cleanup). The backend is now fully manifest-driven; B/C/D are the endpoint + the visible single table + seeding.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_