### PR TITLE
Keep closed assignments visible to enrolled students; staff-gate the solution view

### DIFF
--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -39,6 +39,13 @@ extension WebRoutes {
 
         let query = try req.query.decode(NotebookQuery.self)
         let fileKind = notebookFileKind(from: query.file)
+        // The reference solution is staff-only. The student notebook route is
+        // reachable by any enrolled student (and now, read-only, for closed
+        // assignments), so guard the solution view here rather than relying on
+        // the absence of a UI link — never serve the answer key to a student.
+        if fileKind == .solution, !user.isInstructor {
+            throw Abort(.forbidden, reason: "The solution is only available to course staff.")
+        }
         let queryTitle = (query.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == setupID)

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -113,17 +113,25 @@ struct WebRoutes: RouteCollection {
                     .all()
             }
         } else {
-            // Students see test setups whose assignment is open, plus any setup
-            // where they hold an active extension — so an assignment that the
-            // automatic sweep closed at its deadline stays visible to a student
-            // who was granted more time.
-            var visibleSetupIDs = Set(allAssignments.filter(\.isOpen).map(\.testSetupID))
+            // Enrolled students see every published assignment in their course:
+            // open ones, and ones that were published and have since closed at
+            // their deadline — kept on the list (read-only) so recent labs never
+            // silently disappear. Preview / scheduled / unpublished-draft
+            // assignments stay hidden (see assignmentVisibleToStudentByState).
             let now = Date()
+            var visibleSetupIDs = Set(
+                allAssignments
+                    .filter { assignmentVisibleToStudentByState($0, now: now) }
+                    .map(\.testSetupID))
+            // An active per-student extension also reveals an assignment that was
+            // closed before its deadline (which the by-state rule leaves hidden
+            // for everyone else) to the one student who was granted more time.
             for (setupID, extendedDueAt) in extensionDueAtBySetupID
             where studentHasActiveExtension(extensionDueAt: extendedDueAt, now: now) {
                 visibleSetupIDs.insert(setupID)
             }
-            // Closed assignments the student already opened remain on the list.
+            // Any closed assignment the student already engaged with stays listed
+            // too — covers no-deadline assignments the by-state rule can't classify.
             visibleSetupIDs.formUnion(previouslyOpenedSetupIDs)
             guard !visibleSetupIDs.isEmpty else {
                 return try await req.view.render(
@@ -372,7 +380,13 @@ struct WebRoutes: RouteCollection {
                     startsAt: gate.honorsStartDate ? assignment.startsAt : nil
                 )
             }()
-            let canEdit = isOpenForThisUser || previouslyOpenedSetupIDs.contains(setupID)
+            // A published-but-closed assignment is openable read-only, so it
+            // still gets the open-notebook action even for a student who never
+            // engaged with it (the page renders read-only and hides Submit).
+            let canEdit =
+                isOpenForThisUser
+                || previouslyOpenedSetupIDs.contains(setupID)
+                || (assignment.map { assignmentVisibleToStudentByState($0) } ?? false)
             let badgeSplit = AchievementBadge.dashboardSplit(latestBadgesBySetupID[setupID] ?? [])
             return TestSetupRow(
                 id: setupID,

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -120,8 +120,29 @@ func studentHasActiveExtension(
     return now < extensionDueAt
 }
 
-/// The effective deadline given a baseline and an optional extension: the later
-/// of the two, or whichever is non-nil. Returns nil only when both are nil.
+/// Whether a published assignment should appear to an enrolled student on the
+/// strength of its own state alone — independent of any per-student extension
+/// or prior participation, which the dashboard unions in separately.
+///
+/// Students see an assignment that is currently open, or one that was published
+/// to the class and has since closed at its deadline (so recently-closed labs
+/// stay on the dashboard and remain openable read-only, instead of silently
+/// vanishing). Deliberately hidden so authoring-in-progress content never leaks:
+///   - `.preview` assignments (staff-only beta state),
+///   - not-yet-started assignments (a future `startsAt`),
+///   - not-yet-published drafts — a `.closed` assignment that has no past due
+///     date (a freshly created / cloned assignment, or one closed before its
+///     deadline; those are surfaced only via an extension or prior engagement).
+func assignmentVisibleToStudentByState(_ assignment: APIAssignment, now: Date = Date()) -> Bool {
+    if assignment.isOpen { return true }
+    // Only `.closed` is a candidate for the published-then-closed case; `.preview`
+    // remains staff-only.
+    guard assignment.visibility == .closed else { return false }
+    if let startsAt = assignment.startsAt, now < startsAt { return false }
+    guard let dueAt = assignment.dueAt, dueAt <= now else { return false }
+    return true
+}
+
 func laterDeadline(baseline: Date?, extensionDueAt: Date?) -> Date? {
     guard let extensionDueAt else { return baseline }
     guard let baseline else { return extensionDueAt }

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -79,10 +79,21 @@ func closedAssignmentGate(
     isClosed: Bool
 ) async throws -> Response? {
     guard !user.isInstructor else { return nil }
-    if isClosed, let assignment,
-        !(try await studentHasOpenedAssignment(assignment: assignment, userID: userID, on: req.db))
-    {
-        return req.redirect(to: "/")
+    if isClosed, let assignment {
+        // A published-then-closed assignment is openable read-only — a student
+        // may return to a recently-closed lab to review it. Only bounce a
+        // student from a closed assignment that isn't student-visible by state
+        // (a preview, a not-yet-opened scheduled assignment, or an unpublished
+        // draft) and that they have never engaged with. Submission stays gated
+        // separately by requireOpenStudentAssignment, so this view is read-only.
+        var mayView = assignmentVisibleToStudentByState(assignment)
+        if !mayView {
+            mayView = try await studentHasOpenedAssignment(
+                assignment: assignment, userID: userID, on: req.db)
+        }
+        if !mayView {
+            return req.redirect(to: "/")
+        }
     }
     if let assignmentID = assignment?.id {
         try await AssignmentParticipationStore.recordFirstAccess(

--- a/Tests/APITests/AssignmentExtensionsTests.swift
+++ b/Tests/APITests/AssignmentExtensionsTests.swift
@@ -367,6 +367,39 @@ import XCTVapor
         #expect(studentHasActiveExtension(extensionDueAt: past, now: now) == false)
     }
 
+    // MARK: - Published-vs-draft student visibility (pure logic)
+
+    /// `assignmentVisibleToStudentByState` decides whether an assignment shows
+    /// to an enrolled student on its own state: open ones and published-then-
+    /// closed ones are visible; preview, scheduled, and unpublished drafts are
+    /// hidden so authoring-in-progress content never leaks.
+    @Test func assignmentVisibleToStudentByStateClassifiesPublishedVsDraft() {
+        let now = Date()
+        let past = now.addingTimeInterval(-3_600)
+        let future = now.addingTimeInterval(3_600)
+        let courseID = UUID()
+        func make(_ visibility: AssignmentVisibility, dueAt: Date?, startsAt: Date? = nil) -> APIAssignment {
+            APIAssignment(
+                testSetupID: "s", title: "t", dueAt: dueAt, startsAt: startsAt,
+                visibility: visibility, courseID: courseID)
+        }
+
+        // Open → always visible (deadline state is irrelevant to visibility).
+        #expect(assignmentVisibleToStudentByState(make(.open, dueAt: nil), now: now))
+        #expect(assignmentVisibleToStudentByState(make(.open, dueAt: past), now: now))
+        // Published-then-closed (deadline elapsed) → visible read-only.
+        #expect(assignmentVisibleToStudentByState(make(.closed, dueAt: past), now: now))
+        // Unpublished draft: closed with no deadline → hidden.
+        #expect(!assignmentVisibleToStudentByState(make(.closed, dueAt: nil), now: now))
+        // Closed before its (future) deadline — surfaced only via extension /
+        // engagement, not by state → hidden.
+        #expect(!assignmentVisibleToStudentByState(make(.closed, dueAt: future), now: now))
+        // Preview is staff-only → hidden even once its deadline passes.
+        #expect(!assignmentVisibleToStudentByState(make(.preview, dueAt: past), now: now))
+        // Not yet started (future open date) → hidden.
+        #expect(!assignmentVisibleToStudentByState(make(.closed, dueAt: past, startsAt: future), now: now))
+    }
+
     // MARK: - Per-user open decision (pure logic)
 
     @Test func openForUserCoversDeadlineAndExtensionCases() {

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -337,23 +337,58 @@ import XCTVapor
         }
     }
 
-    @Test func notebookPageClosedAssignmentNeverOpenedRedirectsToDashboard() async throws {
+    @Test func notebookPageClosedPublishedAssignmentNeverOpenedRendersReadOnly() async throws {
         try await withApp(app) { _ in
-            // A student who has never opened a closed assignment (no working
-            // copy, no submission) is redirected to their dashboard instead of
-            // seeing the notebook — this keeps pre-posted links from spoiling
-            // not-yet-opened labs.
+            // A published-then-closed assignment (its deadline has passed) is now
+            // openable read-only by any enrolled student, even one who never
+            // engaged with it — recent labs stay reviewable instead of bouncing
+            // the student to the dashboard. Submission remains separately gated,
+            // so the view is read-only (no Submit button, closed notice shown).
             let cookie = try await loginAsStudent()
             let user = try await studentUser()
             try await enroll(user)
 
-            let setupID = "setup_nb_closed_unopened"
-            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Hidden"))
+            let setupID = "setup_nb_closed_published"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Review me"))
             _ = try await insertAssignment(
                 testSetupID: setupID,
-                title: "Unopened Closed Lab",
-                dueAt: Date(timeIntervalSinceNow: -3600),
+                title: "Closed Published Lab",
+                dueAt: Date(timeIntervalSinceNow: -3600),  // published, deadline passed
                 isOpen: true
+            )
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains(#"data-read-only="true""#))
+                    #expect(html.contains(#"id="nb-submit""#) == false)
+                    #expect(html.contains("This assignment is closed"))
+                })
+        }
+    }
+
+    @Test func notebookPageUnpublishedDraftRedirectsToDashboard() async throws {
+        try await withApp(app) { _ in
+            // A closed assignment with no due date is an unpublished draft, not a
+            // lab that ran and closed: a student who never engaged with it is
+            // still bounced to the dashboard so authoring-in-progress content and
+            // pre-posted links can't spoil it.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_draft"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Draft"))
+            _ = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Draft Lab",
+                dueAt: nil,  // no deadline → unpublished draft
+                isOpen: false
             )
 
             try await app.asyncTest(
@@ -364,6 +399,69 @@ import XCTVapor
                 afterResponse: { res in
                     #expect(res.status == .seeOther)
                     #expect(res.headers.first(name: .location) == "/")
+                })
+        }
+    }
+
+    @Test func notebookPageRejectsSolutionFileForStudent() async throws {
+        try await withApp(app) { _ in
+            // The reference solution is staff-only. A student crafting
+            // ?file=solution on the notebook route must be refused — the answer
+            // key is never served to a student, on any assignment.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_solution_student"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(markdown: "Assignment"),
+                zipEntries: [
+                    ("assignment.ipynb", notebookJSON(markdown: "Assignment")),
+                    ("solution.ipynb", notebookJSON(markdown: "Reference solution")),
+                ]
+            )
+            _ = try await insertAssignment(testSetupID: setupID, title: "Solution Guard Lab", isOpen: true)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook?file=solution",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                })
+        }
+    }
+
+    @Test func notebookPageAllowsSolutionFileForInstructor() async throws {
+        try await withApp(app) { _ in
+            // Course staff may view the solution on the same route — the guard is
+            // role-based, not a blanket block, so instructor preview still works.
+            let cookie = try await loginUser(
+                username: "notebook_instructor", password: "testpassword", role: "instructor", on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "notebook_instructor").first())
+            try await enroll(instructor)
+
+            let setupID = "setup_nb_solution_instructor"
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(markdown: "Assignment"),
+                zipEntries: [
+                    ("assignment.ipynb", notebookJSON(markdown: "Assignment")),
+                    ("solution.ipynb", notebookJSON(markdown: "Reference solution")),
+                ]
+            )
+            _ = try await insertAssignment(testSetupID: setupID, title: "Solution View Lab", isOpen: true)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook?file=solution",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
                 })
         }
     }

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -403,6 +403,52 @@ import XCTVapor
         }
     }
 
