### PR TITLE
Expand the admin diagnostic MCP surface (dashboards + operational views)

### DIFF
--- a/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
@@ -31,12 +31,34 @@ enum AdminMCPServerInstructions {
         metrics, browser-error reports, and logs to diagnose problems — then \
         propose fixes as code, outside this surface.
 
-        Time-series ("sparkline") data behind the dashboards is also available: \
-        get_metrics_card_series (the operational cards — queue depth, jobs \
-        processed, load, p95 wait/execution), get_active_users_series (distinct \
-        active users per bucket), and get_instructor_card_series (one course's \
-        submission/active-student/active-assignment/browser-error counts, scoped \
-        by an explicit courseCode filter — still aggregate counts only, never a \
-        student identifier).
+        What's available, by area:
+        - Deployment: get_deployment_info (version + capability surface).
+        - Runners: list_runners (the fleet) and get_runner_detail (one runner's \
+        capability profile + aggregate per-stage timing + cache-hit rate + \
+        recent snapshots — never the per-job rows).
+        - Queue: get_queue_state (pending depth, in-flight, oldest-pending age, \
+        stuck-submission count).
+        - Metrics: get_metrics_snapshot (point-in-time), get_metrics_card_series \
+        (the dashboard's fixed 24h/7d/30d sparklines), get_metrics_timeseries \
+        (a flexible window/bucket, including HTTP request latency), and \
+        get_request_metrics (slowest routes / status-class counts).
+        - Activity: get_active_users_series (distinct active users per bucket); \
+        get_instructor_card_series (one course's submission / active-student / \
+        active-assignment / browser-error counts, scoped by an explicit \
+        courseCode filter).
+        - Errors & logs: get_browser_diagnostics, query_logs, get_health_alerts.
+        - Storage: get_storage_usage (footprint by component + per-assignment).
+        - Integrations & security: list_connected_agents (MCP OAuth grants), \
+        get_brightspace_sync_status (grade-push health), query_audit_log \
+        (activity COUNTS by action/category only).
+
+        Every one of these returns aggregates or redacted records by \
+        construction — never a student identity, grade, submission content, or \
+        enrollment. Where a source table carries such data (browser \
+        diagnostics, brightspace sync, the audit log, per-job metrics), the tool \
+        omits it: query_audit_log returns counts only (no actor/IP/metadata), \
+        get_brightspace_sync_status drops the student username and grade, and \
+        get_runner_detail exposes only aggregate timing, not the per-job rows \
+        the web page shows.
         """
 }

--- a/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
@@ -30,5 +30,13 @@ enum AdminMCPServerInstructions {
         Use the tools to inspect deployment health, runner/queue state, server \
         metrics, browser-error reports, and logs to diagnose problems — then \
         propose fixes as code, outside this surface.
+
+        Time-series ("sparkline") data behind the dashboards is also available: \
+        get_metrics_card_series (the operational cards — queue depth, jobs \
+        processed, load, p95 wait/execution), get_active_users_series (distinct \
+        active users per bucket), and get_instructor_card_series (one course's \
+        submission/active-student/active-assignment/browser-error counts, scoped \
+        by an explicit courseCode filter — still aggregate counts only, never a \
+        student identifier).
         """
 }

--- a/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
@@ -31,6 +31,19 @@ enum AdminMCPServerInstructions {
         metrics, browser-error reports, and logs to diagnose problems — then \
         propose fixes as code, outside this surface.
 
+        Getting started:
+        - Call get_deployment_info first to confirm the surface is live and see \
+        the version it's running.
+        - A typical flow is "is anything wrong?" (get_health_alerts) → "show me \
+        the underlying numbers" (get_queue_state / list_runners / get_metrics_*) \
+        → "what was logged?" (query_logs / get_browser_diagnostics). Each tool's \
+        own description says exactly what it returns and when to prefer it over a \
+        neighbour.
+        - For trends over time, prefer get_metrics_card_series (the fixed \
+        dashboard windows) or get_metrics_timeseries (an arbitrary window, plus \
+        HTTP request latency); get_metrics_snapshot is the single point-in-time \
+        number. tools/list only shows the tools your grant's scope covers.
+
         What's available, by area:
         - Deployment: get_deployment_info (version + capability surface).
         - Runners: list_runners (the fleet) and get_runner_detail (one runner's \

--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -11,6 +11,9 @@ enum AdminMCPToolCatalog {
         DiagnosticToolRegistry([
             GetDeploymentInfoTool().erased(),
             GetMetricsSnapshotTool().erased(),
+            GetMetricsCardSeriesTool().erased(),
+            GetActiveUsersSeriesTool().erased(),
+            GetInstructorCardSeriesTool().erased(),
             GetHealthAlertsTool().erased(),
             GetBrowserDiagnosticsTool().erased(),
             QueryLogsTool().erased(),

--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -12,11 +12,20 @@ enum AdminMCPToolCatalog {
             GetDeploymentInfoTool().erased(),
             GetMetricsSnapshotTool().erased(),
             GetMetricsCardSeriesTool().erased(),
+            GetMetricsTimeseriesTool().erased(),
             GetActiveUsersSeriesTool().erased(),
             GetInstructorCardSeriesTool().erased(),
+            GetQueueStateTool().erased(),
+            ListRunnersTool().erased(),
+            GetRunnerDetailTool().erased(),
+            GetStorageUsageTool().erased(),
+            GetRequestMetricsTool().erased(),
             GetHealthAlertsTool().erased(),
             GetBrowserDiagnosticsTool().erased(),
+            ListConnectedAgentsTool().erased(),
+            GetBrightSpaceSyncStatusTool().erased(),
             QueryLogsTool().erased(),
+            QueryAuditLogTool().erased(),
         ])
     }
 }

--- a/Sources/APIServer/MCP/Admin/Tools/GetActiveUsersSeriesTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetActiveUsersSeriesTool.swift
@@ -1,0 +1,58 @@
+// APIServer/MCP/Admin/Tools/GetActiveUsersSeriesTool.swift
+//
+// Read tool: the time-series data behind the admin dashboard's "Active Users"
+// chart — distinct active users per time bucket over a trailing window.  Wraps
+// the same builder the dashboard polls (`GET /admin/activity`,
+// `ActivityChartService.chartData`).  Returns per-bucket DISTINCT COUNTS only —
+// never a user identifier.
+
+import Core
+import Vapor
+
+struct GetActiveUsersSeriesTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Window token: "24h" (24 hourly buckets), "1w" (7 daily buckets), or
+        /// "1m" (30 daily buckets). Defaults to "24h".
+        var window: String?
+    }
+
+    /// The existing dashboard chart payload, reused verbatim — distinct-user
+    /// counts per bucket only, no identifiers.
+    typealias Output = ActivityChartData
+
+    static let name = "get_active_users_series"
+    static let description =
+        "Time-series data behind the admin dashboard's \"Active Users\" chart: distinct active users "
+        + "per time bucket over a trailing window. Optional window: \"24h\" (24 hourly buckets, the "
+        + "default), \"1w\" (7 daily buckets), or \"1m\" (30 daily buckets). Each bucket carries a "
+        + "label, an ISO-8601 start, and the distinct-user count. Read-only; per-bucket distinct "
+        + "counts only — no user identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "window": .object([
+                "type": .string("string"),
+                "enum": .array([.string("24h"), .string("1w"), .string("1m")]),
+                "description": .string("Trailing window: 24h (default), 1w, or 1m."),
+            ])
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let window: ActivityWindow
+        if let raw = input.window, !raw.isEmpty {
+            guard let parsed = ActivityWindow(rawValue: raw) else {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name, detail: "Unknown window '\(raw)'. Use 24h, 1w, or 1m.")
+            }
+            window = parsed
+        } else {
+            window = .day
+        }
+
+        return try await ActivityChartService.chartData(window: window, on: context.db)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrightSpaceSyncStatusTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrightSpaceSyncStatusTool.swift
@@ -1,0 +1,108 @@
+// APIServer/MCP/Admin/Tools/GetBrightSpaceSyncStatusTool.swift
+//
+// Read tool: BrightSpace grade-sync health — counts by status (success / error
+// / skipped) over a window plus recent ERROR samples carrying the D2L API error
+// detail, so an agent can tell whether grade pushes are failing and why.
+//
+// PII boundary (code allowlist): brightspace_sync_log is the most PII-laden
+// diagnostic source — it stores a student `username` + the pushed `points`
+// (a grade) per row. The returned DTO is hand-built and DELIBERATELY OMITS
+// username, points, and user_id. It keeps only the status, the D2L error
+// detail (infrastructure text), the test-setup id + assignment title
+// (instructor content), the org-unit id, and the timestamp. Asserted by a
+// per-tool PII test.
+
+import Core
+import Fluent
+import Vapor
+
+struct GetBrightSpaceSyncStatusTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Look-back window in hours (default 168 = 7 days; clamped 1…720).
+        var windowHours: Int?
+        /// Max recent error samples to return (default 20; clamped 1…100).
+        var sampleLimit: Int?
+    }
+
+    struct CountEntry: Encodable, Sendable {
+        let key: String
+        let count: Int
+    }
+
+    /// A failed grade-push, redacted: no username, points, or user_id.
+    struct ErrorSample: Encodable, Sendable {
+        let detail: String?
+        let testSetupID: String
+        let assignmentTitle: String
+        let orgUnitID: String?
+        let attemptedAt: Date
+    }
+
+    struct Output: Encodable, Sendable {
+        let windowHours: Int
+        let total: Int
+        let byStatus: [CountEntry]
+        let recentErrors: [ErrorSample]
+    }
+
+    static let name = "get_brightspace_sync_status"
+    static let description =
+        "BrightSpace grade-sync health: totals and counts by status (success / error / skipped) over "
+        + "a window, plus recent ERROR samples carrying the D2L API error detail. Use it to tell "
+        + "whether grade pushes are failing and why. Optional windowHours (default 168, max 720) and "
+        + "sampleLimit. Read-only; the per-row student username and pushed grade (points) are "
+        + "deliberately omitted — only status, error detail, assignment/test-setup, org unit, and "
+        + "timestamp are returned."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "windowHours": .object([
+                "type": .string("integer"),
+                "description": .string("Look-back window in hours (default 168, max 720)."),
+            ]),
+            "sampleLimit": .object([
+                "type": .string("integer"),
+                "description": .string("Max recent error samples (default 20, max 100)."),
+            ]),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let windowHours = min(max(input.windowHours ?? 168, 1), 720)
+        let sampleLimit = min(max(input.sampleLimit ?? 20, 1), 100)
+        let since = Date().addingTimeInterval(Double(-windowHours) * 3600)
+
+        let rows = try await APIBrightSpaceSyncLog.query(on: context.db)
+            .filter(\.$attemptedAt >= since)
+            .sort(\.$attemptedAt, .descending)
+            .all()
+
+        var byStatus: [String: Int] = [:]
+        for row in rows {
+            byStatus[row.status, default: 0] += 1
+        }
+
+        let recentErrors =
+            rows
+            .filter { $0.status == APIBrightSpaceSyncLog.Status.error.rawValue }
+            .prefix(sampleLimit)
+            .map { row in
+                ErrorSample(
+                    detail: row.detail,
+                    testSetupID: row.testSetupID,
+                    assignmentTitle: row.assignmentTitle,
+                    orgUnitID: row.orgUnitID,
+                    attemptedAt: row.attemptedAt ?? Date())
+            }
+
+        return Output(
+            windowHours: windowHours,
+            total: rows.count,
+            byStatus: byStatus.map { CountEntry(key: $0.key, count: $0.value) }
+                .sorted { ($0.count, $1.key) > ($1.count, $0.key) },
+            recentErrors: Array(recentErrors))
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetInstructorCardSeriesTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetInstructorCardSeriesTool.swift
@@ -1,0 +1,97 @@
+// APIServer/MCP/Admin/Tools/GetInstructorCardSeriesTool.swift
+//
+// Read tool: the time-series (sparkline) data behind the instructor dashboard's
+// four diagnostic cards for one course — submissions, active students, active
+// assignments, and browser errors — across all three windows (24h / 7d / 30d).
+// Wraps the same builder the instructor dashboard polls
+// (`GET /instructor/metrics/cards`, `instructorCardSeries`), scoped to the
+// course identified by `courseCode`.
+//
+// PII boundary (code allowlist — the shipped guarantee, no DB role): the
+// instructor surface is course-scoped by the human's enrollment; this admin
+// surface is deployment-wide, so the tool takes the course code as an explicit
+// query filter rather than a session. The returned payload is PER-BUCKET COUNTS
+// only — submissions, distinct-student COUNT, distinct-assignment COUNT, and
+// browser-error count — never a student identifier. The enrolled-student / setup
+// lookup is an internal scoping step; no identity reaches the output, asserted
+// by a per-tool PII test.
+
+import Core
+import Fluent
+import Vapor
+
+struct GetInstructorCardSeriesTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// The course to scope the series to (e.g. "CS136"). Matched
+        /// case-insensitively against active (non-archived) courses.
+        var courseCode: String
+    }
+
+    /// The existing dashboard sparkline payload, reused verbatim — aggregate
+    /// per-bucket counts only, no row-level identifiers.
+    typealias Output = InstructorCardSeriesResponse
+
+    static let name = "get_instructor_card_series"
+    static let description =
+        "Time-series (sparkline) data behind the instructor dashboard's four cards for one course: "
+        + "per-bucket student submissions, active students (distinct count), active assignments "
+        + "(distinct count), and browser errors. Requires courseCode (e.g. \"CS136\", matched "
+        + "case-insensitively). Returns every selectable window in one payload (24h = 24 hourly "
+        + "buckets, 7d = 28 six-hour buckets, 30d = 30 daily buckets), each with bucket labels, a "
+        + "headline, and the per-bucket series. Read-only; aggregate counts only — no student "
+        + "identities, grades, or submission contents."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "courseCode": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Course code to scope the series to, e.g. \"CS136\" (case-insensitive)."),
+            ])
+        ]),
+        "required": .array([.string("courseCode")]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let code = input.courseCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !code.isEmpty else {
+            throw MCPToolError.invalidArguments(tool: Self.name, detail: "courseCode must not be empty.")
+        }
+        guard
+            let course = try await findActiveCourse(byCode: code, on: context.db),
+            let courseUUID = course.id
+        else {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name, detail: "No active course with code '\(code)'.")
+        }
+
+        let setupIDs = try await APITestSetup.query(on: context.db)
+            .filter(\.$courseID == courseUUID)
+            .all()
+            .compactMap(\.id)
+
+        let studentIDs = try await enrolledStudentIDs(courseUUID: courseUUID, on: context.db)
+
+        return try await context.request.application.diagnostics.instructorCardSeries(
+            setupIDs: setupIDs, studentIDs: studentIDs, on: context.db)
+    }
+
+    /// The course's enrolled students, matching the instructor dashboard's
+    /// scoping (`InstructorDashboardRoutes+Cards`).  Empty when the course has
+    /// no enrollments.
+    private func enrolledStudentIDs(courseUUID: UUID, on db: any Database) async throws -> Set<UUID> {
+        let enrolledUserIDs = try await APICourseEnrollment.query(on: db)
+            .filter(\.$course.$id == courseUUID)
+            .all()
+            .map(\.userID)
+        guard !enrolledUserIDs.isEmpty else { return [] }
+        let students = try await APIUser.query(on: db)
+            .filter(\.$role == UserRole.student.rawValue)
+            .filter(\.$id ~~ enrolledUserIDs)
+            .all()
+        return Set(students.compactMap(\.id))
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetMetricsCardSeriesTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetMetricsCardSeriesTool.swift
@@ -1,0 +1,42 @@
+// APIServer/MCP/Admin/Tools/GetMetricsCardSeriesTool.swift
+//
+// Read tool: the time-series (sparkline) data behind the admin dashboard's five
+// operational diagnostic cards — max queue depth, jobs processed, max load,
+// p95 queue wait, and p95 execution — across all three selectable windows
+// (24h / 7d / 30d).  Wraps the same builder the dashboard polls
+// (`GET /admin/metrics/cards`, `metricsCardSeries`): per-bucket counts,
+// percentiles, and utilisation only — no user, submission, course, or
+// assignment identifiers.  This is the windowed series behind
+// `get_metrics_snapshot`'s point-in-time numbers.
+
+import Core
+import Vapor
+
+struct GetMetricsCardSeriesTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    /// The existing dashboard sparkline payload, reused verbatim — aggregate
+    /// per-bucket series only, no row-level identifiers.
+    typealias Output = MetricsCardSeriesResponse
+
+    static let name = "get_metrics_card_series"
+    static let description =
+        "Time-series (sparkline) data behind the admin dashboard's five operational cards: per-bucket "
+        + "max queue depth, jobs processed, max load (peak utilization %), p95 queue-wait ms, and p95 "
+        + "execution ms. Returns every selectable window in one payload (24h = 24 hourly buckets, "
+        + "7d = 28 six-hour buckets, 30d = 30 daily buckets), each with bucket labels, a headline, and "
+        + "the per-bucket series (a nil entry means no data in that bucket). This is the windowed "
+        + "series behind get_metrics_snapshot's point-in-time numbers — use it to see how throughput, "
+        + "queue pressure, and latency trend over time. Read-only; aggregates only — no student, "
+        + "submission, course, or assignment identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+        return try await context.request.application.diagnostics.metricsCardSeries(on: context.db)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetMetricsTimeseriesTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetMetricsTimeseriesTool.swift
@@ -1,0 +1,59 @@
+// APIServer/MCP/Admin/Tools/GetMetricsTimeseriesTool.swift
+//
+// Read tool: the flexible-window operational time-series — per-bucket runner
+// utilisation, request count + P95 latency, completed jobs, test status counts,
+// and queue-wait/execution P95 over an arbitrary window/bucket size.  Wraps the
+// same builder the admin dashboard's /admin/metrics/timeseries endpoint serves
+// (`metricsTimeSeriesSnapshot`): bucketed aggregates only — no user, submission,
+// course, or assignment identifiers.  Where get_metrics_card_series is fixed to
+// the dashboard's three sparkline windows, this lets an agent zoom into a
+// specific window (e.g. "the last 6 hours in 15-minute buckets") to correlate a
+// latency or error spike.
+
+import Core
+import Vapor
+
+struct GetMetricsTimeseriesTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Trailing window in hours (clamped server-side; defaults to the
+        /// configured recent-metrics window, typically 24).
+        var hours: Int?
+        /// Bucket width in minutes (clamped server-side to a sane range).
+        var bucketMinutes: Int?
+    }
+
+    /// The existing dashboard time-series payload, reused verbatim — bucketed
+    /// aggregates only, no row-level identifiers.
+    typealias Output = InternalMetricsTimeSeriesResponse
+
+    static let name = "get_metrics_timeseries"
+    static let description =
+        "Flexible-window operational time-series: per-bucket avg/max runner utilization, active "
+        + "runners, request count + P95 latency, completed jobs, test status counts (passed/failed/"
+        + "error/timeout), and queue-wait/execution P95. Optional hours (trailing window) and "
+        + "bucketMinutes (bucket width) — both clamped server-side; omit for the configured default "
+        + "(~24h). Unlike get_metrics_card_series (fixed 24h/7d/30d sparkline windows), this zooms "
+        + "into an arbitrary window to correlate a latency or error spike, and it's the only tool that "
+        + "surfaces HTTP request latency. Read-only; bucketed aggregates only — no student, "
+        + "submission, course, or assignment identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "hours": .object([
+                "type": .string("integer"),
+                "description": .string("Trailing window in hours (clamped server-side)."),
+            ]),
+            "bucketMinutes": .object([
+                "type": .string("integer"),
+                "description": .string("Bucket width in minutes (clamped server-side)."),
+            ]),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+        return try await context.request.application.diagnostics.metricsTimeSeriesSnapshot(
+            req: context.request, hours: input.hours, bucketMinutes: input.bucketMinutes)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetQueueStateTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetQueueStateTool.swift
@@ -1,0 +1,101 @@
+// APIServer/MCP/Admin/Tools/GetQueueStateTool.swift
+//
+// Read tool: the current worker-queue state — pending depth, in-flight jobs,
+// oldest-pending age, and the stuck-submission count (the 10-minute reaper's
+// view).  This is the raw data *behind* the `queueBackedUp` health alert
+// (get_health_alerts only reports whether it's firing) and the stuck-submission
+// reaper, so an agent can see how backed up the queue is and whether jobs are
+// orphaned on a crashed runner.  Counts and ages only — no identifiers.
+
+import Core
+import Fluent
+import Vapor
+
+struct GetQueueStateTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    struct Output: Encodable, Sendable {
+        let generatedAt: Date
+        /// Worker-eligible pending submissions (validation + worker-graded
+        /// students) — what the worker queue actually draws from.
+        let pendingWorkerQueue: Int
+        /// All pending submissions, including browser-graded ones the worker
+        /// only picks up as a backstop.
+        let pendingTotal: Int
+        /// Submissions currently assigned or running on a runner.
+        let inFlight: Int
+        /// Age of the oldest pending submission, in seconds (nil if none pending).
+        let oldestPendingAgeSeconds: Int?
+        /// Submissions assigned to a runner but with no result past the stuck
+        /// threshold — the reaper returns these to pending. A non-zero value
+        /// usually means a runner crashed mid-job.
+        let stuckAssignedCount: Int
+        /// The reaper's stuck threshold, in seconds (currently 600 = 10 min).
+        let stuckThresholdSeconds: Int
+        /// Peak worker-queue depth over the recent window (matches the dashboard
+        /// "Max Queue Depth" headline).
+        let maxQueueDepthRecentWindow: Int
+        let recentWindowHours: Int
+    }
+
+    static let name = "get_queue_state"
+    static let description =
+        "Current worker-queue state: pending depth (worker-eligible and total), in-flight jobs "
+        + "(assigned/running), oldest-pending age in seconds, the stuck-submission count (assigned "
+        + "with no result past the 10-minute reaper threshold — usually a crashed runner), and the "
+        + "peak queue depth over the recent window. This is the raw data behind the queueBackedUp "
+        + "health alert (get_health_alerts only says whether it's firing). Read-only; counts and ages "
+        + "only — no identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    private static let stuckThresholdSeconds = 600
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let db = context.db
+        let diagnostics = context.request.application.diagnostics
+        let now = Date()
+
+        let pendingWorkerQueue = try await diagnostics.pendingQueueDepth(on: db)
+        let inFlight = try await diagnostics.inFlightJobCount(on: db)
+
+        let pendingTotal = try await APISubmission.query(on: db)
+            .filter(\.$status == SubmissionStatus.pending.rawValue)
+            .count()
+
+        let oldestPending = try await APISubmission.query(on: db)
+            .filter(\.$status == SubmissionStatus.pending.rawValue)
+            .sort(\.$submittedAt, .ascending)
+            .first()
+        let oldestPendingAgeSeconds = oldestPending?.submittedAt.map {
+            max(0, Int(now.timeIntervalSince($0)))
+        }
+
+        let stuckCutoff = now.addingTimeInterval(Double(-Self.stuckThresholdSeconds))
+        let stuckAssignedCount = try await APISubmission.query(on: db)
+            .filter(\.$status == SubmissionStatus.assigned.rawValue)
+            .filter(\.$assignedAt <= stuckCutoff)
+            .count()
+
+        let windowHours = max(1, diagnostics.configuration.recentMetricsWindowHours)
+        let windowStart = now.addingTimeInterval(Double(-windowHours) * 3600)
+        let maxQueueDepth = try await diagnostics.maxQueueDepthSince(
+            windowStart: windowStart, now: now, on: db)
+
+        return Output(
+            generatedAt: now,
+            pendingWorkerQueue: pendingWorkerQueue,
+            pendingTotal: pendingTotal,
+            inFlight: inFlight,
+            oldestPendingAgeSeconds: oldestPendingAgeSeconds,
+            stuckAssignedCount: stuckAssignedCount,
+            stuckThresholdSeconds: Self.stuckThresholdSeconds,
+            maxQueueDepthRecentWindow: maxQueueDepth,
+            recentWindowHours: windowHours)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetRequestMetricsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetRequestMetricsTool.swift
@@ -1,0 +1,160 @@
+// APIServer/MCP/Admin/Tools/GetRequestMetricsTool.swift
+//
+// Read tool: HTTP request-timing aggregates over a window — total requests,
+// counts by status class (2xx/3xx/4xx/5xx), an overall duration summary, and
+// the slowest routes (by P95).  Reads request_metrics (captured for /api/*,
+// /submissions/*, /testsetups/* — and everything under verbose timing).
+//
+// PII boundary: request_metrics carries no user_id, but a concrete path can
+// embed a submission/test-setup id (e.g. /submissions/sub_ab12). This tool
+// NORMALISES those id-like path segments to ":id" before aggregating, so it
+// reports per-route shapes and never a row-level identifier.
+
+import Core
+import Fluent
+import Vapor
+
+struct GetRequestMetricsTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Look-back window in hours (default 24; clamped 1…720).
+        var windowHours: Int?
+        /// Optional path prefix filter (e.g. "/api/").
+        var pathPrefix: String?
+        /// Max slowest-routes rows to return (default 15; clamped 1…100).
+        var limit: Int?
+    }
+
+    struct StatusClassCount: Encodable, Sendable {
+        let statusClass: String
+        let count: Int
+    }
+
+    struct RouteStat: Encodable, Sendable {
+        /// Normalised "<METHOD> <path>" with id-like segments collapsed to ":id".
+        let route: String
+        let count: Int
+        let errorCount: Int
+        let p95Ms: Int?
+        let maxMs: Int
+    }
+
+    struct Output: Encodable, Sendable {
+        let windowHours: Int
+        let total: Int
+        let byStatusClass: [StatusClassCount]
+        let overall: DurationSummaryResponse
+        let slowestRoutes: [RouteStat]
+    }
+
+    static let name = "get_request_metrics"
+    static let description =
+        "HTTP request-timing aggregates over a window: total requests, counts by status class "
+        + "(2xx/3xx/4xx/5xx), an overall duration summary (avg/p50/p95), and the slowest routes by "
+        + "P95 (with request count, error count, and max duration). Optional windowHours (default 24, "
+        + "max 720), pathPrefix filter, and limit. Captured for /api/*, /submissions/*, /testsetups/* "
+        + "(all paths under verbose timing). Read-only; id-like path segments are normalized to \":id\" "
+        + "so only per-route shapes are reported — never a row-level identifier."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "windowHours": .object([
+                "type": .string("integer"),
+                "description": .string("Look-back window in hours (default 24, max 720)."),
+            ]),
+            "pathPrefix": .object([
+                "type": .string("string"),
+                "description": .string("Optional path prefix filter, e.g. \"/api/\"."),
+            ]),
+            "limit": .object([
+                "type": .string("integer"),
+                "description": .string("Max slowest-routes rows (default 15, max 100)."),
+            ]),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let windowHours = min(max(input.windowHours ?? 24, 1), 720)
+        let limit = min(max(input.limit ?? 15, 1), 100)
+        let since = Date().addingTimeInterval(Double(-windowHours) * 3600)
+
+        var query = APIRequestMetric.query(on: context.db).filter(\.$finishedAt >= since)
+        let prefix = input.pathPrefix.flatMap { $0.isEmpty ? nil : $0 }
+        if let prefix {
+            // Narrow at the DB with a substring match, then refine to a true
+            // prefix in Swift (Fluent has no portable prefix operator).
+            query = query.filter(\.$path ~~ prefix)
+        }
+        var rows = try await query.all()
+        if let prefix {
+            rows = rows.filter { $0.path.hasPrefix(prefix) }
+        }
+
+        var statusClasses: [String: Int] = [:]
+        var durationsByRoute: [String: [Int]] = [:]
+        var errorsByRoute: [String: Int] = [:]
+        var maxByRoute: [String: Int] = [:]
+        var allDurations: [Int] = []
+        for row in rows {
+            statusClasses[Self.statusClass(row.statusCode), default: 0] += 1
+            let route = "\(row.method) \(Self.normalizePath(row.path))"
+            durationsByRoute[route, default: []].append(row.durationMs)
+            maxByRoute[route] = max(maxByRoute[route] ?? 0, row.durationMs)
+            if row.statusCode >= 400 { errorsByRoute[route, default: 0] += 1 }
+            allDurations.append(row.durationMs)
+        }
+
+        let diagnostics = context.request.application.diagnostics
+        let slowestRoutes = durationsByRoute.map { route, durations in
+            RouteStat(
+                route: route,
+                count: durations.count,
+                errorCount: errorsByRoute[route, default: 0],
+                p95Ms: diagnostics.durationSummary(for: durations).p95Ms,
+                maxMs: maxByRoute[route] ?? 0)
+        }
+        .sorted { ($0.p95Ms ?? 0, $0.maxMs) > ($1.p95Ms ?? 0, $1.maxMs) }
+        .prefix(limit)
+
+        return Output(
+            windowHours: windowHours,
+            total: rows.count,
+            byStatusClass: statusClasses.map { StatusClassCount(statusClass: $0.key, count: $0.value) }
+                .sorted { $0.statusClass < $1.statusClass },
+            overall: diagnostics.durationSummary(for: allDurations),
+            slowestRoutes: Array(slowestRoutes))
+    }
+
+    /// "2xx" / "3xx" / "4xx" / "5xx" / "other" for a numeric status code.
+    static func statusClass(_ code: Int) -> String {
+        switch code {
+        case 200..<300: return "2xx"
+        case 300..<400: return "3xx"
+        case 400..<500: return "4xx"
+        case 500..<600: return "5xx"
+        default: return "other"
+        }
+    }
+
+    /// Collapse id-like path segments to ":id" so per-route aggregation never
+    /// surfaces a concrete submission/test-setup id from the path.
+    static func normalizePath(_ path: String) -> String {
+        path.split(separator: "/", omittingEmptySubsequences: false)
+            .map { segment in isIdentifierSegment(String(segment)) ? ":id" : String(segment) }
+            .joined(separator: "/")
+    }
+
+    private static func isIdentifierSegment(_ segment: String) -> Bool {
+        if segment.isEmpty { return false }
+        for prefix in ["sub_", "setup_", "res_", "job_"] where segment.hasPrefix(prefix) {
+            return true
+        }
+        let lower = segment.lowercased()
+        // UUID, long hex, or long numeric run — all stand in for a concrete id.
+        if lower.count >= 32, lower.allSatisfy({ $0.isHexDigit || $0 == "-" }) { return true }
+        if segment.count >= 6, segment.allSatisfy(\.isNumber) { return true }
+        return false
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetRunnerDetailTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetRunnerDetailTool.swift
@@ -1,0 +1,221 @@
+// APIServer/MCP/Admin/Tools/GetRunnerDetailTool.swift
+//
+// Read tool: one runner's detail — identity, capability profile (platform /
+// architecture / language versions / capabilities), an aggregate timing
+// breakdown over its recent jobs (avg execution / queue-wait / overhead /
+// per-stage, plus cache-hit rate and status counts), and its recent load
+// snapshots.  Backs the /admin/runners/:id page.
+//
+// PII boundary (code allowlist — the shipped guarantee): the recent-jobs source
+// (job_execution_metrics) carries user_id / submission_id, so this tool exposes
+// only the AGGREGATE summary computed over those rows — never the row-level job
+// records the web page shows (which carry username + submission id). Snapshots
+// (runner_snapshots) are PII-free and listed as-is.
+
+import Core
+import Fluent
+import Vapor
+
+struct GetRunnerDetailTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// The runner id (as listed by list_runners / get_metrics_snapshot).
+        var runnerID: String
+        /// How many recent jobs to aggregate the timing summary over
+        /// (default 50; clamped 1…200).
+        var sampleSize: Int?
+    }
+
+    struct TimingSummary: Encodable, Sendable {
+        let sampleSize: Int
+        let avgExecutionMs: Int?
+        let avgQueueWaitMs: Int?
+        let avgOverheadMs: Int?
+        let avgCacheAcquireMs: Int?
+        let avgDownloadMs: Int?
+        let avgPrepMs: Int?
+        /// Cache-hit rate over recent jobs that reported a cache flag, as a
+        /// percent; nil when no recent job reported one.
+        let cacheHitRatePercent: Int?
+        let cacheHitSamples: Int
+        let passedCount: Int
+        let failedCount: Int
+        let errorCount: Int
+        let timeoutCount: Int
+    }
+
+    struct SnapshotRow: Encodable, Sendable {
+        let recordedAt: Date
+        let activeJobs: Int
+        let maxJobs: Int
+        let utilizationPercent: Int
+        let lastPollAt: Date?
+    }
+
+    struct Output: Encodable, Sendable {
+        let runnerID: String
+        let hostname: String
+        let runnerVersion: String
+        let activeJobs: Int
+        let maxConcurrentJobs: Int
+        let jobsProcessed: Int
+        let lastActive: String
+        let firstSeenAt: Date?
+        /// Capability tags: platform, architecture, "<language> <version>", and
+        /// capability names — the same set the assignment-compatibility matcher
+        /// checks against.
+        let capabilities: [String]
+        let timing: TimingSummary
+        let recentSnapshots: [SnapshotRow]
+    }
+
+    static let name = "get_runner_detail"
+    static let description =
+        "One runner's detail: identity (hostname, version, load, all-time jobs), its capability "
+        + "profile (platform / architecture / language versions / capabilities — what the "
+        + "assignment-compatibility matcher checks), an aggregate timing breakdown over its recent "
+        + "jobs (avg execution / queue-wait / overhead / cache-acquire / download / prep, cache-hit "
+        + "rate, and passed/failed/error/timeout counts), and recent load snapshots. Use it to "
+        + "diagnose why jobs are slow on a runner or why an assignment won't match it. Requires "
+        + "runnerID (from list_runners). Read-only; aggregates only — the per-job rows the web page "
+        + "shows (with username + submission id) are deliberately omitted."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "runnerID": .object([
+                "type": .string("string"),
+                "description": .string("Runner id, as listed by list_runners or get_metrics_snapshot."),
+            ]),
+            "sampleSize": .object([
+                "type": .string("integer"),
+                "description": .string("Recent jobs to aggregate the timing summary over (default 50, max 200)."),
+            ]),
+        ]),
+        "required": .array([.string("runnerID")]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let runnerID = input.runnerID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !runnerID.isEmpty else {
+            throw MCPToolError.invalidArguments(tool: Self.name, detail: "runnerID must not be empty.")
+        }
+        let sampleSize = min(max(input.sampleSize ?? 50, 1), 200)
+        let db = context.db
+
+        let identity = try await resolveIdentity(runnerID: runnerID, req: context.request)
+        let profile = try? await context.request.application.runnerProfiles.profile(for: runnerID, on: db)
+
+        let recentJobs = try await JobExecutionMetric.query(on: db)
+            .filter(\.$runnerID == runnerID)
+            .sort(\.$completedAt, .descending)
+            .limit(sampleSize)
+            .all()
+        let snapshots = try await RunnerSnapshot.query(on: db)
+            .filter(\.$runnerID == runnerID)
+            .sort(\.$recordedAt, .descending)
+            .limit(50)
+            .all()
+        let firstSnapshot = try await RunnerSnapshot.query(on: db)
+            .filter(\.$runnerID == runnerID)
+            .sort(\.$recordedAt, .ascending)
+            .first()
+
+        return Output(
+            runnerID: identity.workerID,
+            hostname: identity.hostname,
+            runnerVersion: identity.runnerVersion,
+            activeJobs: identity.assignedJobs,
+            maxConcurrentJobs: identity.maxConcurrentJobs,
+            jobsProcessed: identity.jobsProcessed,
+            lastActive: identity.lastActive,
+            firstSeenAt: firstSnapshot?.recordedAt,
+            capabilities: capabilityTags(profile: profile),
+            timing: timingSummary(recentJobs: recentJobs),
+            recentSnapshots: snapshots.map(snapshotRow(for:)))
+    }
+
+    /// Resolve the runner's identity row, falling back to its latest snapshot
+    /// when it has aged out of the in-memory store (offline > 1h), mirroring the
+    /// web detail page's reconstruction so historical runners still resolve.
+    private func resolveIdentity(runnerID: String, req: Request) async throws -> AdminWorkerRow {
+        let rows = try await makeWorkerRows(req: req)
+        if let found = rows.first(where: { $0.workerID == runnerID }) {
+            return found
+        }
+        guard
+            let latest = try await RunnerSnapshot.query(on: req.db)
+                .filter(\.$runnerID == runnerID)
+                .sort(\.$recordedAt, .descending)
+                .first()
+        else {
+            throw MCPToolError.invalidArguments(tool: Self.name, detail: "Unknown runner '\(runnerID)'.")
+        }
+        let processed = try await APISubmission.query(on: req.db)
+            .filter(\.$workerID == runnerID)
+            .filter(\.$status ~~ [SubmissionStatus.complete.rawValue, SubmissionStatus.failed.rawValue])
+            .count()
+        return AdminWorkerRow(
+            workerID: runnerID,
+            hostname: latest.hostname ?? "",
+            runnerVersion: latest.runnerVersion ?? "",
+            maxConcurrentJobs: latest.maxJobs,
+            lastActive: iso8601String(latest.recordedAt),
+            assignedJobs: 0,
+            jobsProcessed: processed,
+            avgExecutionMs: nil,
+            avgQueueWaitMs: nil,
+            avgExecutionFormatted: nil,
+            avgQueueWaitFormatted: nil)
+    }
+
+    private func capabilityTags(profile: RunnerProfile?) -> [String] {
+        guard let capability = profile?.capabilityProfile else { return [] }
+        var values: [String] = []
+        if !capability.platform.isEmpty { values.append(capability.platform) }
+        if !capability.architecture.isEmpty { values.append(capability.architecture) }
+        values.append(contentsOf: capability.languageVersions.map { "\($0.language) \($0.version)" })
+        values.append(contentsOf: capability.capabilities.map(\.name))
+        return values
+    }
+
+    private func timingSummary(recentJobs: [JobExecutionMetric]) -> TimingSummary {
+        let stageBreakdowns = recentJobs.map(stageBreakdown(for:))
+        let cacheFlagged = recentJobs.compactMap { $0.testSetupCacheHit }
+        let cacheHits = cacheFlagged.filter { $0 }.count
+        var statusCounts: [String: Int] = [:]
+        for job in recentJobs {
+            guard let status = job.finalStatus else { continue }
+            statusCounts[status, default: 0] += 1
+        }
+        return TimingSummary(
+            sampleSize: recentJobs.count,
+            avgExecutionMs: average(recentJobs.compactMap { $0.executionMs }),
+            avgQueueWaitMs: average(recentJobs.compactMap { $0.queueWaitMs }),
+            avgOverheadMs: average(recentJobs.compactMap { overheadMs(for: $0) }),
+            avgCacheAcquireMs: average(stageBreakdowns.compactMap { $0?.cacheAcquireMs }),
+            avgDownloadMs: average(stageBreakdowns.compactMap { $0?.downloadMs }),
+            avgPrepMs: average(stageBreakdowns.compactMap { $0?.prepMs }),
+            cacheHitRatePercent: cacheFlagged.isEmpty
+                ? nil : Int((Double(cacheHits) / Double(cacheFlagged.count) * 100).rounded()),
+            cacheHitSamples: cacheFlagged.count,
+            passedCount: statusCounts["passed", default: 0],
+            failedCount: statusCounts["failed", default: 0],
+            errorCount: statusCounts["error", default: 0],
+            timeoutCount: statusCounts["timeout", default: 0])
+    }
+
+    private func snapshotRow(for snapshot: RunnerSnapshot) -> SnapshotRow {
+        let utilization =
+            snapshot.maxJobs > 0
+            ? Int((Double(snapshot.activeJobs) / Double(snapshot.maxJobs) * 100).rounded())
+            : 0
+        return SnapshotRow(
+            recordedAt: snapshot.recordedAt,
+            activeJobs: snapshot.activeJobs,
+            maxJobs: snapshot.maxJobs,
+            utilizationPercent: utilization,
+            lastPollAt: snapshot.lastPollAt)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetStorageUsageTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetStorageUsageTool.swift
@@ -1,0 +1,39 @@
+// APIServer/MCP/Admin/Tools/GetStorageUsageTool.swift
+//
+// Read tool: on-disk footprint — total bytes by component (submissions /
+// test-setups / results+logs / static assets / database) plus a per-assignment
+// breakdown.  Wraps the same builder the admin /admin/storage page uses
+// (`AdminRoutes.makeStorageContext`).  Disk pressure directly causes job
+// failures (free disk is tracked per job), so this is a first-class diagnostic.
+// PII-free: assignment title + course code are instructor content, submission
+// COUNT per assignment is an aggregate — no student identifiers.
+
+import Core
+import Vapor
+
+struct GetStorageUsageTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    /// The existing admin storage panel context, reused verbatim — component
+    /// totals + per-assignment byte/count breakdown, no student identifiers.
+    typealias Output = AdminStorageContext
+
+    static let name = "get_storage_usage"
+    static let description =
+        "On-disk footprint: total bytes by component (submissions / test-setups / results+logs / "
+        + "static assets / database, with the database backend) plus a per-assignment breakdown "
+        + "(test-suite bytes, submission bytes, submission count, sorted largest-first). Use it to "
+        + "diagnose disk pressure (which causes job failures) and see which assignment is consuming "
+        + "space. Read-only; assignment/course identifiers and byte/count aggregates only — no student "
+        + "identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+        return try await AdminRoutes.makeStorageContext(req: context.request)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/ListConnectedAgentsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/ListConnectedAgentsTool.swift
@@ -1,0 +1,61 @@
+// APIServer/MCP/Admin/Tools/ListConnectedAgentsTool.swift
+//
+// Read tool: the MCP OAuth grants ("connected agents") — which agents hold a
+// browser-flow authorization, their scopes, owner, and last-used/expiry/revoked
+// state.  Wraps the same builder the admin /admin/mcp panel uses
+// (`MCPAgentsRoutes.grantRows`, admin/all-grants view).  Use it to diagnose why
+// a connector can't read/write (scope or expiry) or to audit what's connected.
+//
+// PII note: a grant's owner is the human who authorized it. The content MCP
+// consent gate requires `isInstructor` and the admin diagnostic gate requires
+// `isAdmin`, so grant owners are instructors/admins — never students. No grade,
+// submission, or enrollment data is exposed; the refresh-token hash is never
+// included (grantRows omits it).
+
+import Core
+import Fluent
+import Vapor
+
+struct ListConnectedAgentsTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Include revoked grants (default true — they carry a `revoked` flag).
+        var includeRevoked: Bool?
+    }
+
+    struct Output: Encodable, Sendable {
+        let generatedAt: Date
+        let total: Int
+        let agents: [AgentGrantRow]
+    }
+
+    static let name = "list_connected_agents"
+    static let description =
+        "MCP OAuth grants (\"connected agents\"): each agent holding a browser-flow authorization, "
+        + "with its name, scopes, owner (the instructor/admin who authorized it — never a student), "
+        + "and authorized / last-used / expires timestamps and revoked flag. Optional includeRevoked "
+        + "(default true). Use it to diagnose why a connector can't read/write (scope or expiry) or to "
+        + "audit what's connected. Read-only; no refresh-token secrets, grades, submissions, or "
+        + "enrollment."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "includeRevoked": .object([
+                "type": .string("boolean"),
+                "description": .string("Include revoked grants (default true)."),
+            ])
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        var query = MCPGrant.query(on: context.db).sort(\.$createdAt, .descending)
+        if input.includeRevoked == false {
+            query = query.filter(\.$revoked == false)
+        }
+        let grants = try await query.all()
+        let rows = try await MCPAgentsRoutes.grantRows(grants, includeOwner: true, on: context.db)
+        return Output(generatedAt: Date(), total: rows.count, agents: rows)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/ListRunnersTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/ListRunnersTool.swift
@@ -1,0 +1,41 @@
+// APIServer/MCP/Admin/Tools/ListRunnersTool.swift
+//
+// Read tool: the runner fleet — one row per runner seen recently, with load,
+// all-time jobs processed, and rolling average execution / queue-wait.  Wraps
+// the same builder the admin dashboard's runner table uses (`makeWorkerRows`):
+// operational runner state only — no user, submission, course, or assignment
+// identifiers.  Pairs with get_runner_detail (one runner's capability profile +
+// per-stage timing breakdown).
+
+import Core
+import Vapor
+
+struct ListRunnersTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    struct Output: Encodable, Sendable {
+        let generatedAt: Date
+        let activeRunnerCount: Int
+        let runners: [AdminWorkerRow]
+    }
+
+    static let name = "list_runners"
+    static let description =
+        "The runner fleet: one row per runner seen in the last hour — runner id, hostname, version, "
+        + "current load (assigned/max concurrent jobs), all-time jobs processed, and rolling average "
+        + "execution + queue-wait time (last 50 jobs). Use it to see which runners are online and how "
+        + "they're performing; pair with get_runner_detail for one runner's capability profile and "
+        + "per-stage timing breakdown. Read-only; operational runner state only — no student, "
+        + "submission, course, or assignment identifiers."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+        let runners = try await makeWorkerRows(req: context.request)
+        return Output(generatedAt: Date(), activeRunnerCount: runners.count, runners: runners)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/QueryAuditLogTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/QueryAuditLogTool.swift
@@ -1,0 +1,101 @@
+// APIServer/MCP/Admin/Tools/QueryAuditLogTool.swift
+//
+// Read tool: audit-log activity as AGGREGATE COUNTS over a window — totals by
+// action and by category.  Useful for spotting a failed-login spike, a burst of
+// MCP refresh-reuse-detected events, or a wave of role changes, without
+// exposing who did what.
+//
+// PII boundary (the reason this is counts-only): audit_log rows carry an actor
+// (actor_user_id / actor_username — which CAN be a student on login/registration
+// events), a remote IP, and free-form metadata that may embed user ids. The
+// design record (docs/admin-mcp.md §4.2) excluded the table from v1 for exactly
+// this. This tool therefore returns ONLY per-action / per-category counts —
+// never a row, actor, IP, or metadata blob — so the no-student-data guarantee
+// holds by construction.
+
+import Core
+import Fluent
+import Vapor
+
+struct QueryAuditLogTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Look-back window in hours (default 168 = 7 days; clamped 1…2160).
+        var windowHours: Int?
+        /// Optional exact action filter (e.g. "auth.login_failure").
+        var action: String?
+    }
+
+    struct CountEntry: Encodable, Sendable {
+        let key: String
+        let label: String
+        let count: Int
+    }
+
+    struct Output: Encodable, Sendable {
+        let windowHours: Int
+        let total: Int
+        let byAction: [CountEntry]
+        let byCategory: [CountEntry]
+    }
+
+    static let name = "query_audit_log"
+    static let description =
+        "Audit-log activity as aggregate counts over a window: totals by action (e.g. "
+        + "auth.login_failure, mcp.refresh_reuse_detected, user.role_changed) and by category "
+        + "(Authentication, MCP / agents, Users & roles, …). Use it to spot a failed-login spike, a "
+        + "burst of refresh-token-reuse events, or a wave of admin actions. Optional windowHours "
+        + "(default 168, max 2160) and an exact action filter. Read-only and COUNTS ONLY — by design "
+        + "it never returns an audit row, actor, IP, or metadata (actors can be students), so no "
+        + "student identifier is reachable."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "windowHours": .object([
+                "type": .string("integer"),
+                "description": .string("Look-back window in hours (default 168, max 2160)."),
+            ]),
+            "action": .object([
+                "type": .string("string"),
+                "description": .string("Optional exact action filter, e.g. \"auth.login_failure\"."),
+            ]),
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let windowHours = min(max(input.windowHours ?? 168, 1), 2160)
+        let since = Date().addingTimeInterval(Double(-windowHours) * 3600)
+
+        var query = APIAuditLogEntry.query(on: context.db)
+            .filter(\.$createdAt >= since)
+        if let action = input.action, !action.isEmpty {
+            query = query.filter(\.$action == action)
+        }
+        // Project to the action column only — no actor, IP, or metadata is ever
+        // loaded into this tool, let alone returned.
+        let actions = try await query.all(\.$action)
+
+        var byActionRaw: [String: Int] = [:]
+        var byCategoryRaw: [String: Int] = [:]
+        for raw in actions {
+            byActionRaw[raw, default: 0] += 1
+            let display = AuditActionDisplay.categoryLabel(forRaw: raw)
+            byCategoryRaw[display.category, default: 0] += 1
+        }
+
+        let byAction = byActionRaw.map { raw, count in
+            CountEntry(key: raw, label: AuditActionDisplay.categoryLabel(forRaw: raw).label, count: count)
+        }
+        .sorted { ($0.count, $1.key) > ($1.count, $0.key) }
+
+        let byCategory = byCategoryRaw.map { category, count in
+            CountEntry(key: category, label: category, count: count)
+        }
+        .sorted { ($0.count, $1.key) > ($1.count, $0.key) }
+
+        return Output(
+            windowHours: windowHours, total: actions.count, byAction: byAction, byCategory: byCategory)
+    }
+}

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -195,7 +195,7 @@ struct AdminRoutes: RouteCollection {
 
     @Sendable
     func storagePage(req: Request) async throws -> View {
-        let storage = try await makeStorageContext(req: req)
+        let storage = try await Self.makeStorageContext(req: req)
         let ctx = AdminStoragePageContext(
             currentUser: req.currentUserContext,
             activeAdminTab: "storage",
@@ -210,7 +210,11 @@ struct AdminRoutes: RouteCollection {
     /// the results+logs dir, the static asset tree) and the database so an
     /// admin can see where disk is going.  Directory walks are blocking, so
     /// they run on the thread pool off the event loop.
-    private func makeStorageContext(req: Request) async throws -> AdminStorageContext {
+    ///
+    /// `static` so the admin diagnostic MCP tool (`get_storage_usage`) can reuse
+    /// the exact same builder as the `/admin/storage` page — the context is
+    /// PII-free (assignment/course identifiers + byte counts only).
+    static func makeStorageContext(req: Request) async throws -> AdminStorageContext {
         let submissionsDir = req.application.submissionsDirectory
         let testSetupsDir = req.application.testSetupsDirectory
         let resultsDir = req.application.resultsDirectory

--- a/Tests/APITests/MCP/AdminMCPInstructionsCatalogSyncTests.swift
+++ b/Tests/APITests/MCP/AdminMCPInstructionsCatalogSyncTests.swift
@@ -1,0 +1,77 @@
+// Drift guards for the agent-facing copy of the ADMIN DIAGNOSTIC MCP surface.
+// The server-level instructions (`AdminMCPServerInstructions.text`, returned
+// from `initialize`) and each tool's description/schema/annotations are
+// hand-maintained and must stay in sync with the live catalog
+// (`AdminMCPToolCatalog.live`).  These turn that convention into a build
+// failure: adding a diagnostic tool without teaching the instructions about it,
+// shipping an empty description, or contradicting the read-only posture fails
+// here instead of silently degrading what a connected agent sees.  Mirrors
+// `MCPInstructionsCatalogSyncTests` for the content surface.
+
+import Core
+import Testing
+
+@testable import APIServer
+
+@Suite struct AdminMCPInstructionsCatalogSyncTests {
+    private let tools = AdminMCPToolCatalog.live.all
+    private let instructions = AdminMCPServerInstructions.text
+
+    @Test func catalogHasUniqueSnakeCaseNames() {
+        // A wholesale catalog regression (e.g. an empty registry from a bad
+        // merge) should fail loudly, not pass the per-tool loops vacuously.
+        #expect(tools.count >= 16)
+        #expect(Set(tools.map(\.name)).count == tools.count)
+        let allowed = Set("abcdefghijklmnopqrstuvwxyz_")
+        for tool in tools {
+            #expect(
+                !tool.name.isEmpty && tool.name.allSatisfy { allowed.contains($0) },
+                "\(tool.name) is not lower_snake_case")
+        }
+    }
+
+    @Test func everyCatalogToolIsMentionedInInstructions() {
+        for tool in tools {
+            #expect(
+                instructions.contains(tool.name),
+                "AdminMCPServerInstructions.text never mentions \(tool.name) — update the instructions when changing the catalog"
+            )
+        }
+    }
+
+    @Test func everyToolHasDescriptionAndObjectInputSchema() {
+        for tool in tools {
+            #expect(!tool.description.isEmpty, "\(tool.name) has an empty description")
+            guard case .object(let schema) = tool.inputSchema else {
+                Issue.record("\(tool.name) inputSchema is not a JSON object")
+                continue
+            }
+            #expect(
+                schema["type"] == .string("object"),
+                "\(tool.name) inputSchema must declare type:object")
+        }
+    }
+
+    @Test func everyDescriptionStatesReadOnly() {
+        // The whole surface is read-only and the no-student-data guarantee is
+        // load-bearing — every tool's own description must say so, so an agent
+        // reading a single tool (not just the server instructions) still knows.
+        for tool in tools {
+            #expect(
+                tool.description.contains("Read-only"),
+                "\(tool.name) description does not state it is Read-only")
+        }
+    }
+
+    @Test func everyToolIsReadOnlyAndScopedToDiagnosticsRead() throws {
+        for tool in tools {
+            #expect(
+                tool.requiredScopes == [.read],
+                "\(tool.name) must require exactly diagnostics:read on the read-only admin surface")
+            let annotations = try #require(tool.annotations, "\(tool.name) advertises no annotations")
+            #expect(
+                annotations.readOnlyHint == true,
+                "\(tool.name) must advertise readOnlyHint:true")
+        }
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -260,6 +260,327 @@ import XCTVapor
             }
         }
     }
