### PR TITLE
feat(admin-mcp): add operational diagnostic tools (metrics, health alerts)

### DIFF
--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -9,7 +9,9 @@
 enum AdminMCPToolCatalog {
     static var live: DiagnosticToolRegistry {
         DiagnosticToolRegistry([
-            GetDeploymentInfoTool().erased()
+            GetDeploymentInfoTool().erased(),
+            GetMetricsSnapshotTool().erased(),
+            GetHealthAlertsTool().erased(),
         ])
     }
 }

--- a/Sources/APIServer/MCP/Admin/Tools/GetHealthAlertsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetHealthAlertsTool.swift
@@ -1,0 +1,61 @@
+// APIServer/MCP/Admin/Tools/GetHealthAlertsTool.swift
+//
+// Read tool: live evaluation of the server-health alert rules (database
+// reachability, runner offline, queue backed up, error-rate spike) with the
+// configured thresholds — whether each is currently firing, a human summary,
+// and the supporting numbers (counts, ages, rates).  Evaluated on demand, so it
+// reflects current state regardless of whether the alerting webhook is enabled.
+// PII-free: details carry counts/thresholds, never student identifiers.
+
+import Core
+import Vapor
+
+struct GetHealthAlertsTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    struct RuleStatus: Encodable, Sendable {
+        let rule: String
+        let label: String
+        let severity: String
+        let firing: Bool
+        let summary: String
+        let details: [String: String]
+    }
+
+    struct Output: Encodable, Sendable {
+        /// True when any rule is currently firing.
+        let anyFiring: Bool
+        let rules: [RuleStatus]
+    }
+
+    static let name = "get_health_alerts"
+    static let description =
+        "Live server-health rule evaluation: for each rule (database unreachable, runner offline, "
+        + "queue backed up, error-rate spike) reports whether it is currently firing, a human "
+        + "summary, and the supporting numbers (pending count, oldest-pending age, system-failure "
+        + "rate, configured thresholds). Evaluated on demand, independent of whether alert delivery "
+        + "is enabled. Read-only; counts and thresholds only — no student identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+        let app = context.request.application
+        let evaluations = await evaluateHealthRules(
+            on: app, configuration: app.serverHealthAlertConfiguration)
+        let rules = HealthRule.allCases.map { rule -> RuleStatus in
+            let evaluation = evaluations[rule] ?? .ok
+            return RuleStatus(
+                rule: rule.rawValue,
+                label: rule.humanReadable,
+                severity: rule.severity,
+                firing: evaluation.isFiring,
+                summary: evaluation.summary,
+                details: evaluation.details)
+        }
+        return Output(anyFiring: rules.contains { $0.firing }, rules: rules)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetMetricsSnapshotTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetMetricsSnapshotTool.swift
@@ -1,0 +1,38 @@
+// APIServer/MCP/Admin/Tools/GetMetricsSnapshotTool.swift
+//
+// Read tool: the operational metrics snapshot — runner loads/liveness, peak
+// queue depth, recent job status counts, queue-wait/execution duration
+// summaries, and compatibility counters.  Wraps the same PII-free aggregate the
+// admin dashboard's /admin/metrics endpoint serves (InternalMetricsResponse):
+// counts, percentiles, and per-runner operational fields only — no user,
+// submission, course, or assignment identifiers.
+
+import Core
+import Vapor
+
+struct GetMetricsSnapshotTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    /// The existing dashboard aggregate, reused verbatim — already audited as
+    /// PII-free (no row-level student identifiers).
+    typealias Output = InternalMetricsResponse
+
+    static let name = "get_metrics_snapshot"
+    static let description =
+        "Operational metrics snapshot: per-runner load and liveness (active/max jobs, capacity, "
+        + "last poll/heartbeat), peak queue depth, recent job status counts (passed/failed/error/"
+        + "timeout), queue-wait and execution duration summaries (avg/p50/p95), and runner-"
+        + "compatibility counters, over the server's recent window. Use it to diagnose runner "
+        + "health, throughput, and queue pressure. Read-only; aggregates only — no student, "
+        + "submission, course, or assignment identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+        return try await context.request.application.diagnostics.metricsSnapshot(req: context.request)
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -1,0 +1,81 @@
+// Tests for the Phase-3 admin diagnostic tools: get_metrics_snapshot and
+// get_health_alerts.  Both wrap PII-free operational aggregates and enforce
+// admin-only access via AdminToolContext.requireAdminSubject.
+
+import Core
+import Fluent
+import Testing
+import Vapor
+import XCTVapor
+
+@testable import APIServer
+
+@Suite(.serialized) final class AdminMCPToolsTests {
+    let app: Application
+
+    init() async throws {
+        app = try await makeTestApp(prefix: "admin-mcp-tools")
+    }
+
+    private func context(subject: String, scopes: Set<DiagnosticScope> = [.read]) -> AdminToolContext {
+        AdminToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: subject,
+            grantedScopes: scopes)
+    }
+
+    @Test func getMetricsSnapshotReturnsAggregateForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ops-admin", role: "admin")
+            let output = try await GetMetricsSnapshotTool().execute(
+                .init(), context(subject: "ops-admin"))
+            // Empty test deployment: no runners, no jobs — but the aggregate
+            // still resolves with sane defaults.
+            #expect(output.recentWindowHours >= 1)
+            #expect(output.activeRunners == 0)
+            #expect(output.runnerLoads.isEmpty)
+        }
+    }
+
+    @Test func getMetricsSnapshotRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ms-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetMetricsSnapshotTool().execute(.init(), context(subject: "ms-prof"))
+            }
+        }
+    }
+
+    @Test func getHealthAlertsReturnsAllRulesForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ha-admin", role: "admin")
+            let output = try await GetHealthAlertsTool().execute(
+                .init(), context(subject: "ha-admin"))
+            #expect(output.rules.count == HealthRule.allCases.count)
+            // DB is reachable and there are no runners/jobs, so nothing fires.
+            #expect(output.anyFiring == false)
+            #expect(output.rules.allSatisfy { !$0.summary.isEmpty })
+        }
+    }
+
+    @Test func getHealthAlertsRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ha-student", role: "student")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetHealthAlertsTool().execute(.init(), context(subject: "ha-student"))
+            }
+        }
+    }
+}
+
+// Pure-logic catalog check — no app, so kept out of the class suite (which would
+// otherwise build and leak a Vapor app for a test that doesn't need one).
+@Suite struct AdminMCPCatalogTests {
+    @Test func toolsAreRegistered() {
+        let names = Set(AdminMCPToolCatalog.live.all.map(\.name))
+        #expect(
+            names.isSuperset(of: [
+                "get_deployment_info", "get_metrics_snapshot", "get_health_alerts",
+            ]))
+    }
+}

