### PR TITLE
Add MCP get_support_files tool for reading bundled support files

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -113,6 +113,10 @@ enum MCPServerInstructions {
         - Solution — the instructor's reference answer key (.ipynb), validated against the suite. It \
         is instructor-authored content, never a student submission. Read with get_solution, replace \
         with update_solution (which stores it as the validation submission and re-runs validation).
+        - Support files — non-graded helper/data files bundled in the setup zip (e.g. a CSV a check \
+        loads, a helper module tests import). List or read them with get_support_files (byte-capped \
+        reads, so big datasets return a useful head); write one with author_script(tier:"support"). \
+        Confirm a data file is bundled before authoring checks that load it.
         - Global inputs (personalization) — assignment-scoped names that vary the assignment per \
         student: literal `variables` (a name + JSON value) and `expressions` (a name + Python source \
         evaluated against the student's `seed`). They inline into generated/raw tests and substitute \
@@ -131,7 +135,7 @@ enum MCPServerInstructions {
         deployed version and whether writes are honored — call it to confirm a feature/deploy is live \
         (a tool call reflects the running process even if your tool list is cached).
         2. Inspect before editing: get_assignment, get_suite, get_notebook, get_solution, \
-        get_global_inputs. Use \
+        get_support_files, get_global_inputs. Use \
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \

--- a/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
@@ -1,0 +1,190 @@
+// APIServer/MCP/Tools/GetSupportFilesTool.swift
+//
+// Read tool: list an assignment's support files (the non-graded helper/data
+// files bundled in the test-setup zip), or read one of them, by assignment
+// public ID. content:read, course-scoped.
+//
+// "Support file" uses the same classification as the shared-directory
+// extraction (`extractSupportFilesToSharedDirectory`): a zip entry that is
+// neither a graded suite script (read those via get_suite) nor one of the
+// canonical notebooks (get_notebook / get_solution). This is the data a test
+// or personalization expression can load at grading time — e.g. the CSV a
+// pandas notebook check reads — which previously had no read surface at all:
+// an agent could *write* one via author_script(tier:"support") but never
+// confirm what was bundled, or author data-aware checks against its contents.
+//
+// Everything here is instructor-authored content from the setup zip — the same
+// trust tier as get_suite/get_solution; no student data is reachable. Reads
+// are byte-capped (maxBytes) so a large dataset returns a useful head instead
+// of blowing the response budget.
+
+import Core
+import Fluent
+import Foundation
+
+struct GetSupportFilesTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// When present, read this support file; when omitted, list them all.
+        let filename: String?
+        /// Read mode: maximum content bytes returned (default 65536, clamped
+        /// 1...512000). Truncation lands on a UTF-8 character boundary.
+        let maxBytes: Int?
+    }
+
+    struct FileEntry: Encodable, Sendable {
+        let filename: String
+        let sizeBytes: Int
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        /// List mode: every support file in the setup zip (empty when none).
+        /// Nil in read mode.
+        let files: [FileEntry]?
+        /// Read mode: the requested file. Nil in list mode.
+        let filename: String?
+        let sizeBytes: Int?
+        /// UTF-8 content, possibly truncated to maxBytes (see `truncated`).
+        let content: String?
+        let truncated: Bool?
+    }
+
+    static let name = "get_support_files"
+    static let description =
+        "List an assignment's support files, or read one, by assignment public ID. Support files are "
+        + "the non-graded helper/data files bundled in the test-setup zip (e.g. a CSV a notebook check "
+        + "loads, or a helper module tests import) — everything in the zip that is not a graded suite "
+        + "script (read those via get_suite) or the starter/solution notebook (get_notebook / "
+        + "get_solution). Omit filename to list filenames and sizes; pass filename to read that file's "
+        + "UTF-8 content, capped at maxBytes (default 65536) with truncated:true when the file is "
+        + "larger — so a big dataset returns a useful head. Write support files with "
+        + "author_script(tier:\"support\"). Read-only, instructor-authored content only; use it to "
+        + "confirm a data file is actually bundled (and what its columns/rows look like) before "
+        + "authoring checks that depend on it."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "filename": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "A support filename from the list (exact match, subdirectory paths included). "
+                        + "Omit to list all support files."),
+            ]),
+            "maxBytes": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Read mode: max content bytes returned (default 65536, clamped 1-512000)."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "files": .object(["type": .array([.string("array"), .string("null")])]),
+            "filename": .object(["type": .array([.string("string"), .string("null")])]),
+            "sizeBytes": .object(["type": .array([.string("integer"), .string("null")])]),
+            "content": .object(["type": .array([.string("string"), .string("null")])]),
+            "truncated": .object(["type": .array([.string("boolean"), .string("null")])]),
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: true, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.read]
+
+    static let defaultMaxBytes = 65536
+    static let maxMaxBytes = 512_000
+
+    /// Zip entries that are never support files: the canonical notebooks have
+    /// dedicated read tools. Matches `extractSupportFilesToSharedDirectory`.
+    private static let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
+
+        let suiteScripts = Set(setup.decodedManifest()?.testSuites.map(\.script) ?? [])
+        let supportNames = listZipEntries(zipPath: setup.zipPath).filter {
+            !suiteScripts.contains($0) && !Self.reservedNames.contains($0)
+        }
+
+        guard let filename = input.filename else {
+            let entries = supportNames.sorted().map { name in
+                FileEntry(
+                    filename: name,
+                    sizeBytes: extractZipEntry(zipPath: setup.zipPath, entryName: name)?.count ?? 0)
+            }
+            return Output(
+                assignmentPublicID: assignment.publicID,
+                files: entries, filename: nil, sizeBytes: nil, content: nil, truncated: nil)
+        }
+
+        // Read mode. The filename must exactly match a support entry — a
+        // graded script or notebook gets redirected to its dedicated tool, and
+        // anything else (including a traversal attempt) is simply not in the
+        // entry list.
+        guard supportNames.contains(filename) else {
+            if suiteScripts.contains(filename) {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail: "\"\(filename)\" is a graded suite script — read it via get_suite.")
+            }
+            if Self.reservedNames.contains(filename) {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail: "\"\(filename)\" is a notebook — read it via get_notebook or get_solution.")
+            }
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "No support file named \"\(filename)\" in this assignment's setup "
+                    + "(call without filename to list them).")
+        }
+        guard let data = extractZipEntry(zipPath: setup.zipPath, entryName: filename) else {
+            throw MCPToolError.executionFailed(
+                tool: Self.name, detail: "Failed to extract \"\(filename)\" from the setup zip.")
+        }
+
+        let cap = min(max(input.maxBytes ?? Self.defaultMaxBytes, 1), Self.maxMaxBytes)
+        let (content, truncated) = try Self.utf8Content(of: data, cappedAt: cap, filename: filename)
+        return Output(
+            assignmentPublicID: assignment.publicID,
+            files: nil, filename: filename, sizeBytes: data.count,
+            content: content, truncated: truncated)
+    }
+
+    /// Decodes up to `cap` bytes of `data` as UTF-8, backing off to a character
+    /// boundary when the cap splits a multi-byte sequence. Throws when the file
+    /// is not UTF-8 text at all (this tool has no binary transport).
+    private static func utf8Content(
+        of data: Data, cappedAt cap: Int, filename: String
+    ) throws -> (content: String, truncated: Bool) {
+        if data.count <= cap {
+            guard let text = String(data: data, encoding: .utf8) else {
+                throw MCPToolError.invalidArguments(
+                    tool: name,
+                    detail: "\"\(filename)\" is not UTF-8 text; only text support files can be read.")
+            }
+            return (text, false)
+        }
+        var head = data.prefix(cap)
+        // A UTF-8 character is at most 4 bytes, so at most 3 trailing bytes of
+        // a split sequence need dropping before the prefix decodes.
+        for _ in 0..<4 {
+            if let text = String(data: head, encoding: .utf8) {
+                return (text, true)
+            }
+            head = head.dropLast()
+        }
+        throw MCPToolError.invalidArguments(
+            tool: name,
+            detail: "\"\(filename)\" is not UTF-8 text; only text support files can be read.")
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -24,6 +24,7 @@ enum MCPToolCatalog {
             GetSuiteTool().erased(),
             GetNotebookTool().erased(),
             GetSolutionTool().erased(),
+            GetSupportFilesTool().erased(),
             GetGlobalInputsTool().erased(),
             PreviewPersonalizationTool().erased(),
             ValidateAssignmentTool().erased(),

--- a/Tests/APITests/MCP/GetSupportFilesToolTests.swift
+++ b/Tests/APITests/MCP/GetSupportFilesToolTests.swift
@@ -1,0 +1,195 @@
+// Tests for GetSupportFilesTool: it lists/reads only the setup zip's support
+// files (never graded scripts or the canonical notebooks), caps reads at
+// maxBytes on a UTF-8 boundary, and rejects non-text files. Backed by a real
+// test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct GetSupportFilesToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read]
+        )
+    }
+
+    private let manifest = """
+        {"schemaVersion":1,"testSuites":[\
+        {"tier":"public","script":"test_a.sh","points":1}\
+        ],"timeLimitSeconds":10}
+        """
+
+    /// Course + enrolled instructor + setup whose zip holds one graded script,
+    /// both canonical notebooks, and two support files (one nested).
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_sf", courseID: courseID, manifest: manifest)
+        try writeZip(
+            at: app.testSetupsDirectory + "setup_sf.zip",
+            entries: [
+                ("test_a.sh", "exit 0\n"),
+                ("assignment.ipynb", "{}"),
+                ("solution.ipynb", "{}"),
+                ("cases.csv", "caseid,age\n1,20\n2,30\n"),
+                ("data/extra.txt", "nested support file\n"),
+            ])
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_sf", courseID: courseID, title: "Lab")
+    }
+
+    private func writeZip(at zipPath: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sf-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            let url = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.data(using: .utf8)?.write(to: url)
+        }
+        try? FileManager.default.removeItem(atPath: zipPath)
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+    }
+
+    private func run(
+        _ app: Application, publicID: String, filename: String? = nil, maxBytes: Int? = nil
+    ) async throws -> GetSupportFilesTool.Output {
+        try await GetSupportFilesTool().execute(
+            GetSupportFilesTool.Input(
+                assignmentPublicID: publicID, filename: filename, maxBytes: maxBytes),
+            context(app))
+    }
+
+    // MARK: - List mode
+
+    @Test func listsOnlySupportFiles() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+
+            let output = try await run(app, publicID: assignment.publicID)
+            let files = try #require(output.files)
+            let names = files.map(\.filename)
+            #expect(names == ["cases.csv", "data/extra.txt"])  // sorted; scripts + notebooks excluded
+            let csv = try #require(files.first { $0.filename == "cases.csv" })
+            #expect(csv.sizeBytes == "caseid,age\n1,20\n2,30\n".utf8.count)
+            #expect(output.content == nil)
+        }
+    }
+
+    // MARK: - Read mode
+
+    @Test func readsSupportFileContent() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+
+            let output = try await run(app, publicID: assignment.publicID, filename: "cases.csv")
+            #expect(output.content == "caseid,age\n1,20\n2,30\n")
+            #expect(output.truncated == false)
+            #expect(output.sizeBytes == "caseid,age\n1,20\n2,30\n".utf8.count)
+            #expect(output.files == nil)
+        }
+    }
+
+    @Test func readsNestedSupportFile() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+
+            let output = try await run(
+                app, publicID: assignment.publicID, filename: "data/extra.txt")
+            #expect(output.content == "nested support file\n")
+        }
+    }
+
+    @Test func capsContentAtMaxBytesOnUTF8Boundary() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // "é" is 2 bytes in UTF-8; a 5-byte cap lands mid-character and
+            // must back off to the previous boundary ("abcd", 4 bytes).
+            try writeZip(
+                at: app.testSetupsDirectory + "setup_sf.zip",
+                entries: [("test_a.sh", "exit 0\n"), ("note.txt", "abcdé and more")])
+
+            let output = try await run(
+                app, publicID: assignment.publicID, filename: "note.txt", maxBytes: 5)
+            #expect(output.content == "abcd")
+            #expect(output.truncated == true)
+            #expect(output.sizeBytes == "abcdé and more".utf8.count)
+        }
+    }
+
+    // MARK: - Boundaries
+
+    @Test func redirectsGradedScriptToGetSuite() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(app, publicID: assignment.publicID, filename: "test_a.sh")
+            }
+        }
+    }
+
+    @Test func redirectsNotebookToDedicatedTool() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(
+                    app, publicID: assignment.publicID, filename: "solution.ipynb")
+            }
+        }
+    }
+
+    @Test func unknownFilenameThrows() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(app, publicID: assignment.publicID, filename: "missing.csv")
+            }
+            // A traversal-shaped name is just "not in the entry list".
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(
+                    app, publicID: assignment.publicID, filename: "../../etc/passwd")
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            _ = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestSetup(on: app, id: "setup_sf", courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_sf", courseID: courseID, title: "Lab")
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await self.run(app, publicID: assignment.publicID)
+            }
+        }
+    }
+}

