### PR TITLE
Audit batch 4: query efficiency, shared resolvers, cleanup-failure logging, CI dedup

### DIFF
--- a/.github/actions/restore-git-mtimes/action.yml
+++ b/.github/actions/restore-git-mtimes/action.yml
@@ -1,0 +1,26 @@
+name: Restore git mtimes
+description: >
+  Install git-restore-mtime and reset each source file's mtime to its
+  last-commit time, so a restored .build/ cache stays valid for unchanged
+  files and llbuild recompiles only what new commits touched. Requires a
+  fetch-depth: 0 checkout (filter: blob:none is fine) and an apt-based
+  container image.
+runs:
+  using: composite
+  steps:
+    - name: Install git-restore-mtime
+      shell: bash
+      run: |
+        for i in 1 2 3; do
+          apt-get update -qq && apt-get install -y --no-install-recommends git-restore-mtime && break
+          echo "apt-get failed (attempt $i), retrying in 15s..."
+          sleep 15
+        done
+
+    # The container runs git as a different uid than checkout used, so mark
+    # the workspace safe before invoking git.
+    - name: Restore source mtimes from git history
+      shell: bash
+      run: |
+        git config --global --add safe.directory '*'
+        git restore-mtime

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -54,21 +54,9 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Install git-restore-mtime
-        run: |
-          for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends git-restore-mtime && break
-            echo "apt-get failed (attempt $i), retrying in 15s..."
-            sleep 15
-          done
-
       # Reset source mtimes to commit times so llbuild recompiles only files
-      # touched by new commits.  The container runs git as a different uid than
-      # checkout used, so mark the workspace safe first.
-      - name: Restore source mtimes from git history
-        run: |
-          git config --global --add safe.directory '*'
-          git restore-mtime
+      # touched by new commits.
+      - uses: ./.github/actions/restore-git-mtimes
 
       - name: Resolve toolchain cache key
         id: toolchain

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -95,22 +95,9 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Install git-restore-mtime
-        run: |
-          for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends git-restore-mtime && break
-            echo "apt-get failed (attempt $i), retrying in 15s..."
-            sleep 15
-          done
-
       # Normalise source mtimes to commit times so the restored `.build/`
       # stays valid for unchanged files and only new commits recompile.
