### PR TITLE
fix(notebook): make instructor "Reset notebook" visible on first reload

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -743,8 +743,8 @@
                 }
             }
 
-            const shouldSeed = !hasLocalContent || serverIsNewer;
-            if (shouldSeed && contents && typeof contents.save === 'function') {
+            const plan = reseedPlan({ hasLocalContent, serverIsNewer });
+            if (plan.shouldSeed && contents && typeof contents.save === 'function') {
                 await contents.save(lockedNotebookPath, {
                     type: 'notebook',
                     format: 'json',
@@ -762,7 +762,25 @@
 
             if (app.commands && typeof app.commands.execute === 'function') {
                 try {
-                    await app.commands.execute('docmanager:open', { path: lockedNotebookPath });
+                    const widget = await app.commands.execute(
+                        'docmanager:open', { path: lockedNotebookPath });
+                    // CRITICAL for instructor/self "Reset notebook": when the
+                    // server overwrote the working copy since we last saw it,
+                    // JupyterLite's workspace restore has typically already
+                    // re-opened the *previous* (stale) document from IndexedDB
+                    // before our reseed above committed.  `docmanager:open` on
+                    // an already-open path only focuses that widget — it does
+                    // NOT re-read the freshly-seeded contents — so without this
+                    // the reset only becomes visible on a *second* page load
+                    // (the student/TA sees "nothing happened").  Reverting the
+                    // document context forces it to reload from the contents we
+                    // just wrote, so the reset is visible immediately.  Gated on
+                    // `reloadOpenDoc` (server-newer only) so a normal revisit
+                    // never discards the student's unsaved in-editor edits.
+                    if (plan.reloadOpenDoc && widget && widget.context
+                        && typeof widget.context.revert === 'function') {
+                        await widget.context.revert();
+                    }
                 } catch (_) {
                     // Best-effort open only.
                 }
@@ -805,6 +823,32 @@
         if (!serverMtime || serverMtime <= 0) return false;
         if (!seenMtime  || seenMtime  <= 0) return false;
         return serverMtime > seenMtime;
+    }
+
+    // Pure decision used by `syncNotebookFromServerSnapshot` to turn the
+    // two observations (do we already hold a local copy? did the server
+    // overwrite the file since we last looked?) into an action plan.
+    //
+    //   shouldSeed    — write the server snapshot into the IndexedDB
+    //                   contents store.  True when there's no local copy
+    //                   (first visit / different device) OR the server is
+    //                   newer (instructor/self reset).
+    //   reloadOpenDoc — after seeding, force an already-open document
+    //                   widget to re-read the freshly-seeded contents.
+    //                   Only on a server-newer reset: a first-time seed
+    //                   opens the doc fresh anyway, and a preserve case
+    //                   must NOT reload or it would wipe the student's
+    //                   unsaved in-editor edits.
+    function reseedPlan({ hasLocalContent, serverIsNewer }) {
+        const shouldSeed = !hasLocalContent || serverIsNewer;
+        return {
+            shouldSeed,
+            // Only a copy we already held (and the workspace already
+            // re-opened) can be stale on screen.  With no local copy the
+            // `docmanager:open` below loads the freshly-seeded contents
+            // directly, so there's nothing to revert.
+            reloadOpenDoc: !!hasLocalContent && !!serverIsNewer,
+        };
     }
 
     async function waitForJupyterApp(timeoutMs) {
@@ -1307,6 +1351,7 @@
             probeIframeReadiness,
             isKernelInFailureState,
             shouldForceReseed,
+            reseedPlan,
         };
     }
 })();

--- a/Tests/BrowserRunnerJSTests/sync-force-reseed.test.mjs
+++ b/Tests/BrowserRunnerJSTests/sync-force-reseed.test.mjs
@@ -139,3 +139,60 @@ test('shouldForceReseed: negative or NaN inputs → FALSE', async () => {
   assert.equal(shouldForceReseed({ serverMtime: NaN, seenMtime: 100 }), false);
   assert.equal(shouldForceReseed({ serverMtime: 100, seenMtime: NaN }), false);
 });
+
+// ----------------------------------------------------------------
+// reseedPlan: seed + open-document reload decision
+//
+// `shouldForceReseed` decides whether the server overwrote the file;
+// `reseedPlan` turns that (plus "do we already hold a local copy?")
+// into the two actions the sync takes.  The `reloadOpenDoc` flag is the
+// fix for the instructor "Reset notebook" button appearing to do
+// nothing: JupyterLite's workspace restore re-opens the previous
+// (stale) document before the reseed lands, and a plain
+// `docmanager:open` only focuses it.  We must revert the open widget so
+// the reset is visible without a second page load — but ONLY on a
+// server-newer reset, never on a normal revisit (which would discard
+// the student's unsaved edits).
+// ----------------------------------------------------------------
+
+// `reseedPlan` returns a plain object built inside the vm realm, whose
+// prototype differs from the test realm's — so `deepStrictEqual` (the
+// `assert/strict` default) would fail on prototype identity even for
+// identical content.  Assert the two boolean fields individually, as the
+// `shouldForceReseed` cases above do.
+
+test('reseedPlan: instructor reset (local copy present, server newer) → seed + reload', async () => {
+  const { reseedPlan } = await loadHarness();
+  const plan = reseedPlan({ hasLocalContent: true, serverIsNewer: true });
+  assert.equal(plan.shouldSeed, true);
+  assert.equal(plan.reloadOpenDoc, true,
+    'A reset over an already-restored local copy must reload the open widget');
+});
+
+test('reseedPlan: normal revisit (local copy present, server unchanged) → preserve', async () => {
+  // The student's in-progress work: don't seed, and crucially don't
+  // reload the open editor (that would wipe unsaved edits).
+  const { reseedPlan } = await loadHarness();
+  const plan = reseedPlan({ hasLocalContent: true, serverIsNewer: false });
+  assert.equal(plan.shouldSeed, false);
+  assert.equal(plan.reloadOpenDoc, false,
+    'Must never revert an unchanged revisit — that would discard unsaved edits');
+});
+
+test('reseedPlan: first visit (no local copy, server not newer) → seed, no reload', async () => {
+  // A fresh seed opens the document from the just-written contents
+  // anyway, so there's no stale widget to revert.
+  const { reseedPlan } = await loadHarness();
+  const plan = reseedPlan({ hasLocalContent: false, serverIsNewer: false });
+  assert.equal(plan.shouldSeed, true);
+  assert.equal(plan.reloadOpenDoc, false);
+});
+
+test('reseedPlan: no local copy AND server newer → seed, no reload', async () => {
+  // Both reasons to seed; still no open stale widget on a first-ever
+  // open, so reload stays off (the open below loads fresh contents).
+  const { reseedPlan } = await loadHarness();
+  const plan = reseedPlan({ hasLocalContent: false, serverIsNewer: true });
+  assert.equal(plan.shouldSeed, true);
+  assert.equal(plan.reloadOpenDoc, false);
+});

--- a/changelog.d/notebook-reset-open-doc-reload.md
+++ b/changelog.d/notebook-reset-open-doc-reload.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Instructor "Reset notebook" appeared to do nothing on the student's
+  next visit.** The reset overwrote the working copy on the server and the
+  mtime-based cache-bust signal correctly told the browser to force-reseed
+  IndexedDB — but JupyterLite's workspace restore had usually already
+  re-opened the *previous* (stale) document, and `docmanager:open` on an
+  already-open path only focuses it without re-reading the freshly-seeded
+  contents. The reset therefore only became visible on a *second* page
+  load. `syncNotebookFromServerSnapshot` now reverts the open document's
+  context after reseeding when the server copy is newer (a reset), so the
+  starter shows immediately. Gated on the server-newer + had-local-copy
+  case via a new pure `reseedPlan` helper so a normal revisit never
+  discards a student's unsaved in-editor edits. Regression-pinned in
+  `Tests/BrowserRunnerJSTests/sync-force-reseed.test.mjs`.


### PR DESCRIPTION
## What the TA saw

On the per-student submissions page (`/:courseCode/students/:urlToken/submissions`), clicking the **Reset notebook** button "clicks through but nothing happens."

## Diagnosis — not a backend regression

The reset path is fully functional and tested:

- The route is registered (`StudentCourseRoutes.swift`) and the handler (`resetStudentAssignmentNotebook`) overwrites the working copy via `ensureUserNotebookWorkingCopy(overwriteWith: starter)`, bumping the file mtime.
- The end-to-end cache-bust signal (`data-working-copy-mtime` → `shouldForceReseed`, v0.4.153/154) correctly fires.

The gap is in the **client reseed**: JupyterLite's workspace restore has usually already re-opened the *previous (stale)* document from IndexedDB before our reseed lands, and `docmanager:open` on an already-open path only **focuses** the widget — it does not re-read the freshly-seeded contents. So the reset only became visible on a **second** page load, which reads to the TA/student as "the button does nothing."

(There is also no success banner on the instructor page, but a working-copy reset legitimately changes nothing the submissions page displays — that's a separate, optional UX nicety, not the reported failure.)

## Fix

`syncNotebookFromServerSnapshot` now reverts the open document's context after reseeding **when the server copy is newer** (a reset), so the starter shows immediately. A new pure `reseedPlan({ hasLocalContent, serverIsNewer })` helper gates the reload on the server-newer + had-local-copy case, so:

- **Reset:** seed + reload open doc → reset visible on first load.
- **Normal revisit:** no seed, **no reload** → the student's unsaved in-editor edits are never discarded.
- **First/fresh visit:** seed, no reload (the open loads fresh contents anyway).

## Tests

Added four `reseedPlan` cases to `Tests/BrowserRunnerJSTests/sync-force-reseed.test.mjs` alongside the existing `shouldForceReseed` guards. Full JS suite: 75/75 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5PNMZoGHbfMrTSdkZsSJd)_