### PR TITLE
Headless-browser smoke test for the notebook editor (catches the COEP kernel-worker block)

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -1,0 +1,105 @@
+name: Editor smoke test
+
+# Boots the real chickadee-server and drives the JupyterLite notebook editor in
+# a headless browser, asserting the Pyodide kernel comes up and runs a cell.
+# This is the gate the recent editor breakages slipped through: swift test, the
+# render tests, and BrowserRunnerJSTests all prove code/templates *resolve* —
+# none put a browser in front of the editor, so a change that loads the page but
+# blocks the kernel worker (the COEP cross-origin-isolation attempt) or leaves a
+# dead kernel ("Kernel Unknown") passes CI and only fails in front of a student.
+#
+# Runs two ways:
+#   • nightly (schedule) — always-on insurance across the whole editor stack;
+#   • per-PR but PATH-FILTERED — only when a notebook/editor/middleware/asset
+#     file changes, so the PRs that can actually break the editor get the gate
+#     without burdening every unrelated PR.
+#
+# Advisory for now (do NOT mark it a required check while it's path-filtered: a
+# required check that is skipped on most PRs blocks their merge). Promote to
+# required once it has proven stable — see docs/notebook-editor-smoke-test.md.
+
+on:
+  schedule:
+    # ~03:30 America/Toronto (07:30 UTC) — off the nightly coverage slot.
+    - cron: "30 7 * * *"
+  pull_request:
+    paths:
+      - "Public/notebook*.js"
+      - "Public/browser-runner.js"
+      - "Public/pyodide-worker.js"
+      - "Public/assignment-validate.js"
+      - "Public/freeze-watchdog-worker.js"
+      - "Public/jupyterlite/**"
+      - "Public/pyodide/**"
+      - "Public/vendor/**"
+      - "Sources/APIServer/Middleware/COEPMiddleware.swift"
+      - "Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift"
+      - "Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift"
+      - "Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift"
+      - "Sources/APIServer/Bootstrap/AppMiddleware.swift"
+      - "Sources/APIServer/Configuration/SecurityConfig.swift"
+      - "Tools/jupyterlite/**"
+      - "Tools/editor-smoke-test/**"
+      - ".github/workflows/editor-smoke.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: editor-smoke-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Run in the same swift image the other jobs use so the cached server binary
+    # (dynamically linked against this image's Swift runtime) actually runs, and
+    # so the vended Public/pyodide it serves is the exact build CI ships.
+    container:
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      # Normalise source mtimes to commit times so a restored .build/ stays
+      # valid for unchanged files and only new commits recompile.
+      - uses: ./.github/actions/restore-git-mtimes
+
+      - name: Resolve toolchain cache key
+        id: toolchain
+        run: echo "key=$(swift --version | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      # Read-only restore of the shared build cache produced by the Swift Tests
+      # `build` job (same key). On a hit, building just the server product is a
+      # near-no-op; on the nightly/cold path, restore-keys gets the most recent
+      # main build and only changed files recompile.
+      - name: Restore build artifacts
+        uses: actions/cache/restore@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          restore-keys: |
+            ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-
+
+      - name: Build chickadee-server
+        run: swift build --product chickadee-server
+
+      - name: Install Node, Playwright and Chromium
+        working-directory: Tools/editor-smoke-test
+        run: |
+          set -eux
+          # Node + curl from the noble base (curl backs the readiness poll).
+          apt-get update -qq
+          apt-get install -y --no-install-recommends nodejs npm curl ca-certificates
+          npm ci
+          # --with-deps installs the browser's system libraries via apt.
+          npx playwright install --with-deps chromium
+
+      - name: Run editor smoke test
+        run: Tools/editor-smoke-test/run-smoke.sh

--- a/Tools/editor-smoke-test/.gitignore
+++ b/Tools/editor-smoke-test/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+*.log
+*.png
+.playwright/

--- a/Tools/editor-smoke-test/README.md
+++ b/Tools/editor-smoke-test/README.md
@@ -26,7 +26,11 @@ including the cross-origin-isolation headers):
 3. **no blocked-resource errors** (`ERR_BLOCKED_BY_RESPONSE`, COEP/CORP
    refusals) appear in the console or network — this is exactly what the COEP
    attempt tripped, when the cross-origin-isolated page refused its own
-   fast-path-served kernel worker.
+   fast-path-served kernel worker;
+4. **`input()` round-trips without hanging** — a cell calls `input()` and the
+   harness answers the stdin prompt; the echo must come back. This needs the
+   service worker (or SAB) for synchronous stdin, so it catches the "Page
+   Unresponsive" freeze (#959) the trivial cell sails right through.
 
 It is deliberately **auth-free**: the REPL and the vendored Pyodide/JupyterLite
 assets are public static content, so no course/student seeding is needed — yet a
@@ -56,27 +60,35 @@ node editor-check.mjs http://127.0.0.1:8080
 
 ## Self-test (proving the guard discriminates)
 
-`selftest.sh` runs the check twice against the same build and asserts it
-**passes on the good config and fails on the COEP regression** — so the smoke
-test can't silently rot into something that passes no matter what:
+`selftest.sh` runs the check three ways against the same build and asserts it
+**passes on the good config and fails on both the COEP block and the freeze** —
+so the smoke test can't silently rot into something that passes no matter what:
 
 ```bash
 ./selftest.sh
 ```
 
-Demonstrated result (the production breakage, reproduced and caught):
+Demonstrated result (the production breakages, reproduced and caught):
 
 ```
-=== selftest 1/2: default config — expect PASS ===
+=== selftest 1/3: default config — expect PASS ===
 crossOriginIsolated = false
-SMOKE PASS — kernel executed 7*191 = 1337 (isolated=false)
+SMOKE PASS — kernel ran 7*191=1337 and input() round-tripped (isolated=false)
 
-=== selftest 2/2: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL ===
+=== selftest 2/3: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL (COEP worker-block) ===
 crossOriginIsolated = true
 SMOKE FAIL — blocked resource detected while waiting for the kernel (COEP worker-block)
   blocked resources:
     - requestfailed: .../jupyterlite/extensions/@jupyterlite/pyodide-kernel-extension/static/620.*.js — net::ERR_BLOCKED_BY_RESPONSE
+
+=== selftest 3/3: SMOKE_SIMULATE_FROZEN=1 (no service worker) — expect FAIL (input freeze) ===
+crossOriginIsolated = false
+SMOKE FAIL — input() did not return — editor froze on stdin (no service worker / SAB)
 ```
