### PR TITLE
feat(achievements): unified /achievements endpoint (unification B)

### DIFF
--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
@@ -29,11 +29,15 @@ extension PublishedAssignmentRoutes {
     }
 
     struct AchievementsBody: Content {
-        var goals: [ClassGoalInput]
+        /// Legacy class-goals-card shape (replaces only the class-goal subset).
+        var goals: [ClassGoalInput]?
+        /// Unified shape (replaces the entire achievements list).  Wins when present.
+        var achievements: [AchievementInput]?
     }
 
     struct AchievementsResponse: Content {
         var goals: [ClassGoalInput]
+        var achievements: [AchievementInput]
     }
 
     // MARK: - GET /instructor/:assignmentID/achievements
@@ -41,7 +45,13 @@ extension PublishedAssignmentRoutes {
     @Sendable
     func getAchievements(req: Request) async throws -> AchievementsResponse {
         let (_, setup) = try await loadAssignmentAndSetup(req)
-        return AchievementsResponse(goals: classGoalRows(fromManifest: setup.manifest))
+        return makeAchievementsResponse(fromManifest: setup.manifest)
+    }
+
+    private func makeAchievementsResponse(fromManifest manifest: String) -> AchievementsResponse {
+        AchievementsResponse(
+            goals: classGoalRows(fromManifest: manifest),
+            achievements: unifiedAchievementRows(fromManifest: manifest))
     }
 
     // MARK: - PUT /instructor/:assignmentID/achievements
@@ -51,20 +61,25 @@ extension PublishedAssignmentRoutes {
         let (_, setup) = try await loadAssignmentAndSetup(req)
         let body = try req.content.decode(AchievementsBody.self)
 
-        let newGoals = try body.goals.map { try achievement(from: $0) }
-
-        // Preserve any non-class-goal achievements; replace the class-goal set.
-        let existing =
-            (try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8)))?
-            .achievements ?? []
-        let merged = existing.filter { $0.kind != .classGoal } + newGoals
+        let merged: [Achievement]
+        if let unified = body.achievements {
+            // Unified shape: replace the entire achievements list.
+            merged = try unified.map { try achievement(fromUnified: $0) }
+        } else {
+            // Legacy class-goals shape: replace only the class-goal subset.
+            let newGoals = try (body.goals ?? []).map { try achievement(from: $0) }
+            let existing =
+                (try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8)))?
+                .achievements ?? []
+            merged = existing.filter { $0.kind != .classGoal } + newGoals
+        }
 
         try await mutateManifest(setup: setup, on: req.db) { dict in
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
             dict["achievements"] = try JSONSerialization.jsonObject(with: encoder.encode(merged))
         }
