### PR TITLE
feat(admin-mcp): add query_logs backed by a shared recent-events sink

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -1,10 +1,12 @@
 // APIServer/APIServerApp.swift
 
 import CSRF
+import ConsoleKit
 import Core
 import Fluent
 import Foundation
 import Leaf
+import Logging
 import Vapor
 
 /// Library entry point invoked by the `chickadee-server` executable target.
@@ -13,9 +15,22 @@ import Vapor
 public func runAPIServer() async throws {
     var env = try Environment.detect()
     let cliWorkerSecret = extractWorkerSecretArgument(from: &env)
-    try LoggingSystem.bootstrap(from: &env)
+    // Tee logs into the admin diagnostic ring buffer while preserving Vapor's
+    // exact console output: multiplex Vapor's own ConsoleLogger (the same handler
+    // its default bootstrap installs) with the warning+ ring-buffer handler.
+    let adminEventSink = AdminEventSink()
+    try LoggingSystem.bootstrap(from: &env) { level in
+        let console = Terminal()
+        return { label in
+            MultiplexLogHandler([
+                ConsoleLogger(label: label, console: console, level: level),
+                RingBufferLogHandler(label: label, sink: adminEventSink),
+            ])
+        }
+    }
 
     let app = try await Application.make(env)
+    app.adminEventSink = adminEventSink
     app.logger.info("Starting chickadee-server v\(ChickadeeVersion.current)")
 
     do {

--- a/Sources/APIServer/MCP/Admin/AdminEventSink.swift
+++ b/Sources/APIServer/MCP/Admin/AdminEventSink.swift
@@ -1,0 +1,71 @@
+// APIServer/MCP/Admin/AdminEventSink.swift
+//
+// The shared in-process "recent server events" source behind the admin
+// diagnostic surface's query_logs tool (and any future event-driven admin
+// query).  A bounded ring buffer fed by RingBufferLogHandler at log time; PII
+// metadata keys are dropped before an event is stored, so the buffer is born
+// clean.  Per-process and until-restart by design — for a single-instance
+// deployment and live debugging that's the right tradeoff; it graduates to a
+// retention-bounded table (same reader shape) if durability or multi-instance
+// history is ever needed (docs/admin-mcp.md §6.2).
+
+import Foundation
+import Vapor
+
+/// One captured log/diagnostic event.  `metadata` is already PII-redacted.
+struct CapturedEvent: Encodable, Sendable {
+    let timestamp: Date
+    /// Logger.Level raw value ("warning", "error", …).
+    let level: String
+    let label: String
+    let message: String
+    let metadata: [String: String]
+}
+
+/// Bounded ring buffer of recent events.  Thread-safe via a lock because
+/// `LogHandler.log` is synchronous and called from arbitrary threads, so an
+/// actor (async-only) can't sit on that path.
+final class AdminEventSink: @unchecked Sendable {
+    // @unchecked Sendable: every access to `events` is guarded by `lock`.
+    private let lock = NSLock()
+    private var events: [CapturedEvent] = []
+    private let capacity: Int
+
+    init(capacity: Int = 2000) {
+        self.capacity = max(1, capacity)
+    }
+
+    var bufferCapacity: Int { capacity }
+
+    func record(_ event: CapturedEvent) {
+        lock.lock()
+        defer { lock.unlock() }
+        events.append(event)
+        if events.count > capacity {
+            events.removeFirst(events.count - capacity)
+        }
+    }
+
+    /// A point-in-time copy of the buffer, oldest first.
+    func snapshot() -> [CapturedEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}
+
+// MARK: - Application storage
+
+private struct AdminEventSinkKey: StorageKey {
+    typealias Value = AdminEventSink
+}
+
+extension Application {
+    /// The recent-events ring buffer, installed at startup by the logging
+    /// bootstrap (`runAPIServer`).  Nil in contexts that don't bootstrap it
+    /// (e.g. tests, which set it directly when exercising query_logs).
+    var adminEventSink: AdminEventSink? {
+        get { storage[AdminEventSinkKey.self] }
+        set { storage[AdminEventSinkKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -13,6 +13,7 @@ enum AdminMCPToolCatalog {
             GetMetricsSnapshotTool().erased(),
             GetHealthAlertsTool().erased(),
             GetBrowserDiagnosticsTool().erased(),
+            QueryLogsTool().erased(),
         ])
     }
 }

--- a/Sources/APIServer/MCP/Admin/RingBufferLogHandler.swift
+++ b/Sources/APIServer/MCP/Admin/RingBufferLogHandler.swift
@@ -1,0 +1,67 @@
+// APIServer/MCP/Admin/RingBufferLogHandler.swift
+//
+// A swift-log LogHandler that tees log records into the AdminEventSink so the
+// admin query_logs tool can read recent events.  Multiplexed alongside Vapor's
+// real ConsoleLogger in the logging bootstrap (runAPIServer), so console output
+// is unchanged — this handler only observes.
+//
+// Two safeguards keep the buffer free of student data:
+//   • Capture threshold: only warning+ records are kept (the actionable
+//     diagnostic signal; routine info/observability stays out of the buffer and
+//     is available via the metrics tools instead).
+//   • Metadata redaction: known PII keys are dropped before an event is stored.
+//     Free-text in the message itself can't be guaranteed clean, but warning+
+//     server logs are infrastructure, not student content.
+
+import Foundation
+import Logging
+
+struct RingBufferLogHandler: LogHandler {
+    let label: String
+    let sink: AdminEventSink
+
+    var metadata: Logger.Metadata = [:]
+    var metadataProvider: Logger.MetadataProvider?
+    /// Only warning+ is captured.  As a handler in a MultiplexLogHandler, this
+    /// bounds what the multiplex forwards here, so info/debug never reach the
+    /// buffer; the in-`log` guard is belt-and-suspenders.
+    var logLevel: Logger.Level = .warning
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(event: LogEvent) {
+        guard event.level >= .warning else { return }
+        var merged = self.metadata
+        if let provided = metadataProvider?.get() {
+            merged.merge(provided) { _, new in new }
+        }
+        if let explicit = event.metadata {
+            merged.merge(explicit) { _, new in new }
+        }
+        sink.record(
+            CapturedEvent(
+                timestamp: Date(),
+                level: event.level.rawValue,
+                label: label,
+                message: event.message.description,
+                metadata: Self.redact(merged)))
+    }
+
+    /// Metadata keys dropped before storage — anything that could identify a
+    /// student.  Matched case-insensitively.
+    static let piiKeys: Set<String> = [
+        "user_id", "userid", "submission_id", "submissionid", "username", "email",
+        "actor_username", "student_id", "studentid", "name",
+    ]
+
+    static func redact(_ metadata: Logger.Metadata) -> [String: String] {
+        var out: [String: String] = [:]
+        for (key, value) in metadata where !piiKeys.contains(key.lowercased()) {
+            out[key] = value.description
+        }
+        return out
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/QueryLogsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/QueryLogsTool.swift
@@ -1,0 +1,107 @@
+// APIServer/MCP/Admin/Tools/QueryLogsTool.swift
+//
+// Read tool: query recent server log events (warning+ by default) from the
+// in-process AdminEventSink ring buffer.  The buffer is fed by
+// RingBufferLogHandler with PII metadata already dropped at capture, so this
+// tool exposes infrastructure diagnostics without student identifiers. Filter
+// by minimum level, message substring, and look-back window.
+
+import Core
+import Logging
+import Vapor
+
+struct QueryLogsTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Max entries to return, most-recent first (default 100, clamped 1…500).
+        var limit: Int?
+        /// Minimum level to include ("warning", "error", "critical", …).
+        /// Defaults to everything in the buffer (which is already warning+).
+        var minLevel: String?
+        /// Case-insensitive substring the message must contain.
+        var contains: String?
+        /// Look-back window in minutes (default: the whole buffer).
+        var sinceMinutes: Int?
+    }
+
+    struct Entry: Encodable, Sendable {
+        let timestamp: Date
+        let level: String
+        let label: String
+        let message: String
+        let metadata: [String: String]
+    }
+
+    struct Output: Encodable, Sendable {
+        /// Entries matching the filter, most-recent first (capped by `limit`).
+        let entries: [Entry]
+        /// How many matched before the `limit` cap.
+        let matched: Int
+        /// Ring-buffer capacity, so a caller can tell when history may be truncated.
+        let bufferCapacity: Int
+        /// Operational caveat surfaced to the agent.
+        let note: String
+    }
+
+    static let name = "query_logs"
+    static let description =
+        "Recent server log events (warning and above) from an in-process ring buffer, for "
+        + "diagnosis. Filter by minLevel, a message substring (contains), and sinceMinutes. "
+        + "Returns most-recent-first entries with level, label, message, and PII-redacted "
+        + "metadata. Read-only; the buffer is per-process and resets on restart, and student "
+        + "identifiers are dropped at capture."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "limit": .object([
+                "type": .string("integer"), "description": .string("Max entries (default 100, max 500)."),
+            ]),
+            "minLevel": .object([
+                "type": .string("string"),
+                "description": .string("Minimum level: warning | error | critical."),
+            ]),
+            "contains": .object([
+                "type": .string("string"), "description": .string("Case-insensitive message substring."),
+            ]),
+            "sinceMinutes": .object([
+                "type": .string("integer"), "description": .string("Look-back window in minutes."),
+            ]),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let capacity = context.request.application.adminEventSink?.bufferCapacity ?? 0
+        let all = context.request.application.adminEventSink?.snapshot() ?? []
+
+        let limit = min(max(input.limit ?? 100, 1), 500)
+        let minLevel = input.minLevel.flatMap { Logger.Level(rawValue: $0.lowercased()) }
+        let needle = input.contains?.lowercased()
+        let since = input.sinceMinutes.map { Date().addingTimeInterval(Double(-$0) * 60) }
+
+        let matched =
+            all
+            .filter { event in
+                if let since, event.timestamp < since { return false }
+                if let minLevel, let level = Logger.Level(rawValue: event.level), level < minLevel {
+                    return false
+                }
+                if let needle, !event.message.lowercased().contains(needle) { return false }
+                return true
+            }
+
+        // Most-recent first, capped.
+        let entries = matched.suffix(limit).reversed().map { event in
+            Entry(
+                timestamp: event.timestamp, level: event.level, label: event.label,
+                message: event.message, metadata: event.metadata)
+        }
+
+        return Output(
+            entries: Array(entries),
+            matched: matched.count,
+            bufferCapacity: capacity,
+            note: "In-process ring buffer (warning+); per-process and reset on restart.")
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -4,6 +4,7 @@
 
 import Core
 import Fluent
+import Logging
 import Testing
 import Vapor
 import XCTVapor
@@ -112,6 +113,73 @@ import XCTVapor
             }
         }
     }
+
+    @Test func queryLogsFiltersForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ql-admin", role: "admin")
+            let sink = AdminEventSink(capacity: 100)
+            sink.record(
+                CapturedEvent(
+                    timestamp: Date(), level: "warning", label: "a", message: "disk low",
+                    metadata: ["job_id": "j1"]))
+            sink.record(
+                CapturedEvent(
+                    timestamp: Date(), level: "error", label: "b", message: "runner crashed",
+                    metadata: [:]))
+            app.adminEventSink = sink
+
+            let all = try await QueryLogsTool().execute(.init(), context(subject: "ql-admin"))
+            #expect(all.matched == 2)
+            #expect(all.entries.first?.level == "error")  // most-recent first
+
+            let errorsOnly = try await QueryLogsTool().execute(
+                .init(minLevel: "error"), context(subject: "ql-admin"))
+            #expect(errorsOnly.matched == 1)
+
+            let bySubstring = try await QueryLogsTool().execute(
+                .init(contains: "disk"), context(subject: "ql-admin"))
+            #expect(bySubstring.matched == 1)
+            #expect(bySubstring.entries.first?.message == "disk low")
+        }
+    }
+
+    @Test func queryLogsRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ql-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await QueryLogsTool().execute(.init(), context(subject: "ql-prof"))
+            }
+        }
+    }
+}
+
+// Pure-logic tests for the log ring-buffer handler — no app.
+@Suite struct RingBufferLogHandlerTests {
+    @Test func capturesWarningPlusAndRedactsPII() throws {
+        let sink = AdminEventSink(capacity: 10)
+        let handler = RingBufferLogHandler(label: "test", sink: sink)
+        handler.log(
+            event: LogEvent(
+                level: .warning, message: "boom",
+                metadata: ["user_id": "u1", "job_id": "j1"],
+                source: "s", file: "f", function: "fn", line: 1))
+        let event = try #require(sink.snapshot().first)
+        #expect(event.level == "warning")
+        #expect(event.message == "boom")
+        #expect(event.metadata["job_id"] == "j1")
+        // PII key dropped at capture.
+        #expect(event.metadata["user_id"] == nil)
+    }
+
+    @Test func dropsBelowWarning() {
+        let sink = AdminEventSink(capacity: 10)
+        let handler = RingBufferLogHandler(label: "test", sink: sink)
+        handler.log(
+            event: LogEvent(
+                level: .info, message: "hi", metadata: nil,
+                source: "s", file: "f", function: "fn", line: 1))
+        #expect(sink.snapshot().isEmpty)
+    }
 }
 
 // Pure-logic catalog check — no app, so kept out of the class suite (which would
