### PR TITLE
feat(mcp): enrollment-scope admin agents, share one course resolver

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -1,6 +1,9 @@
 // APIServer/Helpers/CourseAccessHelpers.swift
 //
-// Shared enrollment guard used by any route that accesses per-course content.
+// Shared course-visibility and enrollment-access policy. The web routes and
+// the MCP tools both resolve "which courses can this user act on" and "may
+// this user touch this course" through the helpers here, so the two surfaces
+// cannot drift.
 //
 // Rule: instructors and admins can access all courses; students must be
 // enrolled in the specific course that owns the resource.
@@ -13,10 +16,36 @@ import Vapor
 func requireCourseEnrollment(caller: APIUser, courseID: UUID, db: Database) async throws {
     guard !caller.isInstructor else { return }
     guard let callerID = caller.id else { throw Abort(.unauthorized) }
-    let enrolled =
-        try await APICourseEnrollment.query(on: db)
-        .filter(\.$userID == callerID)
+    guard try await userIsEnrolled(userID: callerID, inCourse: courseID, db: db) else {
+        throw Abort(.forbidden)
+    }
+}
+
+/// True when the user holds an enrollment row in course `courseID`. The single
+/// enrollment predicate behind both the web guard above and the MCP tools'
+/// `authorizeCourseAccess`. Deliberately carries no role bypass — role policy
+/// stays with the callers.
+func userIsEnrolled(userID: UUID, inCourse courseID: UUID, db: Database) async throws -> Bool {
+    try await APICourseEnrollment.query(on: db)
+        .filter(\.$userID == userID)
         .filter(\.$course.$id == courseID)
         .count() > 0
-    guard enrolled else { throw Abort(.forbidden) }
+}
+
+/// The courses the user can act on, dashboard-style: the non-archived courses
+/// they hold an enrollment row in, sorted by code. The single visibility
+/// resolver behind the web tab strip (`resolveActiveCourse`) and the MCP
+/// listing surface (`list_courses`, `resources/list`). No role widens this
+/// set: admins see — and their agents may act on — exactly what they are
+/// enrolled in.
+func enrolledCourses(for userID: UUID, on db: Database) async throws -> [APICourse] {
+    let enrollments = try await APICourseEnrollment.query(on: db)
+        .filter(\.$userID == userID)
+        .with(\.$course)
+        .all()
+    return
+        enrollments
+        .map(\.course)
+        .filter { !$0.isArchived }
+        .sorted { $0.code < $1.code }
 }

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -85,9 +85,10 @@ enum MCPServerInstructions {
         test suites, starter notebooks, and reference solutions. It never exposes student data, \
         grades, student submissions, or enrollment management.
 
-        Access scope: you may only act on courses the authenticated account is enrolled in (an admin \
-        account may act on every course); students cannot use this interface. Read tools require the \
-        content:read scope; write tools require content:write.
+        Access scope: you may only act on courses the authenticated account is enrolled in — for \
+        every role, admins included. Enrolling the account in a course widens this agent's reach; \
+        unenrolling revokes it immediately. Students cannot use this interface. Read tools require \
+        the content:read scope; write tools require content:write.
 
         Key concepts:
         - Course — identified by a short code (e.g. "CS136").

--- a/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
+++ b/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
@@ -10,10 +10,11 @@
 // the server-level instructions can reference a recipe by URI instead of a
 // repo path a connected agent cannot fetch.
 //
-// Course-scoped exactly like the tools: the listing is confined to courses the
-// subject can act on (admins: all non-archived; everyone else: their
-// enrolments), and a read re-checks `authorizeCourseAccess`. Nothing here
-// touches student data, grades, or submissions — only authoring content.
+// Course-scoped exactly like the tools: the listing is confined to the
+// subject's non-archived enrolments (admins included — the shared
+// `enrolledCourses` resolver carries no role bypass), and a read re-checks
+// `authorizeCourseAccess`. Nothing here touches student data, grades, or
+// submissions — only authoring content.
 
 import Core
 import Fluent
@@ -69,20 +70,11 @@ struct MCPResourceProvider: Sendable {
     func list(context: ToolContext) async throws -> JSONValue {
         let user = try await context.requireEligibleSubject(tool: "resources/list")
 
+        // The shared visibility resolver: non-archived enrolled courses, for
+        // every role — an admin's agent sees its enrolments, not the world.
         let courses: [APICourse]
-        if user.isAdmin {
-            courses = try await APICourse.query(on: context.db)
-                .filter(\.$isArchived == false)
-                .all()
-        } else if let userID = user.id {
-            let enrollments = try await APICourseEnrollment.query(on: context.db)
-                .filter(\.$userID == userID)
-                .all()
-            let courseIDs = Array(Set(enrollments.map { $0.$course.id }))
-            courses =
-                courseIDs.isEmpty
-                ? []
-                : try await APICourse.query(on: context.db).filter(\.$id ~~ courseIDs).all()
+        if let userID = user.id {
+            courses = try await enrolledCourses(for: userID, on: context.db)
         } else {
             courses = []
         }

--- a/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
+++ b/Sources/APIServer/MCP/Tools/ListCoursesTool.swift
@@ -1,9 +1,9 @@
 // APIServer/MCP/Tools/ListCoursesTool.swift
 //
-// Read tool: lists the courses this agent may act on — the courses its account
-// is enrolled in, or every course for an admin account. Lets an agent discover
-// where it's allowed to read/write before calling course-scoped tools.
-// content:read.
+// Read tool: lists the courses this agent may act on — the non-archived
+// courses its account is enrolled in, for every role (admins included). Lets
+// an agent discover where it's allowed to read/write before calling
+// course-scoped tools. content:read.
 
 import Core
 import Fluent
@@ -22,8 +22,9 @@ struct ListCoursesTool: ContentTool {
 
     static let name = "list_courses"
     static let description =
-        "List the courses this agent may act on: the courses its account is enrolled in "
-        + "(or every course, for an admin account). Returns each course's code and name."
+        "List the courses this agent may act on: the courses its account is enrolled in. "
+        + "This is the agent's full reach — no role widens it; enrolling the account in a course "
+        + "adds it. Returns each course's code and name."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([:]),
@@ -52,27 +53,8 @@ struct ListCoursesTool: ContentTool {
         // Students may not use the MCP interface; only instructors/admins/mcp
         // service accounts get past this.
         let user = try await context.requireEligibleSubject(tool: Self.name)
-
-        let courses: [APICourse]
-        if user.isAdmin {
-            courses = try await APICourse.query(on: context.db).sort(\.$code).all()
-        } else if let userID = user.id {
-            let courseIDs =
-                try await APICourseEnrollment.query(on: context.db)
-                .filter(\.$userID == userID)
-                .all()
-                .map { $0.$course.id }
-            courses =
-                courseIDs.isEmpty
-                ? []
-                : try await APICourse.query(on: context.db)
-                    .filter(\.$id ~~ courseIDs)
-                    .sort(\.$code)
-                    .all()
-        } else {
-            courses = []
-        }
-
+        guard let userID = user.id else { return Output(courses: []) }
+        let courses = try await enrolledCourses(for: userID, on: context.db)
         return Output(courses: courses.map { Output.Course(code: $0.code, name: $0.name) })
     }
 }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -58,23 +58,18 @@ struct ToolContext {
 
     /// Authorizes the token subject for an action scoped to `courseID`.
     ///
-    /// The subject must be MCP-eligible (`requireEligibleSubject`), then: admins
-    /// act globally; every other subject (instructor browser-flow tokens and
-    /// `mcp` service accounts alike) must be enrolled in the target course.
-    /// Throws `MCPToolError.notAuthorized` otherwise, so a tool confines itself
-    /// to the courses its account is enrolled in.
+    /// The subject must be MCP-eligible (`requireEligibleSubject`) and enrolled
+    /// in the target course — admins included. An agent token never reaches
+    /// further than the courses its human is enrolled in (the dashboard tab
+    /// strip): enrolling widens an agent's reach, and unenrolling revokes it on
+    /// the next call, since the enrollment row is re-checked per request.
+    /// Throws `MCPToolError.notAuthorized` otherwise.
     func authorizeCourseAccess(_ courseID: UUID, tool: String) async throws {
         let user = try await requireEligibleSubject(tool: tool)
-        if user.isAdmin { return }
         guard let userID = user.id else {
             throw MCPToolError.notAuthorized(tool: tool, detail: "Token subject is not a valid user.")
         }
-        let enrolled =
-            try await APICourseEnrollment.query(on: db)
-            .filter(\.$userID == userID)
-            .filter(\.$course.$id == courseID)
-            .count() > 0
-        guard enrolled else {
+        guard try await userIsEnrolled(userID: userID, inCourse: courseID, db: db) else {
             throw MCPToolError.notAuthorized(
                 tool: tool,
                 detail: "The MCP account is not enrolled in the target course.")

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -268,18 +268,12 @@ extension Request {
     }
 
     private func loadEnrolledCourseContexts(userID: UUID) async throws -> [CourseContext] {
-        let enrollments = try await APICourseEnrollment.query(on: db)
-            .filter(\.$userID == userID)
-            .with(\.$course)
-            .all()
-        return
-            enrollments
-            .compactMap { e -> CourseContext? in
-                guard let id = e.course.id else { return nil }
-                guard !e.course.isArchived else { return nil }  // hide archived courses everywhere
-                return CourseContext(id: id.uuidString, code: e.course.code, name: e.course.name, isActive: false)
-            }
-            .sorted { $0.code < $1.code }
+        // Delegates to the shared visibility resolver so the tab strip and the
+        // MCP listing surface stay in lockstep by construction.
+        try await enrolledCourses(for: userID, on: db).compactMap { course in
+            guard let id = course.id else { return nil }
+            return CourseContext(id: id.uuidString, code: course.code, name: course.name, isActive: false)
+        }
     }
 }
 

--- a/Tests/APITests/CourseAccessHelpersTests.swift
+++ b/Tests/APITests/CourseAccessHelpersTests.swift
@@ -1,0 +1,101 @@
+// Tests for the shared course-visibility/access helpers in
+// CourseAccessHelpers.swift — the single resolver behind the dashboard tab
+// strip (`resolveActiveCourse`) and the MCP listing surface (`list_courses`,
+// `resources/list`), and the single enrollment predicate behind the web guard
+// and the MCP tools' `authorizeCourseAccess`. These pin the policy: enrollment
+// rows only, archived courses hidden from visibility, no role bypass inside
+// the helpers themselves.
+
+import Fluent
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct CourseAccessHelpersTests {
+    @Test func enrolledCoursesReturnsOnlyEnrollmentRowsSortedByCode() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let zz = try await makeTestCourse(on: app, code: "ZZ100", name: "Last")
+            let aa = try await makeTestCourse(on: app, code: "AA100", name: "First")
+            _ = try await makeTestCourse(on: app, code: "CS246", name: "Not enrolled")
+            let user = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: user.requireID(), courseID: zz.requireID())
+            try await makeTestEnrollment(on: app, userID: user.requireID(), courseID: aa.requireID())
+
+            let courses = try await enrolledCourses(for: user.requireID(), on: app.db)
+            #expect(courses.map(\.code) == ["AA100", "ZZ100"])
+        }
+    }
+
+    @Test func enrolledCoursesHidesArchived() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let live = try await makeTestCourse(on: app, code: "CS136", name: "Live")
+            let old = try await makeTestCourse(on: app, code: "CS001", name: "Retired")
+            old.isArchived = true
+            try await old.save(on: app.db)
+            let user = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: user.requireID(), courseID: live.requireID())
+            try await makeTestEnrollment(on: app, userID: user.requireID(), courseID: old.requireID())
+
+            let courses = try await enrolledCourses(for: user.requireID(), on: app.db)
+            #expect(courses.map(\.code) == ["CS136"])
+        }
+    }
+
+    @Test func enrolledCoursesCarriesNoAdminBypass() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let boss = try await makeTestUser(on: app, username: "boss", role: "admin")
+
+            let courses = try await enrolledCourses(for: boss.requireID(), on: app.db)
+            #expect(courses.isEmpty)
+        }
+    }
+
+    @Test func userIsEnrolledTracksTheEnrollmentRow() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let user = try await makeTestUser(on: app, username: "prof", role: "instructor")
+
+            #expect(
+                try await userIsEnrolled(
+                    userID: user.requireID(), inCourse: course.requireID(), db: app.db) == false)
+            try await makeTestEnrollment(on: app, userID: user.requireID(), courseID: course.requireID())
+            #expect(
+                try await userIsEnrolled(
+                    userID: user.requireID(), inCourse: course.requireID(), db: app.db) == true)
+        }
+    }
+
+    @Test func mcpCourseAccessDeniesUnenrolledAdmin() async throws {
+        // The MCP path: an admin token is enrollment-scoped — denied before
+        // enrolling, allowed after, revoked again on unenroll.
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let boss = try await makeTestUser(on: app, username: "boss", role: "admin")
+            let context = ToolContext(
+                request: Request(application: app, on: app.eventLoopGroup.any()),
+                subject: "boss",
+                grantedScopes: [.read, .write])
+
+            await #expect(throws: MCPToolError.self) {
+                try await context.authorizeCourseAccess(course.requireID(), tool: "test")
+            }
+
+            let enrollment = APICourseEnrollment(
+                userID: try boss.requireID(), courseID: try course.requireID())
+            try await enrollment.save(on: app.db)
+            try await context.authorizeCourseAccess(course.requireID(), tool: "test")
+
+            try await enrollment.delete(on: app.db)
+            await #expect(throws: MCPToolError.self) {
+                try await context.authorizeCourseAccess(course.requireID(), tool: "test")
+            }
+        }
+    }
+}

