### PR TITLE
Revert notebook cross-origin isolation (broke the editor: COEP blocked the kernel worker)

### DIFF
--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -150,11 +150,12 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // calling next), so middleware registered AFTER it only runs for dynamic
     // Leaf-rendered pages — which is why COEPMiddleware (after it) covers the
     // dynamic notebook page, while NotebookAssetIsolationMiddleware (before it)
-    // is needed to decorate the static /jupyterlite/* responses. Together they
-    // cross-origin-isolate the notebook editor so the Pyodide kernel gets
-    // SharedArrayBuffer — the fix for the main-thread freeze when there's no SAB
-    // and the service-worker sync fallback is disabled (see COEPMiddleware /
-    // NotebookAssetIsolationMiddleware).
+    // is needed to decorate the static /jupyterlite/* responses. By default the
+    // JupyterLite assets get no COEP (long-standing behaviour). Cross-origin
+    // isolation for the editor — the fix for the Pyodide main-thread freeze when
+    // there's no SharedArrayBuffer and the service-worker sync fallback is
+    // disabled — is opt-in via NOTEBOOK_CROSS_ORIGIN_ISOLATION (see
+    // COEPMiddleware / NotebookAssetIsolationMiddleware).
     // Registered just OUTSIDE FileMiddleware so it can set immutable cache +
     // application/wasm headers on the content-hashed wasm runner served from
     // Public/runner-wasm/ (FileMiddleware short-circuits, so a middleware after
@@ -165,11 +166,13 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // existing Cache-Control.
     app.middleware.use(StaticAssetCacheMiddleware())
     app.middleware.use(RunnerWasmCacheMiddleware())
-    // Cross-origin isolation for the notebook editor. The asset middleware runs
+    // Cross-origin isolation for the notebook editor (gated by
+    // NOTEBOOK_CROSS_ORIGIN_ISOLATION, default off). The asset middleware runs
     // BEFORE FileMiddleware so it can decorate the short-circuited /jupyterlite/*
     // static responses; COEPMiddleware (after FileMiddleware) covers the dynamic
-    // notebook page itself.
-    app.middleware.use(NotebookAssetIsolationMiddleware())
+    // notebook page itself. Both no-op when the flag is off.
+    let isolateNotebook = securityConfiguration.notebookCrossOriginIsolation
+    app.middleware.use(NotebookAssetIsolationMiddleware(enabled: isolateNotebook))
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
-    app.middleware.use(COEPMiddleware())
+    app.middleware.use(COEPMiddleware(isolateNotebook: isolateNotebook))
 }

