### PR TITLE
Add MCP get_validation_result tool for reading validation runs

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -184,6 +184,11 @@ enum MCPServerInstructions {
         queued -> running -> done progress over an SSE connection), then re-open with \
         update_assignment(visibility:"open") — or visibility:"preview" to beta-test as staff first — \
         once it passes (opening and previewing are refused until it does). \
+        When validation fails, call get_validation_result for the per-test outcomes of your reference \
+        solution's latest run — each check's status plus shortResult/longResult, across all tiers — so \
+        you can see which check failed and why before fixing the suite or solution. It is \
+        validation-only: it resolves the instructor's own reference-solution run and never exposes a \
+        student submission, identity, or grade. \
         Metadata-only edits (update_assignment, set_grading_mode, the section-organization tools) \
         never trigger a regrade or a close.
         - update_notebook replaces only the starter notebook; students keep their in-progress copies \

--- a/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
@@ -1,0 +1,195 @@
+// APIServer/MCP/Tools/GetValidationResultTool.swift
+//
+// Read tool: returns the per-test outcomes of an assignment's latest VALIDATION
+// run (the instructor's reference solution graded against the current suite), by
+// assignment public ID. content:read, course-scoped.
+//
+// This closes the diagnosis loop that `validate_assignment` leaves open: that
+// tool reports only a single word (passed/failed/no-runner), so a failing suite
+// can't be diagnosed without a human copying the per-test grid out of the web
+// UI. Here the agent sees which check failed and why (shortResult / longResult),
+// so it can fix the suite or solution on the instructor's behalf.
+//
+// Hard guardrails (see docs/mcp-validation-access.md):
+//   * Validation submissions ONLY. The submission is resolved from the
+//     assignment (linked validation submission, else the most recent
+//     `kind == .validation` for the setup) and filtered to `.validation`; a
+//     student submission is never reachable, and no raw submission id is
+//     accepted.
+//   * Course-scoped authorization, identical to every other content tool.
+//   * The DTO carries no student identity, grade, or roster — only the
+//     instructor's own reference-solution run. `submissionID` / `userID` are
+//     dropped. All tiers are returned (the agent needs secret-tier outcomes to
+//     debug the suite); this is the same instructor-authored trust tier already
+//     exposed by get_solution / get_suite.
+
+import Core
+import Fluent
+import Foundation
+
+struct GetValidationResultTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+    }
+
+    struct OutcomeDTO: Encodable, Sendable {
+        let testName: String
+        let tier: String
+        let status: String
+        let points: Int
+        let shortResult: String
+        let longResult: String?
+    }
+
+    struct Counts: Encodable, Sendable {
+        let total: Int
+        let pass: Int
+        let fail: Int
+        let error: Int
+        let timeout: Int
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        /// The assignment's current `validationStatus`: passed | failed |
+        /// no-runner | pending | none. Mirrors validate_assignment.
+        let validationStatus: String
+        /// When the run that produced `outcomes` completed (ISO 8601); nil when
+        /// no validation result exists yet.
+        let ranAt: String?
+        /// Collection-level build status: passed | failed | skipped (nil when no
+        /// result yet). A failed build means `outcomes` is empty.
+        let buildStatus: String?
+        let compilerOutput: String?
+        let warnings: [String]
+        let outcomes: [OutcomeDTO]
+        let counts: Counts?
+    }
+
+    static let name = "get_validation_result"
+    static let description =
+        "Get the per-test outcomes of an assignment's latest VALIDATION run (the instructor's reference "
+        + "solution graded against the current suite), by assignment public ID. Unlike validate_assignment "
+        + "(which returns only passed/failed/no-runner), this returns each check's status and its "
+        + "shortResult/longResult so you can see WHICH test failed and WHY, then fix the suite or solution. "
+        + "Validation runs only — it resolves the instructor's own reference-solution run from the "
+        + "assignment and never accepts or returns a student submission, identity, or grade. All tiers "
+        + "(public/release/secret/student) are included so secret-tier failures are visible. A pending or "
+        + "missing run returns the current validationStatus with empty outcomes."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ])
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "validationStatus": .object(["type": .string("string")]),
+            "ranAt": .object(["type": .array([.string("string"), .string("null")])]),
+            "buildStatus": .object(["type": .array([.string("string"), .string("null")])]),
+            "compilerOutput": .object(["type": .array([.string("string"), .string("null")])]),
+            "warnings": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
+            "outcomes": .object(["type": .string("array")]),
+            "counts": .object(["type": .array([.string("object"), .string("null")])]),
+        ]),
+        "required": .array([
+            .string("assignmentPublicID"), .string("validationStatus"), .string("outcomes"),
+        ]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: true, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let assignment = try await context.authorizedAssignment(
+            publicID: input.assignmentPublicID, tool: Self.name)
+        let status = assignment.validationStatus ?? "none"
+
+        guard let submission = try await resolveValidationSubmission(assignment: assignment, on: context.db)
+        else {
+            return Self.empty(assignmentPublicID: assignment.publicID, validationStatus: status)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard
+            let result = try await APIResult.query(on: context.db)
+                .filter(\.$submissionID == submission.requireID())
+                .sort(\.$receivedAt, .descending)
+                .first(),
+            let data = result.collectionJSON.data(using: .utf8),
+            let collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+        else {
+            return Self.empty(assignmentPublicID: assignment.publicID, validationStatus: status)
+        }
+
+        let outcomes = collection.outcomes.map {
+            OutcomeDTO(
+                testName: $0.testName,
+                tier: $0.tier.rawValue,
+                status: $0.status.rawValue,
+                points: $0.points,
+                shortResult: $0.shortResult,
+                longResult: $0.longResult)
+        }
+
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            validationStatus: status,
+            ranAt: ISO8601DateFormatter().string(from: collection.timestamp),
+            buildStatus: collection.buildStatus.rawValue,
+            compilerOutput: collection.compilerOutput,
+            warnings: collection.warnings,
+            outcomes: outcomes,
+            counts: Counts(
+                total: collection.totalTests,
+                pass: collection.passCount,
+                fail: collection.failCount,
+                error: collection.errorCount,
+                timeout: collection.timeoutCount))
+    }
+
+    /// Resolves the assignment's validation (reference-solution) submission,
+    /// never a student one: the linked validation submission if present and
+    /// still `kind == .validation`, else the most recent `.validation`
+    /// submission for the setup. Mirrors `loadExistingSolution`'s resolver,
+    /// filtered to validation submissions.
+    private func resolveValidationSubmission(
+        assignment: APIAssignment, on db: any Database
+    ) async throws -> APISubmission? {
+        if let validationID = assignment.validationSubmissionID,
+            let linked = try await APISubmission.find(validationID, on: db),
+            linked.kind == APISubmission.Kind.validation
+        {
+            return linked
+        }
+        return try await APISubmission.query(on: db)
+            .filter(\.$testSetupID == assignment.testSetupID)
+            .filter(\.$kind == APISubmission.Kind.validation)
+            .sort(\.$submittedAt, .descending)
+            .first()
+    }
+
+    /// The pending / no-result-yet response: the current status with no outcomes
+    /// (mirrors validate_assignment's pending state).
+    private static func empty(assignmentPublicID: String, validationStatus: String) -> Output {
+        Output(
+            assignmentPublicID: assignmentPublicID,
+            validationStatus: validationStatus,
+            ranAt: nil,
+            buildStatus: nil,
+            compilerOutput: nil,
+            warnings: [],
+            outcomes: [],
+            counts: nil)
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -27,6 +27,7 @@ enum MCPToolCatalog {
             GetGlobalInputsTool().erased(),
             PreviewPersonalizationTool().erased(),
             ValidateAssignmentTool().erased(),
+            GetValidationResultTool().erased(),
             UpdateAssignmentTool().erased(),
             SetGradingModeTool().erased(),
             UpdateSuiteTool().erased(),

--- a/Tests/APITests/MCP/GetValidationResultToolTests.swift
+++ b/Tests/APITests/MCP/GetValidationResultToolTests.swift
@@ -1,0 +1,205 @@
+// Tests for GetValidationResultTool: it surfaces the per-test outcomes of an
+// assignment's reference-solution validation run, resolves the validation
+// submission the same way get_solution does (linked, else most-recent
+// validation), and never reaches a student submission. Backed by a real test
+// database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct GetValidationResultToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read]
+        )
+    }
+
+    /// Course + enrolled instructor "tester" + setup + assignment.
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_val", courseID: courseID)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_val", courseID: courseID, title: "Lab")
+    }
+
+    private func testerID(on app: Application) async throws -> UUID {
+        try await #require(
+            APIUser.query(on: app.db).filter(\.$username == "tester").first()
+        ).requireID()
+    }
+
+    private func outcome(
+        _ name: String, _ status: TestStatus, tier: TestTier = .pub, short: String,
+        long: String? = nil
+    ) -> TestOutcome {
+        TestOutcome(
+            testName: name, testClass: nil, tier: tier, status: status, shortResult: short,
+            longResult: long, executionTimeMs: 1, memoryUsageBytes: nil, attemptNumber: 1,
+            isFirstPassSuccess: status == .pass)
+    }
+
+    private func collectionJSON(
+        submissionID: String, outcomes: [TestOutcome], buildStatus: BuildStatus = .passed
+    ) throws -> String {
+        let collection = TestOutcomeCollection(
+            submissionID: submissionID, testSetupID: "setup_val", attemptNumber: 1,
+            buildStatus: buildStatus, compilerOutput: buildStatus == .failed ? "boom" : nil,
+            outcomes: outcomes, totalTests: outcomes.count,
+            passCount: outcomes.filter { $0.status == .pass }.count,
+            failCount: outcomes.filter { $0.status == .fail }.count,
+            errorCount: outcomes.filter { $0.status == .error }.count,
+            timeoutCount: outcomes.filter { $0.status == .timeout }.count,
+            executionTimeMs: 5, runnerVersion: "shell-runner/1.0", timestamp: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(collection)
+        return try #require(String(data: data, encoding: .utf8))
+    }
+
+    private func run(
+        _ app: Application, publicID: String
+    ) async throws
+        -> GetValidationResultTool.Output
+    {
+        try await GetValidationResultTool().execute(
+            GetValidationResultTool.Input(assignmentPublicID: publicID), context(app))
+    }
+
+    // MARK: - Happy path
+
+    @Test func returnsPerTestOutcomesForLinkedValidation() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            try await makeTestSubmission(
+                on: app, id: "sub_val", setupID: "setup_val", userID: testerID(on: app),
+                kind: APISubmission.Kind.validation)
+            try await makeTestResult(
+                on: app, submissionID: "sub_val",
+                collectionJSON: collectionJSON(
+                    submissionID: "sub_val",
+                    outcomes: [
+                        outcome("df is loaded", .pass, short: "ok"),
+                        outcome(
+                            "two charts", .fail, tier: .secret,
+                            short: "too few figures", long: "expected at least: 2\ngot: 0"),
+                    ]))
+            assignment.validationSubmissionID = "sub_val"
+            assignment.validationStatus = "failed"
+            try await assignment.save(on: app.db)
+
+            let output = try await run(app, publicID: assignment.publicID)
+
+            #expect(output.validationStatus == "failed")
+            #expect(output.buildStatus == "passed")
+            #expect(output.outcomes.count == 2)
+            #expect(output.counts?.pass == 1)
+            #expect(output.counts?.fail == 1)
+            #expect(output.ranAt != nil)
+            let failing = try #require(output.outcomes.first { $0.status == "fail" })
+            #expect(failing.tier == "secret")  // secret-tier failures are visible
+            #expect(failing.longResult?.contains("got: 0") == true)
+        }
+    }
+
+    @Test func resolvesMostRecentValidationWhenNoLink() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // No validationSubmissionID link; a validation submission + result
+            // exists for the setup and should be resolved by the fallback.
+            try await makeTestSubmission(
+                on: app, id: "sub_fallback", setupID: "setup_val", userID: testerID(on: app),
+                kind: APISubmission.Kind.validation)
+            try await makeTestResult(
+                on: app, submissionID: "sub_fallback",
+                collectionJSON: collectionJSON(
+                    submissionID: "sub_fallback",
+                    outcomes: [outcome("only check", .pass, short: "ok")]))
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: app.db)
+
+            let output = try await run(app, publicID: assignment.publicID)
+            #expect(output.validationStatus == "passed")
+            #expect(output.outcomes.count == 1)
+            #expect(output.outcomes.first?.testName == "only check")
+        }
+    }
+
+    // MARK: - Guardrails
+
+    @Test func neverSurfacesStudentSubmissions() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // A graded STUDENT submission + result exists, but no validation run.
+            // The tool must not resolve or surface the student's result.
+            try await makeTestSubmission(
+                on: app, id: "sub_student", setupID: "setup_val", userID: testerID(on: app),
+                kind: APISubmission.Kind.student)
+            try await makeTestResult(
+                on: app, submissionID: "sub_student",
+                collectionJSON: collectionJSON(
+                    submissionID: "sub_student",
+                    outcomes: [outcome("student secret", .pass, short: "leaked?")]))
+            assignment.validationStatus = "pending"
+            try await assignment.save(on: app.db)
+
+            let output = try await run(app, publicID: assignment.publicID)
+            #expect(output.outcomes.isEmpty)
+            #expect(output.counts == nil)
+            #expect(output.validationStatus == "pending")
+        }
+    }
+
+    @Test func emptyWhenNoResultYet() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            try await assignment.save(on: app.db)
+
+            let output = try await run(app, publicID: assignment.publicID)
+            #expect(output.outcomes.isEmpty)
+            #expect(output.validationStatus == "none")  // no validationStatus set yet
+            #expect(output.ranAt == nil)
+        }
+    }
+
+    @Test func unknownAssignmentThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(app, publicID: "zzzzzz")
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_val", courseID: courseID)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_val", courseID: courseID, title: "Lab")
+            assignment.validationStatus = "failed"
+            try await assignment.save(on: app.db)
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(app, publicID: assignment.publicID)
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-get-validation-result.md
+++ b/changelog.d/mcp-get-validation-result.md
@@ -1,0 +1,11 @@
+### Added
+
+- **MCP `get_validation_result` tool.** An authorized agent can now read the
+  per-test outcomes of an assignment's latest validation run (each check's
+  status plus `shortResult`/`longResult`, across all tiers), closing the
+  diagnosis loop that `validate_assignment` left open — it reported only
+  passed/failed/no-runner, so a failing suite couldn't be diagnosed without a
+  human copying the per-test grid out of the web UI. The tool is
+  `content:read`, course-scoped, and validation-only: it resolves the
+  instructor's own reference-solution run from the assignment and never accepts
+  or returns a student submission, identity, or grade.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -37,6 +37,7 @@ course-scoped:
 | `get_global_inputs` | `content:read` | Assignment personalization: global variables + per-student expressions |
 | `preview_personalization` | `content:read` | Resolve a seed's `name → value` map + a starter-notebook `{{placeholder}}` audit |
 | `validate_assignment` | `content:read` | Watch validation to completion; live SSE progress |
