### PR TITLE
Fix browser-grading freezes: fail over to the worker backstop

### DIFF
--- a/Public/freeze-watchdog-worker.js
+++ b/Public/freeze-watchdog-worker.js
@@ -18,8 +18,19 @@
 // in telemetry until now. This is pure, best-effort observability: it never
 // touches the editor and never throws into the page.
 //
-// The freeze decision is factored into `evaluateStall()` so it can be unit
-// tested (Tests/BrowserRunnerJSTests/freeze-watchdog.test.mjs) without a worker.
+// SECOND JOB — grading failover. Browser grading runs Pyodide on the main
+// thread, so a synchronous runaway loop in student code freezes the tab and the
+// in-browser grade never completes (and never POSTs a result). Before grading
+// starts the page ARMS this worker with the notebook bytes + a failover URL;
+// when the main thread then stalls past `gradingThresholdMs`, this worker —
+// still alive on its own thread — POSTs the notebook to `/browser-failover` so
+// the native worker backstop grades it. The page DISARMS on completion. This is
+// the one component that can act when the main thread is dead, which is the
+// whole reason the failover lives here.
+//
+// The decisions are factored into `evaluateStall()` / `evaluateGradingFailover()`
+// so they can be unit tested (Tests/BrowserRunnerJSTests/freeze-watchdog.test.mjs)
+// without a worker.
 
 'use strict';
 
@@ -32,6 +43,15 @@ var visible = true;
 var reportedForThisStall = false;
 var timer = null;
 
+// Grading-failover state (armed by the page before in-browser grading begins).
+var gradingArmed = false;
+var gradingNotebook = null;
+var gradingSetupID = null;
+var gradingFailoverUrl = null;
+var gradingCsrf = '';
+var gradingThresholdMs = 30000;
+var gradingFailedOver = false;
+
 // Pure decision: given the current state, should a freeze be reported, and what
 // is the next `reported` flag? Kept side-effect-free for testing.
 function evaluateStall(state, nowMs) {
@@ -41,20 +61,72 @@ function evaluateStall(state, nowMs) {
     return { shouldReport: shouldReport, stalledMs: stalledMs };
 }
 
+// Pure decision: while a grade is armed, has the main thread stalled long enough
+// that we should give up on the in-browser run and fail over to the server?
+// One-shot per arm (the caller latches `gradingFailedOver`). Gated on `visible`
+// for the same reason as the freeze beacon: a backgrounded tab throttles the
+// page's heartbeat timer, which must not read as a freeze.
+function evaluateGradingFailover(state, nowMs) {
+    var stalledMs = nowMs - state.lastBeatMs;
+    var shouldFailover =
+        state.gradingArmed &&
+        !state.gradingFailedOver &&
+        state.visible &&
+        stalledMs >= state.gradingThresholdMs;
+    return { shouldFailover: shouldFailover, stalledMs: stalledMs };
+}
+
 function check() {
-    if (!beaconUrl) return;
-    var decision = evaluateStall(
+    var nowMs = Date.now();
+    if (beaconUrl) {
+        var decision = evaluateStall(
+            {
+                lastBeatMs: lastBeatMs,
+                thresholdMs: thresholdMs,
+                visible: visible,
+                reportedForThisStall: reportedForThisStall,
+            },
+            nowMs
+        );
+        if (decision.shouldReport) {
+            reportedForThisStall = true;
+            beacon(decision.stalledMs);
+        }
+    }
+    var failover = evaluateGradingFailover(
         {
             lastBeatMs: lastBeatMs,
-            thresholdMs: thresholdMs,
+            gradingThresholdMs: gradingThresholdMs,
             visible: visible,
-            reportedForThisStall: reportedForThisStall,
+            gradingArmed: gradingArmed,
+            gradingFailedOver: gradingFailedOver,
         },
-        Date.now()
+        nowMs
     );
-    if (decision.shouldReport) {
-        reportedForThisStall = true;
-        beacon(decision.stalledMs);
+    if (failover.shouldFailover) {
+        gradingFailedOver = true;
+        postGradingFailover();
+    }
+}
+
+// POST the stashed notebook to the failover endpoint so the native backstop
+// grades it. No `keepalive` (a notebook can exceed its 64 KB cap, and a frozen
+// tab stays open — only the main thread is blocked — so the worker's own thread
+// completes the fetch). Best-effort and fully guarded.
+function postGradingFailover() {
+    try {
+        if (!gradingFailoverUrl || !gradingSetupID || !gradingNotebook) return;
+        fetch(gradingFailoverUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'content-type': 'application/json', 'x-csrf-token': gradingCsrf },
+            body: JSON.stringify({ testSetupID: gradingSetupID, notebook: gradingNotebook }),
+        }).catch(function () {
+            /* best-effort failover */
+        });
+        gradingNotebook = null;  // free the bytes; one-shot per arm
+    } catch (_) {
+        /* never throw in the worker */
     }
 }
 
@@ -102,13 +174,39 @@ self.onmessage = function (e) {
                 reportedForThisStall = false;
             }
             break;
+        case 'grading-armed':
+            // The page is about to start an in-browser grade. Stash what we need
+            // to fail over if it freezes.
+            gradingArmed = true;
+            gradingFailedOver = false;
+            gradingNotebook = msg.notebook || null;
+            gradingSetupID = msg.setupID || setupID;
+            gradingFailoverUrl = msg.failoverUrl || '/api/v1/submissions/browser-failover';
+            gradingCsrf = msg.csrfToken || csrfToken;
+            if (typeof msg.thresholdMs === 'number') gradingThresholdMs = msg.thresholdMs;
+            // Measure the stall from the moment grading begins, not from a
+            // pre-existing idle gap — otherwise an editor that sat idle would
+            // trip the failover the instant a grade starts.
+            lastBeatMs = Date.now();
+            if (!timer) timer = setInterval(check, 1000);
+            break;
+        case 'grading-disarmed':
+            // Grade finished (passed, failed, or the page handled the failure
+            // itself). Disarm and free the stashed bytes.
+            gradingArmed = false;
+            gradingFailedOver = false;
+            gradingNotebook = null;
+            break;
         default:
             break;
     }
 };
 
 // Test hook: in Node (no `self.onmessage` dispatch loop), expose the pure
