### PR TITLE
ci: pass --merge to git-restore-mtime so merge-commit changes rebuild

### DIFF
--- a/.github/actions/restore-git-mtimes/action.yml
+++ b/.github/actions/restore-git-mtimes/action.yml
@@ -19,8 +19,17 @@ runs:
 
     # The container runs git as a different uid than checkout used, so mark
     # the workspace safe before invoking git.
+    #
+    # --merge: by default git-restore-mtime IGNORES merge commits, so a file
+    # whose only change is part of a merge commit (a branch updated via
+    # "Update branch" / `git merge main`, or the synthetic PR merge ref
+    # itself) keeps the mtime of its last REGULAR commit — which matches the
+    # restored .build/ cache, so llbuild reuses a stale module and dependents
+    # fail with "cannot find type" / undefined-symbol errors (#342 and #629
+    # both hit this). --merge applies merge commits' dates to files no
+    # regular commit explains, restoring soundness for merge-heavy branches.
     - name: Restore source mtimes from git history
       shell: bash
       run: |
         git config --global --add safe.directory '*'
-        git restore-mtime
+        git restore-mtime --merge


### PR DESCRIPTION
## Summary

`git restore-mtime` (used by the `build` job to keep the restored `.build/` cache sound) **ignores merge commits by default**. A file whose only change is part of a merge commit — a PR branch updated via `git merge main`, or the synthetic `pull/N/merge` ref CI checks out — keeps the mtime of its last *regular* commit. That matches the state the restored cache was built from, so llbuild reuses the stale module and dependent targets fail:

- #342's `build` job failed with undefined-reference link errors (`Core.BundledSection`) — the changed `CourseBundleManifest.swift` only existed in a merge commit, so Core was never recompiled. The v4 `CACHE_SALT` bump worked around it via a clean build, but didn't fix the class.
- #629's `build` job failed with `cannot find type 'BrightSpaceGrading' in scope` — same mechanism: `BrightSpaceAPIClient.swift`'s change lives in a merge commit, APIServer wasn't recompiled, and the test module compiled against the stale cached module.

## Fix

Pass `--merge`, which applies merge-commit dates to files that no regular commit explains. Files touched by a merge get a fresh mtime → llbuild recompiles them → incremental builds on restored caches are sound for merge-updated branches. Ordinary single-commit PRs are unaffected.

## Test plan

- [ ] CI green on this PR (normal commit, unaffected path)
- [ ] Re-run #629 / #800 `build` jobs after merge — their merge refs pick this up automatically and should now recompile the changed modules

https://claude.ai/code/session_01EFUgiFS5YZrd6smdBXN8iQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFUgiFS5YZrd6smdBXN8iQ)_