+    @Test func notebookPageExtendedStudentGetsEditableClosedAssignmentEvenIfNeverStarted() async throws {
+        try await withApp(app) { _ in
+            // CRITICAL: a per-student extension must let the student COMPLETE a
+            // closed assignment for full credit, even one they never started.
+            // The notebook page must render EDITABLE (not read-only) with the
+            // Submit button, because the extension makes it effectively open for
+            // this student — independent of any prior participation.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+
+            let setupID = "setup_nb_extension_editable"
+            _ = try await insertSetup(id: setupID, notebookJSON: notebookJSON(markdown: "Extend me"))
+            let assignment = try await insertAssignment(
+                testSetupID: setupID,
+                title: "Extended Closed Lab",
+                dueAt: Date(timeIntervalSinceNow: -3600),  // deadline passed
+                isOpen: false  // assignment-wide visibility is closed
+            )
+            // Grant a future extension. The student has NEVER opened this
+            // assignment — no participation row, no submission.
+            try await APIAssignmentExtension(
+                assignmentID: try assignment.requireID(),
+                userID: try user.requireID(),
+                extendedDueAt: Date(timeIntervalSinceNow: 48 * 3600)
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/testsetups/\(setupID)/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains(#"data-read-only="false""#),
+                        "An extended student must get an EDITABLE notebook on a closed assignment")
+                    #expect(
+                        html.contains(#"id="nb-submit""#),
+                        "An extended student must see the Submit button so they can complete it")
+                    #expect(html.contains("This assignment is closed") == false)
+                })
+        }
+    }
+
     @Test func notebookPageRejectsSolutionFileForStudent() async throws {
         try await withApp(app) { _ in
             // The reference solution is staff-only. A student crafting

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -202,8 +202,62 @@ import XCTVapor
         }
     }
 
