### PR TITLE
feat(mcp): author_script can fetch a support file from a URL (SSRF-guarded)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,10 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.2"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.0"),
         .package(url: "https://github.com/vapor-community/CSRF.git", from: "3.1.1"),
+        // Already in the resolved graph transitively via Vapor; declared
+        // explicitly so the MCP support-file fetcher can build a dedicated,
+        // no-redirect HTTPClient (the shared Vapor client follows redirects).
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.34.0"),
         // SwiftLint via SimplyDanny's plugin distribution: ships a pre-built
         // binary so CI / fresh checkouts don't pay a SwiftLint-from-source build.
         // Invoked on demand via `scripts/swiftlint.sh`; no `plugins:` entry on
@@ -73,6 +77,7 @@ let package = Package(
                 .product(name: "Leaf", package: "leaf"),
                 .product(name: "JWT", package: "jwt"),
                 .product(name: "CSRF", package: "CSRF"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
             ],
             path: "Sources/APIServer",
             exclude: ["README.md"],

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -115,7 +115,10 @@ enum MCPServerInstructions {
         with update_solution (which stores it as the validation submission and re-runs validation).
         - Support files — non-graded helper/data files bundled in the setup zip (e.g. a CSV a check \
         loads, a helper module tests import). List or read them with get_support_files (byte-capped \
-        reads, so big datasets return a useful head); write one with author_script(tier:"support"). \
+        reads, so big datasets return a useful head); write one with author_script(tier:"support") — \
+        passing the body inline as content, or, for a data file too large to inline faithfully (e.g. a \
+        big CSV), passing sourceUrl (an https URL the server fetches under an SSRF guard: https only, \
+        no private/loopback/metadata hosts, no redirects, 8 MB cap, UTF-8 body). \
         Confirm a data file is bundled before authoring checks that load it.
         - Global inputs (personalization) — assignment-scoped names that vary the assignment per \
         student: literal `variables` (a name + JSON value) and `expressions` (a name + Python source \

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -28,7 +28,14 @@ struct AuthorScriptTool: ContentTool {
     struct Input: Decodable, Sendable {
         let assignmentPublicID: String
         let filename: String
-        let content: String
+        /// The full file body, inline.  Mutually exclusive with `sourceUrl`;
+        /// exactly one of the two must be provided.
+        let content: String?
+        /// An https URL the server fetches and stores as the file body — for a
+        /// data/support file too large to inline faithfully (e.g. a CSV
+        /// fixture).  SSRF-guarded (https only, no private/metadata addresses,
+        /// no redirects, size-capped); see `SupportFileURLFetcher`.
+        let sourceUrl: String?
         /// public/release/secret/student, or "support" for a non-graded helper
         /// file.  When omitted, an existing file keeps its current kind/tier and
         /// a brand-new file defaults to a public test.
@@ -67,8 +74,11 @@ struct AuthorScriptTool: ContentTool {
         + "catches errors in it) and is opaque to readers. Use a graded tier here only when no pattern "
         + "kind or notebook check fits. "
         + "Create or replace a single hand-written test or support file in an assignment's test "
-        + "setup, by its public ID. Provide filename (a bare name, no path separators) and content "
-        + "(the full script body). tier is public/release/secret/student for a graded test, or "
+        + "setup, by its public ID. Provide filename (a bare name, no path separators) and EITHER "
+        + "content (the full body inline) OR sourceUrl (an https URL the server fetches — for a "
+        + "data/support file too large to inline faithfully, e.g. a CSV fixture; the fetch is "
+        + "SSRF-guarded: https only, no private/loopback/metadata addresses, no redirects, size-capped, "
+        + "and the body must be UTF-8 text). tier is public/release/secret/student for a graded test, or "
         + "\"support\" for a helper file that tests or personalization expressions can import but that "
         + "is not itself graded; omit tier to keep an existing file's kind (new files default to a "
         + "public test). For test tiers you may also set points, displayName, dependsOn (prerequisite "
@@ -93,7 +103,18 @@ struct AuthorScriptTool: ContentTool {
             ]),
             "content": .object([
                 "type": .string("string"),
-                "description": .string("The full script body, written verbatim into the setup zip."),
+                "description": .string(
+                    "The full file body, written verbatim into the setup zip. Provide this OR "
+                        + "sourceUrl, not both."),
+            ]),
+            "sourceUrl": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "An https URL the server downloads and stores as the file body — use for a "
+                        + "data/support file too large to inline (e.g. a CSV). The fetch is SSRF-guarded "
+                        + "(https only; the host must not resolve to a loopback/private/link-local/"
+                        + "cloud-metadata address; redirects are not followed; capped at 8 MB; body must "
+                        + "be UTF-8 text). Provide this OR content, not both."),
             ]),
             "tier": .object([
                 "type": .string("string"),
@@ -125,7 +146,9 @@ struct AuthorScriptTool: ContentTool {
                         + "an unknown id is treated as ungrouped."),
             ]),
         ]),
