### PR TITLE
build(deps): migrate Docker base image jammy → noble (Ubuntu 24.04)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -1,15 +1,15 @@
 name: Mirror CI images
 
-# Mirrors the Docker Hub images our CI jobs run in (swift:6.3-jammy /
-# swift:6.3-noble job containers, postgres:16 service) into GHCR, so the
-# test workflows never pull from registry-1.docker.io at job time.
+# Mirrors the Docker Hub images our CI jobs run in (swift:6.3-noble job
+# container, postgres:16 service) into GHCR, so the test workflows never
+# pull from registry-1.docker.io at job time.
 # Unauthenticated Docker Hub pulls from shared Actions runner IPs are
 # rate-limited and were the single largest source of red CI on main
 # (6 "Initialize containers" / docker-pull timeout failures in the
 # three-week window audited for #890).  GHCR pulls from Actions runners
 # are same-infrastructure and not rate-limited.
 #
-# Runs weekly (Docker Hub tags like swift:6.3-jammy are re-pushed with
+# Runs weekly (Docker Hub tags like swift:6.3-noble are re-pushed with
 # fixes) and on demand.  `docker buildx imagetools create` copies the
 # full multi-arch manifest registry-to-registry without a local pull.
 #
@@ -68,6 +68,5 @@ jobs:
             echo "Failed to mirror ${src} after 5 attempts" >&2
             return 1
           }
-          mirror docker.io/library/swift:6.3-jammy swift:6.3-jammy
           mirror docker.io/library/swift:6.3-noble swift:6.3-noble
           mirror docker.io/library/postgres:16 postgres:16

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -22,12 +22,10 @@ jobs:
   format-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # noble (Ubuntu 24.04) rather than jammy (22.04) because SwiftLintBinary
-    # 0.63.2 — shipped by the SwiftLintPlugins package and downloaded on
-    # demand — is linked against GLIBC 2.38, which jammy's glibc 2.35 cannot
-    # satisfy.  The test/build jobs below stay on jammy because they don't
-    # invoke the swiftlint plugin.  Re-unify when SwiftLintBinary publishes
-    # a jammy-compatible release or when the project moves all jobs to noble.
+    # All CI jobs run on noble (Ubuntu 24.04), matching the Dockerfile's build
+    # and runtime base so CI exercises the same glibc the shipped image uses.
+    # noble (glibc 2.39) is also required by SwiftLintBinary, which is linked
+    # against GLIBC 2.38 and cannot run on jammy's glibc 2.35.
     container:
       image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
@@ -79,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -137,7 +135,7 @@ jobs:
     needs: build
     timeout-minutes: 20
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -170,7 +168,7 @@ jobs:
     needs: build
     timeout-minutes: 20
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -222,7 +220,7 @@ jobs:
     needs: build
     timeout-minutes: 25
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -316,7 +314,7 @@ jobs:
     # the test process; --parallel would just have the runner schedule
     # them across multiple xctest binaries that don't share the lock.
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -190,8 +190,11 @@ jobs:
 
       - name: Install system test dependencies
         run: |
+          # python3: the noble base image (unlike jammy) does not bundle it, and
+          # APITests run generated pattern-family cases that shell out to
+          # `#!/usr/bin/env python3`.  worker-tests installs it explicitly too.
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done
@@ -265,8 +268,11 @@ jobs:
 
       - name: Install system test dependencies
         run: |
+          # python3: the noble base image (unlike jammy) does not bundle it, and
+          # APITests run generated pattern-family cases that shell out to
+          # `#!/usr/bin/env python3`.  worker-tests installs it explicitly too.
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -22,7 +22,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-jammy
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # Both paths must use the same Swift / Ubuntu version so the
 # statically-linked-stdlib binaries match the runtime glibc.
 # To update Swift: change the tag here and in the runtime stage.
-# Current: Swift 6.3 on Ubuntu 22.04 (jammy).
+# Current: Swift 6.3 on Ubuntu 24.04 (noble).
 # ============================================================
 
 # Global ARG — must be declared before the first FROM so it can be used in
@@ -19,7 +19,7 @@
 ARG BINARIES=compile
 
 # ── Compile from source ─────────────────────────────────────
-FROM swift:6.3-jammy AS compile
+FROM swift:6.3-noble AS compile
 
 WORKDIR /build
 
@@ -45,7 +45,7 @@ RUN mkdir -p /out \
 # ── Prebuilt binaries from the build context ────────────────
 # Only built when BINARIES=prebuilt; its COPY paths are not evaluated
 # otherwise.  CI downloads the `build-release` artifact into ./artifacts/.
