### PR TITLE
Fix extension/override popover clipping at the right screen edge

### DIFF
--- a/Resources/Views/course-student-submissions.leaf
+++ b/Resources/Views/course-student-submissions.leaf
@@ -335,8 +335,9 @@
 .action-panel {
     position: absolute;
     top: calc(100% + .3rem);
-    left: 0;
+    right: 0;
     z-index: 10;
+    max-width: calc(100vw - 2rem);
     display: flex;
     flex-direction: column;
     gap: .3rem;

--- a/changelog.d/extension-box-overflow.md
+++ b/changelog.d/extension-box-overflow.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Extension/override popover no longer cut off at the screen edge.** On the
+  instructor's per-student submissions page, the deadline-extension and
+  grade-override panels were anchored to the left edge of their toolbar button
+  and opened rightward — after more action buttons were added, the panel
+  extended past the viewport and the date field and Save button were clipped.
+  The panel now opens leftward from the button's right edge and is capped to
+  the viewport width.


### PR DESCRIPTION
## Problem

On the instructor's per-student submissions page (`/instructor/courses/:id/students/:id`), opening the deadline-extension (or grade-override) popover near the right edge of the screen cuts off the date input, Note field, and Save button.

The `.action-panel` popover was absolutely positioned with `left: 0` relative to its toolbar button, so it opened **rightward**. The Actions column is the rightmost column of the table, and as more action buttons were added (re-test, extension, grade override, reset notebook) the extension button shifted further right — pushing the panel past the viewport edge. Hard refresh / switching browsers only "worked" because of zoom or window-width differences.

## Fix

CSS-only, local to the page's `<style>` block:

- Anchor the panel to the button's **right** edge (`right: 0` instead of `left: 0`) so it opens leftward into the page, where there is always room.
- Cap the panel at `max-width: calc(100vw - 2rem)` as a backstop on narrow screens.

Both the extension and grade-override popovers on this page share the `.action-panel` class, so both are fixed. The similar panel on `assignment-submissions.leaf` uses a different, non-absolute layout (`.ext-panel`) and was not affected.

`scripts/check-styles.sh` and `scripts/check-css-vars.sh` pass.

https://claude.ai/code/session_014LmGtQqWDBbqLBJ5YAxAJV

---
_Generated by [Claude Code](https://claude.ai/code/session_014LmGtQqWDBbqLBJ5YAxAJV)_