### PR TITLE
ci: pull job images from a GHCR mirror + cancel superseded PR runs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       # Full (blobless) history so `git restore-mtime` can read commit times.

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,0 +1,66 @@
+name: Mirror CI images
+
+# Mirrors the Docker Hub images our CI jobs run in (swift:6.3-jammy /
+# swift:6.3-noble job containers, postgres:16 service) into GHCR, so the
+# test workflows never pull from registry-1.docker.io at job time.
+# Unauthenticated Docker Hub pulls from shared Actions runner IPs are
+# rate-limited and were the single largest source of red CI on main
+# (6 "Initialize containers" / docker-pull timeout failures in the
+# three-week window audited for #890).  GHCR pulls from Actions runners
+# are same-infrastructure and not rate-limited.
+#
+# Runs weekly (Docker Hub tags like swift:6.3-jammy are re-pushed with
+# fixes) and on demand.  `docker buildx imagetools create` copies the
+# full multi-arch manifest registry-to-registry without a local pull.
+#
+# When the toolchain pin changes (e.g. swift:6.4), add the new tag here
+# FIRST, run this workflow, and only then point swift-tests.yml /
+# test-coverage.yml / docker-build.yml at the new mirrored tag.
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: mirror-ci-images
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror images
+        run: |
+          set -euo pipefail
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          mirror() {
+            src="$1"
+            dst="ghcr.io/${owner}/chickadee/$2"
+            echo "Mirroring ${src} -> ${dst}"
+            for attempt in 1 2 3 4 5; do
+              if docker buildx imagetools create --tag "${dst}" "${src}"; then
+                return 0
+              fi
+              echo "attempt ${attempt} failed; retrying in $((attempt * 15))s"
+              sleep $((attempt * 15))
+            done
+            echo "Failed to mirror ${src} after 5 attempts" >&2
+            return 1
+          }
+          mirror docker.io/library/swift:6.3-jammy swift:6.3-jammy
+          mirror docker.io/library/swift:6.3-noble swift:6.3-noble
+          mirror docker.io/library/postgres:16 postgres:16

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -21,6 +21,13 @@ on:
   schedule:
     - cron: "0 5 * * 1"
   workflow_dispatch:
+  # Also run when this file changes in a PR: it both validates the edit and
+  # solves the bootstrap problem (workflow_dispatch only works once the file
+  # exists on the default branch, but the test workflows can't switch to the
+  # mirrored images until a first run has published them).
+  pull_request:
+    paths:
+      - ".github/workflows/mirror-images.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -29,7 +29,10 @@ jobs:
     # invoke the swiftlint plugin.  Re-unify when SwiftLintBinary publishes
     # a jammy-compatible release or when the project moves all jobs to noble.
     container:
-      image: swift:6.3-noble
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       # Full (blobless) history so `git restore-mtime` can read each file's
@@ -142,7 +148,10 @@ jobs:
     needs: build
     timeout-minutes: 20
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged
 
     steps:
@@ -172,7 +181,10 @@ jobs:
     needs: build
     timeout-minutes: 20
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged
 
     steps:
@@ -221,11 +233,17 @@ jobs:
     needs: build
     timeout-minutes: 25
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged
     services:
       postgres:
-        image: postgres:16
+        image: ghcr.io/jimwallace/chickadee/postgres:16
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_DB: chickadee_test
           POSTGRES_USER: postgres
@@ -309,7 +327,10 @@ jobs:
     # the test process; --parallel would just have the runner schedule
     # them across multiple xctest binaries that don't share the lock.
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged
 
     steps:

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -10,6 +10,14 @@ on:
   # docs/release-process.md.
   merge_group:
 
+# Cancel superseded runs when new commits land on a PR branch (one branch
+# racked up four full CI runs in 70 minutes during the #890 audit).  Pushes
+# to main and merge-queue runs are never cancelled — their group key is the
+# unique ref/SHA and cancel-in-progress is false outside pull_request.
+concurrency:
+  group: swift-tests-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   format-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -22,7 +22,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
       options: --privileged
     env:
       MIN_COVERAGE_PERCENT: "60.0"

--- a/changelog.d/ci-image-mirror.md
+++ b/changelog.d/ci-image-mirror.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **CI images mirrored to GHCR; superseded PR runs cancelled.** The
+  swift/postgres job containers are now pulled from a GHCR mirror
+  (refreshed weekly by `mirror-images.yml`) instead of Docker Hub, whose
+  unauthenticated rate-limited pulls were the largest source of red CI on
+  main (6 docker-pull timeouts in the three-week #890 audit window).
+  `swift-tests.yml` also gained a `concurrency` group that cancels
+  superseded runs on PR branches (pushes to main and merge-queue runs are
+  unaffected).


### PR DESCRIPTION
## What

Implements the two CI improvements identified after the #890 flake audit. Of the 57 failed runs in the three-week window, the largest *remaining* failure class (after #890 fixed the genuine test flakes) was infrastructure: **6 docker-pull timeouts against `registry-1.docker.io`** ("Initialize containers" failures), including the two most recent red runs on `main`. Every workflow run does 6+ unauthenticated Docker Hub pulls from shared Azure runner IPs — exactly where Docker Hub rate-limits.

### 1. GHCR image mirror (commit 1 + 2)

- **`mirror-images.yml`** (new): weekly + on-demand registry-to-registry copy of `swift:6.3-jammy`, `swift:6.3-noble`, `postgres:16` into `ghcr.io/jimwallace/chickadee/…` via `docker buildx imagetools create` (multi-arch manifest copy, no local pull), with retries. Comment documents the toolchain-bump procedure (mirror the new tag first, then re-point the workflows).
- **`swift-tests.yml` / `test-coverage.yml` / `docker-build.yml`** (commit 2): all job containers and the postgres service pull the GHCR mirror, authenticated with `GITHUB_TOKEN` (the packages are workflow-published, so they're repo-linked and Actions get read access). GHCR pulls from Actions runners are same-infrastructure and not rate-limited.

### 2. Cancel superseded PR runs (commit 1)

`swift-tests.yml` gains a `concurrency` group keyed on event + ref with `cancel-in-progress` only for `pull_request` events. During the audit one branch ran full CI four times in ~70 minutes as commits stacked; pushes to `main` and merge-queue runs are never cancelled.

## Sequencing

Commit 1 (mirror workflow + concurrency) landed first; the mirror was then dispatched on this branch to publish the images; commit 2 switched the workflows over once the images existed — so CI on this PR exercises the real GHCR pull path.

https://claude.ai/code/session_01BbzvD2tKzxpGZqncdy1tsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbzvD2tKzxpGZqncdy1tsJ)_