### PR TITLE
fix(notebook): stop locked-path enforcement aborting slow editor boots

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -53,7 +53,10 @@
         frame.getAttribute('src') ||
         `/jupyterlite/notebooks/index.html?workspace=${encodeURIComponent(setupID)}-student&reset=&path=assignment.ipynb`;
     const lockedNotebookPath = normalizeJupyterPath(extractPathFromEditorURL(editorURL));
-    let lastForcedEditorResetMs = 0;
+    // Timestamp of a forced editor reset whose navigation has not committed
+    // yet (cleared by the iframe load event).  Guards the locked-path
+    // enforcement against aborting its own still-loading reset.
+    let forcedEditorResetAt = 0;
     let serverSyncInFlight = false;
     let serverSyncComplete = false;
 
@@ -86,7 +89,14 @@
     });
 
     function mountEditor() {
-        frame.src = editorURL;
+        // The template renders the same URL into the iframe's src, so the
+        // editor is already loading by the time the preflight resolves.
+        // Re-assigning src aborts that in-flight navigation and starts it
+        // over — only navigate when the attribute is missing or different
+        // (an older cached copy of the page).
+        if (frame.getAttribute('src') !== editorURL) {
+            frame.src = editorURL;
+        }
 
         // Quick reachability check helps explain blank/failed editor loads.
         fetch(notebookURL, { method: 'GET' }).then((res) => {
@@ -148,6 +158,9 @@
         }
 
         frame.addEventListener('load', () => {
+            // A document committed; any forced reset we were waiting on has
+            // landed, so the locked-path enforcement may act again.
+            forcedEditorResetAt = 0;
             if (!serverSyncComplete && !serverSyncInFlight) {
                 void syncNotebookFromServerSnapshot();
             }
@@ -631,15 +644,31 @@
     function enforceLockedNotebookPath() {
         if (!lockedNotebookPath || !frame.contentWindow) return;
         try {
-            const currentURL = new URL(frame.contentWindow.location.href, window.location.origin);
+            const rawHref = frame.contentWindow.location.href;
+
+            // Until the iframe commits its first document, location.href is
+            // still the initial "about:blank" — the editor is loading, not
+            // navigated away.  Resetting src in that state aborts the
+            // in-flight load; on a slow connection (or a server busy with a
+            // class-wide rush) each 1.5s tick would abort and restart the
+            // navigation forever, so a healthy-but-slow boot never commits
+            // and the shell watchdog misfires.  Wait for a real document.
+            if (rawHref === 'about:blank') return;
+
+            const currentURL = new URL(rawHref, window.location.origin);
             const currentPath = normalizeJupyterPath(currentURL.searchParams.get('path'));
             const inNotebookApp = currentURL.pathname.includes('/jupyterlite/notebooks/');
 
             if (inNotebookApp && currentPath === lockedNotebookPath) return;
 
+            // The previous document's URL stays current while a forced
+            // reset's navigation is in flight, so the path still reads as
+            // wrong here.  Give the reset a generous window to commit (the
+            // load event clears the stamp) before forcing another one,
+            // otherwise slow recoveries are aborted in the same loop.
             const now = Date.now();
-            if (now - lastForcedEditorResetMs < 1000) return;
-            lastForcedEditorResetMs = now;
+            if (forcedEditorResetAt && now - forcedEditorResetAt < 20000) return;
+            forcedEditorResetAt = now;
             frame.src = editorURL;
         } catch (_) {
             // Ignore transient cross-frame navigation states.

--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -11,6 +11,14 @@
 //                               HTTPSRedirectMiddleware
 //   LeafErrorMiddleware     — catches every downstream error
 //   HTTPSRedirectMiddleware — only when enforceHTTPS, before sessions
+//   EditorAssetFastPathMiddleware — serves the vendored editor asset trees
+//                               (/jupyterlite/build, /jupyterlite/extensions,
+//                               /pyodide, /vendor) BEFORE the session chain so
+//                               a JupyterLite boot's hundreds of asset
+//                               requests skip the per-request Fluent session
+//                               lookup.  Whitelist-only: the auth-guarded
+//                               /jupyterlite/…/files/users/ paths are not
+//                               listed and still ride the full chain below.
 //   sessions.middleware
 //   UserSessionAuthenticator
 //   SessionIdleTimeoutMiddleware — runs before UserActivityMiddleware
@@ -81,6 +89,10 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     if securityConfiguration.enforceHTTPS {
         app.middleware.use(HTTPSRedirectMiddleware(configuration: securityConfiguration))
     }
+    // Vendored editor assets short-circuit here, before any session work.
+    // See EditorAssetFastPathMiddleware for the whitelist + cache policy.
+    app.middleware.use(
+        EditorAssetFastPathMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(app.sessions.middleware)
     app.middleware.use(UserSessionAuthenticator())
     if securityConfiguration.sessionIdleTimeoutSeconds > 0 {

--- a/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
+++ b/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
@@ -1,0 +1,99 @@
+// APIServer/Middleware/EditorAssetFastPathMiddleware.swift
+//
+// Serves the vendored, never-sensitive editor asset trees *before* the
+// session middleware chain runs, and stamps immutable cache headers on the
+// content-hashed JupyterLite bundle files.
+//
+// Why this exists: a JupyterLite boot fetches hundreds of static files, and
+// FileMiddleware sits at the bottom of the chain — so every one of those
+// requests paid a Fluent session lookup (plus idle-timeout / activity
+// bookkeeping) it never needed.  Under a class-wide rush that database
+// traffic is what pushes the editor's index.html latency up.  This
+// middleware short-circuits the chain for asset paths that are vendored
+// bytes by construction.
+//
+// The fast path is a strict prefix WHITELIST, not "/jupyterlite/ minus
+// exclusions": `/jupyterlite/files/users/<uuid>/…` (and the lab/notebooks
+// variants) serve per-student working copies and MUST keep riding the full
+// chain so UserFileNamespaceMiddleware can authenticate the caller.  Only
+// trees that contain checked-in vendored content are listed here.
+//
+// Cache policy:
+//   * /jupyterlite/build/ + /jupyterlite/extensions/ files whose name
+//     carries a webpack content-hash segment (e.g. `100.5a28c9e.js`,
+//     `154.377fd2862adcf65a4294.js`) — the bytes behind a given URL never
+//     change; a rebuild produces a new hash → new URL.  Cached immutably
+//     for a year, eliminating the per-boot revalidation storm.
+//   * Everything else on the fast path (unhashed names like the MathJax
+//     fonts, all of /pyodide/, /vendor/) keeps default ETag revalidation:
+//     re-vendoring rewrites those bytes IN PLACE under stable names —
+//     including the deterministically patched pyodide-kernel wheel — so
+//     immutable caching would pin stale bytes across an upgrade (#574's
+//     failure class).
+//
+// On any miss (file absent, traversal attempt, undecodable path) the
+// request falls through to the normal chain unchanged, so worst case is
+// exactly today's behaviour.
+
+import Vapor
+
+struct EditorAssetFastPathMiddleware: AsyncMiddleware {
+    /// Vendored-only trees. Never list a prefix that can contain
+    /// user-generated or access-controlled files.
+    static let fastPathPrefixes = [
+        "/jupyterlite/build/",
+        "/jupyterlite/extensions/",
+        "/pyodide/",
+        "/vendor/",
+    ]
+
+    private let publicDirectory: String
+
+    init(publicDirectory: String) {
+        self.publicDirectory = publicDirectory.hasSuffix("/") ? publicDirectory : publicDirectory + "/"
+    }
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        guard request.method == .GET || request.method == .HEAD,
+            let path = request.url.path.removingPercentEncoding,
+            !path.contains(".."),
+            Self.fastPathPrefixes.contains(where: { path.hasPrefix($0) })
+        else {
+            return try await next.respond(to: request)
+        }
+
+        let absolutePath = publicDirectory + path.dropFirst()
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: absolutePath, isDirectory: &isDirectory),
+            !isDirectory.boolValue
+        else {
+            return try await next.respond(to: request)
+        }
+
+        let response = try await request.fileio.asyncStreamFile(at: absolutePath)
+        if Self.isContentHashedBundleAsset(path: path) {
+            response.headers.replaceOrAdd(
+                name: .cacheControl, value: "public, max-age=31536000, immutable")
+        }
+        return response
+    }
+
+    /// True for JupyterLite bundle files whose *filename* carries a webpack
+    /// content-hash segment — a dot-separated component of 7+ hex characters
+    /// (`100.5a28c9e.js`, `154.377fd2862adcf65a4294.js.map`).  Unhashed
+    /// names in the same trees (`MathJax_Main-Regular.woff`, `all.json`)
+    /// don't match and keep revalidating.
+    static func isContentHashedBundleAsset(path: String) -> Bool {
+        guard
+            path.hasPrefix("/jupyterlite/build/")
+                || path.hasPrefix("/jupyterlite/extensions/")
+        else {
+            return false
+        }
+        guard let filename = path.split(separator: "/").last else { return false }
+        return filename.split(separator: ".").contains { component in
+            component.count >= 7
+                && component.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) }
+        }
+    }
+}

--- a/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
+++ b/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
@@ -1,0 +1,165 @@
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+/// Exercises EditorAssetFastPathMiddleware in the production ordering:
+/// fast path → UserFileNamespaceMiddleware → FileMiddleware.  The suite
+/// pins the two invariants the fast path must never break:
+///
+///   1. The auth guard on /jupyterlite/…/files/users/ still runs — the
+///      fast path must not serve student working copies to anonymous
+///      callers just because they live under /jupyterlite/.
+///   2. Immutable cache headers land only on content-hashed bundle
+///      filenames; everything else keeps default revalidation so a
+///      re-vendor that rewrites bytes in place is picked up.
+@Suite final class EditorAssetFastPathMiddlewareTests {
+    private let publicDir: String
+    private let tempRoot: String
+
+    init() throws {
+        tempRoot =
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-fastpath-\(UUID().uuidString)")
+            .path
+        publicDir = tempRoot + "/Public/"
+        let fixtures: [(relativePath: String, contents: String)] = [
+            ("jupyterlite/build/100.5a28c9e.js", "hashed-chunk"),
+            ("jupyterlite/build/MathJax_Main-Regular.woff", "font-bytes"),
+            ("jupyterlite/extensions/@jupyterlite/kernel/static/154.377fd2862adcf65a4294.js", "hashed-ext"),
+            ("jupyterlite/extensions/@jupyterlite/kernel/install.json", "{}"),
+            ("jupyterlite/files/users/5f1c0b9a-0000-0000-0000-000000000000/work.ipynb", "student-work"),
+            ("pyodide/pyodide-lock.json", "{}"),
+            ("vendor/jszip.min.js", "jszip"),
+        ]
+        for fixture in fixtures {
+            let absolute = publicDir + fixture.relativePath
+            let directory = (absolute as NSString).deletingLastPathComponent
+            try FileManager.default.createDirectory(
+                atPath: directory, withIntermediateDirectories: true)
+            try fixture.contents.write(
+                toFile: absolute, atomically: true, encoding: .utf8)
+        }
+        // A file OUTSIDE the public root — must never be reachable via the
+        // fast path, traversal or otherwise.
+        try "top-secret".write(
+            toFile: tempRoot + "/secret.txt", atomically: true, encoding: .utf8)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(atPath: tempRoot)
+    }
+
+    private func makeApp() async throws -> Application {
+        let app = try await Application.make(.testing)
+        // Production order: fast path runs before any session/auth work,
+        // the user-namespace guard and FileMiddleware after it.
+        app.middleware.use(EditorAssetFastPathMiddleware(publicDirectory: publicDir))
+        app.middleware.use(UserFileNamespaceMiddleware())
+        app.middleware.use(FileMiddleware(publicDirectory: publicDir))
+        return app
+    }
+
+    @Test func hashedBuildChunkIsServedWithImmutableCaching() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/jupyterlite/build/100.5a28c9e.js") { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "hashed-chunk")
+                #expect(
+                    res.headers.first(name: .cacheControl)
+                        == "public, max-age=31536000, immutable")
+            }
+        }
+    }
+
+    @Test func hashedExtensionAssetIsServedWithImmutableCaching() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .GET, "/jupyterlite/extensions/@jupyterlite/kernel/static/154.377fd2862adcf65a4294.js"
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(
+                    res.headers.first(name: .cacheControl)
+                        == "public, max-age=31536000, immutable")
+            }
+        }
+    }
+
+    @Test func unhashedBundleFilenameKeepsRevalidating() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .GET, "/jupyterlite/build/MathJax_Main-Regular.woff"
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .cacheControl) == nil)
+                #expect(res.headers.first(name: .eTag) != nil)
+            }
+            try await app.testable().test(
+                .GET, "/jupyterlite/extensions/@jupyterlite/kernel/install.json"
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .cacheControl) == nil)
+            }
+        }
+    }
+
+    @Test func pyodideAndVendorAreFastPathedWithoutImmutableCaching() async throws {
+        try await withApp(try await makeApp()) { app in
+            for path in ["/pyodide/pyodide-lock.json", "/vendor/jszip.min.js"] {
+                try await app.testable().test(.GET, path) { res async in
+                    #expect(res.status == .ok)
+                    #expect(res.headers.first(name: .cacheControl) == nil)
+                    #expect(res.headers.first(name: .eTag) != nil)
+                }
+            }
+        }
+    }
+
+    @Test func userNamespaceFilesStillRequireAuthentication() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .GET,
+                "/jupyterlite/files/users/5f1c0b9a-0000-0000-0000-000000000000/work.ipynb"
+            ) { res async in
+                #expect(res.status == .unauthorized)
+                #expect(res.body.string.contains("student-work") == false)
+            }
+        }
+    }
+
+    @Test func traversalAttemptsAreNotServedByTheFastPath() async throws {
+        try await withApp(try await makeApp()) { app in
+            for path in [
+                "/jupyterlite/build/../../secret.txt",
+                "/jupyterlite/build/%2e%2e/%2e%2e/secret.txt",
+            ] {
+                try await app.testable().test(.GET, path) { res async in
+                    #expect(res.status != .ok)
+                    #expect(res.body.string.contains("top-secret") == false)
+                }
+            }
+        }
+    }
+
+    @Test func missingFastPathFileFallsThroughToTheNormalChain() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/jupyterlite/build/absent.js") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    @Test(arguments: [
+        ("/jupyterlite/build/100.5a28c9e.js", true),
+        ("/jupyterlite/build/154.377fd2862adcf65a4294.js.map", true),
+        ("/jupyterlite/extensions/@jupyterlite/kernel/static/remoteEntry.5a28c9e12345.js", true),
+        ("/jupyterlite/build/MathJax_Main-Regular.woff", false),
+        ("/jupyterlite/extensions/@jupyterlite/kernel/install.json", false),
+        ("/jupyterlite/build/bundle.js", false),
+        ("/pyodide/pyodide.asm.wasm", false),
+        ("/vendor/codemirror.js", false),
+    ])
+    func contentHashDetection(path: String, expected: Bool) {
+        #expect(EditorAssetFastPathMiddleware.isContentHashedBundleAsset(path: path) == expected)
+    }
+}

