### PR TITLE
build(deps): bump swift-crypto from 3.15.1 to 4.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "42814e2b1fc4f5e95374b6533d31a1c3db887939f112021db9c13451d7e00845",
+  "originHash" : "c7f392d0bc090266c6128e117fbcce14d7731f25d6b0c0bf47c9965603201a0b",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/leaf.git", from: "4.5.1"),
         .package(url: "https://github.com/vapor/jwt.git", from: "5.1.2"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.15.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.0"),
         .package(url: "https://github.com/vapor-community/CSRF.git", from: "3.1.1"),
         // SwiftLint via SimplyDanny's plugin distribution: ships a pre-built
         // binary so CI / fresh checkouts don't pay a SwiftLint-from-source build.


### PR DESCRIPTION
## Summary

Supersedes #580. Dependabot's branch was stale against main's `Package.resolved` (after the argument-parser and swiftlintplugins bumps) and its rebase request never ran, so this is the same bump rebuilt on current main: cherry-picked dependabot's commit, then re-ran `swift package resolve` so the pin and `originHash` are regenerated by SwiftPM (4-line diff).

## Why take the 4.x major

- 4.x's "breaking" change is dropping Swift < 6.1 — this repo is on Swift 6.3.
- 4.3.1 includes the **CVE-2026-28815** fix (X-Wing HPKE decapsulation input validation). Not an API Chickadee calls directly, but staying on a patched line is the right default for a crypto dependency.
- The APIs Chickadee uses (`HMAC<SHA256>`, `SymmetricKey`, SHA-256 digests, and what JWTKit/Vapor pull transitively) are unchanged across 3→4.

## Verification

- Full local build against 4.5.0 ✅
- 81 tests across 22 crypto-touching suites pass locally: MCP OAuth flow (ES256 token authority, PKCE, refresh rotation), SSO auth flow, worker HMAC signing, CSRF, session keep-alive.
- #580's own CI was fully green on this same version pair back in May.

https://claude.ai/code/session_01EFUgiFS5YZrd6smdBXN8iQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFUgiFS5YZrd6smdBXN8iQ)_