### PR TITLE
Admin + instructor dashboard cards: DB pre-aggregation, Postgres decode fix, and instructor sparklines

### DIFF
--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -34,9 +34,31 @@
             ?? '';
     }
 
+    // Renders a sparkline (one bar per series entry) into `container`.
+    // `series` is an array of numbers / nulls (null = "no data", drawn as an
+    // empty slot). `labels` supplies the per-bar tooltip prefix and
+    // `formatPoint(value)` formats the value in the tooltip. Shared by the
+    // admin and instructor dashboard diagnostic cards.
+    function renderSparkline(container, series, labels, formatPoint) {
+        if (!container) return;
+        series = Array.isArray(series) ? series : [];
+        labels = Array.isArray(labels) ? labels : [];
+        var format = typeof formatPoint === 'function' ? formatPoint : function (v) { return String(v); };
+        var max = series.reduce(function (m, v) { return v == null ? m : Math.max(m, v); }, 0);
+        container.innerHTML = series.map(function (value, i) {
+            var pct = (value != null && max > 0) ? (value / max) * 100 : 0;
+            var title = (labels[i] || '') + ': ' + (value == null ? 'no data' : format(value));
+            return '<div class="spark-slot" title="' + escapeHtml(title) + '">'
+                + '<span class="spark-fill' + (value == null ? ' spark-fill-empty' : '')
+                + '" style="--bar-h:' + pct.toFixed(1) + '%"></span>'
+                + '</div>';
+        }).join('');
+    }
+
     window.ChickadeeUI = {
         escapeHtml: escapeHtml,
         escapeAttr: escapeHtml,
-        getCsrfToken: getCsrfToken
+        getCsrfToken: getCsrfToken,
+        renderSparkline: renderSparkline
     };
 }());

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1347,6 +1347,50 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     color: var(--gray-900);
 }
 
+/* ── Clickable diagnostic cards with sparklines ─────────
+   Shared by the admin dashboard (admin.leaf) and the instructor dashboard
+   (assignments.leaf); both poll a /metrics/cards endpoint and cycle the
+   window on click. */
+.diagnostic-card-cyclable {
+    cursor: pointer;
+    user-select: none;
+}
+.diagnostic-card-cyclable:hover {
+    border-color: var(--health-teal);
+}
+.diagnostic-card-cyclable:focus-visible {
+    outline: 2px solid var(--health-teal-dark);
+    outline-offset: 2px;
+}
+.diagnostic-window-chip {
+    font-weight: 600;
+    color: var(--health-teal-dark);
+}
+.diagnostic-spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 1px;
+    height: 28px;
+    margin-top: .4rem;
+}
+.spark-slot {
+    flex: 1 1 0;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+}
+.spark-fill {
+    width: 100%;
+    height: var(--bar-h, 0);
+    min-height: 2px;
+    background: var(--health-teal);
+    border-radius: 1px 1px 0 0;
+}
+.spark-fill-empty {
+    min-height: 0;
+    background: transparent;
+}
+
 /* ── Assignment editor: header + suite editor (new + edit pages) ─────────
    Shared component classes replacing inline styles duplicated across
    assignment-new.leaf and assignment-edit.leaf (UI audit).  display:* is

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -199,46 +199,8 @@ Admin
 .admin-diagnostics {
     padding-bottom: 1rem;
 }
-/* ── Clickable diagnostic cards with sparklines ───────── */
-.diagnostic-card-cyclable {
-    cursor: pointer;
-    user-select: none;
-}
-.diagnostic-card-cyclable:hover {
-    border-color: var(--health-teal);
-}
-.diagnostic-card-cyclable:focus-visible {
-    outline: 2px solid var(--health-teal-dark);
-    outline-offset: 2px;
-}
-.diagnostic-window-chip {
-    font-weight: 600;
-    color: var(--health-teal-dark);
-}
-.diagnostic-spark {
-    display: flex;
-    align-items: flex-end;
-    gap: 1px;
-    height: 28px;
-    margin-top: .4rem;
-}
-.spark-slot {
-    flex: 1 1 0;
-    height: 100%;
-    display: flex;
-    align-items: flex-end;
-}
-.spark-fill {
-    width: 100%;
-    height: var(--bar-h, 0);
-    min-height: 2px;
-    background: var(--health-teal);
-    border-radius: 1px 1px 0 0;
-}
-.spark-fill-empty {
-    min-height: 0;
-    background: transparent;
-}
+/* Clickable diagnostic-card + sparkline styles are global (styles.css),
+   shared with the instructor dashboard. */
 .admin-section-head {
     gap: .5rem;
 }
@@ -473,18 +435,7 @@ tr.runner-row-offline {
         }
     ];
 