+
+    // MARK: - get_metrics_timeseries
+
+    @Test func getMetricsTimeseriesReturnsBucketsForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ts-admin", role: "admin")
+            let output = try await GetMetricsTimeseriesTool().execute(
+                .init(hours: 6, bucketMinutes: 30), context(subject: "ts-admin"))
+            #expect(output.windowHours >= 1)
+            #expect(!output.buckets.isEmpty)
+        }
+    }
+
+    @Test func getMetricsTimeseriesRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ts-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetMetricsTimeseriesTool().execute(.init(), context(subject: "ts-prof"))
+            }
+        }
+    }
+
+    // MARK: - get_queue_state
+
+    @Test func getQueueStateCountsPendingAndStuckForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "qs-admin", role: "admin")
+            let course = try await makeTestCourse(on: app, code: "QS101")
+            let courseID = try course.requireID()
+            let setup = try await makeTestSetup(on: app, id: "qs_setup", courseID: courseID)
+            let setupID = try setup.requireID()
+            let student = try await makeTestUser(on: app, username: "qs-student", role: "student")
+            let studentID = try student.requireID()
+            _ = try await makeTestSubmission(
+                on: app, id: "qs_pending", setupID: setupID, userID: studentID, status: "pending")
+            let stuck = try await makeTestSubmission(
+                on: app, id: "qs_stuck", setupID: setupID, userID: studentID, status: "assigned")
+            stuck.assignedAt = Date().addingTimeInterval(-700)
+            stuck.workerID = "runner-x"
+            try await stuck.save(on: app.db)
+
+            let output = try await GetQueueStateTool().execute(.init(), context(subject: "qs-admin"))
+            #expect(output.pendingTotal >= 1)
+            #expect(output.stuckAssignedCount == 1)
+            #expect(output.stuckThresholdSeconds == 600)
+            #expect((output.oldestPendingAgeSeconds ?? -1) >= 0)
+        }
+    }
+
+    @Test func getQueueStateRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "qs-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetQueueStateTool().execute(.init(), context(subject: "qs-prof"))
+            }
+        }
+    }
+
+    // MARK: - list_runners / get_runner_detail
+
+    @Test func listRunnersReportsActiveRunnerForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "lr-admin", role: "admin")
+            await app.workerActivityStore.markActive(
+                workerID: "runner-lr", hostname: "host-lr", runnerVersion: "v9", maxConcurrentJobs: 4)
+            let output = try await ListRunnersTool().execute(.init(), context(subject: "lr-admin"))
+            #expect(output.activeRunnerCount >= 1)
+            #expect(output.runners.contains { $0.workerID == "runner-lr" && $0.hostname == "host-lr" })
+        }
+    }
+
+    @Test func listRunnersRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "lr-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ListRunnersTool().execute(.init(), context(subject: "lr-prof"))
+            }
+        }
+    }
+
+    @Test func getRunnerDetailAggregatesAndRedactsJobIdentifiers() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "rd-admin", role: "admin")
+            let student = try await makeTestUser(on: app, username: "rd-student", role: "student")
+            let studentID = try student.requireID()
+            let course = try await makeTestCourse(on: app, code: "RD101")
+            let courseID = try course.requireID()
+            let setup = try await makeTestSetup(on: app, id: "rd_setup", courseID: courseID)
+            let setupID = try setup.requireID()
+            _ = try await makeTestSubmission(
+                on: app, id: "sub_rd_secret", setupID: setupID, userID: studentID)
+            await app.workerActivityStore.markActive(
+                workerID: "runner-rd", hostname: "host-rd", runnerVersion: "v1", maxConcurrentJobs: 4)
+            try await RunnerSnapshot(
+                runnerID: "runner-rd", recordedAt: Date(), activeJobs: 1, maxJobs: 4,
+                availableCapacity: 3, hostname: "host-rd", runnerVersion: "v1", lastPollAt: Date(),
+                lastHeartbeatAt: Date(), serverAssignedJobCountSinceStart: 2
+            ).save(on: app.db)
+            let job = JobExecutionMetric(
+                submissionID: "sub_rd_secret", jobID: "sub_rd_secret", testSetupID: setupID,
+                courseID: courseID, assignmentID: nil, userID: studentID, runnerID: "runner-rd",
+                kind: "student", attemptNumber: 1, enqueuedAt: Date())
+            job.finalStatus = "passed"
+            job.executionMs = 1200
+            job.queueWaitMs = 150
+            job.testSetupCacheHit = true
+            job.completedAt = Date()
+            try await job.save(on: app.db)
+
+            let output = try await GetRunnerDetailTool().execute(
+                .init(runnerID: "runner-rd", sampleSize: nil), context(subject: "rd-admin"))
+            #expect(output.runnerID == "runner-rd")
+            #expect(output.timing.sampleSize == 1)
+            #expect(output.timing.passedCount == 1)
+            #expect(output.timing.cacheHitRatePercent == 100)
+            #expect(!output.recentSnapshots.isEmpty)
+
+            // PII guarantee: neither the student id nor the submission id appears.
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains(studentID.uuidString))
+            #expect(!json.contains("sub_rd_secret"))
+            #expect(!json.lowercased().contains("username"))
+        }
+    }
+
+    @Test func getRunnerDetailRejectsUnknownRunner() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "rd-admin2", role: "admin")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetRunnerDetailTool().execute(
+                    .init(runnerID: "nope", sampleSize: nil), context(subject: "rd-admin2"))
+            }
+        }
+    }
+
+    @Test func getRunnerDetailRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "rd-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetRunnerDetailTool().execute(
+                    .init(runnerID: "runner-rd", sampleSize: nil), context(subject: "rd-prof"))
+            }
+        }
+    }
+
+    // MARK: - get_storage_usage
+
+    @Test func getStorageUsageReturnsComponentsForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "su-admin", role: "admin")
+            let output = try await GetStorageUsageTool().execute(.init(), context(subject: "su-admin"))
+            // Always at least the five component rows (Submissions … Database).
+            #expect(output.rows.count >= 5)
+            #expect(output.rows.contains { $0.label == "Database" })
+            #expect(!output.dbBackend.isEmpty)
+        }
+    }
+
+    @Test func getStorageUsageRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "su-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetStorageUsageTool().execute(.init(), context(subject: "su-prof"))
+            }
+        }
+    }
+
+    // MARK: - get_request_metrics
+
+    @Test func getRequestMetricsAggregatesAndNormalizesPaths() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "rm-admin", role: "admin")
+            let now = Date()
+            try await APIRequestMetric(
+                method: "GET", path: "/api/v1/submissions/sub_abc12345", requestKind: nil,
+                statusCode: 200, startedAt: now, finishedAt: now, durationMs: 50,
+                submissionID: nil, workerID: nil
+            ).save(on: app.db)
+            try await APIRequestMetric(
+                method: "GET", path: "/api/v1/submissions/sub_def67890", requestKind: nil,
+                statusCode: 500, startedAt: now, finishedAt: now, durationMs: 800,
+                submissionID: nil, workerID: nil
+            ).save(on: app.db)
+
+            let output = try await GetRequestMetricsTool().execute(.init(), context(subject: "rm-admin"))
+            #expect(output.total == 2)
+            #expect(output.byStatusClass.contains { $0.statusClass == "2xx" && $0.count == 1 })
+            #expect(output.byStatusClass.contains { $0.statusClass == "5xx" && $0.count == 1 })
+            // Both concrete submission ids collapse to one normalized route.
+            let route = try #require(output.slowestRoutes.first { $0.route.contains("/submissions/:id") })
+            #expect(route.count == 2)
+            #expect(route.errorCount == 1)
+
+            // PII guarantee: concrete submission ids never appear (normalized).
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains("sub_abc12345"))
+            #expect(!json.contains("sub_def67890"))
+        }
+    }
+
+    @Test func getRequestMetricsRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "rm-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetRequestMetricsTool().execute(.init(), context(subject: "rm-prof"))
+            }
+        }
+    }
+
+    // MARK: - list_connected_agents
+
+    @Test func listConnectedAgentsReturnsGrantsForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ca-admin", role: "admin")
+            let owner = try await makeTestUser(on: app, username: "ca-owner", role: "instructor")
+            let ownerID = try owner.requireID()
+            try await MCPOAuthClient(
+                clientID: "cli-ca", name: "Test Agent CA", redirectURIs: ["https://x/cb"]
+            ).save(on: app.db)
+            try await MCPGrant(
+                userID: ownerID, clientID: "cli-ca", scope: "content:read",
+                refreshTokenHash: "secret-refresh-hash", expiresAt: Date().addingTimeInterval(3600)
+            ).save(on: app.db)
+
+            let output = try await ListConnectedAgentsTool().execute(
+                .init(includeRevoked: nil), context(subject: "ca-admin"))
+            let agent = try #require(output.agents.first { $0.agentName == "Test Agent CA" })
+            #expect(agent.scope == "content:read")
+            #expect(agent.owner == "ca-owner")
+
+            // The refresh-token hash is never surfaced.
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains("secret-refresh-hash"))
+        }
+    }
+
+    @Test func listConnectedAgentsRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ca-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await ListConnectedAgentsTool().execute(.init(), context(subject: "ca-prof"))
+            }
+        }
+    }
+
+    // MARK: - get_brightspace_sync_status
+
+    @Test func getBrightSpaceSyncStatusAggregatesAndRedactsStudentGrade() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "bs-admin", role: "admin")
+            try await APIBrightSpaceSyncLog(
+                courseID: nil, testSetupID: "ts", assignmentTitle: "Lab 1", userID: UUID(),
+                username: "bs-secret-student", orgUnitID: "ou1", gradeObjectID: "g1", points: 95.0,
+                status: .error, detail: "D2L returned 500"
+            ).save(on: app.db)
+            try await APIBrightSpaceSyncLog(
+                courseID: nil, testSetupID: "ts", assignmentTitle: "Lab 1", userID: UUID(),
+                username: "bs-other-student", orgUnitID: "ou1", gradeObjectID: "g1", points: 100.0,
+                status: .success, detail: nil
+            ).save(on: app.db)
+
+            let output = try await GetBrightSpaceSyncStatusTool().execute(
+                .init(), context(subject: "bs-admin"))
+            #expect(output.total == 2)
+            #expect(output.byStatus.contains { $0.key == "error" && $0.count == 1 })
+            #expect(output.byStatus.contains { $0.key == "success" && $0.count == 1 })
+            let sample = try #require(output.recentErrors.first)
+            #expect(sample.detail == "D2L returned 500")
+
+            // PII guarantee: no student username, no grade (points).
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains("bs-secret-student"))
+            #expect(!json.contains("bs-other-student"))
+            #expect(!json.lowercased().contains("\"points\""))
+            #expect(!json.lowercased().contains("username"))
+        }
+    }
+
+    @Test func getBrightSpaceSyncStatusRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "bs-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetBrightSpaceSyncStatusTool().execute(.init(), context(subject: "bs-prof"))
+            }
+        }
+    }
+
+    // MARK: - query_audit_log
+
+    @Test func queryAuditLogCountsByActionAndRedactsActors() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "al-admin", role: "admin")
+            try await APIAuditLogEntry(
+                actorUserID: nil, actorUsername: "al-secret-actor",
+                action: AuditAction.loginFailure.rawValue, remoteAddr: "203.0.113.7"
+            ).save(on: app.db)
+            try await APIAuditLogEntry(
+                actorUsername: "al-admin", action: AuditAction.userRoleChanged.rawValue
+            ).save(on: app.db)
+
+            let output = try await QueryAuditLogTool().execute(.init(), context(subject: "al-admin"))
+            #expect(output.total == 2)
+            #expect(output.byAction.contains { $0.key == "auth.login_failure" && $0.count == 1 })
+            #expect(output.byAction.contains { $0.key == "user.role_changed" && $0.count == 1 })
+            #expect(output.byCategory.contains { $0.key == "Authentication" && $0.count == 1 })
+
+            // PII guarantee: no actor identity, no IP — counts only.
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains("al-secret-actor"))
+            #expect(!json.contains("203.0.113.7"))
+        }
+    }
+
+    @Test func queryAuditLogRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "al-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await QueryAuditLogTool().execute(.init(), context(subject: "al-prof"))
+            }
+        }
+    }
 }
 
 // Pure-logic tests for the log ring-buffer handler — no app.
