### PR TITLE
Fix "Session refreshed" 403 when deleting an assignment

### DIFF
--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -486,6 +486,7 @@
                         </a>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
+                            #csrfFormField()
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment"
                                    >
@@ -508,6 +509,7 @@
                         </a>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
+                            #csrfFormField()
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment"
                                    >
@@ -524,6 +526,7 @@
                         </a>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
+                            #csrfFormField()
                             <button class="btn action-btn action-danger" type="submit"
                                     aria-label="Delete assignment" title="Delete assignment"
                                    >

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -434,4 +434,66 @@ import XCTVapor
         }
     }
 
+    /// Regression guard for the "Session refreshed" delete bug.  The three
+    /// assignment delete forms in the Ungrouped table (the `closed` / `open` /
+    /// preview-`#else` branches in assignments.leaf) were missing
+    /// `#csrfFormField()`, so `POST /instructor/:id/delete` arrived with no
+    /// `_csrf` token and the CSRF middleware 403'd it — rendering the
+    /// "Session refreshed" error page instead of deleting.  With no course
+    /// sections defined, every assignment renders in that Ungrouped table, so
+    /// every delete failed.  This asserts each delete form embeds the hidden
+    /// CSRF input across all three visibility states.
+    @Test func deleteAssignmentFormsIncludeCSRFTokenInUngroupedTable() async throws {
+        try await withAssignmentRoutesApp { app in
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            // One assignment in each visibility state that drives a distinct
+            // template branch: open, closed, and preview (the `#else`).
+            try await arInsertSetup(id: "setup_del_open", on: app)
+            let openA = try await arInsertAssignment(
+                testSetupID: "setup_del_open", title: "Open One",
+                isOpen: true, validationStatus: "passed", on: app)
+
+            try await arInsertSetup(id: "setup_del_closed", on: app)
+            let closedA = try await arInsertAssignment(
+                testSetupID: "setup_del_closed", title: "Closed One",
+                isOpen: false, validationStatus: "passed", on: app)
+
+            try await arInsertSetup(id: "setup_del_preview", on: app)
+            let previewA = try await arInsertAssignment(
+                testSetupID: "setup_del_preview", title: "Preview One",
+                isOpen: false, validationStatus: "passed", on: app)
+            previewA.visibility = .preview
+            try await previewA.save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/instructor",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    for assignment in [openA, closedA, previewA] {
+                        let action = "action=\"/instructor/\(assignment.publicID)/delete\""
+                        let actionRange = try #require(
+                            html.range(of: action),
+                            "Expected a delete form for assignment \(assignment.publicID)"
+                        )
+                        let formEnd = try #require(
+                            html.range(of: "</form>", range: actionRange.upperBound..<html.endIndex),
+                            "Delete form for \(assignment.publicID) is not closed"
+                        )
+                        let formSegment = html[actionRange.upperBound..<formEnd.lowerBound]
+                        #expect(
+                            formSegment.contains("name='_csrf'"),
+                            "Delete form for \(assignment.publicID) must include the CSRF hidden field"
+                        )
+                    }
+                })
+
+        }
+    }
+
 }

--- a/changelog.d/fix-delete-assignment-csrf.md
+++ b/changelog.d/fix-delete-assignment-csrf.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Deleting an assignment no longer fails with "Session refreshed".** The
+  three assignment delete forms in the Ungrouped table on the instructor
+  dashboard (the `closed` / `open` / preview branches in `assignments.leaf`)
+  were missing `#csrfFormField()`, so `POST /instructor/:id/delete` arrived
+  without a `_csrf` token and the CSRF middleware rejected it with a 403.
+  Because every assignment renders in that Ungrouped table when no course
+  sections are defined, every delete failed; moving an assignment into a
+  section (whose table already emitted the token) was the only workaround.
+  All eight delete forms on the page now emit the hidden CSRF field.


### PR DESCRIPTION
## Problem

Deleting an assignment from the instructor dashboard always failed with a `403 — Session refreshed` error page ("Your session was refreshed since this page was opened, so your change wasn't saved").

## Root cause

`Resources/Views/assignments.leaf` renders assignments in **two** tables:

1. A **sectioned** table (`section.rows`) — all delete forms here include `#csrfFormField()`.
2. An **Ungrouped** bucket (`ungroupedRows`), which is *also* the table used in flat-table mode **when no course sections exist** — the common case.

The three assignment delete forms in the Ungrouped table (the `closed` / `open` / preview-`#else` branches) were **missing `#csrfFormField()`**. So `POST /instructor/:id/delete` arrived with no `_csrf` token, the app's CSRF middleware aborted with `403 "No CSRF token provided."`, and `LeafErrorMiddleware` rendered that as the friendly "Session refreshed" page (any 403 whose reason contains `csrf`).

Because every assignment lands in the Ungrouped table when no course sections are defined, **every** delete failed. Moving an assignment into a section (whose table already emitted the token) was the only workaround — which is exactly what the reporter observed.

## Fix

- Add `#csrfFormField()` to all three Ungrouped-table assignment delete forms. All eight delete forms on the page now emit the hidden token.
- Add a regression test (`AssignmentRoutesDashboardTests.deleteAssignmentFormsIncludeCSRFTokenInUngroupedTable`) that renders `/instructor` in flat-table mode with open/closed/preview assignments and asserts each delete form embeds the CSRF input.

## Testing

- `swift build --target APIServer` ✓
- New regression test passes ✓

https://claude.ai/code/session_01EHG1wCc5E4QypeqLn26CuK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHG1wCc5E4QypeqLn26CuK)_