### PR TITLE
fix(tests): de-flake WorkerTests — script time limits, spawn retries, global-state races

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -326,6 +326,15 @@ jobs:
         run: apt-get update -qq && apt-get install -y --no-install-recommends file python3
 
       - name: Run WorkerTests
+        # `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` caps Swift
+        # Testing's in-process parallelism, matching the APITests jobs and
+        # the nightly coverage run.  WorkerTests spawn real subprocesses
+        # (/bin/sh scripts, python3 HTTP servers) and daemon Tasks that get
+        # starved when every test fires at once on a 2-core runner; the cap
+        # bounds that contention at the scheduler instead of relying solely
+        # on the in-suite throttles.
+        env:
+          SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "4"
         run: |
           if [ "${{ steps.build-cache.outputs.cache-hit }}" = "true" ]; then
             swift test --skip-build --filter WorkerTests

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -214,7 +214,8 @@ struct WorkerCommand: AsyncParsableCommand {
 
 func resolveWorkerSharedSecret(
     cliWorkerSecret: String?,
-    environment: [String: String]
+    environment: [String: String],
+    currentDirectory: String = FileManager.default.currentDirectoryPath
 ) -> String? {
     let cliSecret = cliWorkerSecret?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     if !cliSecret.isEmpty { return cliSecret }
@@ -223,7 +224,7 @@ func resolveWorkerSharedSecret(
         .trimmingCharacters(in: .whitespacesAndNewlines)
     if !envSecret.isEmpty { return envSecret }
 
-    for path in defaultWorkerSecretFilePaths() {
+    for path in defaultWorkerSecretFilePaths(currentDirectory: currentDirectory) {
         if let fileSecret = readWorkerSecretFromFile(path: path) {
             return fileSecret
         }
@@ -232,10 +233,14 @@ func resolveWorkerSharedSecret(
     return nil
 }
 
-func defaultWorkerSecretFilePaths() -> [String] {
+// `currentDirectory` is injectable so tests can point at a scratch directory
+// instead of mutating the process-global working directory with `chdir`.
+func defaultWorkerSecretFilePaths(
+    currentDirectory: String = FileManager.default.currentDirectoryPath
+) -> [String] {
     var paths: [String] = []
 
-    let cwd = FileManager.default.currentDirectoryPath
+    let cwd = currentDirectory
     if !cwd.isEmpty {
         paths.append(URL(fileURLWithPath: cwd).appendingPathComponent(".worker-secret").path)
     }

--- a/Tests/WorkerTests/NotebookExtractorTests.swift
+++ b/Tests/WorkerTests/NotebookExtractorTests.swift
@@ -383,7 +383,7 @@ import Testing
 
     // MARK: - End-to-end: run the generated module through a real python3
 
-    @Test func generatedModuleLoadsUnderRealPython3() throws {
+    @Test func generatedModuleLoadsUnderRealPython3() async throws {
         // The shape-level tests above can't catch an emitted-Python bug that
         // still *looks* plausible — the v0.4.220 `\/` regression compiled fine
         // as a Swift string but made the inner compile() throw. Only a real
@@ -426,15 +426,16 @@ import Testing
             print(json.dumps({n: hasattr(m, n) for n in names}))
             """
 
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        proc.arguments = ["python3", "-c", probe]
-        let outPipe = Pipe()
-        proc.standardOutput = outPipe
-        proc.standardError = Pipe()
-        try proc.run()
-        proc.waitUntilExit()
+        let proc = try await runProcessRobustly {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            proc.arguments = ["python3", "-c", probe]
+            proc.standardOutput = Pipe()
+            proc.standardError = Pipe()
+            return proc
+        }
 
+        let outPipe = try #require(proc.standardOutput as? Pipe)
         let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         let out = (String(bytes: outData, encoding: .utf8) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/WorkerTests/Support/LocalHTTPTestServer.swift
+++ b/Tests/WorkerTests/Support/LocalHTTPTestServer.swift
@@ -32,7 +32,12 @@ import Darwin
 /// A short-lived local HTTP server backed by a real `python3` subprocess,
 /// bound to an ephemeral `127.0.0.1` port.  Build one with a factory, read
 /// `.port`, and call `.stop()` (typically from a `defer`) when done.
-final class LocalHTTPTestServer {
+///
+/// `@unchecked Sendable`: all stored properties are `let` and fully
+/// initialized before the instance escapes the factory's subprocess slot;
+/// the only post-init mutation is the kill/reap inside `stop()`, which each
+/// owning test calls exactly once from its own `defer`.
+final class LocalHTTPTestServer: @unchecked Sendable {
     let port: Int
     private let process: Process
     private let stdout: Pipe
@@ -98,88 +103,101 @@ final class LocalHTTPTestServer {
 
     // MARK: - Factories
 
+    // Each factory launches its python3 child while holding a subprocess
+    // slot (released after the port handshake, not for the server's
+    // lifetime), so these long-lived helpers can't join the fork storm
+    // `SubprocessThrottle` exists to prevent.
+
     /// Serves files from `directory` (the runner's submission/test-setup
     /// download source).
-    static func staticFiles(directory: URL) throws -> LocalHTTPTestServer {
-        try LocalHTTPTestServer(
-            pythonProgram: #"""
-                import http.server
-                import socketserver
-                import sys
+    static func staticFiles(directory: URL) async throws -> LocalHTTPTestServer {
+        try await withSubprocessSlot {
+            try LocalHTTPTestServer(
+                pythonProgram: #"""
+                    import http.server
+                    import socketserver
+                    import sys
 
-                directory = sys.argv[1]
+                    directory = sys.argv[1]
 
-                class Handler(http.server.SimpleHTTPRequestHandler):
-                    def __init__(self, *args, **kwargs):
-                        super().__init__(*args, directory=directory, **kwargs)
+                    class Handler(http.server.SimpleHTTPRequestHandler):
+                        def __init__(self, *args, **kwargs):
+                            super().__init__(*args, directory=directory, **kwargs)
 
-                    def log_message(self, format, *args):
-                        pass
+                        def log_message(self, format, *args):
+                            pass
 
-                with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
-                    print(httpd.server_address[1], flush=True)
-                    httpd.serve_forever()
-                """#,
-            extraArguments: [directory.path])
+                    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+                        print(httpd.server_address[1], flush=True)
+                        httpd.serve_forever()
+                    """#,
+                extraArguments: [directory.path])
+        }
     }
 
     /// Returns 503 for the first `failuresBeforeSuccess` GETs, then 200 with
     /// `responseBody` — exercises the runner's download-retry path.
-    static func flaky(failuresBeforeSuccess: Int, responseBody: String = "payload") throws -> LocalHTTPTestServer {
-        try LocalHTTPTestServer(
-            pythonProgram: #"""
-                import http.server
-                import socketserver
-                import sys
+    static func flaky(
+        failuresBeforeSuccess: Int, responseBody: String = "payload"
+    ) async throws -> LocalHTTPTestServer {
+        try await withSubprocessSlot {
+            try LocalHTTPTestServer(
+                pythonProgram: #"""
+                    import http.server
+                    import socketserver
+                    import sys
 
-                remaining = int(sys.argv[1])
-                body = sys.argv[2].encode("utf-8")
+                    remaining = int(sys.argv[1])
+                    body = sys.argv[2].encode("utf-8")
 
-                class Handler(http.server.BaseHTTPRequestHandler):
-                    def do_GET(self):
-                        global remaining
-                        if remaining > 0:
-                            remaining -= 1
-                            self.send_response(503)
+                    class Handler(http.server.BaseHTTPRequestHandler):
+                        def do_GET(self):
+                            global remaining
+                            if remaining > 0:
+                                remaining -= 1
+                                self.send_response(503)
+                                self.end_headers()
+                                self.wfile.write(b"unavailable")
+                                return
+                            self.send_response(200)
+                            self.send_header("Content-Length", str(len(body)))
                             self.end_headers()
-                            self.wfile.write(b"unavailable")
-                            return
-                        self.send_response(200)
-                        self.send_header("Content-Length", str(len(body)))
-                        self.end_headers()
-                        self.wfile.write(body)
+                            self.wfile.write(body)
 
-                    def log_message(self, format, *args):
-                        pass
+                        def log_message(self, format, *args):
+                            pass
 
-                with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
-                    print(httpd.server_address[1], flush=True)
-                    httpd.serve_forever()
-                """#,
-            extraArguments: [String(failuresBeforeSuccess), responseBody])
+                    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+                        print(httpd.server_address[1], flush=True)
+                        httpd.serve_forever()
+                    """#,
+                extraArguments: [String(failuresBeforeSuccess), responseBody])
+        }
     }
 
     /// Returns 404 for every request — exercises the terminal (non-retryable)
     /// download-failure path.
-    static func alwaysNotFound() throws -> LocalHTTPTestServer {
-        try LocalHTTPTestServer(
-            pythonProgram: #"""
-                import http.server
-                import socketserver
+    static func alwaysNotFound() async throws -> LocalHTTPTestServer {
+        try await withSubprocessSlot {
+            try LocalHTTPTestServer(
+                pythonProgram: #"""
+                    import http.server
+                    import socketserver
 
-                class Handler(http.server.BaseHTTPRequestHandler):
-                    def do_GET(self):
-                        self.send_response(404)
-                        self.end_headers()
-                        self.wfile.write(b"not found")
+                    class Handler(http.server.BaseHTTPRequestHandler):
+                        def do_GET(self):
+                            self.send_response(404)
+                            self.end_headers()
+                            self.wfile.write(b"not found")
 
-                    def log_message(self, format, *args):
-                        pass
+                        def log_message(self, format, *args):
+                            pass
 
-                with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
-                    print(httpd.server_address[1], flush=True)
-                    httpd.serve_forever()
-                """#,
-            extraArguments: [])
+                    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+                        print(httpd.server_address[1], flush=True)
+                        httpd.serve_forever()
+                    """#,
+                extraArguments: [])
+        }
     }
 }

--- a/Tests/WorkerTests/Support/MockURLProtocol.swift
+++ b/Tests/WorkerTests/Support/MockURLProtocol.swift
@@ -154,8 +154,13 @@ extension URLSession {
     static func mocked() -> URLSession {
         let cfg = URLSessionConfiguration.ephemeral
         cfg.protocolClasses = [MockURLProtocol.self]
-        cfg.timeoutIntervalForRequest = 5
-        cfg.timeoutIntervalForResource = 5
+        // Generous on purpose: every stub replies immediately (even the
+        // "no stub enqueued" path fails fast), so this timeout never gates a
+        // passing run — it can only fire when a loaded CI machine starves the
+        // delivery, which would surface as a spurious URLError instead of the
+        // stubbed response.
+        cfg.timeoutIntervalForRequest = 30
+        cfg.timeoutIntervalForResource = 30
         return URLSession(configuration: cfg)
     }
 }

--- a/Tests/WorkerTests/Support/ScriptRunnerTestSupport.swift
+++ b/Tests/WorkerTests/Support/ScriptRunnerTestSupport.swift
@@ -53,3 +53,32 @@ func runScriptRobustly(
         return output
     }
 }
+
+/// Builds, launches, and reaps a bare `Process` under the shared
+/// subprocess-launch throttle, retrying the *launch* when `Process.run()`
+/// throws.  Under parallel CI load `posix_spawn` can transiently fail
+/// (EAGAIN), which Foundation surfaces as a misleading "file doesn't exist"
+/// CocoaError — the cause of intermittent CI failures in tests that spawn
+/// `/usr/bin/env` directly.  Each attempt gets a fresh `Process` from
+/// `makeProcess` because a failed `run()` leaves the instance unusable.
+/// Returns the exited process; read `terminationStatus` and any attached
+/// pipes off it.
+func runProcessRobustly(
+    attempts: Int = 5,
+    makeProcess: @Sendable () throws -> Process
+) async throws -> Process {
+    try await withSubprocessSlot {
+        for _ in 0..<(attempts - 1) {
+            let process = try makeProcess()
+            if (try? process.run()) != nil {
+                process.waitUntilExit()
+                return process
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        let process = try makeProcess()
+        try process.run()
+        process.waitUntilExit()
+        return process
+    }
+}

--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -206,7 +206,7 @@ import Testing
         return path
     }
 
-    private func makeZip(at zipPath: String, files: [(path: String, contents: String)]) throws {
+    private func makeZip(at zipPath: String, files: [(path: String, contents: String)]) async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("worker-daemon-zip-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -221,32 +221,37 @@ import Testing
             try Data(file.contents.utf8).write(to: path)
         }
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.currentDirectoryURL = tempDir
-        process.arguments = [
-            "python3",
-            "-c",
-            #"""
-            import os
-            import sys
-            import zipfile
+        // Launched via `runProcessRobustly` so concurrent tests can't pile
+        // python3 forks on top of the suite's other real subprocesses, and a
+        // transient spawn failure under load is retried instead of failing
+        // the test.
+        let process = try await runProcessRobustly {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.currentDirectoryURL = tempDir
+            process.arguments = [
+                "python3",
+                "-c",
+                #"""
+                import os
+                import sys
+                import zipfile
 
-            zip_path = sys.argv[1]
-            root = sys.argv[2]
+                zip_path = sys.argv[1]
+                root = sys.argv[2]
 
-            with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-                for current_root, _, filenames in os.walk(root):
-                    for filename in filenames:
-                        full_path = os.path.join(current_root, filename)
-                        archive_name = os.path.relpath(full_path, root)
-                        archive.write(full_path, archive_name)
-            """#,
-            zipPath,
-            tempDir.path,
-        ]
-        try process.run()
-        process.waitUntilExit()
+                with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                    for current_root, _, filenames in os.walk(root):
+                        for filename in filenames:
+                            full_path = os.path.join(current_root, filename)
+                            archive_name = os.path.relpath(full_path, root)
+                            archive.write(full_path, archive_name)
+                """#,
+                zipPath,
+                tempDir.path,
+            ]
+            return process
+        }
         #expect(process.terminationStatus == 0)
     }
 
@@ -254,12 +259,12 @@ import Testing
         root: URL,
         serverPort: Int,
         submissionID: String
-    ) throws -> Job {
+    ) async throws -> Job {
         let submissionPath = root.appendingPathComponent("\(submissionID).ipynb")
         try Data(notebookJSON(code: "print(\(submissionID.debugDescription))\n").utf8).write(to: submissionPath)
 
         let setupZipPath = root.appendingPathComponent("\(submissionID)-setup.zip").path
-        try makeZip(
+        try await makeZip(
             at: setupZipPath,
             files: [
                 ("test.sh", "#!/bin/sh\necho passed\n")
@@ -430,10 +435,10 @@ import Testing
         let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-report-failure-cache")
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
 
-        let server = try LocalHTTPTestServer.staticFiles(directory: root)
+        let server = try await LocalHTTPTestServer.staticFiles(directory: root)
         defer { server.stop() }
 
-        let job = try makeServedJob(root: root, serverPort: server.port, submissionID: "sub_report_fail")
+        let job = try await makeServedJob(root: root, serverPort: server.port, submissionID: "sub_report_fail")
         let poller = MockPoller(jobs: [job, nil, nil, nil])
         let reporter = FlakyReporter(failuresRemaining: 1)
         let runner = MockRunner(
@@ -505,10 +510,10 @@ import Testing
         let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-next-job-cache")
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
 
-        let server = try LocalHTTPTestServer.staticFiles(directory: root)
+        let server = try await LocalHTTPTestServer.staticFiles(directory: root)
         defer { server.stop() }
 
-        let goodJob = try makeServedJob(root: root, serverPort: server.port, submissionID: "sub_good_job")
+        let goodJob = try await makeServedJob(root: root, serverPort: server.port, submissionID: "sub_good_job")
         let badJob = try makeJob(submissionID: "sub_bad_job")
         let poller = MockPoller(jobs: [badJob, goodJob, nil, nil, nil])
         let reporter = MockReporter()
@@ -573,10 +578,10 @@ import Testing
         let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-json-footer-cache")
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
 
-        let server = try LocalHTTPTestServer.staticFiles(directory: root)
+        let server = try await LocalHTTPTestServer.staticFiles(directory: root)
         defer { server.stop() }
 
-        let job = try makeServedJob(root: root, serverPort: server.port, submissionID: "sub_json_footer")
+        let job = try await makeServedJob(root: root, serverPort: server.port, submissionID: "sub_json_footer")
 
         let stdoutWithFooter = """
             Hello, World!
@@ -674,7 +679,7 @@ import Testing
     }
 
     @Test func downloadRetriesThroughShortServerInterruption() async throws {
-        let flakyServer = try LocalHTTPTestServer.flaky(failuresBeforeSuccess: 2, responseBody: "PK\0\0")
+        let flakyServer = try await LocalHTTPTestServer.flaky(failuresBeforeSuccess: 2, responseBody: "PK\0\0")
         defer { flakyServer.stop() }
 
         let poller = MockPoller(jobs: [])
@@ -860,11 +865,13 @@ import Testing
         let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-concurrent-cache")
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
 
-        let server = try LocalHTTPTestServer.staticFiles(directory: root)
+        let server = try await LocalHTTPTestServer.staticFiles(directory: root)
         defer { server.stop() }
 
-        let jobs = try (0..<5).map { i in
-            try makeServedJob(root: root, serverPort: server.port, submissionID: "concurrent_\(i)")
+        var jobs: [Job] = []
+        for i in 0..<5 {
+            jobs.append(
+                try await makeServedJob(root: root, serverPort: server.port, submissionID: "concurrent_\(i)"))
         }
         let poller = MockPoller(jobs: jobs.map(Optional.some) + [nil])
         let reporter = MockReporter()
@@ -907,7 +914,7 @@ import Testing
     @Test func workerDaemonReportsSyntheticFailureWhenSubmissionDownloadTerminallyFails() async throws {
         let cacheRoot = try makeTempCacheRoot(named: "worker-daemon-dl-terminal-cache")
         defer { try? FileManager.default.removeItem(at: cacheRoot) }
-        let failServer = try LocalHTTPTestServer.alwaysNotFound()
+        let failServer = try await LocalHTTPTestServer.alwaysNotFound()
         defer { failServer.stop() }
 
         let job = Job(

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -53,7 +53,7 @@ import Testing
     @Test func scriptExitZeroReportsExitCodeZero() async throws {
         let script = try writeScript("#!/bin/sh\nexit 0")
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 0)
         #expect(output.timedOut == false)
     }
@@ -61,7 +61,7 @@ import Testing
     @Test func scriptExitOneReportsExitCodeOne() async throws {
         let script = try writeScript("#!/bin/sh\nexit 1")
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 1)
         #expect(output.timedOut == false)
     }
@@ -69,7 +69,7 @@ import Testing
     @Test func scriptExitTwoReportsExitCodeTwo() async throws {
         let script = try writeScript("#!/bin/sh\nexit 2")
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 2)
         #expect(output.timedOut == false)
     }
@@ -79,21 +79,21 @@ import Testing
     @Test func stdoutIsCaptured() async throws {
         let script = try writeScript("#!/bin/sh\necho 'hello world'\nexit 0")
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.stdout.contains("hello world"))
     }
 
     @Test func stderrIsCaptured() async throws {
         let script = try writeScript("#!/bin/sh\necho 'oops' >&2\nexit 0")
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.stderr.contains("oops"))
     }
 
     @Test func stdoutAndStderrAreSeparate() async throws {
         let script = try writeScript("#!/bin/sh\necho 'out'\necho 'err' >&2\nexit 0")
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.stdout.contains("out"))
         #expect(output.stdout.contains("err") == false)
         #expect(output.stderr.contains("err"))
@@ -120,7 +120,7 @@ import Testing
                 runner,
                 script: script,
                 workDir: workDir,
-                timeLimitSeconds: 5,
+                timeLimitSeconds: 60,
                 env: ["CHICKADEE_ASSIGNMENT_SEED": "deadbeef" + String(repeating: "c0ffee", count: 9) + "ba"]
             )
         }
@@ -160,7 +160,7 @@ import Testing
                 runner,
                 script: script,
                 workDir: workDir,
-                timeLimitSeconds: 5,
+                timeLimitSeconds: 60,
                 env: [:]
             )
         }
@@ -179,7 +179,7 @@ import Testing
         let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 1)
         #expect(output.timedOut, "Script sleeping 60s should time out with a 1s limit")
         #expect(output.exitCode == -1)
-        #expect(output.executionTimeMs < 10_000)
+        #expect(output.executionTimeMs < 30_000)
     }
 
     #if os(Linux)
@@ -195,7 +195,7 @@ import Testing
         #expect(output.timedOut, "Timed-out script with a background child should still time out")
         #expect(output.exitCode == -1)
         #expect(
-            output.executionTimeMs < 10_000,
+            output.executionTimeMs < 30_000,
             "Timed-out script should reap inherited stdout/stderr handles from background children")
     }
     #endif
@@ -205,7 +205,7 @@ import Testing
     @Test func workDirIsSetCorrectly() async throws {
         let script = try writeScript("#!/bin/sh\ntouch marker.txt\nexit 0")
         let runner = UnsandboxedScriptRunner()
-        _ = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        _ = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         let markerPath = tmpDir.appendingPathComponent("marker.txt").path
         #expect(
             FileManager.default.fileExists(atPath: markerPath),
@@ -219,7 +219,7 @@ import Testing
         guard sandboxedRunnerSupported() else { return }
         let script = try writeScript("#!/bin/sh\nexit 0")
         let runner = SandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 0)
         #expect(output.timedOut == false)
     }
@@ -228,7 +228,7 @@ import Testing
         guard sandboxedRunnerSupported() else { return }
         let script = try writeScript("#!/bin/sh\nexit 1")
         let runner = SandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 1)
         #expect(output.timedOut == false)
     }
@@ -237,7 +237,7 @@ import Testing
         guard sandboxedRunnerSupported() else { return }
         let script = try writeScript("#!/bin/sh\necho 'sandbox out'\nexit 0")
         let runner = SandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.stdout.contains("sandbox out"))
     }
 
@@ -245,7 +245,7 @@ import Testing
         guard sandboxedRunnerSupported() else { return }
         let script = try writeScript("#!/bin/sh\necho 'sandbox err' >&2\nexit 0")
         let runner = SandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.stderr.contains("sandbox err"))
     }
 
@@ -257,7 +257,7 @@ import Testing
         #expect(output.timedOut, "Sandboxed script sleeping 60s should time out with 1s limit")
         #expect(output.exitCode == -1)
         #expect(
-            output.executionTimeMs < 10_000, "Sandboxed timeout should not wait for child processes to exit naturally")
+            output.executionTimeMs < 30_000, "Sandboxed timeout should not wait for child processes to exit naturally")
     }
 
     #if os(Linux)
@@ -273,7 +273,7 @@ import Testing
         #expect(output.timedOut, "Sandboxed script with a background child should still time out")
         #expect(output.exitCode == -1)
         #expect(
-            output.executionTimeMs < 10_000,
+            output.executionTimeMs < 30_000,
             "Sandboxed timeout should reap background children without leaving pipes open")
     }
     #endif
@@ -282,7 +282,7 @@ import Testing
         guard sandboxedRunnerSupported() else { return }
         let script = try writeScript("#!/bin/sh\ntouch sandboxmarker.txt\nexit 0")
         let runner = SandboxedScriptRunner()
-        _ = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 5)
+        _ = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         let markerPath = tmpDir.appendingPathComponent("sandboxmarker.txt").path
         #expect(
             FileManager.default.fileExists(atPath: markerPath),
@@ -312,7 +312,7 @@ import Testing
             "
             """)
         let runner = SandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 10)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(
             output.exitCode != 0,
             "Sandboxed runner should block outbound network access (exit 0 means connection succeeded)")
@@ -340,27 +340,26 @@ import Testing
         #expect(resolved == "env-secret")
     }
 
-    @Test func resolveWorkerSharedSecretUsesDefaultFileWhenSecretsUnset() throws {
-        let previous = FileManager.default.currentDirectoryPath
-        #expect(FileManager.default.changeCurrentDirectoryPath(tmpDir.path))
-        defer { #expect(FileManager.default.changeCurrentDirectoryPath(previous)) }
+    // These three resolve against an explicit `currentDirectory` rather than
+    // calling `changeCurrentDirectoryPath`: the working directory is
+    // process-global, so a chdir here raced every concurrently running test
+    // that resolves relative paths (and the chdir tests raced each other).
 
+    @Test func resolveWorkerSharedSecretUsesDefaultFileWhenSecretsUnset() throws {
         _ = try writeSecretFile("shared-file-secret\n")
         let resolved = resolveWorkerSharedSecret(
             cliWorkerSecret: nil,
-            environment: [:]
+            environment: [:],
+            currentDirectory: tmpDir.path
         )
 
         #expect(resolved == "shared-file-secret")
     }
 
     @Test func defaultWorkerSecretFilePathsIncludesCurrentDirectoryFileFirst() throws {
-        let previous = FileManager.default.currentDirectoryPath
-        #expect(FileManager.default.changeCurrentDirectoryPath(tmpDir.path))
-        defer { #expect(FileManager.default.changeCurrentDirectoryPath(previous)) }
-
-        let paths = defaultWorkerSecretFilePaths()
-        let expectedFirstPath = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let paths = defaultWorkerSecretFilePaths(currentDirectory: tmpDir.path)
+        let expectedFirstPath =
+            tmpDir
             .appendingPathComponent(".worker-secret")
             .path
 
@@ -371,13 +370,11 @@ import Testing
     @Test func resolveWorkerSharedSecretReturnsNilWhenAllSourcesMissing() {
         let emptyDir = tmpDir.appendingPathComponent("empty", isDirectory: true)
         try? FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
-        let previous = FileManager.default.currentDirectoryPath
-        #expect(FileManager.default.changeCurrentDirectoryPath(emptyDir.path))
-        defer { #expect(FileManager.default.changeCurrentDirectoryPath(previous)) }
 
         let resolved = resolveWorkerSharedSecret(
             cliWorkerSecret: nil,
-            environment: [:]
+            environment: [:],
+            currentDirectory: emptyDir.path
         )
 
         #expect(resolved == nil)
@@ -394,22 +391,20 @@ import Testing
 
     // MARK: - R runtime helpers
 
-    private func rscriptAvailable() -> Bool {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        proc.arguments = ["Rscript", "--version"]
-        proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
-        // Only query terminationStatus after a confirmed launch. If run()
-        // fails (e.g. posix_spawn returns EAGAIN under heavy parallel spawn
-        // pressure), terminationStatus on a never-launched task raises an
-        // uncaught NSInvalidArgumentException that aborts the whole process.
-        do {
-            try proc.run()
-        } catch {
-            return false
+    private func rscriptAvailable() async -> Bool {
+        // Probed via `runProcessRobustly` so the availability check can't
+        // join the suite's fork storm under parallel CI load, and a transient
+        // spawn failure (posix_spawn EAGAIN) is retried instead of silently
+        // mis-reporting Rscript as unavailable.
+        let proc = try? await runProcessRobustly {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            proc.arguments = ["Rscript", "--version"]
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = FileHandle.nullDevice
+            return proc
         }
-        proc.waitUntilExit()
+        guard let proc else { return false }
         return proc.terminationStatus == 0
     }
 
@@ -419,56 +414,56 @@ import Testing
     }
 
     @Test func rRuntimePassedExitsZeroWithJSON() async throws {
-        guard rscriptAvailable() else { return }
+        guard await rscriptAvailable() else { return }
         try writeRRuntime()
         let script = try writeScript(
             "source('test_runtime.R')\npassed('all good')",
             name: "test.r"
         )
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 10)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 0)
         #expect(output.stdout.contains("all good"), "stdout should contain the passed message")
         #expect(output.stdout.contains("shortResult"), "stdout should contain shortResult JSON key")
     }
 
     @Test func rRuntimeFailedExitsOneWithJSON() async throws {
-        guard rscriptAvailable() else { return }
+        guard await rscriptAvailable() else { return }
         try writeRRuntime()
         let script = try writeScript(
             "source('test_runtime.R')\nfailed('wrong answer')",
             name: "test.r"
         )
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 10)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 1)
         #expect(output.stdout.contains("wrong answer"))
         #expect(output.stdout.contains("shortResult"))
     }
 
     @Test func rRuntimeErroredExitsTwoWithJSON() async throws {
-        guard rscriptAvailable() else { return }
+        guard await rscriptAvailable() else { return }
         try writeRRuntime()
         let script = try writeScript(
             "source('test_runtime.R')\nerrored('unexpected')",
             name: "test.r"
         )
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 10)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 2)
         #expect(output.stdout.contains("unexpected"))
         #expect(output.stdout.contains("shortResult"))
     }
 
     @Test func rRuntimePassedDefaultMessage() async throws {
-        guard rscriptAvailable() else { return }
+        guard await rscriptAvailable() else { return }
         try writeRRuntime()
         let script = try writeScript(
             "source('test_runtime.R')\npassed()",
             name: "test.r"
         )
         let runner = UnsandboxedScriptRunner()
-        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 10)
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 0)
         #expect(output.stdout.contains("passed"), "default passed() message should be 'passed'")
     }

--- a/changelog.d/worker-test-deflake.md
+++ b/changelog.d/worker-test-deflake.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **WorkerTests de-flaked.** A three-week CI audit showed ~85% of genuine
+  worker-test failures were one mechanism: trivial `/bin/sh` scripts in
+  `WorkerTests.swift` hitting their 5 s script time limit on CPU-starved
+  runners. Those limits (which only bound a hang) are now 60 s, and the
+  kill-path latency assertions are correspondingly relaxed. The second
+  pattern — `Process.run()` transiently failing under fork pressure with a
+  misleading "file doesn't exist" error — is fixed by a shared
+  `runProcessRobustly` helper that launches bare `Process` spawns under the
+  subprocess throttle and retries failed launches; the `LocalHTTPTestServer`
+  factories, the daemon tests' zip builder, and the Rscript probe now all
+  honor the throttle they were documented to use. Also: the three
+  worker-secret tests no longer `chdir` the whole process
+  (`resolveWorkerSharedSecret` / `defaultWorkerSecretFilePaths` take an
+  injectable `currentDirectory`), the mock URLSession timeout no longer
+  gates passing runs, and the `worker-tests` CI job caps Swift Testing
+  parallelism at 4 like the APITests jobs.


### PR DESCRIPTION
## What

Eliminates the WorkerTests CI flakiness, driven by an audit of the last ~750 `swift-tests.yml` runs (2026-05-19 → 2026-06-10): 687 success, 57 failure. Of the worker-test failures, **13 were genuine flakes in two families** (the rest were infra — Docker Hub pulls, container init — or real compile errors on PR branches).

### Family 1 (11×, 6 on `main`): 5 s script time limit hit under CPU starvation

Trivial `/bin/sh` scripts (`exit 0`, `echo`…) in `WorkerTests.swift` intermittently hit their 5 s `timeLimitSeconds` on loaded 2-core runners — empty output, `timedOut=true`, `exitCode=-1`, a different test picked off each time. `runScriptRobustly` deliberately doesn't retry timeouts (a timeout is a "real result" for the timeout tests), so the fix is to make the limit irrelevant to passing runs:

- `timeLimitSeconds` 5/10 → **60** on every should-finish-instantly script (the limit only bounds a hang; the deliberate-timeout tests keep their 1 s limit).
- Kill-path latency assertions `executionTimeMs < 10_000` → `< 30_000` (same starvation class; 30 s still proves the runner didn't wait out the 60 s sleep).

### Family 2 (2×, June): `Process.run()` transient spawn failure

`posix_spawn` EAGAIN under fork pressure surfaces as a misleading `NSCocoaErrorDomain 260 "The file doesn't exist" /usr/bin/env`. New `runProcessRobustly` helper launches bare `Process` spawns **under the shared `SubprocessThrottle`** and retries failed launches with fresh instances. Adopted by:

- `NotebookExtractorTests.generatedModuleLoadsUnderRealPython3` (the observed flake site)
- `WorkerDaemonTests.makeZip` (python3 zip builder)
- `WorkerTests.rscriptAvailable()` (no more false skips of the R tests)

### Latent races fixed before they bite

- **`LocalHTTPTestServer` factories now actually hold a subprocess slot** for launch + port handshake — `SubprocessThrottle`'s doc comment claimed they did, but no call site existed.
- **The three worker-secret tests no longer `chdir` the whole process.** `resolveWorkerSharedSecret` / `defaultWorkerSecretFilePaths` take an injectable `currentDirectory` (defaults preserve production behavior exactly), removing an unserialized process-global mutation that raced every concurrent test — including the three tests racing each other.
- **`MockURLProtocol` session timeouts 5 s → 30 s.** Stubs reply immediately (the no-stub path fails fast), so the timeout can only ever fire as a starvation flake.
- **`worker-tests` CI job caps Swift Testing in-process parallelism at 4** via `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH`, matching the APITests jobs and the nightly coverage run.

## Validation

- 10 consecutive local runs: all 226 tests green.
- 5 runs under 2× CPU oversubscription (8 busy loops on 4 cores, emulating the starved runner): all green.
- `scripts/format.sh` + `scripts/swiftlint.sh --strict`: 0 violations.
- Production diff is behavior-neutral (default parameters only).

## Evidence trail

Flake tally from job logs (verbatim signatures, run IDs in the audit): `scriptExitZeroReportsExitCodeZero` ×2, `scriptExitOneReportsExitCodeOne` ×2, `scriptEnvVarUnsetWhenNoOverride` ×2, `scriptExitTwoReportsExitCodeTwo`, `stdoutIsCaptured`, `stderrIsCaptured`, `stdoutAndStderrAreSeparate`, `workDirIsSetCorrectly` (all Family 1, ~5.3–5.7 s failures, `output.exitCode → -1`); `generatedModuleLoadsUnderRealPython3` ×2 (Family 2). No job-level hangs in the window.

https://claude.ai/code/session_01BbzvD2tKzxpGZqncdy1tsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbzvD2tKzxpGZqncdy1tsJ)_