### PR TITLE
Compact student-dashboard rows: dash for empty submissions + badge overflow pill

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -497,6 +497,15 @@ textarea.form-input {
     font-size: .68rem;
 }
 
+/* "+N" overflow pill on the student-dashboard row: muted so it reads as a
+   "more awards" affordance rather than an award itself.  Its title attribute
+   lists the hidden badges. */
+.achievement-badge-overflow {
+    background: var(--gray-100);
+    border-color: var(--gray-200);
+    color: var(--text-secondary);
+}
+
 .exec-time {
     font-size: .875rem;
     font-weight: 400;

--- a/Resources/Views/_assignment-row.leaf
+++ b/Resources/Views/_assignment-row.leaf
@@ -16,6 +16,9 @@
                     #for(badge in setup.badges):
                     <span class="achievement-badge achievement-badge-compact" title="#(badge.tooltip)">#(badge.label)</span>
                     #endfor
+                    #if(setup.extraBadgeCount > 0):
+                    <span class="achievement-badge achievement-badge-compact achievement-badge-overflow" title="Also earned: #(setup.extraBadgesTooltip)">+#(setup.extraBadgeCount)</span>
+                    #endif
                 </span>
                 #endif
             </div>
@@ -66,7 +69,7 @@
                 #endif
             </div>
         #else:
-            <span class="empty">No submissions yet</span>
+            <span class="empty">—</span>
         #endif
     </td>
     <td>

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -49,7 +49,17 @@ struct TestSetupRow: Encodable {
     /// True when `bestGradeText` is an instructor override rather than the
     /// runner-computed grade.  Drives the "overridden" tag in the template.
     let gradeIsOverridden: Bool
+    /// Inline-visible achievement badges only — capped to
+    /// `AchievementBadge.dashboardBadgeDisplayLimit` so a student with many
+    /// awards doesn't balloon the row height.  The full set still shows on the
+    /// submission view.
     let badges: [AchievementBadge]
+    /// Count of earned badges beyond the inline-visible `badges` slice.  0 when
+    /// every earned badge fits; otherwise drives the "+N" overflow pill.
+    let extraBadgeCount: Int
+    /// Comma-joined labels of the overflow badges, surfaced as the "+N" pill's
+    /// tooltip.  nil when `extraBadgeCount` is 0.
+    let extraBadgesTooltip: String?
     /// True when this student has an active deadline extension on this
     /// assignment.  Used by the template to show the Submit button and
     /// surface the effective deadline even when the assignment-wide
@@ -239,6 +249,30 @@ struct AchievementBadge: Encodable {
         return BuiltInAchievements.classRecords
             .first { $0.id == achievementID }
             .map(AchievementBadge.init(from:))
+    }
+
+    // MARK: Dashboard overflow
+
+    /// The most badges shown inline on a student-dashboard row before the
+    /// remainder collapse into a single "+N" overflow pill.  Bounds the row
+    /// height so a student with many awards doesn't make the assignments table
+    /// grow — the full set is still shown on the submission view, and the
+    /// overflow pill names the hidden ones in its tooltip.
+    static let dashboardBadgeDisplayLimit = 3
+
+    /// Splits a dashboard badge list into the inline-visible slice and an
+    /// overflow summary.  When the list already fits within `limit`,
+    /// `extraCount` is 0 and `extraTooltip` is nil.
+    static func dashboardSplit(
+        _ badges: [AchievementBadge], limit: Int = dashboardBadgeDisplayLimit
+    ) -> (visible: [AchievementBadge], extraCount: Int, extraTooltip: String?) {
+        guard badges.count > limit else { return (badges, 0, nil) }
+        let hidden = badges.suffix(from: limit)
+        return (
+            Array(badges.prefix(limit)),
+            hidden.count,
+            hidden.map(\.label).joined(separator: ", ")
+        )
     }
 }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -380,6 +380,7 @@ struct WebRoutes: RouteCollection {
                 )
             }()
             let canEdit = isOpenForThisUser || previouslyOpenedSetupIDs.contains(setupID)
