### PR TITLE
feat: per-test partial-credit display (#548) + clone-assignment web UI (#546)

### DIFF
--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -254,6 +254,15 @@
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                         </a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/clone"
+                              onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    aria-label="Duplicate assignment" title="Duplicate assignment"
+                                   >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            </button>
+                        </form>
                         <form method="post" action="/instructor/#(row.assignmentID)/retest"
                               onsubmit="return confirm('Retest every submission for this assignment? The worker will re-grade each one against the current test suite.')">
                             #csrfFormField()
@@ -286,6 +295,15 @@
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                         </a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/clone"
+                              onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    aria-label="Duplicate assignment" title="Duplicate assignment"
+                                   >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            </button>
+                        </form>
                         <form method="post" action="/instructor/#(row.assignmentID)/retest"
                               onsubmit="return confirm('Retest every submission for this assignment? The worker will re-grade each one against the current test suite.')">
                             #csrfFormField()
@@ -318,6 +336,15 @@
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                         </a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/clone"
+                              onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    aria-label="Duplicate assignment" title="Duplicate assignment"
+                                   >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            </button>
+                        </form>
                         <form method="post" action="/instructor/#(row.assignmentID)/retest"
                               onsubmit="return confirm('Retest every submission for this assignment? The worker will re-grade each one against the current test suite.')">
                             #csrfFormField()
@@ -484,6 +511,15 @@
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                         </a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/clone"
+                              onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    aria-label="Duplicate assignment" title="Duplicate assignment"
+                                   >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            </button>
+                        </form>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
                             #csrfFormField()
@@ -507,6 +543,15 @@
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                         </a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/clone"
+                              onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    aria-label="Duplicate assignment" title="Duplicate assignment"
+                                   >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            </button>
+                        </form>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
                             #csrfFormField()
@@ -524,6 +569,15 @@
                           >
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"/></svg>
                         </a>
+                        <form method="post" action="/instructor/#(row.assignmentID)/clone"
+                              onsubmit="return confirm('Duplicate this assignment? A closed, unvalidated copy will be created for you to edit.')">
+                            #csrfFormField()
+                            <button class="btn action-btn" type="submit"
+                                    aria-label="Duplicate assignment" title="Duplicate assignment"
+                                   >
+                                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                            </button>
+                        </form>
                         <form method="post" action="/instructor/#(row.assignmentID)/delete"
                               onsubmit="return confirm('Delete this assignment? Students will no longer see it.')">
                             #csrfFormField()

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -70,6 +70,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post(":assignmentID", "open", use: openAssignment)
         r.post(":assignmentID", "close", use: closeAssignment)
         r.post(":assignmentID", "delete", use: deleteAssignment)
+        r.post(":assignmentID", "clone", use: cloneAssignment)
         r.post("setup", ":setupID", "delete", use: deleteUnpublishedSetup)
 
         // Published-assignment editor surface (edit/save, file downloads,
@@ -260,6 +261,28 @@ struct InstructorDashboardRoutes: RouteCollection {
         let assignment = try await loadAssignment(req)
         try await AssignmentAuthoringService.setOpenState(assignment, open: false, on: req.db)
         return req.redirect(to: "/instructor")
+    }
+
+    // MARK: - POST /instructor/:assignmentID/clone
+
+    /// Duplicates an assignment (notebooks, suite zip, manifest) into a new
+    /// closed/unvalidated copy in the same course — the web counterpart of the
+    /// `clone_assignment` MCP tool, both going through
+    /// `AssignmentAuthoringService.cloneAssignment` so they can't drift. Lands
+    /// the instructor on the new copy's edit page to set a due date and
+    /// re-validate before opening.
+    @Sendable
+    func cloneAssignment(req: Request) async throws -> Response {
+        let (source, sourceSetup) = try await loadAssignmentAndSetup(req)
+        let cloned = try await AssignmentAuthoringService.cloneAssignment(
+            source: source,
+            sourceSetup: sourceSetup,
+            newTitle: "\(source.title) (Copy)",
+            targetCourseID: source.courseID,
+            setupsDirectory: req.application.testSetupsDirectory,
+            on: req.db)
+        let notice = "Cloned from \(source.title). Set a due date and re-validate, then open."
+        return req.redirect(to: "/instructor/\(cloned.assignment.publicID)/edit?notice=\(urlEncode(notice))")
     }
 
     // MARK: - POST /instructor/:assignmentID/brightspace

--- a/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
+++ b/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
@@ -220,7 +220,19 @@ extension WebRoutes {
             let isPass = (outcome.status == .pass)
             return (!wasPass && isPass, wasPass && !isPass)
         }()
-        let pointsLabel: String? = weighted && outcome.points > 1 ? "\(outcome.points) pts" : nil
+        // Partial credit (#548): when a test earned a fraction of its points
+        // (0 < score < 1, typically a script that emitted an explicit footer
+        // `score`), surface it as "1.5 / 2 pts" so the student sees the credit
+        // even though the status badge reads Fail. Full credit / no credit keep
+        // the plain weight label, shown only on weighted assignments.
+        let pointsLabel: String? = {
+            if outcome.score > 0, outcome.score < 1 {
+                let earned = formatPoints(outcome.score * Double(outcome.points))
+                let unit = outcome.points == 1 ? "pt" : "pts"
+                return "\(earned) / \(outcome.points) \(unit)"
+            }
+            return weighted && outcome.points > 1 ? "\(outcome.points) pts" : nil
+        }()
         // Surface the instructor hint only on a genuine failure (not pass, not
         // a skipped/blocked test — there the blocker message is the guidance).
         // Hints are shown for failing release rows too, even before the deadline.

--- a/Tests/APITests/AssignmentRoutesLifecycleTests.swift
+++ b/Tests/APITests/AssignmentRoutesLifecycleTests.swift
@@ -67,6 +67,43 @@ import XCTVapor
         }
     }
 