-FROM ubuntu:22.04 AS prebuilt
+FROM ubuntu:24.04 AS prebuilt
 
 WORKDIR /out
 COPY artifacts/chickadee-server artifacts/chickadee-runner /out/
@@ -61,9 +61,9 @@ RUN ls -lh /out/chickadee-server /out/chickadee-runner
 
 # ============================================================
 # Stage 2 — Runtime
-# Must use the same Ubuntu version as the build stage (jammy).
+# Must use the same Ubuntu version as the build stage (noble).
 # ============================================================
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/changelog.d/dockerfile-noble.md
+++ b/changelog.d/dockerfile-noble.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Docker base image: Ubuntu 22.04 (jammy) → 24.04 (noble).** Both Dockerfile
+  stages move together — build (`swift:6.3-jammy` → `swift:6.3-noble`) and
+  runtime/prebuilt (`ubuntu:22.04` → `ubuntu:24.04`) — so the
+  statically-linked-stdlib binaries still match the runtime glibc. All CI jobs
+  are unified onto `swift:6.3-noble` (the historical format-lint-on-noble /
+  tests-on-jammy split is gone, since noble's glibc 2.39 already satisfied the
+  SwiftLintBinary GLIBC 2.38 requirement), and the now-unused jammy image is
+  dropped from the mirror workflow. **Grading-environment note:** the runtime
+  stage's apt packages move to noble's versions — Python 3.10 → 3.12, plus newer
+  numpy / pandas / scipy / matplotlib and R — so student submissions graded on
+  the worker now run against that newer environment. Validate representative
+  assignments before deploying.


### PR DESCRIPTION
## What

Moves the Docker base image **Ubuntu 22.04 (jammy) → 24.04 (noble)** — the intermediate, Swift-supported LTS that Dependabot's #465 skipped when it proposed jumping straight to 26.04 (which has no `swift:6.x` image yet, so that PR was correctly closed).

Both Dockerfile stages move **together** so the `--static-swift-stdlib` binaries still match the runtime glibc (the documented invariant from #465):

| Stage | Before | After |
|---|---|---|
| build | `swift:6.3-jammy` | `swift:6.3-noble` |
| runtime | `ubuntu:22.04` | `ubuntu:24.04` |
| prebuilt | `ubuntu:22.04` | `ubuntu:24.04` |

## CI: collapse the jammy/noble split

`format-lint` already ran on `swift:6.3-noble` (SwiftLintBinary needs GLIBC 2.38; jammy ships 2.35). The test/build jobs stayed on jammy. This unifies **all** jobs onto `swift:6.3-noble` so CI exercises the same glibc the shipped image uses:

- `swift-tests.yml`, `test-coverage.yml`, `docker-build.yml` → all `swift:6.3-noble`
- `mirror-images.yml` drops the now-unused jammy mirror
- the explanatory comment in `swift-tests.yml` is updated

The `swift:6.3-noble` GHCR mirror already exists (format-lint has been using it), so there's no mirror-bootstrap step — and editing `mirror-images.yml` re-runs the mirror job on this PR anyway.

## ⚠️ Grading-environment change — needs your sign-off before merge

The runtime stage installs the **grading environment** student submissions run against, via noble's apt repos. Versions move:

- **Python 3.10 → 3.12**
- newer **numpy / pandas / scipy / matplotlib** (note numpy may cross 1.x → 2.x; pandas 2.x API)
- newer **R** (`r-base`)

This is the deliberate, tested upgrade you flagged in #465 — not something to merge unattended. CI will confirm the image *builds*; it won't confirm grading *behaves identically*. Recommend validating a few representative assignments (esp. anything touching numpy/pandas dtypes or float formatting) on a noble image before this merges.

> Browser-graded assignments are unaffected (they run Pyodide, pinned separately). This only changes the **worker** grading path.

## Not in scope

`scripts/snapshot.sh` / `scripts/restore.sh` use a throwaway `ubuntu:22.04` container purely to tar/untar the data volume — unrelated to the build/grading glibc, left as-is. A stale `jammy` comment in `.claude/hooks/session-start.sh:7` couldn't be updated (the harness blocks self-editing the startup hook); the hook already downloads the `ubuntu24.04` toolchain, so it's functionally correct — just a one-line comment worth fixing manually.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014BvByFZVDdS2GjWJkEzbMN)_