### PR TITLE
feat(admin-mcp): dispatch-layer foundation for read-only diagnostic surface

### DIFF
--- a/Sources/APIServer/Configuration/AdminMCPConfig.swift
+++ b/Sources/APIServer/Configuration/AdminMCPConfig.swift
@@ -1,0 +1,85 @@
+// APIServer/Configuration/AdminMCPConfig.swift
+//
+// Environment-variable knobs for the admin diagnostic MCP server (the
+// /admin/mcp endpoint and its OAuth 2.1 bearer auth).  Part of the AppConfig
+// tree; read once at startup.  Mirrors MCPConfig (the content surface) but is a
+// separate type with its own env namespace, audience, and signing key so the two
+// surfaces stay isolated (docs/admin-mcp.md §3).  Off by default — an operator
+// opts in with ADMIN_MCP_MODE=read_only.
+//
+// Scope of this struct grows by slice: `mode` (and the transport guards) are
+// used by the mount; the OAuth/issuer fields land with the browser consent flow.
+
+struct AdminMCPConfig: Sendable {
+    /// Operating mode for the `/admin/mcp` endpoint: `off` (not mounted) or
+    /// `read_only`.  Default `off`.
+    var mode: AdminMCPMode
+    /// Permitted `Host` header values for `/admin/mcp` (DNS-rebinding
+    /// mitigation).  Empty means "allow any" — development only.
+    var allowedHosts: Set<String>
+    /// Permitted `Origin` header values for `/admin/mcp`.  Empty means "allow any".
+    var allowedOrigins: Set<String>
+    /// Path of the persisted ES256 signing key for admin tokens; auto-generated
+    /// on first start if absent.  Separate from the content surface's key so
+    /// rotating it revokes admin tokens without touching content grants.
+    var signingKeyPath: String
+    /// Explicit token issuer (`iss`).  When nil, derived at startup from
+    /// `PUBLIC_BASE_URL`.
+    var issuer: String?
+    /// Explicit resource identifier / expected audience (`aud`, RFC 8707).
+    /// When nil, derived at startup as `PUBLIC_BASE_URL` + "/admin-mcp".  Distinct
+    /// from the content resource so a content token can't call admin tools.  Note
+    /// the path is "/admin-mcp", NOT "/admin/mcp" — the latter is already the
+    /// admin web page that manages content-MCP service accounts.
+    var resource: String?
+    /// Lifetime of a browser-flow access token, in seconds.  Default 10 minutes.
+    var accessTokenTTLSeconds: Int
+    /// Allow `/admin/mcp` to mount in production even when the Host/Origin
+    /// DNS-rebinding guards are empty.  Default false.
+    var allowOpenTransportGuards: Bool
+
+    init(
+        mode: AdminMCPMode,
+        allowedHosts: Set<String>,
+        allowedOrigins: Set<String>,
+        signingKeyPath: String,
+        issuer: String?,
+        resource: String?,
+        accessTokenTTLSeconds: Int = 600,
+        allowOpenTransportGuards: Bool = false
+    ) {
+        self.mode = mode
+        self.allowedHosts = allowedHosts
+        self.allowedOrigins = allowedOrigins
+        self.signingKeyPath = signingKeyPath
+        self.issuer = issuer
+        self.resource = resource
+        self.accessTokenTTLSeconds = accessTokenTTLSeconds
+        self.allowOpenTransportGuards = allowOpenTransportGuards
+    }
+
+    static func fromEnvironment(workDir: String) -> AdminMCPConfig {
+        AdminMCPConfig(
+            mode: AdminMCPMode.parse(trimmedEnv("ADMIN_MCP_MODE")),
+            allowedHosts: parseSSOIdentityAllowlist(trimmedEnv("ADMIN_MCP_ALLOWED_HOSTS")),
+            allowedOrigins: parseSSOIdentityAllowlist(trimmedEnv("ADMIN_MCP_ALLOWED_ORIGINS")),
+            signingKeyPath: trimmedEnv("ADMIN_MCP_SIGNING_KEY_PATH")
+                ?? (workDir + ".admin-mcp-signing-key"),
+            issuer: trimmedEnv("ADMIN_MCP_ISSUER"),
+            resource: trimmedEnv("ADMIN_MCP_RESOURCE"),
+            accessTokenTTLSeconds: environmentInt("ADMIN_MCP_ACCESS_TOKEN_TTL_SECONDS") ?? 600,
+            allowOpenTransportGuards: environmentBool("ADMIN_MCP_ALLOW_OPEN_GUARDS") ?? false
+        )
+    }
+
+    /// All-defaults config (off, allow-any guards) for tests and the lazy
+    /// `Application.appConfig` fallback.
+    static let `default` = AdminMCPConfig(
+        mode: .off,
+        allowedHosts: [],
+        allowedOrigins: [],
+        signingKeyPath: ".admin-mcp-signing-key",
+        issuer: nil,
+        resource: nil
+    )
+}

--- a/Sources/APIServer/Configuration/AdminMCPMode.swift
+++ b/Sources/APIServer/Configuration/AdminMCPMode.swift
@@ -1,0 +1,53 @@
+// APIServer/Configuration/AdminMCPMode.swift
+//
+// Operating mode for the admin diagnostic MCP server, selected by
+// `ADMIN_MCP_MODE`.  Only two states — there is no `read_write`, because the
+// admin surface is read-only by design (diagnosis, never mutation):
+//
+//   off        — not mounted at all (/admin/mcp 404, no token authority)
+//   read_only  — mounted and authenticated; only `diagnostics:read` is honored
+//
+// Parallel to `MCPMode` (the content surface) but deliberately a separate type:
+// the two surfaces have different scopes, audiences, and role gates, and must
+// not share an enforcement path (docs/admin-mcp.md §2).
+
+enum AdminMCPMode: String, Sendable, CaseIterable {
+    case off
+    case readOnly = "read_only"
+
+    /// True for `read_only`: the `/admin/mcp` transport, discovery metadata, and
+    /// token authority are mounted.  `off` mounts nothing.
+    var isMounted: Bool { self != .off }
+
+    /// The scopes this mode advertises and grants, in stable order.  Single
+    /// source of truth for the discovery document, DCR, and the consent screen.
+    var advertisedScopes: [DiagnosticScope] {
+        switch self {
+        case .off: return []
+        case .readOnly: return [.read]
+        }
+    }
+
+    /// Set form of `advertisedScopes`, used for membership/intersection checks
+    /// by the bearer middleware.
+    var scopeCeiling: Set<DiagnosticScope> { Set(advertisedScopes) }
+
+    /// Parses `ADMIN_MCP_MODE`.  Canonical values are `off` and `read_only`; a
+    /// few obvious synonyms are accepted.  Unset, empty, or unrecognized → `.off`
+    /// (fail safe).  Note: unlike the content surface there is no `read_write`,
+    /// so write-shaped values (`on`, `true`, `rw`) still resolve to `read_only` —
+    /// the most this surface can ever be.
+    static func parse(_ raw: String?) -> AdminMCPMode {
+        guard let raw else { return .off }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "off", "false", "0", "no", "disabled", "none", "":
+            return .off
+        case "read_only", "readonly", "read-only", "read", "ro",
+            "on", "true", "1", "yes", "enabled":
+            return .readOnly
+        default:
+            return .off
+        }
+    }
+}