--- a/changelog.d/notebook-editor-boot-reset-loop.md
+++ b/changelog.d/notebook-editor-boot-reset-loop.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **Slow editor boots no longer aborted by the locked-path enforcement.** On
+  the student notebook page, `enforceLockedNotebookPath()` treated an iframe
+  that hadn't committed its first document yet (`location.href` still
+  `about:blank`) as "student navigated away" and force-reset `frame.src` —
+  with only a 1-second debounce against the 1.5-second enforcement interval.
+  Any boot where the JupyterLite `index.html` took longer than ~1.5s to commit
+  (slow connection, or the server busy with a class-wide 8am rush) was aborted
+  and restarted indefinitely, so the shell never appeared and the phase-1
+  watchdog fired `watchdog_timeout` on a healthy-but-slow boot — the students
+  behind the "Students With Browser Errors" dashboard card. Enforcement now
+  waits for the first committed document before acting, gives a forced reset a
+  generous window to commit (cleared by the iframe load event) before forcing
+  another, and `mountEditor()` no longer re-assigns the identical `src` the
+  template already rendered (which aborted and restarted the eager initial
+  load on every page view).

--- a/changelog.d/notebook-editor-boot-reset-loop.md
+++ b/changelog.d/notebook-editor-boot-reset-loop.md
@@ -15,3 +15,20 @@
   another, and `mountEditor()` no longer re-assigns the identical `src` the
   template already rendered (which aborted and restarted the eager initial
   load on every page view).
