### PR TITLE
Fix sticky pattern-family dependencies on generated test rows

### DIFF
--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -603,10 +603,6 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         return out
     }
 
-    let oldEntryByScript: [String: TestSuiteEntry] = Dictionary(
-        uniqueKeysWithValues: props.testSuites.map { ($0.script, $0) }
-    )
-
     let checkByID: [String: NotebookCheck] = Dictionary(
         uniqueKeysWithValues: resolvedChecks.map { ($0.id, $0) }
     )
@@ -650,14 +646,21 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
             perStudentNames: perStudentExpressionNames)
         {
             order += 1
-            let prior = oldEntryByScript[generated.filename]
-            let perCase = expandDeps(prior?.dependsOn ?? [])
             var combined: [String] = []
             var seen = Set<String>()
-            // Guard first so a missing function reports the guard as the
-            // unmet prerequisite; inherited family deps and any preserved
-            // per-case deps follow (deduped).
-            for d in (guardFilename.map { [$0] } ?? []) + inherited + perCase {
+            // Generated-case deps are fully derived from the *current* spec:
+            // the guard first (so a missing function reports the guard as the
+            // unmet prerequisite), then the family's inherited prerequisites
+            // (deduped).  We deliberately do NOT carry the prior manifest
+            // entry's deps forward.  Doing so made a once-set family-level
+            // dependency permanently "sticky": every regeneration re-read the
+            // old generated row's deps, so clearing `family.dependsOn` (or
+            // dropping a hand-written prereq the family used to point at) could
+            // never remove it from the generated rows — leaving a dangling
+            // reference that no edit could delete, because a hand-written
+            // script is not a generated file and so never entered the
+            // `expandDeps` `toDelete` filter.
+            for d in (guardFilename.map { [$0] } ?? []) + inherited {
                 guard seen.insert(d).inserted else { continue }
                 combined.append(d)
             }

--- a/Tests/APITests/PatternFamilyApplyTests.swift
+++ b/Tests/APITests/PatternFamilyApplyTests.swift
@@ -365,6 +365,80 @@ import Vapor
         }
     }
 