-        return AchievementsResponse(goals: classGoalRows(fromManifest: setup.manifest))
+        return makeAchievementsResponse(fromManifest: setup.manifest)
     }
 
     // MARK: - Conversions

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+UnifiedAchievements.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+UnifiedAchievements.swift
@@ -1,0 +1,160 @@
+// APIServer/Routes/Web/PublishedAssignmentRoutes+UnifiedAchievements.swift
+//
+// Unification B — the typed, all-kinds achievement row used by the single
+// "Achievements" editor table.  `AchievementInput` is a flat, editor-friendly
+// projection of `Achievement`: one row per achievement of any kind, with the
+// kind-specific parameters as optional fields.  `achievement(fromUnified:)`
+// validates + converts a row to the domain model; `achievementInput(from:)` is
+// the reverse for GET.  The PUT/GET handlers live in
+// `PublishedAssignmentRoutes+Achievements.swift`.
+
+import Core
+import Foundation
+import Vapor
+
+extension PublishedAssignmentRoutes {
+
+    /// One row in the unified Achievements table — any kind.
+    struct AchievementInput: Content {
+        var id: String?
+        var name: String
+        /// Raw `AchievementKind` value (classGoal / thresholdBadge / testBadge /
+        /// firstTryPerfect / comeback / persistence / speedRun / classRecord).
+        var kind: String
+        var detail: String?
+        /// Grade cutoff %, 0–100 (classGoal + thresholdBadge target, and the
+        /// grade gate for firstTryPerfect / persistence / speedRun).
+        var thresholdPercent: Double?
+        /// classGoal: share of the class, 0–100.
+        var classPercent: Double?
+        /// classGoal: positive bonus points.
+        var points: Int?
+        /// testBadge: the test filename that must pass.
+        var testName: String?
+        /// classRecord: raw `RecordDimension`.
+        var recordDimension: String?
+        /// firstTryPerfect (max) / persistence (min) attempt cutoff.
+        var attemptThreshold: Int?
+        /// speedRun: total-execution cutoff in ms.
+        var timeThresholdMs: Int?
+        /// comeback: minimum grade jump in percentage points.
+        var jumpThresholdPercent: Int?
+    }
+
+    func achievement(fromUnified input: AchievementInput) throws -> Achievement {
+        let name = input.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            throw WebAssignmentError.invalidParameter(name: "name", reason: "Name must not be empty.")
+        }
+        guard let kind = AchievementKind(rawValue: input.kind) else {
+            throw WebAssignmentError.invalidParameter(
+                name: "kind", reason: "Unknown achievement kind '\(input.kind)'.")
+        }
+        let id = unifiedAchievementID(input.id)
+        let detail = input.detail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanDetail = (detail?.isEmpty == false) ? detail : nil
+
+        switch kind {
+        case .classGoal:
+            return try classGoalAchievement(input, id: id, name: name, detail: cleanDetail)
+        case .thresholdBadge:
+            return Achievement(
+                id: id, name: name, detail: cleanDetail, kind: .thresholdBadge, scope: .individual,
+                reward: AchievementReward(type: .badge, label: name),
+                target: AchievementTarget(kind: .assignmentGrade),
+                threshold: try gradeFraction(input.thresholdPercent, fallback: 0.9))
+        case .testBadge:
+            let test = (input.testName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !test.isEmpty else {
+                throw WebAssignmentError.invalidParameter(
+                    name: "testName", reason: "A test badge needs the filename of the test that must pass.")
+            }
+            return Achievement(
+                id: id, name: name, detail: cleanDetail, kind: .testBadge, scope: .individual,
+                reward: AchievementReward(type: .badge, label: name),
+                target: AchievementTarget(kind: .testPass, ref: test))
+        case .firstTryPerfect, .persistence:
+            return Achievement(
+                id: id, name: name, detail: cleanDetail, kind: kind, scope: .individual,
+                reward: AchievementReward(type: .badge, label: name),
+                target: AchievementTarget(kind: .assignmentGrade),
+                threshold: try gradeFraction(input.thresholdPercent, fallback: 1.0),
+                attemptThreshold: input.attemptThreshold ?? (kind == .firstTryPerfect ? 1 : 5))
+        case .comeback:
+            return Achievement(
+                id: id, name: name, detail: cleanDetail, kind: .comeback, scope: .individual,
+                reward: AchievementReward(type: .badge, label: name),
+                target: AchievementTarget(kind: .assignmentGrade),
+                jumpThresholdPercent: input.jumpThresholdPercent ?? 50)
+        case .speedRun:
+            return Achievement(
+                id: id, name: name, detail: cleanDetail, kind: .speedRun, scope: .individual,
+                reward: AchievementReward(type: .badge, label: name),
+                target: AchievementTarget(kind: .assignmentGrade),
+                threshold: try gradeFraction(input.thresholdPercent, fallback: 1.0),
+                timeThresholdMs: input.timeThresholdMs ?? 2_000)
+        case .classRecord:
+            guard let dim = RecordDimension(rawValue: input.recordDimension ?? "firstToSolve") else {
+                throw WebAssignmentError.invalidParameter(
+                    name: "recordDimension", reason: "Unknown record dimension '\(input.recordDimension ?? "")'.")
+            }
+            return Achievement(
+                id: id, name: name, detail: cleanDetail, kind: .classRecord, scope: .classWide,
+                reward: AchievementReward(type: .title, label: name), recordDimension: dim)
+        }
+    }
+
+    private func classGoalAchievement(
+        _ input: AchievementInput, id: String, name: String, detail: String?
+    ) throws -> Achievement {
+        guard let classPercent = input.classPercent, (0...100).contains(classPercent) else {
+            throw WebAssignmentError.invalidParameter(
+                name: "classPercent", reason: "Class share must be 0–100.")
+        }
+        let points = input.points ?? 0
+        guard points >= 0 else {
+            throw WebAssignmentError.invalidParameter(name: "points", reason: "Bonus points must be ≥ 0.")
+        }
+        return Achievement(
+            id: id, name: name, detail: detail, kind: .classGoal, scope: .classWide,
+            reward: AchievementReward(type: .points, label: name, points: points),
+            target: AchievementTarget(kind: .assignmentGrade),
+            threshold: try gradeFraction(input.thresholdPercent, fallback: 0),
+            classFraction: classPercent / 100)
+    }
+
+    /// Validates a 0–100 grade % and returns the 0…1 fraction; `fallback` (a
+    /// fraction) is used when the field is absent.
+    private func gradeFraction(_ percent: Double?, fallback: Double) throws -> Double {
+        let pct = percent ?? (fallback * 100)
+        guard (0...100).contains(pct) else {
+            throw WebAssignmentError.invalidParameter(
+                name: "thresholdPercent", reason: "Grade threshold must be 0–100.")
+        }
+        return pct / 100
+    }
+
+    private func unifiedAchievementID(_ id: String?) -> String {
+        if let id, !id.isEmpty { return id }
+        return "ach_\(UUID().uuidString.prefix(8))"
+    }
+
+    func achievementInput(from a: Achievement) -> AchievementInput {
+        AchievementInput(
+            id: a.id, name: a.name, kind: a.kind.rawValue, detail: a.detail,
+            thresholdPercent: a.threshold.map { $0 * 100 },
+            classPercent: a.classFraction.map { $0 * 100 },
+            points: a.reward.points,
+            testName: a.target.kind == .testPass ? a.target.ref : nil,
+            recordDimension: a.recordDimension?.rawValue,
+            attemptThreshold: a.attemptThreshold,
+            timeThresholdMs: a.timeThresholdMs,
+            jumpThresholdPercent: a.jumpThresholdPercent)
+    }
+
+    func unifiedAchievementRows(fromManifest manifest: String) -> [AchievementInput] {
+        guard let props = try? JSONDecoder().decode(TestProperties.self, from: Data(manifest.utf8))
+        else { return [] }
+        return props.achievements.map(achievementInput(from:))
+    }
+}