--- a/Tests/APITests/MCP/ListAssignmentsToolTests.swift
+++ b/Tests/APITests/MCP/ListAssignmentsToolTests.swift
@@ -53,16 +53,23 @@ import Vapor
         }
     }
 
-    @Test func allowsAdminSubjectWithoutEnrollment() async throws {
+    @Test func adminSubjectIsEnrollmentScoped() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let course = try await makeTestCourse(on: app, code: "CS136", name: "Systems Programming")
             let courseID = try course.requireID()
-            // An admin subject is global — no enrollment needed.
-            _ = try await makeTestUser(on: app, username: "tester", role: "admin")
+            // Admins are enrollment-scoped like everyone else: denied before
+            // enrolling, allowed after.
+            let admin = try await makeTestUser(on: app, username: "tester", role: "admin")
             try await makeTestSetup(on: app, id: "setup_x", courseID: courseID)
             try await makeTestAssignment(on: app, testSetupID: "setup_x", courseID: courseID, title: "X")
 
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ListAssignmentsTool().execute(
+                    ListAssignmentsTool.Input(courseCode: "CS136"), context(app))
+            }
+
+            try await makeTestEnrollment(on: app, userID: admin.requireID(), courseID: courseID)
             let output = try await ListAssignmentsTool().execute(
                 ListAssignmentsTool.Input(courseCode: "CS136"), context(app))
             #expect(output.assignments.map(\.title) == ["X"])

