### PR TITLE
refactor(validation): enforce materialize-before-save with a token type

### DIFF
--- a/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
+++ b/Sources/APIServer/MCP/Tools/PreviewPersonalizationTool.swift
@@ -157,10 +157,7 @@ struct PreviewPersonalizationTool: ContentTool {
             return trimmed.lowercased()
         }
         // No seed is needed for a literal-only assignment.
-        let hasExpressions =
-            !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.expressions.isEmpty }
-        guard hasExpressions else { return nil }
+        guard manifest.hasExpressions else { return nil }
         let actingUser = try await context.requireEligibleSubject(tool: Self.name)
         guard let userID = actingUser.id, let assignmentID = assignment.id else { return nil }
         return try await AssignmentSeedStore.ensureSeed(

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -120,11 +120,7 @@ func materializeValidationGrading(
 
         // Non-personalized assignments: nothing to resolve or cache — the
         // download route streams the stored zip exactly as before.
-        let hasPersonalization =
-            !manifest.globalVariables.isEmpty
-            || !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.variables.isEmpty || !$0.expressions.isEmpty }
-        guard hasPersonalization else { return }
+        guard manifest.hasPersonalization else { return }
 
         // Resolve the per-(user, assignment) seed when we can. Literal variables
         // substitute without a seed; only `=` expressions need one.

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -64,20 +64,35 @@ func enqueueRunnerValidationSubmission(
     // submission is saved. Saving makes it `pending` — a polling worker can
     // claim and download it immediately — so the substituted `.grading` sidecar
     // and the cached `materializationJSON` MUST already be in place, or the
-    // worker races in and grades the un-substituted template. Materialize first,
-    // then a single save flips the row to claimable with everything ready.
-    // (This resolves personalization once, at enqueue — an instructor save,
-    // which is latency-tolerant — so the worker poll + download paths never run
-    // the personalization evaluator. See `materializeValidationGrading`.)
-    await materializeValidationGrading(
+    // worker races in and grades the un-substituted template. The returned
+    // token is the only way to persist the row, so the ordering is enforced by
+    // the types, not by this comment. (This resolves personalization once, at
+    // enqueue — an instructor save, which is latency-tolerant — so the worker
+    // poll + download paths never run the personalization evaluator.)
+    let materialized = await materializeValidationGrading(
         submission: submission,
         setupID: setupID,
         templateNotebookData: solutionNotebookData,
         testSetupsDirectory: req.application.testSetupsDirectory,
         on: req.db)
 
-    try await submission.save(on: req.db)
+    try await materialized.saveClaimable(on: req.db)
     return subID
+}
+
+/// Proof that `materializeValidationGrading` ran for a validation submission:
+/// the grading sidecar and the in-memory `materializationJSON` cache are in
+/// place, so persisting the row — which flips it to `pending` and makes it
+/// claimable by a polling worker — is now safe.  Only constructible by
+/// `materializeValidationGrading`, so "materialize before save" is a compile-
+/// time guarantee at the enqueue site rather than a comment.
+struct MaterializedValidationSubmission {
+    fileprivate let submission: APISubmission
+
+    /// The single save that makes the row claimable.
+    func saveClaimable(on db: any Database) async throws {
+        try await submission.save(on: db)
+    }
 }
 
 /// Resolve a validation submission's personalization ONCE, so the worker poll +
@@ -92,10 +107,11 @@ func enqueueRunnerValidationSubmission(
 ///     `buildJobPayload` reads it instead of re-evaluating; the values become
 ///     `_ck_inputs.py`.
 ///
-/// IMPORTANT — call this BEFORE saving the submission. It deliberately does NOT
-/// save: the caller persists the row exactly once afterwards, so the submission
+/// Call this BEFORE saving the submission — enforced by the return type: it
+/// deliberately does NOT save, and the `MaterializedValidationSubmission`
+/// token it returns is the only way to persist the row. The submission then
 /// only becomes `pending` (claimable by a polling worker) once the sidecar and
-/// cache are already in place. Saving first opens a race where the worker
+/// cache are already in place; saving first would open a race where the worker
 /// downloads the un-substituted template before this finishes.
 ///
 /// The stored `zipPath` keeps its `{{...}}` template, so `get_solution`, the
@@ -106,6 +122,25 @@ func enqueueRunnerValidationSubmission(
 /// fails clearly, but the worker never times out), and `buildJobPayload` falls
 /// back to live resolution.
 func materializeValidationGrading(
+    submission: APISubmission,
+    setupID: String,
+    templateNotebookData: Data,
+    testSetupsDirectory: String,
+    on db: any Database
+) async -> MaterializedValidationSubmission {
+    await resolveAndCacheValidationMaterialization(
+        submission: submission,
+        setupID: setupID,
+        templateNotebookData: templateNotebookData,
+        testSetupsDirectory: testSetupsDirectory,
+        on: db)
+    return MaterializedValidationSubmission(submission: submission)
+}
+
+/// Best-effort body of `materializeValidationGrading`: any early exit leaves
+/// the submission un-materialized, which downstream paths handle (template
+/// streamed verbatim, live fallback in `buildJobPayload`).
+private func resolveAndCacheValidationMaterialization(
     submission: APISubmission,
     setupID: String,
     templateNotebookData: Data,

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -569,11 +569,8 @@ private func applyNotebookSubstitutionsIfNeeded(
 
     // A seed is only needed to evaluate per-student expressions; literal-only
     // assignments substitute without one (and without an assignment lookup).
-    let hasExpressions =
-        !manifest.globalExpressions.isEmpty
-        || manifest.sections.contains { !$0.expressions.isEmpty }
     var seedHex: String?
-    if hasExpressions, let setupID = setup.id {
+    if manifest.hasExpressions, let setupID = setup.id {
         if let assignment = try? await APIAssignment.query(on: db)
             .filter(\.$testSetupID == setupID)
             .first(),

--- a/Sources/APIServer/Services/PersonalizationSubstitution.swift
+++ b/Sources/APIServer/Services/PersonalizationSubstitution.swift
@@ -98,10 +98,7 @@ enum PersonalizationSubstitution {
         manifest: TestProperties, seedHex: String?, supportFilesDirectory: String?
     ) async -> [String: String]? {
         guard let seedHex, !seedHex.isEmpty else { return nil }
-        let hasExpressions =
-            !manifest.globalExpressions.isEmpty
-            || manifest.sections.contains { !$0.expressions.isEmpty }
-        guard hasExpressions else { return nil }
+        guard manifest.hasExpressions else { return nil }
         let resolution = await resolve(
             manifest: manifest, seedHex: seedHex, supportFilesDirectory: supportFilesDirectory)
         let exprNames = Set(resolution.evaluatedExpressionNames)

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -245,6 +245,23 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// `seed`.
     public let globalExpressions: [PersonalizationExpression]
 
+    /// True when the manifest declares any per-student `=` expression, global
+    /// or section-scoped.  Expressions are the only personalization inputs
+    /// that need a per-(student, assignment) seed to resolve — use this to
+    /// decide whether a seed must be looked up.  Ask `hasPersonalization`
+    /// instead when the question is "is there anything to substitute at all".
+    public var hasExpressions: Bool {
+        !globalExpressions.isEmpty || sections.contains { !$0.expressions.isEmpty }
+    }
+
+    /// True when the manifest declares anything personalization substitutes —
+    /// literal variables or per-student expressions, global or section-scoped.
+    /// Strictly broader than `hasExpressions`: a literal-only assignment still
+    /// substitutes `{{name}}` placeholders, it just needs no seed.
+    public var hasPersonalization: Bool {
+        hasExpressions || !globalVariables.isEmpty || sections.contains { !$0.variables.isEmpty }
+    }
+
     /// Instructor-authored achievements / goals / awards for this assignment —
     /// the generalized form of the hardcoded badge + class-achievement system.
     /// Server-evaluated and display-only; `runnerSanitized()` strips them so a

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -660,7 +660,7 @@ import XCTVapor
 
             // Substitution happens at enqueue, NOT on the download hot path.
             let template = try Data(contentsOf: URL(fileURLWithPath: sub.zipPath))
-            await materializeValidationGrading(
+            _ = await materializeValidationGrading(
                 submission: sub, setupID: setupID, templateNotebookData: template,
                 testSetupsDirectory: self.app.testSetupsDirectory, on: self.app.db)
 
@@ -747,7 +747,7 @@ import XCTVapor
                 userID: try user.requireID())
 
             let template = try Data(contentsOf: URL(fileURLWithPath: sub.zipPath))
-            await materializeValidationGrading(
+            _ = await materializeValidationGrading(
                 submission: sub, setupID: setupID, templateNotebookData: template,
                 testSetupsDirectory: self.app.testSetupsDirectory, on: self.app.db)
 

--- a/Tests/CoreTests/TestPropertiesPersonalizationTests.swift
+++ b/Tests/CoreTests/TestPropertiesPersonalizationTests.swift
@@ -1,0 +1,50 @@
+// Tests/CoreTests/TestPropertiesPersonalizationTests.swift
+//
+// The shared personalization predicates: `hasExpressions` answers "does this
+// manifest need a per-student seed?", `hasPersonalization` answers "is there
+// anything to substitute at all?".  Every caller (notebook first-open, worker
+// + browser grading inputs, validation materialization, MCP preview) goes
+// through these two — the boundary cases here pin the distinction.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct TestPropertiesPersonalizationTests {
+
+    private let expr = PersonalizationExpression(name: "x", expression: "seed % 7")
+    private let literal = FamilyVariable(name: "limit", value: .int(5))
+
+    @Test func emptyManifestHasNeither() {
+        let manifest = TestProperties()
+        #expect(!manifest.hasExpressions)
+        #expect(!manifest.hasPersonalization)
+    }
+
+    @Test func globalExpressionSetsBoth() {
+        let manifest = TestProperties(globalExpressions: [expr])
+        #expect(manifest.hasExpressions)
+        #expect(manifest.hasPersonalization)
+    }
+
+    @Test func sectionExpressionSetsBoth() {
+        let manifest = TestProperties(
+            sections: [TestSuiteSection(id: "s1", name: "S1", expressions: [expr])])
+        #expect(manifest.hasExpressions)
+        #expect(manifest.hasPersonalization)
+    }
+
+    @Test func globalLiteralIsPersonalizationButNeedsNoSeed() {
+        let manifest = TestProperties(globalVariables: [literal])
+        #expect(!manifest.hasExpressions, "Literals substitute without a seed")
+        #expect(manifest.hasPersonalization, "Literal-only manifests still substitute")
+    }
+
+    @Test func sectionLiteralIsPersonalizationButNeedsNoSeed() {
+        let manifest = TestProperties(
+            sections: [TestSuiteSection(id: "s1", name: "S1", variables: [literal])])
+        #expect(!manifest.hasExpressions)
+        #expect(manifest.hasPersonalization)
+    }
+}


### PR DESCRIPTION
Audit follow-up 4/5 — **stacked on #886, merge that first** (this branch includes its commit; the diff collapses once it lands).

The #871 fix established a critical ordering at validation enqueue: materialize BEFORE saving the row, or a polling worker claims it and downloads the un-substituted template. The invariant was comment-enforced.

* `materializeValidationGrading` now returns a `MaterializedValidationSubmission` token (constructible only inside `RunnerValidationHelpers`); `saveClaimable(on:)` on that token is how the enqueue path persists the row.
* Reordering the steps is now a compile error, not a code-review catch.
* The best-effort body moves to a private helper unchanged; tests that drive materialization directly discard the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)