### PR TITLE
Harden in-browser notebook kernel boot: gate boot, guard submit, recover on dead kernel

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -230,9 +230,13 @@
     //       via the ServiceManager API.  Absence of positive evidence
     //       of *health* (e.g. the kernel is in "Starting" /
     //       "Connecting" state, or the status text isn't visible to
-    //       our probe) is NOT treated as failure.  Phase 2 deadline is
-    //       a maximum after which we silently give up watching (we
-    //       were wrong about a problem; the page is the user's now).
+    //       our probe) is NOT treated as failure.  On the FIRST kernel
+    //       failure we reload the editor iframe once (recovery) — a
+    //       dead/unknown kernel is usually a transient cold-boot race a
+    //       fresh load clears; only a SECOND failure surfaces the upload
+    //       fallback + diagnostic.  Phase 2 deadline is a maximum after
+    //       which we silently give up watching (we were wrong about a
+    //       problem; the page is the user's now).
     //
     // Background: v0.4.149's original probe required positive evidence
     // of kernel health (status text "| Idle" or "| Busy"); v0.4.150 +
@@ -256,11 +260,19 @@
     // phase-1 timeout.
     function armEditorWatchdog() {
         if (!failures) return;
-        const startedAt          = Date.now();
+        let startedAt            = Date.now();
         const shellDeadline      = 60000;
         const kernelMaxObserveMs = 120000;
         let shellLoadedAt = null;
         let cancelled     = false;
+        // One-shot automatic recovery: a kernel that registers `dead` /
+        // `unknown` is almost always a transient cold-boot hiccup
+        // (WASM/IndexedDB/service-worker race) that a fresh editor load
+        // clears.  We reload the iframe ONCE before falling back to the
+        // upload panel.  `recovering` suppresses status noise while the
+        // reloaded shell comes back up.
+        let kernelRecoveryAttempted = false;
+        let recovering              = false;
 
         function tick() {
             if (cancelled) return;
@@ -268,6 +280,13 @@
             const probe = probeIframeReadiness(frame);
             if (probe.shellReady && shellLoadedAt === null) {
                 shellLoadedAt = Date.now();
+                if (recovering) {
+                    // The post-recovery editor is back; clear the transient
+                    // "reloading" status and let the student carry on.
+                    recovering = false;
+                    setStatus('', '');
+                    reenableSubmit();
+                }
             }
 
             // Phase 1: shell never seen
@@ -282,16 +301,37 @@
                 return;
             }
 
-            // Shell loaded.  Phase 2 fires ONLY on positive evidence
-            // the kernel has hit a known failure state.
+            // Shell loaded.  Phase 2 fires ONLY on positive evidence the
+            // kernel has hit a known failure state.  The first time we see
+            // it we reload the editor once (recovery); only a SECOND failure
+            // surfaces the fallback UI + diagnostic.
             if (probe.kernelInFailureState) {
-                cancelled = true;
-                failures.showFailure({
-                    kind:         'watchdog_timeout',
-                    failedChecks: ['kernel-unhealthy'],
-                    source:       'kernel',
-                    message:      probe.kernelEvidence || 'kernel in failure state'
+                const plan = planKernelFailureResponse({
+                    recoveryAlreadyAttempted: kernelRecoveryAttempted,
+                    evidence: probe.kernelEvidence
                 });
+                if (plan.action === 'recover') {
+                    kernelRecoveryAttempted = true;
+                    recovering = true;
+                    setStatus('loading',
+                        'The notebook kernel didn’t start — reloading the editor…');
+                    // Reload from the parent side (cross-origin-safe; the same
+                    // mechanism the locked-path reset uses).  JupyterLite's
+                    // workspace restore re-opens the student's saved copy from
+                    // IndexedDB on boot and the reseed preservation logic keeps
+                    // their work, so this reboots the kernel without discarding
+                    // edits.  `forcedEditorResetAt` keeps the locked-path
+                    // enforcer from fighting our navigation.
+                    forcedEditorResetAt = Date.now();
+                    try { frame.src = editorURL; } catch (_) { /* retry on next tick */ }
+                    // Re-arm both phases for the fresh boot.
+                    startedAt     = Date.now();
+                    shellLoadedAt = null;
+                    setTimeout(tick, 2000);
+                    return;
+                }
+                cancelled = true;
+                failures.showFailure(plan.diagnostic);
                 reenableSubmit();
                 return;
             }
@@ -426,6 +466,36 @@
         } catch (_) { /* fall through */ }
 
         return null;
+    }
+
+    // Decides how the watchdog reacts to POSITIVE EVIDENCE that the kernel is
+    // in a failure state (`dead` / `unknown` session, or the "Kernel Unknown"
+    // badge).  Pure so it's unit-testable; the caller performs the reload /
+    // showFailure side effects.
+    //
+    //   * First failure  → 'recover': reload the editor once.  A dead/unknown
+    //                      kernel is usually a transient cold-boot race that a
+    //                      fresh load clears, so we retry before giving up.
+    //   * Second failure → 'fail': the reload didn't help.  Surface the upload
+    //                      fallback and report the diagnostic, with the message
+    //                      annotated so telemetry can distinguish a persistent
+    //                      kernel failure from a first-try one.  The kind /
+    //                      failedChecks / source are unchanged so the admin
+    //                      browser-diagnostics breakdown keeps classifying it.
+    function planKernelFailureResponse({ recoveryAlreadyAttempted, evidence }) {
+        if (!recoveryAlreadyAttempted) {
+            return { action: 'recover' };
+        }
+        const reason = evidence || 'kernel in failure state';
+        return {
+            action: 'fail',
+            diagnostic: {
+                kind:         'watchdog_timeout',
+                failedChecks: ['kernel-unhealthy'],
+                source:       'kernel',
+                message:      reason + ' (persisted after auto-reload)'
+            }
+        };
     }
 
     // Hard fallback: if the notebook hasn't synced within 15 seconds (e.g. the
@@ -1385,6 +1455,7 @@
             parseStructuredPayload,
             probeIframeReadiness,
             kernelFailureEvidence,
+            planKernelFailureResponse,
             shouldForceReseed,
             reseedPlan,
         };

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -72,6 +72,12 @@
     let forcedEditorResetAt = 0;
     let serverSyncInFlight = false;
     let serverSyncComplete = false;
