### PR TITLE
Fix BrightSpace authorize button (CSP form-action) + surface real whoami error

### DIFF
--- a/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
@@ -90,6 +90,13 @@ extension AdminRoutes {
         req.session.data["bs_valence_state"] = state
 
         let callbackWithState = callback + "?state=" + state
+
+        // The CSP is globally `form-action 'self'`; this POST 303s to the LMS
+        // origin, and Chrome/Firefox enforce form-action across that redirect —
+        // so without relaxing it the navigation is silently blocked (the button
+        // appears to "do nothing"). Mirrors the SSO/MCP consent flows.
+        SecurityHeadersMiddleware.allowFormAction(lmsOrigin(appCreds.baseURL), on: req)
+
         return req.redirect(to: appCreds.valenceAuthURL(callback: callbackWithState))
     }
 
@@ -192,6 +199,15 @@ extension AdminRoutes {
     }
 
     // MARK: - Helpers
+
+    /// `scheme://host[:port]` of the LMS base URL, for the `form-action`
+    /// CSP allow-list. Nil when the base URL can't be parsed.
+    func lmsOrigin(_ baseURL: String) -> String? {
+        guard let url = URL(string: baseURL), let scheme = url.scheme, let host = url.host else {
+            return nil
+        }
+        return "\(scheme)://\(host)\(url.port.map { ":\($0)" } ?? "")"
+    }
 
     /// The absolute Trusted-URL callback D2L redirects back to, derived from
     /// `PUBLIC_BASE_URL`. Nil when the base URL isn't configured.

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -54,13 +54,13 @@ struct BrightSpaceSyncConfig: Sendable {
 
 // MARK: - Error
 
-enum BrightSpaceSyncError: Error, CustomStringConvertible {
+enum BrightSpaceSyncError: Error, CustomStringConvertible, LocalizedError {
     case notConfigured
     case userLookupFailed(orgDefinedId: String, status: Int)
     case userNotFound(orgDefinedId: String)
     case gradePushFailed(status: Int, body: String)
     case missingPoints
-    case whoamiFailed(status: Int)
+    case whoamiFailed(status: Int, body: String)
     case orgUnitLookupFailed(orgUnitID: String, status: Int)
     case gradeObjectsFetchFailed(orgUnitID: String, status: Int)
     case classlistFetchFailed(orgUnitID: String, status: Int)
@@ -77,8 +77,8 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible {
             return "BrightSpace grade push failed (HTTP \(s)): \(b)"
         case .missingPoints:
             return "No grade points available to push"
-        case .whoamiFailed(let s):
-            return "BrightSpace whoami failed (HTTP \(s))"
+        case .whoamiFailed(let s, let b):
+            return "BrightSpace whoami failed (HTTP \(s))\(b.isEmpty ? "" : ": \(b)")"
         case .orgUnitLookupFailed(let id, let s):
             return "BrightSpace org unit lookup for '\(id)' failed (HTTP \(s))"
         case .gradeObjectsFetchFailed(let id, let s):
@@ -87,6 +87,11 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible {
             return "BrightSpace classlist fetch for org unit '\(id)' failed (HTTP \(s))"
         }
     }
+
+    // Surface `description` through `localizedDescription` so the UI's
+    // "Connection failed: \(error.localizedDescription)" shows the HTTP status
+    // and D2L's error body, not Swift's generic "(… error N.)".
+    var errorDescription: String? { description }
 }
 
 // MARK: - Read-only lookup result types
@@ -256,7 +261,11 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         let url = signed(url: rawURL, method: "GET")
         let response = try await application.client.get(URI(string: url))
         guard response.status == .ok else {
-            throw BrightSpaceSyncError.whoamiFailed(status: Int(response.status.code))
+            var bodyBuf = response.body
+            let bodyLen = bodyBuf?.readableBytes ?? 0
+            let bodyText = bodyBuf?.readString(length: bodyLen) ?? ""
+            throw BrightSpaceSyncError.whoamiFailed(
+                status: Int(response.status.code), body: String(bodyText.prefix(500)))
         }
         struct WhoAmIResponse: Decodable {
             let identifier: String

--- a/changelog.d/brightspace-whoami-error-detail.md
+++ b/changelog.d/brightspace-whoami-error-detail.md
@@ -1,8 +1,14 @@
 ### Fixed
 
+- **BrightSpace "Authorize" button silently did nothing.** The admin authorize
+  POST 303s to the LMS origin, but the global CSP `form-action 'self'` blocked
+  that cross-origin redirect (Chrome/Firefox enforce form-action across the
+  redirect chain). The handler now relaxes `form-action` to the LMS origin for
+  that response, matching the SSO/MCP consent flows.
 - **BrightSpace "Test connection" now shows the real error.** A failed `whoami`
   surfaced as Swift's generic `"The operation could not be completed.
   (… error N.)"` because `BrightSpaceSyncError` wasn't a `LocalizedError`. It now
   is, and `whoamiFailed` carries D2L's response body — so the admin/instructor
   panels report the actual HTTP status and message (e.g. a 403 "Timestamp out of
   range" vs. an egress-proxy denial). The CLI helper prints the same detail.
+

--- a/changelog.d/brightspace-whoami-error-detail.md
+++ b/changelog.d/brightspace-whoami-error-detail.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **BrightSpace "Test connection" now shows the real error.** A failed `whoami`
+  surfaced as Swift's generic `"The operation could not be completed.
+  (… error N.)"` because `BrightSpaceSyncError` wasn't a `LocalizedError`. It now
+  is, and `whoamiFailed` carries D2L's response body — so the admin/instructor
+  panels report the actual HTTP status and message (e.g. a 403 "Timestamp out of
+  range" vs. an egress-proxy denial). The CLI helper prints the same detail.

--- a/scripts/brightspace-valence-auth.py
+++ b/scripts/brightspace-valence-auth.py
@@ -51,6 +51,7 @@ import http.server
 import os
 import sys
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 import webbrowser
@@ -216,6 +217,19 @@ def verify_whoami(host: str, app_id: str, app_key: str,
         with urllib.request.urlopen(url, timeout=30) as resp:
             import json
             data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        # D2L's body carries the real reason (e.g. "Timestamp out of range",
+        # "Invalid token") — far more useful than just the status.
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", "replace")[:500]
+        except Exception:  # noqa: BLE001
+            pass
+        print(f"\n⚠  whoami verification FAILED: HTTP {exc.code} — {body}", file=sys.stderr)
+        print("   The keys were captured but D2L rejected the call. A 403 with "
+              "'Timestamp out of range' means clock skew; 'Invalid token' means a "
+              "key/signature mismatch.", file=sys.stderr)
+        return
     except Exception as exc:  # noqa: BLE001 — surface any failure to the operator
         print(f"\n⚠  whoami verification FAILED: {exc}", file=sys.stderr)
         print("   The keys were captured but could not be confirmed. Double-check "


### PR DESCRIPTION
Two bug fixes for the BrightSpace authorize flow, found while piloting #966 on prod.

## 1. 🐞 "Authorize" / "Re-authorize" button did nothing
The admin authorize POST 303-redirects to the LMS origin to start the Valence handshake, but the global CSP `form-action 'self'` makes Chrome/Firefox **silently block** that cross-origin navigation — the button appears dead. `brightspaceAuthorize` now relaxes `form-action` to the LMS origin for that response (`SecurityHeadersMiddleware.allowFormAction`), exactly as the SSO login/logout and MCP consent flows do.

## 2. "Test connection" hid the real error
A failed `whoami` showed Swift's generic `"The operation could not be completed. (… error 3.)"` because `BrightSpaceSyncError` wasn't a `LocalizedError`. It now conforms, and `whoamiFailed` carries D2L's **response body**, so the panel reports the actual status + reason (e.g. `403 Invalid token` from a bad key, `403 Timestamp out of range` from clock skew, or an egress-proxy denial page). The CLI helper prints the same.

## Verification
`swift build` clean; `swift-format` clean. Diagnostic/UX only — no change to the signing or grading path.

## Field context
Diagnosed a prod pilot where the env `BRIGHTSPACE_USER_ID` was mistakenly set to the App ID (a placeholder), which is what made `whoami` 403 — these two fixes are what surface that clearly and let the in-app Authorize button actually run.

Follow-up to #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi