### PR TITLE
Add addCases + dependsOn editing to MCP update_pattern_family

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -176,7 +176,9 @@ enum MCPServerInstructions {
         - get_suite returns the full source of truth for reading: hand-written script bodies, \
         complete pattern-family specs, and notebook-check specs. For authoring, update_pattern_family \
         edits a generated case's args/expected and its hint — per-case `hint` or the family-wide \
-        `defaultHint` (create_pattern_family takes the same), validated on save — and author_script \
+        `defaultHint` (create_pattern_family takes the same), validated on save — and can also append \
+        new cases (`addCases`) or replace the family's prerequisites (`dependsOn`) in place, so you \
+        rarely need to recreate a family to grow its coverage or drop a dependency. author_script \
         writes a single \
         hand-written file into the test setup. A test tier (public/release/secret/student) creates or \
         replaces the script AND its suite entry — set points/displayName/dependsOn/sectionID alongside \

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -307,7 +307,7 @@ struct CreatePatternFamilyTool: ContentTool {
         guard !input.cases.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "Provide at least one case.")
         }
-        try Self.assertUniqueCaseKeys(input.cases)
+        try Self.assertUniqueCaseKeys(input.cases, tool: Self.name)
 
         let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
             publicID: input.assignmentPublicID, tool: Self.name)
@@ -344,16 +344,19 @@ struct CreatePatternFamilyTool: ContentTool {
             assignmentClosed: closed)
     }
 
-    private static func assertUniqueCaseKeys(_ cases: [CaseInput]) throws {
+    /// Rejects empty or duplicate case keys.  Shared with
+    /// update_pattern_family's `addCases` path, so it takes the calling tool's
+    /// name for the error.
+    static func assertUniqueCaseKeys(_ cases: [CaseInput], tool: String) throws {
         var seen = Set<String>()
         for c in cases {
             let key = c.key.trimmingCharacters(in: .whitespaces)
             guard !key.isEmpty else {
-                throw MCPToolError.invalidArguments(tool: name, detail: "A case key must not be empty.")
+                throw MCPToolError.invalidArguments(tool: tool, detail: "A case key must not be empty.")
             }
             guard seen.insert(key).inserted else {
                 throw MCPToolError.invalidArguments(
-                    tool: name, detail: "Duplicate case key \"\(key)\".")
+                    tool: tool, detail: "Duplicate case key \"\(key)\".")
             }
         }
     }
@@ -367,22 +370,7 @@ struct CreatePatternFamilyTool: ContentTool {
             points: input.defaultPoints ?? 1,
             hint: normalizedHint(input.defaultHint),
             tolerance: input.tolerance)
-        let cases = try input.cases.map { c -> PatternCase in
-            let args = c.args ?? []
-            let provided =
-                try aligned(c.argsProvided, count: args.count, field: "argsProvided", key: c.key)
-                ?? [Bool](repeating: true, count: args.count)
-            let refs =
-                try aligned(c.argVarRefs, count: args.count, field: "argVarRefs", key: c.key)
-                ?? [String?](repeating: nil, count: args.count)
-            let ref = c.expectedVarRef.flatMap { $0.isEmpty ? nil : $0 }
-            return PatternCase(
-                key: c.key, label: c.label ?? c.key, args: args, expected: c.expected ?? .null,
-                argsProvided: provided, argVarRefs: refs, expectedVarRef: ref,
-                hint: normalizedHint(c.hint), tier: try parseOptionalTier(c.tier, tool: Self.name),
-                points: c.points,
-                enabled: c.enabled ?? true)
-        }
+        let cases = try input.cases.map { try patternCase(from: $0, tool: Self.name) }
         return PatternFamily(
             id: id, name: input.name, kind: kind, functionName: input.function ?? "",
             paramNames: input.paramNames ?? [], defaults: defaults, cases: cases,
@@ -390,13 +378,39 @@ struct CreatePatternFamilyTool: ContentTool {
             dependsOn: input.dependsOn ?? [])
     }
 
