### PR TITLE
Add sparklines with cyclable time windows to admin diagnostic cards

### DIFF
--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -15,25 +15,35 @@ Admin
 </nav>
 <section class="admin-section admin-diagnostics">
     <div class="diagnostics-cards" id="diagnostics-cards">
-        <article class="diagnostic-card">
-            <div class="diagnostic-label">24h Max Queue</div>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-card="maxQueueDepth"
+                 role="button" tabindex="0" aria-label="Max queue depth, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Max Queue</div>
             <div class="diagnostic-value" id="diag-queue-depth">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
         </article>
-        <article class="diagnostic-card">
-            <div class="diagnostic-label">24h Jobs Processed</div>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-card="jobsProcessed"
+                 role="button" tabindex="0" aria-label="Jobs processed, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Jobs Processed</div>
             <div class="diagnostic-value" id="diag-jobs-processed">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
         </article>
-        <article class="diagnostic-card">
-            <div class="diagnostic-label">24h Max Load</div>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-card="load"
+                 role="button" tabindex="0" aria-label="Max load, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Max Load</div>
             <div class="diagnostic-value" id="diag-max-load">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
         </article>
-        <article class="diagnostic-card">
-            <div class="diagnostic-label">P95 Wait Time</div>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-card="queueWaitP95Ms"
+                 role="button" tabindex="0" aria-label="P95 wait time, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> P95 Wait Time</div>
             <div class="diagnostic-value" id="diag-queue-p95">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
         </article>
-        <article class="diagnostic-card">
-            <div class="diagnostic-label">P95 Execution Time</div>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-card="executionP95Ms"
+                 role="button" tabindex="0" aria-label="P95 execution time, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> P95 Execution Time</div>
             <div class="diagnostic-value" id="diag-exec-p95">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
         </article>
     </div>
 </section>