+            let badgeSplit = AchievementBadge.dashboardSplit(latestBadgesBySetupID[setupID] ?? [])
             return TestSetupRow(
                 id: setupID,
                 title: assignment?.title,
@@ -404,7 +405,9 @@ struct WebRoutes: RouteCollection {
                 bestGradeText: overridePercentBySetupID[setupID].map { "\($0)%" }
                     ?? bestGradePercentBySetupID[setupID].map { "\($0)%" },
                 gradeIsOverridden: overridePercentBySetupID[setupID] != nil,
-                badges: latestBadgesBySetupID[setupID] ?? [],
+                badges: badgeSplit.visible,
+                extraBadgeCount: badgeSplit.extraCount,
+                extraBadgesTooltip: badgeSplit.extraTooltip,
                 hasActiveExtension: hasActiveExtension,
                 effectiveDueAtText: effectiveDueAt.map { fmt.string(from: $0) }
             )

--- a/Tests/APITests/BuiltInAchievementsTests.swift
+++ b/Tests/APITests/BuiltInAchievementsTests.swift
@@ -29,6 +29,28 @@ import Testing
             })
     }
 
+    @Test func dashboardSplitCapsBadgesAndSummarisesOverflow() {
+        let badges = (1...5).map { AchievementBadge(id: "b\($0)", label: "Badge \($0)", tooltip: "t\($0)") }
+
+        // Fits within the limit → everything visible, no overflow.
+        let small = AchievementBadge.dashboardSplit(Array(badges.prefix(2)), limit: 3)
+        #expect(small.visible.map(\.id) == ["b1", "b2"])
+        #expect(small.extraCount == 0)
+        #expect(small.extraTooltip == nil)
+
+        // Exactly at the limit → still no overflow pill.
+        let exact = AchievementBadge.dashboardSplit(Array(badges.prefix(3)), limit: 3)
+        #expect(exact.visible.count == 3)
+        #expect(exact.extraCount == 0)
+        #expect(exact.extraTooltip == nil)
+
+        // Over the limit → first `limit` visible, rest summarised in the tooltip.
+        let big = AchievementBadge.dashboardSplit(badges, limit: 3)
+        #expect(big.visible.map(\.id) == ["b1", "b2", "b3"])
+        #expect(big.extraCount == 2)
+        #expect(big.extraTooltip == "Badge 4, Badge 5")
+    }
+
     @Test func badgeDerivesIdentityFromTheAchievement() {
         let ace = AchievementBadge(from: BuiltInAchievements.ace)
         #expect(ace.id == "first_try_perfect")

--- a/changelog.d/dashboard-row-compaction.md
+++ b/changelog.d/dashboard-row-compaction.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Compacter student-dashboard rows.** Assignments with no submissions now
+  show a dash in the Submissions column instead of the taller "No submissions
+  yet" text, and a row's achievement badges are capped to the first three
+  inline awards with the rest collapsed into a "+N" overflow pill (the pill's
+  tooltip names the hidden awards). Prevents rows from ballooning when a student
+  has earned many badges; the full set still shows on the submission view.


### PR DESCRIPTION
## What

Two minor UI tweaks to keep the main assignments page (`/`) compact, both requested on the student dashboard:

1. **Empty Submissions column shows a dash.** Rows with no submissions previously rendered the taller "No submissions yet" text; they now render a `—` (matching the Grade/Due empty-cell pattern), so empty rows don't stretch the table.
2. **Achievement badges cap with a "+N" overflow pill.** A row's earned badges are capped to the first three inline awards; any extra collapse into a muted `+N` pill whose tooltip names the hidden awards. Keeps a row from ballooning when a student has earned many badges. The **full set is still shown on the submission view** — this only affects the at-a-glance dashboard row.

## How

- `Resources/Views/_assignment-row.leaf` — dash for the empty case; overflow pill after the badge loop. Scoped to the **main dashboard partial only** (the instructor per-student page `course-student-submissions.leaf` is intentionally untouched, and its "No submissions yet" render test still passes).
- `WebContextTypes.swift` — `TestSetupRow` gains `extraBadgeCount` / `extraBadgesTooltip`; new `AchievementBadge.dashboardSplit(_:limit:)` helper + `dashboardBadgeDisplayLimit = 3`.
- `WebRoutes.swift` — splits the per-setup badge list through the helper when building each row.
- `Public/styles.css` — muted `.achievement-badge-overflow` pill (palette vars only; `check-css-vars` / `check-styles` pass).

## Tests / checks

- New unit test `dashboardSplitCapsBadgesAndSummarisesOverflow` (fits / at-limit / over-limit).
- `swift build`, `BuiltInAchievementsTests`, `scripts/lint.sh`, `scripts/swiftlint.sh --strict`, `scripts/check-styles.sh`, `scripts/check-css-vars.sh` all green.

https://claude.ai/code/session_01XJn79ivQtF9sbwfXnZNVGA

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJn79ivQtF9sbwfXnZNVGA)_