+    // True once the JupyterLite editor shell is up (the watchdog's reliable
+    // shell-ready signal). The browser-grading submit path waits on this so a
+    // submit clicked during a cold boot can't kick off a SECOND Pyodide
+    // (browser grading runs its own, separate from the editor kernel) that
+    // starves the still-booting kernel — the kernel-unhealthy race.
+    let editorReady = false;
 
     // Capability preflight: gate iframe mounting on the browser actually
     // supporting JupyterLite + Pyodide.  If the preflight module isn't
@@ -259,7 +265,12 @@
     // navigation, transient cross-origin error), we don't regress to a
     // phase-1 timeout.
     function armEditorWatchdog() {
-        if (!failures) return;
+        if (!failures) {
+            // No preflight/watchdog supervision (legacy cached page): don't
+            // gate the submit path on a readiness signal that will never fire.
+            markEditorReady();
+            return;
+        }
         let startedAt            = Date.now();
         const shellDeadline      = 60000;
         const kernelMaxObserveMs = 120000;
@@ -280,6 +291,10 @@
             const probe = probeIframeReadiness(frame);
             if (probe.shellReady && shellLoadedAt === null) {
                 shellLoadedAt = Date.now();
+                // Editor shell is up. Unblock the browser-grading submit path
+                // (it waits on this so it won't race a second Pyodide against
+                // the kernel's cold boot).
+                markEditorReady();
                 if (recovering) {
                     // The post-recovery editor is back; clear the transient
                     // "reloading" status and let the student carry on.
@@ -427,6 +442,32 @@
         }
     }
 
+    // Editor-readiness gate for the browser-grading submit path (see the
+    // `editorReady` declaration). Idempotent; the watchdog flips it on the
+    // editor shell's first appearance. Deliberately does NOT enable Submit —
+    // that stays gated on the notebook sync so a blank notebook can't be
+    // submitted before the student's work loads.
+    function markEditorReady() {
+        editorReady = true;
+    }
+
+    // Resolves once the editor shell is ready, or after `timeoutMs` so a dead
+    // editor never blocks submission forever (browser grading still runs in its
+    // own Pyodide regardless). Polls because readiness is observed by the
+    // watchdog tick. Resolves immediately in the common case (editor long
+    // since ready by the time the student clicks Submit).
+    function awaitEditorReady(timeoutMs) {
+        if (editorReady) return Promise.resolve(true);
+        return new Promise((resolve) => {
+            const started = Date.now();
+            (function poll() {
+                if (editorReady) { resolve(true); return; }
+                if (Date.now() - started >= timeoutMs) { resolve(false); return; }
+                setTimeout(poll, 200);
+            })();
+        });
+    }
+
     // Returns a short evidence string iff we have POSITIVE EVIDENCE the
     // kernel has hit a known failure state, or null otherwise.  Used by the
     // watchdog to decide whether to fire phase-2 ("kernel-unhealthy") and to
@@ -527,6 +568,16 @@
                 if (gradingMode === 'browser') {
                     if (!window.BrowserRunner || typeof window.BrowserRunner.runAndSubmit !== 'function') {
                         throw new Error('Browser grading is unavailable right now. Please reload and try again.');
+                    }
+                    // Browser grading runs its own Pyodide, separate from the
+                    // editor kernel. Don't start it while the kernel is still
+                    // cold-booting — that contention is what leaves the kernel
+                    // dead/unknown. Wait for the editor shell first; resolves
+                    // immediately once ready (the common case) and is bounded so
+                    // a genuinely dead editor still degrades to grading here.
+                    if (!editorReady) {
+                        setStatus('loading', 'Waiting for the editor to finish loading…');
+                        await awaitEditorReady(45000);
                     }
                     // Browser-graded lab: run tests locally in Pyodide then submit atomically.
                     const { outcomes } = await submitBrowserNotebook(notebook, setupID);

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -61,6 +61,13 @@ Notebook
         assignment on a larger screen to edit and submit your notebook.
     </p>
 </div>
+<!-- The editor is booted by notebook.js *after* the capability preflight
+     resolves (mountEditor sets the iframe src from data-editor-url), not
+     eagerly here. Booting eagerly during HTML parse raced the preflight's
+     service-worker registration and IndexedDB probes — the same subsystems the
+     kernel's cold boot uses — and intermittently left the kernel dead
+     ("Kernel Unknown"). Starting at about:blank serializes the load. On phones
+     notebook.js skips the mount entirely, so the iframe stays about:blank. -->
 <iframe
     id="jl-frame"
     class="jl-frame"
@@ -71,22 +78,9 @@ Notebook
     data-editor-url="#(jupyterLiteEditorURL)"
     data-working-copy-mtime="#(workingCopyMtime)"
     data-read-only="#(isClosed)"
-    src="#(jupyterLiteEditorURL)"
+    src="about:blank"
     loading="eager">
 </iframe>
-<script>
-// On phones the editor is hidden behind the "larger screen" notice above,
-// but display:none does not stop the iframe from booting JupyterLite +
-// Pyodide in the background. Abort that navigation immediately after the
-// parser starts it; notebook.js skips mounting at this width and reloads
-// the page if the viewport grows past the breakpoint.
-(function () {
-    if (window.matchMedia && window.matchMedia('(max-width: 640px)').matches) {
-        var frame = document.getElementById('jl-frame');
-        if (frame) frame.src = 'about:blank';
-    }
-})();
-</script>
 <section id="nb-fallback" class="nb-fallback" role="alert" hidden>
     <h2 class="nb-fallback-title">Editor didn&rsquo;t load</h2>
     <p class="nb-fallback-text">

--- a/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
+++ b/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
@@ -384,3 +384,49 @@ test('probeIframeReadiness: kernel failure surfaces evidence string', async () =
   assert.equal(r.kernelInFailureState, true);
   assert.equal(r.kernelEvidence, 'Kernel Unknown badge (iframe dom)');
 });
+
+// ----------------------------------------------------------------
+// One-shot kernel recovery — first failure reloads, second gives up
+// ----------------------------------------------------------------
+
+test('planKernelFailureResponse: first failure → recover (reload once)', async () => {
+  const { planKernelFailureResponse } = await loadHarness();
+  const plan = planKernelFailureResponse({
+    recoveryAlreadyAttempted: false,
+    evidence: 'kernel status: dead',
+  });
+  assert.equal(plan.action, 'recover');
+  assert.equal(plan.diagnostic, undefined,
+    'a recovery does not post a diagnostic — the editor gets one more chance');
+});
+
+test('planKernelFailureResponse: second failure → fail with annotated diagnostic', async () => {
+  const { planKernelFailureResponse } = await loadHarness();
+  const plan = planKernelFailureResponse({
+    recoveryAlreadyAttempted: true,
+    evidence: 'kernel status: dead',
+  });
+  assert.equal(plan.action, 'fail');
+  // The classification fields must be unchanged so the admin browser-diagnostics
+  // breakdown still buckets this as watchdog_timeout / kernel-unhealthy.
+  assert.equal(plan.diagnostic.kind, 'watchdog_timeout');
+  // Element-wise (the helper runs in a vm realm, so its Array isn't
+  // reference-comparable with deepStrictEqual against the test realm's).
+  assert.equal(plan.diagnostic.failedChecks.length, 1);
+  assert.equal(plan.diagnostic.failedChecks[0], 'kernel-unhealthy');
+  assert.equal(plan.diagnostic.source, 'kernel');
+  assert.ok(plan.diagnostic.message.includes('kernel status: dead'),
+    'keeps the original evidence');
+  assert.ok(plan.diagnostic.message.includes('after auto-reload'),
+    'annotates that recovery was attempted so persistent failures are distinguishable');
+});
+
+test('planKernelFailureResponse: second failure with no evidence → safe default message', async () => {
+  const { planKernelFailureResponse } = await loadHarness();
+  const plan = planKernelFailureResponse({
+    recoveryAlreadyAttempted: true,
+    evidence: null,
+  });
+  assert.equal(plan.action, 'fail');
+  assert.equal(plan.diagnostic.message, 'kernel in failure state (persisted after auto-reload)');
+});

--- a/changelog.d/kernel-recovery-reload.md
+++ b/changelog.d/kernel-recovery-reload.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **In-browser notebook editor now recovers from a dead kernel instead of
+  giving up.** When the JupyterLite/Pyodide kernel registers `dead`/`unknown`
+  at boot — a transient cold-boot race (WASM/IndexedDB/service-worker) that hit
+  a small fraction of sessions during a deadline rush — the editor watchdog
+  reloads the iframe once before falling back to the upload panel. The reload
+  re-boots the kernel while preserving the student's saved work (JupyterLite
+  workspace restore + the existing reseed-preservation logic). A kernel failure
+  that persists after the reload still surfaces the fallback UI and is reported
+  with the same `watchdog_timeout` / `kernel-unhealthy` classification, now
+  annotated (`persisted after auto-reload`) so the admin browser-diagnostics
+  breakdown can tell a persistent failure from a recoverable first-try one.