@@ -299,8 +620,11 @@ import XCTVapor
         #expect(
             names.isSuperset(of: [
                 "get_deployment_info", "get_metrics_snapshot", "get_metrics_card_series",
-                "get_active_users_series", "get_instructor_card_series", "get_health_alerts",
-                "get_browser_diagnostics", "query_logs",
+                "get_metrics_timeseries", "get_active_users_series", "get_instructor_card_series",
+                "get_queue_state", "list_runners", "get_runner_detail", "get_storage_usage",
+                "get_request_metrics", "get_health_alerts", "get_browser_diagnostics",
+                "list_connected_agents", "get_brightspace_sync_status", "query_logs",
+                "query_audit_log",
             ]))
     }
 }

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -151,6 +151,115 @@ import XCTVapor
             }
         }
     }
+
+    // MARK: - get_metrics_card_series
+
+    @Test func getMetricsCardSeriesReturnsAllWindowsForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "mcs-admin", role: "admin")
+            let output = try await GetMetricsCardSeriesTool().execute(
+                .init(), context(subject: "mcs-admin"))
+            // One entry per selectable window (24h / 7d / 30d), each with a full
+            // bucket grid — empty test deployment, but the grid still resolves.
+            #expect(output.windows.count == MetricsCardWindow.allCases.count)
+            let day = try #require(output.windows.first { $0.window == "24h" })
+            #expect(day.bucketLabels.count == 24)
+            #expect(day.maxQueueDepth.series.count == 24)
+        }
+    }
+
+    @Test func getMetricsCardSeriesRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "mcs-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetMetricsCardSeriesTool().execute(.init(), context(subject: "mcs-prof"))
+            }
+        }
+    }
+
+    // MARK: - get_active_users_series
+
+    @Test func getActiveUsersSeriesDefaultsToDayWindowForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "aus-admin", role: "admin")
+            let output = try await GetActiveUsersSeriesTool().execute(
+                .init(), context(subject: "aus-admin"))
+            #expect(output.window == "24h")
+            #expect(output.buckets.count == 24)
+
+            let week = try await GetActiveUsersSeriesTool().execute(
+                .init(window: "1w"), context(subject: "aus-admin"))
+            #expect(week.window == "1w")
+            #expect(week.buckets.count == 7)
+        }
+    }
+
+    @Test func getActiveUsersSeriesRejectsUnknownWindow() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "aus-admin2", role: "admin")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetActiveUsersSeriesTool().execute(
+                    .init(window: "90d"), context(subject: "aus-admin2"))
+            }
+        }
+    }
+
+    @Test func getActiveUsersSeriesRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "aus-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetActiveUsersSeriesTool().execute(.init(), context(subject: "aus-prof"))
+            }
+        }
+    }
+
+    // MARK: - get_instructor_card_series
+
+    @Test func getInstructorCardSeriesScopesToCourseAndRedactsStudentID() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ics-admin", role: "admin")
+            let course = try await makeTestCourse(on: app, code: "MCP101")
+            let courseID = try course.requireID()
+            let setup = try await makeTestSetup(on: app, id: "ics_setup", courseID: courseID)
+            let student = try await makeTestUser(on: app, username: "ics-student", role: "student")
+            let studentID = try student.requireID()
+            try await makeTestEnrollment(on: app, userID: studentID, courseID: courseID)
+            _ = try await makeTestSubmission(
+                on: app, id: "ics_sub", setupID: try setup.requireID(), userID: studentID)
+
+            let output = try await GetInstructorCardSeriesTool().execute(
+                .init(courseCode: "mcp101"), context(subject: "ics-admin"))  // case-insensitive
+            let day = try #require(output.windows.first { $0.window == "24h" })
+            #expect(day.submissions.headline == 1)
+            #expect(day.activeStudents.headline == 1)
+            #expect(day.activeAssignments.headline == 1)
+
+            // PII guarantee: no student identifier in the serialized output.
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains(studentID.uuidString))
+            #expect(!json.lowercased().contains("userid"))
+        }
+    }
+
+    @Test func getInstructorCardSeriesRejectsUnknownCourse() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ics-admin2", role: "admin")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetInstructorCardSeriesTool().execute(
+                    .init(courseCode: "NO-SUCH-COURSE"), context(subject: "ics-admin2"))
+            }
+        }
+    }
+
+    @Test func getInstructorCardSeriesRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "ics-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetInstructorCardSeriesTool().execute(
+                    .init(courseCode: "MCP101"), context(subject: "ics-prof"))
+            }
+        }
+    }
 }
 
 // Pure-logic tests for the log ring-buffer handler — no app.
