### PR TITLE
feat(achievements): seed-on-first-save flag for the unified editor (unification C1)

### DIFF
--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -155,7 +155,8 @@ func makeWorkerManifestJSON(
     globalVariables: [FamilyVariable] = [],
     globalExpressions: [PersonalizationExpression] = [],
     achievements: [Achievement] = [],
-    disabledBuiltInAwardIDs: [String] = []
+    disabledBuiltInAwardIDs: [String] = [],
+    builtInAchievementsSeeded: Bool = false
 ) throws -> String {
     // Topologically sort so the runner can process dependencies with a single
     // linear pass (parents always appear before children in the array).
@@ -202,6 +203,9 @@ func makeWorkerManifestJSON(
     try spliceEncodedArray(into: &manifest, key: "achievements", values: achievements)
     if !disabledBuiltInAwardIDs.isEmpty {
         manifest["disabledBuiltInAwardIDs"] = disabledBuiltInAwardIDs
+    }
+    if builtInAchievementsSeeded {
+        manifest["builtInAchievementsSeeded"] = true
     }
 
     let data = try JSONSerialization.data(withJSONObject: manifest)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
@@ -62,6 +62,7 @@ extension PublishedAssignmentRoutes {
         let body = try req.content.decode(AchievementsBody.self)
 
         let merged: [Achievement]
+        let isUnified = body.achievements != nil
         if let unified = body.achievements {
             // Unified shape: replace the entire achievements list.
             merged = try unified.map { try achievement(fromUnified: $0) }
@@ -78,6 +79,9 @@ extension PublishedAssignmentRoutes {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
             dict["achievements"] = try JSONSerialization.jsonObject(with: encoder.encode(merged))
+            // A unified save means the instructor curated the full list — the
+            // manifest is now authoritative (built-in defaults no longer merge in).
+            if isUnified { dict["builtInAchievementsSeeded"] = true }
         }
         return makeAchievementsResponse(fromManifest: setup.manifest)
     }

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+UnifiedAchievements.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+UnifiedAchievements.swift
@@ -152,9 +152,20 @@ extension PublishedAssignmentRoutes {
             jumpThresholdPercent: a.jumpThresholdPercent)
     }
 
+    /// The rows shown in the unified editor table.  Until the instructor first
+    /// saves the table (`builtInAchievementsSeeded`), the built-in defaults the
+    /// manifest hasn't authored yet are merged in so they appear as editable
+    /// rows; after seeding, the manifest is authoritative (a removed built-in
+    /// stays removed).
     func unifiedAchievementRows(fromManifest manifest: String) -> [AchievementInput] {
         guard let props = try? JSONDecoder().decode(TestProperties.self, from: Data(manifest.utf8))
-        else { return [] }
-        return props.achievements.map(achievementInput(from:))
+        else { return BuiltInAchievements.all.map(achievementInput(from:)) }
+        let authored = props.achievements
+        guard !props.builtInAchievementsSeeded else {
+            return authored.map(achievementInput(from:))
+        }
+        let authoredIDs = Set(authored.map(\.id))
+        let defaults = BuiltInAchievements.all.filter { !authoredIDs.contains($0.id) }
+        return (authored + defaults).map(achievementInput(from:))
     }
 }

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -759,7 +759,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         globalVariables: resolvedGlobalVariables,
         globalExpressions: resolvedGlobalExpressions,
         achievements: props.achievements,
-        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs
+        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
+        builtInAchievementsSeeded: props.builtInAchievementsSeeded
     )
 
     // Belt-and-suspenders: the post-expansion manifest is the one the runner

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -257,6 +257,11 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// award + display paths skip any id listed here.  Stripped from the
     /// runner-facing manifest (awards are server-side) via the memberwise default.
     public let disabledBuiltInAwardIDs: [String]
+    /// True once the instructor has saved the unified Achievements table.  Until
+    /// then the editor merges the built-in defaults in for display; after, the
+    /// manifest's `achievements` is authoritative (so a removed built-in stays
+    /// removed).  Stripped from the runner manifest via the memberwise default.
+    public let builtInAchievementsSeeded: Bool
 
     public init(
         schemaVersion: Int = 1,
@@ -273,6 +278,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         globalExpressions: [PersonalizationExpression] = [],
         achievements: [Achievement] = [],
         disabledBuiltInAwardIDs: [String] = [],
+        builtInAchievementsSeeded: Bool = false,
         testItems: [TestItem]? = nil
     ) {
         self.schemaVersion = schemaVersion
@@ -294,6 +300,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         self.globalExpressions = globalExpressions
         self.achievements = achievements
         self.disabledBuiltInAwardIDs = disabledBuiltInAwardIDs
+        self.builtInAchievementsSeeded = builtInAchievementsSeeded
     }
 
     public init(from decoder: Decoder) throws {
@@ -327,6 +334,8 @@ public struct TestProperties: Codable, Equatable, Sendable {
         achievements = try c.decodeIfPresent([Achievement].self, forKey: .achievements) ?? []
         disabledBuiltInAwardIDs =
             try c.decodeIfPresent([String].self, forKey: .disabledBuiltInAwardIDs) ?? []
+        builtInAchievementsSeeded =
+            try c.decodeIfPresent(Bool.self, forKey: .builtInAchievementsSeeded) ?? false
     }
 
     // `patternFamilies` / `notebookChecks` are computed (derived from
@@ -349,6 +358,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         case globalExpressions
         case achievements
         case disabledBuiltInAwardIDs
+        case builtInAchievementsSeeded
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -370,6 +380,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         try c.encode(globalExpressions, forKey: .globalExpressions)
         try c.encode(achievements, forKey: .achievements)
         try c.encode(disabledBuiltInAwardIDs, forKey: .disabledBuiltInAwardIDs)
+        try c.encode(builtInAchievementsSeeded, forKey: .builtInAchievementsSeeded)
     }
 
     /// Manifest view shipped to runners.  Pattern families and notebook

