### PR TITLE
Instructor self-serve BrightSpace org-unit binding (Phase 2)

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -100,9 +100,31 @@ LEARN
         #else:
             <span class="tier tier-closed">not linked</span>
             This course isn't bound to a D2L org unit yet, so no grades will sync.
-            An admin sets the Org Unit ID on the course page.
         #endif
     </p>
+    <div class="bs-orgunit">
+        #if(accountConnected):
+        <form method="post" action="/instructor/brightspace/bind-org-unit" class="bs-connect-form">
+            #csrfFormField()
+            <label class="bs-connect-field">
+                <span class="bs-connect-label">D2L org unit ID</span>
+                <input class="bs-connect-input" type="text" name="orgUnitID" value="#(orgUnitID)"
+                       inputmode="numeric" autocomplete="off" placeholder="e.g. 1106038">
+            </label>
+            <button class="btn btn-primary" type="submit">Link course</button>
+        </form>
+        <p class="card-meta bs-section-note">
+            The org unit is the number in the course's D2L URL
+            (…/d2l/home/<strong>1106038</strong>). It's verified with your LEARN key, and
+            this course will sync grades as your account. Leave blank and save to unlink.
+            An admin can also set it on the course page.
+        </p>
+        #else:
+        <p class="card-meta bs-section-note">
+            Connect your LEARN account above to link this course to its D2L org unit.
+        </p>
+        #endif
+    </div>
 </section>
 
 <!-- ── Summary ───────────────────────────────────────────── -->
@@ -287,6 +309,7 @@ LEARN
 .bs-connect-field { display: flex; flex-direction: column; gap: .2rem; }
 .bs-connect-label { font-size: .78rem; color: var(--gray-600); }
 .bs-connect-input { width: 16rem; max-width: 100%; font-size: .85rem; padding: .3rem .45rem; }
+.bs-orgunit { margin-top: .7rem; }
 .bs-summary-actions { display: flex; gap: .5rem; flex-wrap: wrap; margin-top: .9rem; }
 .bs-section-note { margin: 0 0 .6rem; max-width: 62ch; }
 .bs-grade-form { display: flex; gap: .4rem; align-items: center; margin: 0; }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -193,6 +193,79 @@ extension InstructorDashboardRoutes {
         return req.redirect(to: "/instructor/brightspace")
     }
 
