### PR TITLE
MCP compliance hardening round 2: least-privilege DB role, audit fail-closed, refuse-to-mount, egress allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,3 +86,10 @@ SSO_INSTRUCTOR_USERS=
 # ES256 signing key for MCP access tokens. Auto-generated (mode 0600) on first
 # start if absent; git-ignored. See deploy/README.md for rotation.
 # MCP_SIGNING_KEY_PATH=.mcp-signing-key
+#
+# Dedicated least-privilege DB role for the MCP path (postgres only;
+# defence-in-depth for the student-data wall). When both are set, MCP queries
+# run on a separate pool as this restricted role. Create it with
+# deploy/sql/mcp-least-privilege-role.sql. Leave unset to share the main pool.
+# MCP_DATABASE_USER=chickadee_mcp
+# MCP_DATABASE_PASSWORD=change-me

--- a/.env.example
+++ b/.env.example
@@ -76,9 +76,12 @@ SSO_INSTRUCTOR_USERS=
 # MCP_MODE=read_write       # full content authoring
 #
 # DNS-rebinding guards: set BOTH in production to this deployment's public host
-# and origin. Unset, they default to "allow any" and the server warns at boot.
+# and origin. In production the server REFUSES to mount /mcp when either is
+# unset (open guards defeat the protection); set MCP_ALLOW_OPEN_GUARDS=true to
+# override only when a trusted reverse proxy already pins Host/Origin.
 # MCP_ALLOWED_HOSTS=chickadee.example.com
 # MCP_ALLOWED_ORIGINS=https://chickadee.example.com
+# MCP_ALLOW_OPEN_GUARDS=false
 #
 # ES256 signing key for MCP access tokens. Auto-generated (mode 0600) on first
 # start if absent; git-ignored. See deploy/README.md for rotation.

