### PR TITLE
feat(diagnostics): capture browser error message/stack for diagnosis

### DIFF
--- a/Public/notebook-preflight.js
+++ b/Public/notebook-preflight.js
@@ -131,6 +131,11 @@
         const body = { kind: info.kind };
         if (info.failedChecks && info.failedChecks.length) body.failedChecks = info.failedChecks;
         if (setupID) body.testSetupID = setupID;
+        // Error detail (editor_error + kernel-unhealthy watchdog).  Client-side
+        // caps are generous; the server trims to its own bounds.
+        if (info.message) body.message = String(info.message).slice(0, 2000);
+        if (info.stack)   body.stack   = String(info.stack).slice(0, 8000);
+        if (info.source)  body.source  = String(info.source).slice(0, 64);
 
         await fetch(PREFLIGHT_DIAGNOSTICS_URL, {
             method:  'POST',
@@ -144,11 +149,45 @@
     }
 
     // ----------------------------------------------------------------
+    // Editor-error telemetry
+    // ----------------------------------------------------------------
+    //
+    // Unlike showFailure(), this makes NO visible change to the page — an
+    // uncaught error on the editor page isn't necessarily fatal — it just
+    // posts an "editor_error" diagnostic so we can see what broke.  Capped and
+    // de-duplicated per page load so a tight error loop can't flood the
+    // endpoint (the server also rate-limits per (user, setup, kind, source)).
+
+    const _reportedErrors = new Set();
+    let _errorReportCount = 0;
+    const MAX_ERROR_REPORTS = 8;
+
+    function reportEditorError(info) {
+        try {
+            if (!info || _errorReportCount >= MAX_ERROR_REPORTS) return;
+            const dedupeKey = (info.source || '') + '|' + (info.message || '');
+            if (_reportedErrors.has(dedupeKey)) return;
+            _reportedErrors.add(dedupeKey);
+            _errorReportCount += 1;
+
+            postDiagnostic({
+                kind:    'editor_error',
+                source:  info.source,
+                message: info.message,
+                stack:   info.stack
+            }).catch(function () { /* telemetry is best-effort */ });
+        } catch (_) {
+            // Never let telemetry throw inside an error handler.
+        }
+    }
+
+    // ----------------------------------------------------------------
     // Public surface
     // ----------------------------------------------------------------
 
     window.ChickadeeNotebookFailures = {
-        runPreflight: runPreflight,
-        showFailure:  showFailure
+        runPreflight:     runPreflight,
+        showFailure:      showFailure,
+        reportEditorError: reportEditorError
     };
 })();

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -78,6 +78,33 @@
     // loaded (older cached page, network glitch) fall through to the
     // legacy behaviour of mounting unconditionally.
     const failures = window.ChickadeeNotebookFailures;
+
+    // Editor-page error telemetry: capture uncaught errors / unhandled
+    // rejections on THIS (parent) page and report them quietly, without
+    // changing the UI.  Errors inside the cross-origin JupyterLite iframe are
+    // not visible from here — those surface via the watchdog's kernel-unhealthy
+    // path instead.  Resource-load errors (<img>/<script> 404s) don't bubble to
+    // a non-capturing window listener, so we only see real script errors.
+    if (failures && failures.reportEditorError) {
+        window.addEventListener('error', function (e) {
+            if (!e || (!e.message && !e.error)) return;
+            const err = e.error;
+            failures.reportEditorError({
+                source:  'onerror',
+                message: e.message || (err && err.message) || 'error',
+                stack:   err && err.stack
+            });
+        });
+        window.addEventListener('unhandledrejection', function (e) {
+            const reason = e && e.reason;
+            failures.reportEditorError({
+                source:  'unhandledrejection',
+                message: (reason && reason.message) || String(reason || 'unhandledrejection'),
+                stack:   reason && reason.stack
+            });
+        });
+    }
+
     const preflightPromise = failures
         ? failures.runPreflight()
         : Promise.resolve({ ok: true, failed: [] });
@@ -261,7 +288,9 @@
                 cancelled = true;
                 failures.showFailure({
                     kind:         'watchdog_timeout',
-                    failedChecks: ['kernel-unhealthy']
+                    failedChecks: ['kernel-unhealthy'],
+                    source:       'kernel',
+                    message:      probe.kernelEvidence || 'kernel in failure state'
                 });
                 reenableSubmit();
                 return;