-    @Test func indexHidesClosedAssignmentNeverOpenedFromStudent() async throws {
+    @Test func indexShowsClosedPublishedAssignmentToEnrolledStudentEvenWithoutEngagement() async throws {
         try await withWebRoutesApp { app in
+            // A published assignment that has since closed at its deadline stays
+            // on every enrolled student's dashboard (read-only), even one who
+            // never opened it and holds no extension — recent labs must not
+            // silently disappear just because a student missed the window.
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            try await wrEnrollUser(user, on: app)
+
+            // A browser-graded notebook assignment (like the real Lab 4), closed
+            // at a past deadline, with no submission or participation for this
+            // student.
+            let setupID = "setup_closed_published"
+            let courseID = try await wrMakeCourse(on: app).requireID()
+            let notebookPath = app.testSetupsDirectory + "\(setupID).ipynb"
+            try Data(
+                #"{"cells":[],"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"}},"nbformat":4,"nbformat_minor":5}"#
+                    .utf8
+            ).write(to: URL(fileURLWithPath: notebookPath))
+            let setup = APITestSetup(
+                id: setupID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[{"tier":"public","script":"t.py"}],"timeLimitSeconds":10}"#,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip",
+                notebookPath: notebookPath,
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+            try await wrInsertAssignment(
+                testSetupID: setupID, title: "Closed Published Lab",
+                isOpen: false, dueAt: Date().addingTimeInterval(-3_600), on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains("Closed Published Lab"),
+                        "A published-then-closed assignment must stay visible to every enrolled student")
+                    #expect(
+                        html.contains(#"title="Edit""#),
+                        "The closed published assignment must be openable (read-only), not a dead-end row")
+                })
+        }
+    }
+
+    @Test func indexHidesUnpublishedClosedDraftFromStudent() async throws {
+        try await withWebRoutesApp { app in
+            // A closed assignment with NO due date is an unpublished draft (the
+            // freshly-created / authoring-in-progress state), not a lab that ran
+            // and closed — it must stay hidden from students who never engaged.
             let cookie = try await wrLoginAsStudent(on: app)
             let user = try await wrStudentUser(on: app)
             try await wrEnrollUser(user, on: app)
@@ -221,7 +275,7 @@ import XCTVapor
                     #expect(res.status == .ok)
                     #expect(
                         res.body.string.contains("Secret Lab") == false,
-                        "A closed assignment the student never opened must not appear on the dashboard")
+                        "An unpublished closed draft (no due date) must not appear on the dashboard")
                 })
         }
     }

