### PR TITLE
feat(admin-mcp): add get_browser_diagnostics tool

### DIFF
--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -12,6 +12,7 @@ enum AdminMCPToolCatalog {
             GetDeploymentInfoTool().erased(),
             GetMetricsSnapshotTool().erased(),
             GetHealthAlertsTool().erased(),
+            GetBrowserDiagnosticsTool().erased(),
         ])
     }
 }

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
@@ -1,0 +1,135 @@
+// APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+//
+// Read tool: surface the in-browser editor's error reports (client_diagnostics)
+// for diagnosis — counts by kind/source/failed-check over a window, plus recent
+// redacted samples carrying the actual error message + stack captured in the
+// browser-error enrichment work.
+//
+// PII boundary (code allowlist — the shipped guarantee, no DB role): the
+// returned DTO is hand-built and deliberately OMITS user_id. It keeps the
+// failure kind, source, failed checks, error message/stack (JupyterLite/Pyodide
+// infrastructure text only — capture is restricted to the editor-load path,
+// never student-code execution), the user agent, the test-setup id (instructor
+// content, not student data), and the timestamp. No student identifier is ever
+// included.
+
+import Core
+import Fluent
+import Vapor
+
+struct GetBrowserDiagnosticsTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Look-back window in hours (default 168 = 7 days; clamped 1…720).
+        var windowHours: Int?
+        /// Optional test-setup (assignment) filter.
+        var testSetupID: String?
+        /// Max recent samples to return (default 20; clamped 1…100).
+        var sampleLimit: Int?
+    }
+
+    struct CountEntry: Encodable, Sendable {
+        let key: String
+        let count: Int
+    }
+
+    /// A single browser-error report, redacted: no user_id.
+    struct Sample: Encodable, Sendable {
+        let kind: String
+        let source: String?
+        let failedChecks: String?
+        let message: String?
+        let stack: String?
+        let userAgent: String?
+        let testSetupID: String?
+        let createdAt: Date
+    }
+
+    struct Output: Encodable, Sendable {
+        let windowHours: Int
+        let total: Int
+        let byKind: [CountEntry]
+        let bySource: [CountEntry]
+        let byFailedCheck: [CountEntry]
+        let recentSamples: [Sample]
+    }
+
+    static let name = "get_browser_diagnostics"
+    static let description =
+        "In-browser editor error reports (JupyterLite/Pyodide) for diagnosis: totals and breakdowns "
+        + "by kind (preflight_fail / watchdog_timeout / editor_error), source, and failed capability "
+        + "check over a window, plus recent samples carrying the actual error message and stack. "
+        + "Optionally filter by testSetupID. Read-only; reports infrastructure errors only and never "
+        + "includes a student identifier."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "windowHours": .object([
+                "type": .string("integer"),
+                "description": .string("Look-back window in hours (default 168, max 720)."),
+            ]),
+            "testSetupID": .object([
+                "type": .string("string"),
+                "description": .string("Optional assignment/test-setup id filter."),
+            ]),
+            "sampleLimit": .object([
+                "type": .string("integer"),
+                "description": .string("Max recent samples to return (default 20, max 100)."),
+            ]),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let windowHours = min(max(input.windowHours ?? 168, 1), 720)
+        let sampleLimit = min(max(input.sampleLimit ?? 20, 1), 100)
+        let since = Date().addingTimeInterval(Double(-windowHours) * 3600)
+
+        var query = APIClientDiagnostic.query(on: context.db)
+            .filter(\.$createdAt >= since)
+        if let setup = input.testSetupID, !setup.isEmpty {
+            query = query.filter(\.$testSetupID == setup)
+        }
+        let rows = try await query.sort(\.$createdAt, .descending).all()
+
+        var byKind: [String: Int] = [:]
+        var bySource: [String: Int] = [:]
+        var byCheck: [String: Int] = [:]
+        for row in rows {
+            byKind[row.kind, default: 0] += 1
+            if let source = row.source { bySource[source, default: 0] += 1 }
+            if let checks = row.failedChecks {
+                for check in checks.split(separator: ",") {
+                    byCheck[String(check), default: 0] += 1
+                }
+            }
+        }
+
+        let samples = rows.prefix(sampleLimit).map { row in
+            Sample(
+                kind: row.kind,
+                source: row.source,
+                failedChecks: row.failedChecks,
+                message: row.message,
+                stack: row.stack,
+                userAgent: row.userAgent,
+                testSetupID: row.testSetupID,
+                createdAt: row.createdAt ?? Date())
+        }
+
+        return Output(
+            windowHours: windowHours,
+            total: rows.count,
+            byKind: Self.sortedCounts(byKind),
+            bySource: Self.sortedCounts(bySource),
+            byFailedCheck: Self.sortedCounts(byCheck),
+            recentSamples: Array(samples))
+    }
+
+    /// Counts as entries, highest first then by key for stable ordering.
+    private static func sortedCounts(_ counts: [String: Int]) -> [CountEntry] {
+        counts.map { CountEntry(key: $0.key, count: $0.value) }
+            .sorted { ($0.count, $1.key) > ($1.count, $0.key) }
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -66,6 +66,52 @@ import XCTVapor
             }
         }
     }