@@ -301,6 +330,7 @@
     function probeIframeReadiness(frame) {
         let shellReady = false;
         let kernelInFailureState = false;
+        let kernelEvidence = null;
         let win = null;
         let doc = null;
 
@@ -311,8 +341,10 @@
         try {
             if (win && win.jupyterapp) {
                 shellReady = true;
-                if (isKernelInFailureState(win)) {
+                const evidence = kernelFailureEvidence(win);
+                if (evidence) {
                     kernelInFailureState = true;
+                    kernelEvidence = evidence;
                 }
             }
         } catch (_) { /* fall through */ }
@@ -340,11 +372,12 @@
                 const txt = (doc && doc.body && doc.body.textContent) || '';
                 if (txt.indexOf('Kernel Unknown') !== -1) {
                     kernelInFailureState = true;
+                    kernelEvidence = 'Kernel Unknown badge (iframe dom)';
                 }
             } catch (_) { /* fall through */ }
         }
 
-        return { shellReady, kernelInFailureState };
+        return { shellReady, kernelInFailureState, kernelEvidence };
     }
 
     function reenableSubmit() {
@@ -354,13 +387,13 @@
         }
     }
 
-    // Returns true iff we have POSITIVE EVIDENCE the kernel has hit a
-    // known failure state.  Used by the watchdog to decide whether to
-    // fire phase-2 ("kernel-unhealthy").  We deliberately return false
-    // for the "I don't know" case — kernels that are still bootstrapping
-    // look the same as healthy ones to us, and that's fine.  We'd
-    // rather miss a genuine failure than false-positive on a working
-    // editor.
+    // Returns a short evidence string iff we have POSITIVE EVIDENCE the
+    // kernel has hit a known failure state, or null otherwise.  Used by the
+    // watchdog to decide whether to fire phase-2 ("kernel-unhealthy") and to
+    // attach a diagnosable reason to the diagnostic.  We deliberately return
+    // null for the "I don't know" case — kernels that are still bootstrapping
+    // look the same as healthy ones to us, and that's fine.  We'd rather miss a
+    // genuine failure than false-positive on a working editor.
     //
     // Failure signals (any of):
     //   * ServiceManager session with status `dead` or `unknown`
@@ -368,7 +401,7 @@
     //
     // Each probe is wrapped in try/catch so a TypeError or cross-origin
     // access error doesn't propagate.
-    function isKernelInFailureState(win) {
+    function kernelFailureEvidence(win) {
         try {
             const app = win.jupyterapp;
             const sm  = app && app.serviceManager;
@@ -378,7 +411,9 @@
                     const sessions = Array.from(running);
                     for (let i = 0; i < sessions.length; i++) {
                         const status = sessions[i] && sessions[i].kernel && sessions[i].kernel.status;
-                        if (status === 'unknown' || status === 'dead') return true;
+                        if (status === 'unknown' || status === 'dead') {
+                            return 'kernel status: ' + status;
+                        }
                     }
                 }
             }
@@ -387,10 +422,10 @@
         try {
             const doc = win.document;
             const txt = (doc && doc.body && doc.body.textContent) || '';
-            if (txt.indexOf('Kernel Unknown') !== -1) return true;
+            if (txt.indexOf('Kernel Unknown') !== -1) return 'Kernel Unknown badge';
         } catch (_) { /* fall through */ }
 
-        return false;
+        return null;
     }
 
     // Hard fallback: if the notebook hasn't synced within 15 seconds (e.g. the
@@ -1349,7 +1384,7 @@
             extractTracebackText,
             parseStructuredPayload,
             probeIframeReadiness,
-            isKernelInFailureState,
+            kernelFailureEvidence,
             shouldForceReseed,
             reseedPlan,
         };

