### PR TITLE
feat(mcp): add reorder_assignments tool

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -100,7 +100,9 @@ enum MCPServerInstructions {
         rename or change the default grading mode with rename_course_section, reorder with \
         reorder_course_sections, delete with delete_course_section (assignments in it are ungrouped, \
         not deleted), and assign an assignment with set_assignment_course_section (which adopts the section's \
-        default grading mode). get_assignment reports an assignment's current course section.
+        default grading mode). get_assignment reports an assignment's current course section. Order \
+        the assignments themselves within the list with reorder_assignments (a course-global order, \
+        lower first; the dashboard still groups the ordered assignments by their section for display).
         - Test suite — the ordered checks that grade an assignment. Each item is a hand-written \
         script, a generated pattern family, or a notebook check, and carries a tier \
         (public/release/secret/student), points, an optional section, prerequisites (dependsOn), and \

--- a/Sources/APIServer/MCP/Tools/AssignmentOrderingTools.swift
+++ b/Sources/APIServer/MCP/Tools/AssignmentOrderingTools.swift
@@ -1,0 +1,139 @@
+// APIServer/MCP/Tools/AssignmentOrderingTools.swift
+//
+// reorder_assignments — sets the instructor-defined display order of a course's
+// assignments, mirroring the web instructor dashboard's drag-reorder
+// (`POST /instructor/reorder`, InstructorDashboardRoutes.reorderAssignments).
+// Assignment order is a single course-global integer (`APIAssignment.sortOrder`,
+// lower first); the dashboard buckets the globally-ordered rows by their course
+// section for display.  This is the assignment-level counterpart to
+// reorder_course_sections (which orders the section groups themselves) and, like
+// it, takes a full permutation so every assignment ends with an explicit
+// sortOrder (no mix of numbered/unnumbered rows to sort surprisingly).
+//
+// Organizational metadata only: it writes `sort_order` and never re-runs
+// validation, changes a manifest, or touches the open/closed state.
+
+import Core
+import Fluent
+import Foundation
+
+// MARK: - reorder_assignments
+
+struct ReorderAssignmentsTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let courseCode: String
+        /// The course's assignment public IDs in the new display order — must be
+        /// a permutation of the course's current assignments, not a subset.
+        let orderedAssignmentPublicIDs: [String]
+    }
+
+    struct Output: Encodable, Sendable {
+        struct Assignment: Encodable, Sendable {
+            let publicID: String
+            let title: String
+            let sortOrder: Int
+            /// The course section the assignment belongs to; "" when ungrouped.
+            let sectionID: String
+        }
+        let courseCode: String
+        let assignments: [Assignment]
+    }
+
+    static let name = "reorder_assignments"
+    static let description =
+        "Set the instructor-defined display order of a course's assignments, by course code. "
+        + "orderedAssignmentPublicIDs must list exactly the course's current assignment public IDs "
+        + "(from list_assignments) in the desired order — a permutation, not a subset. Assignment "
+        + "order is course-global (lower first); the dashboard still groups the ordered assignments "
+        + "by their course section for display, so this orders assignments WITHIN each section as "
+        + "well as overall — it does not interleave sections (use reorder_course_sections to order "
+        + "the groups, and set_assignment_course_section to move an assignment between groups). "
+        + "Organizational metadata only: it does not re-run validation or change the open/closed state."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "courseCode": .object([
+                "type": .string("string"),
+                "description": .string("The course code, e.g. \"CS136\"."),
+            ]),
+            "orderedAssignmentPublicIDs": .object([
+                "type": .string("array"),
+                "items": .object(["type": .string("string")]),
+                "description": .string(
+                    "The course's assignment public IDs in the new order (a permutation of all of them)."),
+            ]),
+        ]),
+        "required": .array([.string("courseCode"), .string("orderedAssignmentPublicIDs")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "courseCode": .object(["type": .string("string")]),
+            "assignments": .object([
+                "type": .string("array"),
+                "items": .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "publicID": .object(["type": .string("string")]),
+                        "title": .object(["type": .string("string")]),
+                        "sortOrder": .object(["type": .string("integer")]),
+                        "sectionID": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([
+                        .string("publicID"), .string("title"), .string("sortOrder"),
+                        .string("sectionID"),
+                    ]),
+                ]),
+            ]),
+        ]),
+        "required": .array([.string("courseCode"), .string("assignments")]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let courseID = try await resolveCourseID(code: input.courseCode, tool: Self.name, context: context)
+
+        let ids = input.orderedAssignmentPublicIDs.map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard ids.allSatisfy(isValidAssignmentPublicID(_:)) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "orderedAssignmentPublicIDs contains an invalid assignment public ID.")
+        }
+        guard Set(ids).count == ids.count else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "orderedAssignmentPublicIDs contains a duplicate assignment public ID.")
+        }
+
+        let assignments = try await APIAssignment.query(on: context.db)
+            .filter(\.$courseID == courseID)
+            .all()
+        let existing = Set(assignments.map(\.publicID))
+        guard existing == Set(ids) else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "orderedAssignmentPublicIDs must list exactly the course's current assignment "
+                    + "public IDs (a permutation of all \(existing.count)).")
+        }
+
+        let byID = Dictionary(uniqueKeysWithValues: assignments.map { ($0.publicID, $0) })
+        var ordered: [Output.Assignment] = []
+        for (index, publicID) in ids.enumerated() {
+            guard let assignment = byID[publicID] else { continue }
+            assignment.sortOrder = index + 1
+            try await assignment.save(on: context.db)
+            ordered.append(
+                Output.Assignment(
+                    publicID: publicID,
+                    title: assignment.title,
+                    sortOrder: index + 1,
+                    sectionID: assignment.sectionID?.uuidString ?? ""))
+        }
+        return Output(courseCode: input.courseCode, assignments: ordered)
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -50,6 +50,7 @@ enum MCPToolCatalog {
             DeleteCourseSectionTool().erased(),
             ReorderCourseSectionsTool().erased(),
             SetAssignmentCourseSectionTool().erased(),
+            ReorderAssignmentsTool().erased(),
             CloneAssignmentTool().erased(),
             CreateAssignmentTool().erased(),
         ])

