### PR TITLE
feat(achievements): single Achievements editor table (unification C2)

### DIFF
--- a/Public/achievements-editor.js
+++ b/Public/achievements-editor.js
@@ -1,0 +1,201 @@
+// Public/achievements-editor.js
+//
+// The single "Achievements" editor table (unification C2).  Every achievement —
+// class goals, individual badges, and the built-in awards — is one row
+// (Name / Kind / Summary / Edit / Remove).  Rows are edited in a <dialog> whose
+// fields show/hide by kind.  Loads via GET and saves the whole typed list via
+// PUT /instructor/:id/achievements (the unified `achievements` array).  No icon
+// authoring (the generic badge rendering is used).
+
+(function () {
+    'use strict';
+
+    var KIND_LABEL = {
+        classGoal: 'Class Goal', thresholdBadge: 'Score Badge', testBadge: 'Test Badge',
+        firstTryPerfect: 'First-Try', comeback: 'Comeback', persistence: 'Persistence',
+        speedRun: 'Speed', classRecord: 'Class Record'
+    };
+    // Which modal fields apply to each kind.
+    var KIND_FIELDS = {
+        classGoal: ['thresholdPercent', 'classPercent', 'points'],
+        thresholdBadge: ['thresholdPercent'],
+        testBadge: ['testName'],
+        firstTryPerfect: ['thresholdPercent', 'attemptThreshold'],
+        comeback: ['jumpThresholdPercent'],
+        persistence: ['thresholdPercent', 'attemptThreshold'],
+        speedRun: ['thresholdPercent', 'timeThresholdMs'],
+        classRecord: ['recordDimension']
+    };
+    var DIM_LABEL = {
+        firstToSubmit: 'first to submit', firstToSolve: 'first to 100%',
+        fastest: 'fastest run', shortest: 'fewest attempts'
+    };
+    var NUM_FIELDS = [
+        'thresholdPercent', 'classPercent', 'points',
+        'attemptThreshold', 'timeThresholdMs', 'jumpThresholdPercent'
+    ];
+    var ALL_FIELDS = [
+        'thresholdPercent', 'classPercent', 'points', 'testName',
+        'recordDimension', 'attemptThreshold', 'timeThresholdMs', 'jumpThresholdPercent'
+    ];
+
+    function csrf() {
+        var m = document.querySelector('meta[name="csrf-token"]');
+        return m ? m.getAttribute('content') : '';
+    }
+    function esc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+    function n(v) { return v == null ? '' : v; }
+
+    function summary(row) {
+        switch (row.kind) {
+            case 'classGoal':
+                return '≥ ' + n(row.thresholdPercent) + '% by ' + n(row.classPercent)
+                    + '% of class · +' + n(row.points) + ' pts';
+            case 'thresholdBadge': return 'score ≥ ' + n(row.thresholdPercent) + '%';
+            case 'testBadge': return esc(row.testName) + ' passes';
+            case 'firstTryPerfect': return '100% within ' + n(row.attemptThreshold || 1) + ' attempt(s)';
+            case 'comeback': return 'grade jumped ≥ ' + n(row.jumpThresholdPercent || 50) + ' pts';
+            case 'persistence': return '100% after ≥ ' + n(row.attemptThreshold || 5) + ' attempts';
+            case 'speedRun': return '100% under ' + n(row.timeThresholdMs || 2000) + ' ms';
+            case 'classRecord': return 'record · ' + (DIM_LABEL[row.recordDimension] || n(row.recordDimension));
+            default: return '';
+        }
+    }
+
+    function init() {
+        var block = document.getElementById('achievements-block');
+        if (!block) return;
+        var tbody = block.querySelector('tbody.achievements-body');
+        var assignmentID = block.getAttribute('data-assignment-id') || '';
+        if (!tbody || !assignmentID) return;
+        var url = '/instructor/' + encodeURIComponent(assignmentID) + '/achievements';
+        var status = document.getElementById('achievements-status');
+        var modal = document.getElementById('achievement-modal');
+        var kindSel = document.getElementById('am-kind');
+
+        var state = [];
+        var editingIndex = -1;
+
+        function setStatus(text, kind) {
+            if (!status) return;
+            status.textContent = text || '';
+            status.style.color = kind === 'error'
+                ? 'var(--red)' : (kind === 'ok' ? 'var(--green)' : 'var(--gray-500)');
+        }
+
+        function render() {
+            tbody.innerHTML = '';
+            state.forEach(function (row, i) {
+                var tr = document.createElement('tr');
+                tr.innerHTML =
+                    '<td><strong>' + esc(row.name) + '</strong></td>'
+                    + '<td>' + esc(KIND_LABEL[row.kind] || row.kind) + '</td>'
+                    + '<td>' + summary(row) + '</td>'
+                    + '<td class="time">'
+                    + '<button type="button" class="btn action-btn ach-edit" data-i="' + i + '">Edit</button> '
+                    + '<button type="button" class="btn action-btn action-danger ach-remove" data-i="' + i + '">Remove</button>'
+                    + '</td>';
+                tbody.appendChild(tr);
+            });
+        }
+
+        function fieldEl(name) { return document.getElementById('am-' + name); }
+
+        function showFieldsFor(kind) {
+            var fields = KIND_FIELDS[kind] || [];
+            Array.prototype.slice.call(modal.querySelectorAll('.am-field')).forEach(function (el) {
+                el.style.display = fields.indexOf(el.getAttribute('data-field')) >= 0 ? '' : 'none';
+            });
+        }
+
+        function openModal(row, index) {
+            editingIndex = index;
+            document.getElementById('achievement-modal-title').textContent =
+                index < 0 ? 'Add Achievement' : 'Edit Achievement';
+            fieldEl('name').value = n(row.name);
+            kindSel.value = row.kind || 'classGoal';
+            ALL_FIELDS.forEach(function (f) { fieldEl(f).value = n(row[f]); });
+            showFieldsFor(kindSel.value);
+            if (modal.showModal) modal.showModal();
+        }
+
+        function applyModal() {
+            var kind = kindSel.value;
+            var row = { kind: kind, name: (fieldEl('name').value || '').trim() };
+            if (editingIndex >= 0 && state[editingIndex] && state[editingIndex].id) {
+                row.id = state[editingIndex].id;
+            }
+            (KIND_FIELDS[kind] || []).forEach(function (f) {
+                var v = fieldEl(f).value;
+                if (v === '') return;
+                row[f] = NUM_FIELDS.indexOf(f) >= 0 ? Number(v) : v;
+            });
+            if (!row.name) return;
+            if (editingIndex < 0) { state.push(row); } else { state[editingIndex] = row; }
+            render();
+        }
+
+        if (kindSel) kindSel.addEventListener('change', function () { showFieldsFor(kindSel.value); });
+        if (modal) {
+            modal.addEventListener('close', function () {
+                if (modal.returnValue === 'done') applyModal();
+            });
+        }
+
+        var addBtn = document.getElementById('achievement-add');
+        if (addBtn) {
+            addBtn.addEventListener('click', function () { openModal({ kind: 'classGoal' }, -1); });
+        }
+        block.addEventListener('click', function (e) {
+            var edit = e.target.closest && e.target.closest('.ach-edit');
+            if (edit) {
+                var ei = Number(edit.getAttribute('data-i'));
+                openModal(state[ei] || {}, ei);
+                return;
+            }
+            var rm = e.target.closest && e.target.closest('.ach-remove');
+            if (rm) { state.splice(Number(rm.getAttribute('data-i')), 1); render(); }
+        });
+
+        var saveBtn = document.getElementById('achievements-save');
+        if (saveBtn) {
+            saveBtn.addEventListener('click', function () {
+                setStatus('Saving…', null);
+                fetch(url, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrf() },
+                    body: JSON.stringify({ achievements: state })
+                }).then(function (r) {
+                    if (r.ok) {
+                        return r.json().then(function (body) {
+                            state = (body && body.achievements) || [];
+                            render();
+                            setStatus('Saved.', 'ok');
+                        }).catch(function () { setStatus('Saved.', 'ok'); });
+                    }
+                    return r.text().then(function (t) {
+                        var msg = t || ('HTTP ' + r.status);
+                        try { var p = JSON.parse(t); if (p && p.reason) msg = p.reason; } catch (_) { /* text */ }
+                        setStatus('Save failed: ' + msg.slice(0, 240), 'error');
+                    });
+                }).catch(function (err) {
+                    setStatus('Save failed: ' + (err && err.message ? err.message : err), 'error');
+                });
+            });
+        }
+
+        fetch(url, { headers: { 'x-csrf-token': csrf() } })
+            .then(function (r) { return r.ok ? r.json() : { achievements: [] }; })
+            .then(function (body) { state = (body && body.achievements) || []; render(); })
+            .catch(function () { render(); });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -186,78 +186,6 @@
     </table>
 </section>
 
-<section id="class-goals-block"
-         data-assignment-id="#(assignmentID)"
-         class="editor-block">
-    <div class="editor-block-head">
-        <h2>Class Goals</h2>
-        <div class="toolbar toolbar--end">
-            <button type="button" class="btn action-btn" id="class-goal-add">+ Add Goal</button>
-            <button type="button" class="btn action-btn" id="class-goals-save">Save Goals</button>
-            <span id="class-goals-status" class="upload-status-inline"></span>
-        </div>
-    </div>
-    <table class="results-table" id="class-goals-table">
-        <thead>
-            <tr>
-                <th>Goal</th>
-                <th>Grade ≥ (%)</th>
-                <th>Class ≥ (%)</th>
-                <th>Bonus (pts)</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody class="class-goals-body"></tbody>
-    </table>
-</section>
-
-<section id="badges-block"
-         data-assignment-id="#(assignmentID)"
-         class="editor-block">
-    <div class="editor-block-head">
-        <h2>Badges</h2>
-        <div class="toolbar toolbar--end">
-            <button type="button" class="btn action-btn" id="badge-add">+ Add Badge</button>
-            <button type="button" class="btn action-btn" id="badges-save">Save Badges</button>
-            <span id="badges-status" class="upload-status-inline"></span>
-        </div>
-    </div>
-    <table class="results-table" id="badges-table">
-        <thead>
-            <tr>
-                <th>Badge</th>
-                <th>Icon</th>
-                <th>Earned when</th>
-                <th>Value</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody class="badges-body"></tbody>
-    </table>
-</section>
-
-<section id="builtin-awards-block"
-         data-assignment-id="#(assignmentID)"
-         class="editor-block">
-    <div class="editor-block-head">
-        <h2>Built-in Awards</h2>
-        <div class="toolbar toolbar--end">
-            <button type="button" class="btn action-btn" id="builtin-awards-save">Save</button>
-            <span id="builtin-awards-status" class="upload-status-inline"></span>
-        </div>
-    </div>
-    <table class="results-table" id="builtin-awards-table">
-        <thead>
-            <tr>
-                <th>Award</th>
-                <th>Earned for</th>
-                <th class="time">Active</th>
-            </tr>
-        </thead>
-        <tbody class="builtin-awards-body"></tbody>
-    </table>
-</section>
-
 #if(brightspaceSyncEnabled):
 <!-- ── BrightSpace grade sync ─────────────────────────── -->
 <div class="editor-block">
@@ -416,6 +344,99 @@
     #endfor
     </div>
 </div>
+
+<!-- ── Achievements ──────────────────────────────────────────────────
+     The single Achievements table (class goals, individual badges, and
+     the built-in awards) as first-class editable rows.  Persists via
+     PUT /instructor/:id/achievements (the unified `achievements` list).
+     Lives outside the Save form; rows are edited in the <dialog> below. -->
+<section id="achievements-block"
+         data-assignment-id="#(assignmentID)"
+         class="editor-block">
+    <div class="editor-block-head">
+        <h2>Achievements</h2>
+        <div class="toolbar toolbar--end">
+            <button type="button" class="btn action-btn" id="achievement-add">+ Add Achievement</button>
+            <button type="button" class="btn action-btn" id="achievements-save">Save Achievements</button>
+            <span id="achievements-status" class="upload-status-inline"></span>
+        </div>
+    </div>
+    <table class="results-table" id="achievements-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Kind</th>
+                <th>Earned when</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody class="achievements-body"></tbody>
+    </table>
+
+    <dialog id="achievement-modal">
+        <form method="dialog" id="achievement-modal-form">
+            <h3 id="achievement-modal-title" class="subhead-label">Edit Achievement</h3>
+            <label class="form-label field-gap">
+                Name
+                <input type="text" class="form-input" id="am-name" placeholder="e.g. 80% Mastery">
+            </label>
+            <label class="form-label field-gap">
+                Kind
+                <select class="form-input" id="am-kind">
+                    <option value="classGoal">Class Goal — collaborative grade bonus</option>
+                    <option value="thresholdBadge">Score Badge — grade threshold</option>
+                    <option value="testBadge">Test Badge — a test passes</option>
+                    <option value="firstTryPerfect">First-Try — perfect on attempt 1</option>
+                    <option value="comeback">Comeback — big grade jump</option>
+                    <option value="persistence">Persistence — perfect after many tries</option>
+                    <option value="speedRun">Speed — fast perfect run</option>
+                    <option value="classRecord">Class Record — one holder</option>
+                </select>
+            </label>
+            <label class="form-label field-gap am-field" data-field="thresholdPercent" style="display:none">
+                Grade ≥ (%)
+                <input type="number" class="form-input" id="am-thresholdPercent" min="0" max="100">
+            </label>
+            <label class="form-label field-gap am-field" data-field="classPercent" style="display:none">
+                Class share ≥ (%)
+                <input type="number" class="form-input" id="am-classPercent" min="0" max="100">
+            </label>
+            <label class="form-label field-gap am-field" data-field="points" style="display:none">
+                Bonus points
+                <input type="number" class="form-input" id="am-points" min="0">
+            </label>
+            <label class="form-label field-gap am-field" data-field="testName" style="display:none">
+                Test filename that must pass
+                <input type="text" class="form-input" id="am-testName" placeholder="secrettest_x.py">
+            </label>
+            <label class="form-label field-gap am-field" data-field="recordDimension" style="display:none">
+                Ranked by
+                <select class="form-input" id="am-recordDimension">
+                    <option value="firstToSubmit">First to submit</option>
+                    <option value="firstToSolve">First to 100%</option>
+                    <option value="fastest">Fastest run</option>
+                    <option value="shortest">Fewest attempts</option>
+                </select>
+            </label>
+            <label class="form-label field-gap am-field" data-field="attemptThreshold" style="display:none">
+                Attempts
+                <input type="number" class="form-input" id="am-attemptThreshold" min="1">
+            </label>
+            <label class="form-label field-gap am-field" data-field="timeThresholdMs" style="display:none">
+                Under (ms)
+                <input type="number" class="form-input" id="am-timeThresholdMs" min="1">
+            </label>
+            <label class="form-label field-gap am-field" data-field="jumpThresholdPercent" style="display:none">
+                Grade jump ≥ (points)
+                <input type="number" class="form-input" id="am-jumpThresholdPercent" min="1">
+            </label>
+            <div class="toolbar toolbar--end field-gap">
+                <button type="submit" class="btn btn-primary" value="done">Done</button>
+                <button type="submit" class="btn" value="cancel">Cancel</button>
+            </div>
+        </form>
+    </dialog>
+</section>
 
 <!-- Seed data: current suite state (scripts + families in authored form)
      and families as JSON.  rawJSON emits the string verbatim because the
@@ -611,9 +632,7 @@ function checkUWDates(dateTimeValue, warningEl) {
 </script>
 
 <script src="/global-inputs-editor.js?v=#appVersion()"></script>
-<script src="/class-goals-editor.js?v=#appVersion()"></script>
-<script src="/badges-editor.js?v=#appVersion()"></script>
-<script src="/builtin-awards-editor.js?v=#appVersion()"></script>
+<script src="/achievements-editor.js?v=#appVersion()"></script>
 
 <!-- ── Unified Test Editor modal (shell + renderers) ────────────────────────
      The "+ Add Test" button opens one modal; picking a type morphs the body

--- a/changelog.d/achievements-unify-c2.md
+++ b/changelog.d/achievements-unify-c2.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Achievements unification (C2): one "Achievements" table.** The three separate
+  editor cards (Class Goals, Badges, Built-in Awards) are replaced by a single
+  "Achievements" table at the bottom of the assignment edit page (after the Test
+  Suite). Each achievement — class goals, individual badges, and the built-in
+  awards — is a first-class editable row (Name / Kind / Summary / Edit / Remove);
+  a row is edited in a modal whose fields adapt to the chosen kind. Driven by the
+  unified `GET`/`PUT /achievements`. No custom icons.


### PR DESCRIPTION
## Achievements unification — C2 (the single table) 🎉

**The visible change.** The three editor cards (Class Goals, Badges, Built-in Awards) are gone, replaced by **one "Achievements" table** at the bottom of the assignment edit page (after the Test Suite).

### What an instructor sees
A table where every achievement is a first-class row — **Name · Kind · Earned-when summary · Edit · Remove** — covering class goals, individual badges, and the built-in awards alike. The built-ins show as **editable default rows** (via C1's seed-merge) and can be renamed, retuned, or removed for good.

`+ Add Achievement` and `Edit` open a **`<dialog>` modal** whose fields adapt to the chosen kind (the per-kind columns you picked over inline). No icon authoring — generic rendering.

### How
- New **`Public/achievements-editor.js`**: GET-loads the unified list → renders the table → modal edits (kind dropdown shows/hides the relevant fields) → `Save` PUTs `{ achievements: [...] }` to the unified endpoint.
- `assignment-edit.leaf`: the 3 cards + their 3 `<script>` includes removed; the Achievements `<section>` + the `<dialog>` added after the suite editor. Per-kind modal fields use JS-toggled `display:none` (check-styles-approved).

### Tests
`check-styles` clean; the editor-render + achievement-authoring + seed tests (24) stay green. (The old `class-goals/badges/builtin-awards-editor.js` files are now unreferenced — **D** deletes them along with the `/badges`, `/built-in-awards`, and legacy `goals` endpoints, plus a bulk seed migration for existing assignments.)

### Rollout
A ✅ A2 ✅ A3 ✅ B ✅ C1 ✅ → **C2 (this — the table)** → D (cleanup + bulk seed). After this, the consolidation you asked for is live.

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014BNMMqC4rZXVT1Md22mGuZ)_