+
+    @Test func getBrowserDiagnosticsAggregatesAndRedactsUserID() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "bd-admin", role: "admin")
+            let student = try await makeTestUser(on: app, username: "bd-student", role: "student")
+            let studentID = try student.requireID()
+            let seeds: [(String, String?)] = [
+                ("editor_error", "onerror"),
+                ("editor_error", "unhandledrejection"),
+                ("watchdog_timeout", "kernel"),
+            ]
+            for (kind, source) in seeds {
+                try await APIClientDiagnostic(
+                    userID: studentID, testSetupID: nil, kind: kind,
+                    failedChecks: kind == "watchdog_timeout" ? "kernel-unhealthy" : nil,
+                    userAgent: "TestUA/9", message: "TypeError: boom", stack: "at x (a.js:1:1)",
+                    source: source
+                ).save(on: app.db)
+            }
+
+            let output = try await GetBrowserDiagnosticsTool().execute(
+                .init(), context(subject: "bd-admin"))
+            #expect(output.total == 3)
+            #expect(output.byKind.contains { $0.key == "editor_error" && $0.count == 2 })
+            #expect(output.bySource.contains { $0.key == "onerror" && $0.count == 1 })
+            #expect(output.byFailedCheck.contains { $0.key == "kernel-unhealthy" && $0.count == 1 })
+            let sample = try #require(output.recentSamples.first)
+            #expect(sample.message == "TypeError: boom")
+            #expect(sample.stack == "at x (a.js:1:1)")
+
+            // PII guarantee: the student's user id must not appear anywhere in
+            // the serialized tool output.
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains(studentID.uuidString))
+            #expect(!json.lowercased().contains("userid"))
+        }
+    }
+
+    @Test func getBrowserDiagnosticsRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "bd-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetBrowserDiagnosticsTool().execute(.init(), context(subject: "bd-prof"))
+            }
+        }
+    }
 }
 
 // Pure-logic catalog check — no app, so kept out of the class suite (which would
@@ -76,6 +122,7 @@ import XCTVapor
         #expect(
             names.isSuperset(of: [
                 "get_deployment_info", "get_metrics_snapshot", "get_health_alerts",
+                "get_browser_diagnostics",
             ]))
     }
 }

--- a/changelog.d/admin-mcp-browser-diagnostics.md
+++ b/changelog.d/admin-mcp-browser-diagnostics.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Admin diagnostic MCP — browser-error tool (internal).** Adds
+  `get_browser_diagnostics` to the read-only admin diagnostic surface
+  (`docs/admin-mcp.md`): totals and breakdowns by kind / source / failed
+  capability check over a window, plus recent samples carrying the actual
+  JupyterLite/Pyodide error message and stack captured by the browser-error
+  enrichment. Admin-gated; the response is a hand-built DTO that omits the
+  student `user_id` (the no-student-data guarantee, asserted by a per-tool PII
+  test) — no dedicated DB role.

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -14,8 +14,13 @@ Decisions locked with the maintainer:
 3. **Design doc first** — this file. No code until it's reviewed.
 4. **Auth: reuse the OAuth flow** (same as the content endpoint), gated on
    `isAdmin` — see §3.3.
-5. **PII wall: hybrid** — DTO allowlist everywhere + PII-free DB views and a
-   least-privilege role in production — see §4.
+5. **PII wall: code allowlist (revised — no new DB role).** The guarantee is
+   hand-built DTOs that never include student identifiers, asserted by per-tool
+   PII tests; `query_logs` reads an in-memory redacted ring buffer (no DB). A
+   dedicated admin DB role was dropped as disproportionate (only one tool reads
+   a PII-adjacent table). If DB-enforced hardening is ever wanted, extend the
+   *existing* MCP least-privilege pool with PII-free views — no second role. See
+   §4.
 
 It builds on the shipped content-authoring MCP server (OAuth 2.1 bearer flow,
 `ContentScope`, per-tool scope enforcement, course-scoping). Where this design