--- a/Tests/APITests/AchievementSeedTests.swift
+++ b/Tests/APITests/AchievementSeedTests.swift
@@ -1,0 +1,72 @@
+// Tests/APITests/AchievementSeedTests.swift
+//
+// Unification C1: the unified GET merges the built-in defaults into the editor
+// rows until the instructor first saves the table (builtInAchievementsSeeded),
+// after which the manifest is authoritative — so a removed built-in stays gone.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementSeedTests {
+
+    @Test func defaultsMergeUntilSeededThenManifestIsAuthoritative() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "seed_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "seed_setup", title: "Seed", isOpen: true, on: app)
+
+            // Before any save: the 8 built-in defaults appear as editable rows.
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(PublishedAssignmentRoutes.AchievementsResponse.self)
+                    #expect(body.achievements.count == 8)
+                    #expect(body.achievements.contains { $0.id == "first_try_perfect" })
+                    #expect(body.achievements.contains { $0.id == "trailblazer" })
+                })
+
+            // A unified save with a single custom achievement removes all built-ins.
+            try await app.asyncTest(
+                .PUT, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(
+                        PublishedAssignmentRoutes.AchievementsBody(
+                            goals: nil,
+                            achievements: [
+                                .init(
+                                    id: nil, name: "Solo", kind: "thresholdBadge", detail: nil,
+                                    thresholdPercent: 90, classPercent: nil, points: nil,
+                                    testName: nil, recordDimension: nil, attemptThreshold: nil,
+                                    timeThresholdMs: nil, jumpThresholdPercent: nil)
+                            ]), as: .json)
+                },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            // After seeding: only the curated row — the built-ins stay removed.
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/achievements",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(PublishedAssignmentRoutes.AchievementsResponse.self)
+                    #expect(body.achievements.map(\.name) == ["Solo"])
+                    #expect(!body.achievements.contains { $0.id == "first_try_perfect" })
+                })
+
+            let setup = try #require(try await APITestSetup.find("seed_setup", on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.builtInAchievementsSeeded)
+        }
+    }
+}

--- a/changelog.d/achievements-unify-c1.md
+++ b/changelog.d/achievements-unify-c1.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Achievements unification (C1): seed-on-first-save for the unified editor.**
+  `TestProperties` gains `builtInAchievementsSeeded`. Until an instructor first
+  saves the unified Achievements table, `GET /achievements` merges the built-in
+  defaults into the rows so they appear as editable defaults; the unified `PUT`
+  marks the manifest seeded, after which it is authoritative (a removed built-in
+  stays removed). The flag survives suite rebuilds.


### PR DESCRIPTION
## Achievements unification — C1 (seed-on-first-save)

Backend half of C: makes the built-in awards appear as **editable default rows** in the (coming) unified table, while letting an instructor **remove** them for good.

### The mechanism
- `TestProperties` gains **`builtInAchievementsSeeded`** (`decodeIfPresent`; preserved through `makeWorkerManifestJSON` + `applyPatternFamilies` like `achievements`).
- **GET `/achievements`** merges the built-in defaults the manifest hasn't authored *until* the flag is set — so the table shows all 8 built-ins as editable rows from the start, no migration needed.
- **Unified PUT** sets the flag, so the manifest becomes authoritative: a removed built-in **stays removed** (otherwise the merge would re-add it).

### Tests
`AchievementSeedTests`: before any save → 8 default rows (incl. `first_try_perfect`, `trailblazer`); after a unified save with one custom row → only that row, built-ins gone, and `builtInAchievementsSeeded == true`. The unified + legacy tests stay green. Build + `swift-format` + SwiftLint `--strict` clean.

### Rollout
A ✅ A2 ✅ A3 ✅ B ✅ → **C1 (this)** → **C2 (the table/modal/JS + removing the 3 cards — the visible change)** → D (bulk seed migration for existing assignments + retire `/badges`, `/built-in-awards`, legacy `goals`). C1 is the last backend piece; C2 is the UI.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_