### PR TITLE
Animate inline accordion editors uniformly on the assignment edit page

### DIFF
--- a/Public/achievements-editor.js
+++ b/Public/achievements-editor.js
@@ -78,7 +78,8 @@
             });
 
         var state = [];
-        var open = null;   // { index } of the currently-expanded editor, or null
+        var open = null;          // { index, detailRow } of the open editor, or null
+        var lingeringClose = null; // finishNow() of an in-flight animated collapse
 
         function setStatus(text, kind) {
             if (!status) return;
@@ -98,6 +99,7 @@
                     + '<td>' + esc(SCOPE_LABEL[row.scope] || row.scope) + '</td>'
                     + '<td>' + summary(row) + '</td>'
                     + '<td class="time">'
+                    + ChickadeeUI.accordion.CARET_HTML + ' '
                     + '<button type="button" class="btn action-btn ach-edit" data-i="' + i + '">Edit</button> '
                     + '<button type="button" class="btn action-btn action-danger ach-remove" data-i="' + i + '">Remove</button>'
                     + '</td>';
@@ -125,13 +127,24 @@
             });
         }
 
-        function collapse() {
-            if (!open) return;
-            var detail = tbody.querySelector('tr.suite-detail-row');
-            if (detail && detail.parentNode) detail.parentNode.removeChild(detail);
-            var parent = tbody.querySelector('tr[data-i="' + open.index + '"]');
-            if (parent) parent.classList.remove('suite-row-expanded');
+        // Animated collapse via the shared accordion helper.  `immediate`
+        // tears down synchronously — used before opening another editor and
+        // before render() (which rebuilds the tbody and would wipe the
+        // animation anyway).
+        function collapse(immediate) {
+            if (!open) {
+                if (lingeringClose) { var f = lingeringClose; lingeringClose = null; f(); }
+                return;
+            }
+            var o = open;
             open = null;
+            var parent = o.index >= 0 ? tbody.querySelector('tr[data-i="' + o.index + '"]') : null;
+            var finishNow = ChickadeeUI.accordion.close(o.detailRow, {
+                immediate: !!immediate,
+                parentRow: parent,
+                onDone: function () { lingeringClose = null; }
+            });
+            lingeringClose = immediate ? null : finishNow;
         }
 
         // Build one condition row inside `container` from an optional `cond`.
@@ -166,46 +179,26 @@
         }
 
         function expand(index) {
-            if (open && open.index === index) { collapse(); return; }
-            collapse();
+            if (open && open.index === index) { collapse(false); return; }
+            collapse(true);
 
             var parent = index >= 0 ? tbody.querySelector('tr[data-i="' + index + '"]') : null;
             var row = index >= 0 ? (state[index] || {}) : { scope: 'individual' };
 
-            var tr = document.createElement('tr');
-            tr.className = 'suite-detail-row';
-            var td = document.createElement('td');
-            td.setAttribute('colspan', '4');
-            var host = document.createElement('div');
-            host.className = 'suite-detail-host';
+            var parts = ChickadeeUI.accordion.build({ colspan: 4 });
+            var tr = parts.tr;
+            var host = parts.host;
+            var saveBtn = parts.saveBtn;
+            var cancelBtn = parts.cancelBtn;
+            var st = parts.status;
             host.appendChild(template.content.cloneNode(true));
-
-            var actions = document.createElement('div');
-            actions.className = 'suite-detail-actions';
-            var saveBtn = document.createElement('button');
-            saveBtn.type = 'button';
-            saveBtn.className = 'btn btn-primary btn-compact';
-            saveBtn.textContent = 'Save';
-            var cancelBtn = document.createElement('button');
-            cancelBtn.type = 'button';
-            cancelBtn.className = 'btn btn-compact';
-            cancelBtn.textContent = 'Cancel';
-            var st = document.createElement('span');
-            st.className = 'suite-detail-status card-meta';
-            actions.appendChild(saveBtn);
-            actions.appendChild(cancelBtn);
-            actions.appendChild(st);
-            td.appendChild(host);
-            td.appendChild(actions);
-            tr.appendChild(td);
 
             if (parent) {
                 parent.parentNode.insertBefore(tr, parent.nextSibling);
-                parent.classList.add('suite-row-expanded');
             } else {
                 tbody.appendChild(tr);
             }
-            open = { index: index };
+            open = { index: index, detailRow: tr };
 
             function el(id) { return host.querySelector('#' + id); }
             var scopeSel = el('am-scope');
@@ -278,7 +271,7 @@
                 st.classList.remove('suite-detail-status-error');
                 saveBtn.disabled = true;
                 persist()
-                    .then(function () { collapse(); render(); setStatus('Saved.', 'ok'); })
+                    .then(function () { collapse(true); render(); setStatus('Saved.', 'ok'); })
                     .catch(function (err) {
                         state = snapshot;
                         st.textContent = 'Save failed — ' + ((err && err.message) ? err.message : err);
@@ -286,9 +279,9 @@
                         saveBtn.disabled = false;
                     });
             });
