### PR TITLE
Website responsiveness: dashboard unzip cache, immutable asset caching, response compression

### DIFF
--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -27,7 +27,7 @@
 <a class="skip-link" href="#main-content">Skip to main content</a>
 <nav class="nav">
     <a class="nav-brand" href="/">
-        <img class="nav-brand-logo" src="/images/chickadee-icon-alt.png" alt="">
+        <img class="nav-brand-logo" src="/images/chickadee-icon-alt.png?v=#appVersion()" alt="">
         <span>Chickadee</span>
     </a>
 

--- a/Sources/APIServer/Bootstrap/AppDirectories.swift
+++ b/Sources/APIServer/Bootstrap/AppDirectories.swift
@@ -45,6 +45,10 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     app.storage[WorkerClaimQueueKey.self] = WorkerClaimQueue()
     app.storage[WorkerSecretStoreKey.self] = WorkerSecretStore(initialOverride: startupWorkerSecret)
     app.storage[WorkerActivityStoreKey.self] = WorkerActivityStore()
+    // Seeded eagerly (like the stores above) so request handlers never hit
+    // the lazy-create branch in the accessor — Application.storage writes
+    // are not synchronized.
+    app.storage[NotebookPresenceCacheKey.self] = NotebookPresenceCache()
     app.storage[LocalRunnerAutoStartStoreKey.self] = LocalRunnerAutoStartStore(
         initialEnabled: localRunnerAutoStartEnabled
     )

--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -27,6 +27,9 @@
 //   UserActivityMiddleware
 //   UserFileNamespaceMiddleware
 //   ScanModeMiddleware      — gates destructive POSTs in scan windows
+//   StaticAssetCacheMiddleware — stamps immutable Cache-Control on
+//                             version-fingerprinted (`?v=`) static assets
+//                             served by FileMiddleware
 //   FileMiddleware          — short-circuits the chain for static files
 //   COEPMiddleware          — sets Cross-Origin-Embedder-Policy headers
 //                             on dynamic pages (NOT on JupyterLite static
@@ -123,6 +126,16 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // Allow notebook uploads from the assignment-creation flow.
     app.routes.defaultMaxBodySize = "10mb"
 
+    // Compress compressible response types (text, JS, JSON, SVG — Vapor's
+    // allowlist) when the client advertises Accept-Encoding.  The shared
+    // stylesheet and page scripts shrink ~4–8× on the wire.  Already-compressed
+    // formats (zip, wasm, images, fonts) are not in the allowlist, so the
+    // multi-megabyte Pyodide/JupyterLite payloads don't burn CPU recompressing.
+    // HTML opts out per-response in SecurityHeadersMiddleware: pages embed the
+    // per-session CSRF token, and compressing a secret alongside reflectable
+    // request data is the precondition for BREACH-style compression oracles.
+    app.http.server.configuration.responseCompression = .enabledForCompressibleTypes
+
     // MARK: - Views + static files
 
     app.views.use(.leaf)
@@ -147,6 +160,11 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // application/wasm headers on the content-hashed wasm runner served from
     // Public/runner-wasm/ (FileMiddleware short-circuits, so a middleware after
     // it never sees those responses).
+    // Versioned-asset caching sits outside RunnerWasmCacheMiddleware so the
+    // wasm middleware's more specific policies (immutable hashed wasm,
+    // no-cache loader) win — StaticAssetCacheMiddleware never overwrites an
+    // existing Cache-Control.
+    app.middleware.use(StaticAssetCacheMiddleware())
     app.middleware.use(RunnerWasmCacheMiddleware())
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(COEPMiddleware())

--- a/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
+++ b/Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift
@@ -10,7 +10,9 @@
 //     cache after the user logs out — so clicking a link or hitting Back
 //     shows a logged-in view even though the server-side session is gone.
 //     Scoped to text/html so versioned static assets (Pyodide, JupyterLite,
-//     CodeMirror, images) keep their long-lived caching.
+//     CodeMirror, images) keep their long-lived caching.  text/html responses
+//     are also marked to skip response compression (BREACH — see the inline
+//     comment in respond(to:chainingTo:)).
 //
 //   X-Content-Type-Options: nosniff
 //     Prevents browsers from MIME-sniffing a response away from the declared
