### PR TITLE
Add BrightSpace "Set credentials manually" admin form (UW harvester pattern)

### DIFF
--- a/Resources/Views/admin-brightspace.leaf
+++ b/Resources/Views/admin-brightspace.leaf
@@ -91,6 +91,29 @@ BrightSpace
         #endif
     </div>
 
+    <div class="bs-manual">
+        <h3 class="bs-manual-heading">Set credentials manually</h3>
+        <p class="bs-muted">
+            If your institution registers a central credential service as the
+            app's Trusted URL (e.g. UW's
+            <code>d2l-api-cred.fast.uwaterloo.ca</code>) instead of this server's
+            callback, the "Authorize" button above can't work. Harvest the
+            <strong>User ID</strong> and <strong>User Key</strong> for your
+            service account there, then paste them here — they're verified
+            against D2L and stored live, no env change or restart.
+        </p>
+        <form method="post" action="/admin/brightspace/set-credentials" class="bs-manual-form">
+            #csrfFormField()
+            <label class="bs-field">User ID
+                <input type="text" name="userID" autocomplete="off" spellcheck="false" required>
+            </label>
+            <label class="bs-field">User Key
+                <input type="text" name="userKey" autocomplete="off" spellcheck="false" required>
+            </label>
+            <button class="btn" type="submit">Save &amp; verify</button>
+        </form>
+    </div>
+
     <p class="bs-muted bs-footnote">
         Instructors map assignments to grade items and watch grades flow on
         their course's BrightSpace tab; this page only sets the shared connection.
@@ -126,6 +149,32 @@ BrightSpace
 .bs-footnote {
     font-size: .85rem;
     margin-bottom: 0;
+}
+.bs-manual {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+}
+.bs-manual-heading {
+    margin: 0 0 .4rem;
+    font-size: 1rem;
+}
+.bs-manual-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: .8rem;
+    margin-top: .6rem;
+}
+.bs-field {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+    font-size: .85rem;
+}
+.bs-field input {
+    width: 22rem;
+    max-width: 100%;
 }
 </style>
 #endexport

--- a/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
@@ -188,6 +188,65 @@ extension AdminRoutes {
         return req.redirect(to: "/admin/brightspace")
     }
 
+    // MARK: - POST /admin/brightspace/set-credentials
+
+    /// Stores a User ID/Key pasted in by an admin (e.g. harvested from UW's
+    /// `d2l-api-cred.fast.uwaterloo.ca` credential service, where the app's
+    /// Trusted URL is the central harvester rather than this server's callback,
+    /// so the in-browser authorize flow can't run). Verifies the pair against
+    /// D2L before persisting, then rebuilds the live client — same effect as a
+    /// successful authorize, no env change or restart.
+    @Sendable
+    func brightspaceSetCredentials(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+
+        struct CredentialForm: Content {
+            let userID: String
+            let userKey: String
+        }
+        let form = try req.content.decode(CredentialForm.self)
+        let userID = form.userID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userKey = form.userKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !userID.isEmpty, !userKey.isEmpty else {
+            req.session.data["bs_flash_error"] = "Both User ID and User Key are required."
+            return req.redirect(to: "/admin/brightspace")
+        }
+        guard let appCreds = req.application.brightSpaceAppCredentials else {
+            req.session.data["bs_flash_error"] = "BrightSpace is not configured on this server."
+            return req.redirect(to: "/admin/brightspace")
+        }
+
+        // Verify before persisting so a bad paste fails loudly rather than
+        // silently breaking grade sync.
+        let config = BrightSpaceSyncConfig(app: appCreds, userID: userID, userKey: userKey)
+        let candidate = BrightSpaceAPIClient(config: config)
+        let who: BrightSpaceWhoAmI
+        do {
+            who = try await candidate.whoami(on: req.application)
+        } catch {
+            req.logger.warning(
+                "BrightSpace set-credentials: whoami verification failed: \(error.localizedDescription)")
+            req.session.data["bs_flash_error"] =
+                "Could not verify those credentials against D2L: \(error.localizedDescription)"
+            return req.redirect(to: "/admin/brightspace")
+        }
+
+        let identity = who.uniqueName.isEmpty ? who.displayName : "\(who.displayName) (\(who.uniqueName))"
+        try await BrightSpaceCredentialStore.save(
+            valenceUserID: userID,
+            valenceUserKey: userKey,
+            identityName: identity,
+            capturedByUserID: user.id,
+            on: req.db
+        )
+        req.application.brightSpaceSyncConfig = config
+        req.application.brightSpaceClient = candidate
+        req.logger.info("BrightSpace credentials set manually by \(user.username) as \(identity)")
+
+        req.session.data["bs_flash_success"] = "BrightSpace credentials saved — connected as \(identity)."
+        return req.redirect(to: "/admin/brightspace")
+    }
+
     // MARK: - POST /admin/brightspace/test
 
     @Sendable

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -53,6 +53,7 @@ struct AdminRoutes: RouteCollection {
         admin.post("brightspace", "authorize", use: brightspaceAuthorize)
         admin.get("brightspace", "valence-callback", use: brightspaceValenceCallback)
         admin.post("brightspace", "clear", use: brightspaceClearAuthorization)
+        admin.post("brightspace", "set-credentials", use: brightspaceSetCredentials)
         admin.post("brightspace", "test", use: brightspaceTestConnection)
         admin.get("mcp", use: mcpPage)
         admin.post("mcp", "accounts", use: createMCPAccount)

--- a/changelog.d/brightspace-manual-credentials.md
+++ b/changelog.d/brightspace-manual-credentials.md
@@ -1,0 +1,10 @@
+### Added
+
+- **BrightSpace "Set credentials manually" (admin).** A new field on the Admin →
+  BrightSpace page accepts a pasted Valence **User ID + User Key** — for
+  institutions (like UW) that register a *central credential service* as the
+  app's Trusted URL (`d2l-api-cred.fast.uwaterloo.ca`) rather than this server's
+  own callback, so the in-app authorize handshake can't run. The pair is
+  `whoami`-verified against D2L, stored (same `brightspace_credentials` row,
+  taking precedence over env), and the live client is rebuilt — connecting grade
+  sync with no env edit or restart. See `docs/brightspace-setup.md` Step 1C.

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -37,9 +37,11 @@ the user handshake are two separate steps.
 
 ## Step 1 — Obtain the User ID + User Key
 
-There are two ways to capture the Valence user key. On a **deployed server**,
-prefer the in-app admin flow (1A); for **local/scripted** setup use the CLI
-helper (1B). Both perform the same D2L handshake.
+There are a few ways to capture the Valence user key. On a **deployed server**
+whose own callback is the app's Trusted URL, use the in-app authorize flow (1A);
+where a **central credential service** is the Trusted URL instead (e.g. UW),
+harvest the key there and paste it in (1C); for **local/scripted** setup use the
+CLI helper (1B).
 
 > **Auth scheme note.** This is D2L's legacy **ID-Key Auth** (the
 > `x_a`…`x_t` HMAC signing), which is what an "Application ID + Application Key"
@@ -66,6 +68,30 @@ picks it up within one sweep (≤60 s), no restart.
   key and reverts to env (or disables sync).
 - The captured key rides in D2L's redirect query string, so it lands in the
   host's access log once — treat it as rotatable.
+
+### Step 1C — Central credential service + manual entry (e.g. UW)
+
+Some institutions register a **central credential-harvesting service** as the
+app's Trusted URL rather than each app's own callback. UW's is
+`https://d2l-api-cred.fast.uwaterloo.ca` (registered with **no trailing slash**).
+In this model the in-app "Authorize" button (1A) can't work — D2L only ever
+redirects to that central service, never to this server. Instead:
+
+1. Open the harvester (UW: `https://d2l-api-cred.fast.uwaterloo.ca`) in a
+   **private/incognito** window, enter the LMS host + App ID + App Key, and
+   authenticate **as the service account** (e.g. `sphs-dev`), *not* your personal
+   login. It returns a **User ID** and **User Key**.
+2. In Chickadee, go to **Admin → BrightSpace → "Set credentials manually"**,
+   paste the User ID + User Key, and save. Chickadee `whoami`-verifies the pair,
+   stores it (same `brightspace_credentials` row, taking precedence over env),
+   and rebuilds the live client — no env change or restart.
+
+This is the supported path at UW: the env-key model with the key sourced from the
+harvester. The stored key acts as whatever account you logged into the harvester
+as, so use the **service account** for a shared, person-independent grade sync.
+(You can also drop the harvested values into `BRIGHTSPACE_USER_ID` /
+`BRIGHTSPACE_USER_KEY` in env instead — the manual-entry form just avoids the
+restart.)
 
 ### Step 1B — CLI helper (local / scripted)
 


### PR DESCRIPTION
## Why

We finally cornered the BrightSpace auth saga: at UW, the LEARN team registers the app's **Trusted URL** as a central credential-harvesting service (`https://d2l-api-cred.fast.uwaterloo.ca`), **not** each app's own callback. So Chickadee's in-app "Authorize" handshake can never complete here — D2L only ever redirects to the central harvester. The supported UW pattern is: log into the harvester as the **service account**, get back a Valence **User ID + User Key**, and configure them.

(Confirmed end-to-end: running the App ID/Key through D2L's API Test Tool reached the consent page and returned a valid User ID/Key — so the credentials and our signing were correct all along; the only blocker was that UW won't register our callback as the Trusted URL.)

## What's here

A **"Set credentials manually"** form on **Admin → BrightSpace**: paste the harvested **User ID + User Key**, and Chickadee:
- `whoami`-verifies the pair against D2L (a bad paste fails loudly instead of silently breaking sync),
- stores it in the existing single-row `brightspace_credentials` (takes precedence over env),
- rebuilds the live client — **connecting grade sync with no env edit or restart.**

It reuses the same store + client-rebuild path as the authorize callback. The in-app Authorize button stays (works at institutions whose Trusted URL *is* the app callback); this is the parallel path for the central-harvester model.

Docs: new **Step 1C** in `docs/brightspace-setup.md` covering the harvester + manual entry.

## Verification

`swift build` clean; **24 BrightSpace tests pass**; `swift-format`, SwiftLint `--strict` (0), `check-styles.sh`, `check-css-vars.sh` all clean.

## Tonight's flow once deployed

1. Open `https://d2l-api-cred.fast.uwaterloo.ca` (incognito), log in as `sphs-dev`, enter host + App ID + App Key → copy the **User ID / User Key**.
2. Admin → BrightSpace → **Set credentials manually** → paste → save → "Connected as sphs-dev".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_