-            cancelBtn.addEventListener('click', collapse);
+            cancelBtn.addEventListener('click', function () { collapse(false); });
 
-            if (tr.scrollIntoView) tr.scrollIntoView({ block: 'nearest' });
+            ChickadeeUI.accordion.open(parts, parent);
         }
 
         var addBtn = document.getElementById('achievement-add');

--- a/Public/chickadee-ui.js
+++ b/Public/chickadee-ui.js
@@ -55,10 +55,149 @@
         }).join('');
     }
 
+    // ── Shared accordion (inline detail-row editor) ──────────────────────────
+    //
+    // Both the suite editor (suite-table.js) and the achievements editor
+    // (achievements-editor.js) expand an inline editor in a detail <tr> beneath
+    // the row being edited.  This is the one implementation of that pattern so
+    // the two editors animate and tear down identically.
+    //
+    //   build({colspan})  -> { tr, host, saveBtn, cancelBtn, status, anim }
+    //                        the detail-row skeleton, NOT yet inserted.  The
+    //                        caller inserts parts.tr wherever it belongs (the
+    //                        two editors have different placement rules) and
+    //                        mounts its editor into parts.host.
+    //   open(parts, row)  -> animates the inserted row open (0fr -> 1fr) and
+    //                        marks `row` (the parent) expanded; scrolls it into
+    //                        view.  Pass row=null when appending a brand-new row.
+    //   close(tr, opts)   -> animates the row closed and removes it; returns a
+    //                        finishNow() that completes it synchronously (used
+    //                        when a new editor must open before the old one's
+    //                        animation finishes).  opts.immediate (or the user's
+    //                        reduced-motion setting) tears down synchronously.
+    //                        opts.onDone runs once, just before removal, while
+    //                        content is still mounted — for editor-specific
+    //                        cleanup (e.g. rescuing a singleton editor body).
+    //
+    // The height animation is the single-row grid `grid-template-rows: 0fr->1fr`
+    // technique (see styles.css): it animates the editor's intrinsic height with
+    // no magic max-height, which matters because the family editor's height
+    // varies a lot.
+    var CARET_HTML = '<span class="accordion-caret" aria-hidden="true">'
+        + '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" '
+        + 'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" '
+        + 'stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/>'
+        + '</svg></span>';
+
+    function prefersReducedMotion() {
+        return !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    }
+
+    function buildAccordionRow(opts) {
+        opts = opts || {};
+        var tr = document.createElement('tr');
+        tr.className = 'suite-detail-row';
+        var td = document.createElement('td');
+        td.setAttribute('colspan', String(opts.colspan || 4));
+        var anim = document.createElement('div');
+        anim.className = 'suite-detail-anim';
+        var inner = document.createElement('div');
+        inner.className = 'suite-detail-inner';
+        var host = document.createElement('div');
+        host.className = 'suite-detail-host';
+        var actions = document.createElement('div');
+        actions.className = 'suite-detail-actions';
+        var saveBtn = document.createElement('button');
+        saveBtn.type = 'button';
+        saveBtn.className = 'btn btn-primary btn-compact';
+        saveBtn.textContent = 'Save';
+        var cancelBtn = document.createElement('button');
+        cancelBtn.type = 'button';
+        cancelBtn.className = 'btn btn-compact';
+        cancelBtn.textContent = 'Cancel';
+        var status = document.createElement('span');
+        status.className = 'suite-detail-status card-meta';
+        actions.appendChild(saveBtn);
+        actions.appendChild(cancelBtn);
+        actions.appendChild(status);
+        inner.appendChild(host);
+        inner.appendChild(actions);
+        anim.appendChild(inner);
+        td.appendChild(anim);
+        tr.appendChild(td);
+        return {
+            tr: tr, host: host, saveBtn: saveBtn,
+            cancelBtn: cancelBtn, status: status, anim: anim, inner: inner
+        };
+    }
+
+    function openAccordionRow(parts, parentRow) {
+        if (parentRow) parentRow.classList.add('suite-row-expanded');
+        var anim = parts.anim;
+        var inner = parts.inner;
+        // The inner clips while the row is partly open (the CSS default).  Once
+        // fully open, reveal overflow so editor popovers/tooltips aren't clipped.
+        function reveal() { if (inner) inner.style.overflow = 'visible'; }
+        if (prefersReducedMotion() || !anim) {
+            if (anim) anim.classList.add('is-open');
+            reveal();
+        } else {
+            // Double rAF: let the 0fr starting state paint before flipping to
+            // 1fr, so the grid-template-rows transition actually runs (a single
+            // frame is not reliable across engines).
+            requestAnimationFrame(function () {
+                requestAnimationFrame(function () { anim.classList.add('is-open'); });
+            });
+            var revealed = false;
+            anim.addEventListener('transitionend', function (e) {
+                if (e.propertyName === 'grid-template-rows' && !revealed) { revealed = true; reveal(); }
+            });
+            // Fallback if transitionend never fires (e.g. tab backgrounded).
+            setTimeout(function () { if (!revealed) { revealed = true; reveal(); } }, 280);
+        }
+        if (parts.tr && parts.tr.scrollIntoView) parts.tr.scrollIntoView({ block: 'nearest' });
+        return parts;
+    }
+
+    function closeAccordionRow(tr, opts) {
+        opts = opts || {};
+        var parentRow = opts.parentRow || null;
+        var done = false;
+        function finish() {
+            if (done) return;
+            done = true;
+            if (opts.onDone) { try { opts.onDone(); } catch (e) { /* ignore */ } }
+            if (tr && tr.parentNode) tr.parentNode.removeChild(tr);
+            if (parentRow) parentRow.classList.remove('suite-row-expanded');
+        }
+        var anim = tr ? tr.querySelector('.suite-detail-anim') : null;
+        if (opts.immediate || prefersReducedMotion() || !anim || !tr || !tr.parentNode) {
+            finish();
+            return finish;
+        }
+        // Re-clip before collapsing (open() set overflow:visible once expanded),
+        // so content is clipped as the row shrinks rather than spilling out.
+        var inner = tr.querySelector('.suite-detail-inner');
+        if (inner) inner.style.overflow = 'hidden';
+        anim.addEventListener('transitionend', function (e) {
+            if (e.propertyName === 'grid-template-rows') finish();
+        });
+        // Fallback if transitionend never fires (e.g. a display:none ancestor).
+        setTimeout(finish, 320);
+        anim.classList.remove('is-open');
+        return finish;
+    }
+
     window.ChickadeeUI = {
         escapeHtml: escapeHtml,
         escapeAttr: escapeHtml,
         getCsrfToken: getCsrfToken,
-        renderSparkline: renderSparkline
+        renderSparkline: renderSparkline,
+        accordion: {
+            CARET_HTML: CARET_HTML,
+            build: buildAccordionRow,
+            open: openAccordionRow,
+            close: closeAccordionRow
+        }
     };
 }());

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1507,12 +1507,35 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     outline: none;
 }
 
-/* Inline test editor (accordion) hosted in a detail row under a suite row. */
+/* Inline editor (accordion) hosted in a detail row beneath a suite/achievement
+   row.  Shared by the suite editor (suite-table.js) and the achievements editor
+   (achievements-editor.js) through ChickadeeUI.accordion. */
 .suite-row-expanded > td { background: var(--gray-100); }
+/* A continuous left accent bar ties the open editor to its row (mirrors the
+   status colour-strips at .status-pass &c.). */
+.suite-row-expanded > td:first-child { border-left: 3px solid var(--blue); }
 .suite-detail-row > td {
-    padding: .75rem 1rem 1rem;
+    padding: 0;   /* padding lives on .suite-detail-inner so the collapsed
+                     (grid 0fr) state is genuinely zero-height — no flash */
     background: var(--gray-100);
     border-top: none;
+    border-bottom: 1px solid var(--gray-200);  /* delineate from the next test */
+    border-left: 3px solid var(--blue);
+}
+/* Height animation: a single-row grid transitions grid-template-rows 0fr -> 1fr,
+   animating the editor's intrinsic height with no magic max-height (the family
+   editor's height varies a lot).  The inner clips while the row is partly open
+   (overflow:hidden) and can shrink below its content (min-height:0). */
+.suite-detail-anim {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows .18s ease;
+}
+.suite-detail-anim.is-open { grid-template-rows: 1fr; }
+.suite-detail-inner {
+    overflow: hidden;
+    min-height: 0;
+    padding: .75rem 1rem 1rem;
 }
 .suite-detail-host { display: flex; flex-direction: column; gap: .5rem; }
 .suite-detail-actions {
@@ -1525,6 +1548,40 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 }
 .suite-detail-status { font-size: .8rem; }
 .suite-detail-status-error { color: var(--red); }