--- a/changelog.d/admin-mcp-ops-tools.md
+++ b/changelog.d/admin-mcp-ops-tools.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Admin diagnostic MCP — operational tools (internal).** The read-only admin
+  diagnostic surface (`docs/admin-mcp.md`) gains two tools: `get_metrics_snapshot`
+  (per-runner load/liveness, peak queue depth, recent job status counts,
+  queue-wait/execution percentiles, compatibility counters — the same PII-free
+  aggregate the admin dashboard serves) and `get_health_alerts` (live evaluation
+  of the server-health rules with thresholds). Both enforce admin-only access and
+  expose aggregates only — no student, submission, course, or assignment data.

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -383,9 +383,13 @@ OAuth and DB-wall work lands.
      `/oauth/authorize` branches the role gate on the requested resource
      (`isAdmin` for the admin resource), plus the PII-free DB views +
      least-privilege role for the data tools.
-3. **Clean-source tools.** `get_runner_health`, `get_queue_state`,
-   `get_health_alerts`, `get_job_metrics_summary` — all aggregate/PII-free,
-   lowest risk.
+3. **Clean-source tools.** ✅ **Done (first pass).** Shipped `get_metrics_snapshot`
+   (the dashboard `InternalMetricsResponse` aggregate — runner loads, queue
+   depth, job status counts, duration percentiles, compatibility counters) and
+   `get_health_alerts` (live `evaluateHealthRules`), both admin-gated via
+   `requireAdminSubject` and PII-free. These cover the originally-listed
+   `get_runner_health` / `get_queue_state` / `get_job_metrics_summary` in one
+   snapshot; finer-grained splits can follow if an agent wants them.
 4. **`get_browser_diagnostics` + `query_logs`.** The two that read the enriched
    (formerly PII-adjacent) sources; land them after the DB-view wall and the
    per-tool PII tests are in place.


### PR DESCRIPTION
## What & why

**Phase 3** of the admin diagnostic MCP surface (`docs/admin-mcp.md`): the first read tools that return real operational state — the actual diagnostic value behind this whole effort.

## Tools added

- **`get_metrics_snapshot`** — wraps the existing, already-PII-vetted dashboard aggregate (`InternalMetricsResponse`): per-runner load/liveness (active/max jobs, capacity, last poll/heartbeat), peak queue depth, recent job status counts, queue-wait/execution percentiles (avg/p50/p95), and runner-compatibility counters. This covers the doc's originally-separate `get_runner_health` / `get_queue_state` / `get_job_metrics_summary` in one snapshot, reusing vetted code rather than re-deriving.
- **`get_health_alerts`** — live `evaluateHealthRules()`: database reachability, runner offline, queue backed up, error-rate spike — each with firing state, a human summary, and supporting counts/thresholds. Evaluated on demand, so it works regardless of whether alert *delivery* is enabled.

## Safety

- Both call **`AdminToolContext.requireAdminSubject`** — admin-only at the tool layer (defense in depth, and the operative gate until slice 2c's OAuth `isAdmin` consent lands).
- Both return **aggregates only** — no student, submission, course, or assignment identifiers. `get_metrics_snapshot` reuses the exact response the `/admin/metrics` dashboard already serves, which the earlier audit confirmed PII-free.

## Tests

- `AdminMCPToolsTests` — each tool returns its aggregate for an admin subject and throws `MCPToolError` for instructor/student subjects; `AdminMCPCatalogTests` checks registration. (The catalog check is a struct suite — no leaked Vapor app.) 11/11 pass; dispatcher/content suites unaffected. Build / lint / SwiftLint `--strict` clean.

## Sequencing note

This lands **ahead of slice 2c** (production OAuth token issuance) on purpose: the tools are the high-value, low-risk part and are fully usable now with a directly-minted admin token. 2c — making the surface reachable in production — is awaiting your call on **OAuth surgery vs. an admin-minted diagnostic token** (raised in the previous message). The PII-free DB-view wall is deferred to when the PII-adjacent tools (`get_browser_diagnostics`, `query_logs`) land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg

---
_Generated by [Claude Code](https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg)_