### PR TITLE
fix(security): enrollment-scope instructor web access to course content

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -5,16 +5,23 @@
 // this user touch this course" through the helpers here, so the two surfaces
 // cannot drift.
 //
-// Rule: instructors and admins can access all courses; students must be
-// enrolled in the specific course that owns the resource.
+// Rule: everyone — instructors included — must be enrolled in the specific
+// course that owns the resource. Admins are the one bypass: they administer
+// the whole deployment (and can grant themselves enrollment anyway), so
+// binding them here adds friction without adding security. Their MCP agents
+// are still enrollment-scoped (see ToolContext.authorizeCourseAccess), which
+// keeps agent scope ⊆ human scope for every role.
 
 import Fluent
 import Vapor
 
-/// Throws `.forbidden` unless `caller` is an instructor/admin or is enrolled
-/// in the course identified by `courseID`.
+/// Throws `.forbidden` unless `caller` is an admin or is enrolled in the
+/// course identified by `courseID`. Instructors get no bypass: historically
+/// any instructor account could fetch another course's content — including
+/// test setups carrying secret tests and reference solutions — by URL, even
+/// though the dashboard never showed it to them.
 func requireCourseEnrollment(caller: APIUser, courseID: UUID, db: Database) async throws {
-    guard !caller.isInstructor else { return }
+    guard !caller.isAdmin else { return }
     guard let callerID = caller.id else { throw Abort(.unauthorized) }
     guard try await userIsEnrolled(userID: callerID, inCourse: courseID, db: db) else {
         throw Abort(.forbidden)

--- a/Tests/APITests/TestSetupEditTests.swift
+++ b/Tests/APITests/TestSetupEditTests.swift
@@ -23,8 +23,18 @@ import XCTVapor
     // MARK: - Auth helpers
 
     private func loginAsInstructor(on app: Application) async throws -> String {
-        return try await loginUser(
+        let cookie = try await loginUser(
             username: "testinstructor_edit", password: "testpassword", role: "instructor", on: app)
+        // Instructors are enrollment-scoped (no role bypass on the course
+        // guard), so the fixture instructor must be enrolled in the shared
+        // test course to reach its setups.
+        let user = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == "testinstructor_edit").first())
+        let courseID = try await app.testCourseID()
+        if try await !userIsEnrolled(userID: user.requireID(), inCourse: courseID, db: app.db) {
+            try await makeTestEnrollment(on: app, userID: user.requireID(), courseID: courseID)
+        }
+        return cookie
     }
 
     private func loginAsStudent(on app: Application) async throws -> String {
@@ -209,6 +219,48 @@ import XCTVapor
             #expect(kernelspec?["name"] as? String == "python")
             #expect(kernelspec?["display_name"] as? String == "Python (Pyodide)")
 
+        }
+    }
+
+    @Test func getAssignmentDeniesInstructorFromAnotherCourse() async throws {
+        // The cross-course leak the enrollment-scoped guard closes: an
+        // instructor who is not enrolled in the course that owns the setup
+        // must not fetch its notebook (instructors receive it unfiltered,
+        // secret tiers and all). An admin keeps the bypass.
+        let app = try await makeApp()
+        try await withApp(app) { app in
+            try await insertSetup(id: "setup_xcourse", on: app)
+            let flatPath = app.testSetupsDirectory + "setup_xcourse.ipynb"
+            try sampleNotebookJSON.write(toFile: flatPath, atomically: true, encoding: .utf8)
+            let setup = try #require(try await APITestSetup.find("setup_xcourse", on: app.db))
+            setup.notebookPath = flatPath
+            try await setup.save(on: app.db)
+
+            // An instructor with no enrollment in the owning course: 403.
+            let outsider = try await loginUser(
+                username: "outsider_prof", password: "testpassword", role: "instructor", on: app)
+            try await app.asyncTest(
+                .GET, "/api/v1/testsetups/setup_xcourse/assignment",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: outsider)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                }
+            )
+
+            // An admin without enrollment keeps the bypass: 200.
+            let admin = try await loginUser(
+                username: "root_admin", password: "testpassword", role: "admin", on: app)
+            try await app.asyncTest(
+                .GET, "/api/v1/testsetups/setup_xcourse/assignment",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: admin)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                }
+            )
         }
     }
 

--- a/changelog.d/web-guard-instructor-enrollment.md
+++ b/changelog.d/web-guard-instructor-enrollment.md
@@ -1,0 +1,11 @@
+### Security
+
+- **Instructor web access is now enrollment-scoped.** The shared course
+  guard (`requireCourseEnrollment`) no longer waves instructors through:
+  like students, they must be enrolled in the course that owns the content.
+  Previously any instructor account could fetch another course's notebook
+  and test setup — including secret tests and the reference solution — by
+  URL, even though the dashboard never showed it. Admins keep the bypass
+  (they administer the deployment and can grant themselves enrollment);
+  their MCP agents remain enrollment-scoped, so agent scope stays a subset
+  of human scope for every role.


### PR DESCRIPTION
Second of two PRs implementing the enrollment-scoped visibility decision (first: #902).

**Behavior change:** `requireCourseEnrollment` no longer waves instructors through. Previously any instructor account could fetch another course's content by URL — including `GET /api/v1/testsetups/:id/assignment`, which serves the notebook **unfiltered to instructors, secret tiers and reference solution included** — even though the dashboard never showed them the course. Instructors now need an enrollment row in the owning course, checked through the same `userIsEnrolled` predicate the MCP tools use (introduced in #902).

**Admins keep the bypass**, deliberately: they administer the whole deployment and can grant themselves enrollment anyway, so binding them adds friction without security. Their MCP agents remain enrollment-scoped (#902), preserving the invariant *agent scope ⊆ human scope for every role*. The guard's header comment documents this as the one exception.

Call-site impact (~13 sites: test setup routes, browser runner/results, notebook/submission routes, deadline service): the full APITests suite (1,567 tests) passes with exactly one fixture adjustment — `TestSetupEditTests` logged in an instructor that was never enrolled in the course its setups belonged to; the login helper now enrolls it, which is precisely the behavior change working as intended. New regression test: unenrolled instructor → 403 on the setup notebook, admin without enrollment → 200.

**Stacked on #902**; will retarget/rebase onto `main` once that merges.

https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA

---
_Generated by [Claude Code](https://claude.ai/code/session_013cXhqnZYFJzfzKvcnQzBjA)_