+
+### Changed
+
+- **Vendored editor assets skip the session middleware chain and the
+  content-hashed JupyterLite bundle is cached immutably.** A JupyterLite boot
+  fetches hundreds of static files, each of which previously paid a Fluent
+  session lookup before FileMiddleware served it — the load that drives
+  editor `index.html` latency up during a class-wide rush. The new
+  `EditorAssetFastPathMiddleware` serves a strict whitelist of vendored trees
+  (`/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`, `/vendor`)
+  ahead of the session chain; the auth-guarded `/jupyterlite/…/files/users/`
+  paths are deliberately not on the fast path and still ride the full chain
+  (pinned by a regression test). Webpack content-hashed bundle filenames get
+  `Cache-Control: public, max-age=31536000, immutable`, eliminating the
+  per-boot revalidation storm; unhashed names and all of `/pyodide` +
+  `/vendor` keep ETag revalidation because re-vendoring rewrites those bytes
+  in place under stable names.


### PR DESCRIPTION
## Root cause of the "Students With Browser Errors" rows

`enforceLockedNotebookPath()` (notebook.js) runs on the iframe `load` event and a 1.5 s interval to keep students inside the locked notebook. But before the JupyterLite iframe commits its **first** document, `contentWindow.location.href` is still the initial `about:blank` — which the function read as "student navigated away" and answered by force-resetting `frame.src`, guarded only by a 1 s debounce.