--- a/changelog.d/kernel-recovery-reload.md
+++ b/changelog.d/kernel-recovery-reload.md
@@ -1,13 +1,24 @@
 ### Fixed
 
-- **In-browser notebook editor now recovers from a dead kernel instead of
-  giving up.** When the JupyterLite/Pyodide kernel registers `dead`/`unknown`
-  at boot — a transient cold-boot race (WASM/IndexedDB/service-worker) that hit
-  a small fraction of sessions during a deadline rush — the editor watchdog
-  reloads the iframe once before falling back to the upload panel. The reload
-  re-boots the kernel while preserving the student's saved work (JupyterLite
-  workspace restore + the existing reseed-preservation logic). A kernel failure
-  that persists after the reload still surfaces the fallback UI and is reported
-  with the same `watchdog_timeout` / `kernel-unhealthy` classification, now
-  annotated (`persisted after auto-reload`) so the admin browser-diagnostics
-  breakdown can tell a persistent failure from a recoverable first-try one.
+- **Hardened the in-browser notebook editor against intermittent dead-kernel
+  ("Kernel Unknown") boots.** A small, steady fraction of students hit a
+  JupyterLite/Pyodide kernel that registered `dead`/`unknown` at startup — a
+  load-ordering race, not a content bug. Three layers address it:
+  - **Boot gating (root cause).** The editor iframe no longer boots eagerly from
+    the template `src`. JupyterLite now starts only after the capability
+    preflight resolves (`mountEditor` sets the src), so the kernel's cold boot
+    no longer races the preflight's concurrent service-worker registration and
+    IndexedDB probes — the same subsystems kernel startup depends on.
+  - **Submit guard.** Browser grading runs its own Pyodide, separate from the
+    editor kernel; the submit path now waits for the editor shell before
+    starting it, so a submit clicked during a cold boot can't spin up a second
+    Pyodide and starve the still-booting kernel. The wait is bounded, so a
+    genuinely dead editor still degrades to grading.
+  - **Recovery reload (safety net).** If the kernel still registers
+    `dead`/`unknown`, the watchdog reloads the editor once before falling back
+    to the upload panel, preserving the student's saved work (workspace restore
+    + the existing reseed-preservation logic). A failure that persists after the
+    reload is reported with the same `watchdog_timeout` / `kernel-unhealthy`
+    classification, annotated `persisted after auto-reload` so the admin
+    browser-diagnostics breakdown can distinguish it from a recoverable
+    first-try failure.


### PR DESCRIPTION
## What & why

Admin browser-diagnostics showed `watchdog_timeout` / `kernel-unhealthy` ("Kernel Unknown") reports trickling in for weeks — a small, steady fraction of student sessions where the in-browser JupyterLite/Pyodide kernel registers `dead`/`unknown` at startup. Intermittent, across every browser/OS, worse under load (deadline rushes). That's the signature of a **load-ordering race**, not a content or single-browser bug — confirmed by inspecting the affected assignment's notebook (clean) and the boot path.

This PR fixes it in three layers — root cause, a targeted guard, and a safety net.

### 1. Boot gating (root cause)
The editor iframe was booted **eagerly** from the template `src` during HTML parse (`Resources/Views/notebook.leaf`), *before* the supervisor scripts even load. So the kernel's cold boot ran **concurrently with the preflight's service-worker registration and IndexedDB probes** (`notebook-preflight.js`) — the exact subsystems kernel startup depends on. The "preflight gate" was therefore illusory and the watchdog armed late.

Fix: the template now renders `src="about:blank"`; JupyterLite is mounted by `notebook.js` **after** the preflight resolves (`mountEditor` sets the src from `data-editor-url`). This serializes the load so the preflight's SW/IndexedDB churn finishes before the kernel touches those subsystems. The now-redundant phone-guard inline script is removed (`notebook.js` already skips the mount on phones, so the iframe stays `about:blank`). Cost: ~0.1–0.3 s later editor start, trivial next to a multi-second Pyodide load.