@@ -244,6 +246,12 @@ struct SecurityHeadersMiddleware: AsyncMiddleware {
             contentType.hasPrefix("text/html")
         {
             response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+            // HTML also opts out of the server-wide response compression
+            // (enabled in bootstrapAppMiddleware): pages embed the per-session
+            // CSRF token, and compressing a secret alongside reflectable
+            // request data is the precondition for BREACH-style compression
+            // oracles.  Static assets carry no secrets and stay compressible.
+            response.headers.responseCompression = .disable
         }
         response.headers.replaceOrAdd(name: "X-Content-Type-Options", value: "nosniff")
         response.headers.replaceOrAdd(name: "X-Frame-Options", value: "SAMEORIGIN")

--- a/Sources/APIServer/Middleware/StaticAssetCacheMiddleware.swift
+++ b/Sources/APIServer/Middleware/StaticAssetCacheMiddleware.swift
@@ -1,0 +1,56 @@
+// APIServer/Middleware/StaticAssetCacheMiddleware.swift
+//
+// Long-lived caching for version-fingerprinted static assets.
+//
+// Templates reference shared assets with a cache-buster query derived from
+// the running build (`/styles.css?v=#appVersion()` — see AppVersionTag), so
+// the URL for a given asset changes on every release.  FileMiddleware serves
+// those responses with an ETag but no Cache-Control, leaving the browser to
+// revalidate every asset on every page view — a conditional round trip per
+// stylesheet/script/icon that also rides the full session middleware chain
+// (Fluent session lookup included).  The bytes behind a versioned URL never
+// change — a deploy mints a new query string — so responses whose `v`
+// matches the running version are cached immutably for a year.
+//
+// Requests with a stale or absent `v` keep FileMiddleware's default ETag
+// revalidation, and responses that already carry a Cache-Control (e.g.
+// runner-core.js's `no-cache` from RunnerWasmCacheMiddleware) are left
+// untouched.  Registered just OUTSIDE FileMiddleware, which short-circuits
+// the chain, so this middleware sees its responses on the way back out.
+
+import Core
+import Vapor
+
+struct StaticAssetCacheMiddleware: AsyncMiddleware {
+    /// Extensions the templates reference with a `?v=` buster.  Anything
+    /// else (HTML pages, dynamic routes) is never stamped.
+    static let cacheableExtensions: Set<String> = [
+        "css", "js", "mjs", "png", "svg", "ico", "jpg", "jpeg", "webp", "woff", "woff2",
+    ]
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let response = try await next.respond(to: request)
+        guard
+            request.method == .GET || request.method == .HEAD,
+            response.status == .ok || response.status == .notModified,
+            response.headers.first(name: .cacheControl) == nil,
+            Self.isCacheableAssetPath(request.url.path),
+            request.query[String.self, at: "v"] == ChickadeeVersion.current
+        else {
+            return response
+        }
+        response.headers.replaceOrAdd(
+            name: .cacheControl, value: "public, max-age=31536000, immutable")
+        return response
+    }
+
+    /// True when the path's final component has a cacheable asset extension.
+    static func isCacheableAssetPath(_ path: String) -> Bool {
+        guard
+            let filename = path.split(separator: "/").last,
+            filename.contains("."),
+            let ext = filename.split(separator: ".").last
+        else { return false }
+        return cacheableExtensions.contains(ext.lowercased())
+    }
+}

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -322,6 +322,23 @@ struct WebRoutes: RouteCollection {
             }
         }
 
+        // Notebook presence drives the Edit button.  The zip-derived answer
+        // costs an `unzip` subprocess per setup, so it is resolved through
+        // NotebookPresenceCache (keyed by zip mtime + size) instead of being
+        // recomputed on every dashboard view.
+        var hasNotebookBySetupID: [String: Bool] = [:]
+        for setup in sortedSetups {
+            let setupID = setup.id ?? ""
+            if let path = setup.notebookPath, !path.isEmpty,
+                FileManager.default.fileExists(atPath: path)
+            {
+                hasNotebookBySetupID[setupID] = true
+            } else {
+                hasNotebookBySetupID[setupID] = await req.application.notebookPresenceCache
+                    .zipContainsNotebook(zipPath: setup.zipPath)
+            }
+        }
+
         let rows = sortedSetups.map { setup -> TestSetupRow in
             let setupID = setup.id ?? ""
             let data = Data(setup.manifest.utf8)
@@ -357,17 +374,9 @@ struct WebRoutes: RouteCollection {
                 status = "unpublished"
                 staffOnly = false
             }
-            let hasNotebook: Bool = {
-                // True when the setup has a flat notebook file on disk, or the zip
-                // contains at least one .ipynb entry.
-                if let path = setup.notebookPath, !path.isEmpty,
-                    FileManager.default.fileExists(atPath: path)
-                {
-                    return true
-                }
-                return listZipEntries(zipPath: setup.zipPath)
-                    .contains { $0.hasSuffix(".ipynb") }
-            }()
+            // True when the setup has a flat notebook file on disk, or the zip
+            // contains at least one .ipynb entry (resolved above via the cache).
+            let hasNotebook = hasNotebookBySetupID[setupID] ?? false
             let vanityBaseURL: String? = {
                 guard let assignment,
                     let courseCode = courseState.active?.code,

--- a/Sources/APIServer/Services/NotebookPresenceCache.swift
+++ b/Sources/APIServer/Services/NotebookPresenceCache.swift
@@ -1,0 +1,73 @@
+// APIServer/Services/NotebookPresenceCache.swift
+//
+// Caches the "does this test setup zip contain a notebook?" answer for the
+// student dashboard.  Answering it fresh shells out to `/usr/bin/unzip`
+// (`listZipEntries`) under the global zip process lock — one subprocess
+// spawn per assignment row per page view, with concurrent dashboard loads
+// serializing behind one another on the lock.  The answer only changes when
+// the zip bytes change, so it is cached keyed by the zip's modification
+// date + size; every zip mutation path repacks the archive in place, which
+// refreshes the mtime and invalidates the entry.
+
+import Foundation
+import Vapor
+
+actor NotebookPresenceCache {
+    private struct CachedAnswer {
+        let zipModified: Date
+        let zipSize: UInt64
+        let hasNotebook: Bool
+    }
+
+    /// Safety valve, not a tuning knob: entries are tiny and keyed by setup
+    /// zip path, so the dictionary grows with the number of test setups ever
+    /// rendered.  Reset wholesale in the unlikely event it grows past this.
+    private static let maxEntries = 4096
+
+    private var answers: [String: CachedAnswer] = [:]
+
+    /// True when the zip at `zipPath` contains at least one `.ipynb` entry.
+    /// Returns false when the zip is missing or unreadable, matching
+    /// `listZipEntries`' empty-list behaviour.
+    func zipContainsNotebook(zipPath: String) -> Bool {
+        guard
+            let attributes = try? FileManager.default.attributesOfItem(atPath: zipPath),
+            let zipModified = attributes[.modificationDate] as? Date
+        else { return false }
+        let zipSize = (attributes[.size] as? UInt64) ?? 0
+
+        if let cached = answers[zipPath],
+            cached.zipModified == zipModified,
+            cached.zipSize == zipSize
+        {
+            return cached.hasNotebook
+        }
+
+        let hasNotebook = listZipEntries(zipPath: zipPath).contains { $0.hasSuffix(".ipynb") }
+        if answers.count >= Self.maxEntries { answers.removeAll() }
+        answers[zipPath] = CachedAnswer(
+            zipModified: zipModified,
+            zipSize: zipSize,
+            hasNotebook: hasNotebook
+        )
+        return hasNotebook
+    }
+}
+
+struct NotebookPresenceCacheKey: StorageKey {
+    typealias Value = NotebookPresenceCache
+}
+
+extension Application {
+    var notebookPresenceCache: NotebookPresenceCache {
+        get {
+            if let existing = storage[NotebookPresenceCacheKey.self] {
+                return existing
+            }
+            let created = NotebookPresenceCache()
+            storage[NotebookPresenceCacheKey.self] = created
+            return created
+        }
+        set { storage[NotebookPresenceCacheKey.self] = newValue }
+    }
+}

--- a/Tests/APITests/NotebookPresenceCacheTests.swift
+++ b/Tests/APITests/NotebookPresenceCacheTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite final class NotebookPresenceCacheTests {
+
+    private let tempDir: URL
+
+    init() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("notebook-presence-cache-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    /// Builds (or rebuilds) `name`.zip from the given entries and returns its path.
+    private func writeZip(name: String, entries: [String: String]) throws -> String {
+        let sourceDir = tempDir.appendingPathComponent("\(name)-src-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        for (entryName, content) in entries {
+            try content.write(
+                to: sourceDir.appendingPathComponent(entryName), atomically: true, encoding: .utf8)
+        }
+        let zipPath = tempDir.appendingPathComponent("\(name).zip").path
+        try repackZipFromDirectory(zipPath: zipPath, sourceDir: sourceDir)
+        return zipPath
+    }
+
+    @Test func zipWithNotebookReportsTrue() async throws {
+        let cache = NotebookPresenceCache()
+        let zipPath = try writeZip(
+            name: "with-notebook",
+            entries: ["assignment.ipynb": "{}", "test_a.sh": "exit 0"]
+        )
+        #expect(await cache.zipContainsNotebook(zipPath: zipPath))
+        // Second lookup is served from cache and must agree.
+        #expect(await cache.zipContainsNotebook(zipPath: zipPath))
+    }
+
+    @Test func zipWithoutNotebookReportsFalse() async throws {
+        let cache = NotebookPresenceCache()
+        let zipPath = try writeZip(name: "no-notebook", entries: ["test_a.sh": "exit 0"])
+        #expect(await cache.zipContainsNotebook(zipPath: zipPath) == false)
+    }
+
+    @Test func missingZipReportsFalse() async throws {
+        let cache = NotebookPresenceCache()
+        let zipPath = tempDir.appendingPathComponent("does-not-exist.zip").path
+        #expect(await cache.zipContainsNotebook(zipPath: zipPath) == false)
+    }
+
+    @Test func rewritingZipInvalidatesCachedAnswer() async throws {
+        let cache = NotebookPresenceCache()
+        let zipPath = try writeZip(
+            name: "mutating",
+            entries: ["assignment.ipynb": "{}", "test_a.sh": "exit 0"]
+        )
+        #expect(await cache.zipContainsNotebook(zipPath: zipPath))
+
+        // Rebuild the same zip path without a notebook — the mtime/size key
+        // changes, so the cached `true` must not be returned.
+        let replacement = try writeZip(name: "mutating-replacement", entries: ["test_a.sh": "exit 0"])
+        try FileManager.default.removeItem(atPath: zipPath)
+        try FileManager.default.copyItem(atPath: replacement, toPath: zipPath)
+        #expect(await cache.zipContainsNotebook(zipPath: zipPath) == false)
+    }
+}

--- a/Tests/APITests/ResponseCompressionTests.swift
+++ b/Tests/APITests/ResponseCompressionTests.swift
@@ -1,0 +1,70 @@
+// Exercises the response-compression configuration end to end.  Compression
+// happens in the HTTP server's channel pipeline, not in middleware, so these
+// tests must run against a real listening server (`.running`) — in-memory
+// tests bypass the compressor entirely.
+
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct ResponseCompressionTests {
+
+    private func makeApp() async throws -> Application {
+        let app = try await Application.make(.testing)
+        app.http.server.configuration.responseCompression = .enabledForCompressibleTypes
+        app.middleware.use(SecurityHeadersMiddleware())
+        // Bodies are repeated text so compression is unambiguously worthwhile.
+        let filler = String(repeating: "body { color: #333; margin: 0 auto; } ", count: 100)
+        app.get("styles.css") { _ -> Response in
+            let res = Response(status: .ok)
+            res.headers.contentType = HTTPMediaType(type: "text", subType: "css")
+            res.body = .init(string: filler)
+            return res
+        }
+        app.get("page") { _ -> Response in
+            let res = Response(status: .ok)
+            res.headers.contentType = .html
+            res.body = .init(string: "<html><body>\(filler)</body></html>")
+            return res
+        }
+        return app
+    }
+
+    @Test func compressibleAssetIsGzippedOverTheWire() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+                .GET, "/styles.css",
+                headers: ["Accept-Encoding": "gzip"]
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .contentEncoding) == "gzip")
+            }
+        }
+    }
+
+    @Test func htmlIsExcludedFromCompression() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+                .GET, "/page",
+                headers: ["Accept-Encoding": "gzip"]
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .contentEncoding) == nil)
+                // The opt-out marker is internal — it must never reach the wire.
+                #expect(res.headers.first(name: "X-Vapor-Response-Compression") == nil)
+            }
+        }
+    }
+
+    @Test func clientWithoutAcceptEncodingGetsIdentity() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+                .GET, "/styles.css"
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .contentEncoding) == nil)
+            }
+        }
+    }
+}