--- a/Tests/APITests/UnifiedAchievementsTests.swift
+++ b/Tests/APITests/UnifiedAchievementsTests.swift
@@ -1,0 +1,127 @@
+// Tests/APITests/UnifiedAchievementsTests.swift
+//
+// Unification B: the single /achievements endpoint round-trips the whole typed
+// Achievement list (any kind) via the `achievements` field, while the legacy
+// `goals` shape still works for back-compat.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct UnifiedAchievementsTests {
+
+    private func row(
+        _ name: String, _ kind: String,
+        thresholdPercent: Double? = nil, classPercent: Double? = nil, points: Int? = nil,
+        testName: String? = nil, recordDimension: String? = nil, timeThresholdMs: Int? = nil
+    ) -> PublishedAssignmentRoutes.AchievementInput {
+        .init(
+            id: nil, name: name, kind: kind, detail: nil,
+            thresholdPercent: thresholdPercent, classPercent: classPercent, points: points,
+            testName: testName, recordDimension: recordDimension, attemptThreshold: nil,
+            timeThresholdMs: timeThresholdMs, jumpThresholdPercent: nil)
+    }
+
+    @Test func unifiedListRoundTripsEveryKind() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "ua_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ua_setup", title: "UA", isOpen: true, on: app)
+
+            let rows = [
+                row("Mastery", "classGoal", thresholdPercent: 80, classPercent: 75, points: 5),
+                row("Sharpshooter", "thresholdBadge", thresholdPercent: 90),
+                row("Recursion", "testBadge", testName: "secrettest_rec.py"),
+                row("Speedy", "classRecord", recordDimension: "fastest"),
+                row("Lightning", "speedRun", thresholdPercent: 100, timeThresholdMs: 500),
+            ]
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.AchievementsBody(goals: nil, achievements: rows),
+                        as: .json)
+                },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            let setup = try #require(try await APITestSetup.find("ua_setup", on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.achievements.count == 5)
+            #expect(
+                props.achievements.contains {
+                    $0.kind == .classGoal && $0.threshold == 0.8 && $0.classFraction == 0.75
+                        && $0.reward.points == 5
+                })
+            #expect(props.achievements.contains { $0.kind == .thresholdBadge && $0.threshold == 0.9 })
+            #expect(props.achievements.contains { $0.kind == .testBadge && $0.target.ref == "secrettest_rec.py" })
+            #expect(props.achievements.contains { $0.kind == .classRecord && $0.recordDimension == .fastest })
+            #expect(props.achievements.contains { $0.kind == .speedRun && $0.timeThresholdMs == 500 })
+
+            // GET returns the unified rows AND the legacy class-goal projection.
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(PublishedAssignmentRoutes.AchievementsResponse.self)
+                    #expect(body.achievements.count == 5)
+                    #expect(body.goals.count == 1, "Legacy goals projection still works")
+                })
+        }
+    }
+
+    @Test func unifiedReplacesWholeListLegacyGoalsPreserveOthers() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "ur_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "ur_setup", title: "UR", isOpen: true, on: app)
+
+            // Seed a badge + a goal via the unified PUT.
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.AchievementsBody(
+                            goals: nil,
+                            achievements: [
+                                row("Goal", "classGoal", thresholdPercent: 80, classPercent: 80, points: 3),
+                                row("Badge", "thresholdBadge", thresholdPercent: 90),
+                            ]), as: .json)
+                },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            // A legacy goals-only PUT replaces just the class goals, preserving the badge.
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.AchievementsBody(
+                            goals: [
+                                .init(id: nil, name: "Goal2", thresholdPercent: 70, classPercent: 60, bonusPoints: 2)
+                            ],
+                            achievements: nil), as: .json)
+                },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            let setup = try #require(try await APITestSetup.find("ur_setup", on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.achievements.contains { $0.kind == .thresholdBadge }, "Badge preserved")
+            #expect(props.achievements.filter { $0.kind == .classGoal }.map(\.name) == ["Goal2"])
+        }
+    }
+}

