### PR TITLE
Audit batch 2: grade denormalization, attempt-number race, claim-path and worker-wait fixes

### DIFF
--- a/Public/pattern-family-editor.js
+++ b/Public/pattern-family-editor.js
@@ -60,7 +60,9 @@
         // page reloads.  Each entry has { name, paramNames, paramTypes,
         // returnType, paramCount, isShadowed }.
         var scannedFunctions = null;
-        var scanLoading = false;
+        // Cached in-flight scan promise — concurrent callers share it instead
+        // of spinning on a flag (old 50 ms setInterval poll).
+        var scanPromise = null;
 
         // Section-level variables in scope for the family currently being
         // edited.  Refreshed from the DOM whenever the modal opens.  Used
@@ -298,15 +300,8 @@
         /// scan-notebook endpoint.  Caches the result on `scannedFunctions`.
         function ensureScannedFunctions() {
             if (scannedFunctions !== null) return Promise.resolve(scannedFunctions);
-            if (scanLoading) {
-                return new Promise(function (resolve) {
-                    var iv = setInterval(function () {
-                        if (!scanLoading) { clearInterval(iv); resolve(scannedFunctions || []); }
-                    }, 50);
-                });
-            }
-            scanLoading = true;
-            return fetch(urls.solutionNotebook(), {
+            if (scanPromise) return scanPromise;
+            scanPromise = fetch(urls.solutionNotebook(), {
                 headers: { 'x-csrf-token': csrfToken }
             })
             .then(function (r) { return r.ok ? r.text() : Promise.reject('No solution notebook'); })
@@ -318,8 +313,9 @@
                 });
             })
             .then(function (r) { return r.ok ? r.json() : Promise.reject('Scan failed'); })
-            .then(function (fns) { scannedFunctions = fns || []; scanLoading = false; return scannedFunctions; })
-            .catch(function () { scannedFunctions = []; scanLoading = false; return []; });
+            .then(function (fns) { scannedFunctions = fns || []; return scannedFunctions; })
+            .catch(function () { scannedFunctions = []; return []; });
+            return scanPromise;
         }
 
         function populateFunctionSelect(selectedName) {

--- a/Public/relative-time.js
+++ b/Public/relative-time.js
@@ -1,0 +1,57 @@
+// Shared relative-time rendering for `.js-relative-time[data-iso]` nodes.
+//
+// Replaces six copy-pasted (and drifted) per-template implementations
+// (June 2026 audit). Applies once on load automatically; pages that
+// re-render rows from a poll call
+// `ChickadeeRelativeTime.applyRelativeTimes(scopeEl)` afterwards.
+(function (global) {
+    'use strict';
+
+    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+
+    function formatRelative(isoString) {
+        var date = new Date(isoString);
+        if (Number.isNaN(date.getTime())) return isoString;
+
+        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
+        var abs = Math.abs(seconds);
+
+        if (abs < 60) return relativeFormatter.format(seconds, 'second');
+        var minutes = Math.round(seconds / 60);
+        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
+        var hours = Math.round(minutes / 60);
+        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
+        var days = Math.round(hours / 24);
+        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
+        var weeks = Math.round(days / 7);
+        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
+        var months = Math.round(days / 30);
+        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
+        var years = Math.round(days / 365);
+        return relativeFormatter.format(years, 'year');
+    }
+
+    function applyRelativeTimes(root) {
+        var scope = root || document;
+        var nodes = scope.querySelectorAll('.js-relative-time[data-iso]');
+        nodes.forEach(function (el) {
+            var iso = el.getAttribute('data-iso');
+            if (!iso) return;
+            var date = new Date(iso);
+            if (Number.isNaN(date.getTime())) return;
+            el.textContent = formatRelative(iso);
+            el.title = date.toLocaleString();
+        });
+    }
+
+    global.ChickadeeRelativeTime = {
+        formatRelative: formatRelative,
+        applyRelativeTimes: applyRelativeTimes
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () { applyRelativeTimes(document); });
+    } else {
+        applyRelativeTimes(document);
+    }
+})(typeof self !== 'undefined' ? self : this);

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -58,6 +58,21 @@
         var pushTimer = null;
         var pushInFlight = false;
         var pushPending = false;
+        // Resolvers awaiting "no push in flight or pending" — replaces the
+        // old 50 ms setInterval spin in the form-submit path.
+        var pushSettledWaiters = [];
+
+        function whenPushSettled() {
+            if (!pushInFlight && !pushPending) return Promise.resolve();
+            return new Promise(function (resolve) { pushSettledWaiters.push(resolve); });
+        }
+
+        function notifyPushSettledIfIdle() {
+            if (pushInFlight || pushPending) return;
+            var waiters = pushSettledWaiters;
+            pushSettledWaiters = [];
+            waiters.forEach(function (resolve) { resolve(); });
+        }
 
         // Seed from the server-rendered JSON blob — same shape as
         // `GET /suite`.  Section membership flows through items' sectionID;
@@ -730,6 +745,7 @@
             .finally(function () {
                 pushInFlight = false;
                 if (pushPending) { pushPending = false; doPush(); }
+                notifyPushSettledIfIdle();
             });
         }
 
@@ -1295,12 +1311,9 @@
 
                 if (pushInFlight || pushPending) {
                     e.preventDefault();
-                    var iv = setInterval(function () {
-                        if (!pushInFlight && !pushPending) {
-                            clearInterval(iv);
-                            sectionVarsPromise.finally(resubmit);
-                        }
-                    }, 50);
+                    whenPushSettled().then(function () {
+                        sectionVarsPromise.finally(resubmit);
+                    });
                 } else {
                     // No suite PUT pending — still wait for section-vars
                     // if they're in flight, since they might have been

--- a/Resources/Views/admin-runner.leaf
+++ b/Resources/Views/admin-runner.leaf
@@ -173,44 +173,15 @@ Runner #(runner.workerID)
     line-height: 1.2;
 }
 </style>
+<script src="/relative-time.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
 
-    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-
-    function formatRelative(isoString) {
-        var date = new Date(isoString);
-        if (Number.isNaN(date.getTime())) return isoString;
-        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
-        var abs = Math.abs(seconds);
-        if (abs < 60) return relativeFormatter.format(seconds, 'second');
-        var minutes = Math.round(seconds / 60);
-        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
-        var hours = Math.round(minutes / 60);
-        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
-        var days = Math.round(hours / 24);
-        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
-        var weeks = Math.round(days / 7);
-        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
-        var months = Math.round(days / 30);
-        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
-        var years = Math.round(days / 365);
-        return relativeFormatter.format(years, 'year');
-    }
-
     var offlineBadge = document.getElementById('runner-offline-badge');
 
-    function applyRelativeTimes() {
-        document.querySelectorAll('.js-relative-time[data-iso]').forEach(function (el) {
-            var iso = el.getAttribute('data-iso');
-            if (!iso) return;
-            var date = new Date(iso);
-            if (Number.isNaN(date.getTime())) return;
-            el.textContent = formatRelative(iso);
-            el.title = date.toLocaleString();
-        });
-        // Show/hide the offline badge based on how recently the runner checked in.
+    // Show/hide the offline badge based on how recently the runner checked in.
+    function updateOfflineBadge() {
         if (offlineBadge) {
             var laEl = document.getElementById('runner-last-active');
             var laIso = laEl ? laEl.getAttribute('data-iso') : null;
@@ -219,7 +190,8 @@ Runner #(runner.workerID)
             offlineBadge.style.display = isOffline ? '' : 'none';
         }
     }
-    applyRelativeTimes();
+    ChickadeeRelativeTime.applyRelativeTimes();
+    updateOfflineBadge();
 
     // Poll the runners endpoint every 5 seconds and update the live-status
     // fields in the header (version, hostname, last active) without a full
@@ -228,7 +200,8 @@ Runner #(runner.workerID)
         .getAttribute ? document.querySelector('[data-runner-id]').getAttribute('data-runner-id') : '';
 
     setInterval(function () {
-        applyRelativeTimes();
+        ChickadeeRelativeTime.applyRelativeTimes();
+        updateOfflineBadge();
         if (!RUNNER_ID) return;
         fetch('/admin/runners')
             .then(function (r) { return r.ok ? r.json() : null; })
@@ -243,7 +216,7 @@ Runner #(runner.workerID)
                 if (hEl)  hEl.textContent = runner.hostname      || 'Unknown host';
                 if (laEl && runner.lastActive) {
                     laEl.setAttribute('data-iso', runner.lastActive);
-                    laEl.textContent = formatRelative(runner.lastActive);
+                    laEl.textContent = ChickadeeRelativeTime.formatRelative(runner.lastActive);
                     laEl.title = new Date(runner.lastActive).toLocaleString();
                 }
             })

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -119,6 +119,7 @@ Users
     display: inline;
 }
 </style>
+<script src="/relative-time.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -129,39 +130,6 @@ Users
     if (!usersBody) return;
 
     var collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
-    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-
-    function formatRelative(isoString) {
-        var date = new Date(isoString);
-        if (Number.isNaN(date.getTime())) return isoString;
-        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
-        var abs = Math.abs(seconds);
-        if (abs < 60) return relativeFormatter.format(seconds, 'second');
-        var minutes = Math.round(seconds / 60);
-        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
-        var hours = Math.round(minutes / 60);
-        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
-        var days = Math.round(hours / 24);
-        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
-        var weeks = Math.round(days / 7);
-        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
-        var months = Math.round(days / 30);
-        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
-        var years = Math.round(days / 365);
-        return relativeFormatter.format(years, 'year');
-    }
-
-    function applyRelativeTimes(root) {
-        var scope = root || document;
-        scope.querySelectorAll('.js-relative-time[data-iso]').forEach(function (el) {
-            var iso = el.getAttribute('data-iso');
-            if (!iso) return;
-            var date = new Date(iso);
-            if (Number.isNaN(date.getTime())) return;
-            el.textContent = formatRelative(iso);
-            el.title = date.toLocaleString();
-        });
-    }
 
     var userHeaders = Array.from(usersTable.querySelectorAll('th[data-sort-key]'));
     var activeUserHeader = null;
@@ -237,7 +205,7 @@ Users
         });
     });
 