+
+The freeze case (3) rewrites `jupyter-lite.json` in-flight (`SMOKE_SIMULATE_FROZEN=1`)
+to disable the service-worker manager — the #959 config — so the `input()`
+probe is *proven* to catch the freeze, not just asserted to.
 
 ## Notes
 

--- a/Tools/editor-smoke-test/README.md
+++ b/Tools/editor-smoke-test/README.md
@@ -1,0 +1,87 @@
+# Notebook editor smoke test
+
+A headless-browser smoke test that boots the **real** JupyterLite notebook
+editor against a running `chickadee-server` and asserts the Pyodide kernel
+actually comes up and runs a cell.
+
+This is the gate the recent editor breakages slipped through. `swift test`, the
+render tests, and `BrowserRunnerJSTests` all prove code/templates *resolve* —
+none of them put a browser in front of the editor, so a change that loads the
+page but **blocks the kernel worker** (the COEP cross-origin-isolation attempt)
+or leaves a **dead kernel** ("Kernel Unknown") passes CI and only fails in front
+of a student. This test catches that class of regression before it ships.
+
+See `docs/notebook-editor-smoke-test.md` for the rationale, phasing, and the
+open greenlight decisions (browser matrix, blocking-vs-advisory, CI wiring).
+
+## What it asserts
+
+Loading `/jupyterlite/repl/index.html` (the same Pyodide kernel + vendored
+assets the student editor embeds, served through the same middleware chain —
+including the cross-origin-isolation headers):
+
+1. the editor shell mounts and the kernel boots;
+2. a trivial cell **executes** (`7*191` → `1337`) — real liveness, not an
+   internal flag;
+3. **no blocked-resource errors** (`ERR_BLOCKED_BY_RESPONSE`, COEP/CORP
+   refusals) appear in the console or network — this is exactly what the COEP
+   attempt tripped, when the cross-origin-isolated page refused its own
+   fast-path-served kernel worker.
+
+It is deliberately **auth-free**: the REPL and the vendored Pyodide/JupyterLite
+assets are public static content, so no course/student seeding is needed — yet a
+header/middleware regression still surfaces because the assets flow through the
+real chain.
+
+## Running it
+
+```bash
+# one-time: install the browser
+cd Tools/editor-smoke-test
+npm ci
+npx playwright install chromium
+
+# build the server (once), then run against a single config
+swift build                      # from the repo root
+./run-smoke.sh                   # boots a server, runs the check, tears down
+```
+
+`run-smoke.sh` honours `CHICKADEE_SERVER_BIN`, `PORT`, and
+`NOTEBOOK_CROSS_ORIGIN_ISOLATION`. To point the check at an already-running
+server instead, call the check directly:
+
+```bash
+node editor-check.mjs http://127.0.0.1:8080
+```
+
+## Self-test (proving the guard discriminates)
+
+`selftest.sh` runs the check twice against the same build and asserts it
+**passes on the good config and fails on the COEP regression** — so the smoke
+test can't silently rot into something that passes no matter what:
+
+```bash
+./selftest.sh
+```
+
+Demonstrated result (the production breakage, reproduced and caught):
+
+```
+=== selftest 1/2: default config — expect PASS ===
+crossOriginIsolated = false
+SMOKE PASS — kernel executed 7*191 = 1337 (isolated=false)
+
+=== selftest 2/2: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL ===
+crossOriginIsolated = true
+SMOKE FAIL — blocked resource detected while waiting for the kernel (COEP worker-block)
+  blocked resources:
+    - requestfailed: .../jupyterlite/extensions/@jupyterlite/pyodide-kernel-extension/static/620.*.js — net::ERR_BLOCKED_BY_RESPONSE
+```
+
+## Notes
+
+- `node_modules/` and the downloaded browser are **not** committed (see
+  `.gitignore`); `package-lock.json` pins Playwright.
+- The benign `@jupyterlab/codemirror-extension:commands … No provider for
+  INotebookTracker` console error is the bare REPL (no notebook tracker) and is
+  ignored — it is not a blocked-resource signal and does not fail the check.

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -4,14 +4,16 @@
 //
 // Boots a real chickadee-server in a browser, loads the JupyterLite REPL
 // (the same Pyodide kernel + vendored assets the student editor embeds),
-// and asserts the kernel actually comes up and runs a cell — the thing none
+// and asserts the kernel actually comes up and runs cells — the thing none
 // of `swift test` / render tests / BrowserRunnerJSTests can check, because
 // they never put a browser in front of the editor.
 //
-// This is the gate that would have caught the recent breakages:
+// It catches the three editor breakages we shipped blind:
 //   • the COEP cross-origin-isolation attempt that BLOCKED the Pyodide kernel
 //     worker (the page loaded a kernel only to refuse its worker script);
-//   • a dead kernel / "Kernel Unknown" (cell never executes).
+//   • a dead kernel / "Kernel Unknown" (a cell never executes);
+//   • the "Page Unresponsive" freeze — input()/stdin hangs when the kernel has
+//     neither the service worker nor SharedArrayBuffer for synchronous stdin.
 //
 // It is deliberately auth-free: the REPL and the vendored Pyodide/JupyterLite
 // assets are public static content served through the SAME middleware chain
@@ -20,6 +22,10 @@
 //
 // Usage:   node editor-check.mjs <baseURL>
 // Exit 0 = editor healthy; exit 1 = editor broken (details printed).
+//
+// Env: SMOKE_SIMULATE_FROZEN=1 rewrites jupyter-lite.json in-flight to disable
+// the service-worker manager, reproducing the #959 freeze config so the
+// selftest can prove the input() probe actually catches it.
 
 import { chromium } from "playwright";
 
@@ -28,6 +34,9 @@ const baseURL = (process.argv[2] || process.env.BASE_URL || "http://127.0.0.1:80
   ""
 );
 const replURL = `${baseURL}/jupyterlite/repl/index.html?kernel=python&toolbar=1`;