-    function renderSpark(container, series, labels, formatPoint) {
-        series = Array.isArray(series) ? series : [];
-        var max = series.reduce(function (m, v) { return v == null ? m : Math.max(m, v); }, 0);
-        container.innerHTML = series.map(function (value, i) {
-            var pct = (value != null && max > 0) ? (value / max) * 100 : 0;
-            var title = (labels[i] || '') + ': ' + (value == null ? 'no data' : formatPoint(value));
-            return '<div class="spark-slot" title="' + escapeHtml(title) + '">'
-                + '<span class="spark-fill' + (value == null ? ' spark-fill-empty' : '')
-                + '" style="--bar-h:' + pct.toFixed(1) + '%"></span>'
-                + '</div>';
-        }).join('');
-    }
+    var renderSpark = ChickadeeUI.renderSparkline;
 
     function renderSparkCard(config) {
         if (!cardsPayload || !config.cardEl) return;

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -14,7 +14,35 @@
 <h1>Assignments</h1>
 #endif
 <section class="instructor-diagnostics">
-    #extend("_diagnostic-cards")
+    <div class="diagnostics-cards">
+        <article class="diagnostic-card diagnostic-card-cyclable" data-idash-card="submissions"
+                 role="button" tabindex="0"
+                 aria-label="Submissions, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Submissions</div>
+            <div class="diagnostic-value" id="idash-submissions">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
+        </article>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-idash-card="activeStudents"
+                 role="button" tabindex="0"
+                 aria-label="Active students, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Active Students</div>
+            <div class="diagnostic-value" id="idash-active-students">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
+        </article>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-idash-card="activeAssignments"
+                 role="button" tabindex="0"
+                 aria-label="Active assignments, last 24 hours. Press to change time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Active Assignments</div>
+            <div class="diagnostic-value" id="idash-active-assignments">—</div>
+            <div class="diagnostic-spark" aria-hidden="true"></div>
+        </article>
+        #for(metric in metrics):
+        <article class="diagnostic-card">
+            <div class="diagnostic-label">#(metric.label)</div>
+            <div class="diagnostic-value">#(metric.value)</div>
+        </article>
+        #endfor
+    </div>
 </section>
 <div class="section-toolbar">
     <!-- Add Section inline form -->
@@ -547,6 +575,75 @@ tr.assignment-draggable td {
     'use strict';
 
     ChickadeeRelativeTime.applyRelativeTimes();
+
+    // ── Dashboard diagnostic cards: headline + sparkline, click cycles ────────
+    //   24h / 7d / 30d.  Polls /instructor/metrics/cards (course-scoped) and
+    //   reuses the shared sparkline renderer + global card styles.
+    (function initInstructorCards() {
+        var cards = [
+            { key: 'submissions', name: 'Submissions', valueEl: document.getElementById('idash-submissions') },
+            { key: 'activeStudents', name: 'Active students', valueEl: document.getElementById('idash-active-students') },
+            { key: 'activeAssignments', name: 'Active assignments', valueEl: document.getElementById('idash-active-assignments') }
+        ].filter(function (c) { return c.valueEl; });
+        if (!cards.length) return;
+
+        var windowNouns = { '24h': 'last 24 hours', '1w': 'last 7 days', '1m': 'last 30 days' };
+        var payload = null;
+        var windowIndex = {};
+
+        function pointLabel(v) { return v + (v === 1 ? ' submission' : ''); }
+
+        function renderCard(card) {
+            if (!payload || !card.cardEl) return;
+            var idx = windowIndex[card.key] || 0;
+            var win = payload.windows[idx % payload.windows.length];
+            var data = win && win[card.key];
+            if (!data) return;
+            card.valueEl.textContent = data.headline == null ? '—' : String(data.headline);
+            var chip = card.cardEl.querySelector('.diagnostic-window-chip');
+            if (chip) chip.textContent = win.label;
+            ChickadeeUI.renderSparkline(
+                card.cardEl.querySelector('.diagnostic-spark'),
+                data.series, win.bucketLabels || [],
+                card.key === 'submissions' ? pointLabel : function (v) { return String(v); });
+            card.cardEl.setAttribute(
+                'aria-label',
+                card.name + ', ' + (windowNouns[win.window] || win.label) + '. Press to change time window.');
+        }
+
+        cards.forEach(function (card) {
+            card.cardEl = document.querySelector('.diagnostic-card[data-idash-card="' + card.key + '"]');
+            windowIndex[card.key] = 0;
+            if (!card.cardEl) return;
+            function cycle() {
+                if (!payload || !payload.windows.length) return;
+                windowIndex[card.key] = (windowIndex[card.key] + 1) % payload.windows.length;
+                renderCard(card);
+            }
+            card.cardEl.addEventListener('click', cycle);
+            card.cardEl.addEventListener('keydown', function (e) {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                e.preventDefault();
+                cycle();
+            });
+        });
+
+        async function refresh() {
+            try {
+                var res = await fetch('/instructor/metrics/cards', {
+                    headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
+                    cache: 'no-store'
+                });
+                if (!res.ok) return;
+                payload = await res.json();
+                cards.forEach(renderCard);
+            } catch (_) {
+                // Keep current values on transient polling errors.
+            }
+        }
+        refresh();
+        setInterval(refresh, 60000);
+    }());
 
     // ── Assignment drag-and-drop (within and across sections) ─────────────────
     //

--- a/Sources/APIServer/Diagnostics/InstructorCardSeries.swift
+++ b/Sources/APIServer/Diagnostics/InstructorCardSeries.swift
@@ -1,0 +1,141 @@
+// Sources/APIServer/Diagnostics/InstructorCardSeries.swift
+//
+// Builder for `GET /instructor/metrics/cards`: headline + sparkline series for
+// the instructor dashboard's diagnostic cards, scoped to the active course.
+// Mirrors the admin card series (one response carries every selectable window
+// so the client cycles 24h / 7d / 30d without extra round-trips), but the
+// metrics are course-facing: student submissions, active students, and active
+// assignments over time.
+//
+// Data limiting: the whole series is derived from a *single* fetch of the
+// longest (30-day) window's student submissions, projected to the three
+// columns the buckets need — never the full submissions table.  Unlike the
+// timer-driven RunnerSnapshot table, submissions are activity-bound, so this
+// stays proportional to real course activity.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// All three instructor card series for one window.
+struct InstructorCardWindowSeries: Content, Sendable {
+    let window: String
+    let label: String
+    let bucketLabels: [String]
+    let submissions: MetricsCardSeries
+    let activeStudents: MetricsCardSeries
+    let activeAssignments: MetricsCardSeries
+}
+
+/// Payload of `GET /instructor/metrics/cards`.
+struct InstructorCardSeriesResponse: Content, Sendable {
+    let generatedAt: Date
+    let windows: [InstructorCardWindowSeries]
+}
+
+extension OperationalDiagnosticsService {
+
+    /// A single projected student submission used to build the card buckets.
+    struct InstructorSubmissionPoint: Sendable {
+        let submittedAt: Date
+        let userID: UUID
+        let testSetupID: String
+    }
+
+    /// Builds the per-card sparkline payload for one course.  All three windows
+    /// are derived from one trailing fetch of the longest (30-day) window, so
+    /// the dashboard's poll costs a single query regardless of how many windows
+    /// the cards cycle through.
+    func instructorCardSeries(
+        setupIDs: [String],
+        studentIDs: Set<UUID>,
+        on db: Database,
+        now: Date = Date()
+    ) async throws -> InstructorCardSeriesResponse {
+        let longestWindow = MetricsCardWindow.allCases.max { $0.totalSeconds < $1.totalSeconds } ?? .month
+        let outerStart = now.addingTimeInterval(-longestWindow.totalSeconds)
+
+        let points = try await instructorSubmissionPoints(
+            setupIDs: setupIDs, studentIDs: studentIDs, since: outerStart, on: db)
+
+        let windows = MetricsCardWindow.allCases.map { window in
+            buildInstructorWindow(window: window, now: now, points: points)
+        }
+        return InstructorCardSeriesResponse(generatedAt: now, windows: windows)
+    }
+
+    /// Trailing-window student submissions, projected to only the columns the
+    /// buckets read.  Empty when the course has no setups or no students.
+    private func instructorSubmissionPoints(
+        setupIDs: [String],
+        studentIDs: Set<UUID>,
+        since outerStart: Date,
+        on db: Database
+    ) async throws -> [InstructorSubmissionPoint] {
+        guard !setupIDs.isEmpty, !studentIDs.isEmpty else { return [] }
+        let submissions = try await APISubmission.query(on: db)
+            .filter(\.$testSetupID ~~ setupIDs)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .filter(\.$userID ~~ Array(studentIDs))
+            .filter(\.$submittedAt >= outerStart)
+            .field(\.$submittedAt)
+            .field(\.$userID)
+            .field(\.$testSetupID)
+            .all()
+        return submissions.compactMap { submission in
+            guard let submittedAt = submission.submittedAt, let userID = submission.userID else { return nil }
+            return InstructorSubmissionPoint(
+                submittedAt: submittedAt, userID: userID, testSetupID: submission.testSetupID)
+        }
+    }
+
+    private func buildInstructorWindow(
+        window: MetricsCardWindow,
+        now: Date,
+        points: [InstructorSubmissionPoint]
+    ) -> InstructorCardWindowSeries {
+        let grid = window.bucketWindow(endingAt: now)
+
+        var submissionsPerBucket = [Int](repeating: 0, count: grid.bucketCount)
+        var studentsPerBucket = [Set<UUID>](repeating: [], count: grid.bucketCount)
+        var assignmentsPerBucket = [Set<String>](repeating: [], count: grid.bucketCount)
+        var windowStudents: Set<UUID> = []
+        var windowAssignments: Set<String> = []
+        var windowSubmissions = 0
+
+        for point in points {
+            guard let index = grid.bucketIndex(for: point.submittedAt) else { continue }
+            submissionsPerBucket[index] += 1
+            studentsPerBucket[index].insert(point.userID)
+            assignmentsPerBucket[index].insert(point.testSetupID)
+            windowSubmissions += 1
+            windowStudents.insert(point.userID)
+            windowAssignments.insert(point.testSetupID)
+        }
+
+        let bucketLabels = (0..<grid.bucketCount).map { index in
+            window.label(forBucketStart: grid.bucketStart(forIndex: index))
+        }
+        // A zero bucket is genuine "no activity" here (counts, not gauges), so
+        // the series carries 0 rather than nil — the sparkline draws an empty
+        // bar either way, but the headline math stays simple.
+        return InstructorCardWindowSeries(
+            window: window.rawValue,
+            label: window.displayLabel,
+            bucketLabels: bucketLabels,
+            submissions: MetricsCardSeries(
+                headline: windowSubmissions,
+                series: submissionsPerBucket.map { Optional($0) }
+            ),
+            activeStudents: MetricsCardSeries(
+                headline: windowStudents.count,
+                series: studentsPerBucket.map { Optional($0.count) }
+            ),
+            activeAssignments: MetricsCardSeries(
+                headline: windowAssignments.count,
+                series: assignmentsPerBucket.map { Optional($0.count) }
+            )
+        )
+    }
+}

--- a/Sources/APIServer/Diagnostics/MetricBucketAccumulators.swift
+++ b/Sources/APIServer/Diagnostics/MetricBucketAccumulators.swift
@@ -55,6 +55,20 @@ struct RunnerBucketAccumulator: Sendable, Equatable {
     var utilizationValues: [Int] = []
 }
 
+/// Per-bucket runner summary used to build the time-series response.  Decouples
+/// the wire response from *how* the runner stats were aggregated: the SQLite /
+/// test path summarizes raw `RunnerBucketAccumulator`s in Swift, while Postgres
+/// computes these three values directly in the database (see
+/// `runnerTimeseriesSummaries`).  Both paths must produce identical summaries.
+struct RunnerBucketSummary: Sendable, Equatable {
+    var avgUtilizationPercent: Int?
+    var maxUtilizationPercent: Int?
+    var avgActiveRunners: Int
+
+    static let empty = RunnerBucketSummary(
+        avgUtilizationPercent: nil, maxUtilizationPercent: nil, avgActiveRunners: 0)
+}
+
 struct RequestBucketAccumulator: Sendable, Equatable {
     var requestCount = 0
     var durationValues: [Int] = []
@@ -142,9 +156,28 @@ enum MetricBucketAccumulators {
         return buckets
     }
 
+    /// Collapse raw per-bucket accumulators into the lighter per-bucket
+    /// summaries the response is built from.  Used by the SQLite / test path;
+    /// the Postgres path computes equivalent summaries directly in SQL.
+    static func summarizeRunnerBuckets(
+        _ accumulators: [RunnerBucketAccumulator]
+    ) -> [RunnerBucketSummary] {
+        accumulators.map { runner in
+            let avgActiveRunners =
+                runner.sampleCount > 0
+                ? Int((Double(runner.activeRunnerTotal) / Double(runner.sampleCount)).rounded())
+                : 0
+            return RunnerBucketSummary(
+                avgUtilizationPercent: average(runner.utilizationValues),
+                maxUtilizationPercent: runner.utilizationValues.max(),
+                avgActiveRunners: avgActiveRunners
+            )
+        }
+    }
+
     static func buildBucketResponses(
         window: BucketWindow,
-        runners: [RunnerBucketAccumulator],
+        runners: [RunnerBucketSummary],
         requests: [RequestBucketAccumulator],
         jobs: [JobBucketAccumulator]
     ) -> [InternalMetricsBucketResponse] {
@@ -152,15 +185,11 @@ enum MetricBucketAccumulators {
             let runner = runners[index]
             let request = requests[index]
             let job = jobs[index]
-            let avgActiveRunners =
-                runner.sampleCount > 0
-                ? Int((Double(runner.activeRunnerTotal) / Double(runner.sampleCount)).rounded())
-                : 0
             return InternalMetricsBucketResponse(
                 bucketStart: window.bucketStart(forIndex: index),
-                avgRunnerUtilizationPercent: average(runner.utilizationValues),
-                maxRunnerUtilizationPercent: runner.utilizationValues.max(),
-                avgActiveRunners: avgActiveRunners,
+                avgRunnerUtilizationPercent: runner.avgUtilizationPercent,
+                maxRunnerUtilizationPercent: runner.maxUtilizationPercent,
+                avgActiveRunners: runner.avgActiveRunners,
                 requestCount: request.requestCount,
                 requestP95Ms: percentile95(request.durationValues),
                 completedJobs: job.completedJobs,

--- a/Sources/APIServer/Diagnostics/MetricsCardCache.swift
+++ b/Sources/APIServer/Diagnostics/MetricsCardCache.swift
@@ -1,0 +1,81 @@
+// Sources/APIServer/Diagnostics/MetricsCardCache.swift
+//
+// Single-flight, short-TTL cache in front of `metricsCardSeries`.
+//
+// The card series scans up to 30 days of `RunnerSnapshot` /
+// `JobExecutionMetric` rows — far heavier than the 24h `/admin/metrics`
+// snapshot.  The admin dashboard polls it every 60s, and the instructor
+// dashboard / retest traffic hit the database concurrently.  Without this
+// cache, each poll ran the full scan on its own connection; overlapping
+// requests stacked those long-held connections and exhausted the Fluent
+// pool (observed as `ConnectionPoolTimeoutError` + 500s on unrelated pages).
+//
+// This actor guarantees at most one in-flight computation at a time
+// (concurrent callers await the same task) and serves a cached result for
+// `ttl` seconds, so the expensive query runs at most once per TTL no matter
+// how many pollers or pages ask for it.
+
+import Foundation
+import Vapor
+
+actor MetricsCardCache {
+    private var cached: MetricsCardSeriesResponse?
+    private var cachedAt: Date?
+    private var inFlight: Task<MetricsCardSeriesResponse, Error>?
+    private let ttl: TimeInterval
+
+    init(ttl: TimeInterval = 60) {
+        self.ttl = ttl
+    }
+
+    /// Returns a cached series if it is younger than the TTL, otherwise runs
+    /// `compute` — coalescing concurrent callers onto a single execution so
+    /// the heavy scan never stacks on the connection pool.
+    func series(
+        now: Date = Date(),
+        compute: @escaping @Sendable () async throws -> MetricsCardSeriesResponse
+    ) async throws -> MetricsCardSeriesResponse {
+        if let cached, let cachedAt, now.timeIntervalSince(cachedAt) < ttl {
+            return cached
+        }
+        if let inFlight {
+            return try await inFlight.value
+        }
+
+        let task = Task { try await compute() }
+        inFlight = task
+        do {
+            let result = try await task.value
+            cached = result
+            cachedAt = now
+            inFlight = nil
+            return result
+        } catch {
+            // Don't cache failures, and clear the in-flight slot so the next
+            // caller retries rather than awaiting a dead task.
+            inFlight = nil
+            throw error
+        }
+    }
+}
+
+struct MetricsCardCacheKey: StorageKey {
+    typealias Value = MetricsCardCache
+}
+
+extension Application {
+    /// Process-wide cache fronting the admin card sparkline series.  Lazily
+    /// created on first access (mirrors `workerActivityStore`); a transient
+    /// boot-time race just recomputes once.
+    var metricsCardCache: MetricsCardCache {
+        get {
+            if let existing = storage[MetricsCardCacheKey.self] {
+                return existing
+            }
+            let created = MetricsCardCache()
+            storage[MetricsCardCacheKey.self] = created
+            return created
+        }
+        set { storage[MetricsCardCacheKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
@@ -2,26 +2,48 @@
 //
 // Builder for `GET /admin/metrics/cards`: headline + sparkline series for
 // the five admin diagnostic cards, computed for every selectable window
-// (24h / 7d / 30d) from a single fetch of the longest window's rows.
+// (24h / 7d / 30d).
+//
+// RunnerSnapshot is the one source whose volume is driven by a timer (a
+// heartbeat every ~30s), so 30 days is tens of thousands of rows — far more
+// than the submission-bound job-metric / queue-depth sources.  We therefore
+// pre-aggregate it to per-5-minute summed load *in the database* on Postgres
+// (production), collapsing that scan to a few hundred rows.  SQLite (dev /
+// tests) keeps an equivalent Swift aggregation: the data is tiny there and it
+// sidesteps SQLite's ambiguous Date storage in raw SQL.  Both paths produce
+// the same `RunnerLoadPoint` list, so the card math downstream is identical.
 
 import Fluent
 import Foundation
+import SQLKit
 import Vapor
+
+/// Summed runner load over one fixed time bucket: total busy slots and total
+/// capacity across every runner that reported in the bucket.
+struct RunnerLoadPoint: Sendable {
+    let bucketStart: Date
+    let totalActive: Int
+    let totalMax: Int
+}
+
+/// Width of the load pre-aggregation bucket.  Five minutes is far finer than
+/// the smallest *display* bucket (the 24h window's 1-hour bars), so per-bucket
+/// peaks stay faithful, while capping a 30-day scan at ~8.6k summed rows.
+private let loadBucketSeconds = 300
 
 extension OperationalDiagnosticsService {
 
     /// Builds the per-card sparkline payload.  All three windows are derived
     /// from one trailing fetch of the longest (30-day) window per source, so
-    /// the dashboard's poll costs three queries regardless of how many
-    /// windows the cards can cycle through.
+    /// the dashboard's poll costs a fixed handful of queries regardless of how
+    /// many windows the cards can cycle through.
     func metricsCardSeries(on db: Database, now: Date = Date()) async throws -> MetricsCardSeriesResponse {
         let longestWindow = MetricsCardWindow.allCases.max { $0.totalSeconds < $1.totalSeconds } ?? .month
         let outerStart = now.addingTimeInterval(-longestWindow.totalSeconds)
 
-        // Project only the columns the accumulators read.  Both tables are
-        // wide (JobExecutionMetric carries ~15 stage-timing columns;
-        // RunnerSnapshot several) and this scan spans 30 days, so trimming the
-        // selected columns materially cuts decode time and connection-hold.
+        // Job metrics are submission-bound (one row per job) and P95 can't be
+        // aggregated in portable SQL, so this stays a raw load — projected to
+        // only the columns the accumulators read.
         let jobMetrics = try await JobExecutionMetric.query(on: db)
             .filter(\.$completedAt >= outerStart)
             .field(\.$completedAt)
@@ -29,13 +51,8 @@ extension OperationalDiagnosticsService {
             .field(\.$executionMs)
             .field(\.$finalStatus)
             .all()
-        let runnerSnapshots = try await RunnerSnapshot.query(on: db)
-            .filter(\.$recordedAt >= outerStart)
-            .field(\.$recordedAt)
-            .field(\.$runnerID)
-            .field(\.$activeJobs)
-            .field(\.$maxJobs)
-            .all()
+        // RunnerSnapshot is pre-aggregated (see file header).
+        let loadPoints = try await runnerLoadPoints(since: outerStart, on: db)
         let queueTimeline = try await queueDepthTimeline(windowStart: outerStart, now: now, on: db)
 
         let windows = MetricsCardWindow.allCases.map { window in
@@ -43,7 +60,7 @@ extension OperationalDiagnosticsService {
                 window: window,
                 now: now,
                 jobMetrics: jobMetrics,
-                runnerSnapshots: runnerSnapshots,
+                loadPoints: loadPoints,
                 queueTimeline: queueTimeline
             )
         }
@@ -54,7 +71,7 @@ extension OperationalDiagnosticsService {
         window: MetricsCardWindow,
         now: Date,
         jobMetrics: [JobExecutionMetric],
-        runnerSnapshots: [RunnerSnapshot],
+        loadPoints: [RunnerLoadPoint],
         queueTimeline: QueueDepthTimeline
     ) -> MetricsCardWindowSeries {
         let grid = window.bucketWindow(endingAt: now)
@@ -71,16 +88,7 @@ extension OperationalDiagnosticsService {
         let executionHeadline = MetricBucketAccumulators.percentile95(
             inWindowMetrics.compactMap(\.executionMs))
 
-        var snapshotsByBucket = [[RunnerSnapshot]](repeating: [], count: grid.bucketCount)
-        for snapshot in runnerSnapshots {
-            guard let index = grid.bucketIndex(for: snapshot.recordedAt) else { continue }
-            snapshotsByBucket[index].append(snapshot)
-        }
-        let loadSeries = snapshotsByBucket.map { bucketSnapshots in
-            bucketSnapshots.isEmpty ? nil : peakUtilizationPercent(from: bucketSnapshots)
-        }
-        let inWindowSnapshots = runnerSnapshots.filter { $0.recordedAt >= grid.windowStart }
-        let peak = peakLoad(from: inWindowSnapshots)
+        let load = loadSeriesAndPeak(points: loadPoints, grid: grid)
 
         let bucketLabels = (0..<grid.bucketCount).map { index in
             window.label(forBucketStart: grid.bucketStart(forIndex: index))
@@ -99,9 +107,9 @@ extension OperationalDiagnosticsService {
                 series: jobsSeries.map { Optional($0) }
             ),
             load: MetricsCardLoadSeries(
-                activeJobs: peak?.activeJobs,
-                capacity: peak?.maxJobs,
-                series: loadSeries
+                activeJobs: load.peakActive,
+                capacity: load.peakMax,
+                series: load.series
             ),
             queueWaitP95Ms: MetricsCardSeries(
                 headline: waitHeadline,
@@ -112,5 +120,130 @@ extension OperationalDiagnosticsService {
                 series: jobBuckets.map { MetricBucketAccumulators.percentile95($0.executionValues) }
             )
         )
+    }
+
+    /// Per-display-bucket peak utilization% and the window's peak load pair,
+    /// derived from the pre-aggregated load points.  Only points with capacity
+    /// contribute; a display bucket with no reporting runner stays `nil` (an
+    /// empty slot, not 0%).
+    private func loadSeriesAndPeak(
+        points: [RunnerLoadPoint],
+        grid: BucketWindow
+    ) -> (series: [Int?], peakActive: Int?, peakMax: Int?) {
+        var series = [Int?](repeating: nil, count: grid.bucketCount)
+        var peak: (active: Int, max: Int)?
+
+        for point in points {
+            guard point.totalMax > 0, let index = grid.bucketIndex(for: point.bucketStart) else { continue }
+            let utilization = Int((Double(point.totalActive) / Double(point.totalMax) * 100).rounded())
+            series[index] = series[index].map { Swift.max($0, utilization) } ?? utilization
+
+            if let current = peak {
+                let currentRatio = Double(current.active) / Double(current.max)
+                let pointRatio = Double(point.totalActive) / Double(point.totalMax)
+                if pointRatio > currentRatio
+                    || (pointRatio == currentRatio && point.totalActive > current.active)
+                {
+                    peak = (point.totalActive, point.totalMax)
+                }
+            } else {
+                peak = (point.totalActive, point.totalMax)
+            }
+        }
+        return (series, peak?.active, peak?.max)
+    }
+
+    /// Summed runner load per `loadBucketSeconds` bucket since `outerStart`.
+    /// Postgres aggregates server-side; every other driver (SQLite in dev /
+    /// tests) aggregates in Swift over the raw rows.
+    func runnerLoadPoints(since outerStart: Date, on db: Database) async throws -> [RunnerLoadPoint] {
+        if let sql = db as? SQLDatabase, sql.dialect.name == "postgresql" {
+            return try await runnerLoadPointsViaPostgres(sql, since: outerStart)
+        }
+        return try await runnerLoadPointsInSwift(since: outerStart, on: db)
+    }
+
+    /// One column per (bucket, runner) is reduced to its peak load, then summed
+    /// across runners per bucket — entirely in the database.  Mirrors the
+    /// Swift fallback's semantics.
+    private func runnerLoadPointsViaPostgres(
+        _ sql: SQLDatabase,
+        since outerStart: Date
+    ) async throws -> [RunnerLoadPoint] {
+        struct LoadRow: Decodable {
+            let bucketIndex: Int
+            let totalActive: Int
+            let totalMax: Int
+            enum CodingKeys: String, CodingKey {
+                case bucketIndex = "bucket_index"
+                case totalActive = "total_active"
+                case totalMax = "total_max"
+            }
+        }
+
+        let rows = try await sql.raw(
+            """
+            SELECT bucket_index, SUM(a) AS total_active, SUM(m) AS total_max
+            FROM (
+                SELECT
+                    CAST(FLOOR(EXTRACT(EPOCH FROM recorded_at) / \(unsafeRaw: String(loadBucketSeconds))) AS BIGINT)
+                        AS bucket_index,
+                    runner_id,
+                    MAX(active_jobs) AS a,
+                    MAX(max_jobs) AS m
+                FROM \(unsafeRaw: RunnerSnapshot.schema)
+                WHERE recorded_at >= \(bind: outerStart)
+                GROUP BY bucket_index, runner_id
+            ) per_runner
+            GROUP BY bucket_index
+            ORDER BY bucket_index
+            """
+        ).all(decoding: LoadRow.self)
+
+        return rows.map { row in
+            RunnerLoadPoint(
+                bucketStart: Date(timeIntervalSince1970: Double(row.bucketIndex * loadBucketSeconds)),
+                totalActive: row.totalActive,
+                totalMax: row.totalMax
+            )
+        }
+    }
+
+    /// Swift-side equivalent of `runnerLoadPointsViaPostgres`, used on SQLite
+    /// (dev / tests) where the data is small.  Per (bucket, runner) keep the
+    /// peak active/capacity, then sum across runners per bucket.
+    private func runnerLoadPointsInSwift(
+        since outerStart: Date,
+        on db: Database
+    ) async throws -> [RunnerLoadPoint] {
+        let snapshots = try await RunnerSnapshot.query(on: db)
+            .filter(\.$recordedAt >= outerStart)
+            .field(\.$recordedAt)
+            .field(\.$runnerID)
+            .field(\.$activeJobs)
+            .field(\.$maxJobs)
+            .all()
+
+        // bucket index -> runner id -> (peak active, peak max) in that bucket.
+        var perRunner: [Int: [String: (active: Int, max: Int)]] = [:]
+        for snapshot in snapshots {
+            let bucket = Int(snapshot.recordedAt.timeIntervalSince1970) / loadBucketSeconds
+            var runners = perRunner[bucket] ?? [:]
+            let existing = runners[snapshot.runnerID]
+            runners[snapshot.runnerID] = (
+                active: Swift.max(existing?.active ?? 0, snapshot.activeJobs),
+                max: Swift.max(existing?.max ?? 0, snapshot.maxJobs)
+            )
+            perRunner[bucket] = runners
+        }
+
+        return perRunner.keys.sorted().map { bucket in
+            let runners = perRunner[bucket] ?? [:]
+            return RunnerLoadPoint(
+                bucketStart: Date(timeIntervalSince1970: Double(bucket * loadBucketSeconds)),
+                totalActive: runners.values.reduce(0) { $0 + $1.active },
+                totalMax: runners.values.reduce(0) { $0 + $1.max }
+            )
+        }
     }
 }

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
@@ -18,11 +18,23 @@ extension OperationalDiagnosticsService {
         let longestWindow = MetricsCardWindow.allCases.max { $0.totalSeconds < $1.totalSeconds } ?? .month
         let outerStart = now.addingTimeInterval(-longestWindow.totalSeconds)
 
+        // Project only the columns the accumulators read.  Both tables are
+        // wide (JobExecutionMetric carries ~15 stage-timing columns;
+        // RunnerSnapshot several) and this scan spans 30 days, so trimming the
+        // selected columns materially cuts decode time and connection-hold.
         let jobMetrics = try await JobExecutionMetric.query(on: db)
             .filter(\.$completedAt >= outerStart)
+            .field(\.$completedAt)
+            .field(\.$queueWaitMs)
+            .field(\.$executionMs)
+            .field(\.$finalStatus)
             .all()
         let runnerSnapshots = try await RunnerSnapshot.query(on: db)
             .filter(\.$recordedAt >= outerStart)
+            .field(\.$recordedAt)
+            .field(\.$runnerID)
+            .field(\.$activeJobs)
+            .field(\.$maxJobs)
             .all()
         let queueTimeline = try await queueDepthTimeline(windowStart: outerStart, now: now, on: db)
 

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
@@ -183,7 +183,14 @@ extension OperationalDiagnosticsService {
 
         let rows = try await sql.raw(
             """
-            SELECT bucket_index, SUM(a) AS total_active, SUM(m) AS total_max
+            -- active_jobs / max_jobs are bigint columns, so MAX(...) is bigint
+            -- and SUM(bigint) widens to NUMERIC, which PostgresKit can't decode
+            -- into Swift.Int.  Cast the sums back to BIGINT (the per-bucket
+            -- totals are tiny) so they decode cleanly.
+            SELECT
+                bucket_index,
+                CAST(SUM(a) AS BIGINT) AS total_active,
+                CAST(SUM(m) AS BIGINT) AS total_max
             FROM (
                 SELECT
                     CAST(FLOOR(EXTRACT(EPOCH FROM recorded_at) / \(unsafeRaw: String(loadBucketSeconds))) AS BIGINT)

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
@@ -131,26 +131,35 @@ extension OperationalDiagnosticsService {
         grid: BucketWindow
     ) -> (series: [Int?], peakActive: Int?, peakMax: Int?) {
         var series = [Int?](repeating: nil, count: grid.bucketCount)
-        var peak: (active: Int, max: Int)?
 
         for point in points {
             guard point.totalMax > 0, let index = grid.bucketIndex(for: point.bucketStart) else { continue }
             let utilization = Int((Double(point.totalActive) / Double(point.totalMax) * 100).rounded())
             series[index] = series[index].map { Swift.max($0, utilization) } ?? utilization
+        }
+        let peak = peakLoadPoint(from: points)
+        return (series, peak?.active, peak?.max)
+    }
 
-            if let current = peak {
-                let currentRatio = Double(current.active) / Double(current.max)
-                let pointRatio = Double(point.totalActive) / Double(point.totalMax)
-                if pointRatio > currentRatio
-                    || (pointRatio == currentRatio && point.totalActive > current.active)
-                {
-                    peak = (point.totalActive, point.totalMax)
-                }
-            } else {
+    /// The window's peak load pair — the load point with the highest
+    /// utilization ratio (ties broken by more active jobs).  Shared by the card
+    /// "Max Load" headline and the `/admin/metrics` snapshot.
+    func peakLoadPoint(from points: [RunnerLoadPoint]) -> (active: Int, max: Int)? {
+        var peak: (active: Int, max: Int)?
+        for point in points where point.totalMax > 0 {
+            guard let current = peak else {
+                peak = (point.totalActive, point.totalMax)
+                continue
+            }
+            let currentRatio = Double(current.active) / Double(current.max)
+            let pointRatio = Double(point.totalActive) / Double(point.totalMax)
+            if pointRatio > currentRatio
+                || (pointRatio == currentRatio && point.totalActive > current.active)
+            {
                 peak = (point.totalActive, point.totalMax)
             }
         }
-        return (series, peak?.active, peak?.max)
+        return peak
     }
 
     /// Summed runner load per `loadBucketSeconds` bucket since `outerStart`.
@@ -252,5 +261,93 @@ extension OperationalDiagnosticsService {
                 totalMax: runners.values.reduce(0) { $0 + $1.max }
             )
         }
+    }
+
+    // MARK: - Time-series runner summaries
+
+    /// Per-display-bucket runner utilization summary for `/admin/metrics/
+    /// timeseries`, pre-aggregated so the endpoint never streams the full
+    /// RunnerSnapshot scan.  Postgres aggregates per display bucket in SQL;
+    /// SQLite (dev / tests) reuses the raw-row accumulator — both must yield
+    /// identical summaries (pinned by `runnerTimeseriesSummariesMatchSwift`).
+    func runnerTimeseriesSummaries(
+        window: BucketWindow,
+        on db: Database
+    ) async throws -> [RunnerBucketSummary] {
+        if let sql = db as? SQLDatabase, sql.dialect.name == "postgresql" {
+            return try await runnerTimeseriesSummariesViaPostgres(sql, window: window)
+        }
+        let snapshots = try await RunnerSnapshot.query(on: db)
+            .filter(\.$recordedAt >= window.windowStart)
+            .field(\.$recordedAt)
+            .field(\.$activeJobs)
+            .field(\.$maxJobs)
+            .all()
+        let accumulators = MetricBucketAccumulators.accumulateRunnerSnapshots(snapshots, window: window)
+        return MetricBucketAccumulators.summarizeRunnerBuckets(accumulators)
+    }
+
+    /// SQL equivalent of `accumulateRunnerSnapshots` + `summarizeRunnerBuckets`:
+    /// per display bucket, the per-snapshot utilization is averaged and peaked
+    /// in the database, collapsing the scan to one row per bucket.
+    private func runnerTimeseriesSummariesViaPostgres(
+        _ sql: SQLDatabase,
+        window: BucketWindow
+    ) async throws -> [RunnerBucketSummary] {
+        struct SummaryRow: Decodable {
+            let bucketIndex: Int
+            let sampleCount: Int
+            let utilCount: Int
+            let utilSum: Int
+            let utilMax: Int
+            enum CodingKeys: String, CodingKey {
+                case bucketIndex = "bucket_index"
+                case sampleCount = "sample_count"
+                case utilCount = "util_count"
+                case utilSum = "util_sum"
+                case utilMax = "util_max"
+            }
+        }
+
+        // Align buckets to the window start (matching BucketWindow.bucketIndex)
+        // rather than the epoch, so SQL bucket indices map straight onto the
+        // response array.
+        let windowStartEpoch = String(format: "%.3f", window.windowStart.timeIntervalSince1970)
+        // Per-row utilization, rounded half-away-from-zero and clamped to
+        // [0, 100] — exactly as the Swift accumulator does; NULL when the
+        // runner reported no capacity, so it drops out of the util aggregates.
+        let utilExpr = "LEAST(100, GREATEST(0, ROUND(active_jobs::numeric * 100 / NULLIF(max_jobs, 0))))"
+
+        let rows = try await sql.raw(
+            """
+            SELECT
+                bucket_index,
+                CAST(COUNT(*) AS BIGINT) AS sample_count,
+                CAST(COUNT(util) AS BIGINT) AS util_count,
+                CAST(COALESCE(SUM(util), 0) AS BIGINT) AS util_sum,
+                CAST(COALESCE(MAX(util), 0) AS BIGINT) AS util_max
+            FROM (
+                SELECT
+                    CAST(FLOOR((EXTRACT(EPOCH FROM recorded_at) - \(unsafeRaw: windowStartEpoch))
+                        / \(unsafeRaw: String(window.bucketSeconds))) AS BIGINT) AS bucket_index,
+                    \(unsafeRaw: utilExpr) AS util
+                FROM \(unsafeRaw: RunnerSnapshot.schema)
+                WHERE recorded_at >= \(bind: window.windowStart)
+            ) per_row
+            GROUP BY bucket_index
+            ORDER BY bucket_index
+            """
+        ).all(decoding: SummaryRow.self)
+
+        var summaries = [RunnerBucketSummary](repeating: .empty, count: window.bucketCount)
+        for row in rows {
+            guard row.bucketIndex >= 0, row.bucketIndex < window.bucketCount else { continue }
+            summaries[row.bucketIndex] = RunnerBucketSummary(
+                avgUtilizationPercent: row.utilCount > 0 ? row.utilSum / row.utilCount : nil,
+                maxUtilizationPercent: row.utilCount > 0 ? row.utilMax : nil,
+                avgActiveRunners: row.sampleCount > 0 ? 1 : 0
+            )
+        }
+        return summaries
     }
 }

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
@@ -56,17 +56,16 @@ extension OperationalDiagnosticsService {
         let windowHours = max(1, configuration.recentMetricsWindowHours)
         let windowStart = now.addingTimeInterval(Double(-windowHours) * 3600)
 
-        let runnerSnapshots = try await RunnerSnapshot.query(on: req.db)
-            .filter(\.$recordedAt >= windowStart)
-            .sort(\.$recordedAt, .ascending)
-            .all()
+        // Pre-aggregated in the DB (see runnerLoadPoints) so the snapshot
+        // endpoint never streams the full RunnerSnapshot scan.
+        let loadPoints = try await runnerLoadPoints(since: windowStart, on: req.db)
         let activeSnapshots = await req.application.workerActivityStore.snapshotsSortedByRecent()
             .filter { now.timeIntervalSince($0.lastActive) <= configuration.activeRunnerWindowSeconds }
         let recentMetrics = try await JobExecutionMetric.query(on: req.db)
             .filter(\.$completedAt >= windowStart)
             .all()
         let maxQueueDepth = try await maxQueueDepthSince(windowStart: windowStart, now: now, on: req.db)
-        let peakLoadSnapshot = peakLoad(from: runnerSnapshots)
+        let peakLoadSnapshot = peakLoadPoint(from: loadPoints)
 
         var statusCounts: [String: Int] = [:]
         var queueWaitValues: [Int] = []
@@ -103,9 +102,11 @@ extension OperationalDiagnosticsService {
             generatedAt: now,
             maxQueueDepth: maxQueueDepth,
             jobsProcessed24h: recentMetrics.count,
-            peakUtilizationPercent: peakUtilizationPercent(from: runnerSnapshots),
-            maxLoadActiveJobs: peakLoadSnapshot?.activeJobs,
-            maxLoadCapacity: peakLoadSnapshot?.maxJobs,
+            peakUtilizationPercent: peakLoadSnapshot.flatMap { peak in
+                peak.max > 0 ? Int((Double(peak.active) / Double(peak.max) * 100).rounded()) : nil
+            },
+            maxLoadActiveJobs: peakLoadSnapshot?.active,
+            maxLoadCapacity: peakLoadSnapshot?.max,
             activeRunners: activeSnapshots.count,
             runnerLoads: runnerLoads,
             recentWindowHours: windowHours,
@@ -132,10 +133,9 @@ extension OperationalDiagnosticsService {
         )
         let window = resolved.window
 
-        let runnerSnapshots = try await RunnerSnapshot.query(on: req.db)
-            .filter(\.$recordedAt >= window.windowStart)
-            .sort(\.$recordedAt, .ascending)
-            .all()
+        // Runner snapshots are pre-aggregated per bucket (in SQL on Postgres);
+        // request / job metrics are submission-bound, so they stay raw.
+        let runners = try await runnerTimeseriesSummaries(window: window, on: req.db)
 
         let requestMetrics = try await APIRequestMetric.query(on: req.db)
             .filter(\.$finishedAt >= window.windowStart)
@@ -147,7 +147,6 @@ extension OperationalDiagnosticsService {
             .sort(\.$completedAt, .ascending)
             .all()
 
-        let runners = MetricBucketAccumulators.accumulateRunnerSnapshots(runnerSnapshots, window: window)
         let requests = MetricBucketAccumulators.accumulateRequestMetrics(requestMetrics, window: window)
         let jobs = MetricBucketAccumulators.accumulateJobMetrics(jobMetrics, window: window)
 

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Queries.swift
@@ -192,39 +192,6 @@ extension OperationalDiagnosticsService {
         return QueueDepthTimeline(initialDepth: initialDepth, events: events)
     }
 
-    func peakUtilizationPercent(from snapshots: [RunnerSnapshot]) -> Int? {
-        peakLoad(from: snapshots).flatMap { snapshot in
-            guard snapshot.maxJobs > 0 else { return nil }
-            return Int((Double(snapshot.activeJobs) / Double(snapshot.maxJobs) * 100).rounded())
-        }
-    }
-
-    func peakLoad(from snapshots: [RunnerSnapshot]) -> (activeJobs: Int, maxJobs: Int)? {
-        var latestByBucketAndRunner: [Int: [String: (activeJobs: Int, maxJobs: Int)]] = [:]
-
-        for snapshot in snapshots {
-            let bucket = Int(snapshot.recordedAt.timeIntervalSince1970 / 60)
-            latestByBucketAndRunner[bucket, default: [:]][snapshot.runnerID] = (
-                activeJobs: max(0, snapshot.activeJobs),
-                maxJobs: max(0, snapshot.maxJobs)
-            )
-        }
-
-        return latestByBucketAndRunner.values.compactMap { runnerStates in
-            let totalActiveJobs = runnerStates.values.reduce(0) { $0 + $1.activeJobs }
-            let totalMaxJobs = runnerStates.values.reduce(0) { $0 + $1.maxJobs }
-            guard totalMaxJobs > 0 else { return nil }
-            return (activeJobs: totalActiveJobs, maxJobs: totalMaxJobs)
-        }.max { lhs, rhs in
-            let lhsRatio = Double(lhs.activeJobs) / Double(lhs.maxJobs)
-            let rhsRatio = Double(rhs.activeJobs) / Double(rhs.maxJobs)
-            if lhsRatio == rhsRatio {
-                return lhs.activeJobs < rhs.activeJobs
-            }
-            return lhsRatio < rhsRatio
-        }
-    }
-
     func inFlightJobCount(on db: Database) async throws -> Int {
         try await APISubmission.query(on: db)
             .group(.or) { group in

--- a/Sources/APIServer/Routes/InternalMetricsRoutes.swift
+++ b/Sources/APIServer/Routes/InternalMetricsRoutes.swift
@@ -18,7 +18,16 @@ struct InternalMetricsRoutes: RouteCollection {
     /// a card's window without another round-trip.
     @Sendable
     func cards(req: Request) async throws -> MetricsCardSeriesResponse {
-        try await req.application.diagnostics.metricsCardSeries(on: req.db)
+        // Served from a single-flight, short-TTL cache: the 30-day scan is
+        // expensive, the dashboard polls it every 60s, and it must never stack
+        // on the connection pool (see MetricsCardCache).  The compute closure
+        // uses the application database, not `req.db`, since one caller's task
+        // may be awaited by concurrent callers that outlive the original
+        // request.
+        let app = req.application
+        return try await app.metricsCardCache.series {
+            try await app.diagnostics.metricsCardSeries(on: app.db)
+        }
     }
 
     @Sendable

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Cards.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Cards.swift
@@ -1,0 +1,47 @@
+// APIServer/Routes/Web/InstructorDashboardRoutes+Cards.swift
+//
+// GET /instructor/metrics/cards — JSON sparkline series for the instructor
+// dashboard's diagnostic cards, scoped to the caller's active course.  Polled
+// by assignments.leaf the same way the admin dashboard polls
+// /admin/metrics/cards; the client cycles 24h / 7d / 30d from one payload.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension InstructorDashboardRoutes {
+
+    // MARK: - GET /instructor/metrics/cards
+
+    @Sendable
+    func metricsCards(req: Request) async throws -> InstructorCardSeriesResponse {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+
+        guard let activeCourseUUID = courseState.activeCourseUUID else {
+            return InstructorCardSeriesResponse(generatedAt: Date(), windows: [])
+        }
+
+        let setups = try await loadCourseSetups(req: req, activeCourseUUID: activeCourseUUID)
+        let setupIDs = setups.compactMap(\.id)
+
+        let enrolledUserIDs = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == activeCourseUUID)
+            .all()
+            .map(\.userID)
+        let studentIDs: Set<UUID>
+        if enrolledUserIDs.isEmpty {
+            studentIDs = []
+        } else {
+            let students = try await APIUser.query(on: req.db)
+                .filter(\.$role == UserRole.student.rawValue)
+                .filter(\.$id ~~ enrolledUserIDs)
+                .all()
+            studentIDs = Set(students.compactMap(\.id))
+        }
+
+        return try await req.application.diagnostics.instructorCardSeries(
+            setupIDs: setupIDs, studentIDs: studentIDs, on: req.db)
+    }
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -130,7 +130,6 @@ extension InstructorDashboardRoutes {
         let metrics = try await buildCourseRosterMetrics(
             req: req,
             allSetupIDs: allSetupIDs,
-            enrolledUsers: enrolledUsers,
             activeStudentIDs: activeStudentIDs
         )
 
@@ -265,36 +264,15 @@ extension InstructorDashboardRoutes {
     private func buildCourseRosterMetrics(
         req: Request,
         allSetupIDs: [String],
-        enrolledUsers: [APIUser],
         activeStudentIDs: Set<UUID>
     ) async throws -> [InstructorDashboardMetric] {
         let now = Date()
         let windowStart = now.addingTimeInterval(-24 * 60 * 60)
-        let recentSubmissions =
-            allSetupIDs.isEmpty
-            ? []
-            : try await APISubmission.query(on: req.db)
-                .filter(\.$testSetupID ~~ allSetupIDs)
-                .filter(\.$kind == APISubmission.Kind.student)
-                .filter(\.$submittedAt >= windowStart)
-                .all()
         let workerModeSetupIDs = try await req.application.diagnostics.workerModeTestSetupIDs(
             for: allSetupIDs,
             on: req.db
         )
 
-        let active24h = enrolledUsers.reduce(into: 0) { count, user in
-            guard user.roleValue == .student else { return }
-            if let lastSeenAt = user.lastSeenAt, lastSeenAt >= windowStart {
-                count += 1
-            }
-        }
-
-        let recentStudentSubmissions = recentSubmissions.filter { submission in
-            guard let userID = submission.userID else { return false }
-            return activeStudentIDs.contains(userID)
-        }
-        let activeAssignments24h = Set(recentStudentSubmissions.map(\.testSetupID)).count
         // SQL COUNT instead of loading every course submission ever made just
         // to tally the in-flight ones (June 2026 audit, P1.6).
         let pendingNow: Int
@@ -315,10 +293,10 @@ extension InstructorDashboardRoutes {
             windowStart: windowStart
         )
 
+        // Submissions / active students / active assignments are now rendered
+        // as cyclable sparkline cards (fed by GET /instructor/metrics/cards);
+        // only the two instantaneous gauges remain as static cards here.
         return [
-            InstructorDashboardMetric(label: "24h Active", value: "\(active24h)"),
-            InstructorDashboardMetric(label: "24h Submissions", value: "\(recentStudentSubmissions.count)"),
-            InstructorDashboardMetric(label: "Assignments Active (24h)", value: "\(activeAssignments24h)"),
             InstructorDashboardMetric(label: "Queued Right Now", value: "\(pendingNow)"),
             InstructorDashboardMetric(label: "Students With Browser Errors", value: "\(studentsWithBrowserErrors)"),
         ]
@@ -381,12 +359,12 @@ extension InstructorDashboardRoutes {
         ).count
     }
 
-    /// Five "—" placeholder cards for use when no course is active.
+    /// "—" placeholder cards for use when no course is active.  The
+    /// submissions / active-students / active-assignments cards are the
+    /// cyclable sparkline cards (rendered separately), so only the two static
+    /// gauges appear here.
     static func placeholderDashboardMetrics() -> [InstructorDashboardMetric] {
         [
-            InstructorDashboardMetric(label: "24h Active", value: "—"),
-            InstructorDashboardMetric(label: "24h Submissions", value: "—"),
-            InstructorDashboardMetric(label: "Assignments Active (24h)", value: "—"),
             InstructorDashboardMetric(label: "Queued Right Now", value: "—"),
             InstructorDashboardMetric(label: "Students With Browser Errors", value: "—"),
         ]

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -34,6 +34,8 @@ struct InstructorDashboardRoutes: RouteCollection {
 
         let r = routes.grouped("instructor")
         r.get(use: list)
+        // JSON sparkline series for the dashboard diagnostic cards.
+        r.get("metrics", "cards", use: metricsCards)
         // Students roster tab + its self-updating poll endpoint.
         r.get("students", use: studentsPage)
         r.get("students-data", use: studentsData)

--- a/Tests/APITests/MetricBucketAccumulatorsTests.swift
+++ b/Tests/APITests/MetricBucketAccumulatorsTests.swift
@@ -255,7 +255,7 @@ import Testing
 
         let buckets = MetricBucketAccumulators.buildBucketResponses(
             window: window,
-            runners: runners,
+            runners: MetricBucketAccumulators.summarizeRunnerBuckets(runners),
             requests: requests,
             jobs: jobs
         )
@@ -345,7 +345,7 @@ import Testing
         let jobBuckets = MetricBucketAccumulators.accumulateJobMetrics(jobs, window: window)
         let response = MetricBucketAccumulators.buildBucketResponses(
             window: window,
-            runners: runnerBuckets,
+            runners: MetricBucketAccumulators.summarizeRunnerBuckets(runnerBuckets),
             requests: requestBuckets,
             jobs: jobBuckets
         )

--- a/Tests/APITests/MetricsCardCacheTests.swift
+++ b/Tests/APITests/MetricsCardCacheTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct MetricsCardCacheTests {
+    private func emptyResponse(now: Date = Date()) -> MetricsCardSeriesResponse {
+        MetricsCardSeriesResponse(generatedAt: now, windows: [])
+    }
+
+    /// A second call inside the TTL must return the cached value without
+    /// running the (expensive) compute closure again.
+    @Test func cachesWithinTTL() async throws {
+        let cache = MetricsCardCache(ttl: 60)
+        let counter = Counter()
+        let base = Date(timeIntervalSince1970: 1_000)
+
+        _ = try await cache.series(now: base) {
+            await counter.increment()
+            return self.emptyResponse()
+        }
+        _ = try await cache.series(now: base.addingTimeInterval(30)) {
+            await counter.increment()
+            return self.emptyResponse()
+        }
+
+        #expect(await counter.value == 1)
+    }
+
+    /// Past the TTL the cache recomputes.
+    @Test func recomputesAfterTTL() async throws {
+        let cache = MetricsCardCache(ttl: 60)
+        let counter = Counter()
+        let base = Date(timeIntervalSince1970: 1_000)
+
+        _ = try await cache.series(now: base) {
+            await counter.increment()
+            return self.emptyResponse()
+        }
+        _ = try await cache.series(now: base.addingTimeInterval(61)) {
+            await counter.increment()
+            return self.emptyResponse()
+        }
+
+        #expect(await counter.value == 2)
+    }
+
+    /// Concurrent callers on a cold cache must coalesce onto one computation
+    /// — this is what stops the heavy scan from stacking on the DB pool.
+    @Test func concurrentCallersShareOneComputation() async throws {
+        let cache = MetricsCardCache(ttl: 60)
+        let counter = Counter()
+        let base = Date(timeIntervalSince1970: 1_000)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask {
+                    _ = try await cache.series(now: base) {
+                        await counter.increment()
+                        // Hold long enough that all callers pile up behind the
+                        // single in-flight task.
+                        try? await Task.sleep(nanoseconds: 50_000_000)
+                        return self.emptyResponse()
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        #expect(await counter.value == 1)
+    }
+
+    /// A failed computation is not cached: the next caller retries.
+    @Test func doesNotCacheFailures() async throws {
+        struct Boom: Error {}
+        let cache = MetricsCardCache(ttl: 60)
+        let counter = Counter()
+        let base = Date(timeIntervalSince1970: 1_000)
+
+        await #expect(throws: Boom.self) {
+            _ = try await cache.series(now: base) {
+                await counter.increment()
+                throw Boom()
+            }
+        }
+        _ = try await cache.series(now: base.addingTimeInterval(1)) {
+            await counter.increment()
+            return self.emptyResponse()
+        }
+
+        #expect(await counter.value == 2)
+    }
+
+    private actor Counter {
+        private(set) var value = 0
+        func increment() { value += 1 }
+    }
+}

--- a/Tests/APITests/MetricsCardSeriesTests.swift
+++ b/Tests/APITests/MetricsCardSeriesTests.swift
@@ -92,6 +92,39 @@ import XCTVapor
         self.app = try await makeTestApp(prefix: "chickadee-cards")
     }
 
+    /// The load series sums concurrent runners' busy slots and capacity within
+    /// a bucket, and reports the window's peak pair.  Exercises the Swift
+    /// aggregation on SQLite locally; `api-tests-postgres` runs the same
+    /// assertions through the Postgres SQL path.
+    @Test func runnerLoadPointsSumConcurrentRunners() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            // Two runners reporting in the same 5-minute bucket (~10 min ago):
+            // r1 busy 2/4, r2 busy 1/4 → summed 3/8 in that bucket.
+            try await saveSnapshot(runner: "r1", at: now.addingTimeInterval(-600), active: 2, max: 4)
+            try await saveSnapshot(runner: "r2", at: now.addingTimeInterval(-590), active: 1, max: 4)
+            // A later, quieter bucket (~3 min ago): only r1, busy 0/4.
+            try await saveSnapshot(runner: "r1", at: now.addingTimeInterval(-180), active: 0, max: 4)
+
+            let points = try await app.diagnostics.runnerLoadPoints(
+                since: now.addingTimeInterval(-3600), on: app.db)
+
+            // Two distinct 5-minute buckets.
+            #expect(points.count == 2)
+            let busy = try #require(points.max(by: { $0.totalActive < $1.totalActive }))
+            #expect(busy.totalActive == 3)
+            #expect(busy.totalMax == 8)
+        }
+    }
+
+    private func saveSnapshot(runner: String, at: Date, active: Int, max: Int) async throws {
+        let snapshot = RunnerSnapshot(
+            runnerID: runner, recordedAt: at, activeJobs: active, maxJobs: max,
+            availableCapacity: Swift.max(0, max - active), hostname: runner, runnerVersion: "x",
+            lastPollAt: at, lastHeartbeatAt: at, serverAssignedJobCountSinceStart: 0)
+        try await snapshot.save(on: app.db)
+    }
+
     @Test func cardsEndpointRequiresAuthentication() async throws {
         try await withApp(app) { _ in
             try await app.asyncTest(

--- a/Tests/APITests/MetricsCardSeriesTests.swift
+++ b/Tests/APITests/MetricsCardSeriesTests.swift
@@ -146,6 +146,63 @@ import XCTVapor
         }
     }
 
+    /// The instructor card series buckets student submissions per window and
+    /// reports distinct active students / assignments.  Runs on SQLite locally
+    /// and the Postgres path in CI.
+    @Test func instructorCardSeriesBucketsSubmissions() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            let s1 = try await makeSetup(id: "ics_s1").requireID()
+            let s2 = try await makeSetup(id: "ics_s2").requireID()
+            let studentA = try await makeStudent(username: "ics_a")
+            let studentB = try await makeStudent(username: "ics_b")
+            let studentC = try await makeStudent(username: "ics_c")
+
+            try await saveStudentSubmission(
+                id: "ics_1", setupID: s1, userID: studentA, at: now.addingTimeInterval(-2 * 3600))
+            try await saveStudentSubmission(
+                id: "ics_2", setupID: s2, userID: studentA, at: now.addingTimeInterval(-3 * 3600))
+            try await saveStudentSubmission(
+                id: "ics_3", setupID: s1, userID: studentB, at: now.addingTimeInterval(-1 * 3600))
+            // Outside the 30-day window — excluded everywhere.
+            try await saveStudentSubmission(
+                id: "ics_old", setupID: s1, userID: studentA, at: now.addingTimeInterval(-40 * 86400))
+            // Enrolled-student filter excludes this one (student C not passed in).
+            try await saveStudentSubmission(
+                id: "ics_other", setupID: s1, userID: studentC, at: now.addingTimeInterval(-30 * 60))
+
+            let response = try await app.diagnostics.instructorCardSeries(
+                setupIDs: [s1, s2], studentIDs: [studentA, studentB], on: app.db, now: now)
+
+            let day = try #require(response.windows.first { $0.window == "24h" })
+            #expect(day.submissions.headline == 3)
+            #expect(day.activeStudents.headline == 2)
+            #expect(day.activeAssignments.headline == 2)
+            #expect(day.submissions.series.compactMap { $0 }.reduce(0, +) == 3)
+
+            // The 30-day window also excludes the 40-day-old row and the
+            // non-enrolled student.
+            let month = try #require(response.windows.first { $0.window == "1m" })
+            #expect(month.submissions.headline == 3)
+        }
+    }
+
+    private func makeStudent(username: String) async throws -> UUID {
+        let user = APIUser(username: username, passwordHash: "x", role: "student")
+        try await user.save(on: app.db)
+        return try user.requireID()
+    }
+
+    private func saveStudentSubmission(id: String, setupID: String, userID: UUID, at: Date) async throws {
+        let submission = APISubmission(
+            id: id, testSetupID: setupID, zipPath: "/tmp/\(id).zip",
+            attemptNumber: 1, status: "completed", userID: userID,
+            kind: APISubmission.Kind.student)
+        try await submission.save(on: app.db)
+        submission.submittedAt = at
+        try await submission.update(on: app.db)
+    }
+
     private func saveSnapshot(runner: String, at: Date, active: Int, max: Int) async throws {
         let snapshot = RunnerSnapshot(
             runnerID: runner, recordedAt: at, activeJobs: active, maxJobs: max,

--- a/Tests/APITests/MetricsCardSeriesTests.swift
+++ b/Tests/APITests/MetricsCardSeriesTests.swift
@@ -117,6 +117,35 @@ import XCTVapor
         }
     }
 
+    /// Per-display-bucket runner summaries: per-snapshot utilization is
+    /// averaged and peaked within each bucket.  Exercises the Swift aggregation
+    /// on SQLite locally; `api-tests-postgres` runs the same assertions through
+    /// the Postgres SQL path, pinning the two paths to identical output.
+    @Test func runnerTimeseriesSummariesAggregatePerBucket() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            let window = BucketWindow.resolve(
+                hours: 1, bucketMinutes: 30, defaultHours: 24, now: now
+            ).window
+
+            // Bucket 0 ([-60m, -30m)): r1 at 2/4 (50%) then 4/4 (100%).
+            try await saveSnapshot(runner: "r1", at: now.addingTimeInterval(-3000), active: 2, max: 4)
+            try await saveSnapshot(runner: "r1", at: now.addingTimeInterval(-2700), active: 4, max: 4)
+            // Bucket 1 ([-30m, now)): r2 at 1/2 (50%).
+            try await saveSnapshot(runner: "r2", at: now.addingTimeInterval(-1200), active: 1, max: 2)
+
+            let summaries = try await app.diagnostics.runnerTimeseriesSummaries(
+                window: window, on: app.db)
+
+            #expect(summaries.count == 2)
+            #expect(summaries[0].avgUtilizationPercent == 75)  // (50 + 100) / 2
+            #expect(summaries[0].maxUtilizationPercent == 100)
+            #expect(summaries[0].avgActiveRunners == 1)
+            #expect(summaries[1].avgUtilizationPercent == 50)
+            #expect(summaries[1].maxUtilizationPercent == 50)
+        }
+    }
+
     private func saveSnapshot(runner: String, at: Date, active: Int, max: Int) async throws {
         let snapshot = RunnerSnapshot(
             runnerID: runner, recordedAt: at, activeJobs: active, maxJobs: max,

--- a/changelog.d/admin-card-perf-fix.md
+++ b/changelog.d/admin-card-perf-fix.md
@@ -1,11 +1,14 @@
 ### Fixed
 
-- **Admin diagnostic-card sparklines no longer exhaust the database connection
-  pool.** The `GET /admin/metrics/cards` endpoint scans up to 30 days of
-  `RunnerSnapshot` / `JobExecutionMetric` rows; under the dashboard's 60s poll,
-  concurrent requests stacked that long-running query on separate connections
-  and could drain the Fluent pool, surfacing as `ConnectionPoolTimeoutError`
-  and 500s on unrelated pages. The series is now served from a single-flight,
-  short-TTL cache (`MetricsCardCache`) so the heavy scan runs at most once per
-  minute regardless of caller count, and the two 30-day queries project only
-  the columns the sparklines need.
+- **Admin diagnostic-card sparklines no longer overload the database.** The
+  `GET /admin/metrics/cards` endpoint scanned up to 30 days of `RunnerSnapshot`
+  rows (recorded every ~30s, so tens of thousands of rows); under the
+  dashboard's 60s poll, concurrent requests stacked that long query on separate
+  connections and could drain the Fluent pool, surfacing as
+  `ConnectionPoolTimeoutError` and 500s on unrelated pages. Two changes fix it:
+  (1) on Postgres the runner-load series is now pre-aggregated **in the
+  database** to per-5-minute summed load, collapsing the scan to a few hundred
+  rows (SQLite keeps an equivalent Swift aggregation); and (2) the whole series
+  is served through a single-flight, 60s-TTL cache (`MetricsCardCache`) so the
+  query runs at most once a minute no matter how many pollers or pages request
+  it. The "Max Load" card's peak pair is computed at 5-minute resolution.

--- a/changelog.d/admin-card-perf-fix.md
+++ b/changelog.d/admin-card-perf-fix.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Admin diagnostic-card sparklines no longer exhaust the database connection
+  pool.** The `GET /admin/metrics/cards` endpoint scans up to 30 days of
+  `RunnerSnapshot` / `JobExecutionMetric` rows; under the dashboard's 60s poll,
+  concurrent requests stacked that long-running query on separate connections
+  and could drain the Fluent pool, surfacing as `ConnectionPoolTimeoutError`
+  and 500s on unrelated pages. The series is now served from a single-flight,
+  short-TTL cache (`MetricsCardCache`) so the heavy scan runs at most once per
+  minute regardless of caller count, and the two 30-day queries project only
+  the columns the sparklines need.

--- a/changelog.d/admin-metrics-timeseries-perf.md
+++ b/changelog.d/admin-metrics-timeseries-perf.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **`/admin/metrics` and `/admin/metrics/timeseries` no longer stream the full
+  `RunnerSnapshot` scan.** The snapshot and time-series endpoints loaded every
+  runner heartbeat in the window (a row every ~30s) and bucketed them in Swift —
+  the same unbounded-scan / pool-holding pattern that overloaded the diagnostic
+  cards. The runner-load aggregation is now done **in the database** on Postgres
+  (per-display-bucket utilization average / peak, and the summed-load peak pair),
+  with an equivalent Swift aggregation on SQLite (dev / tests) where the data is
+  tiny. Both paths produce identical results, pinned by a Postgres-exercised
+  parity test. Request- and job-metric series are submission-bound and stay raw.

--- a/changelog.d/instructor-dashboard-sparkline-cards.md
+++ b/changelog.d/instructor-dashboard-sparkline-cards.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Instructor dashboard diagnostic cards now have sparklines + cyclable time
+  windows.** The Submissions, Active Students, and Active Assignments cards on
+  the instructor overview gained the same click-to-cycle 24h / 7d / 30d
+  sparkline treatment as the admin dashboard, fed by a new course-scoped
+  `GET /instructor/metrics/cards` endpoint. The whole series is derived from a
+  single trailing fetch of the longest window's student submissions (projected
+  to the three columns the buckets need), so the dashboard's poll stays cheap.
+  The sparkline renderer and card styles are now shared between the admin and
+  instructor dashboards (`ChickadeeUI.renderSparkline`, global card CSS). The
+  Queued Right Now and Students With Browser Errors gauges remain static cards.


### PR DESCRIPTION
## Incident

After #920 shipped the diagnostic-card sparklines, a dev server hit
`ConnectionPoolTimeoutError` ("Database unreachable"), 500s on the instructor
dashboard, and ~60s-to-first-paint on the cards.

**Root cause (measured):** `GET /admin/metrics/cards` scanned up to **30 days**
of `RunnerSnapshot` rows. That table is driven by a ~30s heartbeat, so a month
is tens of thousands of rows. The dashboard polls every 60s; each poll ran the
full scan on its own pooled connection, draining the Fluent pool → timeouts on
unrelated pages.

## What's in this PR

### 1. Card sparkline DB load (the original fix)
- **Pre-aggregate `RunnerSnapshot` in the database.** On Postgres the
  runner-load series is computed as per-5-minute summed load via grouped SQL,
  collapsing the 30-day scan to a few hundred rows. SQLite (dev/tests) keeps an
  equivalent Swift aggregation. Both paths produce identical `RunnerLoadPoint`
  values.
- **Single-flight, 60s-TTL cache (`MetricsCardCache`)** so concurrent callers
  coalesce onto one in-flight computation.

### 2. Postgres `NUMERIC` decode fix (was failing `api-tests-postgres`)
`SUM()` over the per-runner `MAX(active_jobs)/MAX(max_jobs)` bigint columns
widens to `NUMERIC` in Postgres, which PostgresKit can't decode into
`Swift.Int` — the cards endpoint 500'd in production and `api-tests-postgres`
failed (SQLite has no such type distinction, so `api-tests` stayed green). The
summed totals are now cast back to `BIGINT`. Reproduced and fixed against a
local Postgres 16.

### 3. `/admin/metrics` + `/admin/metrics/timeseries` pre-aggregation
These two endpoints still streamed the full `RunnerSnapshot` scan and bucketed
in Swift — the same unbounded pattern. The runner-load aggregation is now done
in the database on Postgres (per-display-bucket utilization average/peak via
`runnerTimeseriesSummaries`, and the summed-load peak pair via
`runnerLoadPoints`), with an equivalent Swift aggregation on SQLite. Both paths
are pinned identical by a Postgres-exercised parity test. Request/job series
are submission-bound and stay raw.

### 4. Instructor dashboard sparkline cards
Extends the cyclable sparkline cards to the instructor overview: the
Submissions, Active Students, and Active Assignments cards now show a
24h/7d/30d sparkline that cycles on click, fed by a new course-scoped
`GET /instructor/metrics/cards` (`InstructorCardSeries`). The whole payload is
built from a single trailing fetch of the longest window's student submissions,
projected to the columns the buckets read. The sparkline renderer is hoisted to
`ChickadeeUI.renderSparkline` and the clickable-card / spark CSS moved to the
global stylesheet, so both dashboards share one implementation.

## Testing

- `runnerLoadPointsSumConcurrentRunners`, `runnerTimeseriesSummariesAggregatePerBucket`,
  `instructorCardSeriesBucketsSubmissions` — green on **both** SQLite and a local
  Postgres 16 (the latter exercises every raw-SQL path).
- `MetricsCardCacheTests`, `MetricsCardSeriesRouteTests`, `MetricBucketAccumulatorTests`,
  `ObservabilityTests`, `AssignmentRoutesDashboardTests` green.
- Build, swift-format, SwiftLint (0 violations), `check-styles.sh`,
  `check-css-vars.sh` all clean.

https://claude.ai/code/session_01ARZnEGW6cb7gMnjci2sPVi