+    /// Builds one `PatternCase` from a case input, filling the parallel
+    /// `argsProvided` / `argVarRefs` arrays and normalising the hint and
+    /// per-student ref.  Shared with update_pattern_family's `addCases` path so a
+    /// new case is constructed identically however it is authored; all per-kind /
+    /// arity / ref legality is left to the validator that runs inside
+    /// applySuiteEdit.
+    static func patternCase(from c: CaseInput, tool: String) throws -> PatternCase {
+        let args = c.args ?? []
+        let provided =
+            try aligned(c.argsProvided, count: args.count, field: "argsProvided", key: c.key, tool: tool)
+            ?? [Bool](repeating: true, count: args.count)
+        let refs =
+            try aligned(c.argVarRefs, count: args.count, field: "argVarRefs", key: c.key, tool: tool)
+            ?? [String?](repeating: nil, count: args.count)
+        let ref = c.expectedVarRef.flatMap { $0.isEmpty ? nil : $0 }
+        return PatternCase(
+            key: c.key, label: c.label ?? c.key, args: args, expected: c.expected ?? .null,
+            argsProvided: provided, argVarRefs: refs, expectedVarRef: ref,
+            hint: normalizedHint(c.hint), tier: try parseOptionalTier(c.tier, tool: tool),
+            points: c.points,
+            enabled: c.enabled ?? true)
+    }
+
     /// Validates a parallel array's length against the args length, returning it