+const simulateFrozen = process.env.SMOKE_SIMULATE_FROZEN === "1";
+
+const SERVICE_WORKER_MANAGER = "@jupyterlite/application-extension:service-worker-manager";
 
 // A distinctive expression whose result is unlikely to collide with anything
 // else on the page (versions, counts, etc.), so "did the kernel run?" is a
@@ -35,10 +44,17 @@ const replURL = `${baseURL}/jupyterlite/repl/index.html?kernel=python&toolbar=1`
 const PROBE_EXPR = "7*191";
 const PROBE_RESULT = "1337";
 
+// The stdin probe echoes a token back through input() — present only if the
+// kernel resolved synchronous stdin without freezing the page.
+const STDIN_TOKEN = "8675309";
+const STDIN_MARK = `CKSTDIN=${STDIN_TOKEN}`;
+
 // Budgets. The vendored Pyodide is large but local (no network fetch), so a
-// healthy kernel boots well inside these; a blocked/dead kernel blows past.
+// healthy kernel boots well inside these; a blocked/dead/frozen kernel blows past.
 const PAGE_LOAD_MS = 30_000;
 const KERNEL_RUN_MS = 90_000;
+const STDIN_PROMPT_MS = 20_000;
+const STDIN_ECHO_MS = 25_000;
 
 /** Console / network evidence of a blocked resource — the COEP worker-block. */
 function looksBlocked(text) {
@@ -63,6 +79,27 @@ async function main() {
     chromiumSandbox: false,
   });
   const context = await browser.newContext();
+
+  // Freeze simulation: strip the service-worker manager out of the editor
+  // config on the wire, reproducing the #959 "Page Unresponsive" config (no SW;
+  // COEP off ⇒ no SAB either). The trivial cell still runs; input() hangs.
+  if (simulateFrozen) {
+    await context.route("**/jupyter-lite.json*", async (route) => {
+      const response = await route.fetch();
+      let json;
+      try {
+        json = JSON.parse(await response.text());
+      } catch {
+        return route.fulfill({ response });
+      }
+      const opts = (json["jupyter-config-data"] ||= {});
+      const disabled = new Set(opts.disabledExtensions || []);
+      disabled.add(SERVICE_WORKER_MANAGER);
+      opts.disabledExtensions = [...disabled];
+      route.fulfill({ response, body: JSON.stringify(json), contentType: "application/json" });
+    });
+  }
+
   const page = await context.newPage();
 
   const blocked = [];
@@ -84,7 +121,7 @@ async function main() {
     }
   });
 
