### PR TITLE
fix(mcp): validate the MCP-Protocol-Version transport header

### DIFF
--- a/Sources/APIServer/MCP/Protocol/MCPMethod.swift
+++ b/Sources/APIServer/MCP/Protocol/MCPMethod.swift
@@ -8,6 +8,14 @@
 /// The MCP protocol revision this server advertises in `initialize`.
 enum MCPProtocol {
     static let version = "2025-11-25"
+
+    /// Revisions accepted in the `MCP-Protocol-Version` transport header.
+    /// 2025-06-18 is wire-compatible with everything this server implements
+    /// (single-message POSTs, the same tools/resources shapes).  2025-03-26 is
+    /// deliberately absent: that revision allows JSON-RPC batching, which this
+    /// transport does not parse — and clients of that era predate the header
+    /// anyway (an absent header is accepted, see MCPRoutes).
+    static let supportedVersions: Set<String> = [version, "2025-06-18"]
 }
 
 /// MCP JSON-RPC methods recognised by the dispatcher.  Unknown methods yield a

--- a/Sources/APIServer/MCP/Transport/MCPRoutes.swift
+++ b/Sources/APIServer/MCP/Transport/MCPRoutes.swift
@@ -15,6 +15,8 @@
 // DNS-rebinding mitigation (transport spec §Security): the `Origin` header is
 // validated against an allowlist (403 on mismatch), and — because Vapor does
 // not do this by default — the `Host` header is pinned to an allowlist too.
+// The `MCP-Protocol-Version` header is validated when present (400 on an
+// unsupported revision, per §Protocol Version Header).
 // https://modelcontextprotocol.io/specification/2025-11-25/basic/transports
 
 import Core
@@ -63,6 +65,7 @@ struct MCPRoutes: RouteCollection {
     func handlePost(req: Request) async throws -> Response {
         try validateHost(req)
         try validateOrigin(req)
+        if let rejection = try protocolVersionRejection(req) { return rejection }
 
         let rpcRequest: JSONRPCRequest
         do {
@@ -149,6 +152,21 @@ struct MCPRoutes: RouteCollection {
         guard configuration.allowedOrigins.contains(origin) else {
             throw Abort(.forbidden, reason: "Origin is not in the allowlist.")
         }
+    }
+
+    /// Transport spec §Protocol Version Header: a request declaring an
+    /// `MCP-Protocol-Version` this server does not speak is rejected with
+    /// HTTP 400, framed as a JSON-RPC invalid-request error with a null id
+    /// (the body is never read).  An absent header is accepted: every client
+    /// omits it on `initialize` (the version isn't negotiated yet), and
+    /// pre-2025-06-18 clients never send the header at all.
+    private func protocolVersionRejection(_ req: Request) throws -> Response? {
+        guard let version = req.headers.first(name: "MCP-Protocol-Version"),
+            !MCPProtocol.supportedVersions.contains(version)
+        else { return nil }
+        return try jsonResponse(
+            .failure(id: .null, error: .invalidRequest("Unsupported MCP-Protocol-Version: \(version)")),
+            status: .badRequest)
     }
 
     // MARK: - Body / response helpers

--- a/Tests/APITests/MCP/MCPEndpointTests.swift
+++ b/Tests/APITests/MCP/MCPEndpointTests.swift
@@ -76,6 +76,40 @@ import XCTVapor
         }
     }
 
+    @Test func supportedProtocolVersionHeaderIsAccepted() async throws {
+        try await withApp(try await makeApp()) { app in
+            for version in ["2025-11-25", "2025-06-18"] {
+                var headers = jsonHeaders
+                headers.add(name: "MCP-Protocol-Version", value: version)
+                let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
+                try await app.testable().test(
+                    .POST, "/mcp", headers: headers, body: ByteBuffer(string: body)
+                ) { res async in
+                    #expect(res.status == .ok)
+                }
+            }
+        }
+    }
+
+    @Test func unsupportedProtocolVersionHeaderReturns400() async throws {
+        // §Protocol Version Header: an unsupported declared revision is
+        // rejected with 400 before the body is ever read. (An absent header
+        // is accepted — every other test in this suite covers that path.)
+        try await withApp(try await makeApp()) { app in
+            var headers = jsonHeaders
+            headers.add(name: "MCP-Protocol-Version", value: "1999-01-01")
+            let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
+            try await app.testable().test(
+                .POST, "/mcp", headers: headers, body: ByteBuffer(string: body)
+            ) { res async in
+                #expect(res.status == .badRequest)
+                let responseBody = String(buffer: res.body)
+                #expect(responseBody.contains("-32600"))
+                #expect(responseBody.contains("MCP-Protocol-Version"))
+            }
+        }
+    }
+
     @Test func presentOriginWithEmptyAllowlistIsAllowed() async throws {
         // Default config has an empty origin allowlist → "allow any", so a
         // request carrying an Origin (e.g. a browser MCP client) is not

--- a/changelog.d/mcp-protocol-version-header.md
+++ b/changelog.d/mcp-protocol-version-header.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **MCP transport now validates the `MCP-Protocol-Version` header.** A request
+  declaring a protocol revision the server does not speak (anything other than
+  2025-11-25 or 2025-06-18) is rejected with HTTP 400 per the Streamable HTTP
+  transport spec, instead of being silently served. Requests without the
+  header remain accepted — `initialize` is sent before negotiation, and older
+  clients never send it.


### PR DESCRIPTION
From the MCP endpoint audit: the Streamable HTTP transport never read the `MCP-Protocol-Version` header, the one transport-spec requirement (§Protocol Version Header) not implemented.

- A request declaring a revision the server does not speak is rejected with HTTP 400, framed as a JSON-RPC invalid-request error with a null id (the body is never read).
- Accepted revisions: `2025-11-25` and `2025-06-18` (wire-compatible for everything this server implements). `2025-03-26` is deliberately excluded — it allows JSON-RPC batching, which this transport does not parse, and clients of that era predate the header anyway.
- An absent header is still accepted: every client omits it on `initialize`, and older clients never send it.

New tests: supported versions accepted, unsupported version → 400 carrying `-32600`; the absent-header path is covered by every existing test in the suite.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_