-    applyRelativeTimes(document);
+    ChickadeeRelativeTime.applyRelativeTimes(document);
 
     if (userHeaders.length) {
         var defaultUserHeader = userHeaders.find(function (header) {
@@ -322,7 +290,7 @@ Users
         var meta = document.querySelector('meta[name="csrf-token"]');
         var csrfToken = meta ? meta.getAttribute('content') : '';
         usersBody.innerHTML = rows.map(function (u) { return buildUserRow(u, csrfToken); }).join('');
-        applyRelativeTimes(usersBody);
+        ChickadeeRelativeTime.applyRelativeTimes(usersBody);
         if (activeUserHeader) {
             sortUsersByHeader(activeUserHeader, activeUserDirection);
         }

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -222,6 +222,7 @@ tr.runner-row-offline {
     opacity: .5;
 }
 </style>
+<script src="/relative-time.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -236,43 +237,6 @@ tr.runner-row-offline {
             .replaceAll('>', '&gt;')
             .replaceAll('"', '&quot;')
             .replaceAll("'", '&#39;');
-    }
-
-    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-
-    function formatRelative(isoString) {
-        var date = new Date(isoString);
-        if (Number.isNaN(date.getTime())) return isoString;
-
-        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
-        var abs = Math.abs(seconds);
-
-        if (abs < 60) return relativeFormatter.format(seconds, 'second');
-        var minutes = Math.round(seconds / 60);
-        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
-        var hours = Math.round(minutes / 60);
-        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
-        var days = Math.round(hours / 24);
-        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
-        var weeks = Math.round(days / 7);
-        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
-        var months = Math.round(days / 30);
-        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
-        var years = Math.round(days / 365);
-        return relativeFormatter.format(years, 'year');
-    }
-
-    function applyRelativeTimes(root) {
-        var scope = root || document;
-        var nodes = scope.querySelectorAll('.js-relative-time[data-iso]');
-        nodes.forEach(function (el) {
-            var iso = el.getAttribute('data-iso');
-            if (!iso) return;
-            var date = new Date(iso);
-            if (Number.isNaN(date.getTime())) return;
-            el.textContent = formatRelative(iso);
-            el.title = date.toLocaleString();
-        });
     }
 
     var collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
@@ -393,7 +357,7 @@ tr.runner-row-offline {
                 + '<td class="time js-relative-time" data-iso="' + lastActive + '">' + lastActive + '</td>'
                 + '</tr>';
         }).join('');
-        applyRelativeTimes(workersBody);
+        ChickadeeRelativeTime.applyRelativeTimes(workersBody);
         renderMaxLoadSummary();
     }
 
@@ -523,7 +487,7 @@ tr.runner-row-offline {
         }
     }
 
-    applyRelativeTimes(document);
+    ChickadeeRelativeTime.applyRelativeTimes(document);
     recomputeLoadSummaryFromTable();
     refreshWorkers();
     refreshDiagnostics();
@@ -602,7 +566,7 @@ tr.runner-row-offline {
     }
 
     setInterval(function () {
-        applyRelativeTimes(document);
+        ChickadeeRelativeTime.applyRelativeTimes(document);
         refreshWorkers();
     }, 5000);
     setInterval(refreshDiagnostics, 15000);

--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -132,33 +132,7 @@ Server Health Alerts
     </table>
     #endif
 </section>
-<script>
-(function () {
-    'use strict';
-    var formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-    function formatRelative(iso) {
-        var date = new Date(iso);
-        if (Number.isNaN(date.getTime())) return iso;
-        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
-        var abs = Math.abs(seconds);
-        if (abs < 60) return formatter.format(seconds, 'second');
-        var minutes = Math.round(seconds / 60);
-        if (Math.abs(minutes) < 60) return formatter.format(minutes, 'minute');
-        var hours = Math.round(minutes / 60);
-        if (Math.abs(hours) < 24) return formatter.format(hours, 'hour');
-        var days = Math.round(hours / 24);
-        return formatter.format(days, 'day');
-    }
-    document.querySelectorAll('.js-relative-time[data-iso]').forEach(function (el) {
-        var iso = el.getAttribute('data-iso');
-        if (!iso) return;
-        var date = new Date(iso);
-        if (Number.isNaN(date.getTime())) return;
-        el.textContent = formatRelative(iso);
-        el.title = date.toLocaleString();
-    });
-})();
-</script>
+<script src="/relative-time.js?v=#appVersion()"></script>
 <style>
 .alerts-flash { margin-bottom: 1rem; padding: .6rem .8rem; border-radius: .4rem; }
 .alerts-flash--success { background: #d4edda; color: #155724; }

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -541,48 +541,12 @@ tr.assignment-draggable td {
 /* .add-section-details* and .section-block.section-dragging now live in the
    global stylesheet (shared with assignment-edit.leaf). */
 </style>
+<script src="/relative-time.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
 
-    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-
-    function formatRelative(isoString) {
-        var date = new Date(isoString);
-        if (Number.isNaN(date.getTime())) return isoString;
-
-        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
-        var abs = Math.abs(seconds);
-
-        if (abs < 60) return relativeFormatter.format(seconds, 'second');
-        var minutes = Math.round(seconds / 60);
-        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
-        var hours = Math.round(minutes / 60);
-        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
-        var days = Math.round(hours / 24);
-        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
-        var weeks = Math.round(days / 7);
-        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
-        var months = Math.round(days / 30);
-        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
-        var years = Math.round(days / 365);
-        return relativeFormatter.format(years, 'year');
-    }
-
-    function applyRelativeTimes(root) {
-        var scope = root || document;
-        var nodes = scope.querySelectorAll('.js-relative-time[data-iso]');
-        nodes.forEach(function (el) {
-            var iso = el.getAttribute('data-iso');
-            if (!iso) return;
-            var date = new Date(iso);
-            if (Number.isNaN(date.getTime())) return;
-            el.textContent = formatRelative(iso);
-            el.title = date.toLocaleString();
-        });
-    }
-
-    applyRelativeTimes();
+    ChickadeeRelativeTime.applyRelativeTimes();
 
     // ── Assignment drag-and-drop (within and across sections) ─────────────────
     //

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -145,6 +145,7 @@ Students
     vertical-align: middle;
 }
 </style>
+<script src="/relative-time.js?v=#appVersion()"></script>
 <script>
 (function () {
     'use strict';
@@ -159,39 +160,6 @@ Students
 
     var sortCol = 3;
     var sortAsc = false;
-
-    var relativeFormatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
-
-    function formatRelative(isoString) {
-        var date = new Date(isoString);
-        if (Number.isNaN(date.getTime())) return isoString;
-        var seconds = Math.round((date.getTime() - Date.now()) / 1000);
-        var abs = Math.abs(seconds);
-        if (abs < 60) return relativeFormatter.format(seconds, 'second');
-        var minutes = Math.round(seconds / 60);
-        if (Math.abs(minutes) < 60) return relativeFormatter.format(minutes, 'minute');
-        var hours = Math.round(minutes / 60);
-        if (Math.abs(hours) < 24) return relativeFormatter.format(hours, 'hour');
-        var days = Math.round(hours / 24);
-        if (Math.abs(days) < 7) return relativeFormatter.format(days, 'day');
-        var weeks = Math.round(days / 7);
-        if (Math.abs(weeks) < 5) return relativeFormatter.format(weeks, 'week');
-        var months = Math.round(days / 30);
-        if (Math.abs(months) < 12) return relativeFormatter.format(months, 'month');
-        var years = Math.round(days / 365);
-        return relativeFormatter.format(years, 'year');
-    }
-
-    function applyRelativeTimes(root) {
-        (root || document).querySelectorAll('.js-relative-time[data-iso]').forEach(function (el) {
-            var iso = el.getAttribute('data-iso');
-            if (!iso) return;
-            var date = new Date(iso);
-            if (Number.isNaN(date.getTime())) return;
-            el.textContent = formatRelative(iso);
-            el.title = date.toLocaleString();
-        });
-    }
 
     function escapeHtml(value) {
         return String(value == null ? '' : value)
@@ -370,7 +338,7 @@ Students
                 return s.role === 'student' || s.role === '(pending)';
             }).length);
         }
-        applyRelativeTimes(tbody);
+        ChickadeeRelativeTime.applyRelativeTimes(tbody);
         sortRows();
         applyFilter();
         updateEmptyState();
@@ -378,7 +346,7 @@ Students
     }
 
     // ── Initial paint ────────────────────────────────────────────────
-    applyRelativeTimes(document);
+    ChickadeeRelativeTime.applyRelativeTimes(document);
     sortRows();
     updateEmptyState();
     applyLearnFlags();

--- a/Sources/APIServer/Helpers/SubmissionAttemptNumber.swift
+++ b/Sources/APIServer/Helpers/SubmissionAttemptNumber.swift
@@ -37,7 +37,7 @@ func saveSubmissionWithNextAttemptNumber(
             _ = query.filter(\.$userID == userID)
         }
         // max() on an optional field yields Int?? — flatten both levels.
-        let maxAttempt = (try await query.max(\.$attemptNumber) ?? nil) ?? 0
+        let maxAttempt = (try await query.max(\.$attemptNumber)).flatMap { $0 } ?? 0
 
         submission.attemptNumber = maxAttempt + 1
         try await submission.save(on: tx)

--- a/Sources/APIServer/Helpers/SubmissionAttemptNumber.swift
+++ b/Sources/APIServer/Helpers/SubmissionAttemptNumber.swift
@@ -1,0 +1,45 @@
+// APIServer/Helpers/SubmissionAttemptNumber.swift
+//
+// Race-free attempt-number assignment (June 2026 audit, P0.3). The previous
+// count-then-insert pattern let two concurrent submits observe the same prior
+// count and share an attempt number, silently corrupting the prior-attempt
+// delta and the First-Try-Perfect badge.
+
+import Fluent
+import Foundation
+import SQLKit
+
+/// Saves `submission` with the next attempt number for its (test setup, user)
+/// scope, computed and persisted inside one transaction.
+///
+/// On Postgres the transaction additionally takes a per-scope advisory lock
+/// (`pg_advisory_xact_lock`, auto-released at commit) so two truly concurrent
+/// transactions serialize instead of both reading the same `MAX`. On SQLite a
+/// write transaction already serializes writers, so the lock is unnecessary.
+///
+/// `MAX(attempt_number) + 1` is used rather than `COUNT + 1` so deleted rows
+/// can never cause a reused attempt number.
+func saveSubmissionWithNextAttemptNumber(
+    _ submission: APISubmission,
+    userID: UUID?,
+    on db: Database
+) async throws {
+    try await db.transaction { tx in
+        if let sql = tx as? SQLDatabase, sql.dialect.name == "postgresql" {
+            let scope = "chickadee.attempt:\(submission.testSetupID):\(userID?.uuidString ?? "-")"
+            try await sql.raw("SELECT pg_advisory_xact_lock(hashtext(\(bind: scope)))").run()
+        }
+
+        let query = APISubmission.query(on: tx)
+            .filter(\.$testSetupID == submission.testSetupID)
+            .filter(\.$kind == APISubmission.Kind.student)
+        if let userID {
+            _ = query.filter(\.$userID == userID)
+        }
+        // max() on an optional field yields Int?? — flatten both levels.
+        let maxAttempt = (try await query.max(\.$attemptNumber) ?? nil) ?? 0
+
+        submission.attemptNumber = maxAttempt + 1
+        try await submission.save(on: tx)
+    }
+}