@@ -189,7 +298,8 @@ import XCTVapor
         let names = Set(AdminMCPToolCatalog.live.all.map(\.name))
         #expect(
             names.isSuperset(of: [
-                "get_deployment_info", "get_metrics_snapshot", "get_health_alerts",
+                "get_deployment_info", "get_metrics_snapshot", "get_metrics_card_series",
+                "get_active_users_series", "get_instructor_card_series", "get_health_alerts",
                 "get_browser_diagnostics", "query_logs",
             ]))
     }

--- a/changelog.d/admin-mcp-sparkline-series.md
+++ b/changelog.d/admin-mcp-sparkline-series.md
@@ -1,13 +1,23 @@
 ### Added
 
-- **Admin diagnostic MCP: dashboard sparkline series.** The admin MCP
-  diagnostic surface can now read the time-series data behind the
-  instructor/admin dashboard sparklines, served from the same builders the
-  dashboards poll: `get_metrics_card_series` (the five admin operational cards —
-  queue depth, jobs processed, load, p95 queue-wait/execution, all windows),
-  `get_active_users_series` (the "Active Users" chart), and
-  `get_instructor_card_series` (one course's submissions / active students /
-  active assignments / browser errors, scoped by `courseCode`). Read-only and
-  PII-free: every payload is per-bucket aggregate counts/percentiles only — no
-  student identifier reaches the output (the instructor tool's enrolled-student
-  lookup is internal scoping, asserted by a per-tool PII test).
+- **Admin diagnostic MCP: dashboard + operational-surface tools.** The admin MCP
+  diagnostic surface gained eleven read-only tools so an agent has parity with
+  the admin/instructor web dashboards' operational views, each served from the
+  same builder its page uses. Dashboard sparklines: `get_metrics_card_series`
+  (the five operational cards), `get_active_users_series` (the "Active Users"
+  chart), `get_instructor_card_series` (one course's submission / active-student
+  / active-assignment / browser-error counts, scoped by `courseCode`). Operational
+  surface: `get_metrics_timeseries` (flexible window/bucket incl. HTTP request
+  latency), `get_queue_state` (pending/in-flight/oldest-pending/stuck counts),
+  `list_runners` + `get_runner_detail` (capability profile + aggregate per-stage
+  timing + cache-hit rate), `get_storage_usage` (disk footprint by component +
+  per-assignment), `get_request_metrics` (slowest routes / status classes),
+  `list_connected_agents` (MCP OAuth grants), `get_brightspace_sync_status`
+  (grade-push health), and `query_audit_log` (activity counts by action/category).
+  All read-only and PII-free by construction: aggregates/percentiles, redacted
+  DTOs, or counts-only — no student identity, grade, submission content, or
+  enrollment is reachable. The three identity/grade-adjacent sources (audit log,
+  BrightSpace sync, per-job runner metrics) drop the student fields entirely
+  (`query_audit_log` returns no actor/IP/metadata; `get_brightspace_sync_status`
+  drops username + grade; `get_runner_detail` omits the per-job rows the web page
+  shows), each asserted by a per-tool PII test.