+| `get_validation_result` | `content:read` | Per-test outcomes of the reference solution's latest validation run (status + shortResult/longResult, all tiers); validation-only, never student data |
 | `update_assignment` | `content:write` | Metadata: title, due date, visibility (closed/preview/open) |
 | `set_grading_mode` | `content:write` | Set an assignment's grading path (worker vs browser); no regrade/close |
 | `update_suite` | `content:write` | Script metadata: tier, points, displayName, dependsOn, section |

--- a/docs/mcp-validation-access.md
+++ b/docs/mcp-validation-access.md
@@ -1,7 +1,8 @@
-# MCP read access to validation runs (planned)
+# MCP read access to validation runs
 
-**Status:** planned feature, not yet implemented. Captured here so the design
-is settled before we build it.
+**Status:** implemented as the `get_validation_result` tool
+(`Sources/APIServer/MCP/Tools/GetValidationResultTool.swift`), matching the
+surface sketched below. `list_validation_runs` remains deferred.
 
 ## Motivation
 


### PR DESCRIPTION
## Why

An MCP agent can already author content and *trigger* validation (`update_solution`, `update_suite`, `validate_assignment`), but it could only learn the **outcome** of a run as a single word — `passed` / `failed` / `no-runner`. When validation failed, the agent couldn't see *which* check failed or *why*, so diagnosing a broken suite meant a human copying the per-test grid out of the web UI.