-      # The container runs git as a different uid than checkout used, so mark
-      # the workspace safe before invoking git.
-      - name: Restore source mtimes from git history
-        run: |
-          git config --global --add safe.directory '*'
-          git restore-mtime
+      - uses: ./.github/actions/restore-git-mtimes
 
       - name: Resolve toolchain cache key
         id: toolchain

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -600,15 +600,14 @@ extension AdminRoutes {
 // MARK: - Private helpers
 
 private func uniqueCopyCode(base: String, db: Database) async throws -> String {
-    let first = "\(base)-COPY"
-    if try await APICourse.query(on: db).filter(\.$code == first).count() == 0 {
-        return first
-    }
-    for n in 2...10 {
-        let candidate = "\(base)-COPY-\(n)"
-        if try await APICourse.query(on: db).filter(\.$code == candidate).count() == 0 {
-            return candidate
-        }
+    let candidates = ["\(base)-COPY"] + (2...10).map { "\(base)-COPY-\($0)" }
+    let taken = Set(
+        try await APICourse.query(on: db)
+            .filter(\.$code ~~ candidates)
+            .all()
+            .map(\.code))
+    if let available = candidates.first(where: { !taken.contains($0) }) {
+        return available
     }
     throw AppError.conflict(reason: "Could not generate a unique course code. Rename an existing copy first.")
 }

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -76,6 +76,7 @@ struct AdminRoutes: RouteCollection {
             courseIDs: activeCourseIDs, on: req.db)
         let bsSyncEnabled = req.application.brightSpaceClient != nil
         // Archived courses move out of Overview and live on the Retention tab.
+        let iso = ISO8601DateFormatter()
         let courseRows = allCourses.compactMap { course -> AdminCourseRow? in
             guard let id = course.id, !course.isArchived else { return nil }
             return AdminCourseRow(
@@ -87,7 +88,7 @@ struct AdminRoutes: RouteCollection {
                 enrollmentCount: enrollmentCounts[id] ?? 0,
                 assignmentCount: assignmentCounts[id] ?? 0,
                 submissionCount: submissionCounts[id] ?? 0,
-                createdAt: course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—",
+                createdAt: course.createdAt.map { iso.string(from: $0) } ?? "—",
                 brightspaceOrgUnitID: course.brightspaceOrgUnitID,
                 brightspaceSyncEnabled: bsSyncEnabled
             )

--- a/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentHelpers.swift
@@ -136,11 +136,13 @@ func normalizedDeadlineOverrideAfterDueDateChange(
 }
 
 func nextAssignmentSortOrder(req: Request) async throws -> Int {
+    // MAX over the non-null rows only; an explicit filter + sort avoids the
+    // driver-dependent NULL ordering Postgres and SQLite disagree on.
     let maxOrder =
         try await APIAssignment.query(on: req.db)
-        .all()
-        .compactMap(\.sortOrder)
-        .max() ?? 0
+        .filter(\.$sortOrder != nil)
+        .sort(\.$sortOrder, .descending)
+        .first()?.sortOrder ?? 0
     return maxOrder + 1
 }
 

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Sections.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Sections.swift
@@ -168,23 +168,15 @@ extension CourseAdminRoutes {
 
         // When moving into a named section, sync the test setup's grading mode
         // to match the section's defaultGradingMode.  Moving to "ungrouped"
-        // (nil section) leaves the grading mode unchanged.
+        // (nil section) leaves the grading mode unchanged.  Shares
+        // `setManifestGradingMode` with the MCP set_grading_mode tool so both
+        // paths produce identical (sorted-key) manifest bytes — the
+        // manifest-hash retest gate depends on that determinism.
         if let sectionUUID = newSectionID,
             let section = try await APICourseSection.find(sectionUUID, on: req.db),
             let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db)
         {
-            let mode = section.defaultGradingMode  // "browser" | "worker"
-            if var dict = (try? JSONSerialization.jsonObject(with: Data(setup.manifest.utf8))) as? [String: Any],
-                (dict["gradingMode"] as? String) != mode
-            {
-                dict["gradingMode"] = mode
-                if let data = try? JSONSerialization.data(withJSONObject: dict),
-                    let json = String(data: data, encoding: .utf8)
-                {
-                    setup.manifest = json
-                    try await setup.save(on: req.db)
-                }
-            }
+            _ = try await setManifestGradingMode(setup: setup, to: section.defaultGradingMode, on: req.db)
         }
 
         return .ok

--- a/Sources/APIServer/Routes/Web/CourseLookupHelpers.swift
+++ b/Sources/APIServer/Routes/Web/CourseLookupHelpers.swift
@@ -1,0 +1,21 @@
+// APIServer/Routes/Web/CourseLookupHelpers.swift
+//
+// Shared course-by-code resolution for routes that accept a course code in
+// the URL path (vanity URLs, instructor student-history links).
+
+import Fluent
+import Vapor
+
+/// Resolves a non-archived course by its code, case-insensitively.
+///
+/// Codes are matched case-insensitively so URLs work however the user types
+/// them. Fluent has no case-insensitive comparison that is portable across
+/// SQLite and Postgres, so this fetches the (small) active-course set and
+/// compares in Swift — one place to change if that trade-off ever shifts.
+func findActiveCourse(byCode code: String, on db: Database) async throws -> APICourse? {
+    let lowered = code.lowercased()
+    return try await APICourse.query(on: db)
+        .filter(\.$isArchived == false)
+        .all()
+        .first(where: { $0.code.lowercased() == lowered })
+}

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -706,12 +706,7 @@ extension StudentCourseRoutes {
         else {
             throw WebAssignmentError.notFound(resource: "Course or student")
         }
-        let courseCode = courseCodeRaw.lowercased()
-        let course =
-            try await APICourse.query(on: req.db)
-            .filter(\.$isArchived == false)
-            .all()
-            .first(where: { $0.code.lowercased() == courseCode })
+        let course = try await findActiveCourse(byCode: courseCodeRaw, on: req.db)
         guard let course, let courseUUID = course.id else {
             throw WebAssignmentError.notFound(resource: "Course '\(courseCodeRaw)'")
         }

--- a/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
+++ b/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
@@ -52,11 +52,7 @@ struct VanityURLRoutes: RouteCollection {
             throw Abort(.notFound)
         }
 
-        let courseCodeLower = courseCode.lowercased()
-        let activeCourses = try await APICourse.query(on: req.db)
-            .filter(\.$isArchived == false)
-            .all()
-        guard let course = activeCourses.first(where: { $0.code.lowercased() == courseCodeLower }) else {
+        guard let course = try await findActiveCourse(byCode: courseCode, on: req.db) else {
             throw Abort(.notFound)
         }
 
@@ -79,11 +75,12 @@ struct VanityURLRoutes: RouteCollection {
             }
         }
 
-        let assignments = try await APIAssignment.query(on: req.db)
-            .filter(\.$courseID == courseID)
-            .all()
-
-        guard let assignment = assignments.first(where: { $0.slug == slug }) else {
+        guard
+            let assignment = try await APIAssignment.query(on: req.db)
+                .filter(\.$courseID == courseID)
+                .filter(\.$slug == slug)
+                .first()
+        else {
             throw Abort(.notFound)
         }
 

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -86,7 +86,7 @@ extension WorkerDaemon {
             paths: paths,
             stageTimings: &stageTimings
         )
-        defer { try? FileManager.default.removeItem(at: prepared.testSetupDir) }
+        defer { removeWorkspaceItem(at: prepared.testSetupDir, label: "test_setup_dir", job: job) }
 
         let testExecutionStartedAt = Date()
         let outcomes = try await executeTestSuites(
@@ -124,6 +124,26 @@ extension WorkerDaemon {
     }
 
     // MARK: - Per-job setup helpers
+
+    /// Best-effort workspace removal that leaves a structured breadcrumb on
+    /// failure — a silently leaked workdir is a disk leak ops can only find
+    /// from this log line. Quiet when the path is already gone.
+    private func removeWorkspaceItem(at url: URL, label: String, job: Job) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch {
+            writeStructuredRunnerLog(
+                event: "workspace_cleanup_failed",
+                fields: [
+                    "runner_id": workerID,
+                    "submission_id": job.submissionID,
+                    "label": label,
+                    "path": url.path,
+                    "error": String(describing: error),
+                ])
+        }
+    }
 
     private func logJobAccepted(_ job: Job) {
         writeStructuredRunnerLog(
@@ -185,7 +205,7 @@ extension WorkerDaemon {
         }
 
         let cleanupStartedAt = Date()
-        try? FileManager.default.removeItem(at: paths.workDir)
+        removeWorkspaceItem(at: paths.workDir, label: "work_dir", job: job)
         stageTimings.record("cleanup", milliseconds: Int(Date().timeIntervalSince(cleanupStartedAt) * 1000))
 
         let freeDiskMBPostCleanup = freeSpaceMB(at: tempRoot)

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -485,6 +485,35 @@ private struct PassthroughResponder: AsyncResponder {
         }
     }
 
+    @Test func copyCourseSkipsTakenCopyCodes() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+            let source = try await makeCourse(code: "CPY101", name: "Copy Source")
+            // Occupy the first two candidate codes so the copy must fall
+            // through to -COPY-3 — pins the candidate ordering of
+            // uniqueCopyCode.
+            try await makeCourse(code: "CPY101-COPY", name: "Existing Copy")
+            try await makeCourse(code: "CPY101-COPY-2", name: "Existing Copy 2")
+            let courseID = try source.requireID()
+            let (boundCookie, token) = try await csrfCookieAndToken(
+                cookie, path: "/admin/courses/\(courseID.uuidString)")
+
+            try await app.asyncTest(
+                .POST, "/admin/courses/\(courseID.uuidString)/copy",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: boundCookie)
+                    try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+
+            let copied = try #require(
+                try await APICourse.query(on: app.db).filter(\.$code == "CPY101-COPY-3").first())
+            #expect(copied.name == "Copy Source (Copy)")
+        }
+    }
+
     @Test func toggleCourseArchiveFlipsArchivedState() async throws {
         try await withApp(app) { _ in
             let cookie = try await loginAsAdmin()

--- a/changelog.d/maintenance-audit-batch-4.md
+++ b/changelog.d/maintenance-audit-batch-4.md
@@ -1,0 +1,17 @@
+### Changed
+
+- **Maintenance audit batch 4 (efficiency + drift fixes).** Hot-path query
+  cleanups: vanity-URL assignment resolution filters by slug in SQL instead of
+  fetching every assignment in the course; `nextAssignmentSortOrder` no longer
+  loads every assignment to compute a max; admin course-copy probes all
+  candidate `-COPY-n` codes in one query (was up to 10 round-trips, now
+  pinned by a route test); the admin overview reuses one date formatter
+  across course rows. Case-insensitive active-course-by-code resolution is
+  consolidated into a shared `findActiveCourse(byCode:)` (was duplicated in
+  the vanity-URL and student-history routes). The web "move to section"
+  grading-mode sync now calls the same `setManifestGradingMode` helper as the
+  MCP tool, so both paths emit identical sorted-key manifest bytes — the
+  manifest-hash retest gate depends on that determinism. Worker workspace
+  cleanup failures now emit a structured `workspace_cleanup_failed` log event
+  instead of vanishing (silent disk leaks). The duplicated git-restore-mtime
+  CI steps moved into one composite action.


### PR DESCRIPTION
## Maintenance audit batch 4

Fourth audit pass (after #904–#906), focused on efficiency, dead code, and long-term maintainability. Four parallel deep audits were run over (1) dead/unused code, (2) query/allocation hot paths, (3) duplication & structure, and (4) worker/tests/CI. Headline result: **the dead-code sweep found zero confirmed unused Swift, JS, Leaf templates, or scripts** — the previous batches got it all — so this batch is the efficiency and drift-protection remainder.

### Efficiency
- **Vanity URL resolution** (`VanityURLRoutes`): assignment lookup now filters by `slug` in SQL instead of fetching every assignment in the course (student-facing hot path).
- **`nextAssignmentSortOrder`** no longer loads *every assignment in the DB* to compute a max — non-null filter + descending sort, written to be portable across Postgres/SQLite NULL-ordering differences.
- **Admin course copy** (`uniqueCopyCode`): one batched `IN` query over all candidate `-COPY-n` codes instead of up to 10 sequential `count()` round-trips. New test `copyCourseSkipsTakenCopyCodes` pins the candidate ordering.
- **Admin overview**: one `ISO8601DateFormatter` reused across course rows instead of one per row.

### Drift protection / consolidation
- **`findActiveCourse(byCode:)`** — the case-insensitive active-course lookup was independently implemented in `VanityURLRoutes` and `StudentCourseRoutes+History`; now one shared helper.
- **Grading-mode manifest sync**: the web "move to section" path re-implemented MCP's `setManifestGradingMode` inline, but *without* `.sortedKeys` — so web and MCP could write different manifest bytes for identical content, and the manifest-hash compare gates the retest fan-out. Both paths now share the one helper (covered by the existing `moveToSection_syncsBrowserGradingMode` test).
- **CI**: the identical git-restore-mtime install/restore blocks in `swift-tests.yml` and `docker-build.yml` extracted to a local composite action (`.github/actions/restore-git-mtimes`).

### Observability
- **Worker workspace cleanup** failures (`workDir`, per-job test setup dir) now emit a structured `workspace_cleanup_failed` event instead of `try?`-vanishing — a leaked workdir was previously invisible to ops. Quiet when the path is already gone; heartbeat `try?` sites were checked and left alone (failures are already recorded via `recordConnectionLostIfNeeded`).

### Audited and deliberately *not* changed
- **Close-on-edit web vs MCP**: looks like duplication but is intentionally different semantics (MCP preserves `.preview`, web closes unconditionally) — documented in `ContentEditClose.swift`.
- **Test fixture helpers (`arInsert*`/`wrInsert*`)**: the variants differ in exactly the parts that matter (course resolution, manifests, zip paths); a "shared" base would just restate the model initializers.
- **Large files** (`WebRoutes+Submission`, `PatternFamilyRenderer`, etc.): reviewed for seams; all are cohesive single features — no split-for-its-own-sake.
- **`scripts/lib.sh`** for the repo-root two-liner: indirection would cost more than the duplication.

### Verification
- `swift build` clean; `scripts/format.sh` + `scripts/swiftlint.sh --strict` zero violations.
- Targeted suites green: `VanityURLRoutesTests`, `SectionRoutesTests`, `CourseSectionToolsTests`, `CourseSectionManagementToolsTests` (63 tests), `AssignmentExtensionsTests`, `GradeOverridesTests`, CSRF suites (24 tests), and the new `AdminRoutesTests/copyCourseSkipsTakenCopyCodes`.

https://claude.ai/code/session_01Fhd6oxnXHqq8Mf94AXDD8z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fhd6oxnXHqq8Mf94AXDD8z)_