-    /// (or nil when the caller omitted it).
-    private static func aligned<T>(_ value: [T]?, count: Int, field: String, key: String) throws -> [T]? {
+    /// (or nil when the caller omitted it).  Shared with update_pattern_family's
+    /// `addCases` path, so it takes the calling tool's name for the error.
+    static func aligned<T>(
+        _ value: [T]?, count: Int, field: String, key: String, tool: String
+    ) throws -> [T]? {
         guard let value else { return nil }
         guard value.count == count else {
             throw MCPToolError.invalidArguments(
-                tool: name,
+                tool: tool,
                 detail: "case '\(key)': \(field) length (\(value.count)) must match args length (\(count)).")
         }
         return value
@@ -423,7 +437,7 @@ struct CreatePatternFamilyTool: ContentTool {
     /// Trims an empty hint to nil so an omitted/blank cell doesn't store an
     /// empty "💡 Hint" callout.  Matches the empty-string handling used for
     /// per-student refs.
-    private static func normalizedHint(_ raw: String?) -> String? {
+    static func normalizedHint(_ raw: String?) -> String? {
         guard let raw, !raw.isEmpty else { return nil }
         return raw
     }

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -74,11 +74,22 @@ struct UpdatePatternFamilyTool: ContentTool {
         let disableCases: [String]?
         /// Per-case `args` / `expected` edits (the test logic).
         let cases: [CaseEdit]?
+        /// Brand-new cases to append to the family. Each is a full case spec
+        /// (the same shape create_pattern_family takes); keys must not collide
+        /// with an existing case. nil/empty appends nothing — use `cases` to
+        /// edit a case that already exists.
+        let addCases: [CreatePatternFamilyTool.CaseInput]?
+        /// Replaces the family's prerequisites (script filenames or `family:<id>`
+        /// tokens). Pass `[]` to clear all prerequisites; omit (nil) to leave
+        /// them untouched. Expanded + cycle-checked by the same save path the
+        /// web editor uses.
+        let dependsOn: [String]?
 
         init(
             assignmentPublicID: String, familyID: String, defaultTier: String? = nil,
             defaultPoints: Int? = nil, defaultHint: String? = nil, enableCases: [String]? = nil,
-            disableCases: [String]? = nil, cases: [CaseEdit]? = nil
+            disableCases: [String]? = nil, cases: [CaseEdit]? = nil,
+            addCases: [CreatePatternFamilyTool.CaseInput]? = nil, dependsOn: [String]? = nil
         ) {
             self.assignmentPublicID = assignmentPublicID
             self.familyID = familyID
@@ -88,6 +99,8 @@ struct UpdatePatternFamilyTool: ContentTool {
             self.enableCases = enableCases
             self.disableCases = disableCases
             self.cases = cases
+            self.addCases = addCases
+            self.dependsOn = dependsOn
         }
     }
 
@@ -99,6 +112,8 @@ struct UpdatePatternFamilyTool: ContentTool {
         let enabledCaseKeys: [String]
         /// Keys of cases whose args/expected were edited by this call.
         let editedCaseKeys: [String]
+        /// Keys of cases appended by `addCases` in this call.
+        let addedCaseKeys: [String]
         let validationStatus: String?
         /// true when this edit closed a previously-open assignment (re-open with
         /// update_assignment once validation passes).
@@ -113,7 +128,11 @@ struct UpdatePatternFamilyTool: ContentTool {
         + "`hint` (the \"💡 Hint\" shown to the student only when that test fails; empty string clears "
         + "it), and/or edit individual cases' test logic via `cases` "
         + "(each { key, args?, expected? }). args/expected are raw JSON values (a list of args in "
-        + "parameter order, and the expected return). Saving regenerates the family's scripts and "
+        + "parameter order, and the expected return). Append brand-new cases with `addCases` (each a "
+        + "full { key, args, expected, ... } spec like create_pattern_family takes; keys must not "
+        + "already exist — use `cases` to edit an existing one). Replace the family's prerequisites with "
+        + "`dependsOn` (script filenames or `family:<id>` tokens; pass `[]` to clear them). Saving "
+        + "regenerates the family's scripts and "
         + "re-runs validation, which rejects a wrong arg count or an expected value of the wrong shape "
         + "for the family's kind. Saving also closes the assignment if it was open (re-open with "
         + "update_assignment once validation passes). Function-calling families carry an auto-generated "
@@ -193,6 +212,63 @@ struct UpdatePatternFamilyTool: ContentTool {
                     "additionalProperties": .bool(false),
                 ]),
             ]),
+            "addCases": .object([
+                "type": .string("array"),
+                "description": .string(
+                    "New cases to append (keys must not already exist; use `cases` to edit an "
+                        + "existing one)."),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "key": .object([
+                            "type": .string("string"),
+                            "description": .string("Unique case key (also part of the generated filename)."),
+                        ]),
+                        "label": .object(["type": .string("string")]),
+                        "args": .object([
+                            "type": .string("array"),
+                            "description": .string("Args in parameter order (raw JSON values)."),
+                        ]),
+                        "expected": .object([
+                            "description": .string("Expected return (raw JSON), shape per kind.")
+                        ]),
+                        "argVarRefs": .object([
+                            "type": .string("array"),
+                            "description": .string("Parallel to args: \"name\" for a $var ref, or null."),
+                        ]),
+                        "argsProvided": .object([
+                            "type": .string("array"),
+                            "description": .string("Parallel to args: false omits the arg (Python default)."),
+                        ]),
+                        "expectedVarRef": .object([
+                            "type": .string("string"),
+                            "description": .string("Per-student expected: name of a = expression."),
+                        ]),
+                        "hint": .object([
+                            "type": .string("string"),
+                            "description": .string(
+                                "Per-case \"💡 Hint\" shown when this case fails (overrides defaultHint)."),
+                        ]),
+                        "points": .object(["type": .string("integer")]),
+                        "tier": .object([
+                            "type": .string("string"),
+                            "enum": .array([
+                                .string("public"), .string("release"), .string("secret"),
+                                .string("student"),
+                            ]),
+                        ]),
+                        "enabled": .object(["type": .string("boolean")]),
+                    ]),
+                    "required": .array([.string("key")]),
+                    "additionalProperties": .bool(false),
+                ]),
+            ]),
+            "dependsOn": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+                "description": .string(
+                    "Replace the family's prerequisites (script filenames or family:<id> tokens). "
+                        + "Pass [] to clear them; omit to leave unchanged."),
+            ]),
         ]),
         "required": .array([.string("assignmentPublicID"), .string("familyID")]),
         "additionalProperties": .bool(false),
@@ -210,13 +286,16 @@ struct UpdatePatternFamilyTool: ContentTool {
             "editedCaseKeys": .object([
                 "type": .string("array"), "items": .object(["type": .string("string")]),
             ]),
+            "addedCaseKeys": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
             "validationStatus": .object(["type": .string("string")]),
             "assignmentClosed": .object(["type": .string("boolean")]),
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("familyID"), .string("defaultTier"),
             .string("defaultPoints"), .string("enabledCaseKeys"), .string("editedCaseKeys"),
-            .string("assignmentClosed"),
+            .string("addedCaseKeys"), .string("assignmentClosed"),
         ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
@@ -228,21 +307,24 @@ struct UpdatePatternFamilyTool: ContentTool {
         let enable = Set(input.enableCases ?? [])
         let disable = Set(input.disableCases ?? [])
         let caseEdits = input.cases ?? []
+        let addCases = input.addCases ?? []
         guard
             newTier != nil || input.defaultPoints != nil || input.defaultHint != nil
                 || !enable.isEmpty || !disable.isEmpty || !caseEdits.isEmpty
+                || !addCases.isEmpty || input.dependsOn != nil
         else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
                 detail:
                     "Specify at least one of: defaultTier, defaultPoints, defaultHint, enableCases, "
-                    + "disableCases, cases.")
+                    + "disableCases, cases, addCases, dependsOn.")
         }
         guard enable.isDisjoint(with: disable) else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "A case key cannot be in both enableCases and disableCases.")
         }
         let editsByKey = try Self.indexCaseEdits(caseEdits)
