### PR TITLE
fix(csrf): collect the request body before reading the _csrf form field

### DIFF
--- a/Sources/APIServer/Middleware/CSRFTokenRetrieval.swift
+++ b/Sources/APIServer/Middleware/CSRFTokenRetrieval.swift
@@ -2,20 +2,35 @@
 //
 // Custom CSRF token-retrieval used by the app's single `CSRF` instance.
 //
-// It is byte-for-byte equivalent to the vendored library's default retrieval
-// (same header keys, same `_csrf` body field, same `403 "No CSRF token
-// provided."` on a miss) with one addition: when no token is found, it emits a
-// structured `csrf_token_missing` log line.
+// It differs from the vendored library's default retrieval (same header keys,
+// same `_csrf` body field, same `403 "No CSRF token provided."` on a miss) in
+// two ways:
 //
-// Why this exists: a "No CSRF token provided." 403 means the token never
-// reached the server in the request — distinct from "Invalid CSRF token."
-// (token present, wrong session). The two are diagnosed completely differently,
-// but the bare library throws with no context, so production failures were
-// invisible. The log line records enough to tell the sub-cases apart:
-//   * no body / GET-shaped body            → a redirect swallowed the POST body
-//   * urlencoded body, no `_csrf`          → the form rendered without the field
-//   * multipart body                       → the multipart AJAX path didn't run
-// so the next failure in prod explains itself instead of needing a repro.
+// 1. **It collects the request body before reading `_csrf`.** Vapor only
+//    dispatches a request with a pre-collected body when the entire body
+//    arrives in the same channel read as the head (`HTTPServerRequestDecoder`
+//    requires the first body chunk to exactly equal Content-Length; anything
+//    else — a body split across TCP reads, or chunked transfer-encoding —
+//    is dispatched immediately as a *streaming* body). Middleware runs before
+//    the route's `.collect` step, so a synchronous `request.content.get` sees
+//    `body.data == nil` for every such request and the library's default
+//    retrieval 403s it with "No CSRF token provided." even though the form
+//    field is on the wire. That split is routine on real networks/proxies and
+//    never happens under XCTVapor (in-memory bodies are always collected),
+//    which is why this only ever surfaced in production (#868's TA report:
+//    extension save → 403). Collecting first makes the read reliable, and the
+//    route's own `.collect` then short-circuits on the already-collected body.
+//
+// 2. When no token is found, it emits a structured `csrf_token_missing` log
+//    line. A "No CSRF token provided." 403 means the token never reached the
+//    server in the request — distinct from "Invalid CSRF token." (token
+//    present, wrong session). The two are diagnosed completely differently,
+//    but the bare library throws with no context, so production failures were
+//    invisible. The log line records enough to tell the sub-cases apart:
+//      * no body / GET-shaped body            → a redirect swallowed the POST body
+//      * urlencoded body, no `_csrf`          → the form rendered without the field
+//      * multipart body                       → the multipart AJAX path didn't run
+//    so the next failure in prod explains itself instead of needing a repro.
 
 import CSRF
 import Vapor
@@ -36,21 +51,29 @@ func chickadeeCSRFTokenRetrieval(_ request: Request) -> EventLoopFuture<String> 
         return request.eventLoop.makeSucceededFuture(token)
     }
 
-    // `content.get` returns "" for a present-but-empty field (which then fails
-    // validation as "Invalid"), and throws only when the field is absent or the
-    // body can't be decoded — exactly the cases we want to surface.
-    if let token = try? request.content.get(String.self, at: "_csrf") {
-        return request.eventLoop.makeSucceededFuture(token)
-    }
+    // The body may still be streaming at middleware time (see header comment);
+    // collect it before reading. Same size cap as the route's own `.collect`
+    // step, and an oversized body fails here exactly as it would there.
+    return request.body.collect(
+        max: request.application.routes.defaultMaxBodySize.value
+    ).flatMap { _ in
+        // `content.get` returns "" for a present-but-empty field (which then
+        // fails validation as "Invalid"), and throws only when the field is
+        // absent or the body can't be decoded — exactly the cases we want to
+        // surface.
+        if let token = try? request.content.get(String.self, at: "_csrf") {
+            return request.eventLoop.makeSucceededFuture(token)
+        }
 
-    let contentType = request.headers.first(name: .contentType) ?? "none"
-    let contentLength = request.headers.first(name: .contentLength) ?? "none"
-    request.logger.warning(
-        """
-        csrf_token_missing method=\(request.method.rawValue) path=\(request.url.path) \
-        content-type=\(contentType) content-length=\(contentLength)
-        """
-    )
-    return request.eventLoop.makeFailedFuture(
-        Abort(.forbidden, reason: "No CSRF token provided."))
+        let contentType = request.headers.first(name: .contentType) ?? "none"
+        let contentLength = request.headers.first(name: .contentLength) ?? "none"
+        request.logger.warning(
+            """
+            csrf_token_missing method=\(request.method.rawValue) path=\(request.url.path) \
+            content-type=\(contentType) content-length=\(contentLength)
+            """
+        )
+        return request.eventLoop.makeFailedFuture(
+            Abort(.forbidden, reason: "No CSRF token provided."))
+    }
 }