-        "required": .array([.string("assignmentPublicID"), .string("filename"), .string("content")]),
+        // content/sourceUrl are a one-of (validated in execute), so neither is
+        // individually required here.
+        "required": .array([.string("assignmentPublicID"), .string("filename")]),
         "additionalProperties": .bool(false),
     ])
 
@@ -181,15 +204,18 @@ struct AuthorScriptTool: ContentTool {
     // MARK: - Execute
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        guard !input.content.isEmpty else {
-            throw MCPToolError.invalidArguments(tool: Self.name, detail: "`content` must not be empty.")
-        }
         let cleaned = sanitizeSuiteFilename(input.filename)
         guard !cleaned.isEmpty, cleaned == input.filename else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
                 detail: "filename must be a bare filename with no path separators (got \"\(input.filename)\").")
         }
+
+        // Validate the content/sourceUrl one-of up front (cheap, no I/O); the
+        // actual fetch is deferred to `materialize` below, after the call is
+        // authorized and the cheap rejections have passed, so we never make an
+        // outbound request for a call we are about to refuse.
+        let source = try Self.resolveContentSource(input)
 
         let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
             publicID: input.assignmentPublicID, tool: Self.name)
@@ -220,6 +246,10 @@ struct AuthorScriptTool: ContentTool {
             resolved = .test(.pub)
         }
 
+        // Now that the call has cleared the cheap rejections, materialize the
+        // body (fetching sourceUrl if that's the source).
+        let content = try await Self.materialize(source, context: context)
+
         switch resolved {
         case .support:
             // Demoting a currently-graded test to a support file would orphan
@@ -233,10 +263,10 @@ struct AuthorScriptTool: ContentTool {
                         + "or delete it before re-authoring it as a support file.")
             }
             try authorSupportFile(
-                filename: cleaned, content: input.content, setup: setup, assignment: assignment, context: context)
+                filename: cleaned, content: content, setup: setup, assignment: assignment, context: context)
         case .test(let tier):
             try await authorTestScript(
-                filename: cleaned, content: input.content, tier: tier, input: input,
+                filename: cleaned, content: content, tier: tier, input: input,
                 setup: setup, context: context)
         }
 
@@ -252,6 +282,54 @@ struct AuthorScriptTool: ContentTool {
             created: !existedInZip,
             validationStatus: assignment.validationStatus,
             assignmentClosed: closed)
+    }
+
+    // MARK: - Body resolution (inline content or fetched sourceUrl)
+
+    /// Where a file's body comes from: inline `content` or a server-fetched
+    /// `sourceUrl`.
+    private enum ContentSource {
+        case inline(String)
+        case remote(url: String)
+    }
+
+    /// Validates the `content`/`sourceUrl` one-of and returns the source. Cheap
+    /// and side-effect-free (no network) so it can run before authorization.
+    private static func resolveContentSource(_ input: Input) throws -> ContentSource {
+        let inline = input.content
+        let url = input.sourceUrl?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch (inline?.isEmpty == false, url?.isEmpty == false) {
+        case (true, true):
+            throw MCPToolError.invalidArguments(
+                tool: name, detail: "Provide either `content` or `sourceUrl`, not both.")
+        case (false, false):
+            throw MCPToolError.invalidArguments(
+                tool: name,
+                detail: "Provide `content` (the body inline) or `sourceUrl` (an https URL to fetch).")
+        case (true, false):
+            return .inline(inline ?? "")
+        case (false, true):
+            return .remote(url: url ?? "")
+        }
+    }
+
+    /// Produces the file body, fetching `sourceUrl` under the SSRF guard when
+    /// the source is remote. Maps a fetch refusal to an MCP tool error.
+    private static func materialize(_ source: ContentSource, context: ToolContext) async throws -> String {
+        switch source {
+        case .inline(let body):
+            return body
+        case .remote(let url):
+            do {
+                return try await SupportFileURLFetcher.fetch(urlString: url, on: context.request)
+            } catch let error as SupportFileFetchError {
+                throw MCPToolError.invalidArguments(tool: name, detail: error.toolDetail)
+            } catch {
+                throw MCPToolError.executionFailed(
+                    tool: name, detail: "Failed to fetch sourceUrl: \(error).")
+            }
+        }
     }
 
     // MARK: - Test-script authoring (suite-payload path)

