### PR TITLE
feat(admin-mcp): mount /admin-mcp with bearer auth, discovery, audit

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -38,6 +38,15 @@ public func runAPIServer() async throws {
             app.logger.info("MCP token authority ready (signing key: \(app.appConfig.mcp.signingKeyPath)).")
         }
 
+        // Admin diagnostic MCP surface: its own ES256 key (separate from the
+        // content authority) so rotating it revokes admin tokens independently.
+        if app.appConfig.adminMCP.mode.isMounted {
+            app.adminMcpTokenAuthority = try await MCPTokenAuthority.loadOrGenerate(
+                path: app.appConfig.adminMCP.signingKeyPath, keyID: "admin-mcp-1")
+            app.logger.info(
+                "Admin MCP token authority ready (signing key: \(app.appConfig.adminMCP.signingKeyPath)).")
+        }
+
         try await app.execute()
     } catch {
         await app.localRunnerManager.stopIfRunning(logger: app.logger)

--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -211,7 +211,8 @@ extension AppConfig {
     static func testDefaults(
         authMode: AuthMode = .local,
         database: DatabaseSettings = .sqliteInMemory(),
-        mcp: MCPConfig = .default
+        mcp: MCPConfig = .default,
+        adminMCP: AdminMCPConfig = .default
     ) -> AppConfig {
         let auth = AuthConfig(
             mode: authMode,
@@ -244,7 +245,8 @@ extension AppConfig {
             ),
             alerts: .default,
             outboundProxy: nil,
-            mcp: mcp
+            mcp: mcp,
+            adminMCP: adminMCP
         )
     }
 }

--- a/Sources/APIServer/MCP/Admin/AdminMCPBearerAuthMiddleware.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPBearerAuthMiddleware.swift
@@ -1,0 +1,70 @@
+// APIServer/MCP/Admin/AdminMCPBearerAuthMiddleware.swift
+//
+// OAuth 2.1 bearer-token gate for the admin diagnostic MCP endpoint.  Parallel
+// to `MCPBearerAuthMiddleware` but bound to the admin token authority, the admin
+// audience, and the `DiagnosticScope` vocabulary — so a content token (different
+// audience) can never authenticate here, and vice versa.  Validates signature +
+// exp via the admin authority, enforces issuer + audience (RFC 8707), requires
+// at least one diagnostic scope after clamping to the ADMIN_MCP_MODE ceiling,
+// and surfaces the caller on `request.adminMcpPrincipal`.
+
+import Vapor
+
+struct AdminMCPBearerAuthMiddleware: AsyncMiddleware {
+    let expectedIssuer: String
+    let expectedAudience: String
+    let resourceMetadataURL: String
+
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        guard let authority = request.application.adminMcpTokenAuthority else {
+            throw Abort(.internalServerError, reason: "Admin MCP token authority is not configured.")
+        }
+        guard let token = request.headers.bearerAuthorization?.token else {
+            return challenge(status: .unauthorized, error: nil, scope: nil)
+        }
+
+        let claims: MCPAccessTokenClaims
+        do {
+            claims = try await authority.verify(token)
+        } catch {
+            return challenge(status: .unauthorized, error: "invalid_token", scope: nil)
+        }
+
+        // RFC 8707: the token must be issued by us and scoped to the ADMIN
+        // resource. A content token (audience …/mcp) fails this check.
+        guard claims.iss.value == expectedIssuer, claims.aud.value.contains(expectedAudience) else {
+            return challenge(status: .unauthorized, error: "invalid_token", scope: nil)
+        }
+
+        // Clamp the token's scopes to the server-wide ceiling for the current
+        // ADMIN_MCP_MODE (read_only → {diagnostics:read}).  A token left with no
+        // usable scope after clamping is insufficient.
+        let tokenScopes = Set(DiagnosticScope.allCases.filter { claims.scopes.contains($0.rawValue) })
+        let granted = tokenScopes.intersection(request.application.appConfig.adminMCP.mode.scopeCeiling)
+        guard !granted.isEmpty else {
+            return challenge(
+                status: .forbidden,
+                error: "insufficient_scope",
+                scope: request.application.appConfig.adminMCP.mode.scopeCeiling
+                    .map(\.rawValue).sorted().joined(separator: " ")
+            )
+        }
+
+        request.adminMcpPrincipal = AdminMCPPrincipal(
+            subject: claims.sub.value,
+            grantedScopes: granted,
+            actingClientID: claims.clientID,
+            actingClientName: claims.agentName
+        )
+        return try await next.respond(to: request)
+    }
+
+    private func challenge(status: HTTPResponseStatus, error: String?, scope: String?) -> Response {
+        var params = ["Bearer resource_metadata=\"\(resourceMetadataURL)\""]
+        if let error { params.append("error=\"\(error)\"") }
+        if let scope { params.append("scope=\"\(scope)\"") }
+        var headers = HTTPHeaders()
+        headers.replaceOrAdd(name: .wwwAuthenticate, value: params.joined(separator: ", "))
+        return Response(status: status, headers: headers)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPDispatcher.swift
@@ -132,14 +132,36 @@ struct AdminMCPDispatcher: Sendable {
             return .failure(id: id, error: .insufficientScope(required))
         }
 
+        let response: JSONRPCResponse
+        let outcome: String
         do {
             let output = try await tool.invoke(call.arguments ?? .object([:]), context)
-            return .success(id: id, result: mcpToolSuccessResult(output))
+            outcome = MCPToolOutcome.success.rawValue
+            response = .success(id: id, result: mcpToolSuccessResult(output))
         } catch let error as MCPToolError {
-            return .success(id: id, result: errorToolResult(error))
+            outcome = MCPToolOutcome(error).rawValue
+            response = .success(id: id, result: errorToolResult(error))
         } catch {
-            return .failure(id: id, error: .internalError("Tool \(call.name) failed."))
+            outcome = MCPToolOutcome.failed.rawValue
+            response = .failure(id: id, error: .internalError("Tool \(call.name) failed."))
         }
+        // Best-effort audit (read-only surface, so no fail-closed): one row per
+        // executed call, attributed to the subject (suffixed -MCP) so agent reads
+        // are distinguishable from a human's web actions. Never logs arguments.
+        await auditToolCall(name: call.name, context: context, outcome: outcome)
+        return response
+    }
+
+    private func auditToolCall(name: String, context: AdminToolContext, outcome: String) async {
+        var metadata = ["tool": name, "outcome": outcome]
+        if let agent = context.actingClientName {
+            metadata["via_agent"] = agent
+        }
+        await AuditLogger.record(
+            action: .adminMcpToolCalled,
+            metadata: metadata,
+            actorUsernameOverride: "\(context.subject)-MCP",
+            on: context.request)
     }
 
     private func errorToolResult(_ error: MCPToolError) -> JSONValue {

--- a/Sources/APIServer/MCP/Admin/AdminMCPMetadataRoutes.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPMetadataRoutes.swift
@@ -1,0 +1,37 @@
+// APIServer/MCP/Admin/AdminMCPMetadataRoutes.swift
+//
+// Unauthenticated RFC 9728 protected-resource discovery for the admin
+// diagnostic surface, served at the path-based metadata URL
+// `/.well-known/oauth-protected-resource/admin-mcp` (distinct from the content
+// surface's root document).  Points MCP clients at the authorization server and
+// advertises the admin scope.  Must stay reachable without a token, so it is
+// mounted outside the bearer-gated group.
+
+import Core
+import Vapor
+
+struct AdminMCPMetadataRoutes: RouteCollection {
+    let endpoints: AdminMCPEndpoints
+    /// Scopes advertised in the discovery document, derived from ADMIN_MCP_MODE
+    /// so the metadata never claims a scope the server won't grant.
+    let advertisedScopes: [DiagnosticScope]
+
+    func boot(routes: RoutesBuilder) throws {
+        routes.grouped(".well-known", "oauth-protected-resource")
+            .get("admin-mcp", use: protectedResourceMetadata)
+    }
+
+    func protectedResourceMetadata(req: Request) throws -> Response {
+        let scopes = advertisedScopes.map { JSONValue.string($0.rawValue) }
+        let metadata = JSONValue.object([
+            "resource": .string(endpoints.resource),
+            "authorization_servers": .array([.string(endpoints.issuer)]),
+            "scopes_supported": .array(scopes),
+            "bearer_methods_supported": .array([.string("header")]),
+        ])
+        let data = try JSONEncoder().encode(metadata)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        return Response(status: .ok, headers: headers, body: .init(data: data))
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPPrincipal.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPPrincipal.swift
@@ -1,0 +1,58 @@
+// APIServer/MCP/Admin/AdminMCPPrincipal.swift
+//
+// The authenticated caller behind an admin diagnostic MCP request, set by
+// `AdminMCPBearerAuthMiddleware` and read by `AdminMCPRoutes` when it builds the
+// `AdminToolContext`.  Parallel to `MCPPrincipal` but over `DiagnosticScope`.
+// Also home to the admin token authority's Application storage — a separate
+// authority instance (and signing key) from the content surface's, so rotating
+// the admin key revokes admin tokens without touching content grants.
+
+import Vapor
+
+struct AdminMCPPrincipal: Sendable {
+    let subject: String
+    let grantedScopes: Set<DiagnosticScope>
+    /// The OAuth client (agent) the request was authorized through (browser
+    /// flow); nil for directly-minted tokens.  Carried for audit attribution.
+    let actingClientID: String?
+    let actingClientName: String?
+
+    init(
+        subject: String,
+        grantedScopes: Set<DiagnosticScope>,
+        actingClientID: String? = nil,
+        actingClientName: String? = nil
+    ) {
+        self.subject = subject
+        self.grantedScopes = grantedScopes
+        self.actingClientID = actingClientID
+        self.actingClientName = actingClientName
+    }
+}
+
+private struct AdminMCPPrincipalKey: StorageKey {
+    typealias Value = AdminMCPPrincipal
+}
+
+extension Request {
+    /// The admin MCP principal established by `AdminMCPBearerAuthMiddleware` once
+    /// a bearer token has passed validation.  Nil on unauthenticated requests.
+    var adminMcpPrincipal: AdminMCPPrincipal? {
+        get { storage[AdminMCPPrincipalKey.self] }
+        set { storage[AdminMCPPrincipalKey.self] = newValue }
+    }
+}
+
+private struct AdminMCPTokenAuthorityKey: StorageKey {
+    typealias Value = MCPTokenAuthority
+}
+
+extension Application {
+    /// The admin MCP token authority, loaded at startup when
+    /// `appConfig.adminMCP.mode` is mounted.  Separate from `mcpTokenAuthority`
+    /// (the content surface) — its own ES256 signing key.
+    var adminMcpTokenAuthority: MCPTokenAuthority? {
+        get { storage[AdminMCPTokenAuthorityKey.self] }
+        set { storage[AdminMCPTokenAuthorityKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPRoutes.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPRoutes.swift
@@ -1,0 +1,149 @@
+// APIServer/MCP/Admin/AdminMCPRoutes.swift
+//
+// The MCP Streamable HTTP transport for the admin diagnostic surface, mounted at
+// `/admin-mcp` (NOT `/admin/mcp`, which is the admin web page for content-MCP
+// service accounts).  Parallel to `MCPRoutes` but trimmed: no live-progress
+// streaming special case (the admin surface has no streaming tool).  Reuses the
+// generic SSE frame helpers from `MCPRoutes`.
+//
+// Mounted behind `AdminMCPBearerAuthMiddleware`, which authenticates the caller
+// and populates `request.adminMcpPrincipal` before dispatch runs.
+
+import Core
+import Foundation
+import Vapor
+
+struct AdminMCPRoutes: RouteCollection {
+    let dispatcher: AdminMCPDispatcher
+    let configuration: MCPRoutes.Configuration
+
+    func boot(routes: RoutesBuilder) throws {
+        let group = routes.grouped("admin-mcp")
+        group.post(use: handlePost)
+        group.on(.GET, use: streamingUnsupported)
+        group.on(.DELETE, use: streamingUnsupported)
+    }
+
+    func handlePost(req: Request) async throws -> Response {
+        try validateHost(req)
+        try validateOrigin(req)
+        if let rejection = try protocolVersionRejection(req) { return rejection }
+
+        let rpcRequest: JSONRPCRequest
+        do {
+            rpcRequest = try decodeRequest(req)
+        } catch {
+            return try jsonResponse(.failure(id: .null, error: .parseError()), status: .badRequest)
+        }
+
+        guard let principal = req.adminMcpPrincipal else {
+            throw Abort(
+                .unauthorized,
+                reason: "Admin MCP request reached the transport without an authenticated principal.")
+        }
+        let context = AdminToolContext(
+            request: req,
+            subject: principal.subject,
+            grantedScopes: principal.grantedScopes,
+            actingClientID: principal.actingClientID,
+            actingClientName: principal.actingClientName
+        )
+
+        guard let rpcResponse = await dispatcher.dispatch(rpcRequest, context: context) else {
+            return Response(status: .accepted)
+        }
+        if let error = rpcResponse.error, error.code == JSONRPCError.insufficientScopeCode {
+            return try jsonResponse(
+                rpcResponse, status: .forbidden, challenge: insufficientScopeChallenge(error))
+        }
+        if clientAcceptsEventStream(req) {
+            return try eventStreamResponse(rpcResponse)
+        }
+        return try jsonResponse(rpcResponse, status: .ok)
+    }
+
+    func streamingUnsupported(req: Request) async throws -> Response {
+        throw Abort(.methodNotAllowed)
+    }
+
+    // MARK: - Guards
+
+    private func validateHost(_ req: Request) throws {
+        guard !configuration.allowedHosts.isEmpty else { return }
+        let host = req.headers.first(name: "Host")?.lowercased() ?? ""
+        guard configuration.allowedHosts.contains(host) else {
+            throw Abort(.forbidden, reason: "Host header is not in the allowlist.")
+        }
+    }
+
+    private func validateOrigin(_ req: Request) throws {
+        guard !configuration.allowedOrigins.isEmpty else { return }
+        guard let origin = req.headers.first(name: "Origin") else { return }
+        guard configuration.allowedOrigins.contains(origin) else {
+            throw Abort(.forbidden, reason: "Origin is not in the allowlist.")
+        }
+    }
+
+    private func protocolVersionRejection(_ req: Request) throws -> Response? {
+        guard let version = req.headers.first(name: "MCP-Protocol-Version"),
+            !MCPProtocol.supportedVersions.contains(version)
+        else { return nil }
+        return try jsonResponse(
+            .failure(id: .null, error: .invalidRequest("Unsupported MCP-Protocol-Version: \(version)")),
+            status: .badRequest)
+    }
+
+    // MARK: - Body / response helpers
+
+    private func decodeRequest(_ req: Request) throws -> JSONRPCRequest {
+        guard var buffer = req.body.data else {
+            throw Abort(.badRequest, reason: "Missing request body.")
+        }
+        let bytes = buffer.readBytes(length: buffer.readableBytes) ?? []
+        return try JSONDecoder().decode(JSONRPCRequest.self, from: Data(bytes))
+    }
+
+    private func jsonResponse(
+        _ payload: JSONRPCResponse, status: HTTPResponseStatus, challenge: String? = nil
+    ) throws -> Response {
+        let data = try JSONEncoder().encode(payload)
+        var headers = HTTPHeaders()
+        headers.contentType = .json
+        if let challenge {
+            headers.replaceOrAdd(name: .wwwAuthenticate, value: challenge)
+        }
+        return Response(status: status, headers: headers, body: .init(data: data))
+    }
+
+    private func clientAcceptsEventStream(_ req: Request) -> Bool {
+        req.headers[.accept].contains { $0.lowercased().contains("text/event-stream") }
+    }
+
+    /// Frames a single JSON-RPC response as a one-shot SSE stream, reusing the
+    /// generic frame/header helpers from the content transport.
+    private func eventStreamResponse(_ payload: JSONRPCResponse) throws -> Response {
+        let frame = try MCPRoutes.sseMessageFrame(encoding: payload)
+        let response = Response(status: .ok, headers: MCPRoutes.sseHeaders())
+        response.body = .init(stream: { writer in
+            var buffer = ByteBufferAllocator().buffer(capacity: frame.utf8.count)
+            buffer.writeString(frame)
+            writer.write(.buffer(buffer)).whenComplete { _ in
+                writer.write(.end, promise: nil)
+            }
+        })
+        return response
+    }
+
+    private func insufficientScopeChallenge(_ error: JSONRPCError) -> String {
+        var params: [String]
+        if let url = configuration.resourceMetadataURL {
+            params = ["Bearer resource_metadata=\"\(url)\"", "error=\"insufficient_scope\""]
+        } else {
+            params = ["Bearer error=\"insufficient_scope\""]
+        }
+        if case .string(let scope)? = error.data {
+            params.append("scope=\"\(scope)\"")
+        }
+        return params.joined(separator: ", ")
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPServerRegistration.swift
@@ -1,0 +1,105 @@
+// APIServer/MCP/Admin/AdminMCPServerRegistration.swift
+//
+// Wires the admin diagnostic MCP surface into the live application when
+// `appConfig.adminMCP.mode` is mounted (read_only).  Mounts the bearer-gated
+// /admin-mcp transport and the unauthenticated protected-resource discovery
+// document.  Parallel to `registerMCPRoutes` (the content surface); reuses its
+// production DNS-rebinding fail-safe helpers.  Issuer/resource resolve from
+// AdminMCPConfig, falling back to PUBLIC_BASE_URL.
+
+import Core
+import Vapor
+
+/// Resolved OAuth identifiers + endpoint URLs for the admin MCP surface.
+struct AdminMCPEndpoints {
+    let issuer: String
+    let resource: String
+    /// Origin (scheme://host[:port], no trailing slash) the well-known endpoints
+    /// are served from.
+    let metadataOrigin: String
+
+    /// RFC 9728 path-based metadata URL for the admin resource — distinct from
+    /// the content surface's root `…/.well-known/oauth-protected-resource`.
+    var resourceMetadataURL: String {
+        metadataOrigin + "/.well-known/oauth-protected-resource/admin-mcp"
+    }
+
+    /// Resolves identifiers from explicit config, falling back to
+    /// `PUBLIC_BASE_URL`.  Returns nil when neither issuer nor resource can be
+    /// determined — the surface cannot mount safely without them.
+    static func resolve(
+        adminMCP: AdminMCPConfig, security: AppSecurityConfiguration
+    ) -> AdminMCPEndpoints? {
+        let base = security.publicBaseURL?.absoluteString.adminTrimmedTrailingSlash
+        guard let issuer = adminMCP.issuer?.adminTrimmedTrailingSlash ?? base else { return nil }
+        guard let resource = adminMCP.resource ?? base.map({ $0 + "/admin-mcp" }) else { return nil }
+        return AdminMCPEndpoints(issuer: issuer, resource: resource, metadataOrigin: base ?? issuer)
+    }
+}
+
+/// Registers the admin MCP endpoint + discovery metadata when ADMIN_MCP_MODE is
+/// mounted; a no-op otherwise.  Called from `routes(_:)`.
+func registerAdminMCPRoutes(_ app: Application) throws {
+    let admin = app.appConfig.adminMCP
+    guard admin.mode.isMounted else { return }
+    guard let endpoints = AdminMCPEndpoints.resolve(adminMCP: admin, security: app.appConfig.security)
+    else {
+        let mode = admin.mode.rawValue
+        app.logger.warning(
+            "ADMIN_MCP_MODE=\(mode) but no issuer/resource could be resolved (set ADMIN_MCP_ISSUER/ADMIN_MCP_RESOURCE or PUBLIC_BASE_URL); /admin-mcp not mounted."
+        )
+        return
+    }
+
+    // Reuse the content surface's production fail-safe: refuse to mount with the
+    // DNS-rebinding guards left open in production unless explicitly overridden.
+    if let refusal = mcpTransportGuardRefusal(
+        environment: app.environment,
+        allowedHosts: admin.allowedHosts,
+        allowedOrigins: admin.allowedOrigins,
+        allowOpenGuards: admin.allowOpenTransportGuards)
+    {
+        app.logger.error("admin-mcp: \(refusal)")
+        return
+    }
+    if let warning = mcpAllowlistWarning(
+        environment: app.environment,
+        allowedHosts: admin.allowedHosts,
+        allowedOrigins: admin.allowedOrigins)
+    {
+        app.logger.warning("admin-mcp: \(warning)")
+    }
+
+    let dispatcher = AdminMCPDispatcher(
+        serverInfo: MCPServerInfo(
+            name: "Chickadee Admin MCP", version: ChickadeeVersion.current,
+            title: "Chickadee Admin Diagnostics"),
+        tools: AdminMCPToolCatalog.live
+    )
+    let routeConfiguration = MCPRoutes.Configuration(
+        allowedHosts: admin.allowedHosts,
+        allowedOrigins: admin.allowedOrigins,
+        resourceMetadataURL: endpoints.resourceMetadataURL
+    )
+    let bearer = AdminMCPBearerAuthMiddleware(
+        expectedIssuer: endpoints.issuer,
+        expectedAudience: endpoints.resource,
+        resourceMetadataURL: endpoints.resourceMetadataURL
+    )
+
+    try app.grouped(bearer).register(
+        collection: AdminMCPRoutes(dispatcher: dispatcher, configuration: routeConfiguration))
+    try app.register(
+        collection: AdminMCPMetadataRoutes(
+            endpoints: endpoints, advertisedScopes: admin.mode.advertisedScopes))
+
+    app.logger.info(
+        "Admin MCP endpoint mounted at /admin-mcp — issuer=\(endpoints.issuer), resource=\(endpoints.resource)"
+    )
+}
+
+private extension String {
+    var adminTrimmedTrailingSlash: String {
+        hasSuffix("/") ? String(dropLast()) : self
+    }
+}

--- a/Sources/APIServer/MCP/Auth/MCPTokenAuthority.swift
+++ b/Sources/APIServer/MCP/Auth/MCPTokenAuthority.swift
@@ -69,13 +69,40 @@ actor MCPTokenAuthority {
         agentName: String? = nil,
         now: Date = Date()
     ) async throws -> String {
+        try await mint(
+            subject: subject,
+            scopeStrings: scopes.map(\.rawValue),
+            issuer: issuer,
+            audience: audience,
+            ttlSeconds: ttlSeconds,
+            clientID: clientID,
+            agentName: agentName,
+            now: now)
+    }
+
+    /// Mints a token carrying raw scope strings.  Used by surfaces with their own
+    /// scope vocabulary (e.g. the admin diagnostic surface's `diagnostics:read`);
+    /// the `ContentScope` overload delegates here.  The same ES256 key signs both
+    /// — separation between surfaces comes from a distinct `audience` (and a
+    /// distinct authority instance / signing key when configured), not the claim
+    /// shape.
+    func mint(
+        subject: String,
+        scopeStrings: [String],
+        issuer: String,
+        audience: String,
+        ttlSeconds: Int,
+        clientID: String? = nil,
+        agentName: String? = nil,
+        now: Date = Date()
+    ) async throws -> String {
         let claims = MCPAccessTokenClaims(
             sub: SubjectClaim(value: subject),
             iss: IssuerClaim(value: issuer),
             aud: AudienceClaim(value: audience),
             exp: ExpirationClaim(value: now.addingTimeInterval(TimeInterval(ttlSeconds))),
             iat: IssuedAtClaim(value: now),
-            scope: scopes.map(\.rawValue).sorted().joined(separator: " "),
+            scope: scopeStrings.sorted().joined(separator: " "),
             clientID: clientID,
             agentName: agentName
         )

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -141,6 +141,7 @@ enum AuditAction: String, Sendable, CaseIterable {
     case mcpConsentGranted = "mcp.consent_granted"
     case mcpTokenIssued = "mcp.token_issued"
     case mcpRefreshReuseDetected = "mcp.refresh_reuse_detected"
+    case adminMcpToolCalled = "admin_mcp.tool_called"
 
     /// Coarse grouping shown as the "Category" column / filter on /admin/audit.
     var category: AuditCategory {
@@ -162,7 +163,7 @@ enum AuditAction: String, Sendable, CaseIterable {
             return .runner
         case .mcpAccountCreated, .mcpAccountDeleted, .mcpTokenMinted, .mcpToolCalled,
             .mcpGrantRevoked, .mcpAccountEnrolled, .mcpAccountUnenrolled, .mcpClientRegistered,
-            .mcpConsentGranted, .mcpTokenIssued, .mcpRefreshReuseDetected:
+            .mcpConsentGranted, .mcpTokenIssued, .mcpRefreshReuseDetected, .adminMcpToolCalled:
             return .mcp
         }
     }
@@ -209,6 +210,7 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .mcpConsentGranted: return "MCP access authorized"
         case .mcpTokenIssued: return "MCP token issued"
         case .mcpRefreshReuseDetected: return "MCP refresh-token reuse detected"
+        case .adminMcpToolCalled: return "Admin diagnostic tool called"
         }
     }
 }

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -78,4 +78,11 @@ func routes(_ app: Application) throws {
     // GET reuses session auth; the submit is guarded by a single-use consent
     // token instead of the session cookie so it survives the cross-site hop.
     try registerMCPOAuthRoutes(app, sessionAuth: sessionAuth)
+
+    // MARK: - Admin diagnostic MCP (read-only)
+
+    // Bearer-gated /admin-mcp transport + protected-resource discovery, mounted
+    // when ADMIN_MCP_MODE is read_only; a no-op when off. Separate audience +
+    // signing key from the content surface. OAuth issuance lands in a follow-up.
+    try registerAdminMCPRoutes(app)
 }

--- a/Tests/APITests/MCP/AdminMCPBearerTests.swift
+++ b/Tests/APITests/MCP/AdminMCPBearerTests.swift
@@ -1,0 +1,104 @@
+// End-to-end auth tests for the mounted /admin-mcp endpoint: a real
+// AdminMCPBearerAuthMiddleware in front of the transport, exercising token
+// verification, the audience isolation that separates the admin surface from the
+// content surface, and scope clamping.
+
+import Core
+import Foundation
+import JWT
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite(.serialized) struct AdminMCPBearerTests {
+    private let issuer = "https://chickadee.example"
+    private let resource = "https://chickadee.example/admin-mcp"
+    private let contentResource = "https://chickadee.example/mcp"
+
+    /// Builds a test app with the admin MCP surface mounted (read_only) and an
+    /// admin token authority installed, mirroring how runAPIServer wires it.
+    private func makeMountedApp() async throws -> (Application, MCPTokenAuthority) {
+        let adminCfg = AdminMCPConfig(
+            mode: .readOnly, allowedHosts: [], allowedOrigins: [],
+            signingKeyPath: "unused", issuer: issuer, resource: resource)
+        let app = try await makeTestApp(appConfig: .testDefaults(adminMCP: adminCfg))
+        let authority = try await MCPTokenAuthority.make(
+            privateKeyPEM: ES256PrivateKey().pemRepresentation, keyID: "admin-mcp-1")
+        app.adminMcpTokenAuthority = authority
+        return (app, authority)
+    }
+
+    private func post(
+        _ app: Application, body: String, bearer: String?
+    ) async throws -> XCTHTTPResponse {
+        try await app.asyncSendRequest(.POST, "/admin-mcp") { req in
+            req.headers.contentType = .json
+            if let bearer { req.headers.add(name: .authorization, value: "Bearer \(bearer)") }
+            req.body = ByteBuffer(string: body)
+        }
+    }
+
+    private func adminToken(
+        _ authority: MCPTokenAuthority, scopes: [String] = ["diagnostics:read"], audience: String
+    ) async throws -> String {
+        try await authority.mint(
+            subject: "root", scopeStrings: scopes, issuer: issuer, audience: audience, ttlSeconds: 3600)
+    }
+
+    @Test func missingTokenReturns401() async throws {
+        let (app, _) = try await makeMountedApp()
+        try await withApp(app) { app in
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#, bearer: nil)
+            #expect(res.status == .unauthorized)
+        }
+    }
+
+    @Test func validAdminTokenReachesDispatch() async throws {
+        let (app, authority) = try await makeMountedApp()
+        try await withApp(app) { app in
+            let token = try await adminToken(authority, audience: resource)
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#, bearer: token)
+            #expect(res.status == .ok)
+            #expect(res.body.string.contains("2025-11-25"))
+        }
+    }
+
+    @Test func getDeploymentInfoOverBearerReportsReadOnly() async throws {
+        let (app, authority) = try await makeMountedApp()
+        try await withApp(app) { app in
+            let token = try await adminToken(authority, audience: resource)
+            let body =
+                #"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_deployment_info"}}"#
+            let res = try await post(app, body: body, bearer: token)
+            #expect(res.status == .ok)
+            #expect(res.body.string.contains("read_only"))
+        }
+    }
+
+    @Test func contentAudienceTokenIsRejected() async throws {
+        // A token minted for the CONTENT resource must NOT authenticate against
+        // the admin endpoint — this audience isolation is what keeps the two
+        // surfaces separate even though they share a token format.
+        let (app, authority) = try await makeMountedApp()
+        try await withApp(app) { app in
+            let token = try await adminToken(authority, audience: contentResource)
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#, bearer: token)
+            #expect(res.status == .unauthorized)
+        }
+    }
+
+    @Test func tokenWithoutDiagnosticScopeIsForbidden() async throws {
+        // Correct audience but no diagnostics:read scope → clamped to empty → 403.
+        let (app, authority) = try await makeMountedApp()
+        try await withApp(app) { app in
+            let token = try await adminToken(authority, scopes: ["content:read"], audience: resource)
+            let res = try await post(
+                app, body: #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#, bearer: token)
+            #expect(res.status == .forbidden)
+        }
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPEndpointTests.swift
+++ b/Tests/APITests/MCP/AdminMCPEndpointTests.swift
@@ -1,0 +1,92 @@
+// Route-level tests for the /admin-mcp Streamable HTTP endpoint: JSON responses,
+// notification ack, method restrictions, and the DNS-rebinding Origin guard.
+// Mounted behind a stub principal middleware standing in for
+// AdminMCPBearerAuthMiddleware (the auth path is covered in AdminMCPBearerTests).
+
+import Testing
+import XCTVapor
+
+@testable import APIServer
+
+@Suite struct AdminMCPEndpointTests {
+    private struct StubPrincipalMiddleware: AsyncMiddleware {
+        let principal: AdminMCPPrincipal
+        func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+            request.adminMcpPrincipal = principal
+            return try await next.respond(to: request)
+        }
+    }
+
+    private func makeApp(configuration: MCPRoutes.Configuration = .init()) async throws -> Application {
+        let app = try await Application.make(.testing)
+        let dispatcher = AdminMCPDispatcher(
+            serverInfo: MCPServerInfo(name: "Chickadee Admin MCP", version: "test"),
+            tools: AdminMCPToolCatalog.live)
+        let principal = AdminMCPPrincipal(subject: "tester", grantedScopes: Set(DiagnosticScope.allCases))
+        try app.grouped(StubPrincipalMiddleware(principal: principal))
+            .register(collection: AdminMCPRoutes(dispatcher: dispatcher, configuration: configuration))
+        return app
+    }
+
+    private let jsonHeaders: HTTPHeaders = ["Content-Type": "application/json"]
+
+    @Test func postInitializeReturnsToolsOnlyResult() async throws {
+        try await withApp(try await makeApp()) { app in
+            let body = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#
+            try await app.testable().test(
+                .POST, "/admin-mcp", headers: jsonHeaders, body: ByteBuffer(string: body)
+            ) { res async in
+                #expect(res.status == .ok)
+                let text = String(buffer: res.body)
+                #expect(text.contains("2025-11-25"))
+                #expect(text.contains("ADMIN DIAGNOSTIC"))
+            }
+        }
+    }
+
+    @Test func postNotificationReturns202() async throws {
+        try await withApp(try await makeApp()) { app in
+            let body = #"{"jsonrpc":"2.0","method":"notifications/initialized"}"#
+            try await app.testable().test(
+                .POST, "/admin-mcp", headers: jsonHeaders, body: ByteBuffer(string: body)
+            ) { res async in
+                #expect(res.status == .accepted)
+                #expect(res.body.readableBytes == 0)
+            }
+        }
+    }
+
+    @Test func unparseableBodyReturns400() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(
+                .POST, "/admin-mcp", headers: jsonHeaders, body: ByteBuffer(string: "not json")
+            ) { res async in
+                #expect(res.status == .badRequest)
+                #expect(String(buffer: res.body).contains("-32700"))
+            }
+        }
+    }
+
+    @Test func getReturns405() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/admin-mcp") { res async in
+                #expect(res.status == .methodNotAllowed)
+            }
+        }
+    }
+
+    @Test func disallowedOriginReturns403() async throws {
+        let configuration = MCPRoutes.Configuration(allowedOrigins: ["https://allowed.example"])
+        try await withApp(try await makeApp(configuration: configuration)) { app in
+            let headers: HTTPHeaders = [
+                "Content-Type": "application/json", "Origin": "https://evil.example",
+            ]
+            let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
+            try await app.testable().test(
+                .POST, "/admin-mcp", headers: headers, body: ByteBuffer(string: body)
+            ) { res async in
+                #expect(res.status == .forbidden)
+            }
+        }
+    }
+}

--- a/changelog.d/admin-mcp-mount.md
+++ b/changelog.d/admin-mcp-mount.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Admin diagnostic MCP — HTTP mount + bearer auth (internal).** The read-only
+  admin diagnostic surface (`docs/admin-mcp.md`) is now mountable at
+  `POST /admin-mcp` behind `ADMIN_MCP_MODE=read_only`, with its own
+  `AdminMCPBearerAuthMiddleware` (separate ES256 signing key + token audience
+  from the content surface, so a content token can't call admin tools), an
+  RFC 9728 protected-resource discovery document, the production DNS-rebinding
+  fail-safe, and per-call audit (`admin_mcp.tool_called`). Off by default; OAuth
+  consent issuance lands in a follow-up, so it's reachable only with a
+  directly-minted admin token for now.

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -372,11 +372,13 @@ OAuth and DB-wall work lands.
      `get_deployment_info` — proven end to end at the dispatch layer with unit
      tests. **Nothing is mounted**, so there is zero production impact while the
      architecture is reviewed.
-   - **2b — HTTP mount + bearer.** Mount `POST /admin-mcp` behind
-     `ADMIN_MCP_MODE` with a bearer middleware enforcing the admin audience +
-     `diagnostics:read`, the admin `.well-known/oauth-protected-resource`
+   - **2b — HTTP mount + bearer.** ✅ **Done.** Mounts `POST /admin-mcp` behind
+     `ADMIN_MCP_MODE` with `AdminMCPBearerAuthMiddleware` enforcing the admin
+     audience + `diagnostics:read` (separate signing key from the content
+     surface), the admin `.well-known/oauth-protected-resource/admin-mcp`
      discovery, the production DNS-rebinding fail-safe, and admin tool-call
-     audit. Tokens minted via `MCPTokenAuthority` (admin audience) for tests.
+     audit (`admin_mcp.tool_called`). Tokens minted via `MCPTokenAuthority`
+     (admin audience) for tests; production issuance is 2c.
    - **2c — two-resource OAuth consent.** Extend `MCPOAuthRoutes` so
      `/oauth/authorize` branches the role gate on the requested resource
      (`isAdmin` for the admin resource), plus the PII-free DB views +


### PR DESCRIPTION
## What & why

**Phase 2b** of the admin diagnostic MCP surface (`docs/admin-mcp.md`): turn the 2a dispatch-layer foundation into a live, authenticated HTTP endpoint. **Off by default** (`ADMIN_MCP_MODE` unset → not mounted), so no runtime change unless an operator opts in.

## What's here

- **`AdminMCPRoutes`** — Streamable HTTP transport at **`POST /admin-mcp`** (not `/admin/mcp`, which is the content-MCP admin web page). Same Host/Origin DNS-rebinding guards, protocol-version check, and JSON/SSE response handling as the content transport, minus the streaming special case.
- **`AdminMCPBearerAuthMiddleware`** + **`AdminMCPPrincipal`** — verifies tokens via a **dedicated admin token authority** (separate ES256 key), enforces issuer + the **distinct admin audience**, clamps scopes to `diagnostics:read` under `ADMIN_MCP_MODE`, and sets `request.adminMcpPrincipal`.
- **`AdminMCPMetadataRoutes`** — RFC 9728 protected-resource discovery at the path-based `/.well-known/oauth-protected-resource/admin-mcp`.
- **`registerAdminMCPRoutes`** + startup authority load (`admin-mcp-1` key), gated on `ADMIN_MCP_MODE`; reuses the content surface's production DNS-rebinding fail-safe.
- **`MCPTokenAuthority`** gains a scope-string `mint` (so `diagnostics:read` tokens can be minted); **`AdminMCPDispatcher`** audits each executed call as `admin_mcp.tool_called` (new `AuditAction`).

## The isolation that matters

The whole point of a separate surface is that the two can't be confused. A token minted for the **content** resource (`…/mcp`) is **rejected** at `/admin-mcp` (audience mismatch → 401), and vice versa — covered by `contentAudienceTokenIsRejected`. Separate signing keys mean rotating the admin key revokes admin tokens without touching content grants.

## Tests

- `AdminMCPEndpointTests` — transport: initialize (tools-only + admin instructions), notification → 202, parse error → 400, GET → 405, disallowed Origin → 403.
- `AdminMCPBearerTests` — the real auth path: missing token → 401, valid admin token → 200, **content-audience token → 401** (isolation), correct-audience but no `diagnostics:read` → 403, `get_deployment_info` over bearer reports `read_only`.
- 22/22 admin MCP tests pass; content MCP + token authority + audit + AppConfig suites unaffected (46/46). Build / `scripts/lint.sh` / SwiftLint `--strict` all clean.

## Still not reachable in prod

There's no production token-issuance path yet — the endpoint is reachable only with a directly-minted admin token (used in tests). **Slice 2c** adds the two-resource OAuth consent (`isAdmin` gate) and the PII-free DB views + least-privilege role for the data tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg

---
_Generated by [Claude Code](https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg)_