--- a/changelog.d/closed-assignment-visibility.md
+++ b/changelog.d/closed-assignment-visibility.md
@@ -1,0 +1,7 @@
+### Changed
+
+- **Closed assignments stay visible to enrolled students.** A published assignment that has closed at its deadline now remains on every enrolled student's dashboard (shown as `closed`, read-only) and is openable for review, instead of silently disappearing for any student who never opened it while it was open. Recent labs no longer vanish for students who missed the window — including those a platform issue locked out. Unpublished drafts (a `closed` assignment with no past due date), `preview` (staff-only) assignments, and not-yet-started (future open date) assignments stay hidden, so authoring-in-progress content never leaks. New shared helper `assignmentVisibleToStudentByState` drives the dashboard filter and the notebook read-only view gate so they can't drift; submission remains separately gated, so the widened access is strictly read-only.
+
+### Security
+
+- **The reference solution is now staff-gated on the student notebook route.** `GET /testsetups/:id/notebook?file=solution` previously rendered the instructor's answer-key notebook for any enrolled student who crafted the query (the guard relied on the absence of a UI link). It now returns `403` for non-instructors, closing the exposure on open assignments and preventing the closed-assignment read-only view from widening it.


### PR DESCRIPTION
## Why

Diagnosing why HLTH 230 students reported they "can't see recent assignments," I found two compounding issues behind a real incident (Lab 4's in-browser grading kernel was failing, then Lab 4 vanished from dashboards):

1. **Closed assignments silently disappeared** for any student who never opened them while they were open. Students who couldn't engage with a lab (e.g. the kernel locked them out) lost all sight of it once it auto-closed at its deadline. This was intentional ("closed assignments hidden from non-engaged students") but is the wrong behavior for a published lab that ran and closed.
2. While tracing the notebook route, I found a **pre-existing academic-integrity hole**: `GET /testsetups/:id/notebook?file=solution` rendered the instructor's reference solution for *any* enrolled student who crafted the query — there was no role check (the guard relied only on the absence of a UI link). A student could pull the answer key, even for an *open* assignment.

## What changed

**Closed assignments stay visible to enrolled students (read-only).**
- New shared helper `assignmentVisibleToStudentByState` classifies an assignment by its own state: **open** or **published-then-closed** (a `.closed` assignment whose deadline has passed) → visible; **unpublished draft** (`.closed` with no past due date), **`.preview`** (staff-only), and **not-yet-started** (future `startsAt`) → hidden, so authoring-in-progress content never leaks.
- The student dashboard filter and the notebook **read-only view gate** both use this one helper, so they can't drift. A published-then-closed assignment now appears on the dashboard with an open (read-only) action instead of being a dead-end row, and its notebook page renders read-only instead of redirecting.
- **Submission stays separately gated** (`requireOpenStudentAssignment` / `isAssignmentEffectivelyOpen` are unchanged), so the widened access is strictly read-only — a student still cannot submit to a closed assignment without an extension.

**Solution view is now staff-gated.**
- `?file=solution` on the student notebook route returns `403` for non-instructors. Closes the exposure on open assignments and prevents the new closed-assignment read-only view from widening it.

## Tests
- `assignmentVisibleToStudentByState` unit table (open / published-closed / draft / future-due / preview / not-yet-started).
- Dashboard: published-closed assignment is shown to an enrolled, non-engaged student with an open action; unpublished closed draft stays hidden.
- Notebook gate: published-closed assignment renders read-only; unpublished draft still redirects; `?file=solution` → 403 for students, 200 for instructors.
- Full suites green: `NotebookWebRoutesTests`, `WebRoutesIndexTests`, `AssignmentExtensionsTests`, `AssignmentRoutesDashboardTests`, `AssignmentAuthoringServiceTests`. `swift build`, `scripts/format.sh`, `scripts/swiftlint.sh --strict` clean.

## Notes
- Does **not** touch any Lab 4 / HLTH 230 data — this is a behavior fix in code, applied to all courses, per the product decision to always show closed assignments to enrolled students.
- The separate in-browser kernel failure (the original submission freeze) is **not** addressed here; that's the browser-grading reliability issue and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LdPj2Lxoa7JepWuosLufj

---
_Generated by [Claude Code](https://claude.ai/code/session_012LdPj2Lxoa7JepWuosLufj)_