--- a/Sources/APIServer/Migrations/AddClientDiagnosticErrorDetail.swift
+++ b/Sources/APIServer/Migrations/AddClientDiagnosticErrorDetail.swift
@@ -1,0 +1,37 @@
+// APIServer/Migrations/AddClientDiagnosticErrorDetail.swift
+//
+// Adds error-detail columns to client_diagnostics so browser-side failures
+// carry diagnosable signal, not just a symbolic kind:
+//
+//   message — the error message (editor_error + kernel-unhealthy watchdog)
+//   stack   — the JS stack trace (editor_error)
+//   source  — origin of the error: "onerror" | "unhandledrejection" | "kernel"
+//
+// These capture JupyterLite/Pyodide *infrastructure* errors from the editor
+// -load path only — never student-code execution — so no student-authored
+// content is stored here.
+//
+// Shipped as a standalone Add* migration (not folded into
+// CreateClientDiagnostics) because production databases have already applied
+// CreateClientDiagnostics without these columns and would never pick them up
+// from a body change. Fresh deploys run CreateClientDiagnostics then this
+// migration; existing prod runs only this one.
+
+import Fluent
+
+struct AddClientDiagnosticErrorDetail: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        // One column per .update(): SQLite's ALTER TABLE adds a single column
+        // per statement, so batching all three into one update produces invalid
+        // SQL there (Postgres would accept it).
+        try await database.schema("client_diagnostics").field("message", .string).update()
+        try await database.schema("client_diagnostics").field("stack", .string).update()
+        try await database.schema("client_diagnostics").field("source", .string).update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("client_diagnostics").deleteField("message").update()
+        try await database.schema("client_diagnostics").deleteField("stack").update()
+        try await database.schema("client_diagnostics").deleteField("source").update()
+    }
+}

--- a/Sources/APIServer/Models/APIClientDiagnostic.swift
+++ b/Sources/APIServer/Models/APIClientDiagnostic.swift
@@ -2,13 +2,23 @@ import Fluent
 import Vapor
 
 /// Client-side diagnostic record posted from the student submit page when
-/// the in-browser editor (JupyterLite + Pyodide) cannot start.
+/// the in-browser editor (JupyterLite + Pyodide) cannot start — or hits an
+/// uncaught JavaScript error.
 ///
-/// Two kinds:
+/// Three kinds:
 ///   - "preflight_fail"   — capability check failed before the iframe was
 ///                           mounted (e.g. service workers blocked)
 ///   - "watchdog_timeout" — the iframe mounted but the JupyterLite kernel
 ///                           did not become ready within the watchdog window
+///   - "editor_error"     — an uncaught error / unhandled promise rejection
+///                           on the editor page (captured via window.onerror
+///                           / unhandledrejection), carrying message + stack
+///
+/// `message` / `stack` / `source` are populated for "editor_error" and, where
+/// available, for the kernel-unhealthy "watchdog_timeout" subtype. They carry
+/// JupyterLite/Pyodide *infrastructure* error text only — the capture sites are
+/// the editor-load path, never student-code execution — so no student-authored
+/// content lands here.
 final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
     // @unchecked Sendable: mutated only within Vapor's request context.
     static let schema = "client_diagnostics"
@@ -31,6 +41,19 @@ final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
     @OptionalField(key: "user_agent")
     var userAgent: String?
 
+    /// Error message for "editor_error" / kernel-unhealthy records (trimmed).
+    @OptionalField(key: "message")
+    var message: String?
+
+    /// Stack trace for "editor_error" records (trimmed).
+    @OptionalField(key: "stack")
+    var stack: String?
+
+    /// Where the error originated, for triage: "onerror", "unhandledrejection",
+    /// or "kernel". nil for preflight/plain watchdog records.
+    @OptionalField(key: "source")
+    var source: String?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
@@ -41,12 +64,18 @@ final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
         testSetupID: String?,
         kind: String,
         failedChecks: String?,
-        userAgent: String?
+        userAgent: String?,
+        message: String? = nil,
+        stack: String? = nil,
+        source: String? = nil
     ) {
         self.userID = userID
         self.testSetupID = testSetupID
         self.kind = kind
         self.failedChecks = failedChecks
         self.userAgent = userAgent
+        self.message = message
+        self.stack = stack
+        self.source = source
     }
 }

--- a/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
+++ b/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
@@ -10,10 +10,19 @@
 //   "watchdog_timeout"  — the iframe loaded but the JupyterLite kernel did
 //                          not become ready within the 45-second watchdog
 //                          window
+//   "editor_error"      — an uncaught error / unhandled promise rejection on
+//                          the editor page (window.onerror / unhandledrejection),
+//                          carrying message + stack for diagnosis
+//
+// "editor_error" and the kernel-unhealthy "watchdog_timeout" subtype may carry
+// `message` / `stack` / `source`.  These are JupyterLite/Pyodide infrastructure
+// errors captured on the editor-load path only — never student-code execution —
+// so no student-authored content is stored here.
 //
 // Records flow into client_diagnostics for the instructor dashboard's