--- a/Sources/APIServer/MCP/Tools/SupportFileURLFetcher.swift
+++ b/Sources/APIServer/MCP/Tools/SupportFileURLFetcher.swift
@@ -1,0 +1,308 @@
+// APIServer/MCP/Tools/SupportFileURLFetcher.swift
+//
+// Server-side fetch of a support/data file referenced by URL, for the MCP
+// `author_script(sourceUrl:)` path.  An agent often cannot faithfully inline a
+// large data file (a CSV, a fixture) into a tool call, so it passes a URL and
+// the server downloads the bytes instead.
+//
+// A server fetching a caller-supplied URL is a classic SSRF vector, so the
+// fetch is guarded in depth (the caller is an authenticated instructor with
+// content:write, but an account can be compromised and an agent can be
+// prompt-injected, so we never trust the URL):
+//
+//   1. https only — no file://, ftp://, gopher://, data://.
+//   2. No userinfo (`user:pass@`) — a common parser-confusion trick.
+//   3. The host is resolved here and EVERY resulting IP is checked; the fetch is
+//      refused if any address is loopback / private / link-local (incl. the
+//      169.254.169.254 cloud-metadata range) / CGNAT / ULA / multicast /
+//      reserved.  IPv4, IPv6, and IPv4-mapped/compatible forms are normalised
+//      before the check, and obfuscated literals (octal/hex) are caught because
+//      they resolve to a canonical numeric IP that is then classified.
+//   4. Redirects are disallowed — a public URL that 302s to an internal address
+//      is rejected, not followed.
+//   5. The body is capped at `maxBytes`, enforced while streaming (Content-Length
+//      can lie), and the whole request is bounded by a connect/read/overall
+//      timeout (which also stops the fetch being used as an internal port
+//      scanner via timing).
+//
+// One honest residual: AsyncHTTPClient does its own DNS and won't let us pin the
+// address we just validated, so there is a theoretical DNS-rebinding TOCTOU
+// window between our check and its connect.  Disallowing redirects (4) shrinks
+// it; closing it entirely would require a host allowlist, which is deliberately
+// not part of this design.
+//
+// `BlockedIPClassifier` is split out as a pure, network-free function so the
+// security-critical range logic is exhaustively unit-tested without DNS.
+
+import AsyncHTTPClient
+import Foundation
+import NIOCore
+import Vapor
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+/// Errors raised while fetching a support file by URL.  All are surfaced to the
+/// caller (mapped to an MCP `invalidArguments` detail) so the agent learns why
+/// the URL was rejected rather than seeing an opaque failure.
+enum SupportFileFetchError: Error, Equatable, Sendable {
+    case invalidURL(String)
+    case schemeNotAllowed(String)
+    case credentialsInURL
+    case dnsFailed(host: String)
+    case blockedAddress(host: String, ip: String)
+    case unexpectedStatus(Int)
+    case tooLarge(maxBytes: Int)
+    case notUTF8
+
+    /// Human-readable detail for an MCP tool error.
+    var toolDetail: String {
+        switch self {
+        case .invalidURL(let url):
+            return "sourceUrl is not a valid URL: \"\(url)\"."
+        case .schemeNotAllowed(let scheme):
+            return "sourceUrl must be an https:// URL (got scheme \"\(scheme)\")."
+        case .credentialsInURL:
+            return "sourceUrl must not embed credentials (user:pass@…)."
+        case .dnsFailed(let host):
+            return "sourceUrl host \"\(host)\" could not be resolved."
+        case .blockedAddress(let host, let ip):
+            return
+                "sourceUrl host \"\(host)\" resolves to a non-public address (\(ip)); "
+                + "fetching loopback, private, link-local, or cloud-metadata addresses is refused."
+        case .unexpectedStatus(let code):
+            return "sourceUrl returned HTTP \(code) (expected 200, and redirects are not followed)."
+        case .tooLarge(let maxBytes):
+            return "sourceUrl body exceeds the \(maxBytes / (1024 * 1024)) MB support-file limit."
+        case .notUTF8:
+            return "sourceUrl body is not valid UTF-8 text (binary support files are not yet supported)."
+        }
+    }
+}
+
+enum SupportFileURLFetcher {
+    /// Hard cap on a fetched support file.  The MCP route's body limit is 10 MB;
+    /// a support file lives in the same setup zip, so this stays comfortably
+    /// under it.  Compile-time constant — deliberately not an env var.
+    static let maxBytes = 8 * 1024 * 1024
+    static let connectTimeout: TimeAmount = .seconds(10)
+    static let readTimeout: TimeAmount = .seconds(15)
+    static let overallTimeout: TimeAmount = .seconds(20)
+
+    /// Validates the URL (https, no userinfo, has a host) and returns the host.
+    static func validate(_ urlString: String) throws -> String {
+        guard let comps = URLComponents(string: urlString) else {
+            throw SupportFileFetchError.invalidURL(urlString)
+        }
+        guard (comps.scheme ?? "").lowercased() == "https" else {
+            throw SupportFileFetchError.schemeNotAllowed(comps.scheme ?? "")
+        }
+        guard comps.user == nil, comps.password == nil else {
+            throw SupportFileFetchError.credentialsInURL
+        }
+        guard var host = comps.host, !host.isEmpty else {
+            throw SupportFileFetchError.invalidURL(urlString)
+        }
+        // Some Foundation builds keep the [..] around an IPv6 literal host.
+        if host.hasPrefix("[") && host.hasSuffix("]") {
+            host = String(host.dropFirst().dropLast())
+        }
+        return host
+    }
+
+    /// Fetches the URL under the SSRF guards and returns the body as UTF-8 text.
+    static func fetch(urlString: String, on request: Request) async throws -> String {
+        let host = try validate(urlString)
+
+        // Resolve + classify before connecting.  An IP literal is classified
+        // directly; a hostname is resolved (off the event loop) and every
+        // returned address must be public.
+        let addresses: [String]
+        if BlockedIPClassifier.isIPLiteral(host) {
+            addresses = [host]
+        } else {
+            addresses = try await request.application.threadPool.runIfActive(eventLoop: request.eventLoop) {
+                try resolveHostAddresses(host)
+            }.get()
+        }
+        guard !addresses.isEmpty else { throw SupportFileFetchError.dnsFailed(host: host) }
+        for ip in addresses where BlockedIPClassifier.isBlocked(ip) {
+            request.logger.warning(
+                "mcp.support_file_fetch.blocked host=\(host) ip=\(ip)")
+            throw SupportFileFetchError.blockedAddress(host: host, ip: ip)
+        }
+
+        let configuration = HTTPClient.Configuration(
+            redirectConfiguration: .disallow,
+            timeout: .init(connect: connectTimeout, read: readTimeout))
+        let client = HTTPClient(
+            eventLoopGroupProvider: .shared(request.application.eventLoopGroup),
+            configuration: configuration)
+
+        // Run the request, then shut the dedicated client down exactly once
+        // regardless of outcome (a per-call client keeps the no-redirect config
+        // off the shared client).
+        let outcome: Result<Data, Error>
+        do {
+            outcome = .success(try await performFetch(client, urlString: urlString))
+        } catch {
+            outcome = .failure(error)
+        }
+        try? await client.shutdown()
+
+        let bytes = try outcome.get()
+        guard let text = String(data: bytes, encoding: .utf8) else {
+            throw SupportFileFetchError.notUTF8
+        }
+        request.logger.info(
+            "mcp.support_file_fetch host=\(host) bytes=\(bytes.count) status=ok")
+        return text
+    }
+
+    private static func performFetch(_ client: HTTPClient, urlString: String) async throws -> Data {
+        var httpRequest = HTTPClientRequest(url: urlString)
+        httpRequest.method = .GET
+        let response = try await client.execute(httpRequest, timeout: overallTimeout)
+        guard response.status == .ok else {
+            throw SupportFileFetchError.unexpectedStatus(Int(response.status.code))
+        }
+        let buffer: ByteBuffer
+        do {
+            buffer = try await response.body.collect(upTo: maxBytes)
+        } catch {
+            // .collect throws NIOTooManyBytesError once the stream passes the
+            // cap, so we abort mid-download rather than trusting Content-Length.
+            throw SupportFileFetchError.tooLarge(maxBytes: maxBytes)
+        }
+        return Data(buffer.readableBytesView)
+    }
+
+    /// Resolves a hostname to every numeric address it maps to (v4 and v6).
+    /// Blocking (getaddrinfo); call on a thread-pool, not the event loop.
+    static func resolveHostAddresses(_ host: String) throws -> [String] {
+        var hints = addrinfo()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = 0
+        hints.ai_protocol = 0
+
+        var result: UnsafeMutablePointer<addrinfo>?
+        let status = getaddrinfo(host, nil, &hints, &result)
+        guard status == 0, let head = result else {
+            throw SupportFileFetchError.dnsFailed(host: host)
+        }
+        defer { freeaddrinfo(head) }
+
+        var addresses: [String] = []
+        var node: UnsafeMutablePointer<addrinfo>? = head
+        while let current = node {
+            defer { node = current.pointee.ai_next }
+            guard let sockaddr = current.pointee.ai_addr else { continue }
+            var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let rc = getnameinfo(
+                sockaddr, current.pointee.ai_addrlen,
+                &buffer, socklen_t(buffer.count),
+                nil, 0, NI_NUMERICHOST)
+            guard rc == 0 else { continue }
+            // `String(cString: [CChar])` is deprecated; the pointer overload is
+            // not. getnameinfo writes a NUL-terminated string into `buffer`.
+            let ip = buffer.withUnsafeBufferPointer { raw -> String in
+                guard let base = raw.baseAddress else { return "" }
+                return String(cString: base)
+            }
+            if !ip.isEmpty, !addresses.contains(ip) { addresses.append(ip) }
+        }
+        return addresses
+    }
+}
+
+/// Pure (no DNS, no network) classification of a numeric IP literal as a
+/// non-public address that an SSRF guard must refuse.  Returns `true` for any
+/// loopback / private / link-local / cloud-metadata / CGNAT / ULA / multicast /
+/// reserved / unspecified address, and fails closed for an unparseable input.
+enum BlockedIPClassifier {
+    static func isIPLiteral(_ host: String) -> Bool {
+        parseIPv4(host) != nil || parseIPv6(normalizeV6(host)) != nil
+    }
+
+    static func isBlocked(_ ip: String) -> Bool {
+        // getnameinfo can return a "%scope" suffix on link-local v6.
+        let core = ip.split(separator: "%", maxSplits: 1).first.map(String.init) ?? ip
+        if let v4 = parseIPv4(core) { return isBlockedIPv4(v4) }
+        if let v6 = parseIPv6(normalizeV6(core)) { return isBlockedIPv6(v6) }
+        // The caller only passes resolved numeric addresses; an unparseable one
+        // is unexpected, so refuse it.
+        return true
+    }
+
+    // MARK: - Range logic
+
+    static func isBlockedIPv4(_ b: [UInt8]) -> Bool {
+        guard b.count == 4 else { return true }
+        let b0 = b[0], b1 = b[1], b2 = b[2]
+        if b0 == 0 { return true }  // 0.0.0.0/8 "this host"
+        if b0 == 10 { return true }  // 10/8 private
+        if b0 == 127 { return true }  // 127/8 loopback
+        if b0 == 169 && b1 == 254 { return true }  // 169.254/16 link-local + metadata
+        if b0 == 172 && (16...31).contains(b1) { return true }  // 172.16/12 private
+        if b0 == 192 && b1 == 168 { return true }  // 192.168/16 private
+        if b0 == 100 && (64...127).contains(b1) { return true }  // 100.64/10 CGNAT
+        if b0 == 198 && (18...19).contains(b1) { return true }  // 198.18/15 benchmark
+        if b0 == 192 && b1 == 0 && b2 == 0 { return true }  // 192.0.0/24 IETF
+        if b0 == 192 && b1 == 0 && b2 == 2 { return true }  // 192.0.2/24 TEST-NET-1
+        if b0 == 198 && b1 == 51 && b2 == 100 { return true }  // 198.51.100/24 TEST-NET-2
+        if b0 == 203 && b1 == 0 && b2 == 113 { return true }  // 203.0.113/24 TEST-NET-3
+        if b0 >= 224 { return true }  // 224/4 multicast + 240/4 reserved + broadcast
+        return false
+    }
+
+    static func isBlockedIPv6(_ b: [UInt8]) -> Bool {
+        guard b.count == 16 else { return true }
+        // IPv4-mapped ::ffff:a.b.c.d — classify the embedded v4.
+        if b[0..<10].allSatisfy({ $0 == 0 }) && b[10] == 0xff && b[11] == 0xff {
+            return isBlockedIPv4(Array(b[12..<16]))
+        }
+        // NAT64 well-known prefix 64:ff9b::/96 — embeds a v4.
+        if Array(b[0..<12]) == [0, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0] {
+            return isBlockedIPv4(Array(b[12..<16]))
+        }
+        // High 96 bits zero: ::, ::1, and IPv4-compatible ::a.b.c.d.
+        if b[0..<12].allSatisfy({ $0 == 0 }) {
+            let v4 = Array(b[12..<16])
+            return v4.allSatisfy { $0 == 0 } ? true : isBlockedIPv4(v4)
+        }
+        if b[0] == 0xfe && (b[1] & 0xc0) == 0x80 { return true }  // fe80::/10 link-local
+        if (b[0] & 0xfe) == 0xfc { return true }  // fc00::/7 unique-local
+        if b[0] == 0xff { return true }  // ff00::/8 multicast
+        return false
+    }
+
+    // MARK: - Parsing
+
+    /// Strips a "%scope" suffix and surrounding brackets so an inet_pton parse
+    /// of an IPv6 literal succeeds.
+    private static func normalizeV6(_ host: String) -> String {
+        var s = host
+        if s.hasPrefix("[") && s.hasSuffix("]") { s = String(s.dropFirst().dropLast()) }
+        if let pct = s.firstIndex(of: "%") { s = String(s[..<pct]) }
+        return s
+    }
+
+    static func parseIPv4(_ s: String) -> [UInt8]? {
+        var addr = in_addr()
+        let ok = s.withCString { inet_pton(AF_INET, $0, &addr) }
+        guard ok == 1 else { return nil }
+        var net = addr.s_addr  // network byte order: bytes are the octets in order
+        return withUnsafeBytes(of: &net) { Array($0) }
+    }
+
+    static func parseIPv6(_ s: String) -> [UInt8]? {
+        var addr = in6_addr()
+        let ok = s.withCString { inet_pton(AF_INET6, $0, &addr) }
+        guard ok == 1 else { return nil }
+        let bytes = withUnsafeBytes(of: &addr) { Array($0) }
+        return bytes.count == 16 ? bytes : nil
+    }
+}