+        try CreatePatternFamilyTool.assertUniqueCaseKeys(addCases, tool: Self.name)
 
         let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
             publicID: input.assignmentPublicID, tool: Self.name)
@@ -265,6 +347,20 @@ struct UpdatePatternFamilyTool: ContentTool {
                 tool: Self.name,
                 detail: "Unknown case key(s): \(unknown.sorted().joined(separator: ", ")).")
         }
+        // New cases can't reuse an existing key (that would be an edit, not an
+        // add); per-kind/arity legality is left to the save-time validator.
+        let addKeys = Set(addCases.map { $0.key.trimmingCharacters(in: .whitespaces) })
+        let collisions = addKeys.intersection(caseKeys)
+        guard collisions.isEmpty else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail:
+                    "addCases key(s) already exist: \(collisions.sorted().joined(separator: ", ")). "
+                    + "Use `cases` to edit an existing case.")
+        }
+        let newCases = try addCases.map {
+            try CreatePatternFamilyTool.patternCase(from: $0, tool: Self.name)
+        }
 
         let newDefaults = PatternDefaults(
             tier: newTier ?? family.defaults.tier,
@@ -272,8 +368,18 @@ struct UpdatePatternFamilyTool: ContentTool {
             hint: Self.resolveHintEdit(input.defaultHint, existing: family.defaults.hint),
             tolerance: family.defaults.tolerance)
         let updatedFamily = try Self.rebuild(
-            family, defaults: newDefaults, enable: enable, disable: disable, edits: editsByKey)
+            family, defaults: newDefaults,
+            changes: CaseChanges(
+                enable: enable, disable: disable, edits: editsByKey, newCases: newCases),
+            dependsOn: input.dependsOn)
         payload.items[idx].family = updatedFamily
+        // The family's row-level dependsOn wins over `family.dependsOn` in
+        // applySuiteEdit, so when the caller replaces deps, mirror the new value
+        // onto the row too — otherwise the stale row value would override the
+        // family spec on save.
+        if let newDeps = input.dependsOn {
+            payload.items[idx].dependsOn = newDeps
+        }
 
         // applySuiteEdit -> applyPatternFamilies -> validatePatternFamilies runs
         // the structural + per-kind case checks synchronously; surface those as
@@ -290,6 +396,7 @@ struct UpdatePatternFamilyTool: ContentTool {
             defaultPoints: updatedFamily.defaults.points,
             enabledCaseKeys: updatedFamily.cases.filter(\.enabled).map(\.key),
             editedCaseKeys: editsByKey.keys.sorted(),
+            addedCaseKeys: newCases.map(\.key),
             validationStatus: assignment.validationStatus,
             assignmentClosed: closed)
     }
@@ -307,23 +414,35 @@ struct UpdatePatternFamilyTool: ContentTool {
         return byKey
     }
 