--- a/Sources/APIServer/Configuration/SecurityConfig.swift
+++ b/Sources/APIServer/Configuration/SecurityConfig.swift
@@ -22,6 +22,17 @@ struct AppSecurityConfiguration: Sendable {
     /// timeout; zero (or a disabled gate) suppresses the warning so the
     /// client logs out straight at the ceiling.
     let sessionIdleWarningSeconds: TimeInterval
+    /// When true, the student notebook editor page AND the `/jupyterlite/*`
+    /// iframe assets are served with COOP + COEP (`require-corp`) so the page is
+    /// cross-origin isolated and the Pyodide kernel can use `SharedArrayBuffer`
+    /// for synchronous execution — the fix for the main-thread freeze that
+    /// occurs when neither `SharedArrayBuffer` nor the (disabled) service-worker
+    /// sync fallback is available. Set via `NOTEBOOK_CROSS_ORIGIN_ISOLATION`,
+    /// default false: COEP on the editor page has broken the iframe before
+    /// (#574), so this is gated behind a flag — enable on staging, verify the
+    /// editor boots in each target browser, then enable in production, with
+    /// instant rollback by flipping the flag (no redeploy).
+    let notebookCrossOriginIsolation: Bool
 
     static let `default` = AppSecurityConfiguration(
         publicBaseURL: nil,
@@ -29,7 +40,8 @@ struct AppSecurityConfiguration: Sendable {
         trustForwardedProto: true,
         sessionCookieSecure: false,
         sessionIdleTimeoutSeconds: 30 * 60,
-        sessionIdleWarningSeconds: 120
+        sessionIdleWarningSeconds: 120,
+        notebookCrossOriginIsolation: false
     )
 
     static func fromEnvironment(authMode: AuthMode) -> Self {
@@ -60,7 +72,8 @@ struct AppSecurityConfiguration: Sendable {
             trustForwardedProto: environmentBool("TRUST_X_FORWARDED_PROTO") ?? true,
             sessionCookieSecure: environmentBool("SESSION_COOKIE_SECURE") ?? (publicBaseIsHTTPS || authMode != .local),
             sessionIdleTimeoutSeconds: idleSeconds,
-            sessionIdleWarningSeconds: warningSeconds
+            sessionIdleWarningSeconds: warningSeconds,
+            notebookCrossOriginIsolation: environmentBool("NOTEBOOK_CROSS_ORIGIN_ISOLATION") ?? false
         )
     }
 }

--- a/Sources/APIServer/Middleware/COEPMiddleware.swift
+++ b/Sources/APIServer/Middleware/COEPMiddleware.swift
@@ -9,12 +9,12 @@
 //
 //   • /instructor/…/validate — browser-side validation (assignment-validate.js).
 //   • /testsetups/:id/notebook — the student notebook editor (JupyterLite in an
-//     iframe). `NotebookAssetIsolationMiddleware` applies the matching headers
-//     to the `/jupyterlite/*` iframe assets so the iframe document — where the
-//     kernel worker actually runs — is isolated too. Without this the kernel
-//     has no SharedArrayBuffer and (the JupyterLite service worker being
-//     disabled) no service-worker sync fallback either, so a synchronous kernel
-//     operation hard-freezes the page ("Page Unresponsive").
+//     iframe), but ONLY when `isolateNotebook` is true. This is gated behind the
+//     `NOTEBOOK_CROSS_ORIGIN_ISOLATION` flag because COEP on the editor page has
+//     broken the iframe before (#574): the editor must be browser-verified to
+//     still boot under COEP. When enabled, `NotebookAssetIsolationMiddleware`
+//     applies the matching headers to the `/jupyterlite/*` iframe assets so the
+//     iframe document — where the kernel worker actually runs — is isolated too.
 //
 // COEP require-corp only restricts CROSS-origin subresources; same-origin ones
 // (Chickadee vendors Pyodide / CodeMirror / jszip same-origin) load unchanged.
@@ -24,6 +24,13 @@
 import Vapor
 
 struct COEPMiddleware: AsyncMiddleware {
+    /// Whether the student notebook editor page opts into cross-origin isolation.
+    let isolateNotebook: Bool
+
+    init(isolateNotebook: Bool = false) {
+        self.isolateNotebook = isolateNotebook
+    }
+
     func respond(
         to request: Request,
         chainingTo next: any AsyncResponder
@@ -51,8 +58,8 @@ struct COEPMiddleware: AsyncMiddleware {
         // and other instructor pages that load CDN resources.
         if last == "validate" { return true }
 
-        // Student notebook editor page (/testsetups/:id/notebook).
-        if parts.count == 3, parts[0] == "testsetups", last == "notebook" {
+        // Student notebook editor page (/testsetups/:id/notebook), gated.
+        if isolateNotebook, parts.count == 3, parts[0] == "testsetups", last == "notebook" {
             return true
         }
 

--- a/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
+++ b/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
@@ -13,21 +13,29 @@
 // middleware registered AFTER it never sees those static responses. Registered
 // before, this one decorates the response on the way back out.
 //
+// Gated by `NOTEBOOK_CROSS_ORIGIN_ISOLATION` (off by default): when disabled it
+// is a pure pass-through, preserving the long-standing behaviour of serving the
+// JupyterLite assets without COEP. See `COEPMiddleware` for the rationale and
+// the #574 history.
+//
 // `Cross-Origin-Resource-Policy: same-origin` is added so the same-origin
 // parent can embed these documents/assets under its own COEP; `require-corp`
 // itself only constrains cross-origin subresources, which Chickadee does not
-// load (Pyodide / CodeMirror / jszip are vendored same-origin). See
-// `COEPMiddleware` for the rationale and the #574 history.
+// load (Pyodide / CodeMirror / jszip are vendored same-origin).
 
 import Vapor
 
 struct NotebookAssetIsolationMiddleware: AsyncMiddleware {
+    /// Whether to apply cross-origin-isolation headers. When false this
+    /// middleware does nothing.
+    let enabled: Bool
+
     func respond(
         to request: Request,
         chainingTo next: any AsyncResponder
     ) async throws -> Response {
         let response = try await next.respond(to: request)
-        guard request.url.path.hasPrefix("/jupyterlite/") else { return response }
+        guard enabled, request.url.path.hasPrefix("/jupyterlite/") else { return response }
 
         response.headers.replaceOrAdd(name: "Cross-Origin-Opener-Policy", value: "same-origin")
         response.headers.replaceOrAdd(name: "Cross-Origin-Embedder-Policy", value: "require-corp")

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -6,11 +6,12 @@ import XCTVapor
 
 @Suite struct COEPMiddlewareTests {
 
-    /// Wires both isolation middlewares the way `AppMiddleware` does.
-    private func makeApp() async throws -> Application {
+    /// Wires both isolation middlewares the way `AppMiddleware` does, with the
+    /// `NOTEBOOK_CROSS_ORIGIN_ISOLATION` flag passed through.
+    private func makeApp(isolateNotebook: Bool = false) async throws -> Application {
         let app = try await Application.make(.testing)
-        app.middleware.use(NotebookAssetIsolationMiddleware())
-        app.middleware.use(COEPMiddleware())
+        app.middleware.use(NotebookAssetIsolationMiddleware(enabled: isolateNotebook))
+        app.middleware.use(COEPMiddleware(isolateNotebook: isolateNotebook))
 
         app.get("testsetups", ":testSetupID", "notebook") { _ in "notebook" }
         app.get("instructor", ":assignmentID", "validate") { _ in "validate" }
@@ -20,8 +21,32 @@ import XCTVapor
         return app
     }
 
-    @Test func notebookPageIsCrossOriginIsolated() async throws {
+    // MARK: - Flag OFF (default) preserves the long-standing behaviour
+
+    @Test func notebookPageIsNotIsolatedByDefault() async throws {
         try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/testsetups/setup_123/notebook") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+            }
+        }
+    }
+
+    @Test func jupyterliteAssetsAreNotIsolatedByDefault() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+                #expect(res.headers.first(name: "Cross-Origin-Resource-Policy") == nil)
+            }
+        }
+    }
+
+    // MARK: - Flag ON isolates the editor page AND its iframe assets
+
+    @Test func notebookPageIsIsolatedWhenEnabled() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
             try await app.testable().test(.GET, "/testsetups/setup_123/notebook") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
@@ -30,8 +55,8 @@ import XCTVapor
         }
     }
 
-    @Test func jupyterliteAssetsAreCrossOriginIsolated() async throws {
-        try await withApp(try await makeApp()) { app in
+    @Test func jupyterliteAssetsAreIsolatedWhenEnabled() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
             try await app.testable().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
@@ -41,7 +66,9 @@ import XCTVapor
         }
     }
 
-    @Test func validatePageIsCrossOriginIsolated() async throws {
+    // MARK: - Always: validate isolated, unrelated pages untouched
+
+    @Test func validatePageAlwaysReceivesCOEPHeaders() async throws {
         try await withApp(try await makeApp()) { app in
             try await app.testable().test(.GET, "/instructor/assignment_123/validate") { res async in
                 #expect(res.status == .ok)
@@ -51,8 +78,8 @@ import XCTVapor
         }
     }
 
-    @Test func unrelatedPageReceivesNoIsolationHeaders() async throws {
-        try await withApp(try await makeApp()) { app in
+    @Test func unrelatedPageNeverReceivesCOEPHeaders() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
             try await app.testable().test(.GET, "/plain") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)

--- a/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
+++ b/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
@@ -26,7 +26,8 @@ import XCTVapor
             trustForwardedProto: trustForwardedProto,
             sessionCookieSecure: false,
             sessionIdleTimeoutSeconds: 0,
-            sessionIdleWarningSeconds: 0
+            sessionIdleWarningSeconds: 0,
+            notebookCrossOriginIsolation: false
         )
         app.middleware.use(HTTPSRedirectMiddleware(configuration: config))
         app.get("test") { _ in "ok" }

--- a/Tests/APITests/OIDCTests.swift
+++ b/Tests/APITests/OIDCTests.swift
@@ -74,7 +74,8 @@ import XCTVapor
             trustForwardedProto: true,
             sessionCookieSecure: false,
             sessionIdleTimeoutSeconds: 0,
-            sessionIdleWarningSeconds: 0
+            sessionIdleWarningSeconds: 0,
+            notebookCrossOriginIsolation: false
         )
         return app
     }


### PR DESCRIPTION
## Hotfix — revert #961 (cross-origin isolation broke the editor in prod)

`crossOriginIsolated` went `true` on 0.4.466, confirming COEP took effect — and that's exactly what **blocked the worker scripts**, including the Pyodide **kernel worker** (`/jupyterlite/extensions/@jupyterlite/pyodide-kernel-extension/static/…js`) and my freeze-watchdog worker. With the kernel worker refused, the kernel never starts → "Pyodide loads forever." Editor unusable for everyone.

### Confirmed root cause (why my fix couldn't have worked)
Under COEP `require-corp`, **worker scripts must carry CORP** — even same-origin ones. My `NotebookAssetIsolationMiddleware` was registered next to `FileMiddleware`, but the editor asset trees (`/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`, `/vendor`) are served by **`EditorAssetFastPathMiddleware`**, which is registered much earlier and **short-circuits the chain** — so my header middleware never saw those responses. The iframe *document* got isolated (hence `crossOriginIsolated = true`), but the workers/assets it loads got **no CORP** → blocked. (`/freeze-watchdog-worker.js` at the web root wasn't covered at all.)

### What this restores
Reverting #961 brings back the flag-gated (default-off) state from #960 — COEP is **not** applied to the editor, so it works exactly as on 0.4.465. The intermittent freeze returns, but the editor is functional.

### ⚠️ Immediate relief: roll back the image
Because the env flag was removed (per request), there's **no runtime off-switch** — turning COEP off needs a deploy. Fastest fix is to **redeploy the previous image (0.4.465)** while this revert goes through CI.

Follow-up (separate): the *right* long-term path, now that we understand the failure — see the analysis I'm posting in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LdPj2Lxoa7JepWuosLufj

---
_Generated by [Claude Code](https://claude.ai/code/session_012LdPj2Lxoa7JepWuosLufj)_