This was surfaced live while prepping an HLTH 230 assignment: an authored `pandas` notebook check kept failing validation, and the agent had no way to read the per-test outcomes (`df is not defined`, `0 figures`) that pinpoint the cause.

## What

Adds a read-only `get_validation_result(assignmentPublicID)` MCP tool that returns the per-test outcomes of an assignment's latest **validation** run: each check's `status` plus `shortResult` / `longResult`, across all tiers, with collection-level `buildStatus`, `compilerOutput`, `warnings`, `counts`, and `ranAt`. Implements the design already settled in `docs/mcp-validation-access.md`.

## Guardrails (validation runs only — never student data)

- **Scope:** `content:read`, course-scoped via the existing `authorizedAssignment` helper.
- **Validation submissions only.** The submission is resolved from the assignment (linked validation submission, else the most recent `kind == .validation` for the setup) and filtered to `.validation` — exactly the `loadExistingSolution` resolver, narrowed. No raw submission id is accepted; a student submission is never reachable.
- **DTO drops `submissionID` / `userID`** and carries no grade or roster. This is the same instructor-authored trust tier already exposed by `get_solution` / `get_suite`.
- A pending / missing run returns the current `validationStatus` with empty `outcomes` (mirrors `validate_assignment`).

## Catalog/doc sync

Per the MCP design notes, the three agent-facing copies are updated in lockstep: registered in `MCPToolCatalog.live`, mentioned in `MCPServerInstructions.text` (the `initialize` handshake), and added to the `docs/mcp-authoring-roadmap.md` tool index. `docs/mcp-validation-access.md` is flipped from *planned* to *implemented*. The `MCPInstructionsCatalogSyncTests` guards enforce this.

## Tests

New `GetValidationResultToolTests` (6 cases): linked-validation happy path (incl. secret-tier failures visible + `longResult` surfaced), most-recent-validation fallback, **a guardrail test that a student submission is never surfaced**, empty-when-no-result, unknown-assignment throws, and not-enrolled denial. Full build + new tests + catalog-sync guards pass; `swift-format` and SwiftLint (`--strict`) clean.

## Not included

`list_validation_runs` (the optional trend/history surface) remains deferred, as in the design doc. A separate gap — MCP read access to **support files** (e.g. the bundled CSV a notebook check loads) — is noted but out of scope here.

https://claude.ai/code/session_012jVWRmSCErrRbxvNT7uTv9

---
_Generated by [Claude Code](https://claude.ai/code/session_012jVWRmSCErrRbxvNT7uTv9)_