+
+/* Rotating disclosure caret on rows that open an inline editor (pattern-family
+   and notebook-check rows in the suite editor; every achievement row).  Script
+   rows open the modal instead, so they deliberately carry no caret. */
+.accordion-caret {
+    display: inline-flex;
+    align-items: center;
+    color: var(--gray-500);
+    transition: transform .18s ease;
+}
+.suite-row-expanded .accordion-caret { transform: rotate(90deg); }
+
+/* Editor-only row affordances — the shared, student-facing .results-table is
+   untouched.  Firmer separators between tests, and a hover fill (skipping the
+   open row, which has its own background). */
+#suite-sections tbody tr[data-id] > td,
+.achievements-body tr[data-i] > td {
+    border-bottom: 1px solid var(--gray-200);
+}
+/* No separator between the open row and its editor — they read as one unit.
+   Scoped to match the firmer-separator rule above so it actually wins. */
+#suite-sections tbody tr[data-id].suite-row-expanded > td,
+.achievements-body tr[data-i].suite-row-expanded > td {
+    border-bottom: none;
+}
+#suite-sections tbody tr[data-id]:not(.suite-row-expanded):hover > td,
+.achievements-body tr[data-i]:not(.suite-row-expanded):hover > td {
+    background: var(--gray-50);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .suite-detail-anim { transition: none; }
+    .accordion-caret { transition: none; }
+}
 
 /* Achievements editor — composable condition builder (achievements-editor.js). */
 .am-conditions { display: flex; flex-direction: column; gap: .4rem; margin: .4rem 0 .6rem; }

