### PR TITLE
refactor(achievements): single source of truth for kind labels

### DIFF
--- a/Public/achievements-editor.js
+++ b/Public/achievements-editor.js
@@ -10,11 +10,10 @@
 (function () {
     'use strict';
 
-    var KIND_LABEL = {
-        classGoal: 'Class Goal', thresholdBadge: 'Score Badge', testBadge: 'Test Badge',
-        firstTryPerfect: 'First-Try', comeback: 'Comeback', persistence: 'Persistence',
-        speedRun: 'Speed', classRecord: 'Class Record'
-    };
+    // Kind labels come from the server-rendered #am-kind options (their
+    // data-label attributes), so the Swift AchievementKindPresentation
+    // registry is the single source of truth; populated in init().
+    var KIND_LABEL = {};
     // Which modal fields apply to each kind.
     var KIND_FIELDS = {
         classGoal: ['thresholdPercent', 'classPercent', 'points'],
@@ -75,6 +74,11 @@
         var status = document.getElementById('achievements-status');
         var modal = document.getElementById('achievement-modal');
         var kindSel = document.getElementById('am-kind');
+        if (kindSel) {
+            Array.prototype.slice.call(kindSel.options).forEach(function (o) {
+                KIND_LABEL[o.value] = o.getAttribute('data-label') || o.text;
+            });
+        }
 
         var state = [];
         var editingIndex = -1;

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -382,15 +382,13 @@
             </label>
             <label class="form-label field-gap">
                 Kind
+                <!-- Options render from AchievementKindPresentation (the one
+                     source of truth for kinds); achievements-editor.js reads
+                     each option's data-label for its table Kind column. -->
                 <select class="form-input" id="am-kind">
-                    <option value="classGoal">Class Goal — collaborative grade bonus</option>
-                    <option value="thresholdBadge">Score Badge — grade threshold</option>
-                    <option value="testBadge">Test Badge — a test passes</option>
-                    <option value="firstTryPerfect">First-Try — perfect on attempt 1</option>
-                    <option value="comeback">Comeback — big grade jump</option>
-                    <option value="persistence">Persistence — perfect after many tries</option>
-                    <option value="speedRun">Speed — fast perfect run</option>
-                    <option value="classRecord">Class Record — one holder</option>
+                    #for(opt in achievementKindOptions):
+                    <option value="#(opt.value)" data-label="#(opt.label)">#(opt.label) — #(opt.detail)</option>
+                    #endfor
                 </select>
             </label>
             <label class="form-label field-gap am-field" data-field="thresholdPercent" style="display:none">

--- a/Sources/APIServer/Helpers/AchievementKindPresentation.swift
+++ b/Sources/APIServer/Helpers/AchievementKindPresentation.swift
@@ -1,0 +1,51 @@
+// APIServer/Helpers/AchievementKindPresentation.swift
+//
+// Single source of truth for how the editor UI presents each authorable
+// `AchievementKind`.  The assignment editor's kind dropdown renders from
+// `AchievementKindPresentation.all`, and `achievements-editor.js` derives its
+// table labels from those rendered options — so the Swift enum, the dropdown,
+// and the JS labels can't drift.  The switch is exhaustive on purpose: adding
+// a kind fails to compile until it gets a label here, instead of rendering
+// blank in the editor.
+
+import Core
+
+/// One kind as the editor presents it.
+struct AchievementKindOption: Encodable {
+    /// Raw `AchievementKind` value, the row's `kind` field.
+    let value: String
+    /// Short label shown in the editor table's Kind column.
+    let label: String
+    /// One-line explanation; the dropdown shows "label — detail".
+    let detail: String
+}
+
+enum AchievementKindPresentation {
+
+    static var all: [AchievementKindOption] {
+        AchievementKind.allCases.map(option(for:))
+    }
+
+    private static func option(for kind: AchievementKind) -> AchievementKindOption {
+        switch kind {
+        case .classGoal:
+            return .init(
+                value: kind.rawValue, label: "Class Goal", detail: "collaborative grade bonus")
+        case .thresholdBadge:
+            return .init(value: kind.rawValue, label: "Score Badge", detail: "grade threshold")
+        case .testBadge:
+            return .init(value: kind.rawValue, label: "Test Badge", detail: "a test passes")
+        case .firstTryPerfect:
+            return .init(value: kind.rawValue, label: "First-Try", detail: "perfect on attempt 1")
+        case .comeback:
+            return .init(value: kind.rawValue, label: "Comeback", detail: "big grade jump")
+        case .persistence:
+            return .init(
+                value: kind.rawValue, label: "Persistence", detail: "perfect after many tries")
+        case .speedRun:
+            return .init(value: kind.rawValue, label: "Speed", detail: "fast perfect run")
+        case .classRecord:
+            return .init(value: kind.rawValue, label: "Class Record", detail: "one holder")
+        }
+    }
+}

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -136,6 +136,10 @@ struct EditAssignmentContext: Encodable {
     /// "Global Inputs" panel at the top of the edit page iterates this
     /// list to seed its initial rows.  Empty when no globals declared.
     let globalVariableRows: [SuiteSectionVariableShellRow]
+    /// The authorable achievement kinds, in declaration order.  The kind
+    /// dropdown renders from this list and the editor JS derives its table
+    /// labels from the rendered options — see `AchievementKindPresentation`.
+    let achievementKindOptions: [AchievementKindOption]
     let brightspaceSyncEnabled: Bool
     let brightspaceGradeObjectID: String?
     let notice: String?

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -443,6 +443,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             suiteStateJSON: suiteStateJSON(fromManifest: setup.manifest, zipPath: setup.zipPath),
             suiteSectionRows: suiteSectionShellRows(fromManifest: setup.manifest),
             globalVariableRows: globalVariableShellRows(fromManifest: setup.manifest),
+            achievementKindOptions: AchievementKindPresentation.all,
             brightspaceSyncEnabled: req.application.brightSpaceClient != nil,
             brightspaceGradeObjectID: assignment.brightspaceGradeObjectID,
             notice: q?.notice,

--- a/Sources/Core/Achievement.swift
+++ b/Sources/Core/Achievement.swift
@@ -83,7 +83,7 @@ public struct Achievement: Codable, Equatable, Sendable {
 
 /// The variety of achievement — the discriminator that says which optional
 /// parameters apply and how it is evaluated.
-public enum AchievementKind: String, Codable, Sendable {
+public enum AchievementKind: String, CaseIterable, Codable, Sendable {
     /// Collaborative: at least `classFraction` of the class reaches `threshold`
     /// on `target`.  Awards a positive, fractional `points` bonus to everyone
     /// who submitted, scaled by class progress.  Evaluated by the periodic

--- a/Tests/APITests/AchievementKindPresentationTests.swift
+++ b/Tests/APITests/AchievementKindPresentationTests.swift
@@ -1,0 +1,52 @@
+// Tests/APITests/AchievementKindPresentationTests.swift
+//
+// AchievementKindPresentation is the single source of truth for how the
+// editor names achievement kinds: the assignment-edit page renders the kind
+// dropdown from it, and achievements-editor.js derives its table labels from
+// the rendered options.  The exhaustive switch already makes a missing label
+// a compile error; these tests pin the rendered output.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AchievementKindPresentationTests {
+
+    @Test func everyKindHasADistinctOption() {
+        let options = AchievementKindPresentation.all
+        #expect(options.count == AchievementKind.allCases.count)
+        #expect(Set(options.map(\.value)).count == options.count, "raw values must be unique")
+        #expect(Set(options.map(\.label)).count == options.count, "labels must be unique")
+        for option in options {
+            #expect(!option.label.isEmpty)
+            #expect(!option.detail.isEmpty)
+        }
+    }
+
+    @Test func editPageRendersOneOptionPerKind() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await arInsertSetup(id: "kinds_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "kinds_setup", title: "Kinds", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/edit",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    for option in AchievementKindPresentation.all {
+                        #expect(
+                            body.contains(
+                                "<option value=\"\(option.value)\" data-label=\"\(option.label)\">"),
+                            "edit page must render a kind option for \(option.value)")
+                    }
+                })
+        }
+    }
+}


### PR DESCRIPTION
Audit follow-up 5/5: the authorable achievement kinds were named in three hand-maintained places — the `AchievementKind` enum, `KIND_LABEL` in `achievements-editor.js`, and the hardcoded `<option>` list in `assignment-edit.leaf`. Adding a kind in Swift and forgetting the JS rendered blank Kind cells.

* `AchievementKindPresentation` (exhaustive switch — a new case is a compile error until labeled; `AchievementKind` gains `CaseIterable`).
* The edit page renders the kind dropdown from the registry via the editor context.
* The editor JS derives table labels from the rendered options instead of its own literal.
* Tests pin one rendered option per kind + label/value uniqueness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)