-    /// Reconstructs the family with the resolved `defaults`, per-case enabled
-    /// flags, and per-case arg/expected/hint edits; every other field is copied
-    /// verbatim.
+    /// The case-level changes a rebuild applies: which existing cases to
+    /// enable/disable, per-case arg/expected/hint edits, and brand-new cases to
+    /// append.  Grouped so `rebuild` stays within the parameter-count budget.
+    private struct CaseChanges {
+        let enable: Set<String>
+        let disable: Set<String>
+        let edits: [String: CaseEdit]
+        let newCases: [PatternCase]
+    }
+
+    /// Reconstructs the family with the resolved `defaults` and `changes`
+    /// (enable/disable flags, per-case arg/expected/hint edits, and any new
+    /// cases appended after the existing ones), with `dependsOn` replaced when
+    /// provided (nil keeps the existing prerequisites); every other field is
+    /// copied verbatim.
     private static func rebuild(
         _ family: PatternFamily, defaults: PatternDefaults,
-        enable: Set<String>, disable: Set<String>, edits: [String: CaseEdit]
+        changes: CaseChanges, dependsOn: [String]?
     ) throws -> PatternFamily {
         let cases = try family.cases.map { caseSpec -> PatternCase in
             let enabled =
-                enable.contains(caseSpec.key)
-                ? true : (disable.contains(caseSpec.key) ? false : caseSpec.enabled)
-            return try applyCaseEdit(edits[caseSpec.key], to: caseSpec, enabled: enabled)
+                changes.enable.contains(caseSpec.key)
+                ? true : (changes.disable.contains(caseSpec.key) ? false : caseSpec.enabled)
+            return try applyCaseEdit(changes.edits[caseSpec.key], to: caseSpec, enabled: enabled)
         }
         return PatternFamily(
             id: family.id, name: family.name, kind: family.kind, functionName: family.functionName,
-            paramNames: family.paramNames, defaults: defaults, cases: cases,
-            variables: family.variables, dependsOn: family.dependsOn)
+            paramNames: family.paramNames, defaults: defaults, cases: cases + changes.newCases,
+            variables: family.variables, dependsOn: dependsOn ?? family.dependsOn)
     }
 
     /// Applies one case's arg/expected edit, keeping the parallel

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -386,4 +386,113 @@ import Vapor
             }
         }
     }
+
+    @Test func addsNewCases() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    addCases: [
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "04", label: "BMI 40.5 is obese",
+                            args: [.double(40.5)], expected: .string("obese")),
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "05", label: "BMI 17.5 is underweight",
+                            args: [.double(17.5)], expected: .string("underweight")),
+                    ]),
+                context(app))
+            #expect(output.addedCaseKeys == ["04", "05"])
+            #expect(output.enabledCaseKeys == ["01", "02", "03", "04", "05"])
+
+            let family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.cases.count == 5)
+            let added = try #require(family.cases.first { $0.key == "04" })
+            #expect(added.args == [.double(40.5)])
+            #expect(added.expected == .string("obese"))
+            #expect(added.enabled == true)
+            // Existing cases are preserved.
+            #expect(family.cases.first { $0.key == "01" }?.expected == .string("underweight"))
+        }
+    }
+
+    @Test func addCaseWithExistingKeyThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Key "01" already exists — adding it is a collision; the caller
+            // should edit via `cases` instead.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        addCases: [
+                            CreatePatternFamilyTool.CaseInput(
+                                key: "01", args: [.double(19.0)], expected: .string("normal"))
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func addCaseWrongArgCountThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // BMI declares one parameter; a new case with two args must be
+            // rejected by the kind validation that runs on save.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        addCases: [
+                            CreatePatternFamilyTool.CaseInput(
+                                key: "99", args: [.double(1.0), .double(2.0)],
+                                expected: .string("x"))
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func editsAndClearsDependsOn() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Seed two families so one can depend on the other.
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            let setup = try await makeTestSetup(
+                on: app, id: "setup_pf", courseID: courseID, manifest: emptyManifest)
+            try pfWriteEmptyZip(at: app.testSetupsDirectory + "setup_pf.zip")
+            try await applyPatternFamilies(
+                to: setup, nextFamilies: [pfBMIFamily(), pfApproxFamily()],
+                authoredItems: [
+                    .family(id: "bmi_category", sectionID: nil),
+                    .family(id: "bmi_kg_m2", sectionID: nil),
+                ], on: app.db)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_pf", courseID: courseID, title: "Lab")
+
+            // Add a prerequisite via a family:<id> token.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    dependsOn: ["family:bmi_kg_m2"]),
+                context(app))
+            var family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.dependsOn == ["family:bmi_kg_m2"])
+
+            // Clearing with [] drops the prerequisite again.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    dependsOn: []),
+                context(app))
+            family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.dependsOn.isEmpty)
+        }
+    }
 }