--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -303,7 +303,8 @@
                     }).join('')
                 + '</select></td>'
                 + '<td><input type="number" class="form-input suite-family-points" min="0" max="100" value="' + defaultPoints + '" title="Points per case — applied to every generated test" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
-                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
+                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap;align-items:center">'
+                +   ChickadeeUI.accordion.CARET_HTML
                 +   '<button class="btn action-btn family-edit-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Edit family" aria-label="Edit family" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>'
                 +   '<button class="btn action-btn action-danger family-delete-btn" type="button" data-family-id="' + escAttr(family.id || '') + '" title="Delete family" aria-label="Delete family" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>'
                 + '</div></td>'
@@ -333,7 +334,8 @@
                     }).join('')
                 + '</select></td>'
                 + '<td><input type="number" class="form-input suite-check-points" min="0" max="100" value="' + points + '" style="width:4rem;padding:.25rem .5rem;font-size:.8rem"></td>'
-                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap">'
+                + '<td class="time"><div style="display:flex;gap:.4rem;justify-content:flex-end;flex-wrap:wrap;align-items:center">'
+                +   ChickadeeUI.accordion.CARET_HTML
                 +   '<button class="btn action-btn check-edit-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Edit notebook check" aria-label="Edit notebook check" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg></button>'
                 +   '<button class="btn action-btn action-danger check-delete-btn" type="button" data-check-id="' + escAttr(check.id || '') + '" title="Delete notebook check" aria-label="Delete notebook check" style="padding:.3rem .45rem"><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg></button>'
                 + '</div></td>'
@@ -382,6 +384,7 @@
         // are singletons). `renderSuspended` gates renderTree while it's open so
         // a debounced PUT response can't wipe the open detail row.
         var expandedDetail = null;   // { rowID, mechanism, renderer, detailRow }
+        var lingeringClose = null;   // finishNow() of an in-flight animated collapse
         var renderSuspended = false;
         var renderPendingFlag = false;
 
@@ -454,33 +457,47 @@
 
         /// Tear down the open inline editor: cleanup the renderer, remove the
         /// detail row, un-suspend renderTree, and flush any deferred render.