--- a/Tests/APITests/MCP/AssignmentOrderingToolsTests.swift
+++ b/Tests/APITests/MCP/AssignmentOrderingToolsTests.swift
@@ -1,0 +1,129 @@
+// Tests for the assignment-ordering MCP tool — reorder_assignments. Mirrors the
+// web instructor dashboard's drag-reorder (POST /instructor/reorder): it writes
+// the course-global APIAssignment.sortOrder from a full permutation of the
+// course's assignment public IDs. Backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct AssignmentOrderingToolsTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    /// Course + enrolled instructor.
+    @discardableResult
+    private func fixture(on app: Application) async throws -> APICourse {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: course.requireID())
+        return course
+    }
+
+    /// A published assignment with its own backing test setup.
+    @discardableResult
+    private func makeAssignment(
+        on app: Application, setupID: String, title: String, courseID: UUID
+    ) async throws -> APIAssignment {
+        try await makeTestSetup(on: app, id: setupID, courseID: courseID)
+        return try await makeTestAssignment(
+            on: app, testSetupID: setupID, courseID: courseID, title: title)
+    }
+
+    @Test func reordersAssignments() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await fixture(on: app)
+            let courseID = try course.requireID()
+            let a = try await makeAssignment(on: app, setupID: "s_a", title: "A", courseID: courseID)
+            let b = try await makeAssignment(on: app, setupID: "s_b", title: "B", courseID: courseID)
+            let c = try await makeAssignment(on: app, setupID: "s_c", title: "C", courseID: courseID)
+
+            let out = try await ReorderAssignmentsTool().execute(
+                .init(
+                    courseCode: "CS246",
+                    orderedAssignmentPublicIDs: [c.publicID, a.publicID, b.publicID]),
+                context(app))
+            #expect(out.assignments.map(\.title) == ["C", "A", "B"])
+            #expect(out.assignments.map(\.sortOrder) == [1, 2, 3])
+
+            // Persisted course-global sortOrder reflects the new order.
+            let reloadedC = try #require(try await APIAssignment.find(c.id, on: app.db))
+            let reloadedA = try #require(try await APIAssignment.find(a.id, on: app.db))
+            let reloadedB = try #require(try await APIAssignment.find(b.id, on: app.db))
+            #expect(reloadedC.sortOrder == 1)
+            #expect(reloadedA.sortOrder == 2)
+            #expect(reloadedB.sortOrder == 3)
+        }
+    }
+
+    @Test func reorderRejectsSubset() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await fixture(on: app)
+            let courseID = try course.requireID()
+            let a = try await makeAssignment(on: app, setupID: "s_a", title: "A", courseID: courseID)
+            _ = try await makeAssignment(on: app, setupID: "s_b", title: "B", courseID: courseID)
+
+            // Only one of the two assignments — must be a full permutation.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ReorderAssignmentsTool().execute(
+                    .init(courseCode: "CS246", orderedAssignmentPublicIDs: [a.publicID]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func reorderRejectsDuplicateID() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await fixture(on: app)
+            let courseID = try course.requireID()
+            let a = try await makeAssignment(on: app, setupID: "s_a", title: "A", courseID: courseID)
+            _ = try await makeAssignment(on: app, setupID: "s_b", title: "B", courseID: courseID)
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ReorderAssignmentsTool().execute(
+                    .init(courseCode: "CS246", orderedAssignmentPublicIDs: [a.publicID, a.publicID]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func reorderRejectsInvalidID() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ReorderAssignmentsTool().execute(
+                    .init(courseCode: "CS246", orderedAssignmentPublicIDs: ["not-a-valid-id"]),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesUnenrolledCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app)  // tester enrolled only in CS246
+            let other = try await makeTestCourse(on: app, code: "CS999", name: "Other")
+            let foreign = try await makeAssignment(
+                on: app, setupID: "s_x", title: "X", courseID: try other.requireID())
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ReorderAssignmentsTool().execute(
+                    .init(courseCode: "CS999", orderedAssignmentPublicIDs: [foreign.publicID]),
+                    context(app))
+            }
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPAuthorizationCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPAuthorizationCoverageTests.swift
@@ -27,6 +27,9 @@ import Testing
         "authorizeCourseAccess",
         "authorizedAssignment",  // also matches authorizedAssignmentAndSetup
         "requireEligibleSubject",
+        // Course-scoped wrapper: resolves the course code, then calls
+        // authorizeCourseAccess before returning the id (CourseSectionTools.swift).
+        "resolveCourseID",
     ]
 
     /// Tools that legitimately need no per-resource authorization: they touch no

--- a/changelog.d/mcp-reorder-assignments.md
+++ b/changelog.d/mcp-reorder-assignments.md
@@ -1,0 +1,8 @@
+### Added
+
+- **MCP `reorder_assignments` tool.** Agents can now set the instructor-defined
+  display order of a course's assignments — the assignment-level counterpart to
+  `reorder_course_sections`, mirroring the web dashboard's drag-reorder. Takes a
+  full permutation of the course's assignment public IDs and rewrites the
+  course-global `sort_order`; it's organizational metadata, so it never re-runs
+  validation or changes an assignment's open/closed state.

--- a/docs/compliance/tool-inventory.md
+++ b/docs/compliance/tool-inventory.md
@@ -6,7 +6,7 @@ Audit scope: the Model Context Protocol (MCP) server under
 This is a complete, one-row-per-tool inventory of the MCP capability surface,
 walked from the live registry (`MCPToolCatalog.live`,
 `Sources/APIServer/MCP/Transport/MCPServerRegistration.swift:16-57`) down to
-each tool's handler. The catalog registers **36 tools** (the prose digest in
+each tool's handler. The catalog registers **37 tools** (the prose digest in
 `CLAUDE.md` says "thirty-four"; the registry is the source of truth — count it
 from `MCPServerRegistration.swift:18-55`).
 