--- a/changelog.d/admin-mcp-sparkline-series.md
+++ b/changelog.d/admin-mcp-sparkline-series.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Admin diagnostic MCP: dashboard sparkline series.** The admin MCP
+  diagnostic surface can now read the time-series data behind the
+  instructor/admin dashboard sparklines, served from the same builders the
+  dashboards poll: `get_metrics_card_series` (the five admin operational cards —
+  queue depth, jobs processed, load, p95 queue-wait/execution, all windows),
+  `get_active_users_series` (the "Active Users" chart), and
+  `get_instructor_card_series` (one course's submissions / active students /
+  active assignments / browser errors, scoped by `courseCode`). Read-only and
+  PII-free: every payload is per-bucket aggregate counts/percentiles only — no
+  student identifier reaches the output (the instructor tool's enrolled-student
+  lookup is internal scoping, asserted by a per-tool PII test).

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -320,8 +320,17 @@ All `diagnostics:read`. Names are provisional.
 | `query_logs` | Recent structured log records from the in-process ring buffer (§6), filterable by event name / level / time window | PII metadata redacted |
 | `get_health_alerts` | Current `ServerHealthAlertService` rule states (which are firing) + configured thresholds | clean |
 | `get_metrics_card_series` | The time-series (sparkline) data behind the admin dashboard's five operational cards — per-bucket max queue depth, jobs processed, max load, p95 queue-wait, p95 execution — for every window (24h / 7d / 30d). The windowed series behind `get_metrics_snapshot` | aggregate, no row identifiers |
