### PR TITLE
Scope home dashboard + Instructor tab to course enrollment

### DIFF
--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -32,12 +32,8 @@
     </a>
 
     #if(currentUser):
-        #if(currentUser.isInstructor):
-            #if(currentUser.activeCourse):
+        #if(currentUser.isInstructor && currentUser.activeCourse):
             <a class="nav-link" href="/instructor">#(currentUser.activeCourse.code)</a>
-            #else:
-            <a class="nav-link" href="/instructor">Instructor</a>
-            #endif
         #endif
         #if(currentUser.isAdmin):
             <a class="nav-link" href="/admin">Admin</a>

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -68,17 +68,26 @@ struct WebRoutes: RouteCollection {
             }
         }
 
+        // The home dashboard is course-scoped for every role. With no active
+        // enrollment we've either already redirected to /enroll (when an open
+        // course exists to self-enrol into) or there's nothing this user is
+        // affiliated with — render the empty "not enrolled in any courses"
+        // dashboard rather than falling through to a deployment-wide assignment
+        // list. An admin with no enrollment administers courses from /admin; the
+        // home dashboard is never an all-courses view, for any role.
+        guard let activeCourseUUID = courseState.activeCourseUUID else {
+            return try await req.view.render(
+                "index",
+                IndexContext(displayGroups: [], hasAny: false, currentUser: userContext)
+            ).encodeResponse(for: req)
+        }
+
         let fmt = waterlooDateTimeFormatter()
 
-        // Load assignments, filtering by active course when one is resolved.
-        let allAssignments: [APIAssignment]
-        if let activeCourseUUID = courseState.activeCourseUUID {
-            allAssignments = try await APIAssignment.query(on: req.db)
-                .filter(\.$courseID == activeCourseUUID)
-                .all()
-        } else {
-            allAssignments = try await APIAssignment.query(on: req.db).all()
-        }
+        // Load every assignment in the active course.
+        let allAssignments = try await APIAssignment.query(on: req.db)
+            .filter(\.$courseID == activeCourseUUID)
+            .all()
         let assignmentBySetup = Dictionary(
             allAssignments.map { ($0.testSetupID, $0) },
             uniquingKeysWith: { first, _ in first }
@@ -101,17 +110,11 @@ struct WebRoutes: RouteCollection {
 
         let setups: [APITestSetup]
         if user.isInstructor {
-            // Instructors and admins see test setups for the active course.
-            if let activeCourseUUID = courseState.activeCourseUUID {
-                setups = try await APITestSetup.query(on: req.db)
-                    .filter(\.$courseID == activeCourseUUID)
-                    .sort(\.$createdAt, .descending)
-                    .all()
-            } else {
-                setups = try await APITestSetup.query(on: req.db)
-                    .sort(\.$createdAt, .descending)
-                    .all()
-            }
+            // Instructors and admins see every test setup in the active course.
+            setups = try await APITestSetup.query(on: req.db)
+                .filter(\.$courseID == activeCourseUUID)
+                .sort(\.$createdAt, .descending)
+                .all()
         } else {
             // Enrolled students see every published assignment in their course:
             // open ones, and ones that were published and have since closed at

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -504,4 +504,83 @@ import XCTVapor
                 })
         }
     }
