### PR TITLE
Scheduled open date now publishes Preview assignments

### DIFF
--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -186,10 +186,13 @@ func openScheduledAssignment(
     logger: Logger,
     now: Date = Date()
 ) async throws -> Bool {
-    // Only a `.closed` assignment auto-opens on its schedule. A `.preview`
-    // assignment is a deliberate staff-only beta state: it is published to
-    // students manually after testing, never by the scheduled-open sweep.
-    guard assignment.visibility == .closed else { return false }
+    // Both `.closed` and `.preview` auto-open on their schedule. An open date
+    // on a `.preview` assignment is the intended staff workflow: test in the
+    // staff-only state now, and the sweep publishes to students when the open
+    // date arrives (the same semantics `submissionGate` documents for why staff
+    // bypass the start-date gate). Only `.open` is excluded — its open date has
+    // already been consumed.
+    guard assignment.visibility == .closed || assignment.visibility == .preview else { return false }
     guard let startsAt = assignment.startsAt, startsAt <= now else { return false }
     guard assignment.validationStatus == nil || assignment.validationStatus == "passed" else { return false }
     if let dueAt = assignment.dueAt, dueAt <= now { return false }
@@ -208,7 +211,10 @@ func openScheduledAssignments(
     now: Date = Date()
 ) async throws -> Int {
     let assignments = try await APIAssignment.query(on: db)
-        .filter(\.$visibilityRaw == AssignmentVisibility.closed.rawValue)
+        .filter(
+            \.$visibilityRaw
+                ~~ [AssignmentVisibility.closed.rawValue, AssignmentVisibility.preview.rawValue]
+        )
         .filter(\.$startsAt <= now)
         .all()
 

--- a/Tests/APITests/AssignmentAuthoringServiceTests.swift
+++ b/Tests/APITests/AssignmentAuthoringServiceTests.swift
@@ -172,18 +172,34 @@ import Vapor
         }
     }
 
-    @Test func scheduledOpenSweepSkipsPreview() async throws {
+    @Test func scheduledOpenSweepPublishesPreview() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let assignment = try await makeAssignment(on: app, validationStatus: "passed")
             try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
-            // A past open date auto-opens a *closed* assignment, but a Preview
-            // assignment must stay in its staff-only state.
+            // An open date on a Preview assignment is the staff workflow "test
+            // now, publish to students at this time" — the sweep must open it,
+            // not strand it in the staff-only state past its open date.
+            assignment.startsAt = Date().addingTimeInterval(-3600)
+            try await assignment.save(on: app.db)
+            let opened = try await openScheduledAssignment(assignment, on: app.db, logger: app.logger)
+            #expect(opened)
+            #expect(assignment.visibility == .open)
+            #expect(assignment.startsAt == nil, "Open date is consumed once it fires")
+        }
+    }
+
+    @Test func scheduledOpenSweepHoldsPreviewUntilValidationPasses() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await makeAssignment(on: app, validationStatus: "pending")
+            try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
             assignment.startsAt = Date().addingTimeInterval(-3600)
             try await assignment.save(on: app.db)
             let opened = try await openScheduledAssignment(assignment, on: app.db, logger: app.logger)
             #expect(opened == false)
             #expect(assignment.visibility == .preview)
+            #expect(assignment.startsAt != nil, "Open date stays armed so the sweep retries after validation")
         }
     }
 }

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -101,8 +101,20 @@ import XCTVapor
                 validationStatus: "passed", on: app
             )
 
+            // Staff-only preview with a past open date → publishes to students.
+            _ = try await arInsertSetup(id: "setup_open_preview", on: app)
+            let preview = try await arInsertAssignment(
+                testSetupID: "setup_open_preview", title: "Preview ready",
+                isOpen: false,
+                dueAt: Date().addingTimeInterval(86_400),
+                startsAt: Date().addingTimeInterval(-60),
+                validationStatus: "passed", on: app
+            )
+            preview.visibility = .preview
+            try await preview.save(on: app.db)
+
             let openedCount = try await openScheduledAssignments(on: app.db, logger: app.logger)
-            #expect(openedCount == 1)
+            #expect(openedCount == 2)
 
             let readyReloaded = try #require(try await APIAssignment.find(ready.id, on: app.db))
             #expect(readyReloaded.isOpen)
@@ -117,6 +129,10 @@ import XCTVapor
 
             let pastDueReloaded = try #require(try await APIAssignment.find(pastDue.id, on: app.db))
             #expect(pastDueReloaded.isOpen == false, "Must not open a window whose due date already passed")
+
+            let previewReloaded = try #require(try await APIAssignment.find(preview.id, on: app.db))
+            #expect(previewReloaded.visibility == .open, "Preview publishes to students at its open date")
+            #expect(previewReloaded.startsAt == nil, "Open date is consumed once it fires")
         }
     }
 

--- a/changelog.d/lab3-open-trigger.md
+++ b/changelog.d/lab3-open-trigger.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Scheduled open date now publishes Preview assignments.** The scheduled-open
+  sweep only auto-opened `.closed` assignments, so an assignment left in the
+  staff-only Preview state silently sailed past its open date and never reached
+  students (this is what kept a lab from opening at its scheduled 8am). Preview +
+  open date is the intended workflow — staff test now, students get it when the
+  date arrives — so the sweep now publishes Preview assignments too, with the
+  same guards as before (validation must have passed, the due date must not
+  already be behind us).


### PR DESCRIPTION
## Why

Lab 3 (HLTH 230) didn't open at its scheduled 8am on 2026-06-10. Root cause: the assignment was in the staff-only **Preview** state, and the scheduled-open sweep (`openScheduledAssignment`) only auto-opened `.closed` assignments — Preview was deliberately skipped, with `scheduledOpenSweepSkipsPreview` pinning that behavior. Lab 4 and Lab 5 are configured the same way (Preview + scheduled open), so this would have recurred next week.

This skip contradicted the documented semantics in `AssignmentVisibility.submissionGate`, which describes the open date on a Preview assignment as governing "when the assignment auto-publishes to *students*" — i.e. the intended workflow is: staff test in Preview now, the sweep publishes at the open date.

## What

- `openScheduledAssignment` now accepts `.preview` as well as `.closed`; the sweep query (`openScheduledAssignments`) filters both visibilities.
- All existing guards are preserved: runner validation must have passed (a Preview assignment failing validation stays Preview, with the open date still armed so the sweep retries), and a window entirely in the past (due date already passed) still does not open.
- Replaced `scheduledOpenSweepSkipsPreview` with `scheduledOpenSweepPublishesPreview` + `scheduledOpenSweepHoldsPreviewUntilValidationPasses`, and added a Preview case to `openScheduledAssignmentsOpensOnlyEligibleAssignments` to cover the query-level filter.
- Changelog fragment under `changelog.d/`.

https://claude.ai/code/session_01MBnLFVLZ5F1zW7ZXmrL9Br

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBnLFVLZ5F1zW7ZXmrL9Br)_