+| `get_metrics_timeseries` | Flexible-window operational time-series (`metricsTimeSeriesSnapshot`): per-bucket runner utilization, **HTTP request count + P95 latency**, completed jobs, test status counts, queue-wait/execution P95. Arbitrary window/bucket | aggregate, no row identifiers |
 | `get_active_users_series` | The admin dashboard's "Active Users" chart: distinct active users per bucket over a trailing window (`ActivityChartService`) | aggregate, distinct counts only |
 | `get_instructor_card_series` | The instructor dashboard's four cards for one course (by `courseCode`): per-bucket submissions, active students, active assignments, browser errors (`instructorCardSeries`) | aggregate counts only; enrolled-student lookup is internal scoping, no identity reaches the output |
+| `get_queue_state` | Current worker-queue state: pending depth (worker-eligible + total), in-flight, oldest-pending age, stuck-submission count (the reaper's view), recent-window peak depth | aggregate, clean |
+| `list_runners` | The runner fleet (`makeWorkerRows`): id, hostname, version, load, jobs processed, rolling avg execution/queue-wait | clean |
+| `get_runner_detail` | One runner's identity + capability profile + aggregate timing breakdown (avg execution/queue-wait/overhead/per-stage, cache-hit rate, status counts) + recent snapshots | aggregate only; the per-job rows the web page shows (username + submission id) are deliberately omitted |
+| `get_storage_usage` | On-disk footprint (`AdminRoutes.makeStorageContext`): bytes by component + DB + per-assignment breakdown | assignment/course identifiers + byte/count aggregates; no student data |
+| `get_request_metrics` | HTTP request-timing aggregates (`request_metrics`): total, status-class counts, overall duration summary, slowest routes by P95 | id-like path segments normalized to `:id`; no row-level identifier |
+| `list_connected_agents` | MCP OAuth grants (`MCPAgentsRoutes.grantRows`, all-grants view): agent name, scopes, owner, authorized/last-used/expires/revoked | owner is the authorizing instructor/admin — never a student; no refresh-token secret |
+| `get_brightspace_sync_status` | BrightSpace grade-sync health (`brightspace_sync_log`): counts by status + recent error samples (D2L error detail) | **student username + grade (points) hard-dropped**; status/detail/assignment/org-unit/timestamp only |
+| `query_audit_log` | Audit-log activity as **counts only** by action + category over a window (`audit_log`) | counts only — no row, actor, IP, or metadata is ever returned (actors can be students), so the guarantee holds by construction |
 
 A `get_deployment_info` / capability-probe tool mirrors the content surface's
 `get_server_info` and lets the agent confirm the surface is live and what it can
@@ -452,6 +461,19 @@ OAuth and DB-wall work lands.
    explicit `courseCode` filter (not a session) but returns only per-bucket
    counts — the enrolled-student/setup lookup is internal scoping, no student
    identifier reaches the output, asserted by a per-tool PII test.
+6. **Diagnostic-surface coverage round.** ✅ **Done.** Eight more tools so an
+   agent has parity with the admin web dashboards' operational views, each
+   reusing the same builder its page uses: `get_metrics_timeseries`
+   (flexible-window series + HTTP request latency), `get_queue_state`,
+   `list_runners` + `get_runner_detail` (capability profile + aggregate
+   per-stage timing — never the per-job rows), `get_storage_usage`,
+   `get_request_metrics` (id-like path segments normalized), `list_connected_agents`
+   (MCP OAuth grants), `get_brightspace_sync_status` (grade-push health, student
+   username + grade dropped), and `query_audit_log` (counts only — no actor / IP
+   / metadata). The three identity/grade-adjacent sources (audit log, brightspace
+   sync, per-job runner metrics) are realized as counts/aggregates/redacted DTOs
+   so the no-student-data guarantee holds by construction; each is asserted by a
+   per-tool PII test.
 
 ---
 

--- a/docs/admin-mcp.md
+++ b/docs/admin-mcp.md
@@ -319,6 +319,9 @@ All `diagnostics:read`. Names are provisional.
 | `get_browser_diagnostics` | `client_diagnostics` (post-§6): counts by `kind`/`failedChecks`/`user_agent` over a window **plus recent redacted samples** incl. error message/stack | `user_id` dropped |
 | `query_logs` | Recent structured log records from the in-process ring buffer (§6), filterable by event name / level / time window | PII metadata redacted |
 | `get_health_alerts` | Current `ServerHealthAlertService` rule states (which are firing) + configured thresholds | clean |
+| `get_metrics_card_series` | The time-series (sparkline) data behind the admin dashboard's five operational cards — per-bucket max queue depth, jobs processed, max load, p95 queue-wait, p95 execution — for every window (24h / 7d / 30d). The windowed series behind `get_metrics_snapshot` | aggregate, no row identifiers |
+| `get_active_users_series` | The admin dashboard's "Active Users" chart: distinct active users per bucket over a trailing window (`ActivityChartService`) | aggregate, distinct counts only |
+| `get_instructor_card_series` | The instructor dashboard's four cards for one course (by `courseCode`): per-bucket submissions, active students, active assignments, browser errors (`instructorCardSeries`) | aggregate counts only; enrolled-student lookup is internal scoping, no identity reaches the output |
 
 A `get_deployment_info` / capability-probe tool mirrors the content surface's
 `get_server_info` and lets the agent confirm the surface is live and what it can
@@ -437,6 +440,18 @@ OAuth and DB-wall work lands.
      consumer (filter by level / substring / window); future event-driven admin
      queries reuse the same sink. Graduates to a retention-bounded table if
      durability / multi-instance history is ever needed.
+5. **Dashboard sparkline series.** ✅ **Done.** The time-series data behind the
+   instructor/admin dashboard sparklines, exposed verbatim from the same builders
+   the dashboards poll: `get_metrics_card_series` (the five admin operational
+   cards, `metricsCardSeries`), `get_active_users_series` (the "Active Users"
+   chart, `ActivityChartService.chartData`), and `get_instructor_card_series`
+   (one course's four cards, `instructorCardSeries`). `get_metrics_snapshot`
+   gives the point-in-time numbers; these give the windowed series behind them.
+   All admin-gated and PII-free: the operational/active-users series carry only
+   per-bucket aggregates, and the instructor series is course-scoped by an
+   explicit `courseCode` filter (not a session) but returns only per-bucket
+   counts — the enrolled-student/setup lookup is internal scoping, no student
+   identifier reaches the output, asserted by a per-tool PII test.
 
 ---
 


### PR DESCRIPTION
## What

Grows the admin diagnostic MCP surface from 5 tools to **16**, so an agent diagnosing a running deployment has read-only parity with what an admin/instructor can see in the web dashboards. Every tool is served from the *same builder its page uses* (no reimplemented queries), and every tool is read-only and PII-free by construction.

### Dashboard sparklines / charts
| Tool | Backs | Source |
|------|-------|--------|
| `get_metrics_card_series` | Admin dashboard's 5 operational cards (queue depth, jobs, load, p95 wait/exec), all windows | `metricsCardSeries` |
| `get_active_users_series` | Admin "Active Users" chart | `ActivityChartService.chartData` |
| `get_instructor_card_series` | Instructor dashboard's 4 cards for one course (`courseCode`) | `instructorCardSeries` |

### Operational views
| Tool | Answers | Source |
|------|---------|--------|
| `get_metrics_timeseries` | "Zoom into a window; correlate a latency/error spike" — incl. **HTTP request latency** | `metricsTimeSeriesSnapshot` |
| `get_queue_state` | "Is the queue backed up? Are jobs stuck?" (pending/in-flight/oldest/stuck) | queue queries + reaper view |
| `list_runners` / `get_runner_detail` | "Which runners are up? Why are jobs slow / why won't this assignment match?" (capability profile + per-stage timing + cache-hit) | `makeWorkerRows`, runner profile + job metrics |
| `get_storage_usage` | "Disk is filling — what's consuming it?" | `AdminRoutes.makeStorageContext` |
| `get_request_metrics` | "Slowest endpoints / 5xx rate" | `request_metrics` |
| `list_connected_agents` | "Why can't my connector read/write — scope or expiry?" | `MCPAgentsRoutes.grantRows` |
| `get_brightspace_sync_status` | "Are grade pushes failing, and why?" | `brightspace_sync_log` |
| `query_audit_log` | "Failed-login spike? Burst of refresh-reuse events?" (counts) | `audit_log` |

## PII posture (the load-bearing part)

The surface's hard guarantee is "never exposes student data." Clean sources are passed through as aggregates; the three identity/grade-adjacent sources are realized so **no student identifier is reachable**:

- **`query_audit_log` — counts only.** Returns per-action / per-category counts over a window. It never loads or returns an audit row, actor, IP, or metadata blob (actors can be students on login/registration events). The design doc excluded this table from v1 for exactly that reason; counts-only is the safe realization.
- **`get_brightspace_sync_status`** — `brightspace_sync_log` stores a student `username` + the pushed `points` (a grade). The DTO hard-drops both (and `user_id`); it keeps status, the D2L error detail, assignment/test-setup, org unit, and timestamp.
- **`get_runner_detail`** — `job_execution_metrics` carries `user_id`/`submission_id`, so the tool exposes only the **aggregate** timing summary over recent jobs, never the per-job rows the web page shows.
- **`get_request_metrics`** — id-like path segments (`sub_…`, UUIDs, …) are normalized to `:id` before aggregating, so a concrete submission id never appears.
- **`list_connected_agents`** — grant owners are the authorizing instructor/admin (consent gates on `isInstructor`/`isAdmin`), never students; refresh-token hashes are never surfaced.

Each redaction is asserted by a per-tool PII test (seed a student identifier / grade, assert it's absent from the serialized output).

## Changes

- 11 new `DiagnosticTool`s under `Sources/APIServer/MCP/Admin/Tools/` (the 3 sparkline tools + 8 operational tools), registered in `AdminMCPToolCatalog.live`.
- `AdminRoutes.makeStorageContext` extracted to a `static` method so the storage tool reuses the exact `/admin/storage` builder.
- Updated `AdminMCPServerInstructions` (a by-area tour + the redaction guarantees), `docs/admin-mcp.md` (catalog table + sequencing steps 5–6), the catalog registration test, and a changelog fragment.

## Testing

- `swift build` (full) ✓
- `swift test --filter AdminMCPToolsTests` — 38 tests (each tool: admin path + non-admin rejection; PII assertions on the redacted/normalized tools) ✓
- `swift test --filter AdminMCPDispatcherTests --filter AdminMCPEndpointTests` — 15 tests ✓
- `scripts/format.sh` + `scripts/swiftlint.sh --strict` — 0 violations ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)