+
+    // MARK: - Unenrolled admin scoping
+
+    /// An admin who is not enrolled in any course is an *administrator*, not a
+    /// course participant. The home dashboard must not fall through to a
+    /// deployment-wide assignment list for them, and the course-scoped
+    /// "Instructor" nav tab must not appear (their global admin role still gives
+    /// them the Admin tab + /admin). Regression for the unenrolled-admin leak:
+    /// the index `else` branches queried every assignment/setup in the
+    /// deployment, and `isInstructor` (admin-implies-instructor) rendered the tab.
+    @Test func unenrolledAdminSeesNoInstructorTabAndNoOtherCourseAssignments() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await loginUser(
+                username: "admin1", password: "pass", role: "admin", on: app)
+
+            // A closed-enrollment course (so the unenrolled admin is neither
+            // auto-enrolled nor redirected to /enroll) with a published assignment.
+            let course = APICourse(code: "CS200", name: "Other Course", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+            let setupID = "setup_other_course"
+            let manifest = """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+                """
+            try await APITestSetup(
+                id: setupID, manifest: manifest,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip", courseID: courseID
+            ).save(on: app.db)
+            try await APIAssignment(
+                testSetupID: setupID, title: "Other Course Lab", dueAt: nil, isOpen: true, courseID: courseID
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        !html.contains("Other Course Lab"),
+                        "An unenrolled admin must not see assignments from a course they're not in")
+                    #expect(
+                        html.contains("not enrolled in any courses"),
+                        "The dashboard should show the empty not-enrolled state")
+                    #expect(
+                        !html.contains(#"href="/instructor""#),
+                        "The course-scoped Instructor tab must not render for an unenrolled admin")
+                    #expect(
+                        html.contains(#"href="/admin""#),
+                        "The admin keeps their deployment-wide Admin tab")
+                })
+        }
+    }
+
+    /// The other side of the unenrolled-admin fix: an instructor enrolled in a
+    /// course still gets the course-scoped tab, labelled with the active course
+    /// code.
+    @Test func enrolledInstructorSeesCourseScopedInstructorTab() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains(#"href="/instructor""#),
+                        "An enrolled instructor must still see the Instructor tab")
+                    #expect(
+                        html.contains(">CS101</a>"),
+                        "The Instructor tab is labelled with the active course code")
+                })
+        }
+    }
 }

--- a/changelog.d/unenrolled-admin-course-scope.md
+++ b/changelog.d/unenrolled-admin-course-scope.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Unenrolled admins no longer see course content they're not part of.** An
+  admin (or any user) with no course enrollment was shown the course-scoped
+  "Instructor" nav tab and a deployment-wide list of every assignment/test
+  setup on the home dashboard. The home dashboard is now course-scoped for
+  every role — with no active enrollment it renders the empty "not enrolled in
+  any courses" state, and the Instructor tab only appears for a user enrolled
+  in a course (labelled with the active course code). The global admin role
+  still grants the Admin tab and `/admin`; course participation is governed by
+  enrollment, matching the existing `CourseAccessHelpers` policy.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -1,0 +1,213 @@
+# Multi-course roles & university-scale organization
+
+**Status:** Design / planning. No implementation yet. Companion to the fix
+that scoped the home dashboard and the "Instructor" nav tab to course
+enrollment (PR #972) — that fix is the first concrete step toward the model
+described here.
+
+This document is a starting point for "thinking on paper," not a committed
+plan. The decisions in [Open questions](#open-questions-for-the-owner) are
+the owner's to make.
+
+---
+
+## 1. Motivation
+
+Chickadee already runs many courses in one deployment, but its **identity
+model is single-course-shaped** in two ways:
+
+1. **Role is global.** `APIUser.role` is one of
+   `student` / `instructor` / `admin` / `mcp`, applied across the *whole
+   deployment*. A person therefore cannot be an instructor in one course and a
+   student in another — a common real situation (a grad student who TAs CS136
+   and takes CS440; an instructor auditing a colleague's offering; a
+   sessional teaching one course this term and none the next).
+
+2. **There is no organizational layer above courses.** The hierarchy is flat:
+   deployment → courses → assignments. There is no term/semester, no
+   department/faculty, and `admin` is all-or-nothing (the entire deployment).
+
+The recent fix leaned on a principle already stated in
+`Sources/APIServer/Helpers/CourseAccessHelpers.swift`:
+
+> Everyone — instructors included — must be enrolled in the specific course
+> that owns the resource. … admins see — and their agents may act on — exactly
+> what they are enrolled in.
+
+i.e. **enrollment scopes course participation; the global role is a deployment
+capability.** But because role is global, the nav and permission story is
+still "instructor-ish *everywhere* or *nowhere*." The two bugs that fix
+addressed were the last places where the global `isInstructor`
+(admin-implies-instructor) leaked past enrollment scoping.
+
+The natural next step is to make participation *role*-scoped to a course, the
+same way it is already *visibility*-scoped to a course.
+
+---
+
+## 2. Current model (what exists today)
+
+| Concern | Where | Shape |
+|---|---|---|
+| Global role | `Sources/APIServer/Models/APIUser.swift` — `UserRole` enum, `role` field, `isInstructor`/`isAdmin` | One string column on the user. `isInstructor == (role == .instructor \|\| role == .admin)`. |
+| Enrollment | `Sources/APIServer/Models/APICourseEnrollment.swift` | Join row `(user_id, course_id)` — **role-agnostic**. Its own header comment: *"The user's global role determines what they can do; enrollment determines which courses they can see."* |
+| Access policy | `Sources/APIServer/Helpers/CourseAccessHelpers.swift` — `requireCourseEnrollment`, `userIsEnrolled`, `enrolledCourses` | The single chokepoint both the web routes and MCP tools resolve course access through. Admin is the one bypass. |
+| Active-course resolution | `APIUser.swift` — `resolveActiveCourse`, `CourseContext`, `ResolvedCourseState` | Picks the active course from session/DB, auto-enrolls `.auto` courses, returns the enrolled set. |
+| View context | `APIUser.swift` — `CurrentUserContext` | Carries `isAdmin`, `isInstructor`, `activeCourse`, `enrolledCourses` into Leaf. The nav (`Resources/Views/base.leaf`) reads these. |
+| Route gating | `Sources/APIServer/Middleware/RoleMiddleware.swift`; groups in `Sources/APIServer/routes.swift` (`.authenticated` / `.instructor` / `.admin`) | Coarse, **global**-role gates at the group level. |
+| Agent scope | `Sources/APIServer/MCP/Tools/ToolContext.swift` — `authorizeCourseAccess` | Enrollment-scoped, so agent scope ⊆ human scope. |
+
+The good news: visibility is *already* funnelled through one resolver
+(`enrolledCourses` / `resolveActiveCourse`) and access through one helper
+(`CourseAccessHelpers`). Those are the seams Theme 1 threads a role through —
+there is no scattered role logic to chase down.
+
+---
+
+## 3. Theme 1 — Per-course roles (the foundation)
+
+### Goal
+
+A user's capability is determined by their role **in a given course**. The
+global `APIUser.role` shrinks to the one genuinely deployment-wide capability:
+`admin` (super-user). "Instructor in CS136, student in CS440" becomes
+representable and creatable.
+
+### 3.1 Data model
+
+- Add `role` to `course_enrollments` — a new `CourseRole` enum in `Core/`
+  (`Codable`, `Sendable`), mirroring `UserRole`: `student`, `instructor`
+  (and, when wanted, `ta` — see open questions). Default `student`.
+- Reinterpret `APIUser.role`:
+  - `admin` stays a **deployment** super-user (manages courses, users,
+    runners; bypasses course checks).
+  - For everyone else the global role stops carrying course capability —
+    capability comes from the enrollment row. (Whether a vestigial global
+    `instructor` survives as a "may create a course" capability is an open
+    question; today instructors don't create courses, admins do.)
+
+### 3.2 Migration / backfill (behavior-preserving)
+
+- New migration adds `role` to `course_enrollments` (add nullable →
+  backfill → enforce default `student`, the SQLite-friendly three-step).
+- **Backfill rule:** for each existing enrollment, set
+  `role = (user.isInstructor ? .instructor : .student)`. A current global
+  instructor therefore becomes instructor in *every course they're already
+  enrolled in*, and students stay students — so **day-one behavior is
+  identical**. Admins keep their global bypass.
+- This is the key property: Phases 1–3 below can ship with *no observable
+  change*, because the per-course role is seeded to reproduce the global one.
+  The behavior change only arrives when someone *authors* a mixed role
+  (Phase 4).
+
+### 3.3 Read path (visibility / nav)
+
+- `CourseContext` gains `role: CourseRole`; `resolveActiveCourse` /
+  `enrolledCourses` populate it from the enrollment row (it's already loaded —
+  one extra column, no extra query).
+- `CurrentUserContext` exposes the active course's role (e.g. a derived
+  `isInstructorInActiveCourse`). `base.leaf` keys the Instructor tab off
+  *that* instead of the global `isInstructor`. Switching the course tab then
+  switches the same account between instructor and student views — which is
+  exactly the desired UX for a TA-who-is-also-a-student.
+
+### 3.4 Auth path (permissions)
+
+- `CourseAccessHelpers` is the chokepoint: add
+  `requireCourseRole(caller:courseID:atLeast: CourseRole, db:)` alongside the
+  existing `requireCourseEnrollment` (which becomes the `atLeast: .student`
+  case). Admin bypass stays.
+- Authoring endpoints (test-setup CRUD, assignment CRUD, suite editor, MCP
+  content tools) switch from "enrolled" to `atLeast: .instructor`. Submit /
+  view endpoints stay at "enrolled" (`atLeast: .student`).
+- `RoleMiddleware(.instructor)` on the `/instructor` group
+  (`routes.swift`) can no longer be the *fine-grained* check, because the
+  middleware doesn't know the target course. It becomes a **coarse gate**
+  ("is the caller an instructor in *some* course, or admin?" — enough to enter
+  the section), with the authoritative per-course check moving into the
+  handlers, which already resolve the course. (Most instructor handlers
+  already call `requireCourseEnrollment`; this is a one-line swap there.)
+- MCP: `ToolContext.authorizeCourseAccess` becomes role-aware (content tools
+  require instructor-in-course), preserving agent scope ⊆ human scope.
+
+### 3.5 UI touchpoints
+
+- **Enrollment management** (`CourseAdminRoutes+Enrollment.swift`, the CSV
+  bulk-enroll + roster): a per-row role, defaulting to `student`; an
+  instructor enrolls a TA / co-instructor by choosing `instructor`. This is
+  the screen where mixed roles become *creatable*.
+- **Roster + account/"my courses"** views show the role per course.
+- `EnrollUsernamesResult` and the pre-enrollment (`APIPreEnrollment`) flow
+  carry the intended role so a not-yet-registered TA lands with the right
+  role on first login.
+
+### 3.6 Suggested phasing
+
+1. **Core + schema.** `CourseRole`, the migration, the backfill. No reads of
+   the new column yet → zero behavior change.
+2. **Read path.** `CourseContext.role`, nav keyed off active-course role.
+   Still identical behavior (backfill mirrors the global role).
+3. **Auth path.** Helper + handler/middleware switch to role checks. Still
+   identical (same reason).
+4. **Authoring UI.** Per-course role on enroll/roster. **This is where
+   "instructor here, student there" goes live.**
+5. **Shrink the global role.** Collapse `APIUser.role` toward `admin`-only;
+   revisit SSO role mapping (`SSO_INSTRUCTOR_USERS` currently sets the *global*
+   role — see open questions). Longest tail; can lag well behind 1–4.
+
+---
+
+## 4. Theme 2 — University-scale organization (follow-on, lower resolution)
+
+This is sketched, not specified — it should get its own doc once Theme 1
+lands.
+
+- **Terms / semesters.** A `Term` entity ("Fall 2026"); a course belongs to a
+  term. Re-offering CS136 each term becomes "a new course in a new term,"
+  not today's archive-and-recreate. Course-code uniqueness becomes
+  *per-term*; the archive-based retention clock
+  (`SubmissionRetentionService`) re-anchors on term rollover.
+- **Departments / faculties.** An org-unit grouping courses; dashboards and
+  admin organize by department instead of one flat list.
+- **Scoped administration.** Today `admin` is deployment-wide. University
+  scale wants a **department admin** who manages only their department's
+  courses. That is the *same pattern as per-course roles, one level up*:
+  an admin capability attached to an org-unit instead of the deployment.
+  Building Theme 1 first means the "capability scoped to an affiliation"
+  machinery (role-on-join-row, role-aware chokepoint helper) already exists
+  to reuse here.
+
+**Why Theme 1 first:** per-course roles establish the affiliation-scoped
+capability pattern and make the access helper role-aware. Department-scoped
+admin is structurally identical at the org-unit level, so it slots into that
+machinery cleanly rather than inventing a parallel one.
+
+---
+
+## 5. Non-goals (for now)
+
+- Multi-tenant / cross-deployment isolation (several universities in one
+  instance).
+- Arbitrary custom permissions beyond the role ladder.
+- Changing the grading pipeline, runner protocol, or any Core grading type —
+  this is purely an identity/organization concern.
+
+---
+
+## 6. Open questions (for the owner)
+
+1. **Does a global `instructor` survive at all?** Today instructors don't
+   create courses (admins do). If that stays true, global `instructor` may
+   collapse entirely into "instructor on some enrollment," leaving only
+   `admin` as a global role. If instructors should self-serve course
+   creation, we need a deployment-level "may create courses" capability —
+   which is itself a small scoped-admin question (Theme 2).
+2. **TA as a distinct `CourseRole` now or later?** A `ta` between `student`
+   and `instructor` (e.g. can view submissions + grade, cannot edit the
+   suite) is a natural third rung but adds policy surface.
+3. **SSO role mapping.** `SSO_INSTRUCTOR_USERS` / `SSO_ADMIN_USERS` currently
+   set the *global* role at login. Under per-course roles, does an SSO
+   "instructor" become instructor only in courses they're enrolled in, or
+   does it seed a course-creation capability? (Ties to Q1.)
+4. **Term model depth.** Is a lightweight `Term` label enough, or do we want
+   term-scoped enrollment (re-enroll each term) and cross-term analytics?


### PR DESCRIPTION
## Problem

An admin account **not enrolled in any course** was being treated as a course participant on two surfaces:

1. **Home dashboard (`/`)** — when the user had no active course, the index handler's `else` branches queried *every* assignment and test setup in the deployment (`APIAssignment.query(...).all()` / `APITestSetup.query(...).all()`), so an unenrolled admin saw all courses' content.
2. **"Instructor" nav tab** — `base.leaf` rendered it whenever `currentUser.isInstructor` was true, and that flag is **global** (`role == .instructor || role == .admin`), so it showed even with no enrollment. There was even a generic `Instructor` fallback label specifically for the no-active-course case.

This contradicts the policy already documented in `CourseAccessHelpers.swift`: *"admins see — and their agents may act on — exactly what they are enrolled in."* Enrollment is meant to govern course participation; the global admin role governs deployment administration (create courses, manage users/runners) via `/admin`.

## Fix

- **`WebRoutes.index`** now `guard`s on an active course and renders the empty *"not enrolled in any courses"* dashboard otherwise — there is no deployment-wide fallback for any role. Collapsing the two `if let … else { …all() }` blocks into a single course-filtered query also closes the same leak for an **unenrolled student in a closed-enrollment deployment**, and trims the handler's cyclomatic complexity.
- **`base.leaf`** only renders the Instructor tab when the user has an active course, labelled with that course's code. The `Admin` tab (`#if currentUser.isAdmin`) is untouched, so an unenrolled admin keeps their full admin surface.

After the fix, an unenrolled admin sees: brand · **Admin** · account · log out — and an empty home dashboard. Enrolling themselves (or being enrolled) brings the course tab and assignments back.

## Tests

- `unenrolledAdminSeesNoInstructorTabAndNoOtherCourseAssignments` — closed-enrollment course with a published assignment, unenrolled admin: no Instructor tab, no foreign assignment, empty-state message, Admin tab still present.
- `enrolledInstructorSeesCourseScopedInstructorTab` — the other side: an enrolled instructor still gets the tab, labelled with the course code.

Full `WebRoutesIndexTests` (17), `AssignmentRoutesDashboardTests` + `AuthRoutesTests` (32) green; `swift-format`, SwiftLint (`--strict`), and `check-styles`/`check-css-vars` all pass.

## Design note (no code) — `docs/multi-course-roles.md`

This PR also includes a planning doc for the larger goal this fix is a stepping stone toward: structuring Chickadee around **university-level organization** and **per-course affiliation** (a user who is an instructor in one course and a student in another).

The crux: role is currently a single **global** field on `APIUser`, so "instructor here, student there" is unrepresentable. The doc lays out moving role onto `APICourseEnrollment` (with a behavior-preserving backfill that seeds each enrollment's role from today's global role), threading it through the seams that already exist (`CourseAccessHelpers`, `resolveActiveCourse`, `CurrentUserContext`, `RoleMiddleware`), and sketches the org layer above courses (terms, departments, scoped admin) as a sequenced follow-on. It ends with open questions for the owner. **It's a design note only — no implementation in this PR.** If preferred, I can split the doc into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK