### PR TITLE
feat(mcp): warn at startup when production mounts /mcp unguarded

### DIFF
--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -95,6 +95,14 @@ func registerMCPRoutes(_ app: Application) throws {
         return
     }
 
+    if let warning = mcpAllowlistWarning(
+        environment: app.environment,
+        allowedHosts: mcp.allowedHosts,
+        allowedOrigins: mcp.allowedOrigins)
+    {
+        app.logger.warning("\(warning)")
+    }
+
     let dispatcher = MCPDispatcher(
         serverInfo: MCPServerInfo(
             name: "Chickadee MCP", version: ChickadeeVersion.current,
@@ -161,6 +169,24 @@ func registerMCPOAuthRoutes(
 
     app.logger.info(
         "MCP browser OAuth flow mounted at /oauth/{authorize,token,revoke,register}")
+}
+
+/// The operator-facing warning to log when the MCP transport is being mounted
+/// in production with one or both DNS-rebinding guards disabled (an empty
+/// allowlist means "allow any" — see MCPRoutes.Configuration).  Nil when both
+/// are configured, or in non-production environments where empty allowlists
+/// are the normal development default.
+func mcpAllowlistWarning(
+    environment: Environment, allowedHosts: Set<String>, allowedOrigins: Set<String>
+) -> String? {
+    guard environment == .production else { return nil }
+    var unset: [String] = []
+    if allowedHosts.isEmpty { unset.append("MCP_ALLOWED_HOSTS") }
+    if allowedOrigins.isEmpty { unset.append("MCP_ALLOWED_ORIGINS") }
+    guard !unset.isEmpty else { return nil }
+    return "MCP transport mounted with \(unset.joined(separator: " and ")) unset — "
+        + "the Host/Origin DNS-rebinding guards are disabled. Set them to this "
+        + "deployment's public host and origin."
 }
 
 private extension String {

--- a/Tests/APITests/MCP/MCPAllowlistWarningTests.swift
+++ b/Tests/APITests/MCP/MCPAllowlistWarningTests.swift
@@ -1,0 +1,46 @@
+// Tests for the startup warning emitted when the MCP transport is mounted in
+// production with its Host/Origin DNS-rebinding allowlists unset (an empty
+// allowlist disables the corresponding check entirely).
+
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPAllowlistWarningTests {
+    @Test func warnsInProductionWhenBothUnset() throws {
+        let warning = try #require(
+            mcpAllowlistWarning(environment: .production, allowedHosts: [], allowedOrigins: []))
+        #expect(warning.contains("MCP_ALLOWED_HOSTS"))
+        #expect(warning.contains("MCP_ALLOWED_ORIGINS"))
+        #expect(warning.contains("DNS-rebinding"))
+    }
+
+    @Test func warnsInProductionNamingOnlyTheUnsetGuard() throws {
+        let warning = try #require(
+            mcpAllowlistWarning(
+                environment: .production,
+                allowedHosts: ["chickadee.example.com"],
+                allowedOrigins: []))
+        #expect(!warning.contains("MCP_ALLOWED_HOSTS"))
+        #expect(warning.contains("MCP_ALLOWED_ORIGINS"))
+    }
+
+    @Test func silentInProductionWhenBothConfigured() {
+        #expect(
+            mcpAllowlistWarning(
+                environment: .production,
+                allowedHosts: ["chickadee.example.com"],
+                allowedOrigins: ["https://claude.ai"]) == nil)
+    }
+
+    @Test func silentOutsideProduction() {
+        // Empty allowlists are the expected development/testing default; the
+        // warning would be pure noise there.
+        for environment in [Environment.development, .testing] {
+            #expect(
+                mcpAllowlistWarning(environment: environment, allowedHosts: [], allowedOrigins: [])
+                    == nil)
+        }
+    }
+}

--- a/changelog.d/mcp-allowlist-warning.md
+++ b/changelog.d/mcp-allowlist-warning.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Startup warning for an unguarded MCP transport.** Mounting `/mcp` in
+  production with `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` unset now logs a
+  warning naming the unset variable(s) — an empty allowlist disables the
+  corresponding Host/Origin DNS-rebinding guard — instead of silently
+  accepting any value. Development and testing stay quiet, where empty
+  allowlists are the normal default.


### PR DESCRIPTION
From the MCP endpoint audit: an empty `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` allowlist means "allow any" — the right development default, but a silent misconfiguration when `/mcp` is mounted in production (the DNS-rebinding Host/Origin guards are simply off, and nothing says so).

- `registerMCPRoutes` now logs a warning naming exactly the unset variable(s) when the app environment is production. Bearer auth still protects the endpoint either way; this is about making the disabled guard visible to the operator.
- Development and testing stay quiet, where empty allowlists are the normal default.
- The message lives in a pure helper (`mcpAllowlistWarning`) so the production/dev split and the variable naming are directly tested.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_