-// decision. No-op in a real worker scope.
+// decisions. No-op in a real worker scope.
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { evaluateStall: evaluateStall };
+    module.exports = {
+        evaluateStall: evaluateStall,
+        evaluateGradingFailover: evaluateGradingFailover,
+    };
 }

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -50,9 +50,13 @@
     // path, which is Chrome's "Page Unresponsive"). The frozen main thread
     // can't report itself; the worker, on its own thread, can. Fully guarded:
     // this telemetry must never affect the editor.
+    // Hoisted so the browser-grading submit path can arm/disarm the grading
+    // failover (see armGradingFailover / submitBrowserNotebook). null when
+    // Workers are unavailable or construction failed — every use is guarded.
+    let freezeWorker = null;
     if (typeof Worker !== 'undefined') {
         try {
-            const freezeWorker = new Worker('/freeze-watchdog-worker.js');
+            freezeWorker = new Worker('/freeze-watchdog-worker.js');
             let freezeCsrf = '';
             try { freezeCsrf = (typeof getCsrfToken === 'function') ? getCsrfToken() : ''; } catch (_) { /* no token */ }
             freezeWorker.postMessage({
@@ -74,6 +78,52 @@
             });
         } catch (_) {
             // No freeze watchdog — never block the editor over telemetry.
+            freezeWorker = null;
+        }
+    }
+
+    // Arm the freeze-watchdog worker to fail this grade over to the server if the
+    // main thread freezes mid-run (a synchronous runaway loop in student code).
+    // The worker holds the notebook bytes on its own thread, so it can POST the
+    // failover even when the main thread is dead — which the main thread cannot.
+    function armGradingFailover(testSetupID, notebookString) {
+        if (!freezeWorker) return;
+        let csrf = '';
+        try { csrf = (typeof getCsrfToken === 'function') ? getCsrfToken() : ''; } catch (_) { /* no token */ }
+        try {
+            freezeWorker.postMessage({
+                type: 'grading-armed',
+                setupID: testSetupID,
+                notebook: notebookString,
+                failoverUrl: '/api/v1/submissions/browser-failover',
+                csrfToken: csrf,
+            });
+        } catch (_) { /* worker gone */ }
+    }
+
+    function disarmGradingFailover() {
+        if (!freezeWorker) return;
+        try { freezeWorker.postMessage({ type: 'grading-disarmed' }); } catch (_) { /* worker gone */ }
+    }
+
+    // Main-thread failover for a non-freeze browser-grading failure (e.g. Pyodide
+    // won't load): enqueue the server-side backstop grade and return its
+    // submission id, or null if even the failover POST fails. The freeze case is
+    // handled by the worker above; this is the path when an exception is actually
+    // thrown and the main thread is still alive to react.
+    async function postBrowserFailover(testSetupID, notebookString) {
+        try {
+            const res = await fetch('/api/v1/submissions/browser-failover', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'content-type': 'application/json', 'x-csrf-token': getCsrfToken() },
+                body: JSON.stringify({ testSetupID: testSetupID, notebook: notebookString }),
+            });
+            if (!res.ok) return null;
+            const json = await res.json();
+            return (json && json.submissionID) ? json.submissionID : null;
+        } catch (_) {
+            return null;
         }
     }
 
@@ -1252,11 +1302,36 @@
 
     async function submitBrowserNotebook(notebook, testSetupID) {
         setStatus('loading', 'Testing…');
-        const notebookBytes = new Uint8Array(
-            new TextEncoder().encode(JSON.stringify(notebook))
-        );
-        const { outcomes, response, sections, sectionIDs } =
-            await window.BrowserRunner.runAndSubmit(notebookBytes, testSetupID);
+        const notebookString = JSON.stringify(notebook);
+        const notebookBytes = new Uint8Array(new TextEncoder().encode(notebookString));
+
+        // Arm the freeze failover before grading: if the main thread hangs on a
+        // runaway loop, the watchdog worker enqueues a server-side grade with
+        // these bytes. Disarmed below the moment grading resolves either way.
+        armGradingFailover(testSetupID, notebookString);
+
+        let result;
+        try {
+            result = await window.BrowserRunner.runAndSubmit(notebookBytes, testSetupID);
+        } catch (err) {
+            disarmGradingFailover();
+            // Browser grading failed outright (not a freeze — the watchdog covers
+            // those). Fall back to server-side grading so the student's work is
+            // still graded instead of leaving them with only an error.
+            const failoverID = await postBrowserFailover(testSetupID, notebookString);
+            if (failoverID) {
+                setStatus('loading',
+                    'Grading didn’t finish in your browser — we’ve queued it for server grading. Opening grade details…');
+                window.location.assign(`/submissions/${failoverID}`);
+                // The page is navigating away; stop here so the caller's
+                // success-summary code never runs against an empty result.
+                return new Promise(() => {});
+            }
+            throw err;
+        }
+        disarmGradingFailover();
+
+        const { outcomes, response, sections, sectionIDs } = result;
         renderResults(outcomes, response, sections, sectionIDs);
         return { outcomes, response };
     }

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -10,6 +10,15 @@
 //   collection  — JSON text of a TestOutcomeCollection
 //   notebook    — raw bytes of the student's .ipynb file
 //   testSetupID — ID of the test setup this submission targets
+//
+// When in-browser grading FREEZES (a synchronous runaway loop on the Pyodide
+// main thread) or fails outright, the browser never reaches the call above, so
+// no row is created and the worker backstop has nothing to grade. The
+// freeze-watchdog worker / browser-runner catch path instead calls:
+//
+//   POST /api/v1/submissions/browser-failover   (JSON: testSetupID, notebook)
+//
+// which enqueues a `pending` browser-mode submission for the native backstop.
 
 import Core
 import Fluent
@@ -21,6 +30,7 @@ struct BrowserResultRoutes: RouteCollection {
         let submissions = routes.grouped("api", "v1", "submissions")
         submissions.post("browser-result", use: submitBrowserResult)
         submissions.post("runner-submit", use: submitRunnerSubmission)
+        submissions.post("browser-failover", use: submitBrowserFailover)
     }
 
     // MARK: - POST /api/v1/submissions/browser-result
@@ -196,6 +206,131 @@ struct BrowserResultRoutes: RouteCollection {
         return RunnerSubmissionResponse(submissionID: subID)
     }
 
+    // MARK: - POST /api/v1/submissions/browser-failover
+
+    /// Enqueues a server-side ("worker backstop") grade for a browser-graded
+    /// submission whose in-browser Pyodide run failed or *froze*.
+    ///
+    /// Browser grading runs Pyodide on the page's main thread, so a synchronous
+    /// runaway loop in student code hard-freezes the tab: the in-browser per-test
+    /// timeout (a `Promise.race` against a timer) can't fire on the blocked
+    /// thread, grading never completes, and `browser-result` is never POSTed — so
+    /// no submission row is ever created and the v0.4.56 worker backstop (which
+    /// only grades *pending* browser-mode rows) has nothing to claim. The student
+    /// is stuck on "Testing…" forever.
+    ///
+    /// This endpoint closes that gap. The page's freeze-watchdog worker — which
+    /// keeps running on its own thread while the main thread is frozen — calls it
+    /// with the notebook bytes it stashed before grading began; the browser-runner
+    /// catch path also calls it on a non-freeze hard failure. It creates a
+    /// `pending`, browser-mode student submission so the existing native backstop
+    /// grades the `.py` scripts via `python3` — where a runaway loop is SIGKILLed
+    /// and reported as a clean `timeout` instead of a dead kernel.
+    ///
+    /// Gated identically to `browser-result` (enrollment + effective-open), so a
+    /// closed or overdue assignment can't be graded via the failover either.
+    /// Idempotent per (student, setup): a repeated fire (watchdog + catch path,
+    /// retries, reloads) reuses the existing queued/in-flight row instead of
+    /// piling up duplicates.
+    @Sendable
+    func submitBrowserFailover(req: Request) async throws -> RunnerSubmissionResponse {
+        let caller = try req.auth.require(APIUser.self)
+        let body = try req.content.decode(BrowserFailoverBody.self)
+
+        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
+            throw AppError.invalidParameter(name: "testSetupID", reason: "no test setup with that ID")
+        }
+
+        try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
+        _ = try await requireOpenStudentAssignment(for: body.testSetupID, user: caller, on: req)
+
+        // The failover only applies to browser-graded setups — worker-graded
+        // assignments already enqueue through `runner-submit` and can't freeze a
+        // browser kernel. Reject the inverse so a stray call can't smuggle a
+        // worker-mode submission in through this path.
+        let manifestData = Data(setup.manifest.utf8)
+        guard let manifest = decodeManifest(from: manifestData), manifest.gradingMode == .browser
+        else {
+            throw AppError.badRequest(
+                reason: "Browser failover is only for browser-graded assignments.")
+        }
+
+        guard let userID = caller.id else {
+            throw AppError.internalFailure(reason: "Authenticated user has no ID")
+        }
+
+        // Idempotency: a browser-mode setup never has `pending`/`assigned` student
+        // rows except failovers (normal browser submissions are stored `complete`),
+        // so an existing one is an earlier failover for this same attempt — reuse
+        // it rather than enqueue a duplicate grade.
+        if let existing = try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID == body.testSetupID)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .filter(\.$userID == userID)
+            .filter(\.$status ~~ [SubmissionStatus.pending.rawValue, SubmissionStatus.assigned.rawValue])
+            .first()
+        {
+            return RunnerSubmissionResponse(submissionID: existing.id ?? "")
+        }
+
+        // Persist the notebook artifact, merged with the instructor notebook so
+        // the backstop runs the hidden (release/secret) test cells too — exactly
+        // as `browser-result` does.
+        let subsDir = req.application.submissionsDirectory
+        let subID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
+        let nbPath = subsDir + "\(subID).ipynb"
+        let studentData = Data(body.notebook.utf8)
+        let instructorData: Data
+        do {
+            instructorData = try notebookData(for: setup)
+        } catch {
+            req.logger.warning(
+                "Browser failover: could not load instructor notebook for \(setup.id ?? "?"): \(error) — hidden test cells will not be injected"
+            )
+            instructorData = studentData
+        }
+        let notebookToSave = mergeNotebook(student: studentData, instructor: instructorData)
+        try notebookToSave.write(to: URL(fileURLWithPath: nbPath))
+
+        let submission = APISubmission(
+            id: subID,
+            testSetupID: body.testSetupID,
+            zipPath: nbPath,
+            attemptNumber: 0,  // assigned by saveSubmissionWithNextAttemptNumber
+            status: SubmissionStatus.pending.rawValue,
+            filename: "\(subID).ipynb",
+            userID: userID,
+            kind: APISubmission.Kind.student
+        )
+        try await saveSubmissionWithNextAttemptNumber(submission, userID: userID, on: req.db)
+
+        req.logger.warning(
+            "Browser grading failed/froze for setup \(body.testSetupID); enqueued worker backstop grade \(subID)"
+        )
+
+        // Record a diagnostic breadcrumb so the freeze→failover is visible in the
+        // admin browser-diagnostics surface next to the watchdog_timeout /
+        // kernel-unhealthy events that precede it. Infrastructure-only (a
+        // submission id), never student content.
+        let diagnostic = APIClientDiagnostic(
+            userID: userID,
+            testSetupID: body.testSetupID,
+            kind: "submit_failover",
+            failedChecks: nil,
+            userAgent: req.headers.first(name: .userAgent).map { String($0.prefix(512)) },
+            message: "submission=\(subID)",
+            source: "backstop"
+        )
+        try? await diagnostic.save(on: req.db)
+
+        // Wake a local runner in development (production runners poll
+        // continuously). The backstop claims browser-mode pending rows, so unlike
+        // `runner-submit` we DO want to nudge the runner for a browser setup here.
+        await ensureLocalRunnerForSubmissionIfNeeded(req: req)
+
+        return RunnerSubmissionResponse(submissionID: subID)
+    }
+
     /// Rewrites a browser-supplied collection with the server-authoritative
     /// submission ID and attempt number, recomputing `isFirstPassSuccess` from
     /// the true attempt (a pass only counts as a first-pass success on attempt