@@ -231,7 +236,19 @@ differ):
 
 This is the part that must be right.
 
-### 4.1 Principle: redact at the database, not only in the DTO
+> **Decision (revised during build): code allowlist, no new DB role.** The
+> sections below describe the *maximal* hybrid (DB views + a dedicated role).
+> In practice that was disproportionate: only `get_browser_diagnostics` reads a
+> PII-adjacent table (`client_diagnostics`); `query_logs` uses an in-memory
+> redacted ring buffer, and the metrics/health tools return aggregates. So the
+> shipped guarantee is the **code allowlist** (§4.3) — hand-built DTOs that omit
+> student identifiers, asserted by per-tool PII tests (e.g. the seeded
+> `user_id` must not appear anywhere in `get_browser_diagnostics` output). The
+> DB-view layer below is retained as the design of record for *if* DB-enforced
+> hardening is ever required — and even then it would **extend the existing MCP
+> least-privilege pool**, not add a second role.
+
+### 4.1 Principle (aspirational): redact at the database, not only in the DTO
 
 The content MCP already demonstrates the strongest pattern: an optional dedicated
 least-privilege DB pool (`MCP_DATABASE_USER` / `MCP_DATABASE_PASSWORD` →
@@ -399,9 +416,14 @@ OAuth and DB-wall work lands.
    `requireAdminSubject` and PII-free. These cover the originally-listed
    `get_runner_health` / `get_queue_state` / `get_job_metrics_summary` in one
    snapshot; finer-grained splits can follow if an agent wants them.
-4. **`get_browser_diagnostics` + `query_logs`.** The two that read the enriched
-   (formerly PII-adjacent) sources; land them after the DB-view wall and the
-   per-tool PII tests are in place.
+4. **`get_browser_diagnostics` + `query_logs`.**
+   - `get_browser_diagnostics` ✅ **Done.** Reads `client_diagnostics` (the
+     enriched browser-error reports from step 1): counts by kind/source/failed-
+     check over a window + recent samples with the actual message/stack.
+     Admin-gated; the returned DTO omits `user_id` (code-allowlist guarantee),
+     asserted by a per-tool PII test. No DB role (§4 decision).
+   - `query_logs` — remaining: an in-memory redacted log ring buffer + the tool
+     to query it (no DB).
 
 ---
 


### PR DESCRIPTION
## What & why

**Phase 4** of the admin diagnostic MCP surface (`docs/admin-mcp.md`) — and the tool that **closes the loop on your original motivation**: surfacing the in-browser editor's error reports (the browser error you were seeing) for diagnosis.

`get_browser_diagnostics` reads `client_diagnostics` — the reports **enriched with `message` / `stack` / `source` back in Phase 1** — and returns:
- totals + breakdowns by **kind** (`preflight_fail` / `watchdog_timeout` / `editor_error`), **source**, and **failed capability check** over a configurable window (default 7 days)
- **recent samples** carrying the actual error message + stack
- optional `testSetupID` filter

## PII boundary — code allowlist, **no new DB role**

Per the decision we landed on: the returned DTO is **hand-built and omits `user_id`**. It keeps the failure kind, source, failed checks, error message/stack (editor-load infrastructure errors only — never student-code execution), user agent, `testSetupID` (instructor content), and timestamp. A **per-tool PII test** seeds rows for a real student and asserts that student's `user_id` **never appears** anywhere in the serialized output. Admin-only via `requireAdminSubject`. No dedicated DB role — the config surface stays flat.

The design doc §4/§5/§7 are updated to record the revised "code allowlist, no second role" decision.

## Tests

- `AdminMCPToolsTests` (already `.serialized`, so no connection-pool flakiness): aggregation correctness, sample message/stack passthrough, the `user_id` redaction assertion, and non-admin rejection. Catalog registration updated.
- 7/7 in the suite; build / SwiftLint `--strict` clean.

## Remaining

- `query_logs` — an in-memory **redacted log ring buffer** + the tool to query it (no DB). That's the last functional piece of the admin surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg

---
_Generated by [Claude Code](https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg)_