@@ -188,6 +198,46 @@ Admin
 <style>
 .admin-diagnostics {
     padding-bottom: 1rem;
+}
+/* ── Clickable diagnostic cards with sparklines ───────── */
+.diagnostic-card-cyclable {
+    cursor: pointer;
+    user-select: none;
+}
+.diagnostic-card-cyclable:hover {
+    border-color: var(--health-teal);
+}
+.diagnostic-card-cyclable:focus-visible {
+    outline: 2px solid var(--health-teal-dark);
+    outline-offset: 2px;
+}
+.diagnostic-window-chip {
+    font-weight: 600;
+    color: var(--health-teal-dark);
+}
+.diagnostic-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 28px;
+    margin-top: .4rem;
+}
+.spark-slot {
+    flex: 1 1 0;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+}
+.spark-fill {
+    width: 100%;
+    height: var(--bar-h, 0);
+    min-height: 2px;
+    background: var(--health-teal);
+    border-radius: 1px 1px 0 0;
+}
+.spark-fill-empty {
+    min-height: 0;
+    background: transparent;
 }
 .admin-section-head {
     gap: .5rem;
@@ -351,7 +401,7 @@ tr.runner-row-offline {
     var totalRunnerCount = workersBody.querySelectorAll('tr').length;
     var totalRunnerCapacity = 0;
     var totalAssignedJobs = 0;
-    var latestDiagnostics = null;
+    var cardsPayload = null;
 
     function formatDuration(ms) {
         if (ms == null || ms < 0) return '—';
@@ -379,11 +429,9 @@ tr.runner-row-offline {
     }
 
     function renderMaxLoadSummary() {
-        if (!diagMaxLoad) return;
-        if (latestDiagnostics && latestDiagnostics.maxLoadActiveJobs != null && latestDiagnostics.maxLoadCapacity != null) {
-            setText(diagMaxLoad, String(latestDiagnostics.maxLoadActiveJobs) + '/' + String(latestDiagnostics.maxLoadCapacity));
-            return;
-        }
+        // Once the sparkline payload has arrived, the card renderer owns the
+        // Max Load value; this table-derived sum is only the pre-fetch state.
+        if (!diagMaxLoad || cardsPayload) return;
         if (totalRunnerCapacity > 0) {
             setText(diagMaxLoad, String(totalAssignedJobs) + '/' + String(totalRunnerCapacity));
             return;
@@ -391,15 +439,103 @@ tr.runner-row-offline {
         setText(diagMaxLoad, '—');
     }
 
-    function updateDiagnosticsCards(metrics) {
-        if (!metrics) return;
-        latestDiagnostics = metrics;
-        setText(diagQueueDepth, String(metrics.maxQueueDepth == null ? '—' : metrics.maxQueueDepth));
-        setText(diagJobsProcessed, String(metrics.jobsProcessed24h == null ? '—' : metrics.jobsProcessed24h));
-        renderMaxLoadSummary();
-        setText(diagQueueP95, formatDuration(metrics.queueWait && metrics.queueWait.p95Ms));
-        setText(diagExecP95, formatDuration(metrics.execution && metrics.execution.p95Ms));
+    // ── Diagnostic cards: headline + sparkline, click cycles 24h/7d/30d ──
+    var windowNouns = { '24h': 'last 24 hours', '1w': 'last 7 days', '1m': 'last 30 days' };
+    var cardWindowIndex = {};
+    var sparkCards = [
+        {
+            key: 'maxQueueDepth', name: 'Max queue depth', valueEl: diagQueueDepth,
+            headline: function (data) { return data.headline == null ? '—' : String(data.headline); },
+            point: function (v) { return v + (v === 1 ? ' job queued' : ' jobs queued'); }
+        },
+        {
+            key: 'jobsProcessed', name: 'Jobs processed', valueEl: diagJobsProcessed,
+            headline: function (data) { return data.headline == null ? '—' : String(data.headline); },
+            point: function (v) { return v + (v === 1 ? ' job' : ' jobs'); }
+        },
+        {
+            key: 'load', name: 'Max load', valueEl: diagMaxLoad,
+            headline: function (data) {
+                if (data.activeJobs == null || data.capacity == null) return '—';
+                return String(data.activeJobs) + '/' + String(data.capacity);
+            },
+            point: function (v) { return v + '% utilization'; }
+        },
+        {
+            key: 'queueWaitP95Ms', name: 'P95 wait time', valueEl: diagQueueP95,
+            headline: function (data) { return formatDuration(data.headline); },
+            point: formatDuration
+        },
+        {
+            key: 'executionP95Ms', name: 'P95 execution time', valueEl: diagExecP95,
+            headline: function (data) { return formatDuration(data.headline); },
+            point: formatDuration
+        }
+    ];
+
+    function renderSpark(container, series, labels, formatPoint) {
+        series = Array.isArray(series) ? series : [];
+        var max = series.reduce(function (m, v) { return v == null ? m : Math.max(m, v); }, 0);
+        container.innerHTML = series.map(function (value, i) {
+            var pct = (value != null && max > 0) ? (value / max) * 100 : 0;
+            var title = (labels[i] || '') + ': ' + (value == null ? 'no data' : formatPoint(value));
+            return '<div class="spark-slot" title="' + escapeHtml(title) + '">'
+                + '<span class="spark-fill' + (value == null ? ' spark-fill-empty' : '')
+                + '" style="--bar-h:' + pct.toFixed(1) + '%"></span>'
+                + '</div>';
+        }).join('');
     }
+
+    function renderSparkCard(config) {
+        if (!cardsPayload || !config.cardEl) return;
+        var index = cardWindowIndex[config.key] || 0;
+        var win = cardsPayload.windows[index % cardsPayload.windows.length];
+        var data = win && win[config.key];
+        if (!data) return;
+        setText(config.valueEl, config.headline(data));
+        var chip = config.cardEl.querySelector('.diagnostic-window-chip');
+        if (chip) chip.textContent = win.label;
+        var spark = config.cardEl.querySelector('.diagnostic-spark');
+        if (spark) renderSpark(spark, data.series, win.bucketLabels || [], config.point);
+        config.cardEl.setAttribute(
+            'aria-label',
+            config.name + ', ' + (windowNouns[win.window] || win.label) + '. Press to change time window.');
+    }
+
+    function renderAllSparkCards() {
+        sparkCards.forEach(renderSparkCard);
+    }
+
+    async function refreshCards() {
+        try {
+            var response = await fetch('/admin/metrics/cards', {
+                headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
+                cache: 'no-store'
+            });
+            if (!response.ok) return;
+            cardsPayload = await response.json();
+            renderAllSparkCards();
+        } catch (_) {
+            // Keep current card values on transient polling errors.
+        }
+    }
+
+    sparkCards.forEach(function (config) {
+        config.cardEl = document.querySelector('.diagnostic-card[data-card="' + config.key + '"]');
+        if (!config.cardEl) return;
+        cardWindowIndex[config.key] = 0;
+        function cycleWindow() {
+            if (!cardsPayload || !cardsPayload.windows.length) return;
+            cardWindowIndex[config.key] = (cardWindowIndex[config.key] + 1) % cardsPayload.windows.length;
+            renderSparkCard(config);
+        }
+        config.cardEl.addEventListener('click', cycleWindow);
+        config.cardEl.addEventListener('keydown', function (event) {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            event.preventDefault();
+            cycleWindow();
+        });
+    });
 
     function renderWorkers(workers) {
         workers = sortWorkersArray(Array.isArray(workers) ? workers.slice() : []);
@@ -576,24 +712,10 @@ tr.runner-row-offline {
         }
     }
 
-    async function refreshDiagnostics() {
-        try {
-            var response = await fetch('/admin/metrics', {
-                headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
-                cache: 'no-store'
-            });
-            if (!response.ok) return;
-            var metrics = await response.json();
-            updateDiagnosticsCards(metrics);
-        } catch (_) {
-            // Keep current diagnostics values on transient polling errors.
-        }
-    }
-
     ChickadeeRelativeTime.applyRelativeTimes(document);
     recomputeLoadSummaryFromTable();
     refreshWorkers();
-    refreshDiagnostics();
+    refreshCards();
 
     if (workersTable && workersBody && workerHeaders.length) {
         workerHeaders.forEach(function (header) {
@@ -672,7 +794,7 @@ tr.runner-row-offline {
         ChickadeeRelativeTime.applyRelativeTimes(document);
         refreshWorkers();
     }, 5000);
-    setInterval(refreshDiagnostics, 15000);
+    setInterval(refreshCards, 60000);
 
     // ── Active-users activity chart ──────────────────────────────────
     var activityBars = document.getElementById('activity-bars');

--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -194,7 +194,7 @@ extension AppConfig {
                 enabled: true,
                 verboseRequestTiming: false,
                 jobMetricRetentionDays: 30,
-                runnerSnapshotRetentionDays: 14,
+                runnerSnapshotRetentionDays: 30,
                 activeRunnerWindowSeconds: 120,
                 recentMetricsWindowHours: 24,
                 pruneIntervalHours: 24,

--- a/Sources/APIServer/Diagnostics/MetricsCardSeries.swift
+++ b/Sources/APIServer/Diagnostics/MetricsCardSeries.swift
@@ -1,0 +1,181 @@
+// Sources/APIServer/Diagnostics/MetricsCardSeries.swift
+//
+// Types + pure bucket math behind `GET /admin/metrics/cards` — the sparkline
+// series shown on the admin dashboard's diagnostic cards.  One response
+// carries every selectable window (24h / 7d / 30d) for every card so the
+// client can cycle windows instantly without extra round-trips.
+//
+// Mirrors the design of ActivityChartService: fixed-duration buckets rolling
+// back from `now`, aggregated in Swift so SQLite (dev) and Postgres (prod)
+// behave identically, labels formatted in America/Toronto.
+
+import Foundation
+import Vapor
+
+/// The selectable sparkline windows.  Raw values are the wire tokens
+/// (matching the activity chart's `24h` / `1w` / `1m`).
+enum MetricsCardWindow: String, CaseIterable, Sendable {
+    case day = "24h"
+    case week = "1w"
+    case month = "1m"
+
+    /// Short window chip shown on the card, e.g. "7d Max Queue".
+    var displayLabel: String {
+        switch self {
+        case .day: return "24h"
+        case .week: return "7d"
+        case .month: return "30d"
+        }
+    }
+
+    /// Number of buckets (sparkline bars) in this window.
+    var bucketCount: Int {
+        switch self {
+        case .day: return 24  // one bar per hour
+        case .week: return 28  // one bar per 6 hours
+        case .month: return 30  // one bar per day
+        }
+    }
+
+    /// Duration of one bucket, in seconds.
+    var bucketSeconds: Int {
+        switch self {
+        case .day: return 3600
+        case .week: return 21_600
+        case .month: return 86_400
+        }
+    }
+
+    /// Total span covered by the window.
+    var totalSeconds: TimeInterval { Double(bucketCount) * Double(bucketSeconds) }
+
+    /// The bucket grid for this window ending at `now`.
+    func bucketWindow(endingAt now: Date) -> BucketWindow {
+        BucketWindow(
+            windowStart: now.addingTimeInterval(-totalSeconds),
+            bucketSeconds: bucketSeconds,
+            bucketCount: bucketCount
+        )
+    }
+
+    /// Tooltip label for a bucket start, localised to America/Toronto to
+    /// match the rest of the UI.
+    func label(forBucketStart start: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_CA")
+        fmt.timeZone = TimeZone(identifier: "America/Toronto")
+        switch self {
+        case .day:
+            fmt.dateFormat = "HH:mm"
+        case .week:
+            fmt.dateFormat = "EEE HH:mm"
+        case .month:
+            fmt.dateFormat = "MMM d"
+        }
+        return fmt.string(from: start)
+    }
+}
+
+/// One +1 (submitted) / −1 (assigned) step in the worker queue depth.
+struct QueueDepthEvent: Sendable, Equatable {
+    let date: Date
+    let delta: Int
+}
+
+/// The queue depth expressed as a starting depth plus a sorted event stream,
+/// so any sub-window's per-bucket maxima can be derived with one sweep.
+struct QueueDepthTimeline: Sendable, Equatable {
+    /// Depth at the timeline's start (jobs already pending when it opens).
+    let initialDepth: Int
+    /// Events at or after the timeline start, ascending; +1 deltas sort
+    /// before −1 at equal timestamps (matching `maxQueueDepthSince`).
+    let events: [QueueDepthEvent]
+}
+
+/// Headline value + per-bucket sparkline series for one card.  `nil` series
+/// entries mean "no data in this bucket" (rendered as an empty slot, not 0).
+struct MetricsCardSeries: Content, Sendable {
+    let headline: Int?
+    let series: [Int?]
+}
+
+/// The Max Load card: peak concurrent jobs / capacity over the window, with
+/// a per-bucket peak-utilisation-percent sparkline.
+struct MetricsCardLoadSeries: Content, Sendable {
+    let activeJobs: Int?
+    let capacity: Int?
+    let series: [Int?]
+}
+
+/// All five card series for one window.
+struct MetricsCardWindowSeries: Content, Sendable {
+    let window: String
+    let label: String
+    let bucketLabels: [String]
+    let maxQueueDepth: MetricsCardSeries
+    let jobsProcessed: MetricsCardSeries
+    let load: MetricsCardLoadSeries
+    let queueWaitP95Ms: MetricsCardSeries
+    let executionP95Ms: MetricsCardSeries
+}
+
+/// Payload of `GET /admin/metrics/cards`.
+struct MetricsCardSeriesResponse: Content, Sendable {
+    let generatedAt: Date
+    let windows: [MetricsCardWindowSeries]
+}
+
+/// Pure sweep helpers for the card series.  No database access; exists so
+/// the queue-depth bucket math is testable in isolation (same rationale as
+/// MetricBucketAccumulators).
+enum MetricsCardAccumulators {
+    /// Peak queue depth over an entire timeline (the single-number form used
+    /// by `/admin/metrics`' `maxQueueDepth`).
+    static func maxQueueDepth(timeline: QueueDepthTimeline) -> Int {
+        var depth = timeline.initialDepth
+        var maxDepth = depth
+        for event in timeline.events {
+            depth = max(0, depth + event.delta)
+            maxDepth = max(maxDepth, depth)
+        }
+        return maxDepth
+    }
+
+    /// Peak queue depth per bucket of `window`.  The timeline may start
+    /// earlier than the window: events before `window.windowStart` fold into
+    /// the depth carried into the first bucket.  Events past the last bucket
+    /// boundary clamp into the final bucket so a step at exactly `now` still
+    /// counts (parity with `maxQueueDepth(timeline:)`).
+    static func perBucketMaxQueueDepth(
+        timeline: QueueDepthTimeline,
+        window: BucketWindow
+    ) -> [Int] {
+        var depth = timeline.initialDepth
+        var eventIndex = 0
+        let events = timeline.events
+
+        // Fold pre-window events into the carried-in depth.
+        while eventIndex < events.count, events[eventIndex].date < window.windowStart {
+            depth = max(0, depth + events[eventIndex].delta)
+            eventIndex += 1
+        }
+
+        var series: [Int] = []
+        series.reserveCapacity(window.bucketCount)
+        for bucketIndex in 0..<window.bucketCount {
+            let isLastBucket = bucketIndex == window.bucketCount - 1
+            let bucketEnd =
+                isLastBucket
+                ? Date.distantFuture
+                : window.bucketStart(forIndex: bucketIndex + 1)
+            var bucketMax = depth
+            while eventIndex < events.count, events[eventIndex].date < bucketEnd {
+                depth = max(0, depth + events[eventIndex].delta)
+                bucketMax = max(bucketMax, depth)
+                eventIndex += 1
+            }
+            series.append(bucketMax)
+        }
+        return series
+    }
+}

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
@@ -1,0 +1,104 @@
+// Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+//
+// Builder for `GET /admin/metrics/cards`: headline + sparkline series for
+// the five admin diagnostic cards, computed for every selectable window
+// (24h / 7d / 30d) from a single fetch of the longest window's rows.
+
+import Fluent
+import Foundation
+import Vapor
+
+extension OperationalDiagnosticsService {
+
+    /// Builds the per-card sparkline payload.  All three windows are derived
+    /// from one trailing fetch of the longest (30-day) window per source, so
+    /// the dashboard's poll costs three queries regardless of how many
+    /// windows the cards can cycle through.
+    func metricsCardSeries(on db: Database, now: Date = Date()) async throws -> MetricsCardSeriesResponse {
+        let longestWindow = MetricsCardWindow.allCases.max { $0.totalSeconds < $1.totalSeconds } ?? .month
+        let outerStart = now.addingTimeInterval(-longestWindow.totalSeconds)
+
+        let jobMetrics = try await JobExecutionMetric.query(on: db)
+            .filter(\.$completedAt >= outerStart)
+            .all()
+        let runnerSnapshots = try await RunnerSnapshot.query(on: db)
+            .filter(\.$recordedAt >= outerStart)
+            .all()
+        let queueTimeline = try await queueDepthTimeline(windowStart: outerStart, now: now, on: db)
+
+        let windows = MetricsCardWindow.allCases.map { window in
+            cardWindowSeries(
+                window: window,
+                now: now,
+                jobMetrics: jobMetrics,
+                runnerSnapshots: runnerSnapshots,
+                queueTimeline: queueTimeline
+            )
+        }
+        return MetricsCardSeriesResponse(generatedAt: now, windows: windows)
+    }
+
+    private func cardWindowSeries(
+        window: MetricsCardWindow,
+        now: Date,
+        jobMetrics: [JobExecutionMetric],
+        runnerSnapshots: [RunnerSnapshot],
+        queueTimeline: QueueDepthTimeline
+    ) -> MetricsCardWindowSeries {
+        let grid = window.bucketWindow(endingAt: now)
+        let jobBuckets = MetricBucketAccumulators.accumulateJobMetrics(jobMetrics, window: grid)
+
+        let queueSeries = MetricsCardAccumulators.perBucketMaxQueueDepth(
+            timeline: queueTimeline, window: grid)
+        let jobsSeries = jobBuckets.map(\.completedJobs)
+
+        // Headline P95s are computed over the window's full value set, not
+        // averaged bucket P95s, so the 24h numbers match `/admin/metrics`.
+        let inWindowMetrics = jobMetrics.filter { ($0.completedAt ?? .distantPast) >= grid.windowStart }
+        let waitHeadline = MetricBucketAccumulators.percentile95(inWindowMetrics.compactMap(\.queueWaitMs))
+        let executionHeadline = MetricBucketAccumulators.percentile95(
+            inWindowMetrics.compactMap(\.executionMs))
+
+        var snapshotsByBucket = [[RunnerSnapshot]](repeating: [], count: grid.bucketCount)
+        for snapshot in runnerSnapshots {
+            guard let index = grid.bucketIndex(for: snapshot.recordedAt) else { continue }
+            snapshotsByBucket[index].append(snapshot)
+        }
+        let loadSeries = snapshotsByBucket.map { bucketSnapshots in
+            bucketSnapshots.isEmpty ? nil : peakUtilizationPercent(from: bucketSnapshots)
+        }
+        let inWindowSnapshots = runnerSnapshots.filter { $0.recordedAt >= grid.windowStart }
+        let peak = peakLoad(from: inWindowSnapshots)
+
+        let bucketLabels = (0..<grid.bucketCount).map { index in
+            window.label(forBucketStart: grid.bucketStart(forIndex: index))
+        }
+
+        return MetricsCardWindowSeries(
+            window: window.rawValue,
+            label: window.displayLabel,
+            bucketLabels: bucketLabels,
+            maxQueueDepth: MetricsCardSeries(
+                headline: queueSeries.max(),
+                series: queueSeries.map { Optional($0) }
+            ),
+            jobsProcessed: MetricsCardSeries(
+                headline: jobsSeries.reduce(0, +),
+                series: jobsSeries.map { Optional($0) }
+            ),
+            load: MetricsCardLoadSeries(
+                activeJobs: peak?.activeJobs,
+                capacity: peak?.maxJobs,
+                series: loadSeries
+            ),
+            queueWaitP95Ms: MetricsCardSeries(
+                headline: waitHeadline,
+                series: jobBuckets.map { MetricBucketAccumulators.percentile95($0.queueWaitValues) }
+            ),
+            executionP95Ms: MetricsCardSeries(
+                headline: executionHeadline,
+                series: jobBuckets.map { MetricBucketAccumulators.percentile95($0.executionValues) }
+            )
+        )
+    }
+}

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
@@ -109,6 +109,19 @@ extension OperationalDiagnosticsService {
     }
 
     func maxQueueDepthSince(windowStart: Date, now: Date, on db: Database) async throws -> Int {
+        let timeline = try await queueDepthTimeline(windowStart: windowStart, now: now, on: db)
+        return MetricsCardAccumulators.maxQueueDepth(timeline: timeline)
+    }
+
+    /// Builds the worker-eligible queue depth as an event timeline: the depth
+    /// at `windowStart` plus the sorted ±1 steps inside the window.  Shared
+    /// by `maxQueueDepthSince` (single peak) and the card sparkline series
+    /// (per-bucket peaks).
+    func queueDepthTimeline(
+        windowStart: Date,
+        now: Date,
+        on db: Database
+    ) async throws -> QueueDepthTimeline {
         var relevantSubmissions: [String: APISubmission] = [:]
 
         for submission in try await APISubmission.query(on: db)
@@ -145,9 +158,8 @@ extension OperationalDiagnosticsService {
             on: db
         )
 
-        var queueDepth = 0
-        var maxQueueDepth = 0
-        var events: [(date: Date, delta: Int)] = []
+        var initialDepth = 0
+        var events: [QueueDepthEvent] = []
 
         for submission in relevantSubmissions.values {
             let isWorkerEligible =
@@ -160,17 +172,16 @@ extension OperationalDiagnosticsService {
             // Pending at windowStart: submitted before the window opened AND
             // either never assigned, or assigned after the window opened.
             if submittedAt < windowStart, (assignedAt ?? .distantFuture) > windowStart {
-                queueDepth += 1
+                initialDepth += 1
             }
             if submittedAt >= windowStart && submittedAt <= now {
-                events.append((submittedAt, 1))
+                events.append(QueueDepthEvent(date: submittedAt, delta: 1))
             }
             if let assignedAt, assignedAt > windowStart && assignedAt <= now {
-                events.append((assignedAt, -1))
+                events.append(QueueDepthEvent(date: assignedAt, delta: -1))
             }
         }
 
-        maxQueueDepth = queueDepth
         events.sort {
             if $0.date == $1.date {
                 return $0.delta > $1.delta
@@ -178,12 +189,7 @@ extension OperationalDiagnosticsService {
             return $0.date < $1.date
         }
 
-        for event in events {
-            queueDepth = max(0, queueDepth + event.delta)
-            maxQueueDepth = max(maxQueueDepth, queueDepth)
-        }
-
-        return maxQueueDepth
+        return QueueDepthTimeline(initialDepth: initialDepth, events: events)
     }
 
     func peakUtilizationPercent(from snapshots: [RunnerSnapshot]) -> Int? {

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
@@ -69,7 +69,9 @@ struct DiagnosticsConfiguration: Sendable {
             enabled: environmentBool("ENABLE_DIAGNOSTICS_COLLECTION") ?? true,
             verboseRequestTiming: environmentBool("VERBOSE_REQUEST_TIMING") ?? false,
             jobMetricRetentionDays: environmentInt("JOB_METRIC_RETENTION_DAYS") ?? 30,
-            runnerSnapshotRetentionDays: environmentInt("RUNNER_SNAPSHOT_RETENTION_DAYS") ?? 14,
+            // 30 days so the admin cards' longest sparkline window (30d Max
+            // Load) has full data; matches JOB_METRIC_RETENTION_DAYS.
+            runnerSnapshotRetentionDays: environmentInt("RUNNER_SNAPSHOT_RETENTION_DAYS") ?? 30,
             activeRunnerWindowSeconds: TimeInterval(environmentInt("RUNNER_ACTIVE_WINDOW_SECONDS") ?? 120),
             recentMetricsWindowHours: environmentInt("METRICS_RECENT_WINDOW_HOURS") ?? 24,
             pruneIntervalHours: environmentInt("OBSERVABILITY_PRUNE_INTERVAL_HOURS") ?? 24,

--- a/Sources/APIServer/Routes/InternalMetricsRoutes.swift
+++ b/Sources/APIServer/Routes/InternalMetricsRoutes.swift
@@ -5,11 +5,20 @@ struct InternalMetricsRoutes: RouteCollection {
         let admin = routes.grouped("admin")
         admin.get("metrics", use: metrics)
         admin.get("metrics", "timeseries", use: timeseries)
+        admin.get("metrics", "cards", use: cards)
     }
 
     @Sendable
     func metrics(req: Request) async throws -> InternalMetricsResponse {
         try await req.application.diagnostics.metricsSnapshot(req: req)
+    }
+
+    /// Sparkline series for the admin dashboard's diagnostic cards.  One
+    /// payload carries every window (24h / 7d / 30d) so the client can cycle
+    /// a card's window without another round-trip.
+    @Sendable
+    func cards(req: Request) async throws -> MetricsCardSeriesResponse {
+        try await req.application.diagnostics.metricsCardSeries(on: req.db)
     }
 
     @Sendable

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -229,8 +229,10 @@ private struct PassthroughResponder: AsyncResponder {
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let body = String(buffer: res.body)
-                    #expect(body.contains("24h Jobs Processed"))
-                    #expect(body.contains("24h Peak Util") == false)
+                    // The window prefix lives in a chip span the sparkline
+                    // cycler rewrites (24h → 7d → 30d).
+                    #expect(body.contains("</span> Jobs Processed"))
+                    #expect(body.contains("Peak Util") == false)
                 })
 
         }

--- a/Tests/APITests/MetricsCardSeriesTests.swift
+++ b/Tests/APITests/MetricsCardSeriesTests.swift
@@ -1,0 +1,223 @@
+import Fluent
+import Foundation
+import Testing
+import XCTVapor
+
+@testable import APIServer
+@testable import Core
+
+/// Pure bucket-math tests for the admin card sparklines (no app fixture).
+@Suite struct MetricsCardAccumulatorTests {
+    @Test func windowDefinitionsCoverExpectedSpans() {
+        #expect(MetricsCardWindow.day.bucketCount == 24)
+        #expect(MetricsCardWindow.week.bucketCount == 28)
+        #expect(MetricsCardWindow.month.bucketCount == 30)
+        #expect(MetricsCardWindow.day.totalSeconds == 86_400)
+        #expect(MetricsCardWindow.week.totalSeconds == 7 * 86_400)
+        #expect(MetricsCardWindow.month.totalSeconds == 30 * 86_400)
+    }
+
+    @Test func perBucketMaxQueueDepthCarriesDepthAcrossBuckets() {
+        let windowStart = Date(timeIntervalSince1970: 0)
+        let window = BucketWindow(windowStart: windowStart, bucketSeconds: 60, bucketCount: 4)
+        // Two submissions arrive in bucket 0; one is assigned in bucket 2.
+        let timeline = QueueDepthTimeline(
+            initialDepth: 0,
+            events: [
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 10), delta: 1),
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 20), delta: 1),
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 130), delta: -1),
+            ]
+        )
+        let series = MetricsCardAccumulators.perBucketMaxQueueDepth(timeline: timeline, window: window)
+        // Bucket 0 peaks at 2; bucket 1 carries the depth of 2 with no
+        // events; bucket 2 starts at 2 before draining to 1; bucket 3
+        // carries the remaining 1.
+        #expect(series == [2, 2, 2, 1])
+    }
+
+    @Test func perBucketMaxQueueDepthFoldsPreWindowEventsIntoCarriedDepth() {
+        let window = BucketWindow(
+            windowStart: Date(timeIntervalSince1970: 100), bucketSeconds: 50, bucketCount: 2)
+        // Timeline opens earlier than the charted window: the +1/+1/−1 before
+        // 100 must fold into the depth carried into bucket 0.
+        let timeline = QueueDepthTimeline(
+            initialDepth: 1,
+            events: [
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 10), delta: 1),
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 20), delta: 1),
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 30), delta: -1),
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 120), delta: 1),
+            ]
+        )
+        let series = MetricsCardAccumulators.perBucketMaxQueueDepth(timeline: timeline, window: window)
+        #expect(series == [3, 3])
+        // The whole-timeline peak agrees with the bucket maxima.
+        #expect(MetricsCardAccumulators.maxQueueDepth(timeline: timeline) == 3)
+    }
+
+    @Test func perBucketMaxQueueDepthClampsTrailingEventsIntoLastBucket() {
+        let windowStart = Date(timeIntervalSince1970: 0)
+        let window = BucketWindow(windowStart: windowStart, bucketSeconds: 60, bucketCount: 2)
+        // An event landing exactly on the window's end boundary still counts
+        // (parity with maxQueueDepthSince, which includes events at `now`).
+        let timeline = QueueDepthTimeline(
+            initialDepth: 0,
+            events: [QueueDepthEvent(date: Date(timeIntervalSince1970: 120), delta: 1)]
+        )
+        let series = MetricsCardAccumulators.perBucketMaxQueueDepth(timeline: timeline, window: window)
+        #expect(series == [0, 1])
+    }
+
+    @Test func perBucketMaxQueueDepthNeverGoesNegative() {
+        let windowStart = Date(timeIntervalSince1970: 0)
+        let window = BucketWindow(windowStart: windowStart, bucketSeconds: 60, bucketCount: 1)
+        let timeline = QueueDepthTimeline(
+            initialDepth: 0,
+            events: [
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 10), delta: -1),
+                QueueDepthEvent(date: Date(timeIntervalSince1970: 20), delta: 1),
+            ]
+        )
+        let series = MetricsCardAccumulators.perBucketMaxQueueDepth(timeline: timeline, window: window)
+        #expect(series == [1])
+    }
+}
+
+/// Endpoint tests for `GET /admin/metrics/cards`.
+@Suite(.serialized) final class MetricsCardSeriesRouteTests {
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-cards")
+    }
+
+    @Test func cardsEndpointRequiresAuthentication() async throws {
+        try await withApp(app) { _ in
+            try await app.asyncTest(
+                .GET, "/admin/metrics/cards",
+                afterResponse: { response in
+                    #expect(response.status == .seeOther)
+                })
+        }
+    }
+
+    @Test func cardsEndpointReturnsAllWindowsWithSeededData() async throws {
+        try await withApp(app) { _ in
+            let setup = try await makeSetup(id: "setup_cards")
+            // One completed job 10s ago…
+            let submission = APISubmission(
+                id: "sub_cards_done",
+                testSetupID: try setup.requireID(),
+                zipPath: "/tmp/sub_cards_done.zip",
+                attemptNumber: 1,
+                status: "completed",
+                kind: APISubmission.Kind.student
+            )
+            try await submission.save(on: app.db)
+            // submittedAt is a create-timestamp; backdate it post-save.
+            submission.submittedAt = Date().addingTimeInterval(-20)
+            submission.assignedAt = Date().addingTimeInterval(-15)
+            try await submission.update(on: app.db)
+
+            let metric = JobExecutionMetric(
+                submissionID: "sub_cards_done",
+                jobID: "sub_cards_done",
+                testSetupID: try setup.requireID(),
+                courseID: nil,
+                assignmentID: nil,
+                userID: nil,
+                runnerID: "runner-cards",
+                kind: APISubmission.Kind.student,
+                attemptNumber: 1,
+                enqueuedAt: Date().addingTimeInterval(-20)
+            )
+            metric.completedAt = Date().addingTimeInterval(-10)
+            metric.queueWaitMs = 5000
+            metric.executionMs = 5000
+            metric.finalStatus = JobFinalStatus.passed.rawValue
+            try await metric.save(on: app.db)
+
+            // …one still pending (contributes to queue depth)…
+            let pending = APISubmission(
+                id: "sub_cards_pending",
+                testSetupID: try setup.requireID(),
+                zipPath: "/tmp/sub_cards_pending.zip",
+                attemptNumber: 1,
+                status: "pending",
+                kind: APISubmission.Kind.student
+            )
+            try await pending.save(on: app.db)
+            pending.submittedAt = Date().addingTimeInterval(-5)
+            try await pending.update(on: app.db)
+
+            // …and one runner load sample.
+            let snapshot = RunnerSnapshot(
+                runnerID: "runner-cards",
+                recordedAt: Date().addingTimeInterval(-300),
+                activeJobs: 1,
+                maxJobs: 4,
+                availableCapacity: 3,
+                hostname: "host-cards",
+                runnerVersion: "runner/2.0",
+                lastPollAt: Date().addingTimeInterval(-300),
+                lastHeartbeatAt: Date().addingTimeInterval(-300),
+                serverAssignedJobCountSinceStart: 1
+            )
+            try await snapshot.save(on: app.db)
+
+            let cookie = try await loginUser(
+                username: "admin-cards",
+                password: "password123",
+                role: "admin",
+                on: app
+            )
+
+            try await app.asyncTest(
+                .GET, "/admin/metrics/cards",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { response in
+                    #expect(response.status == .ok)
+                    let payload = try response.content.decode(MetricsCardSeriesResponse.self)
+                    #expect(payload.windows.map(\.window) == ["24h", "1w", "1m"])
+                    #expect(payload.windows.map(\.label) == ["24h", "7d", "30d"])
+
+                    let day = try #require(payload.windows.first)
+                    #expect(day.maxQueueDepth.series.count == 24)
+                    #expect(day.bucketLabels.count == 24)
+                    #expect(payload.windows[1].maxQueueDepth.series.count == 28)
+                    #expect(payload.windows[2].maxQueueDepth.series.count == 30)
+
+                    // The completed job shows up in every window's totals.
+                    for window in payload.windows {
+                        #expect(window.jobsProcessed.headline == 1)
+                        #expect(window.queueWaitP95Ms.headline == 5000)
+                        #expect(window.executionP95Ms.headline == 5000)
+                        #expect(window.load.capacity == 4)
+                        #expect(window.load.activeJobs == 1)
+                    }
+                    // The pending submission keeps the queue depth at >= 1.
+                    let queueHeadline = try #require(day.maxQueueDepth.headline)
+                    #expect(queueHeadline >= 1)
+                    // Activity lands in the trailing buckets.
+                    #expect(day.jobsProcessed.series.last == 1)
+                })
+        }
+    }
+
+    private func makeSetup(id: String) async throws -> APITestSetup {
+        let course = APICourse(code: "CARDS_\(id)", name: "Card Series", enrollmentMode: .closed)
+        try await course.save(on: app.db)
+        let setup = APITestSetup(
+            id: id,
+            manifest:
+                #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}"#,
+            zipPath: "/tmp/\(id).zip",
+            courseID: try course.requireID()
+        )
+        try await setup.save(on: app.db)
+        return setup
+    }
+}