--- a/Sources/APIServer/Configuration/MCPConfig.swift
+++ b/Sources/APIServer/Configuration/MCPConfig.swift
@@ -43,6 +43,13 @@ struct MCPConfig: Sendable {
     var maxRegisteredClients: Int
     /// Cap on `redirect_uris` accepted in a single registration.  Default 5.
     var maxRedirectURIsPerClient: Int
+    /// Allow `/mcp` to mount in production even when the Host/Origin
+    /// DNS-rebinding guards (`allowedHosts` / `allowedOrigins`) are empty.
+    /// Default false: production refuses to mount the transport with the guards
+    /// open, since "allow any" defeats the rebinding protection.  Set
+    /// `MCP_ALLOW_OPEN_GUARDS=true` only when another layer (e.g. a trusted
+    /// reverse proxy that pins Host/Origin) provides the same protection.
+    var allowOpenTransportGuards: Bool
 
     init(
         mode: MCPMode,
@@ -56,7 +63,8 @@ struct MCPConfig: Sendable {
         grantTTLDays: Int = 120,
         oauthRateLimitPerMin: Int = 30,
         maxRegisteredClients: Int = 1000,
-        maxRedirectURIsPerClient: Int = 5
+        maxRedirectURIsPerClient: Int = 5,
+        allowOpenTransportGuards: Bool = false
     ) {
         self.mode = mode
         self.allowedHosts = allowedHosts
@@ -70,6 +78,7 @@ struct MCPConfig: Sendable {
         self.oauthRateLimitPerMin = oauthRateLimitPerMin
         self.maxRegisteredClients = maxRegisteredClients
         self.maxRedirectURIsPerClient = maxRedirectURIsPerClient
+        self.allowOpenTransportGuards = allowOpenTransportGuards
     }
 
     static func fromEnvironment(workDir: String) -> MCPConfig {
@@ -85,7 +94,8 @@ struct MCPConfig: Sendable {
             grantTTLDays: environmentInt("MCP_GRANT_TTL_DAYS") ?? 120,
             oauthRateLimitPerMin: max(1, environmentInt("MCP_OAUTH_RATE_LIMIT_PER_MIN") ?? 30),
             maxRegisteredClients: max(1, environmentInt("MCP_MAX_REGISTERED_CLIENTS") ?? 1000),
-            maxRedirectURIsPerClient: max(1, environmentInt("MCP_MAX_REDIRECT_URIS") ?? 5)
+            maxRedirectURIsPerClient: max(1, environmentInt("MCP_MAX_REDIRECT_URIS") ?? 5),
+            allowOpenTransportGuards: environmentBool("MCP_ALLOW_OPEN_GUARDS") ?? false
         )
     }
 

--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -49,8 +49,13 @@ func closeOpenAssignmentForContentEdit(
 func retestSubmissionsAfterContentEdit(setup: APITestSetup, context: ToolContext) async -> Int {
     do {
         let actingUser = try await context.requireEligibleSubject(tool: "retest")
+        // Re-queue runs on the privileged default pool, not the MCP pool: it
+        // reads and flips STUDENT submission rows (a system regrade, not
+        // agent-facing data access), so it must not depend on the MCP path's
+        // (optionally least-privilege) connection. With no dedicated MCP pool
+        // configured this is the same connection, so behaviour is unchanged.
         return try await retestSubmissionsIfManifestChanged(
-            setup: setup, triggeredBy: actingUser.id, on: context.db)
+            setup: setup, triggeredBy: actingUser.id, on: context.request.db)
     } catch {
         context.logger.warning("retestSubmissionsAfterContentEdit failed: \(error)")
         return 0

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -32,7 +32,14 @@ struct ToolContext {
         self.actingClientName = actingClientName
     }
 
-    var db: any Database { request.db }
+    /// The database the MCP tool surface runs on. When a dedicated
+    /// least-privilege pool is configured (`MCP_DATABASE_USER`/`PASSWORD`), every
+    /// MCP query goes through it (`DatabaseID.mcp`) so the student-data wall is
+    /// enforced by the DB role, not only the in-process boundary. Otherwise it
+    /// falls back to the shared default pool.
+    var db: any Database {
+        request.application.usesDedicatedMCPDatabase ? request.db(.mcp) : request.db
+    }
     var logger: Logger { request.logger }
 
     /// Resolves the token subject and confirms it may use the MCP interface at

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -207,6 +207,22 @@ struct MCPDispatcher: Sendable {
         // call is still attributed to what it acted on. Only the identifier is
         // captured here — never the argument values.
         let target = MCPAuditTarget(arguments: call.arguments)
+
+        // Fail closed for writes: a state-changing tool must not run unless its
+        // audit record is durably persisted first. Read tools stay best-effort
+        // (a read that can't be audited still degrades to a logged marker, but
+        // is not blocked).
+        var writeAuditRow: APIAuditLogEntry?
+        if tool.requiredScopes.contains(.write) {
+            writeAuditRow = await recordToolCall(name: call.name, context: context, target: target)
+            guard writeAuditRow != nil else {
+                return .failure(
+                    id: id,
+                    error: .internalError(
+                        "Refusing to run \(call.name): its audit record could not be persisted."))
+            }
+        }
+
         let response: JSONRPCResponse
         let outcome: MCPToolOutcome
         do {
@@ -222,22 +238,31 @@ struct MCPDispatcher: Sendable {
             outcome = .failed
             response = .failure(id: id, error: .internalError("Tool \(call.name) failed."))
         }
-        // Audit every authorized tool call as the human subject, attributed to
-        // the acting agent, recording the target resource and the outcome.
-        await auditToolCall(name: call.name, context: context, target: target, outcome: outcome)
+
+        if let writeAuditRow {
+            // Stamp the outcome onto the row already persisted before the write.
+            await AuditLogger.updateMetadata(
+                writeAuditRow, merging: ["outcome": outcome.rawValue], on: context.request)
+        } else {
+            // Read tool: one best-effort row carrying the outcome.
+            _ = await recordToolCall(
+                name: call.name, context: context, target: target, outcome: outcome)
+        }
         return response
     }
 
-    /// Records an `mcp.tool_called` audit entry. The actor is the token subject
-    /// suffixed with `-MCP` (e.g. `jsmith-MCP`) so agent-made changes are
-    /// tracked separately from the human's own web actions in the admin audit
-    /// log; the acting agent is in `via_agent` when present. The target resource
-    /// (assignment public ID or course code) and the call outcome are recorded
-    /// when known. Never logs tool arguments.
-    func auditToolCall(
+    /// Records an `mcp.tool_called` audit entry and returns the persisted row
+    /// (nil if the write failed). The actor is the token subject suffixed with
+    /// `-MCP` (e.g. `jsmith-MCP`) so agent-made changes are tracked separately
+    /// from the human's own web actions in the admin audit log; the acting agent
+    /// is in `via_agent` when present. The target resource (assignment public ID
+    /// or course code) and, when known, the outcome are recorded. Never logs
+    /// tool arguments.
+    @discardableResult
+    func recordToolCall(
         name: String, context: ToolContext,
         target: MCPAuditTarget? = nil, outcome: MCPToolOutcome? = nil
-    ) async {
+    ) async -> APIAuditLogEntry? {
         var metadata = ["tool": name]
         if let agent = context.actingClientName {
             metadata["via_agent"] = agent
@@ -245,13 +270,22 @@ struct MCPDispatcher: Sendable {
         if let outcome {
             metadata["outcome"] = outcome.rawValue
         }
-        await AuditLogger.record(
+        return await AuditLogger.recordReturning(
             action: .mcpToolCalled,
             targetType: target?.type,
             targetID: target?.id,
             metadata: metadata,
             actorUsernameOverride: "\(context.subject)-MCP",
             on: context.request)
+    }
+
+    /// Best-effort audit used by the streaming `validate_assignment` path (a read
+    /// tool, so no fail-closed): records the call without propagating failure.
+    func auditToolCall(
+        name: String, context: ToolContext,
+        target: MCPAuditTarget? = nil, outcome: MCPToolOutcome? = nil
+    ) async {
+        _ = await recordToolCall(name: name, context: context, target: target, outcome: outcome)
     }
 
     private func successToolResult(_ structured: JSONValue) -> JSONValue {

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -97,6 +97,18 @@ func registerMCPRoutes(_ app: Application) throws {
         return
     }
 
+    // Fail safe: in production, refuse to mount the transport with the
+    // DNS-rebinding guards left open, unless an operator has explicitly opted in
+    // (e.g. a trusted proxy pins Host/Origin).
+    if let refusal = mcpTransportGuardRefusal(
+        environment: app.environment,
+        allowedHosts: mcp.allowedHosts,
+        allowedOrigins: mcp.allowedOrigins,
+        allowOpenGuards: mcp.allowOpenTransportGuards)
+    {
+        app.logger.error("\(refusal)")
+        return
+    }
     if let warning = mcpAllowlistWarning(
         environment: app.environment,
         allowedHosts: mcp.allowedHosts,
@@ -173,22 +185,46 @@ func registerMCPOAuthRoutes(
         "MCP browser OAuth flow mounted at /oauth/{authorize,token,revoke,register}")
 }
 
+/// The DNS-rebinding guard env-var names that are unset (empty allowlist means
+/// "allow any" — see MCPRoutes.Configuration).
+func mcpUnsetGuardNames(allowedHosts: Set<String>, allowedOrigins: Set<String>) -> [String] {
+    var unset: [String] = []
+    if allowedHosts.isEmpty { unset.append("MCP_ALLOWED_HOSTS") }
+    if allowedOrigins.isEmpty { unset.append("MCP_ALLOWED_ORIGINS") }
+    return unset
+}
+
 /// The operator-facing warning to log when the MCP transport is being mounted
-/// in production with one or both DNS-rebinding guards disabled (an empty
-/// allowlist means "allow any" — see MCPRoutes.Configuration).  Nil when both
+/// in production with one or both DNS-rebinding guards disabled.  Nil when both
 /// are configured, or in non-production environments where empty allowlists
-/// are the normal development default.
+/// are the normal development default.  (When the guards are open in production
+/// *without* the `allowOpenGuards` override, `mcpTransportGuardRefusal` blocks
+/// the mount before this warning would ever apply.)
 func mcpAllowlistWarning(
     environment: Environment, allowedHosts: Set<String>, allowedOrigins: Set<String>
 ) -> String? {
     guard environment == .production else { return nil }
-    var unset: [String] = []
-    if allowedHosts.isEmpty { unset.append("MCP_ALLOWED_HOSTS") }
-    if allowedOrigins.isEmpty { unset.append("MCP_ALLOWED_ORIGINS") }
+    let unset = mcpUnsetGuardNames(allowedHosts: allowedHosts, allowedOrigins: allowedOrigins)
     guard !unset.isEmpty else { return nil }
     return "MCP transport mounted with \(unset.joined(separator: " and ")) unset — "
         + "the Host/Origin DNS-rebinding guards are disabled. Set them to this "
         + "deployment's public host and origin."
+}
+
+/// The reason to REFUSE mounting `/mcp`: production, a guard left open, and no
+/// explicit `MCP_ALLOW_OPEN_GUARDS` override.  Nil means it is safe to mount
+/// (possibly still emitting `mcpAllowlistWarning` when overridden).  Outside
+/// production, or with the override set, an open guard is allowed.
+func mcpTransportGuardRefusal(
+    environment: Environment, allowedHosts: Set<String>, allowedOrigins: Set<String>,
+    allowOpenGuards: Bool
+) -> String? {
+    guard environment == .production, !allowOpenGuards else { return nil }
+    let unset = mcpUnsetGuardNames(allowedHosts: allowedHosts, allowedOrigins: allowedOrigins)
+    guard !unset.isEmpty else { return nil }
+    return "Refusing to mount /mcp: \(unset.joined(separator: " and ")) unset in production. "
+        + "The Host/Origin DNS-rebinding guards must be configured, or set "
+        + "MCP_ALLOW_OPEN_GUARDS=true if a trusted reverse proxy pins Host/Origin."
 }
 
 private extension String {

--- a/Sources/APIServer/Services/AuditLogger.swift
+++ b/Sources/APIServer/Services/AuditLogger.swift
@@ -27,31 +27,62 @@ enum AuditLogger {
         actorUsernameOverride: String? = nil,
         on req: Request
     ) async {
-        let actor = actorOverride ?? req.auth.get(APIUser.self)
-        let actorUserID = actor?.id
-        let actorUsername = actorUsernameOverride ?? actor?.username
+        _ = await recordReturning(
+            action: action, targetType: targetType, targetID: targetID, metadata: metadata,
+            actorOverride: actorOverride, actorUsernameOverride: actorUsernameOverride, on: req)
+    }
 
+    /// Like `record`, but returns the persisted entry — or nil when the write
+    /// failed — so a caller can fail closed on a missing audit record (e.g. an
+    /// MCP write tool that must not mutate state unrecorded) or stamp later
+    /// fields onto the same row.  The failure is still logged.
+    static func recordReturning(
+        action: AuditAction,
+        targetType: AuditTargetType? = nil,
+        targetID: String? = nil,
+        metadata: [String: String]? = nil,
+        actorOverride: APIUser? = nil,
+        actorUsernameOverride: String? = nil,
+        on req: Request
+    ) async -> APIAuditLogEntry? {
+        let actor = actorOverride ?? req.auth.get(APIUser.self)
         let trust = req.application.securityConfiguration.trustForwardedProto
-        let remoteAddr = clientIPAddress(from: req, trustForwardedFor: trust)
-        let userAgent = req.headers.first(name: "User-Agent")
-        let metadataJSON = metadata.flatMap(encodeMetadata)
 
         let entry = APIAuditLogEntry(
-            actorUserID: actorUserID,
-            actorUsername: actorUsername,
+            actorUserID: actor?.id,
+            actorUsername: actorUsernameOverride ?? actor?.username,
             action: action.rawValue,
             targetType: targetType?.rawValue,
             targetID: targetID,
-            remoteAddr: remoteAddr,
-            userAgent: userAgent,
-            metadata: metadataJSON
+            remoteAddr: clientIPAddress(from: req, trustForwardedFor: trust),
+            userAgent: req.headers.first(name: "User-Agent"),
+            metadata: metadata.flatMap(encodeMetadata)
         )
         do {
             try await entry.save(on: req.db)
+            return entry
         } catch {
             req.logger.error(
                 "audit_log write failed for action=\(action.rawValue): \(error.localizedDescription)"
             )
+            return nil
+        }
+    }
+
+    /// Best-effort: merges `extra` into an already-persisted entry's metadata and
+    /// saves it.  Used to stamp a final field (e.g. the call outcome) onto a row
+    /// written before the action ran.  A failure here is non-critical — the
+    /// durable record already exists — so it is logged, not propagated.
+    static func updateMetadata(
+        _ entry: APIAuditLogEntry, merging extra: [String: String], on req: Request
+    ) async {
+        var dict = entry.metadata.flatMap(decodeMetadata) ?? [:]
+        for (key, value) in extra { dict[key] = value }
+        entry.metadata = encodeMetadata(dict)
+        do {
+            try await entry.update(on: req.db)
+        } catch {
+            req.logger.error("audit_log metadata update failed: \(error.localizedDescription)")
         }
     }
 
@@ -59,5 +90,10 @@ enum AuditLogger {
         guard !dict.isEmpty else { return nil }
         let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
         return data.flatMap { String(data: $0, encoding: .utf8) }
+    }
+
+    private static func decodeMetadata(_ json: String) -> [String: String]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
     }
 }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -20,6 +20,14 @@ struct DatabaseSettings: Sendable {
     let postgresUsername: String?
     let postgresPassword: String?
     let postgresSearchPath: [String]?
+    /// Optional least-privilege role for the MCP path (postgres only). When both
+    /// are set, a second connection pool is registered under `DatabaseID.mcp`
+    /// using these credentials against the same host/database, and the MCP tool
+    /// surface uses it — so a restricted DB role (no access to student tables)
+    /// enforces the student-data wall at the database layer, independent of the
+    /// in-process boundary. nil → the MCP path shares the main pool.
+    let postgresMCPUsername: String?
+    let postgresMCPPassword: String?
 
     static func fromEnvironment(defaultSQLitePath: String) throws -> Self {
         let backend: DatabaseBackend
@@ -62,7 +70,9 @@ struct DatabaseSettings: Sendable {
                 port: port,
                 database: database,
                 username: username,
-                password: password
+                password: password,
+                mcpUsername: trimmedEnv("MCP_DATABASE_USER"),
+                mcpPassword: trimmedEnv("MCP_DATABASE_PASSWORD")
             )
         }
     }
@@ -77,7 +87,9 @@ struct DatabaseSettings: Sendable {
             postgresDatabase: nil,
             postgresUsername: nil,
             postgresPassword: nil,
-            postgresSearchPath: nil
+            postgresSearchPath: nil,
+            postgresMCPUsername: nil,
+            postgresMCPPassword: nil
         )
     }
 
@@ -91,7 +103,9 @@ struct DatabaseSettings: Sendable {
             postgresDatabase: nil,
             postgresUsername: nil,
             postgresPassword: nil,
-            postgresSearchPath: nil
+            postgresSearchPath: nil,
+            postgresMCPUsername: nil,
+            postgresMCPPassword: nil
         )
     }
 
@@ -101,7 +115,9 @@ struct DatabaseSettings: Sendable {
         database: String,
         username: String,
         password: String,
-        searchPath: [String]? = nil
+        searchPath: [String]? = nil,
+        mcpUsername: String? = nil,
+        mcpPassword: String? = nil
     ) -> Self {
         .init(
             backend: .postgres,
@@ -112,7 +128,9 @@ struct DatabaseSettings: Sendable {
             postgresDatabase: database,
             postgresUsername: username,
             postgresPassword: password,
-            postgresSearchPath: searchPath
+            postgresSearchPath: searchPath,
+            postgresMCPUsername: mcpUsername,
+            postgresMCPPassword: mcpPassword
         )
     }
 }
@@ -130,6 +148,24 @@ enum DatabaseConfigurationError: Error, LocalizedError {
 
 extension DatabaseID {
     static let chickadee = DatabaseID(string: "chickadee")
+    /// Optional dedicated pool for the MCP path, backed by a least-privilege
+    /// Postgres role (see `deploy/sql/mcp-least-privilege-role.sql`). Registered
+    /// only when `MCP_DATABASE_USER`/`MCP_DATABASE_PASSWORD` are set.
+    static let mcp = DatabaseID(string: "mcp")
+}
+
+private struct UsesDedicatedMCPDatabaseKey: StorageKey {
+    typealias Value = Bool
+}
+
+extension Application {
+    /// True when a dedicated least-privilege MCP database pool (`DatabaseID.mcp`)
+    /// is registered. When false, the MCP path shares the main pool. The MCP tool
+    /// surface reads this to choose its connection (see `ToolContext.db`).
+    var usesDedicatedMCPDatabase: Bool {
+        get { storage[UsesDedicatedMCPDatabaseKey.self] ?? false }
+        set { storage[UsesDedicatedMCPDatabaseKey.self] = newValue }
+    }
 }
 
 func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
@@ -178,6 +214,28 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
             as: .chickadee,
             isDefault: true
         )
+
+        // Optional: a second pool for the MCP path backed by a least-privilege
+        // role (no access to student tables). Same host/database/search_path,
+        // different credentials. When unset, MCP shares the main pool above.
+        if let mcpUsername = settings.postgresMCPUsername,
+            let mcpPassword = settings.postgresMCPPassword
+        {
+            var mcpConfiguration = SQLPostgresConfiguration(
+                hostname: host,
+                port: port,
+                username: mcpUsername,
+                password: mcpPassword,
+                database: database,
+                tls: .disable
+            )
+            if let searchPath = settings.postgresSearchPath, !searchPath.isEmpty {
+                mcpConfiguration.searchPath = searchPath
+            }
+            app.databases.use(.postgres(configuration: mcpConfiguration), as: .mcp)
+            app.usesDedicatedMCPDatabase = true
+            app.logger.info("MCP database: dedicated least-privilege role \(mcpUsername) in use")
+        }
     }
 }
 

--- a/Tests/APITests/MCP/MCPAllowlistWarningTests.swift
+++ b/Tests/APITests/MCP/MCPAllowlistWarningTests.swift
@@ -43,4 +43,39 @@ import Vapor
                     == nil)
         }
     }
+
+    // MARK: - Refuse-to-mount (P2-2)
+
+    @Test func refusesInProductionWhenAGuardIsOpen() throws {
+        let reason = try #require(
+            mcpTransportGuardRefusal(
+                environment: .production, allowedHosts: [], allowedOrigins: ["https://claude.ai"],
+                allowOpenGuards: false))
+        #expect(reason.contains("Refusing to mount /mcp"))
+        #expect(reason.contains("MCP_ALLOWED_HOSTS"))
+    }
+
+    @Test func allowsInProductionWhenOverrideSet() {
+        // Operator opts in (e.g. a trusted proxy pins Host/Origin): mount, do not refuse.
+        #expect(
+            mcpTransportGuardRefusal(
+                environment: .production, allowedHosts: [], allowedOrigins: [],
+                allowOpenGuards: true) == nil)
+    }
+
+    @Test func allowsInProductionWhenBothGuardsSet() {
+        #expect(
+            mcpTransportGuardRefusal(
+                environment: .production, allowedHosts: ["chickadee.example.com"],
+                allowedOrigins: ["https://claude.ai"], allowOpenGuards: false) == nil)
+    }
+
+    @Test func neverRefusesOutsideProduction() {
+        for environment in [Environment.development, .testing] {
+            #expect(
+                mcpTransportGuardRefusal(
+                    environment: environment, allowedHosts: [], allowedOrigins: [],
+                    allowOpenGuards: false) == nil)
+        }
+    }
 }