@@ -262,6 +397,15 @@ struct RunnerSubmitBody: Content {
     var notebook: Data
     var testSetupID: String
     var filename: String?
+}
+
+struct BrowserFailoverBody: Content {
+    /// The test setup this submission belongs to.
+    var testSetupID: String
+    /// Raw `.ipynb` JSON text the browser stashed before grading began. Sent as
+    /// a string (not multipart) so the freeze-watchdog worker can post it with a
+    /// plain JSON `fetch` from its own thread while the main thread is frozen.
+    var notebook: String
 }
 
 struct BrowserResultResponse: Content {

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -348,9 +348,10 @@ private func collectClaimCandidates(
         guard let manifest = decodeManifest(from: Data(setup.manifest.utf8)) else { continue }
         resolvedBySetupID[candidate.testSetupID] = (setup, manifest)
         // Accept both worker-mode and browser-mode pending submissions.
-        // Browser-mode submissions only become pending when the client-side
-        // runner fails or times out; the worker serves as a backstop that
-        // runs the .py test scripts natively via python3.
+        // Browser-mode submissions become pending when the client-side runner
+        // fails or freezes (the `browser-failover` endpoint enqueues them) or
+        // when an instructor retests; the worker serves as a backstop that runs
+        // the .py test scripts natively via python3.
         candidates.append((candidate, setup, manifest))
     }
 

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -712,6 +712,131 @@ import XCTVapor
         }
     }
 
