### PR TITLE
Parallelize the student dashboard's independent DB reads

### DIFF
--- a/Sources/APIServer/Routes/Web/WebRoutes+IndexLoading.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+IndexLoading.swift
@@ -1,0 +1,98 @@
+// APIServer/Routes/Web/WebRoutes+IndexLoading.swift
+//
+// Batched data-loading helpers for the student dashboard (GET /).  Extracted
+// from the index handler so the independent reads can run concurrently via
+// `async let` — the handler previously issued every query sequentially, so a
+// dashboard view paid each DB round trip back to back.  Each helper owns its
+// own applicability guard and returns an empty value when it doesn't apply,
+// which keeps the call site a flat set of `async let` bindings.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension WebRoutes {
+    /// Per-user active extensions keyed by testSetupID (the dashboard works
+    /// in setup space; the assignment for each row is looked up separately).
+    /// Loaded before the student visibility filter so an
+    /// auto-closed-at-deadline assignment the student was granted more time
+    /// on still appears in their list.
+    static func loadExtensionDueDates(
+        user: APIUser,
+        allAssignments: [APIAssignment],
+        db: any Database
+    ) async throws -> [String: Date] {
+        guard let userID = user.id, !allAssignments.isEmpty else { return [:] }
+        let assignmentIDs = allAssignments.compactMap(\.id)
+        let extensions = try await APIAssignmentExtension.query(on: db)
+            .filter(\.$assignmentID ~~ Set(assignmentIDs))
+            .filter(\.$userID == userID)
+            .all()
+        let setupIDByAssignmentID = setupIDByAssignmentID(allAssignments)
+        var dueAtBySetupID: [String: Date] = [:]
+        for row in extensions {
+            guard let setupID = setupIDByAssignmentID[row.assignmentID] else { continue }
+            dueAtBySetupID[setupID] = row.extendedDueAt
+        }
+        return dueAtBySetupID
+    }
+
+    /// Setup IDs of assignments the current student has previously engaged
+    /// with.  Engagement = a durable participation row, or a student
+    /// submission (the latter also bridges students who submitted before the
+    /// participation table existed).  Closed assignments in this set stay
+    /// visible (read-only review) and keep their Edit link.  Empty for
+    /// instructors/admins — they already see every setup in the course.  The
+    /// two engagement reads are independent and run concurrently.
+    static func loadPreviouslyOpenedSetupIDs(
+        user: APIUser,
+        allAssignments: [APIAssignment],
+        db: any Database
+    ) async throws -> Set<String> {
+        guard !user.isInstructor, let userID = user.id, !allAssignments.isEmpty else { return [] }
+        let allSetupIDs = Set(allAssignments.map(\.testSetupID))
+        let setupIDByAssignmentID = setupIDByAssignmentID(allAssignments)
+
+        async let submittedFetch = APISubmission.query(on: db)
+            .filter(\.$userID == userID)
+            .filter(\.$testSetupID ~~ allSetupIDs)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .all()
+        async let participationsFetch = APIAssignmentParticipation.query(on: db)
+            .filter(\.$userID == userID)
+            .filter(\.$assignmentID ~~ Set(setupIDByAssignmentID.keys))
+            .all()
+
+        var opened = Set(try await submittedFetch.map(\.testSetupID))
+        for row in try await participationsFetch {
+            if let setupID = setupIDByAssignmentID[row.assignmentID] {
+                opened.insert(setupID)
+            }
+        }
+        return opened
+    }
+
+    /// Sections for the active course, used to group the dashboard rows.
+    static func loadCourseSections(
+        activeCourseUUID: UUID?,
+        db: any Database
+    ) async throws -> [APICourseSection] {
+        guard let activeCourseUUID else { return [] }
+        return try await APICourseSection.query(on: db)
+            .filter(\.$courseID == activeCourseUUID)
+            .sort(\.$sortOrder, .ascending)
+            .all()
+    }
+
+    private static func setupIDByAssignmentID(
+        _ assignments: [APIAssignment]
+    ) -> [UUID: String] {
+        Dictionary(
+            uniqueKeysWithValues: assignments.compactMap { assignment -> (UUID, String)? in
+                guard let id = assignment.id else { return nil }
+                return (id, assignment.testSetupID)
+            }
+        )
+    }
+}

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -84,63 +84,20 @@ struct WebRoutes: RouteCollection {
             uniquingKeysWith: { first, _ in first }
         )
 
-        // Per-user active extensions for the current user, keyed by
-        // testSetupID (the dashboard works in setup space; the assignment for
-        // each row is looked up separately).  Loaded before the student
-        // visibility filter so an auto-closed-at-deadline assignment the
-        // student was granted more time on still appears in their list.
-        var extensionDueAtBySetupID: [String: Date] = [:]
-        if let userID = user.id, !allAssignments.isEmpty {
-            let assignmentIDs = allAssignments.compactMap(\.id)
-            let extensions = try await APIAssignmentExtension.query(on: req.db)
-                .filter(\.$assignmentID ~~ Set(assignmentIDs))
-                .filter(\.$userID == userID)
-                .all()
-            let setupIDByAssignmentID = Dictionary(
-                uniqueKeysWithValues: allAssignments.compactMap { a -> (UUID, String)? in
-                    guard let id = a.id else { return nil }
-                    return (id, a.testSetupID)
-                }
-            )
-            for row in extensions {
-                guard let setupID = setupIDByAssignmentID[row.assignmentID] else { continue }
-                extensionDueAtBySetupID[setupID] = row.extendedDueAt
-            }
-        }
+        // The three independent reads that key off the assignment list run
+        // concurrently (helpers in WebRoutes+IndexLoading.swift): per-user
+        // extensions, prior engagement (keeps closed assignments visible),
+        // and the course sections used to group rows at the bottom of the
+        // page.
+        async let extensionsFetch = Self.loadExtensionDueDates(
+            user: user, allAssignments: allAssignments, db: req.db)
+        async let previouslyOpenedFetch = Self.loadPreviouslyOpenedSetupIDs(
+            user: user, allAssignments: allAssignments, db: req.db)
+        async let sectionsFetch = Self.loadCourseSections(
+            activeCourseUUID: courseState.activeCourseUUID, db: req.db)
 
-        // Closed assignments the current student has previously engaged with
-        // stay visible (read-only review) and keep their Edit link.  Engagement
-        // = a durable participation row, or a student submission (the latter
-        // also bridges students who submitted before the participation table
-        // existed).  Empty for instructors/admins — they already see every
-        // setup in the course.
-        var previouslyOpenedSetupIDs = Set<String>()
-        if !user.isInstructor, let userID = user.id, !allAssignments.isEmpty {
-            let allSetupIDs = Set(allAssignments.map(\.testSetupID))
-            let submittedSetupIDs = try await APISubmission.query(on: req.db)
-                .filter(\.$userID == userID)
-                .filter(\.$testSetupID ~~ allSetupIDs)
-                .filter(\.$kind == APISubmission.Kind.student)
-                .all()
-                .map(\.testSetupID)
-            previouslyOpenedSetupIDs.formUnion(submittedSetupIDs)
-
-            let setupIDByParticipationAssignment = Dictionary(
-                uniqueKeysWithValues: allAssignments.compactMap { a -> (UUID, String)? in
-                    guard let id = a.id else { return nil }
-                    return (id, a.testSetupID)
-                }
-            )
-            let participations = try await APIAssignmentParticipation.query(on: req.db)
-                .filter(\.$userID == userID)
-                .filter(\.$assignmentID ~~ Set(setupIDByParticipationAssignment.keys))
-                .all()
-            for row in participations {
-                if let setupID = setupIDByParticipationAssignment[row.assignmentID] {
-                    previouslyOpenedSetupIDs.insert(setupID)
-                }
-            }
-        }
+        let extensionDueAtBySetupID = try await extensionsFetch
+        let previouslyOpenedSetupIDs = try await previouslyOpenedFetch
 
         let setups: [APITestSetup]
         if user.isInstructor {
@@ -190,19 +147,22 @@ struct WebRoutes: RouteCollection {
             let setupIDs = setups.compactMap(\.id)
             if !setupIDs.isEmpty {
                 // Instructor grade overrides for this student take precedence
-                // over the runner-computed best grade below.
-                let overrideMap = try await loadGradeOverridePercents(setupIDs: setupIDs, on: req.db)
-                for setupID in setupIDs {
-                    if let pct = overrideMap[GradeOverrideKey(setupID: setupID, userID: userID)] {
-                        overridePercentBySetupID[setupID] = pct
-                    }
-                }
-                let submissions = try await APISubmission.query(on: req.db)
+                // over the runner-computed best grade below.  The override and
+                // submission reads are independent and run concurrently.
+                async let overridesFetch = loadGradeOverridePercents(setupIDs: setupIDs, on: req.db)
+                async let submissionsFetch = APISubmission.query(on: req.db)
                     .filter(\.$userID == userID)
                     .filter(\.$testSetupID ~~ setupIDs)
                     .filter(\.$kind == APISubmission.Kind.student)
                     .sort(\.$submittedAt, .descending)
                     .all()
+                let overrideMap = try await overridesFetch
+                for setupID in setupIDs {
+                    if let pct = overrideMap[GradeOverrideKey(setupID: setupID, userID: userID)] {
+                        overridePercentBySetupID[setupID] = pct
+                    }
+                }
+                let submissions = try await submissionsFetch
 
                 var grouped: [String: [APISubmission]] = [:]
                 for submission in submissions {
@@ -222,10 +182,22 @@ struct WebRoutes: RouteCollection {
 
                 let submissionIDs = submissions.compactMap(\.id)
                 if !submissionIDs.isEmpty {
-                    let resultRows = try await APIResult.query(on: req.db)
+                    // Results plus the three achievement reads only share
+                    // inputs computed above, so all four run concurrently.
+                    async let resultsFetch = APIResult.query(on: req.db)
                         .filter(\.$submissionID ~~ submissionIDs)
                         .sort(\.$receivedAt, .descending)
                         .all()
+                    async let disabledFetch = BuiltInAchievements.disabledBySetup(
+                        setupIDs: Array(setupIDs), on: req.db)
+                    async let perSubFetch = BuiltInAchievements.manifestPerSubmissionBySetup(
+                        setupIDs: Array(setupIDs), on: req.db)
+                    // Class-wide badges this user currently holds across all setups.
+                    async let classAchievementsFetch = APIClassAchievement.query(on: req.db)
+                        .filter(\.$userID == userID)
+                        .filter(\.$testSetupID ~~ setupIDs)
+                        .all()
+                    let resultRows = try await resultsFetch
 
                     // Keep one preferred result per submission:
                     // worker result first; browser result only if no worker exists.
@@ -258,10 +230,8 @@ struct WebRoutes: RouteCollection {
                         }
                     }
 
-                    let disabledBySetup = try await BuiltInAchievements.disabledBySetup(
-                        setupIDs: Array(setupIDs), on: req.db)
-                    let perSubBySetup = try await BuiltInAchievements.manifestPerSubmissionBySetup(
-                        setupIDs: Array(setupIDs), on: req.db)
+                    let disabledBySetup = try await disabledFetch
+                    let perSubBySetup = try await perSubFetch
                     for (setupID, latest) in latestSubmissionBySetupID {
                         guard let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
                             let result = preferredResultBySubmissionID[latest.submissionID],
@@ -289,11 +259,7 @@ struct WebRoutes: RouteCollection {
                             disabled: disabledBySetup[setupID] ?? [])
                     }
 
-                    // Batch-query class-wide badges this user currently holds across all setups.
-                    let classAchievements = try await APIClassAchievement.query(on: req.db)
-                        .filter(\.$userID == userID)
-                        .filter(\.$testSetupID ~~ setupIDs)
-                        .all()
+                    let classAchievements = try await classAchievementsFetch
                     for ach in classAchievements {
                         if let badge = AchievementBadge.forClassAchievement(
                             ach.achievementID, disabled: disabledBySetup[ach.testSetupID] ?? [])
@@ -444,16 +410,9 @@ struct WebRoutes: RouteCollection {
             )
         }
 
-        // Fetch sections for the active course to enable grouped display.
-        let allSections: [APICourseSection]
-        if let activeCourseUUID = courseState.activeCourseUUID {
-            allSections = try await APICourseSection.query(on: req.db)
-                .filter(\.$courseID == activeCourseUUID)
-                .sort(\.$sortOrder, .ascending)
-                .all()
-        } else {
-            allSections = []
-        }
+        // Sections for the active course (fetch started up top) enable the
+        // grouped display below.
+        let allSections = try await sectionsFetch
 
         // Build lookup: testSetupID → section UUID
         let sectionBySetupID: [String: UUID] = Dictionary(

--- a/changelog.d/dashboard-query-parallelization.md
+++ b/changelog.d/dashboard-query-parallelization.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Dashboard queries parallelized.** The student dashboard's independent DB
+  reads now run concurrently via `async let` (extensions, prior engagement,
+  course sections; grade overrides + submissions; results + achievement
+  lookups), cutting the handler's sequential round trips roughly in half.
+  The engagement/extension/section loaders moved to
+  `WebRoutes+IndexLoading.swift`. No behaviour change — same queries, same
+  results, fewer back-to-back waits.


### PR DESCRIPTION
## What

Follow-up to #912's future-work note: the dashboard handler (`GET /`) issued every DB query sequentially — ~13 round trips back to back. The independent reads now run concurrently via `async let`, following the established pattern in `StudentCourseRoutes+History.swift`:

- **After the assignment list loads:** per-user extensions, prior engagement (the visibility set for closed assignments), and the course sections all start together; the engagement loader's two queries (submissions + participations) also overlap internally.
- **After the visible setups resolve:** grade overrides + the student's submissions run together.
- **After submissions resolve:** results + disabled/per-submission achievement lookups + class achievements run together (they share only inputs computed above).

The extension/engagement/section loaders moved to `WebRoutes+IndexLoading.swift`, each owning its applicability guard and returning an empty value when it doesn't apply — so the call site is a flat set of `async let` bindings and the (already SwiftLint-exempted) index handler loses ~40 lines.

No behaviour change: same queries, same predicates, same result handling — just fewer back-to-back waits.

## Tests

No new tests — this is a pure scheduling change covered by the existing suites, all green locally: `WebRoutesIndexTests` (14), `AssignmentExtensionsTests`, `AssignmentRoutesDashboardTests`, `ExtensionCSRFTokenTests`, `NotebookWebRoutesTests`. Format, swift-format lint, and SwiftLint (0 violations) pass.

https://claude.ai/code/session_01Q1jnh9yCnzGAdm78Fd3uC4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1jnh9yCnzGAdm78Fd3uC4)_