+    // MARK: - POST /instructor/:id/clone
+
+    @Test func cloneAssignmentCreatesClosedCopyAndRedirectsToEdit() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "setup_clone", on: app)
+            // cloneAssignment copies the setup zip off disk — materialize one.
+            let zipPath = app.testSetupsDirectory + "setup_clone.zip"
+            #expect(FileManager.default.createFile(atPath: zipPath, contents: Data("PK".utf8)))
+            let a = try await arInsertAssignment(
+                testSetupID: "setup_clone", title: "Lab 1", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .POST, "/instructor/\(a.publicID)/clone",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location)?.contains("/edit") == true)
+                })
+
+            // Source is untouched and still open.
+            let source = try await APIAssignment.find(a.id, on: app.db)
+            #expect(source?.isOpen == true)
+
+            // A new, closed copy "<title> (Copy)" with its own setup now exists.
+            let copy = try #require(
+                try await APIAssignment.query(on: app.db).all().first { $0.title == "Lab 1 (Copy)" })
+            #expect(copy.isOpen == false)
+            #expect(copy.publicID != a.publicID)
+            #expect(copy.testSetupID != a.testSetupID)
+        }
+    }
+
     // MARK: - POST /instructor/:id/delete
 
     @Test func deleteAssignmentRemovesRecord() async throws {

--- a/changelog.d/clone-assignment-web-ui.md
+++ b/changelog.d/clone-assignment-web-ui.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Clone / duplicate an assignment from the instructor dashboard (#546).**
+  Each published assignment row gains a "Duplicate" action that copies the
+  assignment (notebooks, test-setup zip, manifest) into a new closed,
+  unvalidated copy in the same course (`POST /instructor/:assignmentID/clone`),
+  then drops the instructor on the copy's edit page to set a due date and
+  re-validate before opening. The web action and the `clone_assignment` MCP
+  tool both go through `AssignmentAuthoringService.cloneAssignment`, so the two
+  clone paths can't drift.

--- a/changelog.d/partial-credit-per-test-display.md
+++ b/changelog.d/partial-credit-per-test-display.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Per-test partial credit is now shown to students (#548).** When a test
+  earned a fraction of its points (a script that emitted an explicit `score`
+  in its stdout footer, `0 < score < 1`), the submission results table now
+  renders the earned fraction next to the result mark — e.g. `1.5 / 2 pts` —
+  instead of only the test weight. Full credit and no credit keep the plain
+  weight label. Parsing, storage, and grade rollup (`earnedPoints = Σ points ×
+  score`) were already wired; this surfaces the per-test breakdown in the UI.


### PR DESCRIPTION
Finishes the two "near-done" backlog items surfaced by the audit. Two independent commits.

## #548 — per-test partial credit display
The grading half was already wired (the `score` field is parsed from the script stdout footer, clamped, and summed as `earnedPoints = Σ points × score`). The only gap was the UI. Now, when a test earned a *fraction* of its points (`0 < score < 1`), the results table shows the earned fraction next to the result mark — e.g. **`1.5 / 2 pts`** — instead of only the weight. Full credit / no credit keep the plain weight label, so existing rows are unchanged.
- `SubmissionResultPresenter.swift` — `pointsLabel` now emits `"<earned> / <points> pt(s)"` for partial scores (reusing `formatPoints`). No template change (label string only).

## #546 — clone assignment from the dashboard
Adds a **Duplicate** action to each published assignment row → `POST /instructor/:assignmentID/clone`, which copies the assignment (notebooks, suite zip, manifest) into a new **closed, unvalidated** copy in the same course and lands the instructor on the copy's edit page to set a due date and re-validate before opening.
- Routes through `AssignmentAuthoringService.cloneAssignment` — the *same* path as the existing `clone_assignment` MCP tool, so the two can't drift.
- `InstructorDashboardRoutes.swift` (handler + route), `assignments.leaf` (Duplicate button in all six published-row blocks), new test `cloneAssignmentCreatesClosedCopyAndRedirectsToEdit`.

## Verification
- `swift build` clean; `swift-format` lint clean; `check-styles.sh` green.
- Tests pass: `AssignmentRoutesDashboardTests`, `WebRoutesSubmissionPageTests`, `CloneAssignmentToolTests` (render safety for both changed templates), and the new `AssignmentRoutesLifecycleTests.cloneAssignmentCreatesClosedCopyAndRedirectsToEdit`.

Note: only ONE inline `#extend` exists per template, so this steers clear of the LeafKit multi-extend bug documented in #934.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxTBVj7biwbXxK6DrhRWbu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxTBVj7biwbXxK6DrhRWbu)_