--- a/changelog.d/mcp-update-pattern-family-addcases-dependson.md
+++ b/changelog.d/mcp-update-pattern-family-addcases-dependson.md
@@ -1,0 +1,11 @@
+### Added
+
+- **MCP `update_pattern_family` can now grow and re-wire a family in place.** The
+  tool gained `addCases` (append brand-new cases to an existing pattern family;
+  keys must not collide with an existing case) and `dependsOn` (replace the
+  family's prerequisites — script filenames or `family:<id>` tokens, `[]` to
+  clear). Previously an agent had to delete and recreate a whole family just to
+  add coverage or drop a redundant prerequisite, which the safety classifier
+  rightly blocks as destructive. Case-building logic is now shared with
+  `create_pattern_family` so the two tools can't drift, and the response reports
+  the appended `addedCaseKeys`.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -45,7 +45,7 @@ course-scoped:
 | `create_suite_section` / `rename_suite_section` / `delete_suite_section` | `content:write` | Manage an assignment's test-suite sections (display groups) |
 | `move_suite_item` | `content:write` | Move a script/family/check into a suite section, or ungroup it |
 | `create_pattern_family` | `content:write` | Create a new pattern family: kind, function, cases (args/expected/hint), defaults (tier/points/`defaultHint`) |
-| `update_pattern_family` | `content:write` | Family defaults (tier/points/`defaultHint`) + per-case args/expected/hint (incl. per-student `$ref`s), enable/disable |
+| `update_pattern_family` | `content:write` | Family defaults (tier/points/`defaultHint`) + per-case args/expected/hint (incl. per-student `$ref`s), enable/disable, append new cases (`addCases`), replace prerequisites (`dependsOn`) |
 | `delete_suite_item` | `content:write` | Remove a script, family (+ its cases), or notebook check from the suite |
 | `author_notebook_check` | `content:write` | Create/replace a notebook check (DataFrame shape/columns/equality, figures, AST, …) |
 | `author_script` | `content:write` | Escape hatch: create/replace a hand-written test (prefer a pattern family / notebook check) or a non-graded support file |


### PR DESCRIPTION
## Why

While tidying a lab's test suite over MCP, I hit two gaps in `update_pattern_family` that forced a destructive workaround:

1. **Removing a redundant prerequisite** required clearing a family's `dependsOn` — but there was no parameter to do it. The only path was delete-and-recreate the whole family.
2. **Adding test coverage** required new cases — but `cases` only edits *existing* keys ("Unknown case key"). Again, the only path was recreate.

Delete-and-recreate of a family is (correctly) blocked by the auto-mode safety classifier, since from the outside it looks like destroying a section's real tests. This PR closes both gaps so the common authoring moves are non-destructive, in-place edits.

## What

`update_pattern_family` gains:

- **`addCases`** — append brand-new cases to an existing family. Each is a full case spec (the same shape `create_pattern_family` takes); a key that already exists is rejected (use `cases` to edit it). The response reports the appended `addedCaseKeys`.
- **`dependsOn`** — replace the family's prerequisites (script filenames or `family:<id>` tokens; pass `[]` to clear). The row-level `dependsOn` is mirrored onto the suite item too, because `applySuiteEdit` lets the row value win over `family.dependsOn` (`SuiteEditHelpers.swift`).

Both ride the existing `applySuiteEdit → applyPatternFamilies → validatePatternFamilies` save path, so arg-count / per-kind / cycle validation still runs synchronously and rejects a bad edit.

## Refactor

Case construction (`CaseInput`, `patternCase(from:tool:)`, `aligned`, `normalizedHint`, `assertUniqueCaseKeys`) is hoisted to shared static helpers on `CreatePatternFamilyTool` so the create and update paths build a case identically and can't drift. No behavior change to `create_pattern_family`.

## Docs / agent copy kept in sync

- Tool `description` + input/output schemas
- Server-level `MCPServerInstructions` (the `initialize` handshake)
- `docs/mcp-authoring-roadmap.md` tool table

## Tests

New cases in `UpdatePatternFamilyToolTests`: appending cases, key-collision rejection, save-time arg-count rejection for an added case, and setting/clearing `dependsOn`. Existing `Create`/`Update` suites still pass (32 tests green); build + `swift-format` + SwiftLint `--strict` all clean.

## Context

Follow-up to a test-suite tidy-up session (HLTH 230 Lab 3) where this limitation surfaced. No version files touched; a `changelog.d/` fragment is included.

https://claude.ai/code/session_01G7Ms9uEA5qAMt1NmGmNgKn

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7Ms9uEA5qAMt1NmGmNgKn)_