--- a/Tests/APITests/MCP/MCPAuditFailClosedTests.swift
+++ b/Tests/APITests/MCP/MCPAuditFailClosedTests.swift
@@ -1,0 +1,108 @@
+// Verifies the audit fail-closed policy (P1-2): a WRITE tool must not mutate
+// state unless its audit record persists first, while a READ tool degrades to
+// best-effort and still succeeds. Audit-write failure is simulated by dropping
+// the audit_log table in the per-test database.
+
+import Core
+import Fluent
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPAuditFailClosedTests {
+    private func dispatcher() -> MCPDispatcher {
+        MCPDispatcher(
+            serverInfo: MCPServerInfo(name: "t", version: "t"),
+            tools: ToolRegistry([UpdateAssignmentTool().erased(), GetAssignmentTool().erased()]))
+    }
+
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "jsmith", grantedScopes: [.read, .write],
+            actingClientID: "agent-1", actingClientName: "Claude Bot")
+    }
+
+    private func fixture(on app: Application) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let prof = try await makeTestUser(on: app, username: "jsmith", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: prof.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "setup_a", courseID: courseID)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_a", courseID: courseID, title: "Original")
+    }
+
+    private func updateCall(_ publicID: String, title: String) -> JSONRPCRequest {
+        JSONRPCRequest(
+            jsonrpc: "2.0", id: .number(1), method: "tools/call",
+            params: .object([
+                "name": .string("update_assignment"),
+                "arguments": .object([
+                    "assignmentPublicID": .string(publicID), "title": .string(title),
+                ]),
+            ]))
+    }
+
+    private func reloadTitle(_ app: Application, _ publicID: String) async throws -> String {
+        try #require(
+            await APIAssignment.query(on: app.db).filter(\.$publicID == publicID).first()
+        ).title
+    }
+
+    @Test func writeToolFailsClosedWhenAuditCannotPersist() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Force the pre-write audit to fail by removing its table.
+            try await app.db.schema("audit_log").delete()
+
+            let response = try #require(
+                await dispatcher().dispatch(
+                    updateCall(assignment.publicID, title: "Changed"), context: context(app)))
+
+            // Fail closed: an error is returned and the write never applied.
+            #expect(response.error != nil)
+            #expect(try await reloadTitle(app, assignment.publicID) == "Original")
+        }
+    }
+
+    @Test func readToolStillSucceedsWhenAuditCannotPersist() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            try await app.db.schema("audit_log").delete()
+
+            let request = JSONRPCRequest(
+                jsonrpc: "2.0", id: .number(1), method: "tools/call",
+                params: .object([
+                    "name": .string("get_assignment"),
+                    "arguments": .object(["assignmentPublicID": .string(assignment.publicID)]),
+                ]))
+            let response = try #require(await dispatcher().dispatch(request, context: context(app)))
+
+            // Reads degrade to best-effort audit; the read still succeeds.
+            #expect(response.error == nil)
+        }
+    }
+
+    @Test func writeToolRecordsSingleRowWithOutcomeWhenAuditHealthy() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+
+            _ = try #require(
+                await dispatcher().dispatch(
+                    updateCall(assignment.publicID, title: "Changed"), context: context(app)))
+
+            let rows = try await APIAuditLogEntry.query(on: app.db)
+                .filter(\.$action == "mcp.tool_called").all()
+            #expect(rows.count == 1)  // pre-write row, stamped with outcome (not a second row)
+            let row = try #require(rows.first)
+            #expect(row.targetID == assignment.publicID)
+            #expect(row.metadata?.contains("\"outcome\":\"success\"") == true)
+            #expect(try await reloadTitle(app, assignment.publicID) == "Changed")
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPDatabasePoolTests.swift
+++ b/Tests/APITests/MCP/MCPDatabasePoolTests.swift
@@ -1,0 +1,36 @@
+// Verifies the dedicated least-privilege MCP database pool seam (P0-1 option 2):
+// it is opt-in, so the default deployment (and the test suite) keeps the MCP
+// path on the shared pool, and the postgres settings thread the MCP role
+// credentials through when provided.
+
+import Fluent
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPDatabasePoolTests {
+    @Test func defaultsToSharedPool() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // No MCP_DATABASE_USER/PASSWORD configured → no dedicated pool, so
+            // ToolContext.db falls back to the shared default connection.
+            #expect(app.usesDedicatedMCPDatabase == false)
+        }
+    }
+
+    @Test func postgresSettingsThreadMCPRoleCredentials() {
+        let withRole = DatabaseSettings.postgres(
+            host: "h", port: 5432, database: "d", username: "u", password: "p",
+            mcpUsername: "chickadee_mcp", mcpPassword: "secret")
+        #expect(withRole.postgresMCPUsername == "chickadee_mcp")
+        #expect(withRole.postgresMCPPassword == "secret")
+
+        // The default factories carry no MCP role (opt-in only).
+        #expect(
+            DatabaseSettings.postgres(
+                host: "h", port: 5432, database: "d", username: "u", password: "p"
+            ).postgresMCPUsername == nil)
+        #expect(DatabaseSettings.sqliteInMemory().postgresMCPUsername == nil)
+    }
+}