--- a/changelog.d/admin-card-sparklines.md
+++ b/changelog.d/admin-card-sparklines.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Sparklines on the admin diagnostic cards.** Each of the five Overview
+  cards (Max Queue, Jobs Processed, Max Load, P95 Wait, P95 Execution) now
+  renders a mini bar chart of its trend, and clicking a card cycles its time
+  window through 24h → 7d → 30d. Backed by a new
+  `GET /admin/metrics/cards` endpoint that returns all three windows in one
+  payload (per-bucket peak queue depth, completed jobs, peak runner
+  utilization, and queue-wait/execution P95s), so cycling is instant and the
+  dashboard polls once a minute instead of every 15 seconds.

--- a/changelog.d/admin-card-sparklines.md
+++ b/changelog.d/admin-card-sparklines.md
@@ -8,3 +8,9 @@
   payload (per-bucket peak queue depth, completed jobs, peak runner
   utilization, and queue-wait/execution P95s), so cycling is instant and the
   dashboard polls once a minute instead of every 15 seconds.
+
+### Changed
+
+- **`RUNNER_SNAPSHOT_RETENTION_DAYS` default raised from 14 to 30** so the
+  30-day Max Load sparkline has full data, matching
+  `JOB_METRIC_RETENTION_DAYS`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -237,7 +237,7 @@ curl -H "Cookie: <admin-session-cookie>" http://localhost:8080/admin/metrics | j
 Retention knobs:
 
 - `JOB_METRIC_RETENTION_DAYS` (default `30`)
