### PR TITLE
Fix BrightSpace Authorize button: relax form-action on the page render

### DIFF
--- a/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
@@ -52,6 +52,15 @@ extension AdminRoutes {
 
         let capturedAt = stored?.capturedAt.map { waterlooDateTimeFormatter().string(from: $0) }
 
+        // Relax `form-action` so the Re-authorize form on THIS page can POST →
+        // 303 to the LMS origin. The browser enforces form-action using the CSP
+        // of the page that *contains* the form, so it must be set here (when
+        // rendering the page), not on the POST response — matching the MCP
+        // consent page pattern (MCPOAuthRoutes.authorizeForm).
+        if let appCreds {
+            SecurityHeadersMiddleware.allowFormAction(lmsOrigin(appCreds.baseURL), on: req)
+        }
+
         let ctx = AdminBrightspaceContext(
             currentUser: req.currentUserContext,
             activeAdminTab: "brightspace",
@@ -88,13 +97,11 @@ extension AdminRoutes {
         // string breaks the match), so we can't echo a state token back through
         // the callback URL. Instead the callback is bound to an authorize that
         // *this* admin session initiated.
+        // (The form-action CSP that lets this POST 303 cross-origin to the LMS
+        // is set on the page render in brightspacePage — the browser enforces
+        // form-action using the CSP of the page that contains the form, not the
+        // POST response, so relaxing it here would be too late.)
         req.session.data["bs_valence_pending"] = "1"
-
-        // The CSP is globally `form-action 'self'`; this POST 303s to the LMS
-        // origin, and Chrome/Firefox enforce form-action across that redirect —
-        // so without relaxing it the navigation is silently blocked (the button
-        // appears to "do nothing"). Mirrors the SSO/MCP consent flows.
-        SecurityHeadersMiddleware.allowFormAction(lmsOrigin(appCreds.baseURL), on: req)
 
         // `x_target` must equal the registered Trusted URL exactly — no query.
         return req.redirect(to: appCreds.valenceAuthURL(callback: callback))

--- a/changelog.d/brightspace-formaction-page.md
+++ b/changelog.d/brightspace-formaction-page.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **BrightSpace "Authorize" button really works now (form-action on the right
+  response).** The earlier fix relaxed `form-action` on the authorize POST
+  response, but the browser enforces `form-action` using the CSP of the page
+  that *contains* the form — so the relaxation has to be on the
+  `GET /admin/brightspace` render, not the POST. Moved it there (matching the
+  MCP consent-page pattern); the button no longer silently does nothing.


### PR DESCRIPTION
## Why

The "Re-authorize" button still silently does nothing in prod. The #969 fix relaxed CSP `form-action` on the **POST** `/admin/brightspace/authorize` response — but browsers enforce `form-action` using the CSP of the page that **contains the form** (the `GET /admin/brightspace` render), not the navigation/redirect response. So the form was still blocked from 303-ing cross-origin to the LMS, and the button appeared dead.

## Fix

Move `SecurityHeadersMiddleware.allowFormAction(lmsOrigin)` into `brightspacePage` (the GET render), exactly where the working **MCP consent** flow does it (`MCPOAuthRoutes.authorizeForm`). Removed the no-op call from the POST handler.

`swift build` clean; `swift-format` clean. Follow-up to #966/#969/#970 — this is the piece that makes the in-app Authorize button actually navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_