@@ -122,7 +190,7 @@ import XCTVapor
         #expect(
             names.isSuperset(of: [
                 "get_deployment_info", "get_metrics_snapshot", "get_health_alerts",
-                "get_browser_diagnostics",
+                "get_browser_diagnostics", "query_logs",
             ]))
     }
 }

--- a/changelog.d/admin-mcp-query-logs.md
+++ b/changelog.d/admin-mcp-query-logs.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Admin diagnostic MCP — query_logs (internal).** Completes the read-only
+  admin diagnostic surface (`docs/admin-mcp.md`) with `query_logs`: recent
+  server log events (warning and above) filterable by level, message substring,
+  and look-back window. Backed by a shared in-process `AdminEventSink` ring
+  buffer fed by a `RingBufferLogHandler` multiplexed alongside Vapor's existing
+  console logger — console output is unchanged, PII metadata keys are dropped at
+  capture, and the buffer is per-process and resets on restart. Admin-gated; no
+  database and no new configuration.

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -422,8 +422,14 @@ OAuth and DB-wall work lands.
      check over a window + recent samples with the actual message/stack.
      Admin-gated; the returned DTO omits `user_id` (code-allowlist guarantee),
      asserted by a per-tool PII test. No DB role (§4 decision).
-   - `query_logs` — remaining: an in-memory redacted log ring buffer + the tool
-     to query it (no DB).
+   - `query_logs` ✅ **Done.** Built as a **shared `AdminEventSink`** (bounded
+     in-process ring buffer, per-process / until-restart) fed by a
+     `RingBufferLogHandler` multiplexed alongside Vapor's real `ConsoleLogger`
+     in the logging bootstrap — console output is unchanged. Captures warning+
+     only, drops PII metadata keys at capture. `query_logs` is its first
+     consumer (filter by level / substring / window); future event-driven admin
+     queries reuse the same sink. Graduates to a retention-bounded table if
+     durability / multi-instance history is ever needed.
 
 ---
 