--- a/changelog.d/mcp-compliance-hardening-2.md
+++ b/changelog.d/mcp-compliance-hardening-2.md
@@ -1,0 +1,15 @@
+### Security
+
+- **MCP compliance hardening, round 2 (UW IRA follow-ups).** Four
+  defence-in-depth controls for the MCP server: (1) an optional dedicated
+  least-privilege PostgreSQL pool for the MCP path
+  (`MCP_DATABASE_USER`/`MCP_DATABASE_PASSWORD` +
+  `deploy/sql/mcp-least-privilege-role.sql`) that walls off student tables at
+  the database layer, with the content-edit re-grade moved to the privileged
+  pool so auto-regrade still works; (2) write tools now **fail closed** when
+  their audit record can't be persisted (reads stay best-effort); (3)
+  production **refuses to mount** `/mcp` when the Host/Origin DNS-rebinding
+  guards are left open, unless `MCP_ALLOW_OPEN_GUARDS=true`; and (4) a
+  documented deployment egress allowlist (`deploy/egress-allowlist.md`)
+  restricting outbound traffic to the server's real destinations — no model
+  API endpoint.

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -77,3 +77,7 @@ SSO_INSTRUCTOR_USERS=instructor1,instructor2
 # MCP_ALLOWED_ORIGINS=https://your-vm.example.com
 # ES256 token signing key; auto-generated (mode 0600) on first boot, git-ignored.
 # MCP_SIGNING_KEY_PATH=.mcp-signing-key