--- a/changelog.d/achievements-unify-b.md
+++ b/changelog.d/achievements-unify-b.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Achievements unification (B): one typed `/achievements` endpoint.**
+  `GET`/`PUT /instructor/:id/achievements` now round-trips the whole typed
+  `Achievement` list — every kind (class goals, threshold/test badges, class
+  records, and the per-submission kinds) — via an `achievements` field with
+  per-kind validation. The legacy `goals` shape still works (replaces only the
+  class-goal subset), so the existing Class Goals card is unaffected until the
+  unified editor table lands.


### PR DESCRIPTION
## Achievements unification — B (one typed `/achievements` endpoint)

Fourth slice. `GET`/`PUT /instructor/:id/achievements` now round-trips the **whole typed `Achievement` list** — every kind — so the unified editor table (C) has one endpoint to drive.

### How
- New **`AchievementInput`** — a flat, editor-friendly projection of `Achievement` (one row per achievement, kind-specific params as optional fields) + `achievement(fromUnified:)` (per-kind validation) and `achievementInput(from:)` (reverse, for GET).
- The body accepts **either** `{ achievements: [...] }` (unified — replaces the whole list) **or** the legacy `{ goals: [...] }` (class-goal subset only). GET returns **both** projections (`goals` + `achievements`), so the existing **Class Goals card keeps working** until C swaps it.

### Tests
`UnifiedAchievementsTests`: a 5-kind round-trip (class goal / threshold badge / test badge / class record / speed badge — asserts thresholds, dimension, time cutoff persisted) + a legacy-`goals`-preserves-the-badge check. The legacy `AchievementAuthoringTests` stay green. Build + `swift-format` + SwiftLint `--strict` clean.

### Rollout — backend done after this
A ✅ → A2 ✅ → A3 ✅ → **B (this)** → **C (the editor table — the visible change)** → D (seed migration + retire `/badges`, `/built-in-awards`, the legacy `goals` shape). After B, everything's in place for C to render the single table.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_