--- a/Tests/APITests/ExtensionCSRFTokenTests.swift
+++ b/Tests/APITests/ExtensionCSRFTokenTests.swift
@@ -15,6 +15,17 @@
 // production error middleware in SecurityAndHealthTests
 // (`leafErrorMiddlewareRendersRecoverableMessageForCSRFFailures`); the test
 // harness here doesn't install LeafErrorMiddleware.
+//
+// `extensionSaveWithStreamedBodyPassesCSRF` pins the *actual* root cause of
+// the production report: Vapor dispatches a request whose body did not arrive
+// in the same channel read as the head (split TCP reads, chunked encoding) as
+// a *streaming* body, and the CSRF token retrieval used to read `_csrf` with
+// a synchronous `content.get` — nil for a streaming body — so the request
+// 403'd "No CSRF token provided." even though the field was on the wire.
+// XCTVapor's in-memory transport always delivers pre-collected bodies, so
+// that path needs a real socket: the test boots the server on a loopback
+// port and POSTs the extension form with `Transfer-Encoding: chunked`, which
+// the decoder deterministically dispatches as a stream.
 
 import Core
 import Fluent
@@ -23,6 +34,10 @@ import Testing
 import XCTVapor
 
 @testable import APIServer
+
+#if canImport(Glibc)
+import Glibc
+#endif
 
 @Suite struct ExtensionCSRFTokenTests {
 
@@ -93,4 +108,115 @@ import XCTVapor
             )
         }
     }
+
+    // MARK: - Streaming body: the production failure mode
+
+    /// A form POST whose body Vapor dispatches as a *stream* (here forced
+    /// deterministically with chunked transfer-encoding over a real socket)
+    /// must still pass CSRF. Before the body-collect fix in
+    /// `chickadeeCSRFTokenRetrieval` this 403'd "No CSRF token provided."
+    @Test func extensionSaveWithStreamedBodyPassesCSRF() async throws {
+        try await withAssignmentRoutesApp { app in
+            let (cookie, student, assignment) = try await seed(on: app)
+            let token = try student.requireURLToken()
+
+            var pageToken = ""
+            var pageCookie = cookie
+            try await app.asyncTest(
+                .GET, "/TEST101/students/\(token)/submissions",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    if let c = res.headers.first(name: .setCookie) { pageCookie = c }
+                    pageToken = extractCSRFToken(from: res.body.string)
+                }
+            )
+            #expect(pageToken.isEmpty == false, "Extension form must carry a CSRF token")
+            // Set-Cookie → Cookie: keep just the `name=value` pair.
+            let cookiePair = pageCookie.components(separatedBy: ";")[0]
+
+            try app.server.start(address: .hostname("127.0.0.1", port: 0))
+            defer { app.server.shutdown() }
+            let port = try #require(app.http.server.shared.localAddress?.port)
+
+            let due = localInput(Date().addingTimeInterval(86_400))
+                .replacingOccurrences(of: ":", with: "%3A")
+            let formBody = "_csrf=\(pageToken)&extendedDueAt=\(due)&note=streamed"
+            let path = "/TEST101/students/\(token)/assignments/\(assignment.publicID)/extension"
+            let request =
+                "POST \(path) HTTP/1.1\r\n"
+                + "Host: 127.0.0.1\r\n"
+                + "Connection: close\r\n"
+                + "Cookie: \(cookiePair)\r\n"
+                + "Content-Type: application/x-www-form-urlencoded\r\n"
+                + "Transfer-Encoding: chunked\r\n"
+                + "\r\n"
+                + String(formBody.utf8.count, radix: 16) + "\r\n"
+                + formBody + "\r\n"
+                + "0\r\n\r\n"
+
+            let response = try rawLoopbackHTTPExchange(port: port, request: request)
+            let statusLine = response.components(separatedBy: "\r\n")[0]
+            #expect(
+                statusLine.contains("303"),
+                "Streamed-body extension save must pass CSRF (got '\(statusLine)')"
+            )
+
+            let saved = try await APIAssignmentExtension.query(on: app.db)
+                .filter(\.$assignmentID == assignment.requireID())
+                .filter(\.$userID == student.requireID())
+                .first()
+            #expect(saved != nil, "Extension row must be persisted from the streamed POST")
+        }
+    }
+}
+
+/// Sends raw bytes to 127.0.0.1:`port` and returns the full response read
+/// until the server closes the connection (`Connection: close` request).
+/// Plain blocking POSIX sockets — the point is to exercise the real server
+/// pipeline, which XCTVapor's in-memory transport bypasses.
+private func rawLoopbackHTTPExchange(port: Int, request: String) throws -> String {
+    #if os(Linux)
+    let sockStream = Int32(SOCK_STREAM.rawValue)
+    #else
+    let sockStream = SOCK_STREAM
+    #endif
+    let fd = socket(AF_INET, sockStream, 0)
+    try #require(fd >= 0, "socket() failed: errno \(errno)")
+    defer { close(fd) }
+
+    var addr = sockaddr_in()
+    addr.sin_family = sa_family_t(AF_INET)
+    addr.sin_port = in_port_t(port).bigEndian
+    try #require(
+        inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr) == 1,
+        "inet_pton failed"
+    )
+    let connectResult = withUnsafePointer(to: &addr) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            connect(fd, sockaddrPointer, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    try #require(connectResult == 0, "connect() failed: errno \(errno)")
+
+    var bytes = Array(request.utf8)
+    var sent = 0
+    while sent < bytes.count {
+        let n = bytes.withUnsafeBytes { raw in
+            send(fd, raw.baseAddress.map { $0 + sent }, bytes.count - sent, 0)
+        }
+        try #require(n > 0, "send() failed: errno \(errno)")
+        sent += n
+    }
+
+    var response: [UInt8] = []
+    var chunk = [UInt8](repeating: 0, count: 4096)
+    while true {
+        let n = chunk.withUnsafeMutableBytes { raw in
+            recv(fd, raw.baseAddress, raw.count, 0)
+        }
+        if n <= 0 { break }
+        response.append(contentsOf: chunk[0..<n])
+    }
+    return String(decoding: response, as: UTF8.self)
 }