--- a/Tests/APITests/MCP/AuthorScriptToolTests.swift
+++ b/Tests/APITests/MCP/AuthorScriptToolTests.swift
@@ -73,12 +73,14 @@ import Vapor
     }
 
     private func input(
-        _ assignment: APIAssignment, filename: String, content: String,
+        _ assignment: APIAssignment, filename: String, content: String? = nil,
+        sourceUrl: String? = nil,
         tier: String? = nil, points: Int? = nil, displayName: String? = nil,
         dependsOn: [String]? = nil, sectionID: String? = nil
     ) -> AuthorScriptTool.Input {
         AuthorScriptTool.Input(
             assignmentPublicID: assignment.publicID, filename: filename, content: content,
+            sourceUrl: sourceUrl,
             tier: tier, points: points, displayName: displayName, dependsOn: dependsOn, sectionID: sectionID)
     }
 

--- a/Tests/APITests/SupportFileURLFetcherTests.swift
+++ b/Tests/APITests/SupportFileURLFetcherTests.swift
@@ -1,0 +1,155 @@
+// APITests/SupportFileURLFetcherTests.swift
+//
+// The SSRF guard for author_script(sourceUrl:) is only as good as its IP-range
+// classification, so the pure `BlockedIPClassifier` is exercised exhaustively
+// here (no DNS, no network), alongside the URL validation. The actual fetch
+// (DNS + HTTP) is integration-territory and not covered by these unit tests.
+
+import Testing
+
+@testable import APIServer
+
+@Suite struct SupportFileURLFetcherTests {
+
+    // MARK: - Blocked addresses (must never be fetched)
+
+    @Test(
+        "non-public IPv4 is blocked",
+        arguments: [
+            "0.0.0.0",  // this-host
+            "0.1.2.3",
+            "10.0.0.1", "10.255.255.255",  // private
+            "127.0.0.1", "127.1.2.3",  // loopback
+            "169.254.169.254",  // cloud metadata (the classic SSRF target)
+            "169.254.0.1",  // link-local
+            "172.16.0.1", "172.20.5.5", "172.31.255.255",  // private
+            "192.168.0.1", "192.168.255.255",  // private
+            "100.64.0.1", "100.127.255.255",  // CGNAT
+            "198.18.0.1", "198.19.255.255",  // benchmark
+            "192.0.0.1",  // IETF protocol assignments
+            "192.0.2.5",  // TEST-NET-1
+            "198.51.100.5",  // TEST-NET-2
+            "203.0.113.5",  // TEST-NET-3
+            "224.0.0.1", "239.255.255.255",  // multicast
+            "240.0.0.1", "255.255.255.255",  // reserved + broadcast
+        ])
+    func blockedIPv4(_ ip: String) {
+        #expect(BlockedIPClassifier.isBlocked(ip), "\(ip) should be blocked")
+    }
+
+    @Test(
+        "non-public IPv6 is blocked",
+        arguments: [
+            "::",  // unspecified
+            "::1",  // loopback
+            "fe80::1",  // link-local
+            "fe80::abcd:1234",
+            "fc00::1",  // unique-local
+            "fd12:3456:789a::1",  // unique-local
+            "ff02::1",  // multicast
+            "ff00::1",
+            "::ffff:127.0.0.1",  // IPv4-mapped loopback
+            "::ffff:10.0.0.1",  // IPv4-mapped private
+            "::ffff:169.254.169.254",  // IPv4-mapped metadata
+            "64:ff9b::7f00:1",  // NAT64-wrapped 127.0.0.1
+        ])
+    func blockedIPv6(_ ip: String) {
+        #expect(BlockedIPClassifier.isBlocked(ip), "\(ip) should be blocked")
+    }
+
+    @Test("link-local IPv6 with a zone suffix is blocked")
+    func blockedIPv6WithZone() {
+        #expect(BlockedIPClassifier.isBlocked("fe80::1%eth0"))
+    }
+
+    // MARK: - Public addresses (allowed)
+
+    @Test(
+        "public IPv4 is allowed",
+        arguments: [
+            "8.8.8.8", "1.1.1.1",
+            "185.199.108.133",  // GitHub Pages / raw.githubusercontent.com range
+            "140.82.112.3",  // GitHub
+            "11.0.0.1",  // just outside 10/8
+            "126.255.255.255", "128.0.0.1",  // either side of 127/8
+            "172.15.255.255", "172.32.0.1",  // either side of 172.16/12
+            "192.167.255.255", "192.169.0.1",  // either side of 192.168/16
+            "100.63.255.255", "100.128.0.1",  // either side of 100.64/10
+            "223.255.255.255",  // just below multicast
+        ])
+    func allowedIPv4(_ ip: String) {
+        #expect(!BlockedIPClassifier.isBlocked(ip), "\(ip) should be allowed")
+    }
+
+    @Test(
+        "public IPv6 is allowed",
+        arguments: [
+            "2606:4700:4700::1111",  // Cloudflare
+            "2001:4860:4860::8888",  // Google
+            "2620:0:2d0:200::7",
+            "::ffff:8.8.8.8",  // IPv4-mapped public
+        ])
+    func allowedIPv6(_ ip: String) {
+        #expect(!BlockedIPClassifier.isBlocked(ip), "\(ip) should be allowed")
+    }
+
+    // MARK: - Parsing fails closed
+
+    @Test("an unparseable address is treated as blocked (fail closed)")
+    func unparseableFailsClosed() {
+        #expect(BlockedIPClassifier.isBlocked("not-an-ip"))
+        #expect(BlockedIPClassifier.isBlocked(""))
+        #expect(BlockedIPClassifier.isBlocked("999.999.999.999"))
+    }
+
+    @Test("IP-literal detection")
+    func ipLiteralDetection() {
+        #expect(BlockedIPClassifier.isIPLiteral("8.8.8.8"))
+        #expect(BlockedIPClassifier.isIPLiteral("::1"))
+        #expect(BlockedIPClassifier.isIPLiteral("2606:4700::1111"))
+        #expect(!BlockedIPClassifier.isIPLiteral("example.com"))
+        #expect(!BlockedIPClassifier.isIPLiteral("raw.githubusercontent.com"))
+    }
+
+    // MARK: - URL validation
+
+    @Test("validate accepts a plain https URL and returns the host")
+    func validateAcceptsHTTPS() throws {
+        let host = try SupportFileURLFetcher.validate("https://raw.githubusercontent.com/o/r/main/data.csv")
+        #expect(host == "raw.githubusercontent.com")
+    }
+
+    @Test("validate strips brackets from an IPv6 literal host")
+    func validateStripsBrackets() throws {
+        let host = try SupportFileURLFetcher.validate("https://[2606:4700::1111]/data.csv")
+        #expect(host == "2606:4700::1111")
+    }
+
+    @Test(
+        "validate rejects non-https schemes",
+        arguments: [
+            "http://example.com/data.csv",
+            "file:///etc/passwd",
+            "ftp://example.com/data.csv",
+            "gopher://example.com/",
+        ])
+    func validateRejectsScheme(_ url: String) {
+        #expect(throws: SupportFileFetchError.self) {
+            try SupportFileURLFetcher.validate(url)
+        }
+    }
+
+    @Test("validate rejects embedded credentials")
+    func validateRejectsUserinfo() {
+        #expect(throws: SupportFileFetchError.self) {
+            try SupportFileURLFetcher.validate("https://user:pass@example.com/data.csv")
+        }
+    }
+
+    @Test("validate rejects a URL with no host")
+    func validateRejectsNoHost() {
+        #expect(throws: SupportFileFetchError.self) {
+            try SupportFileURLFetcher.validate("https:///data.csv")
+        }
+    }
+}