-        function collapseInlineEditor() {
+        /// Animates the collapse via the shared accordion helper unless
+        /// `immediate` is set — programmatic callers (opening another editor,
+        /// the modal) pass immediate so the singleton renderers and
+        /// #family-editor-body are never shared by two live editors at once.
+        function collapseInlineEditor(immediate) {
             var d = expandedDetail;
-            if (!d) return;
+            // No open editor: still flush any collapse that's mid-animation so a
+            // caller about to open a new editor starts from a clean slate.
+            if (!d) {
+                if (lingeringClose) { var f = lingeringClose; lingeringClose = null; f(); }
+                return;
+            }
             expandedDetail = null;
-            if (d.renderer && typeof d.renderer.cleanup === 'function') {
-                try { d.renderer.cleanup(); } catch (e) { /* ignore */ }
-            }
-            // The family editor hosts the singleton #family-editor-body element;
-            // move it out (hidden) before removing the detail row, or removing
-            // the row would delete the one shared editor body for good.
-            if (d.mechanism === 'family') {
-                var fb = document.getElementById('family-editor-body');
-                if (fb) {
-                    fb.hidden = true;
-                    fb.style.display = 'none';
-                    document.body.appendChild(fb);
+            var parentRow = d.rowID
+                ? container.querySelector('tr[data-id="' + cssAttrEscape(d.rowID) + '"]')
+                : null;
+            // The actual teardown runs once, just before the row is removed —
+            // while content is still mounted — so the family editor can rescue
+            // its singleton #family-editor-body before the row goes away.
+            function onTornDown() {
+                lingeringClose = null;
+                if (d.renderer && typeof d.renderer.cleanup === 'function') {
+                    try { d.renderer.cleanup(); } catch (e) { /* ignore */ }
                 }
+                if (d.mechanism === 'family') {
+                    var fb = document.getElementById('family-editor-body');
+                    if (fb) {
+                        fb.hidden = true;
+                        fb.style.display = 'none';
+                        document.body.appendChild(fb);
+                    }
+                }
+                renderSuspended = false;
+                if (renderPendingFlag) { renderPendingFlag = false; renderTree(); }
             }
-            if (d.detailRow && d.detailRow.parentNode) {
-                d.detailRow.parentNode.removeChild(d.detailRow);
-            }
-            if (d.rowID) {
-                var pr = container.querySelector('tr[data-id="' + cssAttrEscape(d.rowID) + '"]');
-                if (pr) pr.classList.remove('suite-row-expanded');
-            }
-            renderSuspended = false;
-            if (renderPendingFlag) { renderPendingFlag = false; renderTree(); }
+            var finishNow = ChickadeeUI.accordion.close(d.detailRow, {
+                immediate: !!immediate,
+                parentRow: parentRow,
+                onDone: onTornDown
+            });
+            lingeringClose = immediate ? null : finishNow;
         }
 
         /// Open an inline editor for a family/check — either editing an existing
@@ -501,44 +518,27 @@
                 if (srcItem) sectionID = srcItem.sectionID || null;
             }
 
-            // Toggle off when re-clicking the row that's already open.
+            // Toggle off when re-clicking the row that's already open (animated).
             if (opts.afterRowID && expandedDetail && expandedDetail.rowID === opts.afterRowID) {
                 collapseInlineEditor();
                 return;
             }
-            collapseInlineEditor();
+            // Close any other open editor synchronously: the family/check
+            // renderers are singletons, so two live editors can't coexist.
+            collapseInlineEditor(true);
 
-            var tr = document.createElement('tr');
-            tr.className = 'suite-detail-row';
-            var td = document.createElement('td');
-            td.setAttribute('colspan', '4');
-            var host = document.createElement('div');
-            host.className = 'suite-detail-host';
-            var actions = document.createElement('div');
-            actions.className = 'suite-detail-actions';
-            var saveBtn = document.createElement('button');
-            saveBtn.type = 'button';
-            saveBtn.className = 'btn btn-primary btn-compact';
-            saveBtn.textContent = 'Save';
-            var cancelBtn = document.createElement('button');
-            cancelBtn.type = 'button';
-            cancelBtn.className = 'btn btn-compact';
-            cancelBtn.textContent = 'Cancel';
-            var status = document.createElement('span');
-            status.className = 'suite-detail-status card-meta';
-            actions.appendChild(saveBtn);
-            actions.appendChild(cancelBtn);
-            actions.appendChild(status);
-            td.appendChild(host);
-            td.appendChild(actions);
-            tr.appendChild(td);
+            var parts = ChickadeeUI.accordion.build({ colspan: 4 });
+            var tr = parts.tr;
+            var host = parts.host;
+            var saveBtn = parts.saveBtn;
+            var cancelBtn = parts.cancelBtn;
+            var status = parts.status;
 
             var parentRow = opts.afterRowID
                 ? container.querySelector('tr[data-id="' + cssAttrEscape(opts.afterRowID) + '"]')
                 : null;
             if (parentRow) {
                 parentRow.parentNode.insertBefore(tr, parentRow.nextSibling);
-                parentRow.classList.add('suite-row-expanded');
             } else {
                 var sidSel = cssAttrEscape(sectionID || '');
                 var tb = container.querySelector('tbody[data-section-id="' + sidSel + '"]')
@@ -586,9 +586,9 @@
                         saveBtn.disabled = false;
                     });
             });
-            cancelBtn.addEventListener('click', collapseInlineEditor);
+            cancelBtn.addEventListener('click', function () { collapseInlineEditor(false); });
 
