### PR TITLE
Scroll to first failing test after browser submission

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1046,8 +1046,21 @@
 
         resultsEl.hidden = false;
 
-        // Scroll results into view so student sees feedback immediately.
-        resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        // Scroll to the first test the student still needs to fix — usually the
+        // question they are actively working on — rather than the top of the
+        // results.  We target the first failing/error/timeout row, ignoring
+        // dependency-skipped rows (those are downstream of an actual failure,
+        // which is the better landing spot).  When everything passes there is
+        // nothing to fix, so fall back to the top of the results so the student
+        // sees the all-green summary.
+        const firstUnresolved = resultsEl.querySelector(
+            'tr.status-fail, tr.status-error, tr.status-timeout'
+        );
+        if (firstUnresolved) {
+            firstUnresolved.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        } else {
+            resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
     }
 
     // Group outcomes for display via the browser runner's shared helper, with a


### PR DESCRIPTION
## Summary

Minor UI fix for the browser-based runner. After a browser-graded notebook submission, the results panel scrolled to the **top of the results** every time. This change scrolls to the **first unresolved test** instead — typically the question the student is actively working on.

## Behavior

- Scroll target is the first `fail` / `error` / `timeout` row, centered in the viewport (`block: 'center'`).
- Dependency-skipped rows are ignored — they're downstream of an actual failure, which is the better landing spot.
- When everything passes there is nothing to fix, so it falls back to the previous behavior (scroll to the top of the results) so the student sees the all-green summary.

## Implementation

Single change in `Public/notebook.js` `renderResults()`: after the results are rendered and unhidden, query for the first failing row via `querySelector('tr.status-fail, tr.status-error, tr.status-timeout')` and `scrollIntoView` on it, falling back to the results container.

## Testing

`node --test Tests/BrowserRunnerJSTests/notebook.test.mjs` passes.

https://claude.ai/code/session_0142XK73FXfHHNW8MifvuPEy

---
_Generated by [Claude Code](https://claude.ai/code/session_0142XK73FXfHHNW8MifvuPEy)_