### PR TITLE
Per-instructor BrightSpace grade-sync identity (Phase 1 + pilot)

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -18,9 +18,70 @@ LEARN
 </section>
 #else:
 
+#if(flashSuccess):
+<div class="notice-banner"><p>#(flashSuccess)</p></div>
+#endif
+#if(flashError):
+<div class="form-error">#(flashError)</div>
+#endif
+
+<!-- ── Your LEARN account (per-instructor identity) ──────── -->
+<section class="bs-section">
+    <h2 class="bs-h2">Your LEARN account</h2>
+    #if(accountConnected):
+    <p class="card-meta bs-section-note">
+        <span class="tier tier-open">connected</span>
+        Connected as <strong>#(accountIdentity)</strong>. Courses that sync as you push
+        grades under this LEARN identity.
+    </p>
+    <div class="bs-connection-row">
+        #if(syncIdentityIsMe):
+        <span class="card-meta">This course syncs grades as you.</span>
+        #else:
+        <form method="post" action="/instructor/brightspace/use-my-identity" class="inline-form">
+            #csrfFormField()
+            <button class="btn action-btn" type="submit">Use my account for this course</button>
+        </form>
+        #endif
+        <form method="post" action="/instructor/brightspace/disconnect" class="inline-form">
+            #csrfFormField()
+            <button class="btn action-btn" type="submit">Disconnect</button>
+        </form>
+    </div>
+    #else:
+    <p class="card-meta bs-section-note">
+        Connect your own LEARN account so Chickadee can push grades as you. Mint a Valence
+        <strong>User ID</strong> + <strong>User Key</strong> from UW's credential service
+        (<code>d2l-api-cred.fast.uwaterloo.ca</code>), then paste them here.
+    </p>
+    <form method="post" action="/instructor/brightspace/connect" class="bs-connect-form">
+        #csrfFormField()
+        <label class="bs-connect-field">
+            <span class="bs-connect-label">User ID</span>
+            <input class="bs-connect-input" type="text" name="userID" autocomplete="off" required>
+        </label>
+        <label class="bs-connect-field">
+            <span class="bs-connect-label">User Key</span>
+            <input class="bs-connect-input" type="password" name="userKey" autocomplete="off" required>
+        </label>
+        <button class="btn btn-primary" type="submit">Connect</button>
+    </form>
+    #endif
+    #if(syncIdentityName):
+    <p class="card-meta bs-connection-note">
+        This course pushes grades as: <strong>#(syncIdentityName)</strong>.
+    </p>
+    #else:
+    <p class="card-meta bs-connection-note">
+        <span class="tier tier-closed">no identity</span>
+        No LEARN identity is connected for this course yet, so grades won't sync.
+    </p>
+    #endif
+</section>
+
 <!-- ── Connection & course link ──────────────────────────── -->
 <section class="bs-section">
-    <h2 class="bs-h2">Connection</h2>
+    <h2 class="bs-h2">Org-unit link</h2>
     <div class="bs-connection-row">
         <button class="btn action-btn" type="button" id="bs-test-btn">Test connection</button>
         <span id="bs-test-result" class="card-meta"></span>
@@ -222,6 +283,10 @@ LEARN
 .bs-card-value { margin-top: .2rem; font-size: 1.4rem; font-weight: 600; color: var(--gray-900); }
 .bs-connection-row { display: flex; align-items: center; gap: .75rem; flex-wrap: wrap; }
 .bs-connection-note { margin-top: .6rem; max-width: 60ch; }
+.bs-connect-form { display: flex; gap: .6rem; align-items: flex-end; flex-wrap: wrap; margin: .4rem 0 0; }
+.bs-connect-field { display: flex; flex-direction: column; gap: .2rem; }
+.bs-connect-label { font-size: .78rem; color: var(--gray-600); }
+.bs-connect-input { width: 16rem; max-width: 100%; font-size: .85rem; padding: .3rem .45rem; }
 .bs-summary-actions { display: flex; gap: .5rem; flex-wrap: wrap; margin-top: .9rem; }
 .bs-section-note { margin: 0 0 .6rem; max-width: 62ch; }
 .bs-grade-form { display: flex; gap: .4rem; align-items: center; margin: 0; }

--- a/Sources/APIServer/Migrations/AddBrightSpaceCredentialUserID.swift
+++ b/Sources/APIServer/Migrations/AddBrightSpaceCredentialUserID.swift
@@ -1,0 +1,25 @@
+// APIServer/Migrations/AddBrightSpaceCredentialUserID.swift
+//
+// Adds `brightspace_credentials.user_id`: the instructor a stored Valence user
+// key belongs to. NULL = the deployment-wide (admin/env) service identity — the
+// original single-row behaviour, kept as a fallback. Captured per-instructor via
+// the "Connect my LEARN account" flow.
+//
+// Registered after CreateBrightSpaceCredentials (the table must exist first).
+// Bare uuid (no FK), matching the existing captured_by_user_id column.
+
+import Fluent
+
+struct AddBrightSpaceCredentialUserID: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("brightspace_credentials")
+            .field("user_id", .uuid)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("brightspace_credentials")
+            .deleteField("user_id")
+            .update()
+    }
+}

--- a/Sources/APIServer/Migrations/AddCourseBrightSpaceSyncUserID.swift
+++ b/Sources/APIServer/Migrations/AddCourseBrightSpaceSyncUserID.swift
@@ -1,0 +1,26 @@
+// APIServer/Migrations/AddCourseBrightSpaceSyncUserID.swift
+//
+// Adds `courses.brightspace_sync_user_id`: the instructor whose connected LEARN
+// identity drives grade sync for that course (the "designated" identity).
+// NULL = fall back to the deployment-wide (admin/env) identity.
+//
+// Like AddBrightSpaceOrgUnitName, this must be registered *before* any migration
+// that queries the APICourse model (Fluent SELECTs every declared column, so the
+// column has to exist on a fresh DB before e.g. AddCourseArchivedAt's backfill
+// runs). Bare uuid (no FK), matching the existing brightspace_org_unit columns.
+
+import Fluent
+
+struct AddCourseBrightSpaceSyncUserID: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("courses")
+            .field("brightspace_sync_user_id", .uuid)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("courses")
+            .deleteField("brightspace_sync_user_id")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIBrightSpaceCredential.swift
+++ b/Sources/APIServer/Models/APIBrightSpaceCredential.swift
@@ -34,12 +34,18 @@ final class APIBrightSpaceCredential: Model, @unchecked Sendable {
     @Field(key: "valence_user_key")
     var valenceUserKey: String
 
-    /// `whoami` display name captured at authorize time, shown in the admin UI
-    /// so the admin can confirm which account they authorized.
+    /// The instructor this credential belongs to. nil = the deployment-wide
+    /// (admin/env) service identity — the original single-row behaviour, kept
+    /// as a fallback when a course has no designated per-instructor identity.
+    @OptionalField(key: "user_id")
+    var userID: UUID?
+
+    /// `whoami` display name captured at authorize time, shown in the UI so the
+    /// instructor/admin can confirm which account they connected.
     @OptionalField(key: "identity_name")
     var identityName: String?
 
-    /// The admin who performed the authorization (audit).
+    /// The admin/instructor who performed the authorization (audit).
     @OptionalField(key: "captured_by_user_id")
     var capturedByUserID: UUID?
 
@@ -52,11 +58,13 @@ final class APIBrightSpaceCredential: Model, @unchecked Sendable {
         valenceUserID: String,
         valenceUserKey: String,
         identityName: String?,
-        capturedByUserID: UUID?
+        capturedByUserID: UUID?,
+        userID: UUID? = nil
     ) {
         self.valenceUserID = valenceUserID
         self.valenceUserKey = valenceUserKey
         self.identityName = identityName
         self.capturedByUserID = capturedByUserID
+        self.userID = userID
     }
 }