--- a/changelog.d/mcp-author-script-source-url.md
+++ b/changelog.d/mcp-author-script-source-url.md
@@ -1,0 +1,22 @@
+### Added
+
+- **MCP `author_script` can fetch a support file from a URL.** A data/support
+  file too large to inline faithfully in a tool call (e.g. a CSV fixture) can
+  now be authored by passing `sourceUrl` (an https URL) instead of `content`;
+  the server downloads the body and stores it as the file. Exactly one of
+  `content`/`sourceUrl` must be supplied.
+
+### Security
+
+- **The `author_script` URL fetch is SSRF-guarded.** Only `https` is allowed;
+  the host is resolved server-side and the fetch is refused if any resulting
+  address is loopback / private / link-local (incl. the `169.254.169.254`
+  cloud-metadata range) / CGNAT / unique-local / multicast / reserved (IPv4,
+  IPv6, and IPv4-mapped/compatible/NAT64 forms are normalised first); redirects
+  are not followed; the body is capped at 8 MB while streaming; and the request
+  is bounded by connect/read/overall timeouts. The fetch runs only after the
+  caller is authorized for the assignment's course, and the address-range logic
+  is exhaustively unit-tested (`BlockedIPClassifier`). No new env var or host
+  allowlist is introduced; the one residual is a theoretical DNS-rebinding TOCTOU
+  window (AsyncHTTPClient re-resolves the host), narrowed by disallowing
+  redirects.