### 2. Submit guard
Browser grading runs its **own** Pyodide in the parent page, separate from the editor kernel (`browser-runner.js` `loadPyodideOnce`, lazy on submit). A submit clicked during a cold boot spins up that second Pyodide and starves the still-booting kernel. The submit path now waits for the editor shell (the watchdog's reliable shell-ready signal) before starting browser grading. Bounded (45 s) so a genuinely dead editor still degrades to grading in the parent context; submit-enable stays gated on notebook sync, so this doesn't reintroduce blank submissions.

### 3. Recovery reload (safety net)
If the kernel still registers `dead`/`unknown`, the watchdog reloads the editor **once** before falling back to the upload panel, preserving the student's saved work (JupyterLite workspace restore + the existing reseed-preservation logic). A failure that persists after the reload is reported with the same `watchdog_timeout` / `kernel-unhealthy` classification, annotated `persisted after auto-reload` so the admin breakdown can distinguish it from a recoverable first-try failure. The recovery decision is a pure, unit-tested `planKernelFailureResponse` helper.

## Ruled out (investigation over-weighted these)
- **Service-worker-manager race** — JupyterLite's SW manager is already disabled (`Tools/jupyterlite/jupyter-lite.json`), so the kernel doesn't depend on a SW; a leftover preflight SW can't re-enable it.
- **COOP/COEP** — correctly scoped (deliberately not set on the notebook page; strict isolation only on `/validate`). Not the cause.
- **Workspace-restore vs server-sync** — real, but a *content-staleness* bug (stale notebook shown), a different symptom from kernel death.

## Tests
- New regression tests in `Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs` for `planKernelFailureResponse` (first failure → recover; second → fail with classification preserved + annotation; no-evidence default).
- Full `node --test Tests/BrowserRunnerJSTests/*.mjs` green (81). `notebook.js` syntax-checks clean; `scripts/check-styles.sh` + `check-css-vars` green for the Leaf change.

## Scope / risk
- Client JS + one Leaf template; no server, schema, or grading-path changes.
- Recovery is one-shot (cannot loop); on any non-recoverable path the student still lands on the existing upload fallback.
- The iframe-reload and boot-gating UX is JS-driven, so the render tests prove the templates resolve but **one manual smoke test in a real browser** (open a browser-graded notebook; confirm the editor mounts after preflight and Submit works) is worth doing before merge.

## Context
Surfaced while diagnosing browser errors via the admin diagnostics MCP. The content/diagnostics MCP outage that kicked this off was operational (the `chickadee_mcp` Postgres role didn't exist → dedicated MCP pool failed `28P01` auth) and was fixed by provisioning the role — no code change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017s4RGziCcwRwK1S8W9c9UE