-- `RUNNER_SNAPSHOT_RETENTION_DAYS` (default `14`)
+- `RUNNER_SNAPSHOT_RETENTION_DAYS` (default `30`)
 - `RUNNER_ACTIVE_WINDOW_SECONDS` (default `120`)
 - `METRICS_RECENT_WINDOW_HOURS` (default `24`)
 - `OBSERVABILITY_PRUNE_INTERVAL_HOURS` (default `24`)

--- a/docs/operational-diagnostics.md
+++ b/docs/operational-diagnostics.md
@@ -220,7 +220,7 @@ Environment flags:
 - `JOB_METRIC_RETENTION_DAYS`
   - default: `30`
 - `RUNNER_SNAPSHOT_RETENTION_DAYS`
-  - default: `14`
+  - default: `30` (covers the admin dashboard's longest sparkline window)
 - `AUDIT_LOG_RETENTION_DAYS`
   - default: `90`; `0` disables the audit-log reaper
 - `SUBMISSION_RETENTION_DAYS`


### PR DESCRIPTION
## Summary

First slice of the activity-graph expansion: the five admin Overview diagnostic cards (Max Queue, Jobs Processed, Max Load, P95 Wait, P95 Execution) now each render a mini bar-chart sparkline of their trend, and **clicking a card cycles its time window through 24h → 7d → 30d** (per card, keyboard-accessible via Enter/Space, matching the sortable-header pattern).

## Server

- New `GET /admin/metrics/cards` endpoint (`InternalMetricsRoutes`) returns **all three windows in one payload** — headline value + per-bucket series for every card — so cycling a window is instant, with no extra round-trips. Bucket grids: 24×1h / 28×6h / 30×1d, labels formatted in America/Toronto like the activity chart.
- `maxQueueDepthSince` refactored to build a reusable `QueueDepthTimeline` (initial depth + sorted ±1 events); a pure sweep (`MetricsCardAccumulators.perBucketMaxQueueDepth`) derives per-bucket queue-depth maxima, carrying depth across buckets and folding pre-window events into the carried-in depth. Single-peak semantics are unchanged (`ObservabilityTests` still green, including the browser-mode exclusion).
- Jobs/P95 series reuse the existing `MetricBucketAccumulators`; load series reuses `peakLoad`/`peakUtilizationPercent` per bucket. All three windows are derived from one trailing 30-day fetch per source (3 queries per poll total).
- Headline P95s are computed over the window's full value set (not averaged bucket P95s), so the 24h numbers match `/admin/metrics`.
- **`RUNNER_SNAPSHOT_RETENTION_DAYS` default raised 14 → 30** so the 30d Max Load sparkline has full data, matching `JOB_METRIC_RETENTION_DAYS` (env var still overrides; docs updated). Empty buckets render as gaps, not zeros.

## Client (`admin.leaf`)

- Cards gain a window chip, a sparkline strip (same `--bar-h` bar idiom as the big activity chart, with per-bucket `title` tooltips), hover/focus affordances, and updated `aria-label`s on cycle.
- The 15-second `/admin/metrics` card poll is replaced by a 60-second `/admin/metrics/cards` poll (still sending `X-Background-Refresh` so the admin's own polling doesn't count as activity). The `/admin/metrics` endpoint itself is untouched.

## Notes

- Per-course expansion of these trends (instructor dashboard) is deliberately out of scope for this PR.

## Testing

- New `MetricsCardAccumulatorTests` (pure bucket math: carry, pre-window folding, boundary clamp, non-negativity) and `MetricsCardSeriesRouteTests` (auth redirect + full payload shape with seeded job metric, pending submission, runner snapshot).
- `ObservabilityTests` + `AdminRoutesTests` pass (one label assertion updated for the new chip markup).
- `swift build`, swift-format, SwiftLint (0 violations), `check-styles.sh`, `check-css-vars.sh` all green.

https://claude.ai/code/session_01UnazNAeomZbPJYV9u29XrA