### PR TITLE
feat(mcp): expose authoring guides as MCP resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,8 @@ COPY --from=binaries /out/chickadee-runner  ./chickadee-runner
 # so updates to templates or JupyterLite are always picked up on redeploy.
 COPY Public     ./Public
 COPY Resources  ./Resources
+# Authoring guides served as MCP resources (see MCPResourceProvider).
+COPY docs       ./docs
 
 # Startup script (server only; runner uses its binary directly).
 COPY deploy/docker-entrypoint.sh ./docker-entrypoint.sh

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -202,10 +202,13 @@ enum MCPServerInstructions {
         substituted per validation-seed just like the starter, so `shift = {{shift}}` becomes a literal \
         that survives import — or make the solution answer a function that reads \
         CHICKADEE_ASSIGNMENT_SEED at call time. Use preview_personalization to confirm what a \
-        placeholder resolves to. Full recipe: docs/personalization-solution-notebooks.md. \
+        placeholder resolves to. Full recipe: read the \
+        chickadee://docs/personalization-solution-notebooks resource. \
         - Resources: each accessible assignment's raw test.properties.json manifest is also exposed \
         as an MCP resource (resources/list, then resources/read on \
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \
-        is the verbatim canonical JSON, useful to read the full authoring spec into context.
+        is the verbatim canonical JSON, useful to read the full authoring spec into context. \
+        Authoring guides are exposed the same way under chickadee://docs/* — e.g. the per-student \
+        solution-notebook recipe above.
         """
 }

--- a/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
+++ b/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
@@ -1,11 +1,14 @@
 // APIServer/MCP/Resources/MCPResourceProvider.swift
 //
-// Backs the MCP `resources/list` and `resources/read` methods. The one resource
-// kind exposed is an assignment's raw test-suite manifest (`test.properties.json`)
-// — the canonical authoring spec (suites, pattern families, sections, required
-// files). `get_suite` is the structured, filtered view; the resource is the
-// verbatim JSON, which is the MCP-idiomatic way to hand the model a document it
-// can read into context.
+// Backs the MCP `resources/list` and `resources/read` methods. Two resource
+// kinds are exposed: an assignment's raw test-suite manifest
+// (`test.properties.json`) — the canonical authoring spec (suites, pattern
+// families, sections, required files) — and a small curated set of authoring
+// guides from `docs/`. `get_suite` is the structured, filtered view of a
+// manifest; the resource is the verbatim JSON, which is the MCP-idiomatic way
+// to hand the model a document it can read into context. The guides exist so
+// the server-level instructions can reference a recipe by URI instead of a
+// repo path a connected agent cannot fetch.
 //
 // Course-scoped exactly like the tools: the listing is confined to courses the
 // subject can act on (admins: all non-archived; everyone else: their
@@ -14,9 +17,36 @@
 
 import Core
 import Fluent
+import Foundation
 import Vapor
 
 struct MCPResourceProvider: Sendable {
+    /// An authoring guide exposed read-only at `chickadee://docs/<slug>`.
+    struct DocResource: Sendable {
+        let slug: String
+        /// Path relative to the application's working directory.
+        let relativePath: String
+        let name: String
+        let description: String
+
+        var uri: String { "chickadee://docs/\(slug)" }
+    }
+
+    /// The curated guides surfaced to agents. The server-level instructions
+    /// reference these by URI; a guide whose file is missing on disk (e.g. a
+    /// deployment that ships no docs tree) silently drops out of the listing
+    /// and reads as an unknown resource.
+    static let docResources: [DocResource] = [
+        DocResource(
+            slug: "personalization-solution-notebooks",
+            relativePath: "docs/personalization-solution-notebooks.md",
+            name: "Guide — per-student answers in notebooks and reference solutions",
+            description: "How a per-student answer can be expressed in a notebook (the "
+                + "extractor's import quarantine rule), and how the reference solution "
+                + "produces the matching per-student value so validation passes. The "
+                + "full recipe the server instructions reference.")
+    ]
+
     /// `chickadee://assignment/<publicID>/manifest`
     static func manifestURI(publicID: String) -> String {
         "chickadee://assignment/\(publicID)/manifest"
@@ -60,7 +90,11 @@ struct MCPResourceProvider: Sendable {
         let courseByID = Dictionary(
             courses.compactMap { course in course.id.map { ($0, course) } },
             uniquingKeysWith: { first, _ in first })
-        guard !courseByID.isEmpty else { return .object(["resources": .array([])]) }
+        // The guides are not course-scoped: a subject with no enrolments yet
+        // still sees them.
+        guard !courseByID.isEmpty else {
+            return .object(["resources": .array(docEntries(context: context))])
+        }
 
         let assignments = try await APIAssignment.query(on: context.db)
             .filter(\.$courseID ~~ Array(courseByID.keys))
@@ -79,7 +113,50 @@ struct MCPResourceProvider: Sendable {
                 "mimeType": .string("application/json"),
             ])
         }
-        return .object(["resources": .array(resources)])
+        return .object(["resources": .array(docEntries(context: context) + resources)])
+    }
+
+    // MARK: - Authoring-guide docs
+
+    /// Listing entries for the curated guides whose files exist on disk.
+    private func docEntries(context: ToolContext) -> [JSONValue] {
+        Self.docResources.compactMap { doc in
+            guard FileManager.default.fileExists(atPath: Self.docPath(doc, context: context)) else {
+                return nil
+            }
+            return .object([
+                "uri": .string(doc.uri),
+                "name": .string(doc.name),
+                "description": .string(doc.description),
+                "mimeType": .string("text/markdown"),
+            ])
+        }
+    }
+
+    private static func docPath(_ doc: DocResource, context: ToolContext) -> String {
+        context.request.application.directory.workingDirectory + doc.relativePath
+    }
+
+    /// Reads a curated guide, or throws the same "unknown resource" error the
+    /// manifest path uses when the slug is unknown or the file is unreadable.
+    private func readDoc(uri: String, context: ToolContext) async throws -> JSONValue {
+        try await context.requireEligibleSubject(tool: "resources/read")
+        guard let doc = Self.docResources.first(where: { $0.uri == uri }),
+            let data = FileManager.default.contents(atPath: Self.docPath(doc, context: context)),
+            let text = String(data: data, encoding: .utf8)
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: "resources/read", detail: "Unknown or inaccessible resource: \(uri)")
+        }
+        return .object([
+            "contents": .array([
+                .object([
+                    "uri": .string(uri),
+                    "mimeType": .string("text/markdown"),
+                    "text": .string(text),
+                ])
+            ])
+        ])
     }
 
     /// `resources/read`: returns the manifest JSON for the assignment named by
@@ -88,6 +165,9 @@ struct MCPResourceProvider: Sendable {
     /// it isn't enrolled in. Result shape: `{ "contents": [ { uri, mimeType,
     /// text } ] }`.
     func read(uri: String, context: ToolContext) async throws -> JSONValue {
+        if uri.hasPrefix("chickadee://docs/") {
+            return try await readDoc(uri: uri, context: context)
+        }
         guard let publicID = Self.manifestPublicID(fromURI: uri),
             let assignment = try await assignmentByPublicID(publicID, on: context.db)
         else {

--- a/Tests/APITests/MCP/MCPResourcesTests.swift
+++ b/Tests/APITests/MCP/MCPResourcesTests.swift
@@ -82,6 +82,53 @@ import Vapor
         }
     }
 
+    // MARK: - Authoring-guide docs
+
+    @Test func listIncludesAuthoringGuides() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            let result = try await MCPResourceProvider().list(context: context(app, subject: "prof"))
+            let uris = Self.resourceURIs(result)
+            #expect(uris.contains("chickadee://docs/personalization-solution-notebooks"))
+        }
+    }
+
+    @Test func readReturnsGuideMarkdown() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            let result = try await MCPResourceProvider().read(
+                uri: "chickadee://docs/personalization-solution-notebooks",
+                context: context(app, subject: "prof"))
+            let text = try #require(Self.firstContentText(result))
+            #expect(text.hasPrefix("# Per-student answers in notebooks"))
+        }
+    }
+
+    @Test func readRejectsUnknownGuideSlug() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await MCPResourceProvider().read(
+                    uri: "chickadee://docs/not-a-guide", context: context(app, subject: "prof"))
+            }
+        }
+    }
+
+    @Test func readRejectsStudentSubjectForGuides() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "stu", role: "student")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await MCPResourceProvider().read(
+                    uri: "chickadee://docs/personalization-solution-notebooks",
+                    context: context(app, subject: "stu"))
+            }
+        }
+    }
+
     // MARK: - resources/read
 
     @Test func readReturnsManifestJSON() async throws {

--- a/changelog.d/mcp-docs-resource.md
+++ b/changelog.d/mcp-docs-resource.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Authoring guides exposed as MCP resources.** The per-student
+  solution-notebook recipe is now readable by connected agents at
+  `chickadee://docs/personalization-solution-notebooks`, and the MCP server
+  instructions point at that resource instead of a repo path the agent cannot
+  fetch. The Docker image now ships `docs/` and the entrypoint syncs it to the
+  data volume alongside Public/ and Resources/.

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -17,10 +17,12 @@ DATA_DIR="${DATA_DIR:-/data}"
 echo "[entrypoint] Syncing static assets to ${DATA_DIR} ..."
 mkdir -p "${DATA_DIR}"
 
-# Replace Public/ and Resources/ on every start so deploys are always fresh.
-rm -rf "${DATA_DIR}/Public" "${DATA_DIR}/Resources"
+# Replace Public/, Resources/, and docs/ on every start so deploys are always
+# fresh. docs/ feeds the MCP authoring-guide resources (MCPResourceProvider).
+rm -rf "${DATA_DIR}/Public" "${DATA_DIR}/Resources" "${DATA_DIR}/docs"
 cp -r /app/Public    "${DATA_DIR}/Public"
 cp -r /app/Resources "${DATA_DIR}/Resources"
+cp -r /app/docs      "${DATA_DIR}/docs"
 
 echo "[entrypoint] Starting chickadee-server ..."
 cd "${DATA_DIR}"


### PR DESCRIPTION
From the MCP endpoint audit: the server-level instructions referenced `docs/personalization-solution-notebooks.md` by repo path — a path a connected agent has no way to fetch.

- The guide is now an MCP resource at `chickadee://docs/personalization-solution-notebooks`: listed in `resources/list` (course-independent — a subject with no enrolments still sees it), readable via `resources/read` as `text/markdown`, gated by the same instructor-eligibility check as everything else.
- The instructions now point at the resource URI, and the trailing Resources bullet documents the `chickadee://docs/*` scheme.
- `MCPResourceProvider.docResources` is a small curated table, so future guides are one entry each; a guide whose file is missing on disk silently drops out of the listing rather than breaking the list.
- Deployment: the Docker image now ships `docs/`, and the entrypoint syncs it to the data volume alongside `Public/` and `Resources/` (the server's working directory is the data dir, so the relative path resolves the same in dev and prod).

Tests: guide listed, markdown read back, unknown slug rejected, student subject rejected.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_