+    // MARK: - Browser failover (freeze → worker backstop)
+
+    /// Helper: POST the JSON browser-failover body with the CSRF token in the
+    /// header (the freeze-watchdog worker / browser-runner both send it there).
+    private func postFailover(
+        setupID: String, notebook: String, csrf: String, cookie: String
+    ) async throws -> (HTTPStatus, String?) {
+        var status: HTTPStatus = .ok
+        var submissionID: String?
+        try await app.asyncTest(
+            .POST, "/api/v1/submissions/browser-failover",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+                req.headers.add(name: "x-csrf-token", value: csrf)
+                try req.content.encode(
+                    BrowserFailoverBody(testSetupID: setupID, notebook: notebook), as: .json)
+            },
+            afterResponse: { res in
+                status = res.status
+                if let json = try? JSONSerialization.jsonObject(
+                    with: Data(res.body.readableBytesView)) as? [String: String]
+                {
+                    submissionID = json["submissionID"]
+                }
+            })
+        return (status, submissionID)
+    }
+
+    /// A frozen/failed browser grade enqueues a `pending`, browser-mode student
+    /// submission that the worker backstop (WorkerJobRoutes) will claim.
+    @Test func browserFailoverEnqueuesPendingSubmission() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())  // browser
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+            let nb = try #require(String(data: minimalNotebook(), encoding: .utf8))
+
+            let (status, submissionID) = try await postFailover(
+                setupID: setupID, notebook: nb, csrf: csrf, cookie: sessionCookie)
+            #expect(status == .ok)
+            let id = try #require(submissionID)
+            #expect(id.isEmpty == false)
+
+            let sub = try #require(try await APISubmission.find(id, on: app.db))
+            #expect(sub.statusValue == .pending, "failover row must be pending for the backstop to claim")
+            #expect(sub.kind == APISubmission.Kind.student)
+            #expect(sub.testSetupID == setupID)
+            #expect(sub.userID != nil)
+        }
+    }
+
+    /// Repeated failover fires (watchdog + catch path, retries, reloads) reuse
+    /// the existing queued row instead of piling up duplicate grades.
+    @Test func browserFailoverIsIdempotentPerStudentAndSetup() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+            let nb = try #require(String(data: minimalNotebook(), encoding: .utf8))
+
+            let (_, first) = try await postFailover(
+                setupID: setupID, notebook: nb, csrf: csrf, cookie: sessionCookie)
+            let (_, second) = try await postFailover(
+                setupID: setupID, notebook: nb, csrf: csrf, cookie: sessionCookie)
+
+            let firstID = try #require(first)
+            let secondID = try #require(second)
+            #expect(firstID == secondID, "second fire must reuse the first row")
+            let pending = try await APISubmission.query(on: app.db)
+                .filter(\.$status == SubmissionStatus.pending.rawValue)
+                .all()
+            #expect(pending.count == 1, "exactly one backstop row should exist, got \(pending.count)")
+        }
+    }
+
+    /// The failover is browser-only: a worker-graded setup already enqueues via
+    /// runner-submit, so the inverse is rejected and no row is created.
+    @Test func browserFailoverRejectsWorkerGradedSetup() async throws {
+        try await withApp(app) { _ in
+            let manifest = """
+                {
+                  "schemaVersion": 1,
+                  "gradingMode": "worker",
+                  "requiredFiles": [],
+                  "testSuites": [ { "tier": "public", "script": "test_public.py" } ],
+                  "timeLimitSeconds": 10,
+                  "makefile": null
+                }
+                """
+            let setupID = try await insertSetup(manifest: manifest)
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+            let nb = try #require(String(data: minimalNotebook(), encoding: .utf8))
+
+            let (status, _) = try await postFailover(
+                setupID: setupID, notebook: nb, csrf: csrf, cookie: sessionCookie)
+            #expect(status == .badRequest)
+
+            let all = try await APISubmission.query(on: app.db).all()
+            #expect(all.isEmpty, "worker-mode failover must not create a submission")
+        }
+    }
+
+    /// A closed (or overdue) assignment can't be graded via the failover any more
+    /// than via the normal browser submit path — same effective-open gate.
+    @Test func browserFailoverRejectsClosedAssignment() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: false)
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+            let nb = try #require(String(data: minimalNotebook(), encoding: .utf8))
+
+            let (status, _) = try await postFailover(
+                setupID: setupID, notebook: nb, csrf: csrf, cookie: sessionCookie)
+            #expect(status == .forbidden, "closed assignment must reject the failover, got \(status)")
+
+            let all = try await APISubmission.query(on: app.db).all()
+            #expect(all.isEmpty, "closed-assignment failover must not create a submission")
+        }
+    }
+
     // MARK: - Private fixtures
 
     private func simpleManifest() -> String {

--- a/Tests/BrowserRunnerJSTests/freeze-watchdog.test.mjs
+++ b/Tests/BrowserRunnerJSTests/freeze-watchdog.test.mjs
@@ -44,6 +44,7 @@ function loadWorker() {
         advance: (ms) => { state.nowMs += ms; },
         fetchCalls,
         evaluateStall: ctx.module.exports.evaluateStall,
+        evaluateGradingFailover: ctx.module.exports.evaluateGradingFailover,
     };
 }
 
@@ -93,4 +94,75 @@ test('worker does not beacon while the tab is hidden', () => {
     w.advance(20000);
     w.tick();
     assert.equal(w.fetchCalls.length, 0);
+});
+
+// --- Grading failover -------------------------------------------------------
+
+test('evaluateGradingFailover: only armed, visible, past threshold, not yet fired', () => {
+    const { evaluateGradingFailover } = loadWorker();
+    const base = {
+        lastBeatMs: 0, gradingThresholdMs: 30000,
+        visible: true, gradingArmed: true, gradingFailedOver: false,
+    };
+    assert.equal(evaluateGradingFailover(base, 31000).shouldFailover, true);
+    assert.equal(evaluateGradingFailover({ ...base, gradingArmed: false }, 31000).shouldFailover, false);
+    assert.equal(evaluateGradingFailover({ ...base, gradingFailedOver: true }, 31000).shouldFailover, false);
+    assert.equal(evaluateGradingFailover({ ...base, visible: false }, 31000).shouldFailover, false);
+    assert.equal(evaluateGradingFailover(base, 5000).shouldFailover, false);
+});
+
+test('armed grade that freezes posts exactly one failover with the stashed notebook', () => {
+    const w = loadWorker();
+    w.send({ type: 'init', beaconUrl: '/api/v1/client-diagnostics', setupID: 'setup_z', csrfToken: 'init-tok', thresholdMs: 8000 });
+    w.send({
+        type: 'grading-armed',
+        setupID: 'setup_z',
+        notebook: '{"cells":[]}',
+        failoverUrl: '/api/v1/submissions/browser-failover',
+        csrfToken: 'grade-tok',
+        thresholdMs: 30000,
+    });
+
+    // Healthy window under the grading threshold → no failover (the 8s beacon
+    // may fire, but no failover POST).
+    w.advance(9000);
+    w.tick();
+    assert.equal(w.fetchCalls.filter(c => c.url === '/api/v1/submissions/browser-failover').length, 0);
+
+    // Past the grading threshold → exactly one failover POST, even if ticked again.
+    w.advance(30000);
+    w.tick();
+    w.tick();
+    const failovers = w.fetchCalls.filter(c => c.url === '/api/v1/submissions/browser-failover');
+    assert.equal(failovers.length, 1);
+    const call = failovers[0];
+    assert.equal(call.opts.method, 'POST');
+    assert.equal(call.opts.headers['x-csrf-token'], 'grade-tok');
+    const body = JSON.parse(call.opts.body);
+    assert.equal(body.testSetupID, 'setup_z');
+    assert.equal(body.notebook, '{"cells":[]}');
+});
+
+test('disarming before the threshold cancels the failover', () => {
+    const w = loadWorker();
+    w.send({ type: 'init', beaconUrl: '/u', setupID: 's', csrfToken: '', thresholdMs: 8000 });
+    w.send({ type: 'grading-armed', setupID: 's', notebook: '{}', failoverUrl: '/fo', thresholdMs: 30000 });
+    // Grade finished fast: disarm, then time passes.
+    w.send({ type: 'grading-disarmed' });
+    w.advance(60000);
+    w.tick();
+    assert.equal(w.fetchCalls.filter(c => c.url === '/fo').length, 0);
+});
+
+test('a heartbeat-fed (healthy) grade never fails over', () => {
+    const w = loadWorker();
+    w.send({ type: 'init', beaconUrl: '/u', setupID: 's', csrfToken: '', thresholdMs: 8000 });
+    w.send({ type: 'grading-armed', setupID: 's', notebook: '{}', failoverUrl: '/fo', thresholdMs: 30000 });
+    // Beats keep arriving (main thread responsive) — stall never reaches 30s.
+    for (let i = 0; i < 30; i++) {
+        w.advance(2000);
+        w.send({ type: 'beat' });
+        w.tick();
+    }
+    assert.equal(w.fetchCalls.filter(c => c.url === '/fo').length, 0);
 });