--- a/Tests/APITests/MCP/ListCoursesToolTests.swift
+++ b/Tests/APITests/MCP/ListCoursesToolTests.swift
@@ -43,16 +43,38 @@ import Vapor
         }
     }
 
-    @Test func adminSeesAllCourses() async throws {
+    @Test func adminSeesOnlyEnrolledCourses() async throws {
+        // Admins are enrollment-scoped like everyone else: an agent token never
+        // reaches further than the courses its human is enrolled in.
         let app = try await makeTestApp()
         try await withApp(app) { app in
-            _ = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let cs136 = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
             _ = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
-            _ = try await makeTestUser(on: app, username: "boss", role: "admin")
+            let boss = try await makeTestUser(on: app, username: "boss", role: "admin")
+            try await makeTestEnrollment(on: app, userID: boss.requireID(), courseID: try cs136.requireID())
 
             let output = try await ListCoursesTool().execute(
                 ListCoursesTool.Input(), context(app, subject: "boss"))
-            #expect(output.courses.map(\.code) == ["CS136", "CS246"])
+            #expect(output.courses.map(\.code) == ["CS136"])
+        }
+    }
+
+    @Test func archivedCoursesAreHidden() async throws {
+        // Mirrors the dashboard tab strip: archiving a course drops it from the
+        // agent's view even while the enrollment row remains.
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let cs136 = try await makeTestCourse(on: app, code: "CS136", name: "Systems")
+            let old = try await makeTestCourse(on: app, code: "CS001", name: "Retired")
+            old.isArchived = true
+            try await old.save(on: app.db)
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: try cs136.requireID())
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: try old.requireID())
+
+            let output = try await ListCoursesTool().execute(
+                ListCoursesTool.Input(), context(app, subject: "tester"))
+            #expect(output.courses.map(\.code) == ["CS136"])
         }
     }
 