--- a/Sources/APIServer/Models/APICourse.swift
+++ b/Sources/APIServer/Models/APICourse.swift
@@ -49,6 +49,13 @@ final class APICourse: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_org_unit_name")
     var brightspaceOrgUnitName: String?
 
+    /// The instructor whose connected LEARN identity drives grade sync for this
+    /// course (the "designated" identity; grades push as that account). Defaults
+    /// to whoever first connects + claims the course; reassignable. Nil = fall
+    /// back to the deployment-wide (admin/env) identity.
+    @OptionalField(key: "brightspace_sync_user_id")
+    var brightspaceSyncUserID: UUID?
+
     /// When this course was archived. Set by `toggleCourseArchive` when a
     /// course is archived (and cleared when un-archived). Archiving is
     /// Chickadee's "end of term" signal, so this is the anchor for the

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -122,8 +122,10 @@ struct ResultRoutes: RouteCollection {
             collectionJSON: json
         )
 
-        // Mark for BrightSpace sync if the assignment is configured for it.
-        if req.application.brightSpaceClient != nil {
+        // Mark for BrightSpace sync if the assignment is configured for it. Gate
+        // on app-level config (not a live global client) so per-instructor-only
+        // deployments still flag results for the per-course sync to pick up.
+        if req.application.brightSpaceAppCredentials != nil {
             if let assignment = try await APIAssignment.query(on: db)
                 .filter(\.$testSetupID == collection.testSetupID)
                 .first(),

--- a/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
@@ -33,7 +33,7 @@ extension AdminRoutes {
     func brightspacePage(req: Request) async throws -> View {
         let appCreds = req.application.brightSpaceAppCredentials
         let authorized = req.application.brightSpaceClient != nil
-        let stored = try await BrightSpaceCredentialStore.load(on: req.db)
+        let stored = try await BrightSpaceCredentialStore.loadGlobal(on: req.db)
 
         let keySource: String
         if stored != nil {
@@ -173,7 +173,7 @@ extension AdminRoutes {
 
     @Sendable
     func brightspaceClearAuthorization(req: Request) async throws -> Response {
-        try await BrightSpaceCredentialStore.clear(on: req.db)
+        try await BrightSpaceCredentialStore.clearGlobal(on: req.db)
         // Fall back to an env-provided user key if one exists; otherwise disable.
         if let envConfig = req.application.appConfig.brightspace {
             req.application.brightSpaceSyncConfig = envConfig

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -25,7 +25,7 @@ extension AdminRoutes {
             createdAt: "",
             brightspaceOrgUnitID: nil,
             brightspaceOrgUnitName: nil,
-            brightspaceSyncEnabled: req.application.brightSpaceClient != nil
+            brightspaceSyncEnabled: req.application.brightSpaceAppCredentials != nil
         )
         return try await req.view.render(
             "admin-course",
@@ -446,7 +446,7 @@ extension AdminRoutes {
             createdAt: course.createdAt.map { ISO8601DateFormatter().string(from: $0) } ?? "—",
             brightspaceOrgUnitID: course.brightspaceOrgUnitID,
             brightspaceOrgUnitName: course.brightspaceOrgUnitName,
-            brightspaceSyncEnabled: req.application.brightSpaceClient != nil
+            brightspaceSyncEnabled: req.application.brightSpaceAppCredentials != nil
         )
 
         // Load enrollments for this course, then fetch the corresponding users.

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -81,7 +81,7 @@ struct AdminRoutes: RouteCollection {
         let activeCourseIDs = allCourses.filter { !$0.isArchived }.compactMap { $0.id }
         let submissionCounts = try await SubmissionRetentionService.submissionCountsByCourse(
             courseIDs: activeCourseIDs, on: req.db)
-        let bsSyncEnabled = req.application.brightSpaceClient != nil
+        let bsSyncEnabled = req.application.brightSpaceAppCredentials != nil
         // Archived courses move out of Overview and live on the Retention tab.
         let iso = ISO8601DateFormatter()
         let courseRows = allCourses.compactMap { course -> AdminCourseRow? in

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -80,6 +80,17 @@ struct InstructorBrightspaceContext: Encodable {
     let courseLinked: Bool
     let orgUnitID: String?
     let orgUnitName: String?
+    /// True when the requesting instructor has connected their own LEARN account.
+    let accountConnected: Bool
+    /// The requesting instructor's connected LEARN identity (whoami display).
+    let accountIdentity: String?
+    /// Display name of the identity this course pushes grades as (its designated
+    /// instructor, or the deployment-wide fallback). Nil = no identity connected.
+    let syncIdentityName: String?
+    /// True when the course's designated sync identity is the requesting user.
+    let syncIdentityIsMe: Bool
+    let flashSuccess: String?
+    let flashError: String?
     let assignmentRows: [BrightspaceAssignmentRow]
     let hasAssignments: Bool
     let logRows: [BrightspaceLogRow]

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -38,8 +38,10 @@ extension InstructorDashboardRoutes {
     /// any grade push fails.
     @Sendable
     func brightspaceTestConnection(req: Request) async throws -> BrightspaceTestResult {
-        guard let client = req.application.brightSpaceClient else {
-            return BrightspaceTestResult(ok: false, message: "BrightSpace is not configured on this server.")
+        let user = try req.auth.require(APIUser.self)
+        guard let client = try await activeCourseBrightSpaceClient(req: req, user: user) else {
+            return BrightspaceTestResult(
+                ok: false, message: "BrightSpace is not connected for this course yet.")
         }
         do {
             let who = try await client.whoami(on: req.application)
@@ -50,6 +52,147 @@ extension InstructorDashboardRoutes {
         }
     }
 
+    /// The BrightSpace client for the active course's designated identity (or
+    /// the deployment-wide fallback). Nil when BrightSpace isn't configured or
+    /// there's no active course.
+    private func activeCourseBrightSpaceClient(
+        req: Request, user: APIUser
+    ) async throws -> BrightSpaceAPIClient? {
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else { return nil }
+        return try await req.application.brightSpaceClient(forCourse: course)
+    }
+
+    // MARK: - POST /instructor/brightspace/connect
+
+    /// Connects the requesting instructor's own LEARN account: verifies a pasted
+    /// Valence User ID + User Key via `whoami`, stores it against this user, and
+    /// — if the active course has no designated identity yet — makes them it
+    /// (so grades for this course push as their LEARN account). This is the
+    /// per-instructor path for institutions whose Valence Trusted URL is a
+    /// central credential harvester rather than this server's own callback.
+    @Sendable
+    func brightspaceConnectAccount(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        struct ConnectForm: Content {
+            let userID: String
+            let userKey: String
+        }
+        let form = try req.content.decode(ConnectForm.self)
+        let valenceUserID = form.userID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let valenceUserKey = form.userKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !valenceUserID.isEmpty, !valenceUserKey.isEmpty else {
+            req.session.data["bs_flash_error"] = "Both User ID and User Key are required."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        guard let appCreds = req.application.brightSpaceAppCredentials else {
+            req.session.data["bs_flash_error"] = "BrightSpace is not configured on this server."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        guard let userUUID = user.id else {
+            req.session.data["bs_flash_error"] = "Could not resolve your account."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        // Verify the pasted pair against D2L before persisting, so a bad paste
+        // fails loudly here rather than silently breaking grade sync.
+        let config = BrightSpaceSyncConfig(app: appCreds, userID: valenceUserID, userKey: valenceUserKey)
+        let candidate = BrightSpaceAPIClient(config: config)
+        let who: BrightSpaceWhoAmI
+        do {
+            who = try await candidate.whoami(on: req.application)
+        } catch {
+            req.logger.warning(
+                "BrightSpace connect: whoami verification failed: \(error.localizedDescription)")
+            req.session.data["bs_flash_error"] =
+                "Could not verify those credentials against D2L: \(error.localizedDescription)"
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        let identity = who.uniqueName.isEmpty ? who.displayName : "\(who.displayName) (\(who.uniqueName))"
+        try await BrightSpaceCredentialStore.save(
+            valenceUserID: valenceUserID,
+            valenceUserKey: valenceUserKey,
+            identityName: identity,
+            capturedByUserID: userUUID,
+            userID: userUUID,
+            on: req.db
+        )
+        await req.application.brightSpaceClientRegistry.invalidate(userUUID.uuidString)
+
+        // Claim the active course's sync identity if it has none yet (default =
+        // whoever connects; any connected instructor can reassign it below).
+        var claimedCourse = false
+        let courseState = try await req.resolveActiveCourse(for: user)
+        if let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db),
+            course.brightspaceSyncUserID == nil
+        {
+            course.brightspaceSyncUserID = userUUID
+            try await course.save(on: req.db)
+            claimedCourse = true
+        }
+
+        req.logger.info("BrightSpace connected by \(user.username) as \(identity)")
+        req.session.data["bs_flash_success"] =
+            claimedCourse
+            ? "Connected as \(identity). This course now syncs grades as your LEARN account."
+            : "Connected as \(identity)."
+        let response = req.redirect(to: "/instructor/brightspace")
+        response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+        return response
+    }
+
+    // MARK: - POST /instructor/brightspace/use-my-identity
+
+    /// Designates the requesting instructor (who must be connected) as the active
+    /// course's grade-sync identity — the "reassign" action that lets a connected
+    /// co-instructor take over pushes for the course.
+    @Sendable
+    func brightspaceUseMyIdentity(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard let userUUID = user.id else {
+            req.session.data["bs_flash_error"] = "Could not resolve your account."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        guard try await BrightSpaceCredentialStore.load(userID: userUUID, on: req.db) != nil else {
+            req.session.data["bs_flash_error"] =
+                "Connect your LEARN account first, then set it as this course's sync identity."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else {
+            req.session.data["bs_flash_error"] = "No active course."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        course.brightspaceSyncUserID = userUUID
+        try await course.save(on: req.db)
+        req.session.data["bs_flash_success"] = "This course now syncs grades as your LEARN account."
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
+    // MARK: - POST /instructor/brightspace/disconnect
+
+    /// Disconnects the requesting instructor's LEARN account (drops the stored
+    /// key + cached client). Any course designating them as its sync identity
+    /// then defers until someone reconnects — no grade is pushed with a stale key.
+    @Sendable
+    func brightspaceDisconnectAccount(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard let userUUID = user.id else {
+            req.session.data["bs_flash_error"] = "Could not resolve your account."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        try await BrightSpaceCredentialStore.clear(userID: userUUID, on: req.db)
+        await req.application.brightSpaceClientRegistry.invalidate(userUUID.uuidString)
+        req.session.data["bs_flash_success"] = "Your LEARN account has been disconnected."
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
     // MARK: - GET /instructor/brightspace/grade-objects
 
     /// Lists the active course's D2L grade items for the mapping dropdown.
@@ -58,12 +201,12 @@ extension InstructorDashboardRoutes {
     @Sendable
     func brightspaceGradeObjects(req: Request) async throws -> [BrightSpaceGradeObject] {
         let user = try req.auth.require(APIUser.self)
-        guard let client = req.application.brightSpaceClient else { return [] }
         let courseState = try await req.resolveActiveCourse(for: user)
         guard let courseUUID = courseState.activeCourseUUID,
             let course = try await APICourse.find(courseUUID, on: req.db),
             let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty
         else { return [] }
+        guard let client = try await req.application.brightSpaceClient(forCourse: course) else { return [] }
         do {
             return try await client.listGradeObjects(orgUnitID: orgUnitID, on: req.application)
         } catch {
@@ -154,19 +297,18 @@ extension InstructorDashboardRoutes {
     /// a manual "Sync now" click pushes everything currently pending.  No-op
     /// when BrightSpace isn't configured.
     private func runImmediateBrightspaceSweep(req: Request) async {
-        guard let client = req.application.brightSpaceClient,
-            let config = req.application.brightSpaceSyncConfig
-        else { return }
+        guard let app = req.application.brightSpaceAppCredentials else { return }
+        let debounce = req.application.brightSpaceSyncConfig?.debounceSecs ?? app.debounceSecs
         // Pass a future `now` so the debounce cutoff lands ahead of every
         // pending row, forcing an immediate push instead of waiting out the
-        // window.
+        // window. Each course resolves its designated identity (or the fallback).
         _ = try? await sweepBrightSpaceGradeSync(
             on: req.db,
-            client: client,
-            config: config,
+            debounceSecs: debounce,
+            resolveClient: { course in try await req.application.brightSpaceClient(forCourse: course) },
             logger: req.logger,
             application: req.application,
-            now: Date().addingTimeInterval(config.debounceSecs + 1)
+            now: Date().addingTimeInterval(debounce + 1)
         )
     }
 
@@ -179,7 +321,25 @@ extension InstructorDashboardRoutes {
         let courseState = try await req.resolveActiveCourse(for: user)
         let userContext = CurrentUserContext(
             user: user, activeCourse: courseState.active, enrolledCourses: courseState.all)
-        let syncEnabled = req.application.brightSpaceClient != nil
+        // "Enabled" = configured at the app level (URL/App ID/App Key); a user
+        // key may still be awaited via per-instructor connect.
+        let syncEnabled = req.application.brightSpaceAppCredentials != nil
+
+        // One-shot flashes from the connect/disconnect/designate actions.
+        let flashSuccess = req.session.data["bs_flash_success"]
+        let flashError = req.session.data["bs_flash_error"]
+        req.session.data["bs_flash_success"] = nil
+        req.session.data["bs_flash_error"] = nil
+
+        // This instructor's own LEARN connection (course-independent).
+        let myCredential: APIBrightSpaceCredential?
+        if let uid = user.id {
+            myCredential = try await BrightSpaceCredentialStore.load(userID: uid, on: req.db)
+        } else {
+            myCredential = nil
+        }
+        let accountConnected = myCredential != nil
+        let accountIdentity = myCredential?.identityName
 
         guard let courseUUID = courseState.activeCourseUUID,
             let course = try await APICourse.find(courseUUID, on: req.db)
@@ -189,6 +349,9 @@ extension InstructorDashboardRoutes {
                 hasActiveCourse: courseState.active != nil, courseIsArchived: false,
                 brightspaceSyncEnabled: syncEnabled, courseLinked: false,
                 orgUnitID: nil, orgUnitName: nil,
+                accountConnected: accountConnected, accountIdentity: accountIdentity,
+                syncIdentityName: nil, syncIdentityIsMe: false,
+                flashSuccess: flashSuccess, flashError: flashError,
                 assignmentRows: [], hasAssignments: false,
                 logRows: [], hasLog: false,
                 summary: BrightspaceSyncSummary(synced: 0, pending: 0, errored: 0, unmapped: 0),
@@ -198,6 +361,22 @@ extension InstructorDashboardRoutes {
         let orgUnitID = course.brightspaceOrgUnitID
         let courseLinked = !(orgUnitID ?? "").isEmpty
         let fmt = waterlooDateTimeFormatter()
+
+        // The identity this course pushes grades as: its designated instructor
+        // (resolved to a display label), else the deployment-wide fallback.
+        var syncIdentityName: String?
+        let syncIdentityIsMe = course.brightspaceSyncUserID != nil && course.brightspaceSyncUserID == user.id
+        if let syncUserID = course.brightspaceSyncUserID {
+            if let cred = try await BrightSpaceCredentialStore.load(userID: syncUserID, on: req.db) {
+                syncIdentityName = cred.identityName
+            } else {
+                // Designated but disconnected — fall back to the username so the
+                // UI can flag that the identity needs to reconnect.
+                syncIdentityName = try await APIUser.find(syncUserID, on: req.db)?.username
+            }
+        } else if req.application.brightSpaceClient != nil {
+            syncIdentityName = "Deployment default account"
+        }
 
         // Assignments, sorted to match the dashboard ordering.
         let assignments = try await APIAssignment.query(on: req.db)
@@ -255,6 +434,9 @@ extension InstructorDashboardRoutes {
             hasActiveCourse: true, courseIsArchived: course.isArchived,
             brightspaceSyncEnabled: syncEnabled, courseLinked: courseLinked,
             orgUnitID: orgUnitID, orgUnitName: course.brightspaceOrgUnitName,
+            accountConnected: accountConnected, accountIdentity: accountIdentity,
+            syncIdentityName: syncIdentityName, syncIdentityIsMe: syncIdentityIsMe,
+            flashSuccess: flashSuccess, flashError: flashError,
             assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
             logRows: logRows, hasLog: !logRows.isEmpty,
             summary: summary, unmappedStudents: unmapped, hasUnmapped: !unmapped.isEmpty)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+LearnCheck.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+LearnCheck.swift
@@ -30,9 +30,9 @@ extension InstructorDashboardRoutes {
         else {
             return .unavailable("No active course selected.")
         }
-        guard let client = req.application.brightSpaceClient else {
+        guard let client = try await req.application.brightSpaceClient(forCourse: course) else {
             return .unavailable(
-                "BrightSpace is not configured on this server.", configured: false)
+                "BrightSpace isn't connected for this course yet.", configured: false)
         }
         guard let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty else {
             return .unavailable(

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -62,7 +62,7 @@ extension InstructorDashboardRoutes {
                 courseEnrollmentMode = course.enrollmentMode.rawValue
                 courseIsArchived = course.isArchived
                 brightspaceLinkAvailable =
-                    req.application.brightSpaceClient != nil
+                    req.application.brightSpaceAppCredentials != nil
                     && !((course.brightspaceOrgUnitID ?? "").isEmpty)
             }
         }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -44,6 +44,11 @@ struct InstructorDashboardRoutes: RouteCollection {
         // BrightSpace tab: status, grade-item mapping, sync log, manual actions.
         r.get("brightspace", use: brightspacePage)
         r.post("brightspace", "test", use: brightspaceTestConnection)
+        // Per-instructor identity: connect your own LEARN account, designate it
+        // as this course's sync identity, or disconnect.
+        r.post("brightspace", "connect", use: brightspaceConnectAccount)
+        r.post("brightspace", "use-my-identity", use: brightspaceUseMyIdentity)
+        r.post("brightspace", "disconnect", use: brightspaceDisconnectAccount)
         r.get("brightspace", "grade-objects", use: brightspaceGradeObjects)
         r.post("brightspace", "sync-now", use: brightspaceSyncNow)
         r.post("brightspace", "retry-failed", use: brightspaceRetryFailed)
@@ -440,7 +445,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             suiteSectionRows: suiteSectionShellRows(fromManifest: setup.manifest),
             globalVariableRows: globalVariableShellRows(fromManifest: setup.manifest),
             achievementSignalOptions: AchievementSignalPresentation.all,
-            brightspaceSyncEnabled: req.application.brightSpaceClient != nil,
+            brightspaceSyncEnabled: req.application.brightSpaceAppCredentials != nil,
             brightspaceGradeObjectID: assignment.brightspaceGradeObjectID,
             notice: q?.notice,
             error: q?.error

--- a/Sources/APIServer/Services/BrightSpaceClientRegistry.swift
+++ b/Sources/APIServer/Services/BrightSpaceClientRegistry.swift
@@ -1,0 +1,93 @@
+// APIServer/Services/BrightSpaceClientRegistry.swift
+//
+// Per-identity cache of BrightSpace API clients, and the per-course identity
+// resolution that decides *whose* LEARN key a grade push runs as.
+//
+// Grade sync moved from one deployment-wide service account to a per-instructor
+// model: each course designates an instructor (`brightspace_sync_user_id`) whose
+// connected Valence key drives its pushes; a course with no designation falls
+// back to the deployment-wide (admin/env) identity. A `BrightSpaceAPIClient`
+// caches negotiated API versions + learned clock skew, so we keep one client per
+// identity rather than rebuilding it every sweep.
+
+import Fluent
+import Vapor
+
+/// Caches one `BrightSpaceAPIClient` per identity key so repeated pushes reuse a
+/// client's negotiated API version + clock-skew state instead of re-negotiating.
+actor BrightSpaceClientRegistry {
+    /// Cache key for the deployment-wide (admin/env) identity.
+    static let globalKey = "__global__"
+
+    private var clients: [String: BrightSpaceAPIClient] = [:]
+
+    /// The client for `key`, built from `config` on first use and cached.
+    func client(forKey key: String, config: BrightSpaceSyncConfig) -> BrightSpaceAPIClient {
+        if let existing = clients[key] { return existing }
+        let created = BrightSpaceAPIClient(config: config)
+        clients[key] = created
+        return created
+    }
+
+    /// Drops a cached client so the next resolve rebuilds it (after a key is
+    /// (re)connected, cleared, or the global config changes).
+    func invalidate(_ key: String) {
+        clients.removeValue(forKey: key)
+    }
+
+    func invalidateAll() {
+        clients.removeAll()
+    }
+}
+
+/// The effective grade-sync config + cache key for a course: its designated
+/// instructor's stored key if set, else the deployment-wide config. Returns nil
+/// when neither is available (BrightSpace not connected for this course).
+func resolveBrightSpaceConfigForCourse(
+    _ course: APICourse,
+    app: BrightSpaceAppCredentials,
+    globalConfig: BrightSpaceSyncConfig?,
+    on db: any Database
+) async throws -> (config: BrightSpaceSyncConfig, key: String)? {
+    if let syncUserID = course.brightspaceSyncUserID,
+        let credential = try await BrightSpaceCredentialStore.load(userID: syncUserID, on: db)
+    {
+        let config = BrightSpaceSyncConfig(
+            app: app, userID: credential.valenceUserID, userKey: credential.valenceUserKey)
+        return (config, syncUserID.uuidString)
+    }
+    if let globalConfig {
+        return (globalConfig, BrightSpaceClientRegistry.globalKey)
+    }
+    return nil
+}
+
+// MARK: - Application storage
+
+struct BrightSpaceClientRegistryKey: StorageKey {
+    typealias Value = BrightSpaceClientRegistry
+}
+
+extension Application {
+    var brightSpaceClientRegistry: BrightSpaceClientRegistry {
+        get {
+            if let existing = storage[BrightSpaceClientRegistryKey.self] { return existing }
+            let created = BrightSpaceClientRegistry()
+            storage[BrightSpaceClientRegistryKey.self] = created
+            return created
+        }
+        set { storage[BrightSpaceClientRegistryKey.self] = newValue }
+    }
+
+    /// Resolves the grade-sync client for a course's designated identity (or the
+    /// deployment-wide fallback), cached per identity. Nil when BrightSpace isn't
+    /// configured at the app level, or no identity is available for the course.
+    func brightSpaceClient(forCourse course: APICourse) async throws -> BrightSpaceAPIClient? {
+        guard let app = brightSpaceAppCredentials else { return nil }
+        guard
+            let resolved = try await resolveBrightSpaceConfigForCourse(
+                course, app: app, globalConfig: brightSpaceSyncConfig, on: db)
+        else { return nil }
+        return await brightSpaceClientRegistry.client(forKey: resolved.key, config: resolved.config)
+    }
+}

--- a/Sources/APIServer/Services/BrightSpaceCredentialStore.swift
+++ b/Sources/APIServer/Services/BrightSpaceCredentialStore.swift
@@ -1,57 +1,86 @@
 // APIServer/Services/BrightSpaceCredentialStore.swift
 //
-// Persistence + resolution for the authorize-captured BrightSpace user key.
+// Persistence + resolution for captured BrightSpace Valence user keys.
 //
-// `resolveSyncConfig` is the single place that decides the active grade-sync
-// identity: an authorized (stored) key takes precedence over an env-supplied
-// user key, with env remaining the bootstrap fallback. Used both at startup
-// (AppServices) and after a fresh authorization (AdminRoutes+BrightSpace) so
-// the running client reflects the latest deliberate action.
+// Two identity scopes share the `brightspace_credentials` table:
+//   • the deployment-wide identity (`user_id IS NULL`) — the admin authorize /
+//     env-supplied service account, kept as a fallback;
+//   • one per-instructor identity (`user_id = <instructor>`) — captured via the
+//     instructor "Connect my LEARN account" flow, used when a course designates
+//     that instructor as its grade-sync identity.
+//
+// `resolveSyncConfig` decides the *global* identity (stored-global > env); the
+// per-course choice (designated instructor > global) lives in
+// `BrightSpaceClientRegistry` / `Application.brightSpaceClient(forCourse:)`.
 
 import Fluent
 import Vapor
 
 enum BrightSpaceCredentialStore {
 
-    /// The most recently authorized credential, or nil if none stored.
-    static func load(on db: any Database) async throws -> APIBrightSpaceCredential? {
+    /// The deployment-wide (admin/env) credential — the row with no `user_id`.
+    static func loadGlobal(on db: any Database) async throws -> APIBrightSpaceCredential? {
         try await APIBrightSpaceCredential.query(on: db)
+            .filter(\.$userID == nil)
             .sort(\.$capturedAt, .descending)
             .first()
     }
 
-    /// Replaces any stored credential with a freshly captured one (single-row).
+    /// The stored credential for one instructor, or nil if they haven't connected.
+    static func load(userID: UUID, on db: any Database) async throws -> APIBrightSpaceCredential? {
+        try await APIBrightSpaceCredential.query(on: db)
+            .filter(\.$userID == userID)
+            .sort(\.$capturedAt, .descending)
+            .first()
+    }
+
+    /// Replaces the credential for one scope with a freshly captured one. A nil
+    /// `userID` targets the deployment-wide identity; a non-nil one targets that
+    /// instructor — so connecting a per-instructor key never disturbs the global
+    /// fallback (or another instructor's key), and vice versa.
     static func save(
         valenceUserID: String,
         valenceUserKey: String,
         identityName: String?,
         capturedByUserID: UUID?,
+        userID: UUID? = nil,
         on db: any Database
     ) async throws {
-        try await APIBrightSpaceCredential.query(on: db).delete()
+        if let userID {
+            try await APIBrightSpaceCredential.query(on: db).filter(\.$userID == userID).delete()
+        } else {
+            try await APIBrightSpaceCredential.query(on: db).filter(\.$userID == nil).delete()
+        }
         let record = APIBrightSpaceCredential(
             valenceUserID: valenceUserID,
             valenceUserKey: valenceUserKey,
             identityName: identityName,
-            capturedByUserID: capturedByUserID
+            capturedByUserID: capturedByUserID,
+            userID: userID
         )
         try await record.save(on: db)
     }
 
-    /// Removes the stored credential (the admin "Clear authorization" action).
-    static func clear(on db: any Database) async throws {
-        try await APIBrightSpaceCredential.query(on: db).delete()
+    /// Removes the deployment-wide credential (admin "Clear authorization").
+    static func clearGlobal(on db: any Database) async throws {
+        try await APIBrightSpaceCredential.query(on: db).filter(\.$userID == nil).delete()
     }
 
-    /// Resolves the active sync config from deployment app creds: a stored
-    /// (authorized) user key wins; otherwise the env-provided full config is
-    /// used; otherwise nil (configured at the app level but awaiting a user key).
+    /// Removes one instructor's credential (the instructor "Disconnect" action).
+    static func clear(userID: UUID, on db: any Database) async throws {
+        try await APIBrightSpaceCredential.query(on: db).filter(\.$userID == userID).delete()
+    }
+
+    /// Resolves the deployment-wide sync config from app creds: a stored global
+    /// (authorized) user key wins; otherwise the env-provided full config; else
+    /// nil (configured at the app level but awaiting a user key). This is the
+    /// fallback used when a course has no designated per-instructor identity.
     static func resolveSyncConfig(
         app: BrightSpaceAppCredentials,
         envConfig: BrightSpaceSyncConfig?,
         on db: any Database
     ) async throws -> BrightSpaceSyncConfig? {
-        if let stored = try await load(on: db) {
+        if let stored = try await loadGlobal(on: db) {
             return BrightSpaceSyncConfig(
                 app: app, userID: stored.valenceUserID, userKey: stored.valenceUserKey)
         }

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -28,13 +28,13 @@ import Vapor
 @discardableResult
 func sweepBrightSpaceGradeSync(
     on db: Database,
-    client: any BrightSpaceGrading,
-    config: BrightSpaceSyncConfig,
+    debounceSecs: TimeInterval,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
     logger: Logger,
     application: Application,
     now: Date = Date()
 ) async throws -> Int {
-    let cutoff = now.addingTimeInterval(-config.debounceSecs)
+    let cutoff = now.addingTimeInterval(-debounceSecs)
 
     // All results that are past the debounce window.
     let pending = try await APIResult.query(on: db)
@@ -86,8 +86,10 @@ func sweepBrightSpaceGradeSync(
             user: context.usersByID[key.userID]
         )
         do {
-            try await pushGrade(for: target, db: db, client: client, logger: logger, application: application)
-            processed += results.count
+            let pushed = try await pushGrade(
+                for: target, db: db, resolveClient: resolveClient, logger: logger,
+                application: application)
+            if pushed { processed += results.count }
         } catch {
             await recordSweepFailure(results, error: error, db: db, logger: logger)
         }
@@ -219,13 +221,18 @@ private func clearPendingFlag(_ results: [APIResult], on db: Database) async thr
     }
 }
 
+/// Pushes one group's grade. Returns false when the push is *deferred* (the
+/// course has no grade-sync identity connected yet) so the caller leaves the
+/// rows pending for a later sweep; true on every terminal outcome (pushed,
+/// skipped, or a no-op flag clear).
+@discardableResult
 private func pushGrade(
     for target: GradePushTarget,
     db: Database,
-    client: any BrightSpaceGrading,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
     logger: Logger,
     application: Application
-) async throws {
+) async throws -> Bool {
     let userID = target.userID
     let testSetupID = target.testSetupID
 
@@ -236,7 +243,7 @@ private func pushGrade(
     else {
         // No BrightSpace grade item configured — no-op.
         try await clearPendingFlag(target.results, on: db)
-        return
+        return true
     }
 
     // The course must have an org unit ID.
@@ -245,7 +252,15 @@ private func pushGrade(
         !orgUnitID.isEmpty
     else {
         try await clearPendingFlag(target.results, on: db)
-        return
+        return true
+    }
+
+    // Resolve the identity this course pushes as (designated instructor, else
+    // the deployment-wide fallback). When none is connected yet, defer: leave
+    // the rows pending so the grade pushes once an instructor connects, rather
+    // than clearing the flag as a permanent no-op.
+    guard let client = try await resolveClient(course) else {
+        return false
     }
 
     // Best grade for this student across the test setup. nil → no submissions
@@ -253,7 +268,7 @@ private func pushGrade(
     guard let points = try await bestPointsForStudent(userID: userID, testSetupID: testSetupID, db: db)
     else {
         try await clearPendingFlag(target.results, on: db)
-        return
+        return true
     }
 
     // Username snapshot for the sync log (readable without a join).
@@ -293,7 +308,7 @@ private func pushGrade(
             try await result.save(on: db)
         }
         await appendSyncLog(.skipped, detail: "No BrightSpace account (orgDefinedId not found)")
-        return
+        return true
     }
 
     // Push the grade.
@@ -324,6 +339,7 @@ private func pushGrade(
     await appendSyncLog(.success, detail: nil)
 
     logger.info("BrightSpace grade synced: user \(userID) assignment '\(assignment.title)' → \(points) pts")
+    return true
 }
 
 /// Best (max) points for this student across all results for the test setup,
@@ -446,21 +462,23 @@ final class BrightSpaceGradeSyncMonitor: @unchecked Sendable {
     func start(application: Application) {
         guard task == nil else { return }
 
-        // The client/config are re-read each cycle rather than captured once, so
-        // an admin authorization (which rebuilds `app.brightSpaceClient` live)
-        // takes effect within one sweep interval without a server restart. When
-        // BrightSpace is configured at the app level but not yet authorized, the
-        // loop idles until a client appears.
+        // The identity is resolved per course each cycle (not captured once), so
+        // a fresh connect / re-designation takes effect within one sweep interval
+        // without a restart. The loop runs whenever BrightSpace is configured at
+        // the app level; each push resolves the course's designated instructor
+        // (or the deployment-wide fallback), deferring courses with no identity
+        // connected yet.
         task = Task {
             while !Task.isCancelled {
-                if let client = application.brightSpaceClient,
-                    let config = application.brightSpaceSyncConfig
-                {
+                if let app = application.brightSpaceAppCredentials {
+                    let debounce = application.brightSpaceSyncConfig?.debounceSecs ?? app.debounceSecs
                     do {
                         let n = try await sweepBrightSpaceGradeSync(
                             on: application.db,
-                            client: client,
-                            config: config,
+                            debounceSecs: debounce,
+                            resolveClient: { course in
+                                try await application.brightSpaceClient(forCourse: course)
+                            },
                             logger: application.logger,
                             application: application
                         )

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -257,6 +257,9 @@ func registerMigrations(on app: Application) {
     // declared column, so the column has to exist before those run on a
     // fresh DB. Existing prod is unaffected — only this new migration runs.
     app.migrations.add(AddBrightSpaceOrgUnitName())
+    // Same ordering constraint as AddBrightSpaceOrgUnitName: a courses column
+    // that must exist before AddCourseArchivedAt queries the APICourse model.
+    app.migrations.add(AddCourseBrightSpaceSyncUserID())
     app.migrations.add(CreateCourseEnrollments())
     app.migrations.add(CreateTestSetups())
     app.migrations.add(CreateSubmissions())
@@ -292,6 +295,8 @@ func registerMigrations(on app: Application) {
     // Single-row store for the admin-authorized BrightSpace Valence user key
     // (durable alternative to BRIGHTSPACE_USER_ID/KEY in env).
     app.migrations.add(CreateBrightSpaceCredentials())
+    // Per-instructor scope on the captured Valence key (NULL = deployment-wide).
+    app.migrations.add(AddBrightSpaceCredentialUserID())
     // Single-use consent requests for the browser OAuth flow (cookie-less
     // POST /oauth/authorize). FK references `users`.
     app.migrations.add(CreateMCPConsentRequests())

--- a/Tests/APITests/BrightSpaceCredentialStoreTests.swift
+++ b/Tests/APITests/BrightSpaceCredentialStoreTests.swift
@@ -30,7 +30,7 @@ import XCTVapor
             let count = try await APIBrightSpaceCredential.query(on: app.db).count()
             #expect(count == 1)
 
-            let loaded = try #require(try await BrightSpaceCredentialStore.load(on: app.db))
+            let loaded = try #require(try await BrightSpaceCredentialStore.loadGlobal(on: app.db))
             #expect(loaded.valenceUserID == "u2")
             #expect(loaded.valenceUserKey == "k2")
             #expect(loaded.identityName == "Bob")
@@ -60,10 +60,93 @@ import XCTVapor
             #expect(r2?.userKey == "storedKey")
 
             // Cleared + no env → nil (configured at app level, awaiting authorize).
-            try await BrightSpaceCredentialStore.clear(on: app.db)
+            try await BrightSpaceCredentialStore.clearGlobal(on: app.db)
             let r3 = try await BrightSpaceCredentialStore.resolveSyncConfig(
                 app: creds, envConfig: nil, on: app.db)
             #expect(r3 == nil)
+        }
+    }
+
+    @Test func perUserCredentials_areScopedAndIsolated() async throws {
+        try await withApp(app) { app in
+            let userA = UUID()
+            let userB = UUID()
+            // A deployment-wide identity and two per-instructor identities coexist.
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "g", valenceUserKey: "gk", identityName: "Global",
+                capturedByUserID: nil, userID: nil, on: app.db)
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "a", valenceUserKey: "ak", identityName: "Alice",
+                capturedByUserID: userA, userID: userA, on: app.db)
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "b", valenceUserKey: "bk", identityName: "Bob",
+                capturedByUserID: userB, userID: userB, on: app.db)
+
+            #expect(try await APIBrightSpaceCredential.query(on: app.db).count() == 3)
+            let global = try #require(try await BrightSpaceCredentialStore.loadGlobal(on: app.db))
+            #expect(global.valenceUserID == "g")
+            #expect(global.userID == nil)
+            #expect(try await BrightSpaceCredentialStore.load(userID: userA, on: app.db)?.valenceUserID == "a")
+            #expect(try await BrightSpaceCredentialStore.load(userID: userB, on: app.db)?.valenceUserID == "b")
+
+            // Re-connecting one instructor replaces only their row.
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "a2", valenceUserKey: "ak2", identityName: "Alice2",
+                capturedByUserID: userA, userID: userA, on: app.db)
+            #expect(try await APIBrightSpaceCredential.query(on: app.db).count() == 3)
+            #expect(try await BrightSpaceCredentialStore.load(userID: userA, on: app.db)?.valenceUserID == "a2")
+            #expect(try await BrightSpaceCredentialStore.loadGlobal(on: app.db)?.valenceUserID == "g")
+            #expect(try await BrightSpaceCredentialStore.load(userID: userB, on: app.db)?.valenceUserID == "b")
+
+            // Disconnecting one instructor leaves the others + the global identity.
+            try await BrightSpaceCredentialStore.clear(userID: userA, on: app.db)
+            #expect(try await BrightSpaceCredentialStore.load(userID: userA, on: app.db) == nil)
+            #expect(try await BrightSpaceCredentialStore.loadGlobal(on: app.db) != nil)
+            #expect(try await BrightSpaceCredentialStore.load(userID: userB, on: app.db) != nil)
+        }
+    }
+
+    @Test func resolveConfigForCourse_designatedWinsThenGlobalThenNil() async throws {
+        try await withApp(app) { app in
+            let appCreds = BrightSpaceAppCredentials(
+                baseURL: "https://x", appID: "a", appKey: "ak", debounceSecs: 90)
+            let globalConfig = BrightSpaceSyncConfig(
+                app: appCreds, userID: "envUser", userKey: "envKey")
+
+            let instructor = UUID()
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "insUser", valenceUserKey: "insKey", identityName: "Ins",
+                capturedByUserID: instructor, userID: instructor, on: app.db)
+
+            let course = try await makeTestCourse(on: app, code: "BSRES")
+
+            // No designation → deployment-wide fallback.
+            let r1 = try await resolveBrightSpaceConfigForCourse(
+                course, app: appCreds, globalConfig: globalConfig, on: app.db)
+            #expect(r1?.config.userID == "envUser")
+            #expect(r1?.key == BrightSpaceClientRegistry.globalKey)
+
+            // Designated instructor with a stored key → their identity wins.
+            course.brightspaceSyncUserID = instructor
+            try await course.save(on: app.db)
+            let r2 = try await resolveBrightSpaceConfigForCourse(
+                course, app: appCreds, globalConfig: globalConfig, on: app.db)
+            #expect(r2?.config.userID == "insUser")
+            #expect(r2?.config.userKey == "insKey")
+            #expect(r2?.key == instructor.uuidString)
+
+            // Designated but disconnected (no stored key) → falls back to global.
+            course.brightspaceSyncUserID = UUID()
+            try await course.save(on: app.db)
+            let r3 = try await resolveBrightSpaceConfigForCourse(
+                course, app: appCreds, globalConfig: globalConfig, on: app.db)
+            #expect(r3?.config.userID == "envUser")
+            #expect(r3?.key == BrightSpaceClientRegistry.globalKey)
+
+            // No global fallback + no usable designation → nil (sync deferred).
+            let r4 = try await resolveBrightSpaceConfigForCourse(
+                course, app: appCreds, globalConfig: nil, on: app.db)
+            #expect(r4 == nil)
         }
     }
 }

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -79,17 +79,6 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
 
     // MARK: Fixture helpers
 
-    private func syncConfig(debounceSecs: TimeInterval = 90) -> BrightSpaceSyncConfig {
-        BrightSpaceSyncConfig(
-            baseURL: "https://example.test",
-            appID: "app",
-            appKey: "appKey",
-            userID: "user",
-            userKey: "userKey",
-            debounceSecs: debounceSecs
-        )
-    }
-
     private func pointsJSON(earned: Int, total: Int) -> String {
         #"{"earnedPoints":\#(earned),"totalPoints":\#(total)}"#
     }
@@ -161,11 +150,25 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         return result
     }
 
+    /// Drives the sweep with a constant per-course identity (the fake), so the
+    /// existing tests exercise grade selection / debounce / caching unchanged.
     private func sweep(client: any BrightSpaceGrading, debounceSecs: TimeInterval = 90) async throws -> Int {
         try await sweepBrightSpaceGradeSync(
             on: app.db,
-            client: client,
-            config: syncConfig(debounceSecs: debounceSecs),
+            debounceSecs: debounceSecs,
+            resolveClient: { _ in client },
+            logger: app.logger,
+            application: app
+        )
+    }
+
+    /// Drives the sweep with a resolver that returns no identity for any course,
+    /// modelling a course whose designated instructor hasn't connected yet.
+    private func sweepWithNoIdentity(debounceSecs: TimeInterval = 90) async throws -> Int {
+        try await sweepBrightSpaceGradeSync(
+            on: app.db,
+            debounceSecs: debounceSecs,
+            resolveClient: { _ in nil },
             logger: app.logger,
             application: app
         )
@@ -326,6 +329,27 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             #expect(pushes.isEmpty)  // validation runs never sync grades
             let result = try #require(try await APIResult.query(on: app.db).first())
             #expect(result.brightspaceSyncPending == false)
+        }
+    }
+
+    @Test func noConnectedIdentityDefersAndLeavesPending() async throws {
+        // A course whose designated instructor hasn't connected (resolver → nil)
+        // must NOT clear the flag — the grade should push once an identity
+        // connects, so the row stays pending for a later sweep.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 6, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+
+            let processed = try await sweepWithNoIdentity()
+
+            #expect(processed == 0)
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncPending == true)
+            #expect(result.brightspaceSyncError == nil)
         }
     }
 

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -47,6 +47,29 @@ import XCTVapor
         }
     }
 
+    @Test func brightspacePageRendersConnectionSectionWhenConfigured() async throws {
+        try await withAssignmentRoutesApp { app in
+            // Configure BrightSpace at the app level and give the instructor an
+            // (auto-enrolled) active course, so the configured + with-course
+            // branch renders — exercising the per-instructor connection UI.
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.test", appID: "a", appKey: "k", debounceSecs: 90)
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("Your LEARN account"))
+                    // Instructor hasn't connected yet → connect form + "no identity".
+                    #expect(html.contains("Connect your own LEARN account"))
+                    #expect(html.contains("no identity"))
+                })
+        }
+    }
+
     // MARK: - Grade-objects feed
 
     @Test func gradeObjectsEmptyWhenUnconfigured() async throws {
@@ -79,9 +102,10 @@ import XCTVapor
                 },
                 afterResponse: { res in
                     #expect(res.status == .ok)
-                    // The "not configured" message only appears on the ok:false
-                    // path, so it's a JSON-spacing-robust proxy for the failure.
-                    #expect(res.body.string.contains("not configured"))
+                    // With no identity connected for the course, the test reports
+                    // failure — a JSON-spacing-robust proxy for the ok:false path.
+                    #expect(res.body.string.contains("ok\":false"))
+                    #expect(res.body.string.contains("not connected"))
                 })
         }
     }

--- a/changelog.d/brightspace-per-instructor.md
+++ b/changelog.d/brightspace-per-instructor.md
@@ -1,0 +1,19 @@
+### Added
+
+- **Per-instructor BrightSpace grade-sync identity.** Grade sync can now push as
+  an individual instructor's connected LEARN account instead of a single
+  deployment-wide service account — the model UW requires, since a service
+  account can't be enrolled in courses but instructors already are. On the
+  instructor **LEARN** tab, "Connect my LEARN account" verifies a pasted Valence
+  User ID + User Key via `whoami` and stores it against that instructor; each
+  course designates one connected instructor (`brightspace_sync_user_id`,
+  default = whoever connects, reassignable via "Use my account for this course").
+  The sweep, manual sync, grade-object listing, connection test, and classlist
+  reconcile all resolve the course's designated identity (cached per identity in
+  a new `BrightSpaceClientRegistry`), falling back to the deployment-wide
+  (admin/env) identity when a course has none. A course whose designated
+  instructor hasn't connected yet **defers** (rows stay pending) rather than
+  clearing — so the grade pushes once they connect. The admin authorize / env
+  path is retained as the fallback identity. New columns:
+  `brightspace_credentials.user_id` (NULL = deployment-wide) and
+  `courses.brightspace_sync_user_id`.

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -12,10 +12,45 @@ operator runbook.
 
 Chickadee uses D2L's Valence **"App + User" key signing**. Every request is
 signed with two HMAC-SHA256 keys: the registered **app** key and a **user**
-key for one D2L service account. There is no token endpoint — signatures are
-computed per request (`BrightSpaceAPIClient.signed(url:method:)`). All pushes
-run *as that one service account*, so where a grade lands is decided by two
-IDs (org unit + grade object), **not** by the credentials.
+key. There is no token endpoint — signatures are computed per request
+(`BrightSpaceAPIClient.signed(url:method:)`).
+
+There are two identity models for the **user** key:
+
+- **Per-instructor (UW).** Each instructor connects their own LEARN account on
+  the instructor **LEARN** tab ("Connect my LEARN account"); each course
+  designates one connected instructor as its grade-sync identity, and pushes run
+  *as that instructor*. This is the model UW requires — a shared service account
+  can't be enrolled in courses, but instructors already are, so their key carries
+  the grade-write permission. See "Per-instructor identity" below.
+- **Deployment-wide service account (fallback).** A single env- or admin-
+  authorized key, used for every course that has no designated instructor. Where
+  a grade lands is then decided by two IDs (org unit + grade object), **not** by
+  the credentials.
+
+## Per-instructor identity
+
+Set up the deployment with only the three **app** vars (`BRIGHTSPACE_URL`,
+`BRIGHTSPACE_APP_ID`, `BRIGHTSPACE_APP_KEY`) — no `BRIGHTSPACE_USER_*`. Then each
+instructor connects their own LEARN account:
+
+1. **Connect.** On the instructor **LEARN** tab → "Connect my LEARN account",
+   paste a Valence **User ID + User Key** minted for *their* account (UW: from the
+   credential harvester `d2l-api-cred.fast.uwaterloo.ca`, Step 1C). Chickadee
+   `whoami`-verifies it and stores it against that instructor
+   (`brightspace_credentials.user_id`). Connecting also makes them the active
+   course's grade-sync identity if it has none yet.
+2. **Designate / reassign.** Each course pushes grades as one designated
+   instructor (`courses.brightspace_sync_user_id`). Any connected co-instructor
+   can take over with "Use my account for this course".
+3. **Bind + map as usual.** Org-unit binding (admin, course page), grade-item
+   mapping, and student matching (Steps 4–6) are unchanged — they just run as the
+   course's designated instructor's key.
+
+A course whose designated instructor hasn't connected yet **defers**: its results
+stay pending and push automatically once someone connects, so nothing is lost. If
+no instructor is designated, grade sync falls back to the deployment-wide service
+account (below), when one is configured.
 
 ## Credentials you need (four secrets + the URL)
 


### PR DESCRIPTION
## Why

UW won't enrol a shared service account (`sphs-dev`) into courses, and D2L grade-write permission is per-enrollment — so the single-service-account model can't work there. But **instructors are already enrolled in their own LEARN courses with grade-write**. This makes grade sync push *as the instructor*, which is also strictly safer (an instructor can only write where LEARN already lets them) and gives correct attribution.

This is **Phase 1 + the pilot slice** of the rollout plan: per-instructor credentials end-to-end, so an enrolled instructor (e.g. on `learntest`) can drive a real grade push without waiting on anyone enrolling a service account. The admin/env service-account path is **retained as a fallback**.

## What changed

**Identity & storage**
- `brightspace_credentials.user_id` (NULL = deployment-wide) + per-user `load`/`save`/`clear` in `BrightSpaceCredentialStore`; saving one scope never disturbs another.
- `courses.brightspace_sync_user_id` — the course's designated grade-sync instructor (default = whoever connects; reassignable).
- `BrightSpaceClientRegistry` caches one API client per identity (reusing its negotiated API version + clock-skew state); `resolveBrightSpaceConfigForCourse` picks the **designated instructor → deployment-wide → nil**.

**Instructor LEARN tab**
- **"Connect my LEARN account"** — verifies a pasted Valence User ID + User Key via `whoami`, stores it against the instructor, and claims the active course if it has no identity yet.
- **"Use my account for this course"** reassigns; **"Disconnect"** drops the key.
- Connection test, grade-object listing, classlist reconcile, manual sync, and the sweep all resolve the **course's** identity instead of one global client.

**Sweep**
- `sweepBrightSpaceGradeSync` takes a per-course `resolveClient` closure. A course with no connected identity **defers** (rows stay pending) rather than clearing the flag — so the grade pushes once an instructor connects. The monitor loop now gates on app-level config, not a live global client.
- Flags that meant "BrightSpace configured" move from `brightSpaceClient != nil` to `brightSpaceAppCredentials != nil` (incl. the `ResultRoutes` pending flag), so per-instructor-only deployments still flag results and render the UI.

**Migrations** are split so each column lands in dependency order on a fresh DB: `AddCourseBrightSpaceSyncUserID` *before* `AddCourseArchivedAt` (which `SELECT`s the `APICourse` model), and `AddBrightSpaceCredentialUserID` *after* `CreateBrightSpaceCredentials`.

## Tests

- Per-user store scoping & isolation (global + two instructors coexist; re-connect/disconnect touch only one scope).
- Per-course resolver precedence (designated → global → nil, incl. designated-but-disconnected falling back).
- Sweep **deferral** when no identity is connected (rows stay pending, no error).
- Configured + active-course **render** of the per-instructor connection UI.
- All 39 BrightSpace tests green; 321 tests across Admin/Result/Course/Instructor/Enrollment/AppConfig/Migration green; `swift-format` + SwiftLint `--strict` + style/CSS checks clean.

## Decisions baked in (from discussion)

- **Designated identity per course**, default = whoever connects, reassignable.
- **Admin/env service account kept** as the fallback identity.

## Follow-ups (later phases, not here)

- Move course→org-unit **binding** into the instructor tab (Phase 2; admin-set today).
- Key health / expiry surfacing; full `brightspace-setup.md` rewrite around per-instructor (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_