Resetting `src` **aborts the in-flight navigation and restarts it**. So any boot where the editor's `index.html` took longer than ~1.5 s to commit — a slow connection, a proxy hiccup, a busy server — was aborted and restarted indefinitely. The shell never appeared, the phase-1 watchdog fired at 60 s, and the student got the "Editor didn't load" fallback plus a `watchdog_timeout` diagnostic with empty `failedChecks`. The trigger is per-student network/server latency crossing the ~1.5 s line, any day, any hour — no incident required.

`mountEditor()` made it worse on every page view: the template already renders the editor URL into the iframe's `src` (eager load during parse), and `mountEditor` unconditionally re-assigned the identical URL after the preflight, aborting and restarting that initial load.

## Fixes

**notebook.js (the bug):**
* `enforceLockedNotebookPath()` returns early while the iframe is still on `about:blank` — a loading editor is not a navigated-away editor.
* After forcing a reset, enforcement waits for that navigation to commit (the `load` event clears the stamp; 20 s grace as a backstop) instead of re-resetting on the 1 s debounce.
* `mountEditor()` only assigns `src` when the attribute is missing or different.

**Bundled follow-ups (the latency the bug was sensitive to):**
* `EditorAssetFastPathMiddleware` — serves the vendored asset trees (`/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`, `/vendor`) **before** the session middleware chain, so a boot's hundreds of asset requests stop paying a Fluent session lookup each. Strict whitelist: the auth-guarded `/jupyterlite/…/files/users/` paths are not on it and still ride the full chain through `UserFileNamespaceMiddleware`.
* Immutable caching (`public, max-age=31536000, immutable`) for webpack content-hashed bundle filenames under `/jupyterlite/build` and `/jupyterlite/extensions` only. Unhashed names (MathJax fonts, `all.json`) and all of `/pyodide` + `/vendor` keep ETag revalidation, because re-vendoring rewrites those bytes **in place** under stable names (including the deterministically patched pyodide-kernel wheel) — immutable there would re-create #574's failure class.