-  const fail = (reason) => {
+  const fail = async (reason) => {
     console.log(`SMOKE FAIL — ${reason}`);
     if (blocked.length) {
       console.log("  blocked resources:");
@@ -94,68 +131,85 @@ async function main() {
       console.log("  console errors:");
       for (const c of consoleErrors.slice(0, 8)) console.log(`    - ${c}`);
     }
+    await browser.close();
+    process.exit(1);
+  };
+
+  // Poll the rendered page for `needle`, bailing early on a blocked resource.
+  const waitForText = async (needle, budgetMs) => {
+    const deadline = Date.now() + budgetMs;
+    while (Date.now() < deadline) {
+      if (blocked.length) return "blocked";
+      const body = await page.evaluate(() => document.body.innerText).catch(() => "");
+      if (body.includes(needle)) return true;
+      await page.waitForTimeout(500);
+    }
+    return false;
+  };
+
+  // Submit code into the REPL's active prompt with Shift+Enter (the Jupyter
+  // CodeConsole run binding — plain Enter only inserts a newline).
+  const runCell = async (code) => {
+    const editor = page.locator(".jp-CodeConsole-input .cm-content").last();
+    await editor.waitFor({ state: "visible", timeout: PAGE_LOAD_MS });
+    await editor.click();
+    await page.keyboard.type(code);
+    await page.keyboard.press("Shift+Enter");
   };
 
   try {
-    console.log(`Loading ${replURL}`);
+    console.log(`Loading ${replURL}${simulateFrozen ? " (SIMULATE_FROZEN)" : ""}`);
     await page.goto(replURL, { waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
 
     const isolated = await page.evaluate(() => globalThis.crossOriginIsolated === true);
     console.log(`crossOriginIsolated = ${isolated}`);
 
-    // Wait for the REPL's prompt input to mount (the editor shell is up).
-    // The console's active prompt is the last `.cm-content`; target it
-    // specifically so we don't type into the banner cell.
-    const editor = page.locator(".jp-CodeConsole-input .cm-content").last();
-    await editor.waitFor({ state: "visible", timeout: PAGE_LOAD_MS });
-
-    // Drive a real cell: focus the prompt, type the probe, execute with
-    // Shift+Enter (the Jupyter CodeConsole run binding — plain Enter only
-    // inserts a newline). A healthy kernel echoes the result into an output
-    // area; a blocked/dead kernel never does, so the output wait is our
-    // liveness check. Execution submitted before the kernel finishes booting
-    // is queued and runs once it is ready, so we don't pre-wait on readiness.
-    await editor.click();
-    await page.keyboard.type(PROBE_EXPR);
-    await page.keyboard.press("Shift+Enter");
-
-    const deadline = Date.now() + KERNEL_RUN_MS;
-    let ran = false;
-    while (Date.now() < deadline) {
-      // Bail out early the moment we see a blocked-resource error — that's a
-      // definitive COEP/worker failure, no point waiting out the full budget.
-      if (blocked.length) {
-        fail("blocked resource detected while waiting for the kernel (COEP worker-block)");
-        await browser.close();
-        process.exit(1);
-      }
-      const body = await page.evaluate(() => document.body.innerText).catch(() => "");
-      if (body.includes(PROBE_RESULT)) {
-        ran = true;
-        break;
-      }
-      await page.waitForTimeout(500);
+    // (1) Liveness: a trivial cell executes. Execution submitted before the
+    // kernel finishes booting is queued and runs once it is ready, so we don't
+    // pre-wait on readiness.
+    await runCell(PROBE_EXPR);
+    const ran = await waitForText(PROBE_RESULT, KERNEL_RUN_MS);
+    if (ran === "blocked") {
+      return await fail("blocked resource detected while waiting for the kernel (COEP worker-block)");
+    }
+    if (!ran) {
+      return await fail(`kernel did not execute ${PROBE_EXPR} → ${PROBE_RESULT} within ${KERNEL_RUN_MS}ms`);
     }
 
-    if (!ran) {
-      fail(`kernel did not execute ${PROBE_EXPR} → ${PROBE_RESULT} within ${KERNEL_RUN_MS}ms`);
-      await browser.close();
-      process.exit(1);
+    // (2) Freeze probe: input() must resolve without hanging the page. Needs
+    // the service worker (or SAB) for synchronous stdin; without either, the
+    // editor goes "Page Unresponsive" (#959) and the echo never returns.
+    await runCell(`print("CKSTDIN=" + input())`);
+    try {
+      const stdin = page.locator(".jp-Stdin-input").last();
+      await stdin.waitFor({ state: "visible", timeout: STDIN_PROMPT_MS });
+      await stdin.fill(STDIN_TOKEN);
+      await page.keyboard.press("Enter");
+    } catch {
+      // Prompt never rendered (or the page is frozen) — the echo wait below
+      // is the arbiter and will fail the check.
+    }
+    const answered = await waitForText(STDIN_MARK, STDIN_ECHO_MS);
+    if (answered === "blocked") {
+      return await fail("blocked resource detected during the input() probe");
+    }
+    if (!answered) {
+      return await fail(
+        "input() did not return — editor froze on stdin (no service worker / SAB)"
+      );
     }
 
     if (blocked.length) {
-      fail("kernel ran but blocked-resource errors were observed");
-      await browser.close();
-      process.exit(1);
+      return await fail("cells ran but blocked-resource errors were observed");
     }
 
-    console.log(`SMOKE PASS — kernel executed ${PROBE_EXPR} = ${PROBE_RESULT} (isolated=${isolated})`);
+    console.log(
+      `SMOKE PASS — kernel ran ${PROBE_EXPR}=${PROBE_RESULT} and input() round-tripped (isolated=${isolated})`
+    );
     await browser.close();
     process.exit(0);
   } catch (err) {
-    fail(`exception: ${err}`);
-    await browser.close();
-    process.exit(1);
+    return await fail(`exception: ${err}`);
   }
 }
 

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -53,7 +53,15 @@ function looksBlocked(text) {
 }
 
 async function main() {
-  const browser = await chromium.launch({ headless: true });
+  // `--no-sandbox` / chromiumSandbox:false: CI runs this in a root container,
+  // where Chromium's setuid sandbox refuses to start. Chromium's *process*
+  // sandbox is unrelated to the web-platform cross-origin-isolation / COEP
+  // behaviour under test, so disabling it does not affect what we assert.
+  const browser = await chromium.launch({
+    headless: true,
+    args: ["--no-sandbox"],
+    chromiumSandbox: false,
+  });
   const context = await browser.newContext();
   const page = await context.newPage();
 

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -1,0 +1,154 @@
+// editor-check.mjs
+//
+// Headless-browser smoke test for the JupyterLite notebook editor.
+//
+// Boots a real chickadee-server in a browser, loads the JupyterLite REPL
+// (the same Pyodide kernel + vendored assets the student editor embeds),
+// and asserts the kernel actually comes up and runs a cell — the thing none
+// of `swift test` / render tests / BrowserRunnerJSTests can check, because
+// they never put a browser in front of the editor.
+//
+// This is the gate that would have caught the recent breakages:
+//   • the COEP cross-origin-isolation attempt that BLOCKED the Pyodide kernel
+//     worker (the page loaded a kernel only to refuse its worker script);
+//   • a dead kernel / "Kernel Unknown" (cell never executes).
+//
+// It is deliberately auth-free: the REPL and the vendored Pyodide/JupyterLite
+// assets are public static content served through the SAME middleware chain
+// as the student editor — including the cross-origin-isolation headers — so a
+// header/middleware regression surfaces here without any course seeding.
+//
+// Usage:   node editor-check.mjs <baseURL>
+// Exit 0 = editor healthy; exit 1 = editor broken (details printed).
+
+import { chromium } from "playwright";
+
+const baseURL = (process.argv[2] || process.env.BASE_URL || "http://127.0.0.1:8099").replace(
+  /\/$/,
+  ""
+);
+const replURL = `${baseURL}/jupyterlite/repl/index.html?kernel=python&toolbar=1`;
+
+// A distinctive expression whose result is unlikely to collide with anything
+// else on the page (versions, counts, etc.), so "did the kernel run?" is a
+// clean substring check.
+const PROBE_EXPR = "7*191";
+const PROBE_RESULT = "1337";
+
+// Budgets. The vendored Pyodide is large but local (no network fetch), so a
+// healthy kernel boots well inside these; a blocked/dead kernel blows past.
+const PAGE_LOAD_MS = 30_000;
+const KERNEL_RUN_MS = 90_000;
+
+/** Console / network evidence of a blocked resource — the COEP worker-block. */
+function looksBlocked(text) {
+  if (!text) return false;
+  return (
+    text.includes("ERR_BLOCKED_BY_RESPONSE") ||
+    text.includes("BlockedByResponse") ||
+    text.includes("Cross-Origin-Embedder-Policy") ||
+    text.includes("ERR_BLOCKED_BY_CSP") ||
+    /blocked.*(worker|cross-origin)/i.test(text)
+  );
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const blocked = [];
+  const consoleErrors = [];
+
+  page.on("console", (msg) => {
+    const text = msg.text();
+    if (msg.type() === "error") consoleErrors.push(text);
+    if (looksBlocked(text)) blocked.push(`console: ${text}`);
+  });
+  page.on("pageerror", (err) => {
+    consoleErrors.push(String(err));
+    if (looksBlocked(String(err))) blocked.push(`pageerror: ${err}`);
+  });
+  page.on("requestfailed", (req) => {
+    const why = req.failure()?.errorText || "";
+    if (looksBlocked(why) || why.includes("net::ERR_BLOCKED")) {
+      blocked.push(`requestfailed: ${req.url()} — ${why}`);
+    }
+  });
+
+  const fail = (reason) => {
+    console.log(`SMOKE FAIL — ${reason}`);
+    if (blocked.length) {
+      console.log("  blocked resources:");
+      for (const b of blocked.slice(0, 8)) console.log(`    - ${b}`);
+    }
+    if (consoleErrors.length) {
+      console.log("  console errors:");
+      for (const c of consoleErrors.slice(0, 8)) console.log(`    - ${c}`);
+    }
+  };
+
+  try {
+    console.log(`Loading ${replURL}`);
+    await page.goto(replURL, { waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
+
+    const isolated = await page.evaluate(() => globalThis.crossOriginIsolated === true);
+    console.log(`crossOriginIsolated = ${isolated}`);
+
+    // Wait for the REPL's prompt input to mount (the editor shell is up).
+    // The console's active prompt is the last `.cm-content`; target it
+    // specifically so we don't type into the banner cell.
+    const editor = page.locator(".jp-CodeConsole-input .cm-content").last();
+    await editor.waitFor({ state: "visible", timeout: PAGE_LOAD_MS });
+
+    // Drive a real cell: focus the prompt, type the probe, execute with
+    // Shift+Enter (the Jupyter CodeConsole run binding — plain Enter only
+    // inserts a newline). A healthy kernel echoes the result into an output
+    // area; a blocked/dead kernel never does, so the output wait is our
+    // liveness check. Execution submitted before the kernel finishes booting
+    // is queued and runs once it is ready, so we don't pre-wait on readiness.
+    await editor.click();
+    await page.keyboard.type(PROBE_EXPR);
+    await page.keyboard.press("Shift+Enter");
+
+    const deadline = Date.now() + KERNEL_RUN_MS;
+    let ran = false;
+    while (Date.now() < deadline) {
+      // Bail out early the moment we see a blocked-resource error — that's a
+      // definitive COEP/worker failure, no point waiting out the full budget.
+      if (blocked.length) {
+        fail("blocked resource detected while waiting for the kernel (COEP worker-block)");
+        await browser.close();
+        process.exit(1);
+      }
+      const body = await page.evaluate(() => document.body.innerText).catch(() => "");
+      if (body.includes(PROBE_RESULT)) {
+        ran = true;
+        break;
+      }
+      await page.waitForTimeout(500);
+    }
+
+    if (!ran) {
+      fail(`kernel did not execute ${PROBE_EXPR} → ${PROBE_RESULT} within ${KERNEL_RUN_MS}ms`);
+      await browser.close();
+      process.exit(1);
+    }
+
+    if (blocked.length) {
+      fail("kernel ran but blocked-resource errors were observed");
+      await browser.close();
+      process.exit(1);
+    }
+
+    console.log(`SMOKE PASS — kernel executed ${PROBE_EXPR} = ${PROBE_RESULT} (isolated=${isolated})`);
+    await browser.close();
+    process.exit(0);
+  } catch (err) {
+    fail(`exception: ${err}`);
+    await browser.close();
+    process.exit(1);
+  }
+}
+
+main();

--- a/Tools/editor-smoke-test/package-lock.json
+++ b/Tools/editor-smoke-test/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "chickadee-editor-smoke-test",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chickadee-editor-smoke-test",
+      "version": "0.0.0",
+      "dependencies": {
+        "playwright": "^1.49.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/Tools/editor-smoke-test/package.json
+++ b/Tools/editor-smoke-test/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "chickadee-editor-smoke-test",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Headless-browser smoke test: boots the JupyterLite editor against a running chickadee-server and asserts the Pyodide kernel comes up.",
+  "type": "module",
+  "dependencies": {
+    "playwright": "^1.49.1"
+  }
+}

--- a/Tools/editor-smoke-test/run-smoke.sh
+++ b/Tools/editor-smoke-test/run-smoke.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# run-smoke.sh — boot a chickadee-server, run the headless-browser editor smoke
+# test against it, tear it down, and exit with the test's result.
+#
+# This is the single-config runner (used by CI and by selftest.sh). It boots
+# the server with local auth on an ephemeral SQLite DB so no external services
+# are needed, then drives the real JupyterLite editor through the real
+# middleware chain — which is where the COEP/header regressions actually bit us.
+#
+# Env knobs:
+#   CHICKADEE_SERVER_BIN   path to the built server (default: debug build)
+#   PORT                   port to bind (default: 8099)
+#   NOTEBOOK_CROSS_ORIGIN_ISOLATION   forwarded as-is (selftest flips this to
+#                          reproduce the COEP worker-block)
+#
+# Exit 0 = editor healthy; non-zero = broken (or boot/setup failure).
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+REPO_ROOT="$(cd ../.. && pwd)"
+PORT="${PORT:-8099}"
+BIN="${CHICKADEE_SERVER_BIN:-$REPO_ROOT/.build/debug/chickadee-server}"
+WORKDIR="$(mktemp -d)"
+LOG="$WORKDIR/server.log"
+
+if [ ! -x "$BIN" ]; then
+  # Fall back to the platform-triple debug path (Linux CI layout).
+  alt="$(ls "$REPO_ROOT"/.build/*/debug/chickadee-server 2>/dev/null | head -1 || true)"
+  if [ -n "$alt" ]; then BIN="$alt"; else
+    echo "run-smoke: server binary not found (set CHICKADEE_SERVER_BIN or run 'swift build')" >&2
+    exit 2
+  fi
+fi
+
+cleanup() {
+  if [ -n "${SRV_PID:-}" ] && kill -0 "$SRV_PID" 2>/dev/null; then
+    kill "$SRV_PID" 2>/dev/null || true
+    wait "$SRV_PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "run-smoke: booting $BIN on 127.0.0.1:$PORT (isolation=${NOTEBOOK_CROSS_ORIGIN_ISOLATION:-unset})"
+ENABLE_NON_SSO_AUTH_MODES=true \
+AUTH_MODE=local \
+DATABASE_BACKEND=sqlite \
+SQLITE_PATH="$WORKDIR/smoke.sqlite" \
+MCP_MODE=off \
+LOG_LEVEL=info \
+NOTEBOOK_CROSS_ORIGIN_ISOLATION="${NOTEBOOK_CROSS_ORIGIN_ISOLATION:-false}" \
+  "$BIN" serve --hostname 127.0.0.1 --port "$PORT" >"$LOG" 2>&1 &
+SRV_PID=$!
+
+# Wait for readiness (up to ~40s).
+ready=0
+for _ in $(seq 1 40); do
+  if curl -fsS --max-time 2 -o /dev/null "http://127.0.0.1:$PORT/login" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "run-smoke: server exited during boot — log follows:" >&2
+    tail -20 "$LOG" >&2
+    exit 2
+  fi
+  sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+  echo "run-smoke: server did not become ready — log follows:" >&2
+  tail -20 "$LOG" >&2
+  exit 2
+fi
+
+node editor-check.mjs "http://127.0.0.1:$PORT"

--- a/Tools/editor-smoke-test/run-smoke.sh
+++ b/Tools/editor-smoke-test/run-smoke.sh
@@ -44,14 +44,21 @@ cleanup() {
 trap cleanup EXIT
 
 echo "run-smoke: booting $BIN on 127.0.0.1:$PORT (isolation=${NOTEBOOK_CROSS_ORIGIN_ISOLATION:-unset})"
-ENABLE_NON_SSO_AUTH_MODES=true \
-AUTH_MODE=local \
-DATABASE_BACKEND=sqlite \
-SQLITE_PATH="$WORKDIR/smoke.sqlite" \
-MCP_MODE=off \
-LOG_LEVEL=info \
-NOTEBOOK_CROSS_ORIGIN_ISOLATION="${NOTEBOOK_CROSS_ORIGIN_ISOLATION:-false}" \
-  "$BIN" serve --hostname 127.0.0.1 --port "$PORT" >"$LOG" 2>&1 &
+# Launch from the repo root: Vapor's DirectoryConfiguration.detect() resolves
+# Public/ (the vended JupyterLite + Pyodide the editor loads) from the working
+# directory, so the server must run with the repo root as its CWD — not this
+# script's directory.
+(
+  cd "$REPO_ROOT"
+  ENABLE_NON_SSO_AUTH_MODES=true \
+  AUTH_MODE=local \
+  DATABASE_BACKEND=sqlite \
+  SQLITE_PATH="$WORKDIR/smoke.sqlite" \
+  MCP_MODE=off \
+  LOG_LEVEL=info \
+  NOTEBOOK_CROSS_ORIGIN_ISOLATION="${NOTEBOOK_CROSS_ORIGIN_ISOLATION:-false}" \
+    exec "$BIN" serve --hostname 127.0.0.1 --port "$PORT"
+) >"$LOG" 2>&1 &
 SRV_PID=$!
 
 # Wait for readiness (up to ~40s).

--- a/Tools/editor-smoke-test/selftest.sh
+++ b/Tools/editor-smoke-test/selftest.sh
@@ -1,40 +1,43 @@
 #!/usr/bin/env bash
 #
-# selftest.sh — prove the smoke test actually detects the regression it exists
-# to catch. Runs the editor check twice against the same server build:
+# selftest.sh — prove the smoke test actually detects the regressions it exists
+# to catch. Runs the editor check three ways against the same server build:
 #
 #   1. default config (service worker, NO cross-origin isolation) — must PASS;
 #   2. NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — must FAIL, because COEP
 #      require-corp on the editor page blocks the fast-path-served Pyodide
-#      kernel worker (the exact production breakage from the COEP attempt).
+#      kernel worker (the COEP attempt's kernel-worker block);
+#   3. SMOKE_SIMULATE_FROZEN=1 — must FAIL, because disabling the service worker
+#      (and with COEP off, no SAB) leaves input()/stdin no synchronous path and
+#      the editor goes "Page Unresponsive" (the #959 freeze).
 #
-# If the "good" config fails or the "bad" config passes, the smoke test is not
+# If the good config fails or either bad config passes, the smoke test is not
 # discriminating and this exits non-zero — i.e. it guards the guard.
 
 set -uo pipefail
 cd "$(dirname "$0")"
 
-echo "=== selftest 1/2: default config — expect PASS ==="
-if PORT="${PORT_GOOD:-8099}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false ./run-smoke.sh; then
-  good_pass=1
-else
-  good_pass=0
-fi
+echo "=== selftest 1/3: default config — expect PASS ==="
+PORT="${PORT_GOOD:-8099}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false ./run-smoke.sh
+good_ok=$([ $? -eq 0 ] && echo 1 || echo 0)
 
 echo
-echo "=== selftest 2/2: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL ==="
-if PORT="${PORT_BAD:-8100}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=true ./run-smoke.sh; then
-  bad_pass=1
-else
-  bad_pass=0
-fi
+echo "=== selftest 2/3: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL (COEP worker-block) ==="
+PORT="${PORT_COEP:-8100}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=true ./run-smoke.sh
+coep_failed=$([ $? -ne 0 ] && echo 1 || echo 0)
 
 echo
-if [ "$good_pass" -eq 1 ] && [ "$bad_pass" -eq 0 ]; then
-  echo "SELFTEST PASS — smoke test passes on the good config and fails on the COEP regression."
+echo "=== selftest 3/3: SMOKE_SIMULATE_FROZEN=1 (no service worker) — expect FAIL (input freeze) ==="
+PORT="${PORT_FROZEN:-8101}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false SMOKE_SIMULATE_FROZEN=1 ./run-smoke.sh
+frozen_failed=$([ $? -ne 0 ] && echo 1 || echo 0)
+
+echo
+if [ "$good_ok" -eq 1 ] && [ "$coep_failed" -eq 1 ] && [ "$frozen_failed" -eq 1 ]; then
+  echo "SELFTEST PASS — passes on the good config and fails on both the COEP block and the freeze."
   exit 0
 fi
 echo "SELFTEST FAIL — the smoke test is not discriminating:"
-echo "  good-config passed? $good_pass (want 1)"
-echo "  bad-config  passed? $bad_pass (want 0)"
+echo "  good config passed?      $good_ok       (want 1)"
+echo "  COEP config failed?      $coep_failed   (want 1)"
+echo "  freeze config failed?    $frozen_failed (want 1)"
 exit 1

--- a/Tools/editor-smoke-test/selftest.sh
+++ b/Tools/editor-smoke-test/selftest.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# selftest.sh — prove the smoke test actually detects the regression it exists
+# to catch. Runs the editor check twice against the same server build:
+#
+#   1. default config (service worker, NO cross-origin isolation) — must PASS;
+#   2. NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — must FAIL, because COEP
+#      require-corp on the editor page blocks the fast-path-served Pyodide
+#      kernel worker (the exact production breakage from the COEP attempt).
+#
+# If the "good" config fails or the "bad" config passes, the smoke test is not
+# discriminating and this exits non-zero — i.e. it guards the guard.
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+echo "=== selftest 1/2: default config — expect PASS ==="
+if PORT="${PORT_GOOD:-8099}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false ./run-smoke.sh; then
+  good_pass=1
+else
+  good_pass=0
+fi
+
+echo
+echo "=== selftest 2/2: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL ==="
+if PORT="${PORT_BAD:-8100}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=true ./run-smoke.sh; then
+  bad_pass=1
+else
+  bad_pass=0
+fi
+
+echo
+if [ "$good_pass" -eq 1 ] && [ "$bad_pass" -eq 0 ]; then
+  echo "SELFTEST PASS — smoke test passes on the good config and fails on the COEP regression."
+  exit 0
+fi
+echo "SELFTEST FAIL — the smoke test is not discriminating:"
+echo "  good-config passed? $good_pass (want 1)"
+echo "  bad-config  passed? $bad_pass (want 0)"
+exit 1

--- a/changelog.d/editor-smoke-test.md
+++ b/changelog.d/editor-smoke-test.md
@@ -1,0 +1,18 @@
+### Added
+
+- **Pre-merge headless-browser smoke test for the notebook editor.** A new
+  Playwright harness (`Tools/editor-smoke-test/`) boots the real
+  `chickadee-server` and drives the JupyterLite editor in headless Chromium,
+  asserting the Pyodide kernel actually comes up and runs a cell (`7*191` →
+  `1337`) with no blocked-resource errors. This is the gate the recent editor
+  breakages slipped through: `swift test`, the render tests, and the
+  `BrowserRunnerJSTests` only prove code/templates *resolve* — none put a
+  browser in front of the editor, so the COEP cross-origin-isolation attempt
+  that blocked the Pyodide kernel worker passed CI and only failed in front of a
+  student. The harness is verified to catch exactly that regression: its
+  `selftest.sh` fails unless the editor passes on the default config **and**
+  fails under `NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (which reproduces the
+  blocked worker), so the guard can't silently rot. Wired into CI as a new
+  `Editor smoke test` workflow that runs nightly and per-PR (path-filtered to
+  the notebook/editor/middleware/asset files that can break the editor);
+  advisory for now. See `docs/notebook-editor-smoke-test.md`.

--- a/changelog.d/editor-smoke-test.md
+++ b/changelog.d/editor-smoke-test.md
@@ -3,16 +3,19 @@
 - **Pre-merge headless-browser smoke test for the notebook editor.** A new
   Playwright harness (`Tools/editor-smoke-test/`) boots the real
   `chickadee-server` and drives the JupyterLite editor in headless Chromium,
-  asserting the Pyodide kernel actually comes up and runs a cell (`7*191` →
-  `1337`) with no blocked-resource errors. This is the gate the recent editor
-  breakages slipped through: `swift test`, the render tests, and the
+  asserting the Pyodide kernel actually comes up, runs a cell (`7*191` →
+  `1337`) with no blocked-resource errors, and round-trips `input()` without
+  hanging. This is the gate the recent editor breakages slipped through: `swift test`, the render tests, and the
   `BrowserRunnerJSTests` only prove code/templates *resolve* — none put a
   browser in front of the editor, so the COEP cross-origin-isolation attempt
   that blocked the Pyodide kernel worker passed CI and only failed in front of a
   student. The harness is verified to catch exactly that regression: its
   `selftest.sh` fails unless the editor passes on the default config **and**
-  fails under `NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (which reproduces the
-  blocked worker), so the guard can't silently rot. Wired into CI as a new
+  fails on both `NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (the blocked kernel
+  worker) and `SMOKE_SIMULATE_FROZEN=1` (the service worker disabled, which
+  reproduces the #959 "Page Unresponsive" freeze — `input()` hangs while the
+  trivial cell still runs), so the guard can't silently rot. Wired into CI as a
+  new
   `Editor smoke test` workflow that runs nightly and per-PR (path-filtered to
   the notebook/editor/middleware/asset files that can break the editor);
   advisory for now. See `docs/notebook-editor-smoke-test.md`.

--- a/docs/notebook-editor-smoke-test.md
+++ b/docs/notebook-editor-smoke-test.md
@@ -1,7 +1,31 @@
-# Plan: pre-merge browser smoke test for the notebook editor
+# Pre-merge browser smoke test for the notebook editor
 
-Status: **proposal — needs greenlight.** Companion to the editor telemetry
-(`editor_ready` / `sw_state` / `byBrowser`) added alongside this doc.
+Status: **implemented (Phase 1), advisory.** The harness lives in
+`Tools/editor-smoke-test/` and runs in CI via the `Editor smoke test` workflow
+(nightly + path-filtered per-PR). Companion to the editor telemetry
+(`editor_ready` / `sw_state` / `byBrowser`).
+
+## Status update — what shipped
+
+Phase 1 is in: headless Chromium, full-app harness, assertions (1)–(4) below,
+advisory. It is **verified to catch the regression it exists for** — run
+`Tools/editor-smoke-test/selftest.sh`, which boots the same server build twice
+and asserts the editor **passes on the default config and fails under**
+`NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (the COEP attempt, which makes the
+cross-origin-isolated editor page refuse its own fast-path-served Pyodide kernel
+worker → `net::ERR_BLOCKED_BY_RESPONSE`). Demonstrated result:
+
+```
+default config:                       crossOriginIsolated=false  SMOKE PASS (kernel ran 7*191=1337)
+NOTEBOOK_CROSS_ORIGIN_ISOLATION=true: crossOriginIsolated=true   SMOKE FAIL (kernel worker ERR_BLOCKED_BY_RESPONSE)
+```
+
+The decisions below were resolved as: **Chromium-only** to start (WebKit is
+Phase 2); **advisory** (not a required check — it is path-filtered, so a
+required check would block the merge of every PR that skips it; promote to
+required after it proves stable); **full app** harness (it drives the real
+`/jupyterlite/repl` through the real middleware chain, no course seeding). The
+original proposal follows for context.
 
 ## Why
 

--- a/docs/notebook-editor-smoke-test.md
+++ b/docs/notebook-editor-smoke-test.md
@@ -7,21 +7,29 @@ Status: **implemented (Phase 1), advisory.** The harness lives in
 
 ## Status update — what shipped
 
-Phase 1 is in: headless Chromium, full-app harness, assertions (1)–(4) below,
-advisory. It is **verified to catch the regression it exists for** — run
-`Tools/editor-smoke-test/selftest.sh`, which boots the same server build twice
-and asserts the editor **passes on the default config and fails under**
-`NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (the COEP attempt, which makes the
-cross-origin-isolated editor page refuse its own fast-path-served Pyodide kernel
-worker → `net::ERR_BLOCKED_BY_RESPONSE`). Demonstrated result:
+Phase 1 + assertion (5) are in: headless Chromium, full-app harness, assertions
+(1)–(5) below, advisory. It is **verified to catch the regressions it exists
+for** — run `Tools/editor-smoke-test/selftest.sh`, which boots the same server
+build and asserts the editor **passes on the default config and fails on both**
+known breakages:
 
 ```
-default config:                       crossOriginIsolated=false  SMOKE PASS (kernel ran 7*191=1337)
-NOTEBOOK_CROSS_ORIGIN_ISOLATION=true: crossOriginIsolated=true   SMOKE FAIL (kernel worker ERR_BLOCKED_BY_RESPONSE)
+default config:                       crossOriginIsolated=false  SMOKE PASS  (kernel ran 7*191=1337, input() round-tripped)
+NOTEBOOK_CROSS_ORIGIN_ISOLATION=true: crossOriginIsolated=true   SMOKE FAIL  (kernel worker ERR_BLOCKED_BY_RESPONSE)
+SMOKE_SIMULATE_FROZEN=1 (no SW):      crossOriginIsolated=false  SMOKE FAIL  (input() hung — "Page Unresponsive")
 ```
 
-The decisions below were resolved as: **Chromium-only** to start (WebKit is
-Phase 2); **advisory** (not a required check — it is path-filtered, so a
+- **COEP worker-block** (#960/#961): the COEP attempt makes the cross-origin-
+  isolated editor page refuse its own fast-path-served Pyodide kernel worker.
+- **Freeze** (#959): `SMOKE_SIMULATE_FROZEN=1` rewrites `jupyter-lite.json`
+  in-flight to disable the service-worker manager (the config that shipped the
+  "Page Unresponsive" freeze); with COEP off there's no SAB either, so `input()`
+  has no synchronous stdin path and hangs. The trivial `7*191` cell still runs
+  in this config — which is exactly why a liveness-only check missed the freeze
+  and the `input()` probe was needed.
+
+The decisions below were resolved as: **Chromium-only** to start (WebKit is a
+future add); **advisory** (not a required check — it is path-filtered, so a
 required check would block the merge of every PR that skips it; promote to
 required after it proves stable); **full app** harness (it drives the real
 `/jupyterlite/repl` through the real middleware chain, no course seeding). The


### PR DESCRIPTION
## What

A pre-merge headless-browser smoke test for the JupyterLite notebook editor. It boots the **real** `chickadee-server` and drives the editor in headless Chromium, asserting the Pyodide kernel actually comes up and runs a cell — the class of check none of our current CI can do.

This is the gate the recent editor breakages slipped through. `swift test`, the render tests, and `BrowserRunnerJSTests` all prove code/templates *resolve* — none put a browser in front of the editor, so the COEP cross-origin-isolation attempt that **blocked the Pyodide kernel worker** passed CI and only failed in front of a student (Isabelle's "Page Unresponsive", the kernel that loaded only to refuse its worker).

## Verified to catch the real bug

The whole point was to confirm it finds the problems we've already hit. It does. `selftest.sh` boots the same server build twice and asserts the editor **passes on the default config and fails under the COEP attempt**:

```
default config:                       crossOriginIsolated=false  SMOKE PASS (kernel ran 7*191=1337)
NOTEBOOK_CROSS_ORIGIN_ISOLATION=true: crossOriginIsolated=true   SMOKE FAIL (kernel worker net::ERR_BLOCKED_BY_RESPONSE)
```

That second case is exactly the production breakage: the cross-origin-isolated editor page refusing its own fast-path-served kernel worker (`/jupyterlite/extensions/@jupyterlite/pyodide-kernel-extension/...` → `ERR_BLOCKED_BY_RESPONSE`). Encoding it in `selftest.sh` means the guard can't silently rot into something that passes no matter what.

## How it's wired

- **`Tools/editor-smoke-test/`** — the Playwright harness:
  - `editor-check.mjs` — loads `/jupyterlite/repl`, waits for the kernel, runs `7*191` → `1337`, and fails on any blocked-resource console/network error. Auth-free: the REPL + vendored Pyodide/JupyterLite assets are public static content served through the **same middleware chain** as the student editor (which is where COEP/headers actually bit us), so no course/student seeding is needed.
  - `run-smoke.sh` — boots a server (local auth, ephemeral SQLite), runs the check, tears down.
  - `selftest.sh` — the discriminating self-test above.
- **`.github/workflows/editor-smoke.yml`** — runs **nightly** (always-on insurance) **and per-PR but path-filtered** to the notebook/editor/middleware/asset files that can actually break the editor, so unrelated PRs aren't slowed. Reuses the shared `.build` cache and builds just the server product.

## Advisory, not required (for now)

Because the PR job is path-filtered, it must **not** be a required check yet — a required check that's skipped on most PRs blocks their merge. Recommend leaving it advisory until it proves stable, then promoting to required. WebKit/Safari and an `input()`-no-hang assertion (the freeze regression) are Phase 2 — see `docs/notebook-editor-smoke-test.md`.

## Notes

- `node_modules/` and the downloaded browser are **not** committed (`.gitignore`); `package-lock.json` pins Playwright. CI does `npm ci && npx playwright install --with-deps chromium`.
- Branched off `main` as its own PR (kept separate from the in-flight closed-assignment-visibility work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LdPj2Lxoa7JepWuosLufj

---
_Generated by [Claude Code](https://claude.ai/code/session_012LdPj2Lxoa7JepWuosLufj)_