--- a/Tests/APITests/MCP/MCPResourcesTests.swift
+++ b/Tests/APITests/MCP/MCPResourcesTests.swift
@@ -49,12 +49,16 @@ import Vapor
         }
     }
 
-    @Test func listForAdminIncludesEveryCourse() async throws {
+    @Test func listForAdminIsEnrollmentScoped() async throws {
+        // Admins are enrollment-scoped like everyone else: the agent's listing
+        // covers exactly the courses the admin is enrolled in.
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let courseA = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
             let courseB = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
-            _ = try await makeTestUser(on: app, username: "boss", role: "admin")
+            let boss = try await makeTestUser(on: app, username: "boss", role: "admin")
+            try await makeTestEnrollment(
+                on: app, userID: boss.requireID(), courseID: courseA.requireID())
             try await makeTestSetup(on: app, id: "setup_a", courseID: courseA.requireID())
             try await makeTestSetup(on: app, id: "setup_b", courseID: courseB.requireID())
             let a = try await makeTestAssignment(
@@ -65,7 +69,7 @@ import Vapor
             let result = try await MCPResourceProvider().list(context: context(app, subject: "boss"))
             let uris = Self.resourceURIs(result)
             #expect(uris.contains(MCPResourceProvider.manifestURI(publicID: a.publicID)))
-            #expect(uris.contains(MCPResourceProvider.manifestURI(publicID: b.publicID)))
+            #expect(!uris.contains(MCPResourceProvider.manifestURI(publicID: b.publicID)))
         }
     }
 

--- a/changelog.d/mcp-enrollment-scoped-visibility.md
+++ b/changelog.d/mcp-enrollment-scoped-visibility.md
@@ -1,0 +1,13 @@
+### Security
+
+- **MCP admin agents are now enrollment-scoped.** An agent token authorized by
+  an admin can act only on the courses that admin is enrolled in — the same
+  rule every other account already had — instead of every course on the
+  deployment. Enrolling widens an agent's reach; unenrolling revokes it on the
+  agent's next call. Archived courses are likewise hidden from the agent's
+  `list_courses` / `resources/list` view, matching the dashboard. The
+  dashboard tab strip and the MCP listing now share one visibility resolver
+  (`enrolledCourses`), and the web guard and MCP authorization share one
+  enrollment predicate (`userIsEnrolled`), so the user view and the agent
+  view can no longer drift. Existing admin agents that relied on global
+  reach must enroll the admin account in the relevant courses.


### PR DESCRIPTION
First of two PRs implementing the enrollment-scoped visibility decision: **agent scope ⊆ human scope, for every role.**

**Behavior change (breaking for admin agents):** an MCP token authorized by an admin previously reached every course on the deployment. It is now enrollment-scoped like every other account — `list_courses`, `resources/list`, and `authorizeCourseAccess` all confine the agent to the admin's enrolled courses. Enrolling widens an agent's reach; unenrolling revokes it on the agent's very next call (the row is re-checked per request). Archived courses also drop out of the agent's listing, matching the dashboard tab strip (previously `list_courses` returned archived courses and the admin/instructor paths disagreed about them).

**Consistency by construction:** the dashboard (`resolveActiveCourse` → `loadEnrolledCourseContexts`) and the MCP listing surface now consume one shared visibility resolver, `enrolledCourses(for:on:)` (non-archived enrollments, code-sorted), and the web enrollment guard and MCP `authorizeCourseAccess` share one predicate, `userIsEnrolled(userID:inCourse:db:)`. The three previously hand-rolled copies had already drifted on archived-course handling; now there is nothing to drift between.

Copy updated to match: server instructions ("an admin account may act on every course" is gone) and the `list_courses` description.

Tests: resolver unit tests (sorting, archived hidden, no admin bypass), MCP admin-scope round-trip (denied → enroll → allowed → unenroll → denied), flipped the three tests that asserted admin-global behavior, new archived-course listing test. Full APITests suite passes locally (1,566 tests).

A follow-up PR tightens the instructor web access guard onto the same predicate.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_