### PR TITLE
feat(mcp): negotiate initialize protocol version, log clientInfo

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -18,6 +18,23 @@ struct MCPInitializeResult: Encodable, Sendable {
     let instructions: String?
 }
 
+/// The client-supplied params of an `initialize` request.  Only the fields the
+/// server reacts to are modelled — the requested protocol revision (echoed
+/// back when supported) and the client's self-identification (logged for
+/// operational visibility, never trusted for anything).  Unknown fields and
+/// malformed params are ignored rather than rejected: a lenient initialize
+/// maximises client compatibility, and the server-chosen version is the
+/// correct answer to an unreadable request anyway.
+struct MCPInitializeParams: Decodable, Sendable {
+    let protocolVersion: String?
+    let clientInfo: ClientInfo?
+
+    struct ClientInfo: Decodable, Sendable {
+        let name: String?
+        let version: String?
+    }
+}
+
 /// Capabilities this server advertises at initialization.  `tools` and
 /// `resources` are advertised; `prompts` is not.  `listChanged` is false on
 /// both (no server-initiated list-change notifications), and resources are not

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -32,7 +32,7 @@ struct MCPDispatcher: Sendable {
 
         switch method {
         case .initialize:
-            return initializeResponse(id: id)
+            return initializeResponse(id: id, params: request.params, context: context)
         case .ping:
             return .success(id: id, result: .object([:]))
         case .initialized:
@@ -220,9 +220,29 @@ struct MCPDispatcher: Sendable {
         ])
     }
 
-    private func initializeResponse(id: JSONRPCID) -> JSONRPCResponse {
+    private func initializeResponse(
+        id: JSONRPCID, params: JSONValue?, context: ToolContext?
+    ) -> JSONRPCResponse {
+        let client = try? (params ?? .object([:])).decoded(as: MCPInitializeParams.self)
+        // Version negotiation (lifecycle spec): echo the requested revision
+        // when this server supports it; otherwise answer with the latest we
+        // speak and let the client decide whether to continue.
+        let negotiated =
+            client?.protocolVersion.flatMap { requested in
+                MCPProtocol.supportedVersions.contains(requested) ? requested : nil
+            } ?? MCPProtocol.version
+        // Surface who connected in the logs — operational visibility into
+        // which agents/libraries speak to this server, nothing more.
+        if let context {
+            let name = client?.clientInfo?.name ?? "unknown"
+            let clientVersion = client?.clientInfo?.version ?? "unknown"
+            let requested = client?.protocolVersion ?? "none"
+            context.logger.info(
+                "MCP initialize: client=\(name)/\(clientVersion) requestedProtocolVersion=\(requested) negotiated=\(negotiated)"
+            )
+        }
         let result = MCPInitializeResult(
-            protocolVersion: MCPProtocol.version,
+            protocolVersion: negotiated,
             capabilities: .v1,
             serverInfo: serverInfo,
             instructions: MCPServerInstructions.text

--- a/Tests/APITests/MCP/MCPDispatcherTests.swift
+++ b/Tests/APITests/MCP/MCPDispatcherTests.swift
@@ -50,6 +50,42 @@ import Testing
         #expect(instructions.contains("escape hatch"))
     }
 
+    @Test func initializeEchoesSupportedRequestedProtocolVersion() async throws {
+        // Lifecycle spec: when the client requests a revision the server
+        // supports, the server responds with that same revision.
+        let response = try #require(
+            await dispatcher.dispatch(
+                request(
+                    "initialize",
+                    params: .object(["protocolVersion": .string("2025-06-18")]))))
+        let result = try #require(response.result?.objectFields)
+        #expect(result["protocolVersion"] == .string("2025-06-18"))
+    }
+
+    @Test func initializeAnswersLatestForUnsupportedRequestedVersion() async throws {
+        // An unsupported requested revision gets the latest the server
+        // speaks; the client then decides whether to continue.
+        let response = try #require(
+            await dispatcher.dispatch(
+                request(
+                    "initialize",
+                    params: .object(["protocolVersion": .string("1999-01-01")]))))
+        let result = try #require(response.result?.objectFields)
+        #expect(result["protocolVersion"] == .string("2025-11-25"))
+    }
+
+    @Test func initializeToleratesMalformedParams() async throws {
+        // A lenient initialize maximises client compatibility: unreadable
+        // params fall back to the server-chosen version rather than erroring.
+        let response = try #require(
+            await dispatcher.dispatch(
+                request(
+                    "initialize",
+                    params: .object(["protocolVersion": .int(42)]))))
+        let result = try #require(response.result?.objectFields)
+        #expect(result["protocolVersion"] == .string("2025-11-25"))
+    }
+
     @Test func pingReturnsEmptyObject() async throws {
         let response = try #require(await dispatcher.dispatch(request("ping")))
         #expect(response.result == .object([:]))

--- a/changelog.d/mcp-initialize-negotiation.md
+++ b/changelog.d/mcp-initialize-negotiation.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **MCP `initialize` now negotiates the protocol version and logs the
+  client's identity.** A supported requested revision (2025-06-18 or
+  2025-11-25) is echoed back per the lifecycle spec; an unsupported one gets
+  the latest the server speaks. The connecting client's `clientInfo`
+  name/version and the negotiated revision are logged for operational
+  visibility into which agents talk to the server.


### PR DESCRIPTION
From the MCP endpoint audit: `initialize` ignored its params entirely — the requested `protocolVersion` was never echoed and `clientInfo` was discarded.

- Per the lifecycle spec, a supported requested revision (2025-06-18 / 2025-11-25) is now echoed back; an unsupported one gets the latest the server speaks, letting the client decide whether to continue.
- The connecting client's `clientInfo` name/version, the requested revision, and the negotiated result are logged — operational visibility into which agents/libraries talk to the server, nothing more.
- Malformed params stay lenient (fall back to the server-chosen version) to maximise client compatibility.

**Stacked on #895** (reuses `MCPProtocol.supportedVersions`); will retarget/rebase onto `main` once that merges.

New dispatcher tests: supported version echoed, unsupported falls back, malformed params tolerated.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_