+# Optional least-privilege DB role for the MCP path (postgres; defence-in-depth
+# for the student-data wall). Create it with deploy/sql/mcp-least-privilege-role.sql.
+# MCP_DATABASE_USER=chickadee_mcp
+# MCP_DATABASE_PASSWORD=change-me

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -298,6 +298,12 @@ roster data; see `docs/compliance/ira-audit-report.md` for the full posture.
 Restrict the server's *outbound* traffic at the deployment layer following
 [egress-allowlist.md](egress-allowlist.md).
 
+For defence-in-depth on a PostgreSQL deployment, point the MCP path at a
+least-privilege role with no access to student tables: create it with
+[sql/mcp-least-privilege-role.sql](sql/mcp-least-privilege-role.sql) and set
+`MCP_DATABASE_USER` / `MCP_DATABASE_PASSWORD`. The MCP tools then run on a
+dedicated connection pool as that role; the rest of the app keeps its own.
+
 **Signing-key rotation.** MCP access tokens are ES256 JWTs signed with a key
 auto-generated on first start at `MCP_SIGNING_KEY_PATH` (default
 `.mcp-signing-key`, mode 0600, and git-ignored). To rotate:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -295,6 +295,8 @@ MCP_ALLOWED_ORIGINS=https://chickadee.example.com
 The MCP server **never** calls an external model API — it is the server an
 agent connects *to*. It also never exposes student submissions, grades, or
 roster data; see `docs/compliance/ira-audit-report.md` for the full posture.