--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -23,6 +23,41 @@ struct AppConfig: Sendable {
     let alerts: ServerHealthAlertConfiguration
     let outboundProxy: OutboundProxyConfig?
     let mcp: MCPConfig
+    let adminMCP: AdminMCPConfig
+
+    /// Explicit initializer (replacing the synthesized memberwise one) so
+    /// `adminMCP` can default to `.default`: existing construction sites that
+    /// don't care about the admin diagnostic surface stay unchanged, and only
+    /// the env loader wires the real value.
+    init(
+        auth: AuthConfig,
+        oidc: OIDCEnvConfig,
+        security: AppSecurityConfiguration,
+        scanMode: ScanModeConfiguration,
+        database: DatabaseSettings,
+        lockout: LoginRateLimitConfiguration,
+        workers: WorkerConfig,
+        brightspace: BrightSpaceSyncConfig?,
+        diagnostics: DiagnosticsConfiguration,
+        alerts: ServerHealthAlertConfiguration,
+        outboundProxy: OutboundProxyConfig?,
+        mcp: MCPConfig,
+        adminMCP: AdminMCPConfig = .default
+    ) {
+        self.auth = auth
+        self.oidc = oidc
+        self.security = security
+        self.scanMode = scanMode
+        self.database = database
+        self.lockout = lockout
+        self.workers = workers
+        self.brightspace = brightspace
+        self.diagnostics = diagnostics
+        self.alerts = alerts
+        self.outboundProxy = outboundProxy
+        self.mcp = mcp
+        self.adminMCP = adminMCP
+    }
 
     /// Loads the entire config tree from `Environment.get(...)`.
     ///
@@ -54,7 +89,8 @@ struct AppConfig: Sendable {
             diagnostics: DiagnosticsConfiguration.fromEnvironment(),
             alerts: ServerHealthAlertConfiguration.fromEnvironment(),
             outboundProxy: OutboundProxyConfig.fromEnvironment(),
-            mcp: MCPConfig.fromEnvironment(workDir: workDir)
+            mcp: MCPConfig.fromEnvironment(workDir: workDir),
+            adminMCP: AdminMCPConfig.fromEnvironment(workDir: workDir)
         )
     }
 
@@ -114,6 +150,11 @@ struct AppConfig: Sendable {
         if mcp.mode.isMounted {
             logger.info(
                 "mcp: mode=\(mcp.mode.rawValue), tokenTTL=\(mcp.tokenTTLSeconds)s, accessTokenTTL=\(mcp.accessTokenTTLSeconds)s, grantTTL=\(mcp.grantTTLDays)d, allowedHosts=\(mcp.allowedHosts.count), allowedOrigins=\(mcp.allowedOrigins.count), signingKeyPath=\(mcp.signingKeyPath)"
+            )
+        }
+        if adminMCP.mode.isMounted {
+            logger.info(
+                "adminMCP: mode=\(adminMCP.mode.rawValue), accessTokenTTL=\(adminMCP.accessTokenTTLSeconds)s, allowedHosts=\(adminMCP.allowedHosts.count), allowedOrigins=\(adminMCP.allowedOrigins.count), signingKeyPath=\(adminMCP.signingKeyPath)"
             )
         }
     }