--- a/Tests/APITests/ExtensionCSRFTokenTests.swift
+++ b/Tests/APITests/ExtensionCSRFTokenTests.swift
@@ -135,10 +135,6 @@ import Glibc
             // Set-Cookie → Cookie: keep just the `name=value` pair.
             let cookiePair = pageCookie.components(separatedBy: ";")[0]
 
-            try await app.server.start(address: .hostname("127.0.0.1", port: 0))
-            defer { app.server.shutdown() }
-            let port = try #require(app.http.server.shared.localAddress?.port)
-
             let due = localInput(Date().addingTimeInterval(86_400))
                 .replacingOccurrences(of: ":", with: "%3A")
             let formBody = "_csrf=\(pageToken)&extendedDueAt=\(due)&note=streamed"
@@ -155,7 +151,18 @@ import Glibc
                 + formBody + "\r\n"
                 + "0\r\n\r\n"
 
-            let response = try rawLoopbackHTTPExchange(port: port, request: request)
+            // The sync `shutdown()` is `noasync`, and `defer` can't await —
+            // shut down explicitly on both exits instead.
+            try await app.server.start(address: .hostname("127.0.0.1", port: 0))
+            let response: String
+            do {
+                let port = try #require(app.http.server.shared.localAddress?.port)
+                response = try rawLoopbackHTTPExchange(port: port, request: request)
+            } catch {
+                await app.server.shutdown()
+                throw error
+            }
+            await app.server.shutdown()
             let statusLine = response.components(separatedBy: "\r\n")[0]
             #expect(
                 statusLine.contains("303"),

--- a/Tests/APITests/ExtensionCSRFTokenTests.swift
+++ b/Tests/APITests/ExtensionCSRFTokenTests.swift
@@ -135,7 +135,7 @@ import Glibc
             // Set-Cookie → Cookie: keep just the `name=value` pair.
             let cookiePair = pageCookie.components(separatedBy: ";")[0]
 
-            try app.server.start(address: .hostname("127.0.0.1", port: 0))
+            try await app.server.start(address: .hostname("127.0.0.1", port: 0))
             defer { app.server.shutdown() }
             let port = try #require(app.http.server.shared.localAddress?.port)
 
@@ -199,7 +199,7 @@ private func rawLoopbackHTTPExchange(port: Int, request: String) throws -> Strin
     }
     try #require(connectResult == 0, "connect() failed: errno \(errno)")
 