+Restrict the server's *outbound* traffic at the deployment layer following
+[egress-allowlist.md](egress-allowlist.md).
 
 **Signing-key rotation.** MCP access tokens are ES256 JWTs signed with a key
 auto-generated on first start at `MCP_SIGNING_KEY_PATH` (default

--- a/deploy/egress-allowlist.md
+++ b/deploy/egress-allowlist.md
@@ -1,0 +1,80 @@
+# Outbound network egress allowlist
+
+Deployment-layer control for the Chickadee API server's **outbound** traffic.
+The application has no built-in egress firewall; this restriction belongs in the
+hosting environment (container/host firewall, a Squid forward proxy, or a
+Kubernetes `NetworkPolicy`). It is part of the UW Information Risk Assessment
+posture — see `docs/compliance/ira-audit-report.md` §5.
+
+## What the server actually connects to
+
+Chickadee's outbound destinations are a small, fixed set. **None of them is a
+model / LLM API** — Chickadee *is* the MCP server an agent connects to; it never
+calls a model itself (verified in `docs/compliance/data-flow-inventory.md`).
+
+| Destination | Purpose | Driven by | Required? |
+|-------------|---------|-----------|-----------|
+| OIDC IdP host (e.g. UW DUO `sso-*.sso.duosecurity.com`) | SSO discovery, JWKS, token, revocation | `OIDC_AUTH_SERVER` | when `AUTH_MODE` is `sso`/`dual` |
+| BrightSpace / D2L host (e.g. `d2l.uwaterloo.ca`) | Grade sync (Valence HMAC) | `BRIGHTSPACE_URL` | only if grade sync enabled |
+| `uwaterloo.ca` | Academic-dates iCalendar feed (cached 24 h) | hard-coded | optional UI feature |
+| Alert webhook host | Health alerts | operator-configured webhook | optional |
+| Chickadee API server itself | Worker poll / report / artifact download | `WORKER_PUBLIC_BASE_URL` / internal | internal only |
+
+If `OUTBOUND_HTTP_PROXY` is set, all of the above egress is funnelled through
+that proxy; the allowlist can then be enforced at the proxy instead of per host.
+
+**No model API endpoint appears in this list, and none should.** If a future
+change adds an outbound call, update this file and
+`docs/compliance/data-flow-inventory.md` in the same change.
+
+## Option A — Squid forward proxy allowlist
+
+Point the server at the proxy with `OUTBOUND_HTTP_PROXY=http://proxy-host:3128`
+and allow only the destinations above. Replace the example hosts with your
+deployment's actual IdP / D2L hosts.
+
+```squid
+# /etc/squid/conf.d/chickadee-egress.conf
+acl chickadee_allowed dstdomain sso-4ccc589b.sso.duosecurity.com
+acl chickadee_allowed dstdomain d2l.uwaterloo.ca
+acl chickadee_allowed dstdomain .uwaterloo.ca
+# Add your alert webhook host here if you use one.
+
+http_access allow chickadee_allowed
+http_access deny all
+```
+
+## Option B — host firewall (nftables)
+
+When the server has a dedicated egress identity (its own user/uid or a
+container), restrict outbound to the resolved destination set. Prefer the proxy
+approach when hosts are DNS-based; firewalls match IPs, which can rotate.
+
+```nft
+table inet chickadee_egress {
+    chain output {
+        type filter hook output priority 0; policy drop;
+        ct state established,related accept
+        oifname "lo" accept
+        # DNS so hostnames can resolve
+        udp dport 53 accept
+        tcp dport 53 accept
+        # Allow only the resolved egress targets (fill in IPs / use ipset):
+        ip daddr @chickadee_allowed_ips tcp dport 443 accept
+        # Internal worker traffic stays on the cluster/private network.
+    }
+}
+```
+
+## Option C — Kubernetes NetworkPolicy
+
+Default-deny egress, then allow DNS and the specific external hosts (via an
+egress gateway or CIDR set) plus the in-cluster worker/DB services. Keep the
+allowed external set to the table above.
+
+## Verification
+
+- Egress to a host *not* in the table above should fail.
+- The MCP endpoint (`/mcp`) is **inbound** only; it is not affected by this
+  allowlist. Restrict who may reach it with the `MCP_ALLOWED_HOSTS` /
+  `MCP_ALLOWED_ORIGINS` guards and SSO/OAuth, not here.

--- a/deploy/sql/mcp-least-privilege-role.sql
+++ b/deploy/sql/mcp-least-privilege-role.sql
@@ -1,0 +1,77 @@
+-- Least-privilege PostgreSQL role for the Chickadee MCP path.
+--
+-- Defence-in-depth for the student-data wall (compliance remediation P0-1,
+-- option 2). The in-process boundary (MCPStudentDataBoundary + the wall guard
+-- test) is the primary enforced control; this role makes "the MCP path cannot
+-- read student submissions, grades, or PII" true at the DATABASE layer too.
+--
+-- How it is used: point the server at this role with
+--   MCP_DATABASE_USER=chickadee_mcp
+--   MCP_DATABASE_PASSWORD=...
+-- which registers a dedicated connection pool (DatabaseID.mcp) that every MCP
+-- tool query runs on (see Sources/APIServer/Utilities/DatabaseConfiguration.swift
+-- and ToolContext.db). The main app keeps using its own (owner) role, so the
+-- web UI, worker, and migrations are unaffected. The MCP audit row and the
+-- content-edit re-grade run on the main pool, not this one.
+--
+-- IMPORTANT: review and TEST this against your schema before production use.
+-- Grants must cover everything the MCP write tools do; a missing grant surfaces
+-- as a tool failure. Run as a superuser / the database owner. Replace the
+-- password and (if you use a non-public schema / search_path) the schema name.
+
+\set mcp_role 'chickadee_mcp'
+
+-- 1. The role (login, no inherited superuser/createdb).
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'chickadee_mcp') THEN
+        CREATE ROLE chickadee_mcp LOGIN PASSWORD 'CHANGE-ME';
+    END IF;
+END$$;
+
+GRANT USAGE ON SCHEMA public TO chickadee_mcp;
+
+-- 2. Authoring tables — full DML (the MCP tools create/edit this content).
+GRANT SELECT, INSERT, UPDATE, DELETE ON
+    courses, course_sections, assignments, test_setups, assignment_requirements
+    TO chickadee_mcp;
+
+-- 3. Identity / enrolment — SELECT only, needed for authorization
+--    (subject -> role, and per-course enrolment checks). No write.
+GRANT SELECT ON users, course_enrollments TO chickadee_mcp;
+
+-- 4. Submissions / results — SELECT only, and Row-Level Security restricts what
+--    the role can see to the instructor's own VALIDATION runs. Even if a future
+--    MCP query forgot the in-app kind filter, the database returns no student
+--    rows. The table owner (the main app role) bypasses RLS, so the web app and
+--    worker are unaffected.
+GRANT SELECT ON submissions, results TO chickadee_mcp;
+
+ALTER TABLE submissions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS mcp_validation_submissions ON submissions;
+CREATE POLICY mcp_validation_submissions ON submissions
+    FOR SELECT TO chickadee_mcp
+    USING (kind = 'validation');
+
+ALTER TABLE results ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS mcp_validation_results ON results;
+CREATE POLICY mcp_validation_results ON results
+    FOR SELECT TO chickadee_mcp
+    USING (EXISTS (
+        SELECT 1 FROM submissions s
+        WHERE s.id = results.submission_id AND s.kind = 'validation'
+    ));
+
+-- 5. Everything else is DENIED by omission — no GRANT is issued, so the role
+--    cannot touch any of these student-data tables:
+--      grade_overrides, client_diagnostics, submission_diagnostics,
+--      job_execution_metrics, assignment_extensions, assignment_participations,
+--      assignment_personalization_seeds, class_achievements, achievement_results,
+--      user_activity_events, brightspace_sync_log, pre_enrollments, audit_log,
+--      request_metrics, runner_profiles, runner_snapshots, oauth_* ...
+--    Do NOT add blanket "GRANT ... ON ALL TABLES" — that would defeat the wall.
+
+-- 6. Verify (run as chickadee_mcp):
+--      SELECT count(*) FROM submissions;            -- only validation rows
+--      SELECT * FROM grade_overrides LIMIT 1;       -- must ERROR: permission denied
+--      SELECT * FROM users LIMIT 1;                 -- allowed (authz)