+    /// Regression: clearing a family's `dependsOn` propagates to its generated
+    /// cases, so the prerequisite can then be removed.  Previously generated-row
+    /// deps carried the prior manifest entry's deps forward, so a once-set
+    /// family-level prerequisite (e.g. a hand-written `*_exists` script the
+    /// family pointed at) stuck to every generated row forever — clearing
+    /// `family.dependsOn` left it in place, and the script could never be
+    /// deleted (its generated rows still depended on it → dangling reference).
+    @Test func apply_clearingFamilyDepsDropsThemFromGeneratedCasesAndUnblocksDelete() async throws {
+        try await withPatternFamilyFixture { fixture in
+            try updateScriptInZip(
+                zipPath: fixture.setup.zipPath,
+                filename: "publictest_prereq.py",
+                content: "# prereq\npassed('ok')\n"
+            )
+            let prereq = AuthoredRawScript(
+                script: "publictest_prereq.py",
+                tier: .pub, points: 1, displayName: nil, dependsOn: []
+            )
+            let withDep = PatternFamily(
+                id: "bmi_category", name: "BMI", kind: .boundaryEquality,
+                functionName: "bmi_category", paramNames: ["bmi"],
+                cases: pfBMIFamily().cases,
+                dependsOn: ["publictest_prereq.py"]
+            )
+            // 1. Save with the family pointing at the prereq — every generated
+            //    row inherits it.
+            _ = try await applyPatternFamilies(
+                to: fixture.setup,
+                nextFamilies: [withDep],
+                authoredItems: [.script(prereq), .family(id: "bmi_category")],
+                on: fixture.app.db
+            )
+            let afterDep = try pfDecodeManifest(fixture.setup.manifest)
+            #expect(
+                afterDep.testSuites.contains {
+                    $0.generatedBy != nil && $0.dependsOn.contains("publictest_prereq.py")
+                },
+                "precondition: generated rows inherit the family-level prereq")
+
+            // 2. Clear the family's deps — every generated row must drop the
+            //    prereq (this is the assertion that failed before the fix).
+            let cleared = PatternFamily(
+                id: "bmi_category", name: "BMI", kind: .boundaryEquality,
+                functionName: "bmi_category", paramNames: ["bmi"],
+                cases: pfBMIFamily().cases,
+                dependsOn: []
+            )
+            _ = try await applyPatternFamilies(
+                to: fixture.setup,
+                nextFamilies: [cleared],
+                authoredItems: [.script(prereq), .family(id: "bmi_category")],
+                on: fixture.app.db
+            )
+            let afterClear = try pfDecodeManifest(fixture.setup.manifest)
+            #expect(
+                afterClear.testSuites.allSatisfy { !$0.dependsOn.contains("publictest_prereq.py") },
+                "clearing family.dependsOn drops the prereq from every generated row")
+
+            // 3. With nothing depending on it, the prereq can now be removed —
+            //    the save's post-expansion dependency validation no longer
+            //    rejects it as a dangling reference.
+            _ = try await applyPatternFamilies(
+                to: fixture.setup,
+                nextFamilies: [cleared],
+                authoredItems: [.family(id: "bmi_category")],
+                on: fixture.app.db
+            )
+            let afterRemove = try pfDecodeManifest(fixture.setup.manifest)
+            #expect(!afterRemove.testSuites.contains { $0.script == "publictest_prereq.py" })
+            #expect(
+                afterRemove.testSuites.allSatisfy { !$0.dependsOn.contains("publictest_prereq.py") })
+        }
+    }
+
     /// Removing a family drops `family:<id>` tokens from other entries'
     /// dependsOn — no dangling refs remain.
     @Test func apply_removingFamilyClearsFamilyRefsFromOtherEntries() async throws {

--- a/changelog.d/pattern-family-dependency-clear.md
+++ b/changelog.d/pattern-family-dependency-clear.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **Clearing a pattern family's prerequisites now actually drops them from the
+  generated test rows.** Generated-case `dependsOn` was rebuilt as
+  `[guard] + family.dependsOn + the prior manifest row's deps`, and that last
+  term made a once-set family-level prerequisite permanently "sticky": once a
+  family pointed at a script (e.g. a hand-written `*_exists` check), every
+  regeneration re-read the old generated row and re-added the dependency, so
+  clearing `family.dependsOn` never propagated. The practical symptom was an
+  un-deletable script — the suite editor and the MCP `delete_suite_item` /
+  `update_pattern_family` tools both rejected removing it with a dangling
+  "depends on … which is not listed in testSuites" error, because a
+  hand-written script is not a generated file and so never entered the deletion
+  diff. Generated-case dependencies are now derived solely from the current
+  spec (`[guard] + family.dependsOn`), so clearing the family's prerequisites
+  removes them from every generated row and unblocks the delete.


### PR DESCRIPTION
## What & why

While cleaning up redundant "is defined" rows in two assignments, I hit a case where a hand-written test script could **not** be deleted — through the MCP tools *or* the web suite editor — because a pattern family's generated case rows kept depending on it even after the family's prerequisite was cleared.

### Root cause

In `applyPatternFamilies`, each generated case's `dependsOn` was rebuilt as:

```
[guard] + expandDeps(family.dependsOn) + expandDeps(prior manifest row's dependsOn)
```

That last term carried the **previous** generated row's deps forward on every regeneration. Since a generated row's deps are always `[guard] + family.dependsOn`, the term effectively "remembered" a once-set family-level prerequisite and re-applied it forever. Clearing `family.dependsOn` updated the family record but never propagated to the generated rows.

The symptom: an un-deletable script. The deletion diff (`expandDeps`'s `toDelete` filter) only covers *generated* files, so a hand-written prerequisite a family used to point at never got filtered out, and `validateManifestDependencies` rejected the delete with `depends on … which is not listed in testSuites`. This affected both `delete_suite_item` / `update_pattern_family` (MCP) **and** the web editor's `PUT /suite`.

### Fix

Generated-case dependencies are now derived solely from the current spec — `[guard] + family.dependsOn` — with no carry-forward of the prior manifest row's deps. Clearing a family's prerequisites now drops them from every generated row, which unblocks deleting the (now unreferenced) script.

This is the correct model: generated rows are *derived*, never *authored*, so there is no independent per-case dependency to preserve.

## Tests

- New regression test `apply_clearingFamilyDepsDropsThemFromGeneratedCasesAndUnblocksDelete` (apply with a family-level prereq → clear it → confirm every generated row drops it → confirm the prereq script can then be removed without a dangling-reference error).
- Full pattern-family / suite / MCP-tool suites pass: `PatternFamilyApplyTests`, `PatternFamilyExistenceGuardTests`, `PatternFamilySectionsTests`, `SuiteRouteTests`, `ScriptEditRoutesTests`, `ManifestValidationTests`, and the `*ToolTests` for delete/update/create suite/family (126 tests across both runs).
- `swift-format --strict` and SwiftLint `--strict` clean.

## Notes

- No `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` edits — a `changelog.d/` fragment is included per the release process.
- Generated script *bytes* are unchanged (only the manifest `dependsOn` arrays change), so `spec_hash` / `TestSetupCache` keys stay stable.

https://claude.ai/code/session_01X8NoBbU4P9TjoCtmVgpJAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8NoBbU4P9TjoCtmVgpJAq)_