### PR TITLE
feat(mcp): cursor pagination for tools/list and resources/list

### DIFF
--- a/Sources/APIServer/MCP/Protocol/MCPListPagination.swift
+++ b/Sources/APIServer/MCP/Protocol/MCPListPagination.swift
@@ -1,0 +1,53 @@
+// APIServer/MCP/Protocol/MCPListPagination.swift
+//
+// Cursor-based pagination for the MCP list operations (`tools/list`,
+// `resources/list`).  Cursors are opaque to clients per the spec; here they
+// encode a plain offset, which is stable because both lists have a
+// deterministic order (name-sorted tools, title-sorted resources).
+// https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination
+
+import Core
+import Foundation
+
+enum MCPListPagination {
+    /// Entries per page.  Generous: the 34-tool catalog fits one page, so only
+    /// genuinely large listings (resources on a big deployment) paginate.
+    static let defaultPageSize = 100
+
+    /// The opaque cursor naming the page that starts at `offset`.
+    static func cursor(forOffset offset: Int) -> String {
+        Data("offset:\(offset)".utf8).base64EncodedString()
+    }
+
+    /// Decodes a cursor minted by `cursor(forOffset:)`; nil for anything else.
+    static func offset(fromCursor cursor: String) -> Int? {
+        guard let data = Data(base64Encoded: cursor),
+            let text = String(data: data, encoding: .utf8),
+            text.hasPrefix("offset:"),
+            let value = Int(text.dropFirst("offset:".count)),
+            value >= 0
+        else { return nil }
+        return value
+    }
+
+    /// Slices `entries` into the page named by `cursor` (nil = first page) and
+    /// the `nextCursor` to advertise (nil on the last page).  Returns nil when
+    /// the cursor is unparseable — the caller reports invalidParams.  A
+    /// well-formed cursor past the end of the list (e.g. the list shrank
+    /// between pages) yields an empty final page rather than an error.
+    static func page(
+        _ entries: [JSONValue], cursor: String?, pageSize: Int = defaultPageSize
+    ) -> (page: [JSONValue], nextCursor: String?)? {
+        let start: Int
+        if let cursor {
+            guard let offset = offset(fromCursor: cursor) else { return nil }
+            start = offset
+        } else {
+            start = 0
+        }
+        guard start < entries.count else { return ([], nil) }
+        let end = min(start + pageSize, entries.count)
+        let next = end < entries.count ? self.cursor(forOffset: end) : nil
+        return (Array(entries[start..<end]), next)
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -7,6 +7,7 @@
 // https://modelcontextprotocol.io/specification/2025-11-25
 
 import Core
+import Foundation
 
 /// Maps a JSON-RPC request to an MCP response.  Returns nil for notifications,
 /// which receive no response per the spec.
@@ -40,11 +41,11 @@ struct MCPDispatcher: Sendable {
             // with an id, ack with an empty result rather than erroring.
             return .success(id: id, result: .object([:]))
         case .toolsList:
-            return .success(id: id, result: toolsListResult(context: context))
+            return toolsListResult(id: id, params: request.params, context: context)
         case .toolsCall:
             return await toolsCallResult(id: id, params: request.params, context: context)
         case .resourcesList:
-            return await resourcesListResult(id: id, context: context)
+            return await resourcesListResult(id: id, params: request.params, context: context)
         case .resourcesRead:
             return await resourcesReadResult(id: id, params: request.params, context: context)
         }
@@ -54,7 +55,9 @@ struct MCPDispatcher: Sendable {
 
     private let resources = MCPResourceProvider()
 
-    private func resourcesListResult(id: JSONRPCID, context: ToolContext?) async -> JSONRPCResponse {
+    private func resourcesListResult(
+        id: JSONRPCID, params: JSONValue?, context: ToolContext?
+    ) async -> JSONRPCResponse {
         guard let context else {
             return .failure(id: id, error: .internalError("Resource execution context is unavailable."))
         }
@@ -62,7 +65,11 @@ struct MCPDispatcher: Sendable {
             return .failure(id: id, error: .insufficientScope(ContentScope.read.rawValue))
         }
         do {
-            return .success(id: id, result: try await resources.list(context: context))
+            let full = try await resources.list(context: context)
+            guard case .object(let fields) = full, case .array(let entries)? = fields["resources"] else {
+                return .failure(id: id, error: .internalError("Failed to list resources."))
+            }
+            return paginatedListResponse(id: id, key: "resources", entries: entries, params: params)
         } catch {
             return .failure(id: id, error: .internalError("Failed to list resources."))
         }
@@ -116,7 +123,7 @@ struct MCPDispatcher: Sendable {
     /// to {read}, so write tools drop out of the listing here rather than being
     /// advertised only to fail with 403 on call.  When no context is available
     /// (non-transport callers / tests), all tools are listed.
-    private func toolsListResult(context: ToolContext?) -> JSONValue {
+    private func toolsListResult(id: JSONRPCID, params: JSONValue?, context: ToolContext?) -> JSONRPCResponse {
         let visible =
             context.map { ctx in
                 tools.all.filter { ctx.grantedScopes.isSuperset(of: $0.requiredScopes) }
@@ -135,7 +142,36 @@ struct MCPDispatcher: Sendable {
             }
             return .object(fields)
         }
-        return .object(["tools": .array(entries)])
+        return paginatedListResponse(id: id, key: "tools", entries: entries, params: params)
+    }
+
+    // MARK: - List pagination
+
+    private struct ListParams: Decodable {
+        let cursor: String?
+    }
+
+    /// Applies spec pagination to a full list result: slices `entries` by the
+    /// caller's cursor and attaches `nextCursor` while more pages remain.  An
+    /// unparseable cursor is invalidParams, per the spec.
+    /// https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination
+    private func paginatedListResponse(
+        id: JSONRPCID, key: String, entries: [JSONValue], params: JSONValue?
+    ) -> JSONRPCResponse {
+        let cursor: String?
+        do {
+            cursor = try (params ?? .object([:])).decoded(as: ListParams.self).cursor
+        } catch {
+            return .failure(id: id, error: .invalidParams("\"cursor\" must be a string."))
+        }
+        guard let result = MCPListPagination.page(entries, cursor: cursor) else {
+            return .failure(id: id, error: .invalidParams("Invalid cursor."))
+        }
+        var fields: [String: JSONValue] = [key: .array(result.page)]
+        if let next = result.nextCursor {
+            fields["nextCursor"] = .string(next)
+        }
+        return .success(id: id, result: .object(fields))
     }
 
     // MARK: - tools/call

--- a/Tests/APITests/MCP/MCPListPaginationTests.swift
+++ b/Tests/APITests/MCP/MCPListPaginationTests.swift
@@ -1,0 +1,120 @@
+// Tests for MCP list pagination: the opaque-cursor helper itself, and the
+// dispatcher's tools/list wiring (page + nextCursor walk, invalid-cursor
+// rejection).  resources/list shares the same paginatedListResponse path, so
+// the cursor semantics proven here apply to both list operations.
+
+import Core
+import Testing
+
+@testable import APIServer
+
+@Suite struct MCPListPaginationTests {
+    // MARK: - Cursor helper
+
+    @Test func cursorRoundTrips() {
+        for offset in [0, 1, 100, 12345] {
+            #expect(MCPListPagination.offset(fromCursor: MCPListPagination.cursor(forOffset: offset)) == offset)
+        }
+    }
+
+    @Test func malformedCursorsAreRejected() {
+        for cursor in ["", "!!!", "bm90LWFuLW9mZnNldA==", MCPListPagination.cursor(forOffset: 0) + "x"] {
+            #expect(MCPListPagination.offset(fromCursor: cursor) == nil)
+        }
+    }
+
+    @Test func pageWalksAList() throws {
+        let entries = (0..<5).map { JSONValue.int($0) }
+
+        let first = try #require(MCPListPagination.page(entries, cursor: nil, pageSize: 2))
+        #expect(first.page == [.int(0), .int(1)])
+        let second = try #require(MCPListPagination.page(entries, cursor: first.nextCursor, pageSize: 2))
+        #expect(second.page == [.int(2), .int(3)])
+        let third = try #require(MCPListPagination.page(entries, cursor: second.nextCursor, pageSize: 2))
+        #expect(third.page == [.int(4)])
+        #expect(third.nextCursor == nil)
+    }
+
+    @Test func staleCursorPastTheEndYieldsEmptyFinalPage() throws {
+        // The list shrank between pages: a well-formed but now out-of-range
+        // cursor is not an error, just an empty last page.
+        let entries = [JSONValue.int(0)]
+        let result = try #require(
+            MCPListPagination.page(entries, cursor: MCPListPagination.cursor(forOffset: 5), pageSize: 2))
+        #expect(result.page.isEmpty)
+        #expect(result.nextCursor == nil)
+    }
+
+    @Test func unparseableCursorIsNil() {
+        #expect(MCPListPagination.page([], cursor: "garbage") == nil)
+    }
+
+    // MARK: - Dispatcher wiring
+
+    private static func stubTool(named name: String) -> AnyContentTool {
+        AnyContentTool(
+            name: name,
+            description: "Stub tool \(name).",
+            inputSchema: .object(["type": .string("object")]),
+            outputSchema: nil,
+            annotations: nil,
+            requiredScopes: [.read],
+            invoke: { _, _ in .object([:]) })
+    }
+
+    /// 150 stub tools: enough to spill into a second page at the default page
+    /// size of 100.  Zero-padded names keep the registry's name-sort stable.
+    private let dispatcher = MCPDispatcher(
+        serverInfo: MCPServerInfo(name: "Chickadee MCP", version: "test"),
+        tools: ToolRegistry((1...150).map { stubTool(named: String(format: "stub_%03d", $0)) })
+    )
+
+    private func toolsList(params: JSONValue?) async throws -> JSONRPCResponse {
+        let request = JSONRPCRequest(
+            jsonrpc: "2.0", id: .number(1), method: "tools/list", params: params)
+        return try #require(await dispatcher.dispatch(request))
+    }
+
+    @Test func toolsListPaginatesPastTheDefaultPageSize() async throws {
+        let first = try await toolsList(params: nil)
+        let (firstNames, firstCursor) = try Self.namesAndCursor(first)
+        #expect(firstNames.count == 100)
+        #expect(firstNames.first == "stub_001")
+        let cursor = try #require(firstCursor)
+
+        let second = try await toolsList(params: .object(["cursor": .string(cursor)]))
+        let (secondNames, secondCursor) = try Self.namesAndCursor(second)
+        #expect(secondNames.count == 50)
+        #expect(secondNames.first == "stub_101")
+        #expect(secondCursor == nil)
+        #expect(Set(firstNames).isDisjoint(with: secondNames))
+    }
+
+    @Test func toolsListRejectsInvalidCursor() async throws {
+        let response = try await toolsList(params: .object(["cursor": .string("garbage")]))
+        #expect(response.error?.code == -32_602)
+    }
+
+    @Test func toolsListRejectsNonStringCursor() async throws {
+        let response = try await toolsList(params: .object(["cursor": .int(7)]))
+        #expect(response.error?.code == -32_602)
+    }
+
+    // MARK: - Helpers
+
+    private static func namesAndCursor(_ response: JSONRPCResponse) throws -> ([String], String?) {
+        guard case .object(let fields)? = response.result,
+            case .array(let tools)? = fields["tools"]
+        else {
+            throw IssueRecorded("tools/list result is not an object with a tools array")
+        }
+        let names = tools.compactMap { entry -> String? in
+            guard case .object(let tool) = entry, case .string(let name)? = tool["name"] else { return nil }
+            return name
+        }
+        if case .string(let cursor)? = fields["nextCursor"] {
+            return (names, cursor)
+        }
+        return (names, nil)
+    }
+}

--- a/changelog.d/mcp-list-pagination.md
+++ b/changelog.d/mcp-list-pagination.md
@@ -1,0 +1,8 @@
+### Added
+
+- **MCP list pagination.** `tools/list` and `resources/list` now honor the
+  spec's cursor-based pagination: results carry a `nextCursor` when more pages
+  remain (page size 100), and an unparseable `cursor` is rejected with
+  `-32602` instead of being silently ignored. Today's 34-tool catalog still
+  fits one page; the resource listing (one entry per accessible assignment)
+  is what this protects on large deployments.


### PR DESCRIPTION
From the MCP endpoint audit: neither list operation implemented the spec's cursor-based pagination — fine for 34 tools, but `resources/list` returns one entry per accessible assignment and has no bound on a large deployment (an admin sees every course).

- `tools/list` and `resources/list` now slice through a shared `paginatedListResponse` path: page size 100, `nextCursor` attached while more pages remain.
- Cursors are opaque base64 offsets (`MCPListPagination`), stable because both lists are deterministically ordered (name-sorted tools, title-sorted resources).
- An unparseable or non-string `cursor` is rejected with `-32602` per the spec; a well-formed cursor past the end (list shrank between pages) yields an empty final page rather than an error.
- No-cursor requests on short lists return exactly the same shape as before (no `nextCursor` key), so existing clients see no change.

Tests: cursor round-trip and rejection, page walk, stale-cursor behavior, and a dispatcher-level walk across a 150-tool stub registry plus invalid-cursor → `-32602`.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_