--- a/docs/compliance/ira-audit-report.md
+++ b/docs/compliance/ira-audit-report.md
@@ -281,8 +281,10 @@ destinations are:
 makes no model call. No telemetry, analytics, or runtime CDN fetches were found
 (browser libraries are vendored, per `CLAUDE.md`). The gap is that egress
 restriction is left entirely to the network layer with no artifact in the repo
-to verify. Remediation: `remediation-plan.md` P2-1 (deployment-layer allowlist
-limited to the five destinations above; explicitly *no* model endpoint).
+to verify. **Remediation landed:** `deploy/egress-allowlist.md` now documents
+the deployment-layer allowlist (Squid / nftables / NetworkPolicy options)
+limited to the five destinations above — explicitly *no* model endpoint — for
+the operator to apply in the hosting environment.
 
 ---
 

--- a/docs/compliance/ira-audit-report.md
+++ b/docs/compliance/ira-audit-report.md
@@ -154,11 +154,18 @@ roster PII" is **not demonstrable from configuration** today. It is true of the
 current code by convention. The brief's bar — architectural enforcement, not a
 comment — is **not yet met.**
 
-**Remediation:** `remediation-plan.md` P0-1 — a repository boundary
-(`AuthoringStore`) that physically excludes student models from the MCP path
-(compile-time wall), and/or a least-privilege DB role with no `SELECT` on
-student tables (deployment-time wall). Recommended: do the repository boundary
-first (in-repo, reviewer-verifiable), add the DB role as defence in depth.
+**Remediation landed:** both forms now exist. (1) In-process boundary —
+`MCPStudentDataBoundary` is the single validation-filtered accessor to the
+`submissions`/`results` tables, and `MCPStudentDataWallTests` fails the build if
+any tool handler names a student-data model directly (a compile-/test-time
+wall, verifiable from the repo). (2) Deployment-time DB wall — an optional
+dedicated connection pool (`MCP_DATABASE_USER`/`MCP_DATABASE_PASSWORD`,
+`DatabaseID.mcp`) lets the MCP path run as a least-privilege role with **no**
+access to student tables and validation-only RLS on `submissions`/`results`
+(`deploy/sql/mcp-least-privilege-role.sql`); the content-edit re-grade was moved
+to the privileged pool so the role can fully wall off student submissions
+without breaking auto-regrade. The operator provisions the role; the in-process
+boundary is enforced unconditionally.
 
 ---
 