-            if (tr.scrollIntoView) tr.scrollIntoView({ block: 'nearest' });
+            ChickadeeUI.accordion.open(parts, parentRow);
         }
 
         /// Entry point for the "+ Add Test" dropdown to author a NEW inline test
@@ -604,7 +604,8 @@
         // Let the modal close any open inline editor before it opens, so the two
         // hosts never run simultaneously (the renderSuspended guard would
         // otherwise defer the modal's save render until the inline one closes).
-        window.chickadeeCollapseInlineEditor = collapseInlineEditor;
+        // Immediate (no animation) so the modal opens against a settled DOM.
+        window.chickadeeCollapseInlineEditor = function () { collapseInlineEditor(true); };
 
         // ── Persistence (items only; sections go through dedicated endpoints) ──
 

--- a/changelog.d/accordion-animation.md
+++ b/changelog.d/accordion-animation.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Animated, easier-to-scan inline editors on the assignment edit page.** The
+  inline "accordion" editors (pattern families / notebook checks in the suite
+  editor, and the achievements editor) now expand and collapse with a smooth
+  height animation instead of popping open. The open editor is tied to its row
+  with a left accent bar and a rotating disclosure caret, rows highlight on
+  hover, and per-test separators are firmer so individual tests are easier to
+  tell apart. The animation is honoured uniformly through a single shared
+  helper (`ChickadeeUI.accordion`) and respects `prefers-reduced-motion`.


### PR DESCRIPTION
## What & why

The assignment edit page has two inline "accordion" editors — the suite editor (pattern families / notebook checks) and the achievements editor — that expand an editor in a detail row beneath the row being edited. Both **hand-rolled the same skeleton and tore it down instantly**, so the expand felt abrupt and adjacent tests were hard to tell apart.

This factors the open/close + animation into **one shared helper** so the two editors behave identically and can't drift, and adds light styling so individual tests are easier to scan.

## Changes

**Shared helper — `ChickadeeUI.accordion` (`Public/chickadee-ui.js`)**: `build` / `open` / `close`. Both `suite-table.js` and `achievements-editor.js` now call it instead of duplicating the detail-row construction.

**Animation (Part A)**
- Smooth height animation via the single-row grid `grid-template-rows: 0fr → 1fr` technique — animates the editor's *intrinsic* height with no magic `max-height` (the family editor's height varies a lot).
- Inner overflow is revealed once fully open so editor popovers/tooltips aren't clipped, then re-clipped before collapse.
- Programmatic callers (opening another editor, the test-editor modal) close **immediately**; user Cancel / re-click-to-toggle / Save **animate**. An in-flight animated close is force-finished before a new editor opens, so the singleton family/check renderers and `#family-editor-body` are never shared by two live editors.
- Respects `prefers-reduced-motion`.

**Distinguish individual tests (Part B, CSS — applies to both editors)**
- A continuous left accent bar ties the open editor to its row (mirrors the existing status colour-strips).
- A rotating disclosure caret on inline-expandable rows. Script rows open the modal instead, so they deliberately carry no caret.
- Hover fill + firmer per-test separators, scoped to `#suite-sections` / `.achievements-body` so the **shared student-facing results table is untouched**.

## Verification
- `scripts/check-styles.sh` and `scripts/check-css-vars.sh` pass; all new colours route through existing palette vars (light + dark).
- JS syntax-checked (`node --check`) on all three files.
- Rendered the real `styles.css` + `chickadee-ui.js` in headless Chromium: confirmed the open end-state (accent bar, caret rotation, separators) in light **and** dark mode, that the detail-row height interpolates smoothly (`28 → 183 → 219 → 236 → 240px`), and that reduced-motion jumps straight to full height.

Render tests don't exercise page JS, so a quick manual click-through of the family / check / "+ Add Test" / achievement editors on the edit page is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PkfRZLDyVG1sAQc4p9Jx8z

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkfRZLDyVG1sAQc4p9Jx8z)_