--- a/changelog.d/browser-grading-failover.md
+++ b/changelog.d/browser-grading-failover.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Frozen in-browser grades now fall back to the worker backstop.** Browser
+  grading runs Pyodide on the page's main thread, so a non-terminating (or
+  blocking) student submission froze the tab: the in-browser per-test timeout
+  couldn't fire on the blocked thread, grading never completed, and — because a
+  browser submission row is only created when grading *finishes* — nothing was
+  ever enqueued, so the v0.4.56 worker backstop had nothing to grade and the
+  student was stuck on "Testing…" indefinitely. The freeze-watchdog worker (the
+  one thread still alive while the main thread is frozen) now POSTs the stashed
+  notebook to a new `POST /api/v1/submissions/browser-failover` endpoint after a
+  grading stall, and the browser-runner does the same on a non-freeze hard
+  failure. That enqueues a `pending` browser-mode submission the native backstop
+  grades via `python3`, where a runaway loop is killed and reported as a clean
+  `timeout` instead of a dead kernel. The failover is gated identically to a
+  normal browser submission (enrollment + effective-open) and is idempotent per
+  (student, assignment). A `submit_failover` diagnostic breadcrumb makes the
+  fallback visible in the admin browser-diagnostics surface.


### PR DESCRIPTION
## Problem

A student (HLTH 230 Lab 4) reported submissions stuck on "Testing…" forever, with Chickadee eventually freezing. The admin browser-diagnostics surface showed the signature clearly on that assignment's test setup: the submit funnel reached `suite_started` but **never** `suite_done`, with repeated `watchdog_timeout` / `kernel-unhealthy` events across four different browser/OS combinations.

Root cause: **browser grading runs Pyodide on the page's main thread.** A non-terminating (or blocking) student submission freezes the tab — the in-browser per-test timeout (a `Promise.race` against a JS timer) can't fire on the blocked thread, so grading never completes. And because a browser submission row is only ever created when grading *finishes* (`browser-result`), a frozen first attempt creates **no row at all**. The v0.4.56 worker backstop only grades *pending* browser-mode rows, so it had nothing to claim — the fallback we thought existed couldn't cover the freeze case.

## Fix

Make a frozen/failed browser grade enqueue a `pending` browser-mode submission so the existing native backstop grades the `.py` scripts via `python3` — where a runaway loop is SIGKILLed and reported as a clean `timeout` outcome the student can see and fix, instead of a dead kernel.

- **New endpoint `POST /api/v1/submissions/browser-failover`** (`BrowserResultRoutes.swift`). Gated identically to a normal browser submit (enrollment + effective-open, so a closed/overdue assignment can't be graded via the failover either), browser-mode only, idempotent per (student, setup). Merges the instructor notebook so hidden (release/secret) tiers run, and emits a `submit_failover` diagnostic breadcrumb so the fallback is visible in the admin browser-diagnostics surface.
- **`freeze-watchdog-worker.js`** — the one thread still alive while the main thread is frozen — is *armed* by the page before grading with the notebook bytes; if the main thread stalls past 30s it POSTs the failover. This is the component that handles the actual freeze, since the main thread is dead.
- **`notebook.js`** arms the worker before grading, disarms on completion, and on a *non-freeze* hard failure posts the failover directly and navigates the (still-alive) page to the queued submission.

For a true freeze the page stays dead until the student reloads, after which the server-side grade is on their submissions page; the watchdog can't revive the main thread, but it does guarantee the grade gets produced.

## Tests

- Swift (`BrowserRunnerRoutesTests`): enqueue creates a pending browser-mode student row; idempotency per (student, setup); worker-mode setup rejected; closed assignment rejected. **All 24 in-suite tests pass.**
- JS (`freeze-watchdog.test.mjs`): pure `evaluateGradingFailover`; armed freeze posts exactly one failover with the stashed notebook; disarm cancels; a heartbeat-fed (healthy) grade never fails over. **All 89 BrowserRunner JS tests pass.**

## Operational note

As an immediate mitigation (separate from this PR), **Lab 4 was flipped to `worker` grading** so the native runner — which enforces a real per-test timeout — unblocks the class now. Per the request in-session, that should be flipped back to `browser` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnHL5b3NuDMW4bcdLsDYTm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnHL5b3NuDMW4bcdLsDYTm)_