--- a/Sources/APIServer/Migrations/AddResultGradeColumns.swift
+++ b/Sources/APIServer/Migrations/AddResultGradeColumns.swift
@@ -1,0 +1,57 @@
+import Fluent
+import SQLKit
+
+/// Denormalizes the grade out of `results.collection_json` (June 2026 audit,
+/// finding P1.1). Adds `earned_points` / `total_points` / `pass_count` /
+/// `total_tests` columns and backfills them from the JSON blob in one
+/// statement, so the student dashboard, instructor roster, grades CSV export,
+/// and the achievement / BrightSpace sweeps can read a grade as a column
+/// instead of decoding the full result blob per row.
+///
+/// `collection_json` remains the source of truth for everything else; new rows
+/// get the columns stamped by `APIResult.populateGradeFields()` at write time.
+struct AddResultGradeColumns: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        // One ADD COLUMN per statement — SQLite rejects a multi-column ALTER.
+        try await database.schema("results").field("earned_points", .double).update()
+        try await database.schema("results").field("total_points", .double).update()
+        try await database.schema("results").field("pass_count", .int).update()
+        try await database.schema("results").field("total_tests", .int).update()
+
+        guard let sql = database as? SQLDatabase else { return }
+
+        // Backfill from the blob. Every row was written by JSONEncoder so the
+        // JSON is well-formed; the LIKE guard skips anything that isn't an
+        // object (defensive — a malformed row would otherwise abort startup).
+        if sql.dialect.name == "postgresql" {
+            try await sql.raw(
+                """
+                UPDATE results SET
+                    earned_points = (collection_json::jsonb->>'earnedPoints')::double precision,
+                    total_points  = (collection_json::jsonb->>'totalPoints')::double precision,
+                    pass_count    = (collection_json::jsonb->>'passCount')::integer,
+                    total_tests   = (collection_json::jsonb->>'totalTests')::integer
+                WHERE collection_json LIKE '{%'
+                """
+            ).run()
+        } else {
+            try await sql.raw(
+                """
+                UPDATE results SET
+                    earned_points = json_extract(collection_json, '$.earnedPoints'),
+                    total_points  = json_extract(collection_json, '$.totalPoints'),
+                    pass_count    = json_extract(collection_json, '$.passCount'),
+                    total_tests   = json_extract(collection_json, '$.totalTests')
+                WHERE collection_json LIKE '{%'
+                """
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("results").deleteField("total_tests").update()
+        try await database.schema("results").deleteField("pass_count").update()
+        try await database.schema("results").deleteField("total_points").update()
+        try await database.schema("results").deleteField("earned_points").update()
+    }
+}

--- a/Sources/APIServer/Migrations/CreateAuditFollowupIndexes.swift
+++ b/Sources/APIServer/Migrations/CreateAuditFollowupIndexes.swift
@@ -22,6 +22,9 @@ struct CreateAuditFollowupIndexes: ChickadeeMigration {
         try await sql.raw(
             "CREATE INDEX IF NOT EXISTS idx_submissions_submitted_at ON submissions(submitted_at)"
         ).run()
+        try await sql.raw(
+            "CREATE INDEX IF NOT EXISTS idx_submissions_assigned_at ON submissions(assigned_at)"
+        ).run()
 
         // Admin runner dashboard GROUP BY (polled every 5s) counts submissions
         // per worker by status — a full-table scan without this.
@@ -47,6 +50,7 @@ struct CreateAuditFollowupIndexes: ChickadeeMigration {
         try await sql.raw("DROP INDEX IF EXISTS idx_assignments_validation_submission_id").run()
         try await sql.raw("DROP INDEX IF EXISTS idx_client_diagnostics_created_at").run()
         try await sql.raw("DROP INDEX IF EXISTS idx_submissions_worker_status").run()
+        try await sql.raw("DROP INDEX IF EXISTS idx_submissions_assigned_at").run()
         try await sql.raw("DROP INDEX IF EXISTS idx_submissions_submitted_at").run()
         try await sql.raw("DROP INDEX IF EXISTS idx_request_metrics_finished_at").run()
     }

--- a/Sources/APIServer/Models/APIResult.swift
+++ b/Sources/APIServer/Models/APIResult.swift
@@ -22,6 +22,26 @@ final class APIResult: Model, Content, @unchecked Sendable {
     @OptionalField(key: "source")
     var source: String?
 
+    // MARK: - Denormalized grade fields
+    //
+    // Copied out of `collection_json` at write time (and backfilled by
+    // `AddResultGradeColumns`) so list pages, the CSV export, and the
+    // periodic sweeps can read a grade without decoding the full result
+    // blob per row. `collection_json` stays the source of truth for
+    // everything else.
+
+    @OptionalField(key: "earned_points")
+    var earnedPoints: Double?
+
+    @OptionalField(key: "total_points")
+    var totalPoints: Double?
+
+    @OptionalField(key: "pass_count")
+    var passCount: Int?
+
+    @OptionalField(key: "total_tests")
+    var totalTests: Int?
+
     @Timestamp(key: "received_at", on: .create)
     var receivedAt: Date?
 
@@ -50,5 +70,57 @@ final class APIResult: Model, Content, @unchecked Sendable {
         self.submissionID = submissionID
         self.collectionJSON = collectionJSON
         self.source = source
+        populateGradeFields()
+    }
+
+    /// Stamps the denormalized grade columns from `collectionJSON`. Called by
+    /// the designated initializer so every creation path (worker report,
+    /// browser report, bundle import) gets the columns without remembering to.
+    func populateGradeFields() {
+        guard let data = collectionJSON.data(using: .utf8),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return }
+        earnedPoints = (root["earnedPoints"] as? Double) ?? (root["earnedPoints"] as? Int).map(Double.init)
+        totalPoints = (root["totalPoints"] as? Double) ?? (root["totalPoints"] as? Int).map(Double.init)
+        passCount = root["passCount"] as? Int
+        totalTests = root["totalTests"] as? Int
+    }
+}
+
+// MARK: - Column-first grade accessors
+//
+// Same semantics as gradePercentFromCollectionJSON / gradePointsFromCollectionJSON
+// / gradeTotalPointsFromCollectionJSON in AssignmentHelpers.swift, but reading
+// the denormalized columns. Rows that predate the columns (all four nil — e.g.
+// written mid-deploy before AddResultGradeColumns ran) fall back to parsing the
+// blob, so the two paths can never disagree.
+extension APIResult {
+    private var hasGradeColumns: Bool {
+        earnedPoints != nil || totalPoints != nil || passCount != nil || totalTests != nil
+    }
+
+    /// Whole-result grade percent: weighted (earned/total) when totalPoints > 0,
+    /// else unweighted pass/total test counts. Nil when neither is available.
+    var gradePercentValue: Int? {
+        guard hasGradeColumns else { return gradePercentFromCollectionJSON(collectionJSON) }
+        if let earned = earnedPoints, let total = totalPoints, total > 0 {
+            return Int((earned / total * 100).rounded())
+        }
+        guard let pass = passCount, let total = totalTests, total > 0 else { return nil }
+        return Int((Double(pass) / Double(total) * 100).rounded())
+    }
+
+    /// Earned points (weighted when available, else pass count) for CSV/LEARN export.
+    var gradePointsValue: Double? {
+        guard hasGradeColumns else { return gradePointsFromCollectionJSON(collectionJSON) }
+        if let total = totalPoints, total > 0, let earned = earnedPoints { return earned }
+        return passCount.map(Double.init)
+    }
+
+    /// Total possible weighted points; nil when the result predates weighted grading.
+    var gradeTotalPointsValue: Double? {
+        guard hasGradeColumns else { return gradeTotalPointsFromCollectionJSON(collectionJSON) }
+        if let total = totalPoints, total > 0 { return total }
+        return nil
     }
 }

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -72,27 +72,21 @@ struct BrowserResultRoutes: RouteCollection {
         let notebookToSave = mergeNotebook(student: body.notebook, instructor: instructorData)
         try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
 
-        // Count prior submissions to derive the attempt number.
-        let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == body.testSetupID)
-            .filter(\.$userID == caller.id)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .count()
-        let attemptNumber = priorCount + 1
-
         // Create the submission record as "complete" immediately — browser
         // results are authoritative and no native worker re-run is queued.
+        // The attempt number is assigned race-free inside one transaction.
         let submission = APISubmission(
             id: subID,
             testSetupID: body.testSetupID,
             zipPath: nbPath,
-            attemptNumber: attemptNumber,
+            attemptNumber: 0,  // assigned by saveSubmissionWithNextAttemptNumber
             status: "complete",
             filename: "\(subID).ipynb",
             userID: caller.id,
             kind: APISubmission.Kind.student
         )
-        try await submission.save(on: req.db)
+        try await saveSubmissionWithNextAttemptNumber(submission, userID: caller.id, on: req.db)
+        let attemptNumber = submission.attemptNumber ?? 1
 
         // Persist the browser result, tagged source="browser".  The browser
         // builds its collection before it knows the server-authoritative attempt
@@ -176,24 +170,18 @@ struct BrowserResultRoutes: RouteCollection {
         let notebookToSave = mergeNotebook(student: body.notebook, instructor: instructorData)
         try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
 
-        let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == body.testSetupID)
-            .filter(\.$userID == caller.id)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .count()
-
         let submittedFilename = normalizedNotebookFilename(body.filename)
         let submission = APISubmission(
             id: subID,
             testSetupID: body.testSetupID,
             zipPath: nbPath,
-            attemptNumber: priorCount + 1,
+            attemptNumber: 0,  // assigned by saveSubmissionWithNextAttemptNumber
             status: "pending",
             filename: submittedFilename,
             userID: caller.id,
             kind: APISubmission.Kind.student
         )
-        try await submission.save(on: req.db)
+        try await saveSubmissionWithNextAttemptNumber(submission, userID: caller.id, on: req.db)
 
         // For browser-mode test setups the client-side WASM runner picks up the job;
         // waking the local native runner would waste resources and claim nothing

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -35,13 +35,20 @@ struct ResultRoutes: RouteCollection {
         }
         let collection = report.collection
 