### PR DESCRIPTION
## What

Adds a `sourceUrl` option to the MCP `author_script` tool. A data/support file too large for an agent to inline faithfully in a tool call (e.g. a 193 KB CSV fixture) can now be authored by passing an https URL; the server downloads the body and stores it as the file. Exactly one of `content` (inline) / `sourceUrl` (fetched) must be supplied.

## Why

The support-file write path already accepts up to 10 MB of inline `content`, so size was never the blocker — the gap is that an agent can't reliably reproduce a large/numeric data file inline in a tool call. Delivering it **by reference** (a URL the server fetches) closes that gap, so data-driven assignments can be authored over MCP rather than only by hand-uploading a test-setup zip.

## Security — SSRF posture

A server fetching a caller-supplied URL is a classic SSRF vector. The chosen posture is **IP-range guards, no host allowlist, no new env var**. Guards (in `SupportFileURLFetcher`):

- **https only** — no `file://`, `ftp://`, `gopher://`, `data://`; and no `user:pass@` userinfo.
- **Address check** — the host is resolved server-side and the fetch is refused if **any** resulting address is loopback / private / link-local (incl. the `169.254.169.254` cloud-metadata range) / CGNAT / unique-local / multicast / reserved. IPv4, IPv6, and IPv4-mapped/compatible/NAT64 forms are normalised first; obfuscated literals (octal/hex) are caught because they resolve to a canonical numeric IP that is then classified.
- **No redirects** — a public URL that 302s to an internal address is rejected, not followed.
- **Bounded** — body capped at 8 MB enforced *while streaming* (Content-Length can lie); connect/read/overall timeouts (which also stop the fetch being used as an internal port scanner via timing); body must be UTF-8 text.
- **Authorize-first** — the one-of is validated up front (cheap, no I/O) and the fetch is deferred until after the caller is authorized for the assignment's course and the cheap rejections pass, so no outbound request is made on an unauthorized caller's behalf.