@@ -44,7 +44,7 @@ from `MCPServerRegistration.swift:18-55`).
 | `validate_assignment` | `ValidateAssignmentTool.swift:36` | `assignmentPublicID` | course-enrol (`:82`) | enqueues validation run; reads `validationStatus` | passed/failed/no-runner |
 | `get_validation_result` | `GetValidationResultTool.swift:69` | `assignmentPublicID` | course-enrol (`:113`) | validation submission + its `APIResult` only | per-test outcomes (no student identity) |
 
-## Write tools (`content:write`) — 23
+## Write tools (`content:write`) — 24
 
 | Tool | Handler (`file`) | Resource arg | Authz | Writes / touches |
 |------|------------------|--------------|-------|------------------|
@@ -71,6 +71,7 @@ from `MCPServerRegistration.swift:18-55`).
 | `delete_course_section` | `CourseSectionTools.swift:409` | section id | course-enrol (`:586`) | `APICourseSection` (assignments ungrouped) |
 | `reorder_course_sections` | `CourseSectionTools.swift:483` | `courseCode` | course-enrol (`:632`) | `APICourseSection` order |
 | `set_assignment_course_section` | `CourseSectionTools.swift:208` | `assignmentPublicID` + section | course-enrol (`:247`, `:453`) | `APIAssignment` section ref |