--- a/Tests/APITests/StaticAssetCacheMiddlewareTests.swift
+++ b/Tests/APITests/StaticAssetCacheMiddlewareTests.swift
@@ -1,0 +1,95 @@
+import Core
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct StaticAssetCacheMiddlewareTests {
+
+    private static let immutable = "public, max-age=31536000, immutable"
+
+    private func makeApp() async throws -> Application {
+        let app = try await Application.make(.testing)
+        app.middleware.use(StaticAssetCacheMiddleware())
+        app.get("styles.css") { _ -> Response in
+            let res = Response(status: .ok)
+            res.headers.contentType = HTTPMediaType(type: "text", subType: "css")
+            res.body = .init(string: "body {}")
+            return res
+        }
+        // Mirrors RunnerWasmCacheMiddleware's loader policy: a more specific
+        // Cache-Control set further down the chain must survive.
+        app.get("runner-core.js") { _ -> Response in
+            let res = Response(status: .ok)
+            res.headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+            return res
+        }
+        app.get("page") { _ in "html" }
+        return app
+    }
+
+    @Test func versionedAssetGetsImmutableCacheControl() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .GET, "/styles.css?v=\(ChickadeeVersion.current)"
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .cacheControl) == Self.immutable)
+            }
+        }
+    }
+
+    @Test func unversionedAssetKeepsDefaultRevalidation() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/styles.css") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .cacheControl) == nil)
+            }
+        }
+    }
+
+    @Test func staleVersionIsNotStamped() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/styles.css?v=0.0.0-stale") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .cacheControl) == nil)
+            }
+        }
+    }
+
+    @Test func existingCacheControlIsPreserved() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .GET, "/runner-core.js?v=\(ChickadeeVersion.current)"
+            ) { res async in
+                #expect(res.headers.first(name: .cacheControl) == "no-cache")
+            }
+        }
+    }
+
+    @Test func nonAssetPathIsNotStamped() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .GET, "/page?v=\(ChickadeeVersion.current)"
+            ) { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .cacheControl) == nil)
+            }
+        }
+    }
+
+    @Test(arguments: [
+        ("/styles.css", true),
+        ("/app.js", true),
+        ("/images/chickadee-icon-alt.png", true),
+        ("/vendor/codemirror.js", true),
+        ("/favicon.ico", true),
+        ("/", false),
+        ("/submissions/abc123", false),
+        ("/testsetups/setup_1/notebook", false),
+        ("/noextension", false),
+    ])
+    func isCacheableAssetPath(path: String, expected: Bool) {
+        #expect(StaticAssetCacheMiddleware.isCacheableAssetPath(path) == expected)
+    }
+}