## Risk assessment

* **notebook.js:** every change degrades to the status quo or better. If a browser reports something other than `about:blank` pre-commit, behaviour falls back to reset-with-grace (one abort per 20 s instead of per ~1 s). A genuinely wrong committed document is still reset immediately on the first tick. The watchdog fallback (upload picker) is unchanged as the terminal safety net.
* **Fast path:** on any miss (absent file, traversal, undecodable path) it falls through to the normal chain — worst case is exactly today's behaviour. It serves only files FileMiddleware already serves unauthenticated today, so no access-control change. The one real hazard — accidentally fast-pathing the per-student working copies — is excluded by the whitelist design and **pinned by a regression test** (`userNamespaceFilesStillRequireAuthentication`).
* **Immutable caching:** only applied to content-hashed filenames whose bytes can't change under the same URL; a JupyterLite rebuild produces new hashes → new URLs. The detection rule is pinned by parameterized tests against real tree filenames.

## Verification

* New suite `EditorAssetFastPathMiddlewareTests` reproduces the production middleware ordering with fixture files: hashed assets get immutable headers, unhashed/pyodide/vendor keep ETags, `files/users` still 401s unauthenticated, traversal attempts are not served, misses fall through.
* Full CI (api-tests + postgres, worker, browser-runner, format-lint, CodeQL) — green on the first push; this push re-runs it over the middleware change.

https://claude.ai/code/session_01TVJGqPrPP35h6SwLmt9PrY