The address-range logic is split into a pure, network-free `BlockedIPClassifier` and exhaustively unit-tested (loopback / private / metadata / CGNAT / ULA / multicast / reserved, v4 + v6 + mapped + NAT64, boundary cases, fail-closed on unparseable input).

**One honest residual:** AsyncHTTPClient does its own DNS and won't let us pin the address we validated, so there is a theoretical DNS-rebinding TOCTOU window between the check and its connect. Disallowing redirects narrows it; closing it entirely would need a host allowlist, which is deliberately not part of this design.

## Notes

- `AsyncHTTPClient` is declared as an explicit dependency (already in the resolved graph transitively via Vapor — `Package.resolved` unchanged) so the fetcher can build a dedicated **no-redirect** client; the shared Vapor client follows redirects and can't be reconfigured per-request.
- Agent-facing copy updated in both the tool `description`/`inputSchema` and `MCPServerInstructions`.
- Binary support files remain out of scope (UTF-8 text only) — a documented follow-up.

## Tests

- New `SupportFileURLFetcherTests` — 12 tests / 55 parameterized cases, all green.
- Existing `AuthorScriptToolTests` (8) still pass after the `content` → optional + one-of refactor.
- Clean build (warnings-as-errors), swift-format clean, SwiftLint `--strict` 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZC7BWVpHQHQ6oozYpJ7f5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZC7BWVpHQHQ6oozYpJ7f5)_