### PR TITLE
fix(templates): remove live Leaf directive from base.leaf HTML comment

### DIFF
--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="/styles.css?v=#appVersion()">
     <!-- Shared JS utilities (escapeHtml / escapeAttr / getCsrfToken).  Loaded
          in <head> rather than next to app.js because inline page scripts and
-         template-loaded modules in #import("content") execute during parse,
-         before the end-of-body script tags, and they reference ChickadeeUI
-         (some at parse time, e.g. csrf-token captures). -->
+         template-loaded modules execute during parse, before the end-of-body
+         script tags, and they reference ChickadeeUI at parse time
+         (e.g. csrf-token captures). -->
     <script src="/chickadee-ui.js?v=#appVersion()"></script>
 </head>
 <body>

--- a/changelog.d/fix-base-leaf-comment-import.md
+++ b/changelog.d/fix-base-leaf-comment-import.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Admin page rendered raw HTML comment text** (regression in v0.4.415).  The `chickadee-ui.js` load comment in `base.leaf` contained `#import("content")` in its body; Leaf evaluated that as a live directive, injected the page HTML mid-comment, and the first `-->` in that content closed the comment early — leaving the remaining comment text visible on the page and duplicating the courses table.  Reworded the comment to avoid the `#` directive syntax.


### PR DESCRIPTION
## Summary

- The `chickadee-ui.js` load comment added in v0.4.415 (#906) contained `#import("content")` in its text body inside `base.leaf`
- Leaf evaluates `#` directives wherever they appear — including inside HTML comments — so it injected the full page content mid-comment
- The first `-->` in the injected page HTML closed the comment early, causing the rest of the comment literal to render as visible text on the page and duplicating the courses table

One-line fix: rewrote the comment to avoid the `#` directive syntax.

## Test plan

- [ ] Load `/admin` — confirm no raw comment text visible, courses table appears once
- [ ] Load any other page — confirm no regressions

https://claude.ai/code/session_01TKTfhYNBjjR9mENVBbypJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKTfhYNBjjR9mENVBbypJn)_