+| `reorder_assignments` | `AssignmentOrderingTools.swift:23` | `courseCode` | course-enrol (`resolveCourseID`) | `APIAssignment` order (`sort_order`) |
 
 ## Escape-hatch / general-capability audit
 

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -65,6 +65,7 @@ The catalog:
 | `delete_course_section` | `content:write` | Delete a course section (assignments in it are ungrouped, not deleted) |
 | `reorder_course_sections` | `content:write` | Set the display order of a course's sections |
 | `set_assignment_course_section` | `content:write` | Place an assignment into a course section (adopts its grading mode), or ungroup it |
+| `reorder_assignments` | `content:write` | Set the display order of a course's assignments (course-global; permutation, not a subset); no regrade/close |
 | `clone_assignment` | `content:write` | Duplicate an assignment (closed, unvalidated) |
 | `create_assignment` | `content:write` | New notebook-based assignment from scratch |
 


### PR DESCRIPTION
## What

Adds a new MCP content tool, **`reorder_assignments`**, that lets an authorized agent set the instructor-defined display order of a course's assignments — mirroring the web instructor dashboard's drag-reorder (`POST /instructor/reorder`).

It is the assignment-level counterpart to the existing `reorder_course_sections`: it takes a full permutation of a course's assignment public IDs (from `list_assignments`) and rewrites the course-global `APIAssignment.sortOrder` (lower first). The dashboard still buckets the ordered rows by their course section for display, so this orders assignments within each section as well as overall.

## Why this shape

- **Mirrors the existing `reorder_course_sections` precedent** exactly (bulk permutation → direct `sort_order` writes), so the two reorder tools read symmetrically.
- Assignment order is a plain column on `APIAssignment`, independent of the test manifest, so this needs **none** of the `applySuiteEdit` / validation / close machinery that `move_suite_item` requires. It's pure organizational metadata: **no validation re-run, no manifest change, no open/closed change.**
- A **full permutation** (rejecting subsets) is the safer agent contract than the web's per-section subset: every assignment ends with an explicit `sortOrder`, so there's no surprising mix of numbered/unnumbered rows in the dashboard's sort tiers.
- Cross-section moves remain the job of `set_assignment_course_section`; ordering the section groups themselves remains `reorder_course_sections`.

## Authorization & scope

`content:write` + `resolveCourseID` → `authorizeCourseAccess` (course-enrollment check, admins included). Rejects invalid public IDs, duplicates, and any ID-set that isn't an exact permutation of the course's assignments.

## Touch points

- `Sources/APIServer/MCP/Tools/AssignmentOrderingTools.swift` — new `ReorderAssignmentsTool`.
- `MCPServerRegistration.swift` — registered in `MCPToolCatalog.live`.
- `InitializeTypes.swift` — mentioned in `MCPServerInstructions.text` (required by the drift test).
- `docs/mcp-authoring-roadmap.md` + `docs/compliance/tool-inventory.md` — catalog/audit docs kept in sync (tool counts: 36 → 37, write tools 23 → 24).
- `Tests/APITests/MCP/AssignmentOrderingToolsTests.swift` — reorder, subset/duplicate/invalid-ID rejection, unenrolled-course denial.
- `changelog.d/` fragment.

## Verification (local)

- `swift build --build-tests` — clean.
- New tests: 5/5 pass against real Postgres.
- `MCPInstructionsCatalogSyncTests`: 5/5 pass (catalog ↔ instructions drift).
- `scripts/lint.sh` (swift-format) and `scripts/swiftlint.sh --strict`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM5ZLRPd8nHdpRm6E4rqma

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM5ZLRPd8nHdpRm6E4rqma)_