### PR DESCRIPTION
## What & why

The **final tool** of the admin diagnostic MCP surface (`docs/admin-mcp.md`): `query_logs` — recent server log events for diagnosis. Built per your "how does this scale?" steer as a **shared source**, not query_logs-specific plumbing.

## Design

- **`AdminEventSink`** — a bounded in-process ring buffer (per-process, until-restart): the general "recent events" source. `query_logs` is its first consumer; future event-driven admin queries reuse it. Graduates to a retention-bounded table if durability / multi-instance history is ever needed.
- **`RingBufferLogHandler`** — a swift-log `LogHandler` (implements the current `log(event:)` API) **multiplexed alongside Vapor's real `ConsoleLogger`** in the logging bootstrap. Console output is **byte-for-byte unchanged** — I reconstructed the exact handler Vapor's default installs (`ConsoleLogger(label:console:level:)` + `Terminal()`). Captures **warning+ only** and **drops known PII metadata keys at capture**, so the buffer is born clean.
- **`query_logs`** — admin-gated; filter by `minLevel`, message `contains`, `sinceMinutes`; most-recent-first, capped. No DB, no new config.

## The one sensitive change

The logging bootstrap (`APIServerApp.swift`) is the single touch to process-global logging. It's a faithful tee: the multiplex's console element is the *same* `ConsoleLogger`+`Terminal` the default `LoggingSystem.bootstrap(from:)` creates (confirmed against the Vapor source), so prod log output is preserved; the ring handler only observes.

## Safety / tests

- `RingBufferLogHandlerTests`: captures warning+, **redacts PII metadata** (seeded `user_id` dropped), drops below-warning.
- `query_logs` filtering (level / substring) + non-admin rejection; catalog registration. Admin tool tests are `.serialized` (connection-pool safe, per the earlier fix). 11/11 in the suites; build / SwiftLint `--strict` clean.

## This completes the surface

Admin diagnostic tool catalog: `get_deployment_info`, `get_metrics_snapshot`, `get_health_alerts`, `get_browser_diagnostics`, `query_logs` — mounted at `/admin-mcp`, bearer + resource-aware OAuth (`isAdmin`), audited, off by default, no student data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg

---
_Generated by [Claude Code](https://claude.ai/code/session_017taV2MrfqZNZSKvmbNDQWg)_