--- a/changelog.d/mcp-get-support-files.md
+++ b/changelog.d/mcp-get-support-files.md
@@ -1,0 +1,11 @@
+### Added
+
+- **MCP `get_support_files` tool.** An authorized agent can now list an
+  assignment's support files — the non-graded helper/data files bundled in the
+  test-setup zip (e.g. the CSV a notebook check loads) — and read one as UTF-8
+  text, byte-capped (default 64 KB) so large datasets return a useful head.
+  Previously an agent could *write* a support file via
+  `author_script(tier:"support")` but had no way to confirm what was bundled or
+  author data-aware checks against its contents. Graded scripts and the
+  starter/solution notebooks are excluded (their dedicated read tools cover
+  them). `content:read`, course-scoped, instructor-authored content only.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -34,6 +34,7 @@ course-scoped:
 | `get_suite` | `content:read` | Full test-suite definition: items, tiers, points, deps, sections, plus each script's raw body, each family's full spec (cases' args/expected), and each notebook check's spec |
 | `get_notebook` | `content:read` | The starter notebook (.ipynb JSON) |
 | `get_solution` | `content:read` | The reference solution notebook (.ipynb JSON), resolved from the validation submission |
+| `get_support_files` | `content:read` | List the setup zip's non-graded helper/data files, or read one (UTF-8, byte-capped) |
 | `get_global_inputs` | `content:read` | Assignment personalization: global variables + per-student expressions |
 | `preview_personalization` | `content:read` | Resolve a seed's `name → value` map + a starter-notebook `{{placeholder}}` audit |
 | `validate_assignment` | `content:read` | Watch validation to completion; live SSE progress |


### PR DESCRIPTION
## Why

The MCP authoring surface could *write* a support file (`author_script(tier:"support")`) but never list or read what's bundled in a test-setup zip. Surfaced live while prepping HLTH 230's Assignment 4: its notebook loads `assignment4_vitaldb_cases.csv`, and the agent had no way to confirm the CSV is actually in the setup or see its columns — so checks had to be authored blind (superset column matching, no row-count assertion). Follow-up to #918, which closed the validation-results half of the same diagnosis gap.

## What

Adds a read-only `get_support_files(assignmentPublicID, filename?, maxBytes?)` MCP tool:

- **List mode** (no `filename`): every support file in the setup zip with its size. "Support file" uses the same classification as `extractSupportFilesToSharedDirectory` — a zip entry that is neither a graded suite script nor `assignment.ipynb` / `solution.ipynb`.
- **Read mode** (`filename`): the file's UTF-8 content, capped at `maxBytes` (default 64 KB, max 500 KB) with `truncated: true` when larger — so a big dataset returns a useful head instead of blowing the response budget. Truncation backs off to a UTF-8 character boundary; non-text files are rejected with a clear error.

## Boundaries

- Graded scripts redirect to `get_suite`; the canonical notebooks redirect to `get_notebook` / `get_solution` — each artifact keeps exactly one read surface.
- The filename must exactly match a listed zip entry, so traversal-shaped names are simply "not found" (no path interpretation happens).
- `content:read`, course-scoped via the standard `authorizedAssignment` helper. Everything reachable is instructor-authored setup content — the same trust tier as `get_suite` / `get_solution`; no student data.

## Catalog/doc sync

Registered in `MCPToolCatalog.live`, mentioned in `MCPServerInstructions.text` (concepts + workflow step 2), and added to the `docs/mcp-authoring-roadmap.md` tool index — the three copies `MCPInstructionsCatalogSyncTests` enforces.

## Tests

New `GetSupportFilesToolTests` (8 cases): list excludes scripts + notebooks and reports sizes; read returns exact content (including a nested `data/extra.txt` path); `maxBytes` cap lands on a UTF-8 boundary (multi-byte char split test); graded-script and notebook redirects; unknown/traversal filenames throw; not-enrolled denial. Full build, new tests + catalog-sync guards, `swift-format`, and SwiftLint `--strict` all clean.

https://claude.ai/code/session_012jVWRmSCErrRbxvNT7uTv9

---
_Generated by [Claude Code](https://claude.ai/code/session_012jVWRmSCErrRbxvNT7uTv9)_