### PR TITLE
feat(mcp): advertise display titles on tools/list entries

### DIFF
--- a/Sources/APIServer/MCP/Tools/ContentTool.swift
+++ b/Sources/APIServer/MCP/Tools/ContentTool.swift
@@ -15,6 +15,11 @@ protocol ContentTool: Sendable {
 
     /// Stable tool name: the `tools/list` identifier and the registry key.
     static var name: String { get }
+    /// Human-friendly display name surfaced as the tool's `title` in
+    /// `tools/list`, so clients render "Get Server Info" rather than
+    /// `get_server_info`.  Defaults to a Title-Case derivation of `name`;
+    /// override only when the derivation reads badly.
+    static var title: String { get }
     /// Human-readable description surfaced in `tools/list`.
     static var description: String { get }
     /// JSON Schema (draft 2020-12) describing `Input`, surfaced in `tools/list`.
@@ -66,6 +71,11 @@ struct MCPToolAnnotations: Encodable, Sendable {
 }
 
 extension ContentTool {
+    /// Title-Case derivation of the snake_case `name`
+    /// ("get_server_info" → "Get Server Info").
+    static var title: String {
+        name.split(separator: "_").map { String($0).capitalized }.joined(separator: " ")
+    }
     /// Tools declare no output schema unless they override this.
     static var outputSchema: JSONValue? { nil }
     /// By default a tool is annotated read-only iff its only required scope is
@@ -100,6 +110,7 @@ enum MCPToolError: Error, Sendable, Equatable {
 /// `JSONValue`.
 struct AnyContentTool: Sendable {
     let name: String
+    let title: String
     let description: String
     let inputSchema: JSONValue
     let outputSchema: JSONValue?
@@ -113,6 +124,7 @@ extension ContentTool {
     func erased() -> AnyContentTool {
         AnyContentTool(
             name: Self.name,
+            title: Self.title,
             description: Self.description,
             inputSchema: Self.inputSchema,
             outputSchema: Self.outputSchema,

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -131,6 +131,7 @@ struct MCPDispatcher: Sendable {
         let entries = visible.map { tool -> JSONValue in
             var fields: [String: JSONValue] = [
                 "name": .string(tool.name),
+                "title": .string(tool.title),
                 "description": .string(tool.description),
                 "inputSchema": tool.inputSchema,
             ]

--- a/Tests/APITests/MCP/ContentToolTests.swift
+++ b/Tests/APITests/MCP/ContentToolTests.swift
@@ -36,6 +36,15 @@ import Vapor
         #expect(registry.all.map(\.name) == ["echo"])
     }
 
+    @Test func titleDerivesFromSnakeCaseName() {
+        // The default title Title-Cases the snake_case name; a single-word
+        // name just capitalizes.
+        #expect(EchoTool.title == "Echo")
+        #expect(GetServerInfoTool.title == "Get Server Info")
+        #expect(SetAssignmentCourseSectionTool.title == "Set Assignment Course Section")
+        #expect(EchoTool().erased().title == "Echo")
+    }
+
     @Test func erasedInvokeDecodesRunsAndEncodes() async throws {
         try await withApp(try await Application.make(.testing)) { app in
             let request = Request(application: app, on: app.eventLoopGroup.any())

--- a/Tests/APITests/MCP/MCPListPaginationTests.swift
+++ b/Tests/APITests/MCP/MCPListPaginationTests.swift
@@ -54,6 +54,7 @@ import Testing
     private static func stubTool(named name: String) -> AnyContentTool {
         AnyContentTool(
             name: name,
+            title: name,
             description: "Stub tool \(name).",
             inputSchema: .object(["type": .string("object")]),
             outputSchema: nil,
@@ -88,6 +89,20 @@ import Testing
         #expect(secondNames.first == "stub_101")
         #expect(secondCursor == nil)
         #expect(Set(firstNames).isDisjoint(with: secondNames))
+    }
+
+    @Test func toolsListEntriesCarryTitles() async throws {
+        // Wire-level check that the dispatcher surfaces each tool's display
+        // title (this suite's stub registry is the convenient place to see a
+        // full entry).
+        let response = try await toolsList(params: nil)
+        guard case .object(let fields)? = response.result,
+            case .array(let tools)? = fields["tools"],
+            case .object(let first)? = tools.first
+        else {
+            throw IssueRecorded("tools/list result has no first entry")
+        }
+        #expect(first["title"] == .string("stub_001"))
     }
 
     @Test func toolsListRejectsInvalidCursor() async throws {

--- a/changelog.d/mcp-tool-titles.md
+++ b/changelog.d/mcp-tool-titles.md
@@ -1,0 +1,6 @@
+### Added
+
+- **MCP tools advertise display titles.** Every entry in `tools/list` now
+  carries a human-friendly `title` (derived from the tool name, e.g.
+  `get_server_info` → "Get Server Info") so MCP clients can render readable
+  names instead of snake_case identifiers.


### PR DESCRIPTION
From the MCP endpoint audit: tool entries had no `title` (optional since the 2025-06-18 spec revision), so clients render raw snake_case names.

- `ContentTool` gains a `title` requirement with a default Title-Case derivation from `name` (`get_server_info` → "Get Server Info") — all 34 current names derive cleanly, and a tool can override if a future name reads badly.
- `AnyContentTool` carries the title through erasure and the dispatcher emits it on every `tools/list` entry.

**Stacked on #897** (both touch `toolsListResult`); will retarget/rebase onto `main` once that merges.

Tests: derivation (single- and multi-word names), title survives erasure, and a wire-level check that `tools/list` entries carry the field.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_