--- a/docs/compliance/remediation-plan.md
+++ b/docs/compliance/remediation-plan.md
@@ -16,7 +16,7 @@ infrastructure or policy decision (noted per item).
 | P0-2 | **Done** | `MCPAuthorizationCoverageTests` source-scan guard. |
 | P0-3 | **Done** | `.mcp-signing-key` git-ignored; rotation documented in `deploy/README.md`. |
 | P1-1 | **Done** | Audit records outcome + target resource; arguments still never logged. |
-| P1-2 | **In progress** | Policy chosen: write tools fail closed if their audit row can't persist; reads degrade best-effort with an error marker. |
+| P1-2 | **Done** | Write tools fail closed if their audit row can't persist; reads degrade best-effort with a logged marker. |
 | P1-3 | **Done** | Solution-resolver guard test (answer key read only via `get_solution`). |
 | P2-1 | **Done** (artifact) | `deploy/egress-allowlist.md` documents the Squid / nftables / NetworkPolicy options; operator applies it. |
 | P2-2 | **Done** | Production refuses to mount `/mcp` with open Host/Origin guards unless `MCP_ALLOW_OPEN_GUARDS=true`. |

--- a/docs/compliance/remediation-plan.md
+++ b/docs/compliance/remediation-plan.md
@@ -12,7 +12,7 @@ infrastructure or policy decision (noted per item).
 
 | Item | Status | Notes |
 |------|--------|-------|
-| P0-1 | **Done** (option 1) | `MCPStudentDataBoundary` chokepoint + wall guard test. Option 2 (DB role) deferred — needs DB provisioning. |
+| P0-1 | **Done** | Option 1: `MCPStudentDataBoundary` chokepoint + wall guard test (in-process). Option 2: dedicated least-privilege DB pool seam (`MCP_DATABASE_USER`/`PASSWORD`) + `deploy/sql/mcp-least-privilege-role.sql`; operator provisions the role. |
 | P0-2 | **Done** | `MCPAuthorizationCoverageTests` source-scan guard. |
 | P0-3 | **Done** | `.mcp-signing-key` git-ignored; rotation documented in `deploy/README.md`. |
 | P1-1 | **Done** | Audit records outcome + target resource; arguments still never logged. |

--- a/docs/compliance/remediation-plan.md
+++ b/docs/compliance/remediation-plan.md
@@ -16,10 +16,10 @@ infrastructure or policy decision (noted per item).
 | P0-2 | **Done** | `MCPAuthorizationCoverageTests` source-scan guard. |
 | P0-3 | **Done** | `.mcp-signing-key` git-ignored; rotation documented in `deploy/README.md`. |
 | P1-1 | **Done** | Audit records outcome + target resource; arguments still never logged. |
-| P1-2 | **Deferred** | Needs the fail-closed vs best-effort policy decision (Steward). |
+| P1-2 | **In progress** | Policy chosen: write tools fail closed if their audit row can't persist; reads degrade best-effort with an error marker. |
 | P1-3 | **Done** | Solution-resolver guard test (answer key read only via `get_solution`). |
-| P2-1 | **Deferred** | Deployment-layer egress allowlist — infra artifact + deploy. |
-| P2-2 | **Partial** | Env templates document the Host/Origin guards; flipping prod to refuse-to-mount left as a deployment policy call. |
+| P2-1 | **Done** (artifact) | `deploy/egress-allowlist.md` documents the Squid / nftables / NetworkPolicy options; operator applies it. |
+| P2-2 | **Done** | Production refuses to mount `/mcp` with open Host/Origin guards unless `MCP_ALLOW_OPEN_GUARDS=true`. |
 | P2-3 | **Done** | Compliance docs cross-linked; tool count corrected to 36. |
 
 Status legend: the **current state** of each control is in `ira-audit-report.md`.


### PR DESCRIPTION
## MCP compliance hardening — the four deferred remediation items

Follow-up to #928. Implements the deferred P0/P1/P2 items from
`docs/compliance/remediation-plan.md`. Each is its own commit with tests; full
build green, `swift-format --strict` clean, SwiftLint `--strict` 0 violations,
178 MCP tests pass.

### P0-1 option 2 — least-privilege DB role (defence-in-depth)
- Optional dedicated connection pool (`DatabaseID.mcp`) registered when
  `MCP_DATABASE_USER`/`MCP_DATABASE_PASSWORD` are set; `ToolContext` routes
  every MCP query through it. **Unset (default, incl. CI) → shares the main
  pool, behaviour unchanged.**
- `deploy/sql/mcp-least-privilege-role.sql`: a role with authoring DML + authz
  SELECT, validation-only **RLS** on `submissions`/`results`, and no access to
  the student-data tables.
- The content-edit auto-regrade now runs on the **privileged** pool (it
  re-queues student submissions — a system action, not agent-facing read), so
  the restricted role can fully wall off student submissions without breaking
  auto-regrade.

### P1-2 — audit fail-closed
- Write tools persist their `mcp.tool_called` row **before** executing and
  **refuse to run** if it can't be persisted; the outcome is stamped onto that
  same row after. Read tools stay best-effort (failed audit logs a marker, does
  not block the read). New `AuditLogger.recordReturning` / `updateMetadata`.

### P2-2 — refuse-to-mount
- Production refuses to mount `/mcp` when `MCP_ALLOWED_HOSTS`/`MCP_ALLOWED_ORIGINS`
  are open, unless `MCP_ALLOW_OPEN_GUARDS=true` (for a trusted proxy that pins
  Host/Origin). Non-production unchanged.

### P2-1 — egress allowlist artifact
- `deploy/egress-allowlist.md`: Squid / nftables / NetworkPolicy options
  limited to the server's five real outbound destinations — explicitly **no
  model API endpoint**.

### Policy note for review
For **P1-2** I used the balanced default — **writes fail closed, reads
best-effort** — flagged for your confirmation. The **operator-owned** pieces
remain yours: provisioning the DB role/credential, deploying the egress
allowlist, and the connector contract / Policy 46 / IRA submission.

https://claude.ai/code/session_01JH7jsR6JD5g9a61pvmkL5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH7jsR6JD5g9a61pvmkL5s)_