--- a/changelog.d/website-responsiveness-performance.md
+++ b/changelog.d/website-responsiveness-performance.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Website responsiveness pass.** Three hot-path fixes that make page loads
+  feel snappier: (1) the student dashboard no longer spawns an `unzip`
+  subprocess per assignment row on every view — notebook presence is now
+  answered by `NotebookPresenceCache`, keyed by zip mtime + size so any suite
+  edit still invalidates it; (2) version-fingerprinted static assets
+  (`/styles.css?v=…`, page scripts, icons) are now served with
+  `Cache-Control: immutable` via `StaticAssetCacheMiddleware`, eliminating the
+  per-navigation revalidation round trips (each of which also paid a Fluent
+  session lookup) — a release mints new URLs, so busting is unchanged;
+  (3) response compression is enabled for compressible types (CSS/JS/JSON/SVG
+  shrink ~4–8× on the wire). HTML is deliberately excluded from compression
+  because pages embed the per-session CSRF token (BREACH); already-compressed
+  formats (zip, wasm, images) are not recompressed.


### PR DESCRIPTION
## What

Three hot-path fixes that make page loads feel snappier, found by auditing what actually happens per page view:

### 1. Dashboard: stop spawning `unzip` per assignment row (`NotebookPresenceCache`)

`GET /` answered "does this setup have a notebook?" by calling `listZipEntries` — a `/usr/bin/unzip` **subprocess spawn per assignment row, per page view**, serialized behind the global zip process lock. Under a class-wide rush, concurrent dashboards queue behind one another on that lock.