-    var bytes = Array(request.utf8)
+    let bytes = Array(request.utf8)
     var sent = 0
     while sent < bytes.count {
         let n = bytes.withUnsafeBytes { raw in
@@ -218,5 +218,8 @@ private func rawLoopbackHTTPExchange(port: Int, request: String) throws -> Strin
         if n <= 0 { break }
         response.append(contentsOf: chunk[0..<n])
     }
-    return String(decoding: response, as: UTF8.self)
+    return try #require(
+        String(bytes: response, encoding: .utf8),
+        "Response was not valid UTF-8"
+    )
 }

--- a/changelog.d/csrf-streamed-body.md
+++ b/changelog.d/csrf-streamed-body.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **CSRF no longer rejects form POSTs whose body arrives as a stream.** Vapor
+  only delivers a pre-collected body when the entire body lands in the same
+  channel read as the request head; a form POST split across TCP reads (routine
+  on real networks/proxies, and guaranteed for chunked transfer-encoding) was
+  dispatched to the CSRF middleware with a still-streaming body, so the
+  synchronous `_csrf` body read failed and the request 403'd
+  "No CSRF token provided." even though the field was on the wire — the
+  intermittent, production-only failure behind the TA's extension-grant report
+  (#868). The token retrieval now collects the body (same size cap as the
+  route's own collect step) before reading the field, and a live-socket
+  regression test pins the streamed-body path.


### PR DESCRIPTION
## The bug (the TA's extension-grant 403)

The production error was **"No CSRF token provided."** — the `_csrf` field "never reached the server" even though the form provably renders and submits it (#868 pinned that). The missing piece is *when* the middleware reads the body:

- Vapor's `HTTPServerRequestDecoder` only dispatches a request with a **pre-collected** body when the entire body arrives in the same channel read as the head (the first body chunk must exactly equal `Content-Length`).
- Anything else — a body split across TCP reads (routine on real networks/proxies), or chunked transfer-encoding — is dispatched **immediately with a streaming body**.
- The route's `.collect` step runs *after* middleware, so the CSRF token retrieval's synchronous `request.content.get(String.self, at: "_csrf")` sees `body.data == nil`, throws, and the request 403s — with the token sitting on the wire.

This is why it was intermittent and production-only: XCTVapor's in-memory transport always delivers pre-collected bodies, so #868's regression tests (and any local repro) could never hit the streaming path. The same flaw exists in the vendored library's default retrieval; Chickadee's custom retrieval inherited it.

## The fix

`chickadeeCSRFTokenRetrieval` now collects the body (`request.body.collect`, same `defaultMaxBodySize` cap as the route layer) before reading the `_csrf` field. The route's own collect step then short-circuits on the already-collected body, so downstream behaviour is unchanged. Header-borne tokens (AJAX) never touch the body and are unaffected.

## Regression test

`extensionSaveWithStreamedBodyPassesCSRF` boots the real server on a loopback port and POSTs the extension form over a raw socket with `Transfer-Encoding: chunked` — which the decoder deterministically dispatches as a streaming body. Verified both ways:

- **Without the fix:** `HTTP/1.1 403 Forbidden` (the exact production failure)
- **With the fix:** `303 See Other` and the extension row is persisted

`ExtensionCSRFTokenTests`, `SpaceCourseCodeCSRFTests`, `CSRFTests`, `SecurityAndHealthTests`, `AuthRoutesTests` all pass (35 tests / 11 suites); swift-format + SwiftLint clean.

## Audit (rest of the CSRF surface)

- **Routes:** every session-authenticated state-changing route is behind the `csrf` middleware (auth/instructor/admin groups). Exemptions are deliberate and sound: `POST /logout` (documented stale-token rationale), SSO callback (OAuth `state`), MCP consent POST (single-use consent token), worker endpoints (HMAC), MCP transport (bearer JWT).
- **Browser JS:** every live `fetch()` POST/PUT/DELETE attaches `x-csrf-token` from the meta tag; plain forms all use `#csrfFormField()`.
- **One stale finding:** `Public/setup-edit.js` PUTs `/api/v1/testsetups/:id/assignment` without a token — but no template loads that file anymore (legacy Phase-8 page superseded by the JupyterLite draft flow). Worth deleting in a separate cleanup rather than patching dead code.

https://claude.ai/code/session_011NjxmsxToLpFAWjZEoGGeR

---
_Generated by [Claude Code](https://claude.ai/code/session_011NjxmsxToLpFAWjZEoGGeR)_