-// "Students With Browser Errors" card.  Rate-limited per (user, setup, kind)
-// so a stuck student reloading 50 times doesn't fill the table.
+// "Browser Errors" card and the admin diagnostic tooling.  Rate-limited per
+// (user, setup, kind, source) so a stuck student reloading 50 times doesn't
+// fill the table, while distinct error sources are still preserved.
 
 import Fluent
 import Foundation
@@ -34,27 +43,35 @@ struct ClientDiagnosticsRoutes: RouteCollection {
 
         let body = try req.content.decode(ClientDiagnosticBody.self)
 
-        let allowedKinds: Set<String> = ["preflight_fail", "watchdog_timeout"]
+        let allowedKinds: Set<String> = ["preflight_fail", "watchdog_timeout", "editor_error"]
         guard allowedKinds.contains(body.kind) else {
             throw AppError.badRequest(reason: "Unknown kind")
         }
 
-        // De-duplicate within an hour so reloads don't multiply rows.
-        let limiter = req.application.clientDiagnosticsRateLimiter
-        let key = ClientDiagnosticsRateLimiter.Key(
-            userID: userID,
-            testSetupID: body.testSetupID,
-            kind: body.kind
-        )
-        let admitted = await limiter.admit(key: key, now: Date())
-        guard admitted else { return .accepted }
-
         // Trim defensive bounds — these are short strings in practice but we
-        // do not want a hostile client filling rows with megabyte payloads.
+        // do not want a hostile client filling rows with large payloads.
         let trimmedAgent = req.headers.first(name: .userAgent).map { String($0.prefix(512)) }
         let trimmedChecks = body.failedChecks.map { checks -> String in
             String(checks.joined(separator: ",").prefix(256))
         }
+        let trimmedSource = body.source.map { String($0.prefix(64)) }
+        let trimmedMessage = body.message.map { String($0.prefix(1024)) }
+        let trimmedStack = body.stack.map { String($0.prefix(4096)) }
+
+        // De-duplicate within an hour so reloads don't multiply rows.  The
+        // source is part of the key so distinct error origins (onerror vs.
+        // unhandledrejection vs. kernel) each keep a slot rather than the first
+        // one suppressing the rest; preflight/watchdog records pass nil and so
+        // dedupe by (user, setup, kind) exactly as before.
+        let limiter = req.application.clientDiagnosticsRateLimiter
+        let key = ClientDiagnosticsRateLimiter.Key(
+            userID: userID,
+            testSetupID: body.testSetupID,
+            kind: body.kind,
+            subkey: trimmedSource
+        )
+        let admitted = await limiter.admit(key: key, now: Date())
+        guard admitted else { return .accepted }
 
         // Verify the supplied setup exists before storing the FK.  A stale
         // page (e.g. the assignment was deleted between page load and the
@@ -72,7 +89,10 @@ struct ClientDiagnosticsRoutes: RouteCollection {
             testSetupID: verifiedSetupID,
             kind: body.kind,
             failedChecks: trimmedChecks,
-            userAgent: trimmedAgent
+            userAgent: trimmedAgent,
+            message: trimmedMessage,
+            stack: trimmedStack,
+            source: trimmedSource
         )
         try await record.save(on: req.db)
         return .accepted
@@ -82,12 +102,18 @@ struct ClientDiagnosticsRoutes: RouteCollection {
 // MARK: - Request body
 
 struct ClientDiagnosticBody: Content {
-    /// "preflight_fail" | "watchdog_timeout"
+    /// "preflight_fail" | "watchdog_timeout" | "editor_error"
     var kind: String
     /// Symbolic names of the capability checks that failed (preflight only).
     var failedChecks: [String]?
     /// The assignment the student was trying to load (best-effort).
     var testSetupID: String?
+    /// Error message (editor_error + kernel-unhealthy watchdog).
+    var message: String?
+    /// JS stack trace (editor_error).
+    var stack: String?
+    /// Origin of the error: "onerror" | "unhandledrejection" | "kernel".
+    var source: String?
 }
 
 // MARK: - Rate limiter
@@ -101,6 +127,10 @@ actor ClientDiagnosticsRateLimiter {
         let userID: UUID
         let testSetupID: String?
         let kind: String
+        /// Optional sub-discriminator (the error source) so distinct origins
+        /// aren't collapsed by the (user, setup, kind) dedup. nil for
+        /// preflight/watchdog records.
+        var subkey: String?
     }
 
     private var lastAdmitted: [Key: Date] = [:]

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -317,4 +317,8 @@ func registerMigrations(on app: Application) {
     // Denormalized grade columns on results + one-time backfill from the
     // collection_json blob (June 2026 audit, P1.1).
     app.migrations.add(AddResultGradeColumns())
+
+    // Error-detail columns on client_diagnostics (message/stack/source) so
+    // browser-side failures carry diagnosable signal.
+    app.migrations.add(AddClientDiagnosticErrorDetail())
 }

--- a/Tests/APITests/ClientDiagnosticsRoutesTests.swift
+++ b/Tests/APITests/ClientDiagnosticsRoutesTests.swift
@@ -166,6 +166,72 @@ import XCTVapor
         }
     }
 
+    @Test func persistsEditorErrorRecord() async throws {
+        try await withApp(app) { _ in
+            // An uncaught JS error / unhandled rejection on the editor page is
+            // posted as kind=editor_error carrying message + stack + source so
+            // the actual failure is diagnosable, not just a symbolic bucket.
+            let auth = try await loginAsStudent()
+            try await insertSetup(id: "setup_editor_err")
+            let body = #"""
+                {"kind":"editor_error","testSetupID":"setup_editor_err","source":"onerror","message":"TypeError: x is undefined","stack":"at foo (a.js:1:1)\nat bar (b.js:2:2)"}
+                """#
+            let res = try await postJSON(body, auth: auth, userAgent: "TestUA/3.0")
+            #expect(res.status == .accepted)
+
+            let records = try await APIClientDiagnostic.query(on: app.db).all()
+            #expect(records.count == 1)
+            let rec = try #require(records.first)
+            #expect(rec.kind == "editor_error")
+            #expect(rec.source == "onerror")
+            #expect(rec.message == "TypeError: x is undefined")
+            #expect(rec.stack?.contains("at foo") == true)
+            #expect(rec.failedChecks == nil)
+        }
+    }
+
+    @Test func editorErrorMessageAndStackAreTruncated() async throws {
+        try await withApp(app) { _ in
+            let auth = try await loginAsStudent()
+            let longMessage = String(repeating: "m", count: 5000)
+            let longStack = String(repeating: "s", count: 10000)
+            let body = """
+                {"kind":"editor_error","source":"unhandledrejection",\
+                "message":"\(longMessage)","stack":"\(longStack)"}
+                """
+            let res = try await postJSON(body, auth: auth)
+            #expect(res.status == .accepted)
+
+            let rec = try #require(try await APIClientDiagnostic.query(on: app.db).first())
+            #expect(rec.message?.count == 1024)
+            #expect(rec.stack?.count == 4096)
+        }
+    }
+
+    @Test func editorErrorsWithDifferentSourceAreNotDeduplicated() async throws {
+        try await withApp(app) { _ in
+            // The error source is part of the dedup key, so onerror vs.
+            // unhandledrejection on the same (user, setup, kind) each keep a
+            // slot; a repeat of the same source within the window is dropped.
+            let auth = try await loginAsStudent()
+            let res1 = try await postJSON(
+                #"{"kind":"editor_error","testSetupID":"setup_ed","source":"onerror","message":"a"}"#,
+                auth: auth)
+            #expect(res1.status == .accepted)
+            let res2 = try await postJSON(
+                #"{"kind":"editor_error","testSetupID":"setup_ed","source":"unhandledrejection","message":"b"}"#,
+                auth: auth)
+            #expect(res2.status == .accepted)
+            let res3 = try await postJSON(
+                #"{"kind":"editor_error","testSetupID":"setup_ed","source":"onerror","message":"c"}"#,
+                auth: auth)
+            #expect(res3.status == .accepted)
+
+            let count = try await APIClientDiagnostic.query(on: app.db).count()
+            #expect(count == 2)
+        }
+    }
+
     @Test func acceptsMissingTestSetupID() async throws {
         try await withApp(app) { _ in
             let auth = try await loginAsStudent()

--- a/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
+++ b/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
@@ -331,22 +331,56 @@ test('probeIframeReadiness: ServiceManager reports kernel status "starting" → 
     'starting kernels must not be flagged as failed (v0.4.152 regression guard)');
 });
 
-test('isKernelInFailureState: empty running sessions → not in failure', async () => {
-  const { isKernelInFailureState } = await loadHarness();
+test('kernelFailureEvidence: empty running sessions → null (no evidence)', async () => {
+  const { kernelFailureEvidence } = await loadHarness();
   const fakeWin = {
     jupyterapp: {
       serviceManager: { sessions: { running() { return []; } } },
     },
     document: { body: { textContent: '' } },
   };
-  assert.equal(isKernelInFailureState(fakeWin), false);
+  assert.equal(kernelFailureEvidence(fakeWin), null);
 });
 
-test('isKernelInFailureState: API access throws → not in failure (no evidence)', async () => {
-  const { isKernelInFailureState } = await loadHarness();
+test('kernelFailureEvidence: API access throws → null (no evidence)', async () => {
+  const { kernelFailureEvidence } = await loadHarness();
   const fakeWin = {
     get jupyterapp() { throw new Error('cross-origin'); },
     document: { body: { textContent: '' } },
   };
-  assert.equal(isKernelInFailureState(fakeWin), false);
+  assert.equal(kernelFailureEvidence(fakeWin), null);
+});
+
+test('kernelFailureEvidence: dead session → returns the status as evidence', async () => {
+  const { kernelFailureEvidence } = await loadHarness();
+  const fakeWin = {
+    jupyterapp: {
+      serviceManager: { sessions: { running() { return [{ kernel: { status: 'dead' } }]; } } },
+    },
+    document: { body: { textContent: '' } },
+  };
+  assert.equal(kernelFailureEvidence(fakeWin), 'kernel status: dead');
+});
+
+test('kernelFailureEvidence: "Kernel Unknown" DOM text → returns badge evidence', async () => {
+  const { kernelFailureEvidence } = await loadHarness();
+  const fakeWin = {
+    jupyterapp: { serviceManager: null },
+    document: { body: { textContent: 'Python (Pyodide) Kernel Unknown' } },
+  };
+  assert.equal(kernelFailureEvidence(fakeWin), 'Kernel Unknown badge');
+});
+
+test('probeIframeReadiness: kernel failure surfaces evidence string', async () => {
+  const { probeIframeReadiness } = await loadHarness();
+  const frame = makeFrame({
+    winFactory: () => null,
+    docFactory: () => makeDoc({
+      classList: ['jp-Toolbar'],
+      bodyText: 'Python (Pyodide) Kernel Unknown',
+    }),
+  });
+  const r = probeIframeReadiness(frame);
+  assert.equal(r.kernelInFailureState, true);
+  assert.equal(r.kernelEvidence, 'Kernel Unknown badge (iframe dom)');
 });

--- a/changelog.d/browser-error-capture.md
+++ b/changelog.d/browser-error-capture.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Browser-error detail capture.** The in-browser editor now records uncaught
+  JavaScript errors and unhandled promise rejections on the notebook page
+  (`window.onerror` / `unhandledrejection`) as a new `editor_error` client
+  diagnostic, and the kernel-unhealthy watchdog path now attaches the concrete
+  failure evidence (e.g. `kernel status: dead`, `Kernel Unknown badge`).
+  `client_diagnostics` gains `message`, `stack`, and `source` columns, and the
+  per-(user, setup, kind) rate limit now also keys on the error source so
+  distinct origins aren't collapsed. Capture is restricted to the editor-load
+  path — never student-code execution — so no student-authored content is
+  stored. Groundwork for the admin diagnostic tooling described in
+  `docs/admin-mcp.md`.

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -6,12 +6,16 @@ diagnosis* — letting an authorized agent inspect server health, telemetry, and
 error reports to help diagnose bugs. It is deliberately **read-only** and
 **never exposes student data**.
 
-Decisions locked with the maintainer before drafting:
+Decisions locked with the maintainer:
 
 1. **Separate MCP service**, not more tools on the existing `/mcp` endpoint.
 2. **Read-only.** Diagnosis only; "fixing bugs" happens through code changes and
    PRs, never through a live mutation surface.
 3. **Design doc first** — this file. No code until it's reviewed.
+4. **Auth: reuse the OAuth flow** (same as the content endpoint), gated on
+   `isAdmin` — see §3.3.
+5. **PII wall: hybrid** — DTO allowlist everywhere + PII-free DB views and a
+   least-privilege role in production — see §4.
 
 It builds on the shipped content-authoring MCP server (OAuth 2.1 bearer flow,
 `ContentScope`, per-tool scope enforcement, course-scoping). Where this design
@@ -140,35 +144,36 @@ Read-only is enforced three ways, defense in depth:
    performs a mutating Fluent query, asserted by a guard test analogous to the
    content-side template guards.
 
-### 3.3 Authentication: admin-minted service tokens (recommended)
+### 3.3 Authentication: reuse the OAuth flow (decided)
 
-The content surface uses the full browser OAuth 2.1 + PKCE + DCR flow because
-**arbitrary instructors** authorize a **public** agent (the Claude connector)
-over the internet, and the consent screen + cross-site-cookie handling exist to
-make that safe.
+**Decision: the admin surface authenticates the same way the content endpoint
+does** — the browser OAuth 2.1 + PKCE + DCR flow — with the consent gate raised
+from `isInstructor` to `isAdmin`. One auth mechanism across both MCP surfaces
+means one mental model, one set of discovery endpoints, per-grant revocation,
+refresh-token rotation with theft detection, and per-client audit attribution —
+all already built and hardened for the content surface.
 
-The admin surface has exactly one class of principal — deployment admins — and a
-much smaller, more trusted population. The full DCR/consent/refresh machinery
-buys little here and adds the awkward problem of multiplexing two resources
-through one `/oauth/authorize` (the role check would have to switch on the
-requested resource). **Recommendation: admin-minted service tokens.**
+What this decision implies (the work to do):
 
-- An admin, on the admin panel, mints a bearer token for the admin MCP
-  resource. The mint is gated on `isAdmin` server-side; the token is minted by
-  the existing `MCPTokenAuthority` with `aud = …/admin/mcp`, scope
-  `diagnostics:read`, and a configurable TTL (`ADMIN_MCP_TOKEN_TTL_SECONDS`,
-  default e.g. 24h). This mirrors the content surface's "Phase 1 admin-minted
-  token" path (`MCPConfig.tokenTTLSeconds`).
-- The admin pastes that token into their MCP client config (or it's wired into
-  the agent's environment). No DCR, no consent redirect, no ITP cookie concerns.
-- Revocation: short TTL + a deny-list / "rotate admin MCP key" button that
-  invalidates outstanding tokens by rotating the signing key, reusing the worker
-  -secret rotation UX pattern.
+- **Two-resource consent.** `/oauth/authorize` branches the role gate on the
+  requested resource (RFC 8707 `resource` / requested scopes): an authorization
+  targeting `…/admin/mcp` requires `isAdmin`; one targeting `…/mcp` keeps the
+  existing `isInstructor` check. The role is re-checked at consent submit and on
+  every refresh, exactly as today (`MCPOAuthRoutes`).
+- **Distinct audience.** Tokens for the admin resource carry `aud = …/admin/mcp`
+  and the `diagnostics:read` scope; the admin bearer middleware enforces that
+  audience, so a content token can't call admin tools and vice versa (§2).
+- **Discovery.** A second `.well-known/oauth-protected-resource` describes the
+  admin resource (the `MCPMetadataRoutes` pattern), advertising
+  `diagnostics:read` under `ADMIN_MCP_MODE`.
+- **DCR.** Dynamic client registration is shared; requested scopes are still
+  clamped to each resource's advertised ceiling.
 
-Alternative (recorded, not recommended for v1): reuse the browser OAuth flow with
-the admin resource and an `isAdmin` consent gate. Choose this only if we later
-want to authorize a *public* agent against the admin surface, which is not a
-current goal.
+Recorded alternative (not chosen): admin-minted service tokens — a button on the
+admin panel minting a `diagnostics:read` bearer via `MCPTokenAuthority`. Simpler
+plumbing and no two-resource consent, but it diverges from "works like our other
+endpoint" and offers only coarse, rotate-the-key revocation. Revisit only if a
+headless/CI consumer makes the interactive consent flow impractical.
 
 Every admin tool call is written to the `audit_log` (new `AuditAction` cases,
 e.g. `admin.diagnostic_queried`, or reuse `mcpToolCalled` with
@@ -183,8 +188,9 @@ e.g. `admin.diagnostic_queried`, or reuse `mcpToolCalled` with
   below).
 - `MCPRoutes` transport with the Host/Origin DNS-rebinding guards.
 - `MCPMetadataRoutes` pattern for a second `.well-known/oauth-protected-resource`
-  describing the admin resource (only if we adopt OAuth; the service-token path
-  needs none).
+  describing the admin resource (required — §3.3 reuses the OAuth flow).
+- `MCPOAuthRoutes` for the consent/token/refresh/DCR flow, extended with the
+  two-resource role gate (`isAdmin` on the admin resource).
 - `MCPTokenAuthority` for minting/verifying ES256 tokens (parameterized by
   audience).
 
@@ -352,8 +358,9 @@ Each phase is independently shippable and reviewable.
 2. **Scaffold the admin surface.** `AdminMCPConfig`/`AdminMCPMode`/
    `DiagnosticScope`, the parameterized/parallel bearer middleware +
    `AdminToolContext` (`requireAdminSubject`), mount `POST /admin/mcp` behind
-   `ADMIN_MCP_MODE`, admin-minted token mint on the admin panel, audit-log
-   wiring, and the PII-free DB views + least-privilege role. One trivial tool
+   `ADMIN_MCP_MODE`, the two-resource OAuth consent gate (`isAdmin` on the admin
+   resource) + the admin `.well-known` discovery, audit-log wiring, and the
+   PII-free DB views + least-privilege role. One trivial tool
    (`get_deployment_info`) to prove the pipeline end-to-end.
 3. **Clean-source tools.** `get_runner_health`, `get_queue_state`,
    `get_health_alerts`, `get_job_metrics_summary` — all aggregate/PII-free,
@@ -375,9 +382,11 @@ Each phase is independently shippable and reviewable.
   clean. Mitigation: capture from infrastructure paths (not student-code
   execution), truncate, and treat the DB-view wall as the real boundary for
   structured columns.
-- **OAuth vs. service token.** §3.3 recommends service tokens; if a future goal
-  is authorizing a public agent against the admin surface, the OAuth path
-  resurfaces with the two-resource consent-gate complexity.
+- **Two-resource OAuth consent.** §3.3 reuses the OAuth flow (decided), which
+  means `/oauth/authorize` must branch its role gate on the requested resource.
+  The main risk is getting that branch right so an admin-resource consent can
+  never be satisfied by an instructor-only session; covered by tests that assert
+  an `isInstructor`-but-not-`isAdmin` user is refused the admin resource.
 - **Does the agent need anything beyond read?** Read-only is the decision. If a
   diagnosis routinely needs an action (e.g. "reap these stuck jobs"), that's a
   separate, explicitly-authorized proposal — not a quiet expansion of this


### PR DESCRIPTION
## What & why

Phase 1 of the admin-diagnostics groundwork laid out in `docs/admin-mcp.md`.

The motivating problem: the in-browser editor produced almost no diagnosable signal. `client_diagnostics` stored only a symbolic `kind` + `failedChecks` — **no error text, no stack, and no `window.onerror` capture at all** — so several failure modes (blank iframe, a kernel that never starts, silent package-load failures, uncaught JS errors) never reached the server. A tool reading that table could tell you *that* a cohort hit errors, never *why*. This PR fixes the capture so there's something worth reading.

## Changes

- **New `editor_error` kind.** `window.onerror` / `unhandledrejection` on the editor page are captured and posted quietly (no UI change), carrying `message` + `stack` + `source`.
- **Kernel-failure evidence.** The kernel-unhealthy watchdog path now attaches the concrete evidence it detected (e.g. `kernel status: dead`, `Kernel Unknown badge`) instead of just a bare `kernel-unhealthy` flag. `isKernelInFailureState` → `kernelFailureEvidence` (returns the reason string or null).
- **Schema.** `client_diagnostics` gains `message` / `stack` / `source` columns via `AddClientDiagnosticErrorDetail` (one column per `ALTER` so SQLite is happy).
- **Rate limiting.** The per-`(user, setup, kind)` dedup key now also includes the error `source`, so distinct origins aren't collapsed; the client also caps + dedupes (≤8 reports/page).
- **No student data.** Capture is restricted to the editor-load path — **never student-code execution** (`browser-runner.js` is untouched) — so no student-authored content lands in the table. This upholds the "no student data" rule for the planned admin surface.
- **Doc.** Records the two locked decisions in `docs/admin-mcp.md`: auth reuses the **OAuth flow** (`isAdmin` gate, two-resource consent), PII wall is the **hybrid** (DTO allowlist + PII-free DB views/role).

## Tests

- 3 new `ClientDiagnosticsRoutesTests` (editor_error persistence, message/stack truncation, source-aware dedup) — 14/14 pass.
- `watchdog-probe.test.mjs` updated for the renamed helper + new evidence assertions — 20/20 pass.
- `swift build` clean, `scripts/lint.sh` clean, SwiftLint `--strict` 0 violations.

## Not in this PR

The admin MCP surface itself (Phases 2–4 in `docs/admin-mcp.md`) — this is just the capture-enrichment groundwork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg

---
_Generated by [Claude Code](https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg)_