-        try await persistToDB(collection, on: req)
-
-        // Advance the submission's state machine to "complete".
-        if let submission = try await APISubmission.find(collection.submissionID, on: req.db) {
+        // Persist the result and advance the submission to "complete" in one
+        // transaction: a failure between the two used to leave a result row
+        // with the submission stuck `assigned` until the stuck-submission
+        // reaper re-queued and regraded it (wasted work, duplicate results).
+        let completedSubmission = try await req.db.transaction { tx -> APISubmission? in
+            try await persistToDB(collection, on: req, db: tx)
+            guard let submission = try await APISubmission.find(collection.submissionID, on: tx)
+            else { return nil }
             submission.status = "complete"
-            try await submission.save(on: req.db)
+            try await submission.save(on: tx)
+            return submission
+        }
 
+        if let submission = completedSubmission {
             // Record execution diagnostics (execution time + queue wait).
             await req.application.diagnostics.recordWorkerExecutionReport(
                 collection: collection,
@@ -102,7 +109,9 @@ struct ResultRoutes: RouteCollection {
 
     // MARK: - DB persistence
 
-    private func persistToDB(_ collection: TestOutcomeCollection, on req: Request) async throws {
+    private func persistToDB(
+        _ collection: TestOutcomeCollection, on req: Request, db: Database
+    ) async throws {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         let json = try String(data: encoder.encode(collection), encoding: .utf8) ?? "{}"
@@ -115,12 +124,12 @@ struct ResultRoutes: RouteCollection {
 
         // Mark for BrightSpace sync if the assignment is configured for it.
         if req.application.brightSpaceClient != nil {
-            if let assignment = try await APIAssignment.query(on: req.db)
+            if let assignment = try await APIAssignment.query(on: db)
                 .filter(\.$testSetupID == collection.testSetupID)
                 .first(),
                 let gradeObjectID = assignment.brightspaceGradeObjectID,
                 !gradeObjectID.isEmpty,
-                let course = try await APICourse.find(assignment.courseID, on: req.db),
+                let course = try await APICourse.find(assignment.courseID, on: db),
                 let orgUnitID = course.brightspaceOrgUnitID,
                 !orgUnitID.isEmpty
             {
@@ -130,7 +139,7 @@ struct ResultRoutes: RouteCollection {
             }
         }
 
-        try await result.save(on: req.db)
+        try await result.save(on: db)
     }
 }
 

--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -39,20 +39,16 @@ struct SubmissionRoutes: RouteCollection {
         // concurrent submissions doesn't serialize on synchronous file I/O.
         try await req.fileio.writeFile(.init(data: decoded), at: zipPath)
 
-        // Count prior submissions for this test setup to determine attempt number.
-        let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == body.testSetupID)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .count()
-
+        // Attempt number for API submissions stays per-setup (no user identity
+        // on this path), assigned race-free inside one transaction.
         let submission = APISubmission(
             id: subID,
             testSetupID: body.testSetupID,
             zipPath: zipPath,
-            attemptNumber: priorCount + 1,
+            attemptNumber: 0,  // assigned by saveSubmissionWithNextAttemptNumber
             kind: APISubmission.Kind.student
         )
-        try await submission.save(on: req.db)
+        try await saveSubmissionWithNextAttemptNumber(submission, userID: nil, on: req.db)
         await req.application.diagnostics.recordSubmissionCreated(
             submission: submission,
             on: req.db,
@@ -108,20 +104,15 @@ struct SubmissionRoutes: RouteCollection {
         // Offload the disk write to the NIO thread pool (see createSubmission).
         try await req.fileio.writeFile(.init(data: fileData), at: filePath)
 
-        let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == body.testSetupID)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .count()
-
         let submission = APISubmission(
             id: subID,
             testSetupID: body.testSetupID,
             zipPath: filePath,
-            attemptNumber: priorCount + 1,
+            attemptNumber: 0,  // assigned by saveSubmissionWithNextAttemptNumber
             filename: submittedFilename,
             kind: APISubmission.Kind.student
         )
-        try await submission.save(on: req.db)
+        try await saveSubmissionWithNextAttemptNumber(submission, userID: nil, on: req.db)
         await req.application.diagnostics.recordSubmissionCreated(
             submission: submission,
             on: req.db,

--- a/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
+++ b/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
@@ -181,10 +181,13 @@ func enrollUsernamesInCourse(
     var seen = Set<String>()
     let uniqueUsernames = usernames.filter { seen.insert($0).inserted }
 
-    let usernameSet = Set(uniqueUsernames)
-    let allUsers = try await APIUser.query(on: db).all()
+    // Look up just the CSV's usernames instead of loading every user row.
+    let matchedUsers =
+        uniqueUsernames.isEmpty
+        ? []
+        : try await APIUser.query(on: db).filter(\.$username ~~ uniqueUsernames).all()
     var byUsername: [String: APIUser] = [:]
-    for u in allUsers where usernameSet.contains(u.username) {
+    for u in matchedUsers {
         byUsername[u.username] = u
     }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -10,6 +10,7 @@
 import Core
 import Fluent
 import Foundation
+import SQLKit
 import Vapor
 
 // MARK: - Intermediate query results
@@ -277,13 +278,6 @@ extension InstructorDashboardRoutes {
                 .filter(\.$kind == APISubmission.Kind.student)
                 .filter(\.$submittedAt >= windowStart)
                 .all()
-        let allCourseStudentSubmissions =
-            allSetupIDs.isEmpty
-            ? []
-            : try await APISubmission.query(on: req.db)
-                .filter(\.$testSetupID ~~ allSetupIDs)
-                .filter(\.$kind == APISubmission.Kind.student)
-                .all()
         let workerModeSetupIDs = try await req.application.diagnostics.workerModeTestSetupIDs(
             for: allSetupIDs,
             on: req.db
@@ -301,12 +295,19 @@ extension InstructorDashboardRoutes {
             return activeStudentIDs.contains(userID)
         }
         let activeAssignments24h = Set(recentStudentSubmissions.map(\.testSetupID)).count
-        let pendingNow = allCourseStudentSubmissions.filter { submission in
-            guard let userID = submission.userID else { return false }
-            return activeStudentIDs.contains(userID)
-                && workerModeSetupIDs.contains(submission.testSetupID)
-                && ["pending", "assigned"].contains(submission.status)
-        }.count
+        // SQL COUNT instead of loading every course submission ever made just
+        // to tally the in-flight ones (June 2026 audit, P1.6).
+        let pendingNow: Int
+        if workerModeSetupIDs.isEmpty || activeStudentIDs.isEmpty {
+            pendingNow = 0
+        } else {
+            pendingNow = try await APISubmission.query(on: req.db)
+                .filter(\.$testSetupID ~~ Array(workerModeSetupIDs))
+                .filter(\.$kind == APISubmission.Kind.student)
+                .filter(\.$status ~~ ["pending", "assigned"])
+                .filter(\.$userID ~~ Array(activeStudentIDs))
+                .count()
+        }
         let studentsWithBrowserErrors = try await countStudentsWithBrowserErrors(
             req: req,
             allSetupIDs: allSetupIDs,
@@ -402,6 +403,37 @@ extension InstructorDashboardRoutes {
         enrolledStudentIDs: Set<UUID>
     ) async throws -> [String: Int] {
         guard !allSetupIDs.isEmpty, !enrolledStudentIDs.isEmpty else { return [:] }
+
+        // Grouped COUNT(DISTINCT user_id) instead of loading every matching
+        // submission row and building per-setup sets in Swift — this runs on
+        // the instructor landing page and degrades linearly with term volume
+        // (June 2026 audit, P1.6; same pattern as the admin runner counts).
+        if let sql = req.db as? SQLDatabase {
+            struct SubmitterCountRow: Decodable {
+                let testSetupID: String
+                let submitters: Int
+                enum CodingKeys: String, CodingKey {
+                    case testSetupID = "test_setup_id"
+                    case submitters
+                }
+            }
+            let rows = try await sql.select()
+                .column("test_setup_id")
+                .column(
+                    SQLFunction("COUNT", args: SQLDistinct(SQLColumn("user_id"))), as: "submitters"
+                )
+                .from("submissions")
+                .where("test_setup_id", .in, allSetupIDs)
+                .where("kind", .equal, APISubmission.Kind.student)
+                // Bind UUIDs (not strings) so the Postgres uuid column and the
+                // SQLite text storage both compare correctly.
+                .where("user_id", .in, Array(enrolledStudentIDs))
+                .groupBy("test_setup_id")
+                .all(decoding: SubmitterCountRow.self)
+            return Dictionary(uniqueKeysWithValues: rows.map { ($0.testSetupID, $0.submitters) })
+        }
+
+        // Non-SQL fallback (not hit by the sqlite/postgres drivers in use).
         let studentSubmissions = try await APISubmission.query(on: req.db)
             .filter(\.$testSetupID ~~ allSetupIDs)
             .filter(\.$kind == APISubmission.Kind.student)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -105,12 +105,14 @@ extension InstructorDashboardRoutes {
                 .filter(\.$course.$id == activeCourseUUID)
                 .all()
                 .map { $0.userID }
-            let enrolledSet = Set(enrolledUserIDs)
-            let allStudents = try await APIUser.query(on: req.db)
+            guard !enrolledUserIDs.isEmpty else { return [] }
+            // Filter to the enrolled IDs in SQL instead of fetching every
+            // student in the system and filtering in memory.
+            return try await APIUser.query(on: req.db)
                 .filter(\.$role == "student")
+                .filter(\.$id ~~ enrolledUserIDs)
                 .sort(\.$username, .ascending)
                 .all()
-            return allStudents.filter { u in u.id.map { enrolledSet.contains($0) } ?? false }
         }
         return try await APIUser.query(on: req.db)
             .filter(\.$role == "student")
@@ -187,7 +189,7 @@ extension InstructorDashboardRoutes {
         var bestPointsByUserAndSetup: [String: Double] = [:]
         for submission in submissions {
             guard let result = preferredResultBySubmissionID[submission.id],
-                let points = gradePointsFromCollectionJSON(result.collectionJSON)
+                let points = result.gradePointsValue
             else {
                 continue
             }
@@ -350,7 +352,7 @@ extension InstructorDashboardRoutes {
             for submission in history {
                 guard let subID = submission.id,
                     let result = preferredResultBySubmissionID[subID],
-                    let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+                    let pct = result.gradePercentValue
                 else {
                     continue
                 }
@@ -465,7 +467,7 @@ extension InstructorDashboardRoutes {
             let subID = submission.id ?? ""
             let gradeText: String
             if let result = preferredResultBySubmissionID[subID],
-                let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+                let pct = result.gradePercentValue
             {
                 gradeText = "\(pct)%"
             } else {
@@ -810,13 +812,25 @@ func preferredResultsBySubmissionID(
     for submissionIDs: [String],
     on db: Database
 ) async throws -> [String: APIResult] {
-    let results =
-        submissionIDs.isEmpty
-        ? []
-        : try await APIResult.query(on: db)
-            .filter(\.$submissionID ~~ submissionIDs)
-            .sort(\.$receivedAt, .descending)
-            .all()
+    // Chunk the IN-list: a term-scale grades export can pass 100k+ IDs, which
+    // exceeds bind-parameter limits (SQLite 32k variables, Postgres 65,535
+    // wire parameters) in a single query. Each submission's results live
+    // entirely inside the chunk holding its ID, so the fold below is
+    // order-equivalent to the unchunked query.
+    let chunkSize = 5_000
+    var results: [APIResult] = []
+    var index = submissionIDs.startIndex
+    while index < submissionIDs.endIndex {
+        let end =
+            submissionIDs.index(index, offsetBy: chunkSize, limitedBy: submissionIDs.endIndex)
+            ?? submissionIDs.endIndex
+        results.append(
+            contentsOf: try await APIResult.query(on: db)
+                .filter(\.$submissionID ~~ Array(submissionIDs[index..<end]))
+                .sort(\.$receivedAt, .descending)
+                .all())
+        index = end
+    }
 
     var preferredResultBySubmissionID: [String: APIResult] = [:]
     for result in results {

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -9,10 +9,8 @@
 // grant / edit / revoke a deadline extension that lets that one student
 // keep submitting after the assignment-wide deadline.
 //
-// Phase 2 of the audit refactor moved these handlers from
-// `AssignmentRoutes` onto `StudentCourseRoutes`; the file name still
-// starts with `AssignmentRoutes+` for blame continuity until the next
-// rename pass.
+// These handlers were moved from `AssignmentRoutes` onto
+// `StudentCourseRoutes` in the Phase 2 audit refactor.
 
 import Core
 import Fluent
@@ -312,7 +310,7 @@ extension StudentCourseRoutes {
             let subID = submission.id ?? ""
             let gradeText: String
             if let result = preferredResultBySubmissionID[subID],
-                let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+                let pct = result.gradePercentValue
             {
                 gradeText = "\(pct)%"
             } else {
@@ -771,7 +769,7 @@ extension StudentCourseRoutes {
             for submission in history {
                 guard let subID = submission.id,
                     let result = preferredResultBySubmissionID[subID],
-                    let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+                    let pct = result.gradePercentValue
                 else {
                     continue
                 }
@@ -875,7 +873,7 @@ extension StudentCourseRoutes {
             guard let psID = ps.id, let pr = preferredResultBySubmissionID[psID] else {
                 return nil
             }
-            return gradePercentFromCollectionJSON(pr.collectionJSON)
+            return pr.gradePercentValue
         }
         return AchievementBadge.forSubmission(
             BadgeContext(

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -97,12 +97,13 @@ func groupOutcomesBySection(
 
 /// The built-in badges (per-submission + class records) for one submission,
 /// sourced from the manifest when seeded, else the registry minus any disabled.
+/// Takes the page's already-loaded `setup` so it doesn't re-fetch the row.
 /// Lifted out of `submissionPage` to keep that handler within its length budget.
 func builtInBadgesForSubmission(
-    submission: APISubmission, badgeContext: BadgeContext,
-    classAchievements: [APIClassAchievement], on db: Database
-) async throws -> [AchievementBadge] {
-    let setup = try? await APITestSetup.find(submission.testSetupID, on: db)
+    badgeContext: BadgeContext,
+    classAchievements: [APIClassAchievement],
+    setup: APITestSetup?
+) -> [AchievementBadge] {
     let disabled = setup.map { BuiltInAchievements.disabled(in: $0) } ?? []
     return AchievementBadge.forSubmission(
         badgeContext,
@@ -204,23 +205,20 @@ extension WebRoutes {
         try fileData.write(to: URL(fileURLWithPath: filePath))
         let fallbackFilename = isZip ? nil : (uploadFilename ?? "submission.\(storedExt)")
 
-        // Attempt number is scoped to this student for this test setup.
-        let priorCount = try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID == setupID)
-            .filter(\.$userID == user.id)
-            .filter(\.$kind == APISubmission.Kind.student)
-            .count()
-
+        // Attempt number is scoped to this student for this test setup,
+        // assigned race-free inside one transaction (concurrent submits used
+        // to share a number, corrupting the prior-attempt delta and the
+        // First-Try-Perfect badge).
         let submission = APISubmission(
             id: subID,
             testSetupID: setupID,
             zipPath: filePath,
-            attemptNumber: priorCount + 1,
+            attemptNumber: 0,  // assigned by saveSubmissionWithNextAttemptNumber
             filename: fallbackFilename,
             userID: user.id,
             kind: APISubmission.Kind.student
         )
-        try await submission.save(on: req.db)
+        try await saveSubmissionWithNextAttemptNumber(submission, userID: user.id, on: req.db)
         await req.application.diagnostics.recordSubmissionCreated(
             submission: submission, on: req.db, logger: req.logger
         )
@@ -285,33 +283,14 @@ extension WebRoutes {
             .sort(\.$submittedAt, .descending)
             .all()
 
-        let submissionIDs = submissions.compactMap(\.id)
-        var preferredResultBySubmissionID: [String: APIResult] = [:]
-        if !submissionIDs.isEmpty {
-            let results = try await APIResult.query(on: req.db)
-                .filter(\.$submissionID ~~ submissionIDs)
-                .sort(\.$receivedAt, .descending)
-                .all()
-            for row in results {
-                let key = row.submissionID
-                if let existing = preferredResultBySubmissionID[key] {
-                    let existingSource = existing.source ?? "worker"
-                    let currentSource = row.source ?? "worker"
-                    if existingSource == "worker" { continue }
-                    if currentSource == "worker" {
-                        preferredResultBySubmissionID[key] = row
-                    }
-                } else {
-                    preferredResultBySubmissionID[key] = row
-                }
-            }
-        }
+        let preferredResultBySubmissionID = try await preferredResultsBySubmissionID(
+            for: submissions.compactMap(\.id), on: req.db)
 
         let rows = submissions.map { submission -> SubmissionHistoryRow in
             let subID = submission.id ?? ""
             let gradeText: String
             if let result = preferredResultBySubmissionID[subID],
-                let pct = gradePercentFromCollectionJSON(result.collectionJSON)
+                let pct = result.gradePercentValue
             {
                 gradeText = "\(pct)%"
             } else {
@@ -425,10 +404,12 @@ extension WebRoutes {
         let individualBadges = try await earnedIndividualBadgesForDisplay(
             displayResult: displayResult, submission: submission,
             gradePercent: processed.gradePercent, decoder: decoder, on: req.db)
+        let setupForBadges = try await APITestSetup.find(submission.testSetupID, on: req.db)
         let badges =
-            try await builtInBadgesForSubmission(
-                submission: submission, badgeContext: processed.badgeContext,
-                classAchievements: classAchievements, on: req.db)
+            builtInBadgesForSubmission(
+                badgeContext: processed.badgeContext,
+                classAchievements: classAchievements,
+                setup: setupForBadges)
             + individualBadges
 
         let sectionedOutcomes = buildSectionedOutcomes(

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -247,7 +247,7 @@ struct WebRoutes: RouteCollection {
                     for submission in submissions {
                         guard let subID = submission.id,
                             let result = preferredResultBySubmissionID[subID],
-                            let gradePercent = gradePercentFromCollectionJSON(result.collectionJSON)
+                            let gradePercent = result.gradePercentValue
                         else {
                             continue
                         }
@@ -276,7 +276,7 @@ struct WebRoutes: RouteCollection {
                             guard let psID = ps.id,
                                 let pr = preferredResultBySubmissionID[psID]
                             else { return nil }
-                            return gradePercentFromCollectionJSON(pr.collectionJSON)
+                            return pr.gradePercentValue
                         }
                         latestBadgesBySetupID[setupID] = AchievementBadge.forSubmission(
                             BadgeContext(

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -185,10 +185,11 @@ struct WorkerJobRoutes: RouteCollection {
         guard let submissionID = submission.id, let setupID = setup.id else {
             throw WorkerJobError.internalInconsistency(reason: "Claimed submission or test setup missing id")
         }
+        let downloadVersion = await testSetupDownloadVersion(for: setup)
         guard
             let submissionURL = URL(string: "\(base)/api/v1/worker/submissions/\(submissionID)/download"),
             let testSetupURL = URL(
-                string: "\(base)/api/v1/worker/testsetups/\(setupID)/download?v=\(testSetupDownloadVersion(for: setup))"
+                string: "\(base)/api/v1/worker/testsetups/\(setupID)/download?v=\(downloadVersion)"
             )
         else {
             throw WorkerJobError.internalInconsistency(reason: "Failed to build worker download URLs from base=\(base)")
@@ -302,17 +303,34 @@ private struct BlockedCandidate {
 private func collectClaimCandidates(
     on db: Database
 ) async throws -> [(APISubmission, APITestSetup, TestProperties)] {
-    let studentSubmissions = try await APISubmission.query(on: db)
+    // Cap the scan: a poll claims exactly one job, so walking the entire
+    // pending queue (potentially tens of thousands of rows after a retest
+    // fan-out) inside the globally-serialized claim transaction collapsed
+    // claim throughput exactly when the queue was deepest (June 2026 audit,
+    // P1.3). The cap only matters when the first `claimCandidateScanLimit`
+    // candidates are all requirement-incompatible with this runner — the next
+    // poll retries, and most assignments carry no runner requirements at all.
+    //
+    // Fresh student work (retestedAt == nil) keeps absolute priority over
+    // retests (#427) by querying the two groups separately — which also
+    // replaces the old full-scan + in-memory re-sort.
+    let claimCandidateScanLimit = 50
+    var studentSubmissions = try await APISubmission.query(on: db)
         .filter(\.$status == "pending")
         .filter(\.$kind == APISubmission.Kind.student)
+        .filter(\.$retestedAt == nil)
         .sort(\.$submittedAt, .ascending)
+        .limit(claimCandidateScanLimit)
         .all()
-        .sorted { lhs, rhs in
-            let lhsIsRetest = lhs.retestedAt != nil
-            let rhsIsRetest = rhs.retestedAt != nil
-            if lhsIsRetest != rhsIsRetest { return !lhsIsRetest }
-            return (lhs.submittedAt ?? .distantPast) < (rhs.submittedAt ?? .distantPast)
-        }
+    if studentSubmissions.count < claimCandidateScanLimit {
+        studentSubmissions += try await APISubmission.query(on: db)
+            .filter(\.$status == "pending")
+            .filter(\.$kind == APISubmission.Kind.student)
+            .filter(\.$retestedAt != nil)
+            .sort(\.$submittedAt, .ascending)
+            .limit(claimCandidateScanLimit - studentSubmissions.count)
+            .all()
+    }
 
     // Many pending submissions often target the same test setup (e.g. a class
     // submitting to one assignment before a deadline). Resolve each setup +
@@ -340,6 +358,7 @@ private func collectClaimCandidates(
         .filter(\.$status == "pending")
         .filter(\.$kind == APISubmission.Kind.validation)
         .sort(\.$submittedAt, .ascending)
+        .limit(claimCandidateScanLimit)
         .all()
 
     for validation in pendingValidation {
@@ -481,13 +500,47 @@ private func normalizedWorkerBindHost(_ raw: String) -> String {
     return host
 }
 
-private func testSetupDownloadVersion(for setup: APITestSetup) -> String {
-    var material = Data(setup.manifest.utf8)
-    if let zipData = try? Data(contentsOf: URL(fileURLWithPath: setup.zipPath)) {
-        material.append(Data("|zip=".utf8))
-        material.append(zipData)
+/// Memoizes the (manifest, zip) content hash per setup so the hot claim path
+/// doesn't re-read and re-SHA the full setup zip for every job handed out
+/// (June 2026 audit, P1.8). Keyed on manifest text + zip (path, size, mtime):
+/// suite edits rewrite both the manifest and the zip, so any real change
+/// invalidates the entry.
+private actor TestSetupDownloadVersionCache {
+    static let shared = TestSetupDownloadVersionCache()
+
+    private struct Key: Hashable {
+        let manifest: String
+        let zipPath: String
+        let zipSize: UInt64
+        let zipModified: Date
     }
-    return String(sha256HexDigest(material).prefix(16))
+
+    private var entries: [String: (key: Key, version: String)] = [:]
+
+    func version(for setup: APITestSetup) -> String {
+        let setupID = setup.id ?? setup.zipPath
+        let attributes = try? FileManager.default.attributesOfItem(atPath: setup.zipPath)
+        let key = Key(
+            manifest: setup.manifest,
+            zipPath: setup.zipPath,
+            zipSize: (attributes?[.size] as? UInt64) ?? 0,
+            zipModified: (attributes?[.modificationDate] as? Date) ?? .distantPast)
+
+        if let cached = entries[setupID], cached.key == key { return cached.version }
+
+        var material = Data(setup.manifest.utf8)
+        if let zipData = try? Data(contentsOf: URL(fileURLWithPath: setup.zipPath)) {
+            material.append(Data("|zip=".utf8))
+            material.append(zipData)
+        }
+        let version = String(sha256HexDigest(material).prefix(16))
+        entries[setupID] = (key, version)
+        return version
+    }
+}
+
+private func testSetupDownloadVersion(for setup: APITestSetup) async -> String {
+    await TestSetupDownloadVersionCache.shared.version(for: setup)
 }
 
 // MARK: - Application-level claim serializer

--- a/Sources/APIServer/Services/AchievementEvaluationService.swift
+++ b/Sources/APIServer/Services/AchievementEvaluationService.swift
@@ -19,7 +19,11 @@ import Fluent
 import Foundation
 import Vapor
 
-private let achievementSweepInterval: TimeInterval = 60
+// 5 minutes: class-goal progress is a dashboard nicety, and each sweep walks
+// every non-frozen goal-bearing assignment's submissions — at term scale a
+// 60-second cadence spent most of its time re-running the same heavy scan
+// (June 2026 audit, P1.2). Deadline locking still lands within one interval.
+private let achievementSweepInterval: TimeInterval = 300
 
 /// Fraction of a class goal reached, `0...1`: the share of the roster meeting
 /// the threshold, scaled by the goal's target share.  Returns `1.0` once
@@ -45,8 +49,18 @@ func evaluateClassGoalAchievements(
     let assignments = try await APIAssignment.query(on: db).all()
     var written = 0
 
+    // One batched query for every referenced setup instead of a find() per
+    // assignment (June 2026 audit, P1.2 — this sweep runs on a timer forever).
+    let setupIDs = Array(Set(assignments.map(\.testSetupID)))
+    var setupByID: [String: APITestSetup] = [:]
+    if !setupIDs.isEmpty {
+        for setup in try await APITestSetup.query(on: db).filter(\.$id ~~ setupIDs).all() {
+            if let id = setup.id { setupByID[id] = setup }
+        }
+    }
+
     for assignment in assignments {
-        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: db),
+        guard let setup = setupByID[assignment.testSetupID],
             let setupID = setup.id,
             let props = try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
         else { continue }
@@ -125,7 +139,7 @@ func bestAssignmentGradeByStudent(testSetupID: String, on db: Database) async th
     var best: [UUID: Double] = [:]
     for sub in identified {
         guard let result = preferred[sub.id],
-            let percent = gradePercentFromCollectionJSON(result.collectionJSON)
+            let percent = result.gradePercentValue
         else { continue }
         let value = Double(percent) / 100
         if value > (best[sub.userID] ?? -1) { best[sub.userID] = value }

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -223,7 +223,7 @@ private func bestPointsForStudent(
         // recorded totalPoints for setups whose manifest is unavailable.
         let total =
             try await suiteTotalPoints(testSetupID: testSetupID, db: db)
-            ?? resultsForGrade.compactMap { gradeTotalPointsFromCollectionJSON($0.collectionJSON) }.max()
+            ?? resultsForGrade.compactMap { $0.gradeTotalPointsValue }.max()
         guard let total, total > 0 else { throw BrightSpaceSyncError.missingPoints }
         return Double(override.overridePercent) / 100.0 * total
     }
@@ -231,7 +231,7 @@ private func bestPointsForStudent(
     guard
         let points =
             resultsForGrade
-            .compactMap({ gradePointsFromCollectionJSON($0.collectionJSON) })
+            .compactMap({ $0.gradePointsValue })
             .max()
     else {
         throw BrightSpaceSyncError.missingPoints

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -252,4 +252,8 @@ func registerMigrations(on app: Application) {
     // Audit-followup indexes (June 2026): request_metrics(finished_at) and
     // other uncovered hot-path filters. Index-only, runs last.
     app.migrations.add(CreateAuditFollowupIndexes())
+
+    // Denormalized grade columns on results + one-time backfill from the
+    // collection_json blob (June 2026 audit, P1.1).
+    app.migrations.add(AddResultGradeColumns())
 }

--- a/Sources/RunnerCore/OutputInterpretation.swift
+++ b/Sources/RunnerCore/OutputInterpretation.swift
@@ -77,9 +77,11 @@ public func interpretScriptOutput(_ output: ScriptOutput) -> InterpretedScriptRe
     }
 
     // Strip the JSON footer line from stdout before showing it to students.
+    // Reuses `lines` from above rather than splitting a potentially large
+    // stdout a second time.
     let strippedStdout: String
     if footer != nil {
-        var stdoutLines = splitOnNewlines(output.stdout)
+        var stdoutLines = lines
         if let lastIdx = stdoutLines.indices.last(where: { !trimHorizontal(stdoutLines[$0]).isEmpty }) {
             stdoutLines.remove(at: lastIdx)
         }

--- a/Sources/Worker/JobPoller.swift
+++ b/Sources/Worker/JobPoller.swift
@@ -74,7 +74,11 @@ struct JobPoller: Sendable {
         case 200:
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            do { return try decoder.decode(Core.Job.self, from: data) } catch { throw .transportError(error) }
+            // A decode failure is a server/worker schema mismatch, not a network
+            // problem — classify it distinctly so ops doesn't chase a transport
+            // issue that doesn't exist (June 2026 audit, P2.5). Still retryable:
+            // the mismatch usually resolves when the other side is upgraded.
+            do { return try decoder.decode(Core.Job.self, from: data) } catch { throw .decodingFailed(error) }
         case 204:
             return nil
         case 409:
@@ -98,6 +102,7 @@ enum JobPollerError: Error, LocalizedError {
     case httpError(Int, String)
     case transportError(any Error)
     case duplicateWorkerID(String)
+    case decodingFailed(any Error)
 
     var errorDescription: String? {
         switch self {
@@ -109,6 +114,8 @@ enum JobPollerError: Error, LocalizedError {
             return "Transport error: \(error.localizedDescription)"
         case .duplicateWorkerID(let message):
             return "Duplicate worker ID: \(message)"
+        case .decodingFailed(let error):
+            return "Failed to decode job payload (server/worker version mismatch?): \(error)"
         }
     }
 }

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -613,16 +613,29 @@ extension WorkerDaemon {
         job: Job,
         startedAt: Date
     ) -> TestOutcomeCollection {
-        let passCount = outcomes.filter { $0.status == .pass }.count
-        let failCount = outcomes.filter { $0.status == .fail }.count
-        let errorCount = outcomes.filter { $0.status == .error }.count
-        let timeoutCount = outcomes.filter { $0.status == .timeout }.count
-        let totalMs = outcomes.reduce(0) { $0 + $1.executionTimeMs }
-        let totalPoints = outcomes.reduce(0) { $0 + $1.points }
+        // One pass over the outcomes instead of six (4 × filter().count +
+        // 2 × reduce) — the codebase's own stated antipattern.
+        var passCount = 0
+        var failCount = 0
+        var errorCount = 0
+        var timeoutCount = 0
+        var totalMs = 0
+        var totalPoints = 0
         // Weighted, partial-credit-aware: points × score per outcome (a script
         // with no footer `score` scores 1 on a pass / 0 otherwise, so this equals
         // the old "sum points for passing tests" for non-partial-credit suites).
-        let earnedPoints = outcomes.reduce(0.0) { $0 + Double($1.points) * $1.score }
+        var earnedPoints = 0.0
+        for outcome in outcomes {
+            switch outcome.status {
+            case .pass: passCount += 1
+            case .fail: failCount += 1
+            case .error: errorCount += 1
+            case .timeout: timeoutCount += 1
+            }
+            totalMs += outcome.executionTimeMs
+            totalPoints += outcome.points
+            earnedPoints += Double(outcome.points) * outcome.score
+        }
 
         let buildStatus: BuildStatus = outcomes.isEmpty ? .failed : .passed
 

--- a/Sources/Worker/RunnerDaemon.swift
+++ b/Sources/Worker/RunnerDaemon.swift
@@ -269,8 +269,13 @@ func readWorkerSecretFromFile(path: String) -> String? {
 actor WorkerDaemon {
     static let downloadSession: URLSession = {
         let cfg = URLSessionConfiguration.default
-        cfg.timeoutIntervalForRequest = 5
-        cfg.timeoutIntervalForResource = 15
+        // Request timeout is per-idle-interval (resets whenever bytes arrive);
+        // resource timeout caps the WHOLE transfer. The old 15 s resource cap
+        // meant a large setup zip on a slow link could *never* download — a
+        // deterministic failure no retry can fix (June 2026 audit). 10 min is
+        // a backstop against truly hung transfers, not a tuning knob.
+        cfg.timeoutIntervalForRequest = 15
+        cfg.timeoutIntervalForResource = 600
         return URLSession(configuration: cfg)
     }()
 
@@ -371,6 +376,17 @@ actor WorkerDaemon {
                     slot: slot,
                     status: "unexpected_response",
                     message: "unexpected response from API server",
+                    httpStatus: nil,
+                    backoff: &backoff
+                )
+            } catch JobPollerError.decodingFailed(let underlying) {
+                // Schema mismatch between server and worker — retryable (it
+                // resolves when the lagging side is upgraded), but logged under
+                // its own status so it can't be mistaken for a network problem.
+                try await handleRetryablePollError(
+                    slot: slot,
+                    status: "job_decode_failed",
+                    message: String(describing: underlying),
                     httpStatus: nil,
                     backoff: &backoff
                 )

--- a/Sources/Worker/ScriptInvocation.swift
+++ b/Sources/Worker/ScriptInvocation.swift
@@ -64,7 +64,7 @@ func scriptInvocation(for script: URL) -> ScriptInvocation {
     let source: String
     if let handle = try? FileHandle(forReadingFrom: script) {
         defer { try? handle.close() }
-        let data = (try? handle.read(upToCount: 2048)) ?? nil
+        let data = try? handle.read(upToCount: 2048)
         source = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
     } else {
         source = ""

--- a/Sources/Worker/ScriptInvocation.swift
+++ b/Sources/Worker/ScriptInvocation.swift
@@ -59,9 +59,13 @@ private func shInvocation(for script: URL) -> ScriptInvocation {
 /// owns the substrate-only bits (reading the file, the executable-bit fallback).
 func scriptInvocation(for script: URL) -> ScriptInvocation {
     // Leading source for shebang / content classification (substrate I/O).
+    // Bounded read: only the first 2 KB matter, so don't pull a large support
+    // file fully into memory just to classify it.
     let source: String
-    if let data = try? Data(contentsOf: script) {
-        source = String(data: data.prefix(2048), encoding: .utf8) ?? ""
+    if let handle = try? FileHandle(forReadingFrom: script) {
+        defer { try? handle.close() }
+        let data = (try? handle.read(upToCount: 2048)) ?? nil
+        source = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
     } else {
         source = ""
     }

--- a/Sources/Worker/ScriptRunner.swift
+++ b/Sources/Worker/ScriptRunner.swift
@@ -43,15 +43,37 @@ struct LinuxProcessLaunchConfiguration {
 #endif
 
 private final class CapturedPipeBuffer: Sendable {
-    private let storage = Mutex(Data())
+    /// Per-stream capture cap. A student script printing in a tight loop for
+    /// its whole time limit could otherwise grow this buffer without bound,
+    /// OOM the worker (taking down the other concurrent jobs), and ride the
+    /// blob into `longResult` → JSON → DB (June 2026 audit, P2.1). 1 MB keeps
+    /// every realistic traceback intact.
+    static let maxCapturedBytes = 1_048_576
+
+    private struct State {
+        var data = Data()
+        var truncated = false
+    }
+
+    private let storage = Mutex(State())
 
     func append(_ chunk: Data) {
         guard !chunk.isEmpty else { return }
-        storage.withLock { $0.append(chunk) }
+        storage.withLock { state in
+            guard !state.truncated else { return }
+            let remaining = Self.maxCapturedBytes - state.data.count
+            if chunk.count <= remaining {
+                state.data.append(chunk)
+            } else {
+                if remaining > 0 { state.data.append(chunk.prefix(remaining)) }
+                state.truncated = true
+                state.data.append(Data("\n... output truncated (limit 1 MB) ...\n".utf8))
+            }
+        }
     }
 
     func snapshot() -> Data {
-        storage.withLock { $0 }
+        storage.withLock { $0.data }
     }
 }
 
@@ -92,8 +114,7 @@ func executeScriptProcess(
 
     // Spawn a timeout Task instead of DispatchQueue.asyncAfter so the timeout
     // participates in Swift structured concurrency and supports cooperative
-    // cancellation. The main path still calls waitUntilExit() — acceptable in
-    // the worker daemon context where one thread per active job is expected.
+    // cancellation.
     let timeoutTask: Task<Void, Never>?
     if usesExternalTimeout {
         timeoutTask = nil
@@ -106,7 +127,29 @@ func executeScriptProcess(
         }
     }
 
-    proc.waitUntilExit()
+    // Suspend until exit instead of blocking on waitUntilExit(): the Swift
+    // cooperative pool has ~one thread per core and never grows, so a blocking
+    // wait per running script could pin every pool thread — starving the
+    // heartbeat tasks and (worst case) the timeout Task that is supposed to
+    // kill the hung script (June 2026 audit, P1.5).
+    //
+    // The handler is installed after run(), so guard the already-exited race:
+    // if the process exited before the handler was set the handler never
+    // fires, and if it exits in between both paths may fire — `resumed` keeps
+    // the continuation single-shot either way.
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let resumed = Mutex(false)
+        let resumeOnce: @Sendable () -> Void = {
+            let alreadyResumed = resumed.withLock { wasResumed in
+                let previous = wasResumed
+                wasResumed = true
+                return previous
+            }
+            if !alreadyResumed { continuation.resume() }
+        }
+        proc.terminationHandler = { _ in resumeOnce() }
+        if !proc.isRunning { resumeOnce() }
+    }
     timeoutTask?.cancel()
 
     if usesExternalTimeout && proc.terminationStatus == 124 {
@@ -282,7 +325,7 @@ private struct LinuxScriptPipes {
 /// Result of `waitpid`-loop bookkeeping. `status` is the raw wait status; the
 /// caller maps it to `ScriptOutput.exitCode` after taking the timeout flag
 /// into account.
-private struct LinuxWaitOutcome {
+private struct LinuxWaitOutcome: Sendable {
     let status: Int32
     let timedOut: Bool
 }
@@ -337,7 +380,16 @@ func executeLinuxScriptProcess(
     pipes.stdoutPipe.fileHandleForWriting.closeFile()
     pipes.stderrPipe.fileHandleForWriting.closeFile()
 
-    let wait = linuxWaitForChild(pid: pid, timeLimitSeconds: timeLimitSeconds)
+    // Run the waitpid poll loop on a dedicated OS thread and suspend here:
+    // the loop blocks (usleep between WNOHANG polls) for up to the full time
+    // limit, and the cooperative pool must not lose a thread per running
+    // script (June 2026 audit, P1.5). One short-lived thread per active job,
+    // bounded by --max-jobs.
+    let wait = await withCheckedContinuation { (continuation: CheckedContinuation<LinuxWaitOutcome, Never>) in
+        Thread.detachNewThread {
+            continuation.resume(returning: linuxWaitForChild(pid: pid, timeLimitSeconds: timeLimitSeconds))
+        }
+    }
 
     let elapsed = Int(Date().timeIntervalSince(start) * 1000)
     let stdoutData = finishPipeCapture(for: pipes.stdoutPipe, buffer: pipes.stdoutBuffer)

--- a/Sources/Worker/TestSetupCache.swift
+++ b/Sources/Worker/TestSetupCache.swift
@@ -34,6 +34,37 @@ actor TestSetupCache {
     ) {
         self.cacheRoot = cacheRoot
         self.maxEntries = maxEntries
+        // Reconcile with what's already on disk: the LRU list used to be
+        // memory-only, so entries surviving a daemon restart were never
+        // tracked — they served hits but could never be evicted, growing
+        // /tmp without bound across restarts and manifest edits (June 2026
+        // audit, P2.4). Seed oldest-first so eviction order approximates LRU.
+        lruKeys = Self.existingEntryKeysSortedByAge(cacheRoot: cacheRoot)
+    }
+
+    /// Keys of committed cache entries already on disk, oldest modification
+    /// first. `.tmp` staging leftovers are ignored (and cleaned by the next
+    /// populate of their key).
+    private static func existingEntryKeysSortedByAge(cacheRoot: URL) -> [String] {
+        let fm = FileManager.default
+        guard
+            let entries = try? fm.contentsOfDirectory(
+                at: cacheRoot, includingPropertiesForKeys: [.contentModificationDateKey])
+        else { return [] }
+        return
+            entries
+            .filter { !$0.lastPathComponent.hasSuffix(".tmp") }
+            .filter { fm.fileExists(atPath: $0.appendingPathComponent("prepared").path) }
+            .sorted { lhs, rhs in
+                let lhsDate =
+                    (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                let rhsDate =
+                    (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                return lhsDate < rhsDate
+            }
+            .map(\.lastPathComponent)
     }
 
     // MARK: - Public interface
@@ -60,7 +91,30 @@ actor TestSetupCache {
         let didHit: Bool
     }
 
-    func acquire(
+    nonisolated func acquire(
+        testSetupID: String,
+        populate: @escaping @Sendable () async throws -> URL
+    ) async throws -> AcquireResult {
+        // The scratch copy of a multi-MB prepared directory runs OUTSIDE actor
+        // isolation so concurrent acquires for other setups don't serialize
+        // behind file I/O (June 2026 audit, P2.4). The committed source dir is
+        // immutable, so the only hazard is eviction racing the copy — rare
+        // (needs 16+ distinct setups churning), and retried once below: with
+        // the entry gone, the retry takes the populate path.
+        do {
+            let source = try await acquireSource(testSetupID: testSetupID, populate: populate)
+            let scratch = try Self.copyToScratch(source: source.directory, label: testSetupID)
+            return AcquireResult(directory: scratch, didHit: source.didHit)
+        } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+            let source = try await acquireSource(testSetupID: testSetupID, populate: populate)
+            let scratch = try Self.copyToScratch(source: source.directory, label: testSetupID)
+            return AcquireResult(directory: scratch, didHit: source.didHit)
+        }
+    }
+
+    /// Actor-isolated bookkeeping half of `acquire`: returns the committed
+    /// prepared directory (populating it if needed) without copying it.
+    private func acquireSource(
         testSetupID: String,
         populate: @escaping @Sendable () async throws -> URL
     ) async throws -> AcquireResult {
@@ -75,8 +129,7 @@ actor TestSetupCache {
                 fields: [
                     "test_setup_id": testSetupID
                 ])
-            let scratch = try copyToScratch(source: preparedDir, label: testSetupID)
-            return AcquireResult(directory: scratch, didHit: true)
+            return AcquireResult(directory: preparedDir, didHit: true)
         }
 
         // ── Already populating — await in-flight task ─────────────────────
@@ -90,10 +143,9 @@ actor TestSetupCache {
             // Another caller may have already registered this key in lruKeys;
             // touchLRU is idempotent and safe to call from any code path.
             touchLRU(key: testSetupID)
-            let scratch = try copyToScratch(source: populated, label: testSetupID)
             // Awaiting an in-flight populate is a miss from the caller's
             // perspective — work was still being done on their behalf.
-            return AcquireResult(directory: scratch, didHit: false)
+            return AcquireResult(directory: populated, didHit: false)
         }
 
         // ── Cache miss — start population ────────────────────────────────────
@@ -123,8 +175,7 @@ actor TestSetupCache {
                 fields: [
                     "test_setup_id": testSetupID
                 ])
-            let scratch = try copyToScratch(source: populated, label: testSetupID)
-            return AcquireResult(directory: scratch, didHit: false)
+            return AcquireResult(directory: populated, didHit: false)
         } catch {
             inProgress.removeValue(forKey: testSetupID)
             cleanupPartialEntry(testSetupID: testSetupID)
@@ -188,8 +239,8 @@ actor TestSetupCache {
     // MARK: - File operations
 
     /// Copy the prepared cache entry into a fresh temporary directory that
-    /// the caller owns exclusively.
-    private func copyToScratch(source: URL, label: String) throws -> URL {
+    /// the caller owns exclusively. Static (non-isolated) — see `acquire`.
+    private static func copyToScratch(source: URL, label: String) throws -> URL {
         let dest = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "chickadee_ts_\(label)_\(UUID().uuidString)",

--- a/Tests/WorkerTests/JobPollerTests.swift
+++ b/Tests/WorkerTests/JobPollerTests.swift
@@ -158,7 +158,7 @@ import FoundationNetworking
         }
     }
 
-    @Test func throwsTransportError_onMalformedJson200() async throws {
+    @Test func throwsDecodingFailed_onMalformedJson200() async throws {
         try await withMockURLProtocolLock {
             MockURLProtocol.reset()
             MockURLProtocol.enqueue(.status(200, body: Data("not json".utf8)))
@@ -167,8 +167,9 @@ import FoundationNetworking
             do {
                 _ = try await poller.requestJob(activeJobs: 0)
                 Issue.record("expected throw")
-            } catch JobPollerError.transportError {
-                // ok — Job decode failure is mapped onto transportError per JobPoller.swift:73
+            } catch JobPollerError.decodingFailed {
+                // ok — a Job decode failure is a server/worker schema mismatch,
+                // classified distinctly from transport errors (June 2026 audit).
             } catch {
                 Issue.record("unexpected error: \(error)")
             }

--- a/changelog.d/audit-do-it-all-batch.md
+++ b/changelog.d/audit-do-it-all-batch.md
@@ -1,0 +1,34 @@
+### Changed
+
+- **Grades are now denormalized onto the `results` table.** New
+  `earned_points` / `total_points` / `pass_count` / `total_tests` columns
+  (backfilled from the result blob in one migration statement) replace the
+  per-row JSON decode on the student dashboard, instructor roster, grades CSV
+  export, submission history, and the achievement / BrightSpace sweeps. The
+  CSV export also chunks its result lookups, so term-scale exports no longer
+  exceed database bind-parameter limits.
+- The worker claim scan is capped at 50 candidates per group (fresh student
+  work still beats retests), the achievement sweep batch-loads test setups and
+  runs every 5 minutes instead of every minute, instructor-dashboard counts
+  use SQL aggregates, and the per-claim test-setup zip hash is memoized.
+- Worker script waits no longer block Swift concurrency pool threads
+  (termination handlers / a dedicated wait thread), per-stream script output
+  capture is capped at 1 MB, and the artifact download timeout was raised from
+  15 s (which deterministically failed large setup zips) to 10 minutes.
+- Six drifted per-template relative-time formatters were replaced by one
+  shared `Public/relative-time.js`.
+
+### Fixed
+
+- **Concurrent submissions can no longer share an attempt number.** Attempt
+  numbers are now assigned inside a transaction (`MAX + 1`, with a per-student
+  advisory lock on Postgres), fixing corruption of the prior-attempt delta and
+  the First-Try-Perfect badge.
+- Persisting a worker result and marking its submission complete now happen in
+  one transaction, so a failure between the two no longer strands a graded
+  submission in `assigned` until the reaper regrades it.
+- A worker job-payload decode failure (server/worker version mismatch) is now
+  logged as `job_decode_failed` instead of masquerading as a transport error.
+- The runner's test-setup cache reconciles with disk at startup, so entries
+  surviving a restart are evictable again instead of accumulating in /tmp
+  forever.

--- a/docs/audit-2026-06.md
+++ b/docs/audit-2026-06.md
@@ -8,7 +8,71 @@ within each section; the cross-cutting priority list is at the top.
 This is an *audit document*.  Each item is sized so it can become an issue/PR
 on its own.
 
-### Implementation status (this branch)
+### Implementation status (second pass — "do it all" batch)
+
+Implemented on top of the "now" batch:
+
+- **P1.1 — grade denormalization.**  `AddResultGradeColumns` adds
+  `earned_points` / `total_points` / `pass_count` / `total_tests` to `results`
+  with a one-statement SQL backfill (dialect-specific: `jsonb->>'…'` on
+  Postgres, `json_extract` on SQLite).  `APIResult`'s designated initializer
+  stamps the columns (`populateGradeFields()`), covering the worker, browser,
+  and bundle-import creation paths.  Column-first accessors
+  (`gradePercentValue` / `gradePointsValue` / `gradeTotalPointsValue`) replace
+  the per-row blob parses at all twelve read sites (dashboard, roster, CSV,
+  history, achievement sweep, BrightSpace sweep); rows with all-nil columns
+  fall back to the JSON parse so the two paths can never disagree.
+- **P0.2 — bind-limit chunking.**  `preferredResultsBySubmissionID` chunks its
+  `IN`-list at 5,000 IDs (each submission's results live entirely inside its
+  ID's chunk, so the per-submission fold is order-equivalent).
+- **P0.3 — attempt-number race.**  `saveSubmissionWithNextAttemptNumber`
+  computes `MAX(attempt_number)+1` and saves inside one transaction, with a
+  per-(setup, user) `pg_advisory_xact_lock` on Postgres (SQLite write
+  transactions already serialize).  Rewired all five count-then-insert sites
+  (web submit, two API paths, two browser paths); validation submissions keep
+  the old behavior.
+- **P1.3 — claim-scan cap.**  `collectClaimCandidates` queries fresh-then-retest
+  groups separately with `LIMIT 50` each (preserving #427 priority in SQL,
+  dropping the full scan + in-memory re-sort); validation scan capped too.
+- **P1.8 — per-claim zip hashing memoized** (`TestSetupDownloadVersionCache`,
+  keyed on manifest + zip path/size/mtime).
+- **P1.2 — achievement sweep**: setups batch-loaded in one query instead of a
+  find() per assignment; interval 60 s → 5 min.
+- **P1.6 — dashboard aggregates**: pending-now is a SQL `COUNT`; per-setup
+  unique submitters is `COUNT(DISTINCT user_id) … GROUP BY`.
+- **P2.3 — result persist + status flip transactional** (`ResultRoutes`).
+- **P2.4 — TestSetupCache** seeds its LRU from disk at init (restart no longer
+  orphans entries) and copies to scratch outside actor isolation (one
+  re-acquire retry covers an eviction racing the copy).
+- **P2.5 — `JobPollerError.decodingFailed`** distinguishes schema mismatch from
+  transport failure (`job_decode_failed` log status).
+- **P1.5 — process-wait continuations.**  macOS: `terminationHandler` +
+  single-shot continuation (with already-exited rescue); Linux fork path:
+  `waitpid` loop on a dedicated thread + continuation.  The cooperative pool
+  no longer loses a thread per running script, so heartbeats and the timeout
+  task keep running.
+- **P2.1 — output capture capped** at 1 MB per stream with a truncation marker.
+- **Worker odds and ends:** artifact-download resource timeout 15 s → 10 min
+  (was deterministically failing large zips); `scriptInvocation` bounded 2 KB
+  read; `interpretScriptOutput` single stdout split; `makeCollection` single
+  pass; `submissions(assigned_at)` index added.
+- **Frontend:** `Public/relative-time.js` replaces the six drifted
+  per-template `formatRelative` copies (all six templates rewired); the two
+  50 ms `setInterval` spinners (pattern-family scan, suite-table form submit)
+  replaced with cached/settled promises; `loadGradesCSVStudents` and
+  `EnrollCSVHelper` filter in SQL instead of loading all users.
+
+**Still open (refactor-only, no behavior change):** role/status string → enum
+sweep, the generic periodic-service extraction, `loadAssignmentAndSetup` /
+`AppError` adoption completion, the oversized-file splits,
+`NotebookWorkingCopyStore` extraction (+ moving the legacy notebook sweep to a
+startup migration), the multipart `ManyOrSingle<File>` dedup, the shared
+`chickadee-ui.js` (escaper/csrf/setStatus) module, BrightSpace sweep
+per-result query batching, and `GET /api/v1/submissions` pagination.  These
+are mechanical consolidations whose value is maintainability rather than
+correctness or scale; they should land as focused PRs.
+
+### Implementation status (first pass — "now" batch)
 
 The "now" batch has been implemented on this branch alongside the audit:
 


### PR DESCRIPTION
Implements the remaining high-value findings from `docs/audit-2026-06.md` (the items deferred from #904). Full mapping is in the doc's new *Implementation status (second pass)* section.

## Highlights

**Grade denormalization (P1.1 — the audit's highest-leverage change).** `AddResultGradeColumns` adds `earned_points` / `total_points` / `pass_count` / `total_tests` to `results`, backfilled from the JSON blob in one dialect-specific statement. All twelve read sites (student dashboard, instructor roster, grades CSV, history pages, achievement + BrightSpace sweeps) now read columns instead of decoding the full result blob per row, with a JSON-parse fallback for any unbackfilled row so the paths can never disagree. `preferredResultsBySubmissionID` also chunks its `IN`-list at 5,000 IDs, fixing the term-scale CSV export that would exceed bind-parameter limits outright.

**Attempt-number race (P0.3).** `saveSubmissionWithNextAttemptNumber` assigns `MAX(attempt_number)+1` and saves in one transaction (per-(setup, student) advisory lock on Postgres); all five count-then-insert sites rewired. Concurrent submits can no longer share an attempt number.

**Worker claim path (P1.3/P1.8).** The candidate scan is capped at 50 per priority group with fresh-over-retest preserved in SQL (the full-queue scan + in-memory re-sort is gone), and the per-claim setup-zip SHA-256 is memoized by (manifest, path, size, mtime).

**Worker robustness (P1.5/P2.x).** Script waits no longer pin Swift cooperative-pool threads (termination handler + single-shot continuation; dedicated `waitpid` thread on the Linux fork path) — heartbeats and the timeout task keep running under full load. Output capture capped at 1 MB/stream; `JobPollerError.decodingFailed` separates schema mismatches from transport errors; `TestSetupCache` reconciles with disk at startup and copies scratch trees off-actor; the 15 s artifact-download cap (which deterministically failed large zips) is now a 10-minute backstop; result persist + status flip are transactional.

**Sweeps + dashboards (P1.2/P1.6).** Achievement sweep batch-loads setups and runs every 5 min; instructor-dashboard counts are SQL aggregates (`COUNT`, `COUNT(DISTINCT …) GROUP BY`); CSV/enroll user lookups filter in SQL.

**Frontend.** One shared `Public/relative-time.js` replaces six drifted per-template copies (all six templates rewired, verified by `check-styles`); the two 50 ms `setInterval` spin-waits are replaced with cached/settled promises.

## Still open (refactor-only)

Role/status enums, the generic periodic-service extraction, helper-adoption completion (`loadAssignmentAndSetup`, `AppError`), file splits, `chickadee-ui.js`, BrightSpace per-result query batching, and `GET /api/v1/submissions` pagination — mechanical consolidations listed in the audit doc for focused follow-up PRs.

## Verification

Local: full `swift build`, previously-failing-then-fixed `RoleMiddlewareTests` (a SQLite multi-column `ALTER` in the new migration — caught by the full local suite and fixed to one `ADD COLUMN` per statement), worker + assignment suites, 71 JS tests, SwiftLint `--strict`, `swift-format`, `check-styles` all green.

https://claude.ai/code/session_018vvwmzoom1NSd1fyAiiPad

---
_Generated by [Claude Code](https://claude.ai/code/session_018vvwmzoom1NSd1fyAiiPad)_