The answer only changes when the zip bytes change, so it's now cached in an actor keyed by the zip's mtime + size. Every zip mutation path repacks the archive in place (refreshing the mtime), so any suite edit invalidates the entry automatically. The cache is seeded eagerly at bootstrap like the other stores, since `Application.storage` writes aren't synchronized.

### 2. Immutable caching for version-fingerprinted assets (`StaticAssetCacheMiddleware`)

Templates already bust caches with `?v=#appVersion()`, but FileMiddleware serves those responses with ETag only — so every navigation paid a conditional round trip per stylesheet/script/icon, each riding the full session chain (Fluent session lookup included).

Since the bytes behind a versioned URL never change (a release mints new URLs), responses whose `v` matches the running `ChickadeeVersion` now get `Cache-Control: public, max-age=31536000, immutable`. Stale/absent `v` keeps ETag revalidation; existing Cache-Control headers (the runner-wasm policies) always win — the middleware never overwrites one. The nav logo now carries the `?v=` buster like every other shared asset.

### 3. Response compression (`.enabledForCompressibleTypes`)

`styles.css` (54 KB) and the page scripts (suite-table.js is 81 KB) shipped uncompressed. Vapor's compressible-types allowlist (text, JS, JSON, SVG) now compresses them ~4–8× on the wire.

Two deliberate exclusions:
- **HTML opts out** per-response in `SecurityHeadersMiddleware`: pages embed the per-session CSRF token, and compressing a secret alongside reflectable request data is the precondition for BREACH-style compression oracles.
- **Already-compressed formats** (zip, wasm, images, fonts) aren't in the allowlist, so the multi-megabyte Pyodide/JupyterLite payloads don't burn CPU recompressing.

## Tests

13 new tests:
- `StaticAssetCacheMiddlewareTests` — stamping on version match, no-op on stale/absent `v`, existing Cache-Control preserved, non-asset paths untouched, plus parameterized path-classification cases.
- `NotebookPresenceCacheTests` — real zips via `repackZipFromDirectory`; presence/absence, missing zip, and rewrite-invalidates-cache.
- `ResponseCompressionTests` — run against a **real listening server** (`.running`), since compression lives in the channel pipeline that in-memory tests bypass: CSS gzips over the wire, HTML stays identity, the internal opt-out marker never reaches the wire, no Accept-Encoding → identity.

Full suite: 1948/1951 pass locally; the 3 failures (`DraftSupportFilesTests`, `MCPModeScopeContractTests`, `SuiteSectionToolsTests`) only occur when all 204 suites share one process (250+ s timeouts, `.connectionRequestTimeout`) and pass cleanly in isolation — they're load flakes of a configuration CI doesn't use (CI runs targets separately, APITests non-parallel).

## Future work (not in this PR)

- The `index` handler issues ~13 sequential DB round trips; several groups are independent and could run under `async let` (worth it once the subprocess cost is gone, if dashboard latency is still visible).
- Other `listZipEntries` call sites (instructor editor paths) are single-setup per request and were left fresh-reading deliberately.

https://claude.ai/code/session_01Q1jnh9yCnzGAdm78Fd3uC4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1jnh9yCnzGAdm78Fd3uC4)_