### PR TITLE
docs: changelog fragment for the swift-crypto 4.5.0 bump

### DIFF
--- a/changelog.d/swift-crypto-4.md
+++ b/changelog.d/swift-crypto-4.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **swift-crypto bumped 3.15.1 → 4.5.0** (#916, supersedes #580). The 4.x
+  line's breaking change is dropping Swift < 6.1 (Chickadee is on 6.3) and it
+  includes the upstream CVE-2026-28815 X-Wing HPKE fix. The HMAC/SHA-256 and
+  JWT APIs Chickadee uses are unchanged; verified against the MCP OAuth
+  (ES256), SSO, and worker HMAC test suites.


### PR DESCRIPTION
## Summary

#916 (swift-crypto 3.15.1 → 4.5.0) merged without a `changelog.d/` fragment, so the auto-release workflow skipped it — the latest tag **v0.4.427** sits one commit behind main and the deployed `:latest` image doesn't include the crypto bump.

This adds the missing fragment. On merge, auto-release folds it, bumps to the next version, tags it, and the tag build pushes the Docker image — getting the crypto bump (and everything before it) onto deployed servers.

No code changes; one new markdown file under `changelog.d/`.

https://claude.ai/code/session_01EFUgiFS5YZrd6smdBXN8iQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFUgiFS5YZrd6smdBXN8iQ)_