### PR TITLE
Port UW D2L Valence client hardening (version negotiation, pagination, clock skew)

### DIFF
--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -27,8 +27,13 @@ struct BrightSpaceSyncConfig: Sendable {
     let userKey: String
     let debounceSecs: TimeInterval
 
-    static let leAPIVersion = "1.85"
-    static let lpAPIVersion = "1.28"
+    // Fallback API versions, used only when live version negotiation
+    // (`/d2l/api/{product}/versions/`) is unavailable. Set to UW-known-good
+    // values (the reference client pins le=1.75 / lp=1.47); the client prefers
+    // the server's advertised `LatestVersion`. Hardcoding a version the LMS
+    // doesn't support 404s every call, so these are a floor, not the target.
+    static let leAPIVersion = "1.75"
+    static let lpAPIVersion = "1.47"
 
     static func fromEnvironment() -> Self? {
         guard
@@ -125,6 +130,34 @@ struct BrightSpaceClasslistEntry: Content, Sendable {
     let username: String?
 }
 
+// MARK: - Paged list envelope
+
+/// Decodes the two interchangeable Valence list envelopes: bookmark-paged
+/// (`Items` + `PagingInfo`) and continuation-URL (`Objects` + `Next`). The
+/// reference client's `get_paged` branches on which keys are present; the
+/// pagination step itself is `valenceNextPageURL`.
+struct ValencePagedEnvelope<Element: Decodable>: Decodable {
+    let items: [Element]?
+    let objects: [Element]?
+    let pagingInfo: PagingInfo?
+    let next: String?
+    struct PagingInfo: Decodable {
+        let bookmark: String?
+        let hasMoreItems: Bool?
+        enum CodingKeys: String, CodingKey {
+            case bookmark = "Bookmark"
+            case hasMoreItems = "HasMoreItems"
+        }
+    }
+    enum CodingKeys: String, CodingKey {
+        case items = "Items"
+        case objects = "Objects"
+        case pagingInfo = "PagingInfo"
+        case next = "Next"
+    }
+    var elements: [Element] { items ?? objects ?? [] }
+}
+
 // MARK: - Grading seam
 
 /// The network-touching BrightSpace operations the grade-sync sweep depends on.
@@ -148,6 +181,14 @@ protocol BrightSpaceGrading: Sendable {
 actor BrightSpaceAPIClient: BrightSpaceGrading {
     private let config: BrightSpaceSyncConfig
 
+    /// Negotiated API version per D2L product code ("lp"/"le"), cached for the
+    /// client's lifetime (the client is rebuilt on (re)authorize / restart).
+    private var negotiatedVersions: [String: String] = [:]
+
+    /// Clock-skew correction (seconds) learned from a D2L "Timestamp out of
+    /// range" 403; added to the request timestamp on every subsequent signing.
+    private var serverSkewSeconds = 0
+
     init(config: BrightSpaceSyncConfig) {
         self.config = config
     }
@@ -158,13 +199,14 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
     //
     // Signing base string: "<METHOD>&<lowercase_path>&<unix_timestamp>" where
     // path is the URL path only (no query string, no host) and the timestamp is
-    // seconds. Verified against Brightspace's official valence-sdk-python
+    // seconds (plus any learned clock skew). Verified against Brightspace's
+    // official valence-sdk-python
     // (`'{0}&{1}&{2}'.format(method.upper(), path.lower(), time)`).
     // x_c = HMAC-SHA256(appKey, baseString) as base64url (no padding)
     // x_d = HMAC-SHA256(userKey, baseString) as base64url (no padding)
     private func signed(url urlString: String, method: String) -> String {
-        let timestamp = Int(Date().timeIntervalSince1970)
-        guard let path = URL(string: urlString)?.path else { return urlString }
+        let timestamp = Int(Date().timeIntervalSince1970) + serverSkewSeconds
+        let path = valencePath(of: urlString)
         let baseString = valenceRequestBaseString(method: method, path: path, timestamp: timestamp)
         let appSig = hmacSHA256Base64URL(key: config.appKey, message: baseString)
         let userSig = hmacSHA256Base64URL(key: config.userKey, message: baseString)
@@ -179,6 +221,99 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         return Data(mac).base64URLEncodedString()
     }
 
+    // MARK: - Request transport (signing + clock-skew retry)
+
+    /// Signs `rawURL` for `method` ("GET"/"PUT") and sends it. If D2L rejects the
+    /// request with a "Timestamp out of range" 403, learns the clock skew from
+    /// the response body and retries exactly once with a corrected timestamp.
+    private func sendSigned(
+        method: String,
+        rawURL: String,
+        on app: Application,
+        beforeSend: (@Sendable (inout ClientRequest) throws -> Void)? = nil
+    ) async throws -> ClientResponse {
+        func attempt() async throws -> ClientResponse {
+            let uri = URI(string: signed(url: rawURL, method: method))
+            if method.uppercased() == "PUT" {
+                return try await app.client.put(uri) { req in try beforeSend?(&req) }
+            }
+            return try await app.client.get(uri) { req in try beforeSend?(&req) }
+        }
+        let response = try await attempt()
+        guard response.status == .forbidden else { return response }
+        // Peek the body non-destructively (a copied ByteBuffer has its own reader
+        // index) so a genuine permission 403 is still returned intact to the caller.
+        var bodyBuf = response.body
+        let len = bodyBuf?.readableBytes ?? 0
+        let bodyText = (len > 0 ? bodyBuf?.readString(length: len) : nil) ?? ""
+        guard let serverTime = valenceServerTimeFromTimestampError(body: bodyText) else {
+            return response
+        }
+        serverSkewSeconds = serverTime - Int(Date().timeIntervalSince1970)
+        return try await attempt()
+    }
+
+    // MARK: - API version negotiation
+
+    /// Resolves the API version for a D2L product code ("lp"/"le"): an ops env
+    /// pin wins (`BRIGHTSPACE_LE_API_VERSION` / `BRIGHTSPACE_LP_API_VERSION`),
+    /// otherwise the server's advertised `LatestVersion` from
+    /// `/d2l/api/{product}/versions/` (cached), falling back to `fallback` when
+    /// discovery is unavailable. Avoids 404s from requesting an unsupported
+    /// version (the reference client pins these by hand).
+    private func apiVersion(_ product: String, fallback: String, on app: Application) async -> String {
+        if let pinned = trimmedEnv("BRIGHTSPACE_\(product.uppercased())_API_VERSION") {
+            return pinned
+        }
+        if let cached = negotiatedVersions[product] { return cached }
+        let rawURL = "\(config.baseURL)/d2l/api/\(product)/versions/"
+        do {
+            let response = try await sendSigned(method: "GET", rawURL: rawURL, on: app)
+            guard response.status == .ok else { return fallback }
+            struct ProductVersions: Decodable {
+                let latestVersion: String
+                enum CodingKeys: String, CodingKey { case latestVersion = "LatestVersion" }
+            }
+            let latest = try response.content.decode(ProductVersions.self)
+                .latestVersion.trimmingCharacters(in: .whitespaces)
+            let resolved = latest.isEmpty ? fallback : latest
+            negotiatedVersions[product] = resolved
+            return resolved
+        } catch {
+            return fallback
+        }
+    }
+
+    // MARK: - Paged list reads
+
+    /// Follows a Valence list endpoint across every page (either paging
+    /// convention) and returns the concatenated elements. The 10_000-page guard
+    /// is a safety stop against a server that never clears its "more" flag.
+    private func fetchAllPages<Element: Decodable>(
+        firstRawURL: String,
+        on app: Application,
+        failure: (Int) -> BrightSpaceSyncError
+    ) async throws -> [Element] {
+        var url = firstRawURL
+        var collected: [Element] = []
+        for _ in 0..<10_000 {
+            let response = try await sendSigned(method: "GET", rawURL: url, on: app)
+            guard response.status == .ok else { throw failure(Int(response.status.code)) }
+            let page = try response.content.decode(ValencePagedEnvelope<Element>.self)
+            collected.append(contentsOf: page.elements)
+            guard
+                let next = valenceNextPageURL(
+                    firstPageURL: firstRawURL,
+                    baseURL: config.baseURL,
+                    pagingBookmark: page.pagingInfo?.bookmark,
+                    pagingHasMore: page.pagingInfo?.hasMoreItems,
+                    next: page.next)
+            else { break }
+            url = next
+        }
+        return collected
+    }
+
     // MARK: - Push grade
 
     /// Push `earnedPoints` for `bsUserID` to the BrightSpace grade item.
@@ -190,9 +325,10 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         earnedPoints: Double,
         on application: Application
     ) async throws {
+        let leVersion = await apiVersion(
+            "le", fallback: BrightSpaceSyncConfig.leAPIVersion, on: application)
         let rawURL =
-            "\(config.baseURL)/d2l/api/le/\(BrightSpaceSyncConfig.leAPIVersion)/\(orgUnitID)/grades/\(gradeObjectID)/values/\(bsUserID)"
-        let url = signed(url: rawURL, method: "PUT")
+            "\(config.baseURL)/d2l/api/le/\(leVersion)/\(orgUnitID)/grades/\(gradeObjectID)/values/\(bsUserID)"
 
         struct NumericGradeValue: Content {
             let gradeObjectType: Int
@@ -204,7 +340,7 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         }
         let body = NumericGradeValue(gradeObjectType: 1, pointsNumerator: earnedPoints)
 
-        let response = try await application.client.put(URI(string: url)) { req in
+        let response = try await sendSigned(method: "PUT", rawURL: rawURL, on: application) { req in
             req.headers.contentType = .json
             try req.content.encode(body, as: .json)
         }
@@ -224,11 +360,12 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
     func lookupUserID(orgDefinedId: String, on application: Application) async throws -> String? {
         guard !orgDefinedId.isEmpty else { return nil }
 
+        let lpVersion = await apiVersion(
+            "lp", fallback: BrightSpaceSyncConfig.lpAPIVersion, on: application)
         let encoded = orgDefinedId.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? orgDefinedId
-        let rawURL = "\(config.baseURL)/d2l/api/lp/\(BrightSpaceSyncConfig.lpAPIVersion)/users/?orgDefinedId=\(encoded)"
-        let url = signed(url: rawURL, method: "GET")
+        let rawURL = "\(config.baseURL)/d2l/api/lp/\(lpVersion)/users/?orgDefinedId=\(encoded)"
 
-        let response = try await application.client.get(URI(string: url))
+        let response = try await sendSigned(method: "GET", rawURL: rawURL, on: application)
 
         guard response.status == .ok else {
             throw BrightSpaceSyncError.userLookupFailed(
@@ -257,9 +394,10 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
     /// endpoint, returning the identity the keys act as.  Used by the
     /// "Test connection" button — surfaces auth problems before grades fail.
     func whoami(on application: Application) async throws -> BrightSpaceWhoAmI {
-        let rawURL = "\(config.baseURL)/d2l/api/lp/\(BrightSpaceSyncConfig.lpAPIVersion)/users/whoami"
-        let url = signed(url: rawURL, method: "GET")
-        let response = try await application.client.get(URI(string: url))
+        let lpVersion = await apiVersion(
+            "lp", fallback: BrightSpaceSyncConfig.lpAPIVersion, on: application)
+        let rawURL = "\(config.baseURL)/d2l/api/lp/\(lpVersion)/users/whoami"
+        let response = try await sendSigned(method: "GET", rawURL: rawURL, on: application)
         guard response.status == .ok else {
             var bodyBuf = response.body
             let bodyLen = bodyBuf?.readableBytes ?? 0
@@ -298,10 +436,11 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
     /// so the caller can flag an unverified binding without throwing.
     func getOrgUnit(orgUnitID: String, on application: Application) async throws -> BrightSpaceOrgUnitInfo? {
         guard !orgUnitID.isEmpty else { return nil }
+        let lpVersion = await apiVersion(
+            "lp", fallback: BrightSpaceSyncConfig.lpAPIVersion, on: application)
         let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
-        let rawURL = "\(config.baseURL)/d2l/api/lp/\(BrightSpaceSyncConfig.lpAPIVersion)/orgstructure/\(encoded)"
-        let url = signed(url: rawURL, method: "GET")
-        let response = try await application.client.get(URI(string: url))
+        let rawURL = "\(config.baseURL)/d2l/api/lp/\(lpVersion)/orgstructure/\(encoded)"
+        let response = try await sendSigned(method: "GET", rawURL: rawURL, on: application)
         if response.status == .notFound { return nil }
         guard response.status == .ok else {
             throw BrightSpaceSyncError.orgUnitLookupFailed(
@@ -328,10 +467,11 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
     /// instructor can pick one instead of hand-typing the numeric ID.
     func listGradeObjects(orgUnitID: String, on application: Application) async throws -> [BrightSpaceGradeObject] {
         guard !orgUnitID.isEmpty else { return [] }
+        let leVersion = await apiVersion(
+            "le", fallback: BrightSpaceSyncConfig.leAPIVersion, on: application)
         let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
-        let rawURL = "\(config.baseURL)/d2l/api/le/\(BrightSpaceSyncConfig.leAPIVersion)/\(encoded)/grades/"
-        let url = signed(url: rawURL, method: "GET")
-        let response = try await application.client.get(URI(string: url))
+        let rawURL = "\(config.baseURL)/d2l/api/le/\(leVersion)/\(encoded)/grades/"
+        let response = try await sendSigned(method: "GET", rawURL: rawURL, on: application)
         guard response.status == .ok else {
             throw BrightSpaceSyncError.gradeObjectsFetchFailed(
                 orgUnitID: orgUnitID, status: Int(response.status.code))
@@ -364,16 +504,14 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         -> [BrightSpaceClasslistEntry]
     {
         guard !orgUnitID.isEmpty else { return [] }
+        let leVersion = await apiVersion(
+            "le", fallback: BrightSpaceSyncConfig.leAPIVersion, on: application)
         let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
-        let rawURL = "\(config.baseURL)/d2l/api/le/\(BrightSpaceSyncConfig.leAPIVersion)/\(encoded)/classlist/"
-        let url = signed(url: rawURL, method: "GET")
-        let response = try await application.client.get(URI(string: url))
-        guard response.status == .ok else {
-            throw BrightSpaceSyncError.classlistFetchFailed(
-                orgUnitID: orgUnitID, status: Int(response.status.code))
-        }
-        // D2L returns a JSON array of ClasslistUser objects; we keep only the
-        // two identity fields we match on.
+        // The non-paged /classlist/ can truncate on large courses; /classlist/paged/
+        // returns a bookmark-paged envelope we walk to completion (see fetchAllPages).
+        let rawURL = "\(config.baseURL)/d2l/api/le/\(leVersion)/\(encoded)/classlist/paged/"
+        // D2L returns ClasslistUser objects; we keep only the two identity fields
+        // we match on.
         struct ClasslistUserResponse: Decodable {
             let orgDefinedId: String?
             let username: String?
@@ -382,8 +520,12 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
                 case username = "Username"
             }
         }
-        let decoded = try response.content.decode([ClasslistUserResponse].self)
-        return decoded.map {
+        let rows: [ClasslistUserResponse] = try await fetchAllPages(
+            firstRawURL: rawURL, on: application
+        ) { status in
+            .classlistFetchFailed(orgUnitID: orgUnitID, status: status)
+        }
+        return rows.map {
             BrightSpaceClasslistEntry(orgDefinedID: $0.orgDefinedId, username: $0.username)
         }
     }

--- a/Sources/APIServer/Services/BrightSpaceAppCredentials.swift
+++ b/Sources/APIServer/Services/BrightSpaceAppCredentials.swift
@@ -90,6 +90,76 @@ func brightSpaceHMACSHA256Base64URL(key: String, message: String) -> String {
     return Data(mac).base64URLEncodedString()
 }
 
+/// The path component fed to `valenceRequestBaseString`: the portion of
+/// `urlString` between the host and the query (`?`) / fragment (`#`),
+/// percent-decoded. Mirrors the reference client's `unquote_plus(path.lower())`
+/// (`valenceRequestBaseString` applies the lowercasing). Unlike
+/// `URL(string:)?.path` this never returns nil, so a URL Foundation declines to
+/// parse is still signed rather than silently sent unauthenticated. Our request
+/// URLs only ever carry numeric IDs and lowercase route names in the path — the
+/// one caller-supplied value, `orgDefinedId`, rides in the query — so no
+/// percent-encoded alphabetic character can reach the path, making this
+/// decode-then-lowercase order equivalent to the reference's lowercase-then-decode.
+func valencePath(of urlString: String) -> String {
+    var path = Substring(urlString)
+    if let cut = path.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+        path = path[..<cut]
+    }
+    if let scheme = path.range(of: "://") {
+        let afterHost = path[scheme.upperBound...]
+        if let slash = afterHost.firstIndex(of: "/") {
+            path = afterHost[slash...]
+        } else {
+            return "/"
+        }
+    }
+    let raw = String(path)
+    return raw.removingPercentEncoding ?? raw
+}
+
+/// The URL of the next page in a Valence list response, or nil when pagination
+/// is complete. Mirrors the reference client's `get_paged`, which follows either
+/// D2L paging convention:
+///   • `PagingInfo` / `Bookmark` — re-issue the first-page URL with
+///     `?bookmark=<bm>` while `HasMoreItems` is true;
+///   • `Next` — a continuation URL (absolute, or a path relative to the host).
+func valenceNextPageURL(
+    firstPageURL: String,
+    baseURL: String,
+    pagingBookmark: String?,
+    pagingHasMore: Bool?,
+    next: String?
+) -> String? {
+    // Bookmark convention: a `PagingInfo` block was present.
+    if pagingHasMore != nil || pagingBookmark != nil {
+        guard pagingHasMore == true, let bookmark = pagingBookmark, !bookmark.isEmpty else {
+            return nil
+        }
+        let encoded = bookmark.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? bookmark
+        let basePath = firstPageURL.split(separator: "?", maxSplits: 1).first.map(String.init) ?? firstPageURL
+        return "\(basePath)?bookmark=\(encoded)"
+    }
+    // Continuation-URL convention.
+    if let next, !next.isEmpty {
+        if next.hasPrefix("http://") || next.hasPrefix("https://") { return next }
+        return baseURL + (next.hasPrefix("/") ? next : "/" + next)
+    }
+    return nil
+}
+
+/// Parses D2L's clock-skew error body. A request whose `x_t` timestamp is
+/// outside the server's tolerance gets HTTP 403 with the body
+/// `"Timestamp out of range, <serverUnixTimeSeconds>"`. Returns the server's
+/// Unix time (seconds) so the client can set its skew and retry, or nil when the
+/// body isn't a timestamp error (e.g. a genuine permission 403).
+func valenceServerTimeFromTimestampError(body: String) -> Int? {
+    guard body.range(of: "Timestamp out of range", options: .caseInsensitive) != nil else {
+        return nil
+    }
+    let digits = body.drop(while: { !$0.isNumber }).prefix(while: { $0.isNumber })
+    return Int(digits)
+}
+
 /// Percent-encodes a query-parameter value so reserved characters (`:` `/` `?`
 /// `=` `&`) in the callback don't leak into the surrounding query. Equivalent
 /// to Python's `urllib.parse.quote(value, safe='')`.

--- a/Tests/APITests/BrightSpaceTransportTests.swift
+++ b/Tests/APITests/BrightSpaceTransportTests.swift
@@ -1,0 +1,186 @@
+// Tests/APITests/BrightSpaceTransportTests.swift
+//
+// Pins the D2L Valence request-transport layer ported from UW's reference
+// client (learn_api / d2lvalence): signing-path extraction, list pagination
+// (both Valence conventions), and the clock-skew error parse. None of these
+// hit a live D2L — they exercise the pure helpers the actor composes, so a
+// regression in the URL/JSON contract fails here instead of only in prod.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct BrightSpaceTransportTests {
+
+    // MARK: - Signing path extraction
+
+    @Test func valencePath_stripsQueryHostAndDecodes() {
+        // Full URL with a query → path only, query dropped.
+        #expect(
+            valencePath(of: "https://learntest.uwaterloo.ca/d2l/api/lp/1.47/users/?orgDefinedId=12345")
+                == "/d2l/api/lp/1.47/users/")
+        // Host with an explicit port.
+        #expect(
+            valencePath(of: "https://host:443/d2l/api/le/1.75/grades/") == "/d2l/api/le/1.75/grades/")
+        // Fragment dropped.
+        #expect(valencePath(of: "https://h/a/b#frag") == "/a/b")
+        // Already a bare path (no scheme) — returned unchanged.
+        #expect(
+            valencePath(of: "/d2l/api/lp/1.47/users/whoami") == "/d2l/api/lp/1.47/users/whoami")
+        // Host with no path component.
+        #expect(valencePath(of: "https://host") == "/")
+        // Percent-encoded path is decoded (mirrors unquote_plus on the server).
+        #expect(
+            valencePath(of: "https://h/d2l/api/le/1.75/o%20u/classlist/paged/")
+                == "/d2l/api/le/1.75/o u/classlist/paged/")
+    }
+
+    @Test func valencePath_feedsBaseStringIdenticallyToReference() {
+        // The whole point of the extractor: signing a full URL yields the same
+        // base string the reference client computes from the path alone.
+        let full = "https://learntest.uwaterloo.ca/d2l/api/lp/1.47/users/whoami"
+        let base = valenceRequestBaseString(
+            method: "GET", path: valencePath(of: full), timestamp: 1_700_000_000)
+        #expect(base == "GET&/d2l/api/lp/1.47/users/whoami&1700000000")
+    }
+
+    // MARK: - Pagination (bookmark convention)
+
+    @Test func nextPageURL_bookmarkConvention_followsWhileMoreItems() {
+        let first = "https://h/d2l/api/le/1.75/1106038/classlist/paged/"
+        // HasMoreItems → re-issue the base URL with the bookmark.
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: first, baseURL: "https://h",
+                pagingBookmark: "abc", pagingHasMore: true, next: nil)
+                == "\(first)?bookmark=abc")
+        // No more items → done.
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: first, baseURL: "https://h",
+                pagingBookmark: "abc", pagingHasMore: false, next: nil) == nil)
+        // PagingInfo present but empty bookmark → done (don't loop forever).
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: first, baseURL: "https://h",
+                pagingBookmark: "", pagingHasMore: true, next: nil) == nil)
+    }
+
+    @Test func nextPageURL_bookmark_isPercentEncodedAndReplacesPriorQuery() {
+        // A bookmark with reserved characters is encoded; any existing query on
+        // the first-page URL is replaced (not appended) so bookmarks don't stack.
+        let url = valenceNextPageURL(
+            firstPageURL: "https://h/d2l/api/le/1.75/1/classlist/paged/?bookmark=old",
+            baseURL: "https://h",
+            pagingBookmark: "a b/c", pagingHasMore: true, next: nil)
+        #expect(url == "https://h/d2l/api/le/1.75/1/classlist/paged/?bookmark=a%20b/c")
+    }
+
+    // MARK: - Pagination (continuation-URL convention)
+
+    @Test func nextPageURL_nextConvention_absoluteAndRelative() {
+        // Absolute Next URL is used verbatim.
+        let absolute = "https://h/d2l/api/le/1.75/1/classlist/paged/?bookmark=z"
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: "ignored", baseURL: "https://h",
+                pagingBookmark: nil, pagingHasMore: nil, next: absolute) == absolute)
+        // Relative Next (leading slash) is resolved against the host.
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: "ignored", baseURL: "https://h",
+                pagingBookmark: nil, pagingHasMore: nil, next: "/d2l/api/x?bookmark=z")
+                == "https://h/d2l/api/x?bookmark=z")
+        // Relative Next without a leading slash still resolves.
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: "ignored", baseURL: "https://h",
+                pagingBookmark: nil, pagingHasMore: nil, next: "d2l/api/x")
+                == "https://h/d2l/api/x")
+    }
+
+    @Test func nextPageURL_singlePage_isNil() {
+        // No PagingInfo and no Next (e.g. a plain object) → no further pages.
+        #expect(
+            valenceNextPageURL(
+                firstPageURL: "https://h/x", baseURL: "https://h",
+                pagingBookmark: nil, pagingHasMore: nil, next: nil) == nil)
+    }
+
+    // MARK: - Paged envelope decoding (D2L key contract)
+
+    @Test func pagedEnvelope_decodesBookmarkStyle() throws {
+        let json = """
+            {
+              "Items": [
+                { "OrgDefinedId": "20771234", "Username": "jdoe" },
+                { "OrgDefinedId": "20775678", "Username": "asmith" }
+              ],
+              "PagingInfo": { "Bookmark": "bm-2", "HasMoreItems": true }
+            }
+            """
+        struct Row: Decodable {
+            let orgDefinedId: String?
+            let username: String?
+            enum CodingKeys: String, CodingKey {
+                case orgDefinedId = "OrgDefinedId"
+                case username = "Username"
+            }
+        }
+        let env = try JSONDecoder().decode(
+            ValencePagedEnvelope<Row>.self, from: Data(json.utf8))
+        #expect(env.elements.count == 2)
+        #expect(env.elements.first?.username == "jdoe")
+        #expect(env.pagingInfo?.bookmark == "bm-2")
+        #expect(env.pagingInfo?.hasMoreItems == true)
+    }
+
+    @Test func pagedEnvelope_decodesObjectsNextStyle() throws {
+        let json = """
+            { "Objects": [ { "Id": 7 } ], "Next": "/d2l/api/x?bookmark=z" }
+            """
+        struct Row: Decodable {
+            let id: Int
+            enum CodingKeys: String, CodingKey { case id = "Id" }
+        }
+        let env = try JSONDecoder().decode(
+            ValencePagedEnvelope<Row>.self, from: Data(json.utf8))
+        #expect(env.elements.map(\.id) == [7])
+        #expect(env.pagingInfo == nil)
+        #expect(env.next == "/d2l/api/x?bookmark=z")
+    }
+
+    // MARK: - Clock-skew error parse
+
+    @Test func serverTimeFromTimestampError_extractsServerTime() {
+        #expect(
+            valenceServerTimeFromTimestampError(body: "Timestamp out of range, 1700000000")
+                == 1_700_000_000)
+        // Tolerant of missing space and of case.
+        #expect(
+            valenceServerTimeFromTimestampError(body: "Timestamp out of range,1700000000")
+                == 1_700_000_000)
+        #expect(
+            valenceServerTimeFromTimestampError(body: "timestamp out of range 1700000000")
+                == 1_700_000_000)
+    }
+
+    @Test func serverTimeFromTimestampError_nilOnNonTimestamp403() {
+        // A genuine permission/auth 403 must NOT be mistaken for a skew error
+        // (otherwise we'd silently retry instead of surfacing it).
+        #expect(valenceServerTimeFromTimestampError(body: "Invalid token") == nil)
+        #expect(valenceServerTimeFromTimestampError(body: "") == nil)
+        // The phrase without a trailing number yields no usable server time.
+        #expect(valenceServerTimeFromTimestampError(body: "Timestamp out of range") == nil)
+    }
+
+    // MARK: - Version fallback floor
+
+    @Test func fallbackAPIVersions_matchReferenceKnownGood() {
+        // Negotiation prefers the server's LatestVersion; when discovery is
+        // unavailable these UW-known-good floors are used (reference client pins).
+        #expect(BrightSpaceSyncConfig.leAPIVersion == "1.75")
+        #expect(BrightSpaceSyncConfig.lpAPIVersion == "1.47")
+    }
+}

--- a/changelog.d/brightspace-valence-versioning.md
+++ b/changelog.d/brightspace-valence-versioning.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **BrightSpace/Valence client hardened against UW's reference library.** The
+  D2L request layer in `BrightSpaceAPIClient` now negotiates the API version per
+  product (`GET /d2l/api/{lp,le}/versions/` → `LatestVersion`, cached; env pins
+  `BRIGHTSPACE_LP_API_VERSION` / `BRIGHTSPACE_LE_API_VERSION` override) instead
+  of hardcoding a version the LMS may not support — a too-high version 404s every
+  call and masks the real cause. Fallback floors moved to UW-known-good values
+  (`lp 1.47`, `le 1.75`). The classlist read now follows `/classlist/paged/`
+  across all pages (both Valence paging conventions) so large courses aren't
+  silently truncated. A `403 "Timestamp out of range"` now teaches the client its
+  clock skew and retries once. Signing-path extraction no longer silently sends
+  an unsigned request when `URL(string:)` declines to parse. Ported from UW IST's
+  `learn_api` / `d2lvalence` reference client; pinned by `BrightSpaceTransportTests`.


### PR DESCRIPTION
## Why

Comparing UW IST's reference D2L client (`learn_api` / the bundled `d2lvalence.auth`) against `BrightSpaceAPIClient` surfaced four request-layer gaps that don't show up until a live grade-sync deployment. The core crypto (per-request signing, the auth-URL handshake) already matched the reference byte-for-byte; the gaps were all in the HTTP layer. This lands them ahead of the first production push.

## What changed

- **API version negotiation.** We were hardcoding `le = 1.85` / `lp = 1.28`. D2L does **not** gracefully down-resolve a too-high version — it 404s, which looks exactly like the "course not found" symptom and masks the real cause. The client now resolves the version per product from `GET /d2l/api/{lp,le}/versions/` (`LatestVersion`, cached for the client's lifetime), with ops env pins (`BRIGHTSPACE_LP_API_VERSION` / `BRIGHTSPACE_LE_API_VERSION`) and UW-known-good fallback floors (`lp 1.47`, `le 1.75`, matching the reference client's pins).
- **Classlist pagination.** The unbounded `/classlist/` truncates on large courses. Reads now follow `/classlist/paged/` to completion via a bookmark follower that handles **both** Valence paging conventions (`Items`+`PagingInfo`/`Bookmark` and `Objects`+`Next`), mirroring the reference `get_paged`.
- **Clock-skew retry.** A `403 "Timestamp out of range, <serverTime>"` now teaches the client its skew (`serverTime − localTime`) and retries once, instead of surfacing like a permission error.
- **Signing-path hardening.** `valencePath(of:)` replaces `URL(string:)?.path`, so a URL Foundation declines to parse is still signed rather than **silently sent unauthenticated** (the old fallback returned the URL unsigned).

## Tests

New `BrightSpaceTransportTests` pins the pure helpers — path extraction, both pagination conventions, the paged-envelope D2L key contract, the skew-error parse, and the version floors — without a live D2L. `swift test --filter BrightSpace` → 35 tests / 6 suites green; `swift-format` + SwiftLint `--strict` clean.

## Not in scope

Identity model is unchanged here — this is purely the transport layer and is identity-agnostic (works the same whether the user key comes from a shared service account or a per-instructor key). The per-instructor architecture is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_