--- a/Sources/APIServer/MCP/Admin/AdminMCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPDispatcher.swift
@@ -1,0 +1,191 @@
+// APIServer/MCP/Admin/AdminMCPDispatcher.swift
+//
+// Routes a decoded JSON-RPC message to its handler for the admin diagnostic
+// surface and produces the response (or nil, for notifications).  Parallel to
+// `MCPDispatcher` but trimmed: tools only (no resources), read-only (no
+// fail-closed write audit).  Reuses the generic transport/JSON-RPC types
+// (`JSONRPCRequest`, `MCPMethod`, `MCPInitializeResult`, pagination, the
+// success-result envelope) — only the scope/context/registry layer differs.
+//
+// Audit of admin tool calls lands with the bearer/principal slice (the acting
+// agent identity comes from the authenticated principal); this layer is pure
+// dispatch.
+
+import Core
+import Foundation
+
+struct AdminMCPDispatcher: Sendable {
+    let serverInfo: MCPServerInfo
+    let tools: DiagnosticToolRegistry
+
+    init(serverInfo: MCPServerInfo, tools: DiagnosticToolRegistry = DiagnosticToolRegistry([])) {
+        self.serverInfo = serverInfo
+        self.tools = tools
+    }
+
+    func dispatch(_ request: JSONRPCRequest, context: AdminToolContext? = nil) async -> JSONRPCResponse? {
+        guard let id = request.id else { return nil }
+
+        guard request.jsonrpc == "2.0" else {
+            return .failure(id: id, error: .invalidRequest("Unsupported \"jsonrpc\" version: \(request.jsonrpc)"))
+        }
+        guard let method = MCPMethod(rawValue: request.method) else {
+            return .failure(id: id, error: .methodNotFound(request.method))
+        }
+
+        switch method {
+        case .initialize:
+            return initializeResponse(id: id, params: request.params, context: context)
+        case .ping:
+            return .success(id: id, result: .object([:]))
+        case .initialized:
+            return .success(id: id, result: .object([:]))
+        case .toolsList:
+            return toolsListResult(id: id, params: request.params, context: context)
+        case .toolsCall:
+            return await toolsCallResult(id: id, params: request.params, context: context)
+        case .resourcesList, .resourcesRead:
+            // The admin surface advertises tools only (no resources capability).
+            return .failure(id: id, error: .methodNotFound(request.method))
+        }
+    }
+
+    // MARK: - tools/list
+
+    /// Advertises only the tools the caller can invoke: a tool is listed when
+    /// the caller's granted scopes cover its `requiredScopes`.  With no context
+    /// (tests), all tools are listed.
+    private func toolsListResult(id: JSONRPCID, params: JSONValue?, context: AdminToolContext?) -> JSONRPCResponse {
+        let visible =
+            context.map { ctx in
+                tools.all.filter { ctx.grantedScopes.isSuperset(of: $0.requiredScopes) }
+            } ?? tools.all
+        let entries = visible.map { tool -> JSONValue in
+            var fields: [String: JSONValue] = [
+                "name": .string(tool.name),
+                "title": .string(tool.title),
+                "description": .string(tool.description),
+                "inputSchema": tool.inputSchema,
+            ]
+            if let outputSchema = tool.outputSchema {
+                fields["outputSchema"] = outputSchema
+            }
+            if let annotations = tool.annotations, let encoded = try? JSONValue(encoding: annotations) {
+                fields["annotations"] = encoded
+            }
+            return .object(fields)
+        }
+        return paginatedListResponse(id: id, key: "tools", entries: entries, params: params)
+    }
+
+    // MARK: - List pagination
+
+    private struct ListParams: Decodable {
+        let cursor: String?
+    }
+
+    private func paginatedListResponse(
+        id: JSONRPCID, key: String, entries: [JSONValue], params: JSONValue?
+    ) -> JSONRPCResponse {
+        let cursor: String?
+        do {
+            cursor = try (params ?? .object([:])).decoded(as: ListParams.self).cursor
+        } catch {
+            return .failure(id: id, error: .invalidParams("\"cursor\" must be a string."))
+        }
+        guard let result = MCPListPagination.page(entries, cursor: cursor) else {
+            return .failure(id: id, error: .invalidParams("Invalid cursor."))
+        }
+        var fields: [String: JSONValue] = [key: .array(result.page)]
+        if let next = result.nextCursor {
+            fields["nextCursor"] = .string(next)
+        }
+        return .success(id: id, result: .object(fields))
+    }
+
+    // MARK: - tools/call
+
+    private struct ToolCallParams: Decodable {
+        let name: String
+        let arguments: JSONValue?
+    }
+
+    private func toolsCallResult(id: JSONRPCID, params: JSONValue?, context: AdminToolContext?) async -> JSONRPCResponse
+    {
+        guard let context else {
+            return .failure(id: id, error: .internalError("Tool execution context is unavailable."))
+        }
+        let call: ToolCallParams
+        do {
+            call = try (params ?? .object([:])).decoded(as: ToolCallParams.self)
+        } catch {
+            return .failure(id: id, error: .invalidParams("tools/call requires a \"name\" and optional \"arguments\"."))
+        }
+        guard let tool = tools.tool(named: call.name) else {
+            return .failure(id: id, error: .invalidParams("Unknown tool: \(call.name)"))
+        }
+        // Per-tool scope enforcement, defence in depth on top of the bearer
+        // middleware's token-level gate.  The transport maps insufficient scope
+        // to HTTP 403.
+        guard context.grantedScopes.isSuperset(of: tool.requiredScopes) else {
+            let required = tool.requiredScopes.map(\.rawValue).sorted().joined(separator: " ")
+            return .failure(id: id, error: .insufficientScope(required))
+        }
+
+        do {
+            let output = try await tool.invoke(call.arguments ?? .object([:]), context)
+            return .success(id: id, result: mcpToolSuccessResult(output))
+        } catch let error as MCPToolError {
+            return .success(id: id, result: errorToolResult(error))
+        } catch {
+            return .failure(id: id, error: .internalError("Tool \(call.name) failed."))
+        }
+    }
+
+    private func errorToolResult(_ error: MCPToolError) -> JSONValue {
+        let message: String
+        switch error {
+        case .unknownTool(let name):
+            message = "Unknown tool: \(name)"
+        case .invalidArguments(let tool, let detail):
+            message = "Invalid arguments for \(tool): \(detail)"
+        case .notAuthorized(let tool, let detail):
+            message = "Not authorized for \(tool): \(detail)"
+        case .executionFailed(let tool, let detail):
+            message = "\(tool) failed: \(detail)"
+        }
+        return .object([
+            "content": .array([.object(["type": .string("text"), "text": .string(message)])]),
+            "isError": .bool(true),
+        ])
+    }
+
+    private func initializeResponse(
+        id: JSONRPCID, params: JSONValue?, context: AdminToolContext?
+    ) -> JSONRPCResponse {
+        let client = try? (params ?? .object([:])).decoded(as: MCPInitializeParams.self)
+        let negotiated =
+            client?.protocolVersion.flatMap { requested in
+                MCPProtocol.supportedVersions.contains(requested) ? requested : nil
+            } ?? MCPProtocol.version
+        if let context {
+            let name = client?.clientInfo?.name ?? "unknown"
+            let clientVersion = client?.clientInfo?.version ?? "unknown"
+            let requested = client?.protocolVersion ?? "none"
+            context.logger.info(
+                "Admin MCP initialize: client=\(name)/\(clientVersion) requestedProtocolVersion=\(requested) negotiated=\(negotiated)"
+            )
+        }
+        let result = MCPInitializeResult(
+            protocolVersion: negotiated,
+            capabilities: .toolsOnly,
+            serverInfo: serverInfo,
+            instructions: AdminMCPServerInstructions.text
+        )
+        do {
+            return .success(id: id, result: try JSONValue(encoding: result))
+        } catch {
+            return .failure(id: id, error: .internalError("Failed to encode initialize result."))
+        }
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
@@ -1,0 +1,34 @@
+// APIServer/MCP/Admin/AdminMCPServerInstructions.swift
+//
+// Server-level guidance surfaced in the admin diagnostic surface's `initialize`
+// result. Teaches a connecting agent what this surface is for, what it can and
+// cannot see, and the hard no-student-data guarantee — the admin analog of
+// `MCPServerInstructions` for the content surface.
+
+enum AdminMCPServerInstructions {
+    static let text = """
+        This is Chickadee's ADMIN DIAGNOSTIC surface — a separate, read-only MCP \
+        server for operational diagnosis. It is distinct from the content-authoring \
+        MCP server (a different endpoint, audience, and scope) and exists so an \
+        authorized agent can help diagnose server errors and operational issues.
+
+        Access model:
+        - Read-only. Every tool only reads; nothing here mutates server state. \
+        "Fixing" happens through code changes and pull requests, never through \
+        this surface.
+        - Admin-only. The authenticated account must have the admin role. There is \
+        no course scoping — this surface is deployment-wide.
+        - Scope: tools require `diagnostics:read`.
+
+        Data guarantee:
+        - This surface NEVER exposes student data. No student identities, grades, \
+        submissions, submission contents, or enrollment. Diagnostic results are \
+        aggregates and redacted records by construction (a student identifier is \
+        not reachable through the tools). Assignment/test-setup identifiers and \
+        timings/statuses/error text are instructor/operational data and may appear.
+
+        Use the tools to inspect deployment health, runner/queue state, server \
+        metrics, browser-error reports, and logs to diagnose problems — then \
+        propose fixes as code, outside this surface.
+        """
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -1,0 +1,15 @@
+// APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+//
+// The tools exposed over the admin diagnostic MCP surface — read-only
+// operational diagnosis only.  Nothing here touches student data, grades,
+// enrolment, or content authoring.  Parallel to `MCPToolCatalog.live` (the
+// content surface); the two catalogs never mix.
+
+/// The admin diagnostic tool catalog.
+enum AdminMCPToolCatalog {
+    static var live: DiagnosticToolRegistry {
+        DiagnosticToolRegistry([
+            GetDeploymentInfoTool().erased()
+        ])
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminToolContext.swift
+++ b/Sources/APIServer/MCP/Admin/AdminToolContext.swift
@@ -1,0 +1,64 @@
+// APIServer/MCP/Admin/AdminToolContext.swift
+//
+// Execution context handed to an admin diagnostic tool's `execute`.  Parallel to
+// `ToolContext` (the content surface) but with a fundamentally different
+// authorization model: there is NO course scoping.  The admin surface is
+// deployment-wide, so the only gate is "the token subject is an admin"
+// (`requireAdminSubject`) — enforced at the OAuth consent + bearer layer and,
+// for DB-touching tools, re-checked here as defense in depth.
+
+import Fluent
+import Vapor
+
+struct AdminToolContext {
+    let request: Request
+    let subject: String
+    let grantedScopes: Set<DiagnosticScope>
+    /// The OAuth client (agent) acting on the subject's behalf; carried for
+    /// audit attribution.  nil for non-browser callers / tests.
+    let actingClientID: String?
+    let actingClientName: String?
+
+    init(
+        request: Request,
+        subject: String,
+        grantedScopes: Set<DiagnosticScope>,
+        actingClientID: String? = nil,
+        actingClientName: String? = nil
+    ) {
+        self.request = request
+        self.subject = subject
+        self.grantedScopes = grantedScopes
+        self.actingClientID = actingClientID
+        self.actingClientName = actingClientName
+    }
+
+    /// The database admin diagnostic tools run on.  For now the shared default
+    /// pool; the dedicated least-privilege admin role (SELECT on PII-free
+    /// diagnostic views only) lands with the read-tool slice (docs/admin-mcp.md
+    /// §4).
+    var db: any Database { request.db }
+    var logger: Logger { request.logger }
+
+    /// Resolves the token subject and confirms it is an admin.  Students and
+    /// instructors are refused even if they somehow obtained a token — the
+    /// guarantee doesn't rest solely on token issuance.  DB-free liveness tools
+    /// (e.g. get_deployment_info) deliberately skip this so they stay useful
+    /// when the database is down; the bearer/OAuth layer is the primary admin
+    /// gate.
+    @discardableResult
+    func requireAdminSubject(tool: String) async throws -> APIUser {
+        guard
+            let user = try await APIUser.query(on: db)
+                .filter(\.$username == subject)
+                .first()
+        else {
+            throw MCPToolError.notAuthorized(tool: tool, detail: "Unknown token subject.")
+        }
+        guard user.isAdmin else {
+            throw MCPToolError.notAuthorized(
+                tool: tool, detail: "The admin diagnostic interface requires an admin account.")
+        }
+        return user
+    }
+}

--- a/Sources/APIServer/MCP/Admin/DiagnosticScope.swift
+++ b/Sources/APIServer/MCP/Admin/DiagnosticScope.swift
@@ -1,0 +1,13 @@
+// APIServer/MCP/Admin/DiagnosticScope.swift
+//
+// OAuth scope for the admin diagnostic MCP surface.  Deliberately separate from
+// `ContentScope`: this surface is deployment-wide and read-only, and nothing
+// here grants content authoring or any write access.  Keeping it a distinct type
+// (with its own token audience, §3.3 of docs/admin-mcp.md) means a content token
+// can never satisfy an admin tool's scope check, and vice versa.
+
+/// An admin-diagnostics OAuth scope.  Read-only by construction — there is no
+/// write case, so the surface cannot express mutation.
+enum DiagnosticScope: String, CaseIterable, Sendable {
+    case read = "diagnostics:read"
+}

--- a/Sources/APIServer/MCP/Admin/DiagnosticTool.swift
+++ b/Sources/APIServer/MCP/Admin/DiagnosticTool.swift
@@ -1,0 +1,105 @@
+// APIServer/MCP/Admin/DiagnosticTool.swift
+//
+// The tool abstraction for the admin diagnostic MCP surface.  Parallel to
+// `ContentTool` but over `DiagnosticScope` + `AdminToolContext`: a deliberate
+// thin duplication rather than generalizing the shipped content stack, so the
+// two surfaces stay isolated and a change to one can't destabilize the other
+// (docs/admin-mcp.md §3.4).  Every diagnostic tool is read-only.
+
+import Core
+
+/// A single admin diagnostic tool.
+protocol DiagnosticTool: Sendable {
+    associatedtype Input: Decodable & Sendable
+    associatedtype Output: Encodable & Sendable
+
+    /// Stable tool name: the `tools/list` identifier and the registry key.
+    static var name: String { get }
+    /// Human-friendly display name (defaults to a Title-Case derivation of `name`).
+    static var title: String { get }
+    /// Human-readable description surfaced in `tools/list`.
+    static var description: String { get }
+    /// JSON Schema (draft 2020-12) describing `Input`, surfaced in `tools/list`.
+    static var inputSchema: JSONValue { get }
+    /// JSON Schema (draft 2020-12) describing `Output` (defaults to nil).
+    static var outputSchema: JSONValue? { get }
+    /// Behavioural hints surfaced as the tool's `annotations` (defaults to
+    /// read-only, since the whole surface is read-only).
+    static var annotations: MCPToolAnnotations? { get }
+    /// Scopes the caller's token must carry (defaults to `diagnostics:read`).
+    static var requiredScopes: Set<DiagnosticScope> { get }
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output
+}
+
+extension DiagnosticTool {
+    static var title: String {
+        name.split(separator: "_").map { String($0).capitalized }.joined(separator: " ")
+    }
+    static var outputSchema: JSONValue? { nil }
+    static var annotations: MCPToolAnnotations? { MCPToolAnnotations(readOnlyHint: true) }
+    /// The admin surface is read-only, so every tool requires exactly
+    /// `diagnostics:read` unless it overrides this.
+    static var requiredScopes: Set<DiagnosticScope> { [.read] }
+}
+
+// MARK: - Type erasure
+
+/// A type-erased `DiagnosticTool` stored in the name-keyed registry.  `invoke`
+/// performs decode -> execute -> encode so the dispatcher only ever handles
+/// `JSONValue`.
+struct AnyDiagnosticTool: Sendable {
+    let name: String
+    let title: String
+    let description: String
+    let inputSchema: JSONValue
+    let outputSchema: JSONValue?
+    let annotations: MCPToolAnnotations?
+    let requiredScopes: Set<DiagnosticScope>
+    let invoke: @Sendable (_ arguments: JSONValue, _ context: AdminToolContext) async throws -> JSONValue
+}
+
+extension DiagnosticTool {
+    /// Erases this tool for storage in the registry.
+    func erased() -> AnyDiagnosticTool {
+        AnyDiagnosticTool(
+            name: Self.name,
+            title: Self.title,
+            description: Self.description,
+            inputSchema: Self.inputSchema,
+            outputSchema: Self.outputSchema,
+            annotations: Self.annotations,
+            requiredScopes: Self.requiredScopes,
+            invoke: { arguments, context in
+                let input: Input
+                do {
+                    input = try arguments.decoded(as: Input.self)
+                } catch {
+                    throw MCPToolError.invalidArguments(tool: Self.name, detail: String(describing: error))
+                }
+                let output = try await self.execute(input, context)
+                return try JSONValue(encoding: output)
+            }
+        )
+    }
+}
+
+// MARK: - Registry
+
+/// Name-keyed registry of admin diagnostic tools.
+struct DiagnosticToolRegistry: Sendable {
+    private let toolsByName: [String: AnyDiagnosticTool]
+
+    init(_ tools: [AnyDiagnosticTool]) {
+        toolsByName = Dictionary(tools.map { ($0.name, $0) }, uniquingKeysWith: { existing, _ in existing })
+    }
+
+    /// All registered tools, sorted by name for stable `tools/list` output.
+    var all: [AnyDiagnosticTool] {
+        toolsByName.values.sorted { $0.name < $1.name }
+    }
+
+    func tool(named name: String) -> AnyDiagnosticTool? {
+        toolsByName[name]
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetDeploymentInfoTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetDeploymentInfoTool.swift
@@ -1,0 +1,70 @@
+// APIServer/MCP/Admin/Tools/GetDeploymentInfoTool.swift
+//
+// Read tool: report the deployed server's version and diagnostic-surface
+// capability. The admin analog of the content surface's get_server_info, and the
+// first tool that proves the admin dispatch pipeline end to end.
+//
+// Deliberately DB-free: returns only static server metadata, so it stays a
+// useful liveness check even when the database is unavailable (which is itself a
+// thing an operator wants to diagnose).  No student, course, or DB state.
+
+import Core
+import Vapor
+
+struct GetDeploymentInfoTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    struct Output: Encodable, Sendable {
+        /// The deployed Chickadee version (`ChickadeeVersion.current`).
+        let version: String
+        /// The Vapor environment name (e.g. "production", "development").
+        let environment: String
+        /// The active admin-MCP mode ("read_only"; the endpoint is unmounted in
+        /// "off", so a reachable call is never that).
+        let adminMcpMode: String
+        /// Scopes the admin surface advertises and honors, in stable order.
+        let advertisedScopes: [String]
+        /// The content-authoring MCP mode ("off" / "read_only" / "read_write"),
+        /// a capability probe of the other surface.
+        let contentMcpMode: String
+    }
+
+    static let name = "get_deployment_info"
+    static let description =
+        "Report the deployed server's version and capability surface: the Chickadee version, the "
+        + "Vapor environment, the admin diagnostic MCP mode and its advertised scopes, and the "
+        + "content-authoring MCP mode. Use it to confirm a deploy is live (a tool call hits the "
+        + "running process, unlike a cached tool list). Read-only; touches no course, student, or "
+        + "database state."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "version": .object(["type": .string("string")]),
+            "environment": .object(["type": .string("string")]),
+            "adminMcpMode": .object(["type": .string("string")]),
+            "advertisedScopes": .object([
+                "type": .string("array"), "items": .object(["type": .string("string")]),
+            ]),
+            "contentMcpMode": .object(["type": .string("string")]),
+        ]),
+        "required": .array([
+            .string("version"), .string("environment"), .string("adminMcpMode"),
+            .string("advertisedScopes"), .string("contentMcpMode"),
+        ]),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        let config = context.request.application.appConfig
+        return Output(
+            version: ChickadeeVersion.current,
+            environment: context.request.application.environment.name,
+            adminMcpMode: config.adminMCP.mode.rawValue,
+            advertisedScopes: config.adminMCP.mode.advertisedScopes.map(\.rawValue),
+            contentMcpMode: config.mcp.mode.rawValue)
+    }
+}

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -35,13 +35,14 @@ struct MCPInitializeParams: Decodable, Sendable {
     }
 }
 
-/// Capabilities this server advertises at initialization.  `tools` and
-/// `resources` are advertised; `prompts` is not.  `listChanged` is false on
-/// both (no server-initiated list-change notifications), and resources are not
-/// subscribable.
+/// Capabilities this server advertises at initialization.  `tools` is always
+/// advertised; `resources` is optional and omitted from the wire when nil (a
+/// surface that has no resources doesn't advertise the capability).  `prompts`
+/// is not advertised.  `listChanged` is false (no server-initiated list-change
+/// notifications), and resources are not subscribable.
 struct MCPServerCapabilities: Encodable, Sendable {
     let tools: ListChanged
-    let resources: Resources
+    let resources: Resources?
 
     struct ListChanged: Encodable, Sendable {
         let listChanged: Bool
@@ -52,11 +53,29 @@ struct MCPServerCapabilities: Encodable, Sendable {
         let listChanged: Bool
     }
 
-    /// The capability set advertised by v1: tools + resources, neither pushing
-    /// list-change notifications, resources not subscribable.
+    enum CodingKeys: String, CodingKey {
+        case tools, resources
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(tools, forKey: .tools)
+        // Omit `resources` entirely when nil so a tools-only surface doesn't
+        // advertise a capability it doesn't implement.
+        try container.encodeIfPresent(resources, forKey: .resources)
+    }
+
+    /// The capability set advertised by v1 (the content surface): tools +
+    /// resources, neither pushing list-change notifications, resources not
+    /// subscribable.
     static let v1 = MCPServerCapabilities(
         tools: ListChanged(listChanged: false),
         resources: Resources(subscribe: false, listChanged: false))
+
+    /// Tools-only capability set (the admin diagnostic surface): no resources.
+    static let toolsOnly = MCPServerCapabilities(
+        tools: ListChanged(listChanged: false),
+        resources: nil)
 }
 
 /// Identifies this server to the client in the `initialize` result.  `name` is

--- a/Tests/APITests/MCP/AdminMCPDispatcherTests.swift
+++ b/Tests/APITests/MCP/AdminMCPDispatcherTests.swift
@@ -1,0 +1,207 @@
+// Tests for the admin diagnostic MCP surface (docs/admin-mcp.md): the
+// AdminMCPMode/DiagnosticScope contract, the AdminMCPDispatcher (lifecycle,
+// tools-only capabilities, scope-gated tools/list, tools/call), the
+// get_deployment_info tool, and the AdminToolContext.requireAdminSubject gate.
+//
+// Distinct from AdminMCPRoutesTests, which covers the unrelated /admin/mcp web
+// page that manages content-MCP service accounts.
+
+import Core
+import Fluent
+import Testing
+import Vapor
+import XCTVapor
+
+@testable import APIServer
+
+// MARK: - Mode / scope contract (pure logic)
+
+@Suite struct AdminMCPModeTests {
+    @Test func parseResolvesCanonicalAndSynonyms() {
+        #expect(AdminMCPMode.parse("off") == .off)
+        #expect(AdminMCPMode.parse(nil) == .off)
+        #expect(AdminMCPMode.parse("") == .off)
+        #expect(AdminMCPMode.parse("read_only") == .readOnly)
+        #expect(AdminMCPMode.parse("readonly") == .readOnly)
+        // No read_write exists; write-shaped values resolve to read_only (the
+        // most this surface can ever be), not to a write mode.
+        #expect(AdminMCPMode.parse("on") == .readOnly)
+        #expect(AdminMCPMode.parse("true") == .readOnly)
+        // Unrecognized → fail safe to off.
+        #expect(AdminMCPMode.parse("garbage") == .off)
+    }
+
+    @Test func advertisedScopesAndCeiling() {
+        #expect(AdminMCPMode.off.advertisedScopes.isEmpty)
+        #expect(AdminMCPMode.off.isMounted == false)
+        #expect(AdminMCPMode.readOnly.advertisedScopes == [.read])
+        #expect(AdminMCPMode.readOnly.scopeCeiling == [.read])
+        #expect(AdminMCPMode.readOnly.isMounted)
+    }
+}
+
+// MARK: - Dispatcher (pure logic, no app)
+
+@Suite struct AdminMCPDispatcherLogicTests {
+    private let dispatcher = AdminMCPDispatcher(
+        serverInfo: MCPServerInfo(name: "Chickadee Admin MCP", version: "test-9.9.9"),
+        tools: AdminMCPToolCatalog.live
+    )
+
+    private func request(
+        _ method: String, id: JSONRPCID? = .number(1), params: JSONValue? = nil
+    ) -> JSONRPCRequest {
+        JSONRPCRequest(jsonrpc: "2.0", id: id, method: method, params: params)
+    }
+
+    @Test func initializeAdvertisesToolsOnlyAndAdminInstructions() async throws {
+        let response = try #require(await dispatcher.dispatch(request("initialize")))
+        let result = try #require(response.result?.objectFields)
+
+        let caps = try #require(result["capabilities"]?.objectFields)
+        #expect(caps["tools"] == .object(["listChanged": .bool(false)]))
+        // Tools-only surface: the resources capability is omitted from the wire.
+        #expect(caps["resources"] == nil)
+
+        let info = try #require(result["serverInfo"]?.objectFields)
+        #expect(info["name"] == .string("Chickadee Admin MCP"))
+
+        let instructions = try #require(result["instructions"]?.stringValue)
+        #expect(instructions.contains("ADMIN DIAGNOSTIC"))
+        #expect(instructions.contains("NEVER exposes student data"))
+        #expect(instructions.contains("Read-only"))
+    }
+
+    @Test func toolsListIncludesGetDeploymentInfoAsReadOnly() async throws {
+        let response = try #require(await dispatcher.dispatch(request("tools/list")))
+        let tools = try #require(response.result?.objectFields?["tools"]?.arrayValue)
+        let tool = try #require(
+            tools.first { $0.objectFields?["name"]?.stringValue == "get_deployment_info" })
+        let annotations = try #require(tool.objectFields?["annotations"]?.objectFields)
+        #expect(annotations["readOnlyHint"] == .bool(true))
+    }
+
+    @Test func pingReturnsEmptyObject() async throws {
+        let response = try #require(await dispatcher.dispatch(request("ping")))
+        #expect(response.result == .object([:]))
+    }
+
+    @Test func unknownMethodIsMethodNotFound() async throws {
+        let response = try #require(await dispatcher.dispatch(request("does/not/exist")))
+        #expect(response.error?.code == -32_601)
+    }
+
+    @Test func resourcesAreNotSupported() async throws {
+        // The admin surface advertises tools only, so resource methods are
+        // method-not-found here (the content surface implements them).
+        let response = try #require(await dispatcher.dispatch(request("resources/list")))
+        #expect(response.error?.code == -32_601)
+    }
+
+    @Test func notificationGetsNoResponse() async throws {
+        let response = await dispatcher.dispatch(request("initialized", id: nil))
+        #expect(response == nil)
+    }
+}
+
+// MARK: - Tool execution + admin gate (app-backed)
+
+@Suite(.serialized) final class AdminMCPToolExecutionTests {
+    let app: Application
+    let dispatcher: AdminMCPDispatcher
+
+    init() async throws {
+        app = try await makeTestApp(prefix: "admin-mcp")
+        dispatcher = AdminMCPDispatcher(
+            serverInfo: MCPServerInfo(name: "Chickadee Admin MCP", version: "test"),
+            tools: AdminMCPToolCatalog.live)
+    }
+
+    private func context(
+        _ scopes: Set<DiagnosticScope>, subject: String = "root"
+    ) -> AdminToolContext {
+        AdminToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: subject,
+            grantedScopes: scopes)
+    }
+
+    private func toolCall(_ name: String) -> JSONRPCRequest {
+        JSONRPCRequest(
+            jsonrpc: "2.0", id: .number(1), method: "tools/call",
+            params: .object(["name": .string(name)]))
+    }
+
+    @Test func getDeploymentInfoReturnsVersionAndModes() async throws {
+        try await withApp(app) { _ in
+            let response = try #require(
+                await dispatcher.dispatch(toolCall("get_deployment_info"), context: context([.read])))
+            let result = try #require(response.result?.objectFields)
+            #expect(result["isError"] == .bool(false))
+
+            let structured = try #require(result["structuredContent"]?.objectFields)
+            #expect(structured["version"]?.stringValue == ChickadeeVersion.current)
+            // Test app defaults: both MCP surfaces off.
+            #expect(structured["adminMcpMode"]?.stringValue == "off")
+            #expect(structured["contentMcpMode"]?.stringValue == "off")
+            #expect(structured["environment"] != nil)
+        }
+    }
+
+    @Test func toolCallWithoutReadScopeIsRejected() async throws {
+        try await withApp(app) { _ in
+            // No granted scopes → insufficient scope, surfaced as a JSON-RPC
+            // error (not an isError tool result), which the transport maps to 403.
+            let response = try #require(
+                await dispatcher.dispatch(toolCall("get_deployment_info"), context: context([])))
+            #expect(response.error != nil)
+            #expect(response.result == nil)
+        }
+    }
+
+    @Test func toolsListHidesToolsWhenScopeMissing() async throws {
+        try await withApp(app) { _ in
+            let response = try #require(
+                await dispatcher.dispatch(
+                    JSONRPCRequest(jsonrpc: "2.0", id: .number(1), method: "tools/list", params: nil),
+                    context: context([])))
+            let tools = try #require(response.result?.objectFields?["tools"]?.arrayValue)
+            #expect(tools.isEmpty)
+        }
+    }
+
+    @Test func requireAdminSubjectAcceptsAdminRejectsOthers() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "the-admin", role: "admin")
+            _ = try await makeTestUser(on: app, username: "the-prof", role: "instructor")
+            _ = try await makeTestUser(on: app, username: "the-student", role: "student")
+
+            let admin = try await context([.read], subject: "the-admin").requireAdminSubject(tool: "x")
+            #expect(admin.username == "the-admin")
+
+            for subject in ["the-prof", "the-student", "nobody-at-all"] {
+                let ctx = context([.read], subject: subject)
+                await #expect(throws: MCPToolError.self) {
+                    try await ctx.requireAdminSubject(tool: "x")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Test helpers
+
+private extension JSONValue {
+    var objectFields: [String: JSONValue]? {
+        if case .object(let fields) = self { return fields }
+        return nil
+    }
+    var stringValue: String? {
+        if case .string(let value) = self { return value }
+        return nil
+    }
+    var arrayValue: [JSONValue]? {
+        if case .array(let values) = self { return values }
+        return nil
+    }
+}

--- a/changelog.d/admin-mcp-foundation.md
+++ b/changelog.d/admin-mcp-foundation.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Admin diagnostic MCP — foundation (internal).** The dispatch-layer scaffold
+  for a separate, read-only, admin-only MCP surface for operational diagnosis
+  (`docs/admin-mcp.md`): `AdminMCPMode` / `DiagnosticScope` / `AdminMCPConfig`
+  (`ADMIN_MCP_MODE`, off by default), `AdminToolContext` with an admin-only gate,
+  a parallel `DiagnosticTool` registry + `AdminMCPDispatcher` (tools-only,
+  read-only), and the first tool `get_deployment_info`. Nothing is mounted yet —
+  this slice has no runtime effect; the HTTP transport, bearer auth, and OAuth
+  consent land in following slices.

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -105,22 +105,28 @@ The transport/JSON-RPC machinery, by contrast, is generic and worth reusing
 
 ### 3.1 Endpoint, mode, config
 
-| Aspect | Content MCP (today) | Admin MCP (proposed) |
-|--------|---------------------|----------------------|
-| Endpoint | `POST /mcp` | `POST /admin/mcp` |
+| Aspect | Content MCP (today) | Admin MCP |
+|--------|---------------------|-----------|
+| Endpoint | `POST /mcp` | `POST /admin-mcp` |
 | Enable flag | `MCP_MODE` (`off`/`read_only`/`read_write`) | `ADMIN_MCP_MODE` (`off`/`read_only`) |
-| Resource / audience | `…/mcp` | `…/admin/mcp` (distinct) |
+| Resource / audience | `…/mcp` | `…/admin-mcp` (distinct) |
 | Issuer | `PUBLIC_BASE_URL` | same issuer, different resource |
 | Config struct | `MCPConfig` | `AdminMCPConfig` (parallel) |
-| Catalog | `MCPToolCatalog.live` | `MCPToolCatalog.adminLive` |
+| Catalog | `MCPToolCatalog.live` | `AdminMCPToolCatalog.live` |
 | Default | `off` | `off` |
 
+**Path note:** the endpoint is `/admin-mcp`, **not** `/admin/mcp` — the latter is
+already the admin *web page* that manages content-MCP service accounts and
+connected agents (`AdminMCPRoutesTests`). A hyphenated top-level path avoids the
+collision and keeps the bearer-gated transport out of the session-gated `/admin`
+web group. The audience matches the path.
+
 `AdminMCPConfig` parallels `MCPConfig` (mount guards `ADMIN_MCP_ALLOWED_HOSTS` /
-`ADMIN_MCP_ALLOWED_ORIGINS`, signing key, token TTL, rate limits) and is read
-once at startup into the `AppConfig` tree, with a redacted line in the startup
-summary like every other subsystem. Mounting reuses the production fail-safe in
-`registerMCPRoutes` (refuse to mount in production with the DNS-rebinding guards
-open unless `ADMIN_MCP_ALLOW_OPEN_GUARDS=true`).
+`ADMIN_MCP_ALLOWED_ORIGINS`, signing key, access-token TTL) and is read once at
+startup into the `AppConfig` tree, with a redacted line in the startup summary
+like every other subsystem. Mounting reuses the production fail-safe pattern
+(refuse to mount in production with the DNS-rebinding guards open unless
+`ADMIN_MCP_ALLOW_OPEN_GUARDS=true`).
 
 Note there is **no `read_write`** for the admin surface — read-only is a
 hard property of the surface, not a mode toggle, so the enum can't even express
@@ -349,19 +355,32 @@ queryable). Add a bounded **in-process ring buffer**:
 
 ## 7. Implementation sequencing
 
-Each phase is independently shippable and reviewable.
+Each step is independently shippable and reviewable. Phase 2 (the surface
+itself) is split into thin slices so the architecture can be reviewed before the
+OAuth and DB-wall work lands.
 
-1. **Capture (Track 1).** Browser-error enrichment (§6.1) + the log ring buffer
-   (§6.2). No MCP yet — these improve existing dashboards/ops on their own and
-   create the signal the tools will read. Doing this first means the motivating
-   browser error starts producing diagnosable records immediately.
-2. **Scaffold the admin surface.** `AdminMCPConfig`/`AdminMCPMode`/
-   `DiagnosticScope`, the parameterized/parallel bearer middleware +
-   `AdminToolContext` (`requireAdminSubject`), mount `POST /admin/mcp` behind
-   `ADMIN_MCP_MODE`, the two-resource OAuth consent gate (`isAdmin` on the admin
-   resource) + the admin `.well-known` discovery, audit-log wiring, and the
-   PII-free DB views + least-privilege role. One trivial tool
-   (`get_deployment_info`) to prove the pipeline end-to-end.
+1. **Capture (Track 1).** ✅ **Done** (PR #942). Browser-error enrichment (§6.1):
+   `editor_error` kind + message/stack/source on `client_diagnostics`,
+   `window.onerror`/`unhandledrejection` capture, kernel-failure evidence. The
+   log ring buffer (§6.2) is deferred to land alongside `query_logs` (step 4).
+2. **Scaffold the admin surface.** Split into:
+   - **2a — dispatch-layer foundation.** ◀ **This slice.** `AdminMCPMode` /
+     `DiagnosticScope` / `AdminMCPConfig` (+ `AppConfig` wiring + startup
+     summary), `AdminToolContext` (`requireAdminSubject`), the `DiagnosticTool`
+     protocol / registry, `AdminMCPDispatcher` (tools-only, read-only),
+     `AdminMCPServerInstructions`, `AdminMCPToolCatalog`, and the first tool
+     `get_deployment_info` — proven end to end at the dispatch layer with unit
+     tests. **Nothing is mounted**, so there is zero production impact while the
+     architecture is reviewed.
+   - **2b — HTTP mount + bearer.** Mount `POST /admin-mcp` behind
+     `ADMIN_MCP_MODE` with a bearer middleware enforcing the admin audience +
+     `diagnostics:read`, the admin `.well-known/oauth-protected-resource`
+     discovery, the production DNS-rebinding fail-safe, and admin tool-call
+     audit. Tokens minted via `MCPTokenAuthority` (admin audience) for tests.
+   - **2c — two-resource OAuth consent.** Extend `MCPOAuthRoutes` so
+     `/oauth/authorize` branches the role gate on the requested resource
+     (`isAdmin` for the admin resource), plus the PII-free DB views +
+     least-privilege role for the data tools.
 3. **Clean-source tools.** `get_runner_health`, `get_queue_state`,
    `get_health_alerts`, `get_job_metrics_summary` — all aggregate/PII-free,
    lowest risk.


### PR DESCRIPTION
## What & why

**Phase 2a** of the admin diagnostic MCP surface (`docs/admin-mcp.md`) — a separate, **read-only, admin-only** MCP surface for operational diagnosis, kept fully apart from the course-scoped content surface (distinct scope, audience, and role gate, per the design decision in §2/§3).

This is the **dispatch-layer foundation only**. **Nothing is mounted**, so the PR has **zero runtime effect** — it establishes the architecture for review before the HTTP/OAuth/DB-wall slices land.

## What's here

- **`AdminMCPMode`** (`off` / `read_only` — no `read_write`; read-only is structural, not a toggle), **`DiagnosticScope`** (`diagnostics:read`), **`AdminMCPConfig`** (`ADMIN_MCP_MODE`, off by default), wired into `AppConfig` with a redacted startup-summary line.
- **`AdminToolContext`** with `requireAdminSubject` — admin-only gate, **no course scoping** (the surface is deployment-wide).
- A **parallel** `DiagnosticTool` protocol + registry and **`AdminMCPDispatcher`** (tools-only, read-only). Reuses the generic JSON-RPC transport types but *not* the content surface's `ContentScope`/`ToolContext` — isolation over a risky generalization of shipped code, as the design doc calls for.
- **`AdminMCPServerInstructions`** and the first tool **`get_deployment_info`** (DB-free liveness + capability probe), in `AdminMCPToolCatalog`.
- **`MCPServerCapabilities`** gains a tools-only variant (`resources` omitted from the wire when nil) so the admin surface doesn't advertise resources. Content's `.v1` is unchanged.

## Two notes for reviewers

- **Path collision avoided.** The future mount path is **`/admin-mcp`**, *not* `/admin/mcp` — the latter is already the admin web page managing content-MCP service accounts (`AdminMCPRoutesTests`). The audience matches.
- **Auth decision recorded.** The doc's §3.3 is updated to the locked decision: reuse the **OAuth flow** with a two-resource consent gate (`isAdmin` on the admin resource), landing in slice 2c.

## Tests

- `AdminMCPModeTests` (mode/scope contract), `AdminMCPDispatcherLogicTests` (lifecycle, tools-only capabilities, scope-gated `tools/list`, unknown/resource methods → method-not-found), `AdminMCPToolExecutionTests` (`get_deployment_info`, scope rejection, `requireAdminSubject` accepts admin / rejects instructor+student+unknown) — 12/12 pass.
- Content MCP + `AppConfig` regression suites unaffected (52/52).
- `swift build` clean, `scripts/lint.sh` clean, SwiftLint `--strict` 0 violations.

## Next slices (in `docs/admin-mcp.md` §7)

- **2b** — mount `POST /admin-mcp` behind `ADMIN_MCP_MODE` + admin-audience bearer + `.well-known` discovery + tool-call audit.
- **2c** — two-resource OAuth consent (`isAdmin` gate) + PII-free DB views & least-privilege role for the data tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg

---
_Generated by [Claude Code](https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg)_