### PR TITLE
build(deps): refresh transitive pins and tighten manifest floors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
+        "revision" : "7744c2a035c68ec14726c709f031835e3e30bde1",
+        "version" : "1.34.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "2033b3e661238dda3d30e36a2d40987499d987de",
-        "version" : "5.2.0"
+        "revision" : "a93a262fefb0938b799191b54f581ffa43422d96",
+        "version" : "5.5.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
-        "version" : "1.1.3"
+        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
+        "version" : "1.1.4"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
-        "version" : "1.5.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -276,8 +276,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
+        "version" : "1.13.2"
       }
     },
     {
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
-        "version" : "2.10.1"
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
+        "version" : "2.101.0"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
-        "version" : "1.34.0"
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
-        "version" : "1.43.0"
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
+        "version" : "2.37.1"
       }
     },
     {
@@ -375,8 +375,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,20 +14,20 @@ let package = Package(
         .library(name: "RunnerCore", targets: ["RunnerCore"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.121.3"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.121.4"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.13.0"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.12.0"),
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.9.0"),
         .package(url: "https://github.com/vapor/leaf.git", from: "4.5.1"),
         .package(url: "https://github.com/vapor/jwt.git", from: "5.1.2"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.1"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.2"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.0"),
         .package(url: "https://github.com/vapor-community/CSRF.git", from: "3.1.1"),
         // SwiftLint via SimplyDanny's plugin distribution: ships a pre-built
         // binary so CI / fresh checkouts don't pay a SwiftLint-from-source build.
         // Invoked on demand via `scripts/swiftlint.sh`; no `plugins:` entry on
         // any target, so `swift build` / `swift test` are unaffected.
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.63.0"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.63.3"),
     ],
     targets: [
         // MARK: - Runner core

--- a/changelog.d/dep-pin-refresh.md
+++ b/changelog.d/dep-pin-refresh.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Dependency maintenance: refreshed transitive pins and tightened manifest floors.**
+  Ran `swift package update` to pick up the minor/patch transitive bumps
+  Dependabot doesn't manage (it only moves the `Package.swift` floors): `swift-nio`
+  2.99.0 → 2.101.0 (+ http2/ssl/extras), `jwt-kit` 5.2.0 → 5.5.0, `swift-collections`
+  1.5.0 → 1.6.0, `swift-log` 1.12.0 → 1.13.2, `swift-system` 1.6.4 → 1.7.2,
+  `async-http-client` 1.33.1 → 1.34.0, plus `swift-http-types`, `swift-metrics`,
+  `swift-asn1`, and `swift-async-algorithms`. Also raised the lagging `from:` floors
+  in `Package.swift` to match what's resolved (`vapor` 4.121.4, `swift-argument-parser`
+  1.8.2, `SwiftLintPlugins` 0.63.3). No direct-dependency major-version changes; no
+  source changes.


### PR DESCRIPTION
## What

Routine dependency maintenance — the bit Dependabot doesn't cover.

Dependabot only moves the `from:` floors in `Package.swift`; it never refreshes the **transitive** pins in `Package.resolved`. Those had drifted a few minor/patch versions behind. This runs `swift package update` and tightens the lagging direct-dep floors to match what's resolved.

### `Package.resolved` (transitive, all minor/patch)

| Package | From | To |
|---|---|---|
| swift-nio | 2.99.0 | 2.101.0 |
| swift-nio-http2 | 1.43.0 | 1.44.0 |
| swift-nio-ssl | 2.37.0 | 2.37.1 |
| swift-nio-extras | 1.34.0 | 1.34.1 |
| jwt-kit | 5.2.0 | 5.5.0 |
| swift-collections | 1.5.0 | 1.6.0 |
| swift-log | 1.12.0 | 1.13.2 |
| swift-system | 1.6.4 | 1.7.2 |
| async-http-client | 1.33.1 | 1.34.0 |
| swift-http-types | 1.5.1 | 1.6.0 |
| swift-metrics | 2.10.1 | 2.11.0 |
| swift-asn1 | 1.7.0 | 1.7.1 |
| swift-async-algorithms | 1.1.3 | 1.1.4 |

### `Package.swift` (floors raised to match resolved)

- `vapor` 4.121.3 → 4.121.4
- `swift-argument-parser` 1.7.1 → 1.8.2
- `SwiftLintPlugins` 0.63.0 → 0.63.3

## Why

These accumulate silently between manual refreshes. No direct-dependency **major** changes; every direct dep is already on its current major. No source changes.

## Verification

- `swift build` — green (full debug build, 238s).
- Relying on CI for the full test matrix (the changes are pin-only with no source diff).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014BvByFZVDdS2GjWJkEzbMN)_