+    // MARK: - POST /instructor/brightspace/bind-org-unit
+
+    /// Instructor self-serve org-unit binding: sets (or clears) the active
+    /// course's D2L org unit, makes the binder the course's grade-sync identity
+    /// (the "binder = default" rule), and verifies the org unit with that
+    /// instructor's own LEARN key. Requires the instructor to have connected —
+    /// verification and every subsequent push run as their key, so a key that
+    /// can't see the org unit fails loudly here instead of at grade-push time.
+    @Sendable
+    func brightspaceBindOrgUnit(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard let userUUID = user.id else {
+            req.session.data["bs_flash_error"] = "Could not resolve your account."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        struct BindForm: Content { let orgUnitID: String? }
+        let rawOrgUnit = (try req.content.decode(BindForm.self).orgUnitID ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else {
+            req.session.data["bs_flash_error"] = "No active course."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        // Clearing the binding (blank submit) — leave the sync identity alone.
+        if rawOrgUnit.isEmpty {
+            course.brightspaceOrgUnitID = nil
+            course.brightspaceOrgUnitName = nil
+            try await course.save(on: req.db)
+            req.session.data["bs_flash_success"] = "Org-unit binding cleared."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        // Binding requires a connected key — the org unit is verified with it,
+        // and pushes run as it.
+        guard try await BrightSpaceCredentialStore.load(userID: userUUID, on: req.db) != nil else {
+            req.session.data["bs_flash_error"] =
+                "Connect your LEARN account first — the org unit is verified with your key."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        // The binder becomes the course's sync identity, then we verify the org
+        // unit using their (now course-resolved) key.
+        course.brightspaceOrgUnitID = rawOrgUnit
+        course.brightspaceSyncUserID = userUUID
+        course.brightspaceOrgUnitName = nil
+        try await course.save(on: req.db)
+
+        guard let client = try await req.application.brightSpaceClient(forCourse: course) else {
+            req.session.data["bs_flash_success"] = "Org unit \(rawOrgUnit) saved (unverified)."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        do {
+            if let info = try await client.getOrgUnit(orgUnitID: rawOrgUnit, on: req.application) {
+                course.brightspaceOrgUnitName = info.name
+                try await course.save(on: req.db)
+                req.session.data["bs_flash_success"] =
+                    "Linked to \(info.name) (org unit \(rawOrgUnit)); this course syncs grades as your LEARN account."
+            } else {
+                req.session.data["bs_flash_error"] =
+                    "Saved org unit \(rawOrgUnit), but D2L reports no such org unit (or your key can't see it) — check the ID."
+            }
+        } catch {
+            req.logger.warning("BrightSpace org-unit verification failed for \(rawOrgUnit): \(error)")
+            req.session.data["bs_flash_error"] =
+                "Saved org unit \(rawOrgUnit), but couldn't verify it in D2L: \(error.localizedDescription)"
+        }
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
     // MARK: - GET /instructor/brightspace/grade-objects
 
     /// Lists the active course's D2L grade items for the mapping dropdown.

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -49,6 +49,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post("brightspace", "connect", use: brightspaceConnectAccount)
         r.post("brightspace", "use-my-identity", use: brightspaceUseMyIdentity)
         r.post("brightspace", "disconnect", use: brightspaceDisconnectAccount)
+        r.post("brightspace", "bind-org-unit", use: brightspaceBindOrgUnit)
         r.get("brightspace", "grade-objects", use: brightspaceGradeObjects)
         r.post("brightspace", "sync-now", use: brightspaceSyncNow)
         r.post("brightspace", "retry-failed", use: brightspaceRetryFailed)

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -70,6 +70,84 @@ import XCTVapor
         }
     }
 
+    @Test func brightspacePageShowsBindFormWhenConnected() async throws {
+        try await withAssignmentRoutesApp { app in
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.test", appID: "a", appKey: "k", debounceSecs: 90)
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "testinstructor").first())
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "vu", valenceUserKey: "vk", identityName: "Test Instructor",
+                capturedByUserID: instructor.id, userID: instructor.id, on: app.db)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("D2L org unit ID"))
+                    #expect(html.contains("Link course"))
+                    #expect(html.contains("Connected as"))
+                })
+        }
+    }
+
+    // MARK: - Org-unit binding (instructor self-serve)
+
+    @Test func bindOrgUnitRejectedWhenNotConnected() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/bind-org-unit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(["orgUnitID": "1106038"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+            // Not connected → binding is refused, course untouched.
+            let course = try #require(try await APICourse.find(courseID, on: app.db))
+            #expect(course.brightspaceOrgUnitID == nil)
+            #expect(course.brightspaceSyncUserID == nil)
+        }
+    }
+
+    @Test func bindOrgUnitSetsBindingAndSyncIdentityWhenConnected() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "testinstructor").first())
+            // Simulate a connected LEARN account for the instructor.
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "vu", valenceUserKey: "vk", identityName: "Test Instructor",
+                capturedByUserID: instructor.id, userID: instructor.id, on: app.db)
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/bind-org-unit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    try req.content.encode(["orgUnitID": "1106038"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+            // The binder is recorded as the org unit + the course's sync identity
+            // (verification is skipped here — no app creds → no live D2L call).
+            let course = try #require(try await APICourse.find(courseID, on: app.db))
+            #expect(course.brightspaceOrgUnitID == "1106038")
+            #expect(course.brightspaceSyncUserID == instructor.id)
+        }
+    }
+
     // MARK: - Grade-objects feed
 
     @Test func gradeObjectsEmptyWhenUnconfigured() async throws {

--- a/changelog.d/brightspace-instructor-binding.md
+++ b/changelog.d/brightspace-instructor-binding.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Instructor self-serve BrightSpace org-unit binding.** Instructors can now
+  link a course to its D2L org unit directly from the LEARN tab (previously
+  admin-only on the course page). The org unit is verified with the instructor's
+  own connected LEARN key — so a key that can't see the org unit fails loudly at
+  bind time instead of at grade-push time — and binding makes the instructor the
+  course's grade-sync identity (the "binder = default" rule). Requires a connected
+  account; the admin course-page binding remains as an override.


### PR DESCRIPTION
## Why

Phase 2 of the per-instructor BrightSpace rollout (builds on #975). Course→org-unit binding was admin-only on the course page; moving it onto the instructor LEARN tab is what makes the per-instructor flow self-serve, and it implements the **"binder = default sync identity"** decision.

## What changed

New `POST /instructor/brightspace/bind-org-unit`:
- **Requires the instructor to have connected their LEARN account** — the org unit is verified with *their* key, and pushes run as it, so a key that can't see the org unit fails loudly at bind time rather than silently at grade-push time.
- Sets the course's org unit and makes the binder the course's **grade-sync identity** (`brightspace_sync_user_id`) — the binder-default rule.
- Verifies via `getOrgUnit` using the instructor's course-resolved client, caching the D2L name (or surfacing "no such org unit / your key can't see it" on failure). A blank submit unlinks.
- The admin course-page binding stays as an override.

The LEARN tab "Org-unit link" section now renders an inline **"Link course"** form (org-unit ID input) when the instructor is connected, replacing the old "an admin sets it" note.

## Tests

- Bind refused when not connected (course untouched).
- Bind sets org unit **and** sync identity when connected.
- Bind form renders for a connected instructor.
- 42 BrightSpace tests green post-rebase; `swift-format` + SwiftLint `--strict` + style/CSS checks clean.

## Rollout status

- **Phase 1** ✅ merged (#975) — per-instructor credentials + identity-aware sync.
- **Phase 2** ← this PR — instructor self-serve binding.
- **Phase 4** next — paged classlist reconcile UI, key-health/expiry surfacing, full `brightspace-setup.md` rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_