### PR TITLE
refactor(personalization): shared hasExpressions/hasPersonalization predicates

### DIFF
--- a/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+++ b/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
@@ -157,10 +157,7 @@ struct PreviewPersonalizationTool: ContentTool {
             return trimmed.lowercased()
         }
         // No seed is needed for a literal-only assignment.
-        let hasExpressions =
-            !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.expressions.isEmpty }
-        guard hasExpressions else { return nil }
+        guard manifest.hasExpressions else { return nil }
         let actingUser = try await context.requireEligibleSubject(tool: Self.name)
         guard let userID = actingUser.id, let assignmentID = assignment.id else { return nil }
         return try await AssignmentSeedStore.ensureSeed(

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -120,11 +120,7 @@ func materializeValidationGrading(
 
         // Non-personalized assignments: nothing to resolve or cache — the
         // download route streams the stored zip exactly as before.
-        let hasPersonalization =
-            !manifest.globalVariables.isEmpty
-            || !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.variables.isEmpty || !$0.expressions.isEmpty }
-        guard hasPersonalization else { return }
+        guard manifest.hasPersonalization else { return }
 
         // Resolve the per-(user, assignment) seed when we can. Literal variables
         // substitute without a seed; only `=` expressions need one.

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -569,11 +569,8 @@ private func applyNotebookSubstitutionsIfNeeded(
 
     // A seed is only needed to evaluate per-student expressions; literal-only
     // assignments substitute without one (and without an assignment lookup).
-    let hasExpressions =
-        !manifest.globalExpressions.isEmpty
-        || manifest.sections.contains { !$0.expressions.isEmpty }
     var seedHex: String?
-    if hasExpressions, let setupID = setup.id {
+    if manifest.hasExpressions, let setupID = setup.id {
         if let assignment = try? await APIAssignment.query(on: db)
             .filter(\.$testSetupID == setupID)
             .first(),

--- a/Sources/APIServer/Services/PersonalizationSubstitution.swift
+++ b/Sources/APIServer/Services/PersonalizationSubstitution.swift
@@ -98,10 +98,7 @@ enum PersonalizationSubstitution {
         manifest: TestProperties, seedHex: String?, supportFilesDirectory: String?
     ) async -> [String: String]? {
         guard let seedHex, !seedHex.isEmpty else { return nil }
-        let hasExpressions =
-            !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.expressions.isEmpty }
-        guard hasExpressions else { return nil }
+        guard manifest.hasExpressions else { return nil }
         let resolution = await resolve(
             manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportFilesDirectory)
         let exprNames = Set(resolution.evaluatedExpressionNames)

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -245,6 +245,23 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// `seed`.
     public let globalExpressions: [PersonalizationExpression]
 
+    /// True when the manifest declares any per-student `=` expression, global
+    /// or section-scoped.  Expressions are the only personalization inputs
+    /// that need a per-(student, assignment) seed to resolve — use this to
+    /// decide whether a seed must be looked up.  Ask `hasPersonalization`
+    /// instead when the question is "is there anything to substitute at all".
+    public var hasExpressions: Bool {
+        !globalExpressions.isEmpty || sections.contains { !$0.expressions.isEmpty }
+    }
+
+    /// True when the manifest declares anything personalization substitutes —
+    /// literal variables or per-student expressions, global or section-scoped.
+    /// Strictly broader than `hasExpressions`: a literal-only assignment still
+    /// substitutes `{{name}}` placeholders, it just needs no seed.
+    public var hasPersonalization: Bool {
+        hasExpressions || !globalVariables.isEmpty || sections.contains { !$0.variables.isEmpty }
+    }
+
     /// Instructor-authored achievements / goals / awards for this assignment —
     /// the generalized form of the hardcoded badge + class-achievement system.
     /// Server-evaluated and display-only; `runnerSanitized()` strips them so a

--- a/Tests/CoreTests/TestPropertiesPersonalizationTests.swift
+++ b/Tests/CoreTests/TestPropertiesPersonalizationTests.swift
@@ -1,0 +1,50 @@
+// Tests/CoreTests/TestPropertiesPersonalizationTests.swift
+//
+// The shared personalization predicates: `hasExpressions` answers "does this
+// manifest need a per-student seed?", `hasPersonalization` answers "is there
+// anything to substitute at all?".  Every caller (notebook first-open, worker
+// + browser grading inputs, validation materialization, MCP preview) goes
+// through these two — the boundary cases here pin the distinction.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct TestPropertiesPersonalizationTests {
+
+    private let expr = PersonalizationExpression(name: "x", expression: "seed % 7")
+    private let literal = FamilyVariable(name: "limit", value: .int(5))
+
+    @Test func emptyManifestHasNeither() {
+        let manifest = TestProperties()
+        #expect(!manifest.hasExpressions)
+        #expect(!manifest.hasPersonalization)
+    }
+
+    @Test func globalExpressionSetsBoth() {
+        let manifest = TestProperties(globalExpressions: [expr])
+        #expect(manifest.hasExpressions)
+        #expect(manifest.hasPersonalization)
+    }
+
+    @Test func sectionExpressionSetsBoth() {
+        let manifest = TestProperties(
+            sections: [TestSuiteSection(id: "s1", name: "S1", expressions: [expr])])
+        #expect(manifest.hasExpressions)
+        #expect(manifest.hasPersonalization)
+    }
+
+    @Test func globalLiteralIsPersonalizationButNeedsNoSeed() {
+        let manifest = TestProperties(globalVariables: [literal])
+        #expect(!manifest.hasExpressions, "Literals substitute without a seed")
+        #expect(manifest.hasPersonalization, "Literal-only manifests still substitute")
+    }
+
+    @Test func sectionLiteralIsPersonalizationButNeedsNoSeed() {
+        let manifest = TestProperties(
+            sections: [TestSuiteSection(id: "s1", name: "S1", variables: [literal])])
+        #expect(!manifest.hasExpressions)
+        #expect(manifest.hasPersonalization)
+    }
+}


### PR DESCRIPTION
Audit follow-up 2/5: four call sites hand-rolled the "does this manifest personalize?" check, and one (validation materialization) was deliberately broader — it also counts literal variables. That asymmetry is a copy-paste trap.

* `TestProperties.hasExpressions` — any per-student `=` expression (global or section); the only inputs that need a seed.
* `TestProperties.hasPersonalization` — anything to substitute at all (expressions OR literal variables); strictly broader.
* All four call sites (`gradingInputs`, MCP preview seed resolver, notebook first-open, validation materializer) now share them; behavior unchanged.
* CoreTests pin the boundary case: a literal-only manifest substitutes but needs no seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)