### PR TITLE
BrightSpace sync-identity health visibility (Phase 4)

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -31,8 +31,8 @@ LEARN
     #if(accountConnected):
     <p class="card-meta bs-section-note">
         <span class="tier tier-open">connected</span>
-        Connected as <strong>#(accountIdentity)</strong>. Courses that sync as you push
-        grades under this LEARN identity.
+        Connected as <strong>#(accountIdentity)</strong>#(accountConnectedSince).
+        Courses that sync as you push grades under this LEARN identity.
     </p>
     <div class="bs-connection-row">
         #if(syncIdentityIsMe):
@@ -67,11 +67,20 @@ LEARN
         <button class="btn btn-primary" type="submit">Connect</button>
     </form>
     #endif
-    #if(syncIdentityName):
+    #if(syncIdentityConnected):
     <p class="card-meta bs-connection-note">
         This course pushes grades as: <strong>#(syncIdentityName)</strong>.
     </p>
-    #else:
+    #endif
+    #if(syncIdentityNeedsReconnect):
+    <p class="card-meta bs-connection-note">
+        <span class="tier tier-closed">needs reconnect</span>
+        This course is set to sync as <strong>#(syncIdentityName)</strong>, but that account
+        is disconnected — grades are <strong>paused</strong> until they reconnect, or another
+        connected instructor takes over with "Use my account for this course".
+    </p>
+    #endif
+    #if(!syncIdentityName):
     <p class="card-meta bs-connection-note">
         <span class="tier tier-closed">no identity</span>
         No LEARN identity is connected for this course yet, so grades won't sync.

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -84,11 +84,21 @@ struct InstructorBrightspaceContext: Encodable {
     let accountConnected: Bool
     /// The requesting instructor's connected LEARN identity (whoami display).
     let accountIdentity: String?
+    /// When the requesting instructor connected their account (formatted), if connected.
+    let accountConnectedSince: String?
     /// Display name of the identity this course pushes grades as (its designated
     /// instructor, or the deployment-wide fallback). Nil = no identity connected.
     let syncIdentityName: String?
     /// True when the course's designated sync identity is the requesting user.
     let syncIdentityIsMe: Bool
+    /// False when the course names a designated instructor who no longer has a
+    /// stored key (disconnected) — grades are deferring until they reconnect.
+    let syncIdentityConnected: Bool
+    /// True when there's a designated identity but it's disconnected (the
+    /// "needs reconnect" / grades-paused state). Pre-computed so the template
+    /// can branch with flat sibling conditionals (LeafKit 1.14.2 mis-parses
+    /// `#if` nested inside an `#if/#else`).
+    let syncIdentityNeedsReconnect: Bool
     let flashSuccess: String?
     let flashError: String?
     let assignmentRows: [BrightspaceAssignmentRow]

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -385,6 +385,29 @@ extension InstructorDashboardRoutes {
         )
     }
 
+    /// Resolves how the active course's grade-sync identity is shown: the display
+    /// name (designated instructor, the disconnected instructor's username, or the
+    /// deployment-wide fallback), whether that identity still has a stored key, and
+    /// whether it's the requesting user.
+    private func resolveSyncIdentityDisplay(
+        course: APICourse, user: APIUser, req: Request
+    ) async throws -> (name: String?, connected: Bool, isMe: Bool) {
+        let isMe = course.brightspaceSyncUserID != nil && course.brightspaceSyncUserID == user.id
+        if let syncUserID = course.brightspaceSyncUserID {
+            if let cred = try await BrightSpaceCredentialStore.load(userID: syncUserID, on: req.db) {
+                return (cred.identityName, true, isMe)
+            }
+            // Designated but disconnected — fall back to the username so the UI
+            // can flag that the identity needs to reconnect.
+            let username = try await APIUser.find(syncUserID, on: req.db)?.username
+            return (username, false, isMe)
+        }
+        if req.application.brightSpaceClient != nil {
+            return ("Deployment default account", true, isMe)
+        }
+        return (nil, false, isMe)
+    }
+
     /// Assembles the full BrightSpace-tab context for the active course.
     private func buildBrightspaceContext(
         req: Request, user: APIUser
@@ -404,6 +427,8 @@ extension InstructorDashboardRoutes {
         req.session.data["bs_flash_success"] = nil
         req.session.data["bs_flash_error"] = nil
 
+        let fmt = waterlooDateTimeFormatter()
+
         // This instructor's own LEARN connection (course-independent).
         let myCredential: APIBrightSpaceCredential?
         if let uid = user.id {
@@ -413,6 +438,10 @@ extension InstructorDashboardRoutes {
         }
         let accountConnected = myCredential != nil
         let accountIdentity = myCredential?.identityName
+        // Pre-rendered " (since …)" suffix (empty when nil) so the template
+        // interpolates it directly — avoids an inline `#if` in the middle of a
+        // sentence, which LeafKit 1.14.2 mis-parses.
+        let accountConnectedSince = myCredential?.capturedAt.map { " (since \(fmt.string(from: $0)))" }
 
         guard let courseUUID = courseState.activeCourseUUID,
             let course = try await APICourse.find(courseUUID, on: req.db)
@@ -423,7 +452,9 @@ extension InstructorDashboardRoutes {
                 brightspaceSyncEnabled: syncEnabled, courseLinked: false,
                 orgUnitID: nil, orgUnitName: nil,
                 accountConnected: accountConnected, accountIdentity: accountIdentity,
+                accountConnectedSince: accountConnectedSince,
                 syncIdentityName: nil, syncIdentityIsMe: false,
+                syncIdentityConnected: false, syncIdentityNeedsReconnect: false,
                 flashSuccess: flashSuccess, flashError: flashError,
                 assignmentRows: [], hasAssignments: false,
                 logRows: [], hasLog: false,
@@ -433,23 +464,12 @@ extension InstructorDashboardRoutes {
 
         let orgUnitID = course.brightspaceOrgUnitID
         let courseLinked = !(orgUnitID ?? "").isEmpty
-        let fmt = waterlooDateTimeFormatter()
 
-        // The identity this course pushes grades as: its designated instructor
-        // (resolved to a display label), else the deployment-wide fallback.
-        var syncIdentityName: String?
-        let syncIdentityIsMe = course.brightspaceSyncUserID != nil && course.brightspaceSyncUserID == user.id
-        if let syncUserID = course.brightspaceSyncUserID {
-            if let cred = try await BrightSpaceCredentialStore.load(userID: syncUserID, on: req.db) {
-                syncIdentityName = cred.identityName
-            } else {
-                // Designated but disconnected — fall back to the username so the
-                // UI can flag that the identity needs to reconnect.
-                syncIdentityName = try await APIUser.find(syncUserID, on: req.db)?.username
-            }
-        } else if req.application.brightSpaceClient != nil {
-            syncIdentityName = "Deployment default account"
-        }
+        // How the course's grade-sync identity is shown + whether it's still connected.
+        let syncIdentity = try await resolveSyncIdentityDisplay(course: course, user: user, req: req)
+        let syncIdentityName = syncIdentity.name
+        let syncIdentityConnected = syncIdentity.connected
+        let syncIdentityIsMe = syncIdentity.isMe
 
         // Assignments, sorted to match the dashboard ordering.
         let assignments = try await APIAssignment.query(on: req.db)
@@ -508,7 +528,10 @@ extension InstructorDashboardRoutes {
             brightspaceSyncEnabled: syncEnabled, courseLinked: courseLinked,
             orgUnitID: orgUnitID, orgUnitName: course.brightspaceOrgUnitName,
             accountConnected: accountConnected, accountIdentity: accountIdentity,
+            accountConnectedSince: accountConnectedSince,
             syncIdentityName: syncIdentityName, syncIdentityIsMe: syncIdentityIsMe,
+            syncIdentityConnected: syncIdentityConnected,
+            syncIdentityNeedsReconnect: syncIdentityName != nil && !syncIdentityConnected,
             flashSuccess: flashSuccess, flashError: flashError,
             assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
             logRows: logRows, hasLog: !logRows.isEmpty,

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -94,6 +94,31 @@ import XCTVapor
         }
     }
 
+    @Test func brightspacePageWarnsWhenSyncIdentityDisconnected() async throws {
+        try await withAssignmentRoutesApp { app in
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.test", appID: "a", appKey: "k", debounceSecs: 90)
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            // Designate a user as the course's sync identity but give them NO stored
+            // key (disconnected) → the page must flag "needs reconnect".
+            let ghost = try await makeTestUser(
+                on: app, username: "ghost_\(UUID().uuidString.lowercased().prefix(6))")
+            let course = try #require(try await APICourse.find(courseID, on: app.db))
+            course.brightspaceSyncUserID = ghost.id
+            try await course.save(on: app.db)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("needs reconnect"))
+                    #expect(html.contains("paused"))
+                })
+        }
+    }
+
     // MARK: - Org-unit binding (instructor self-serve)
 
     @Test func bindOrgUnitRejectedWhenNotConnected() async throws {

--- a/changelog.d/brightspace-identity-health.md
+++ b/changelog.d/brightspace-identity-health.md
@@ -1,0 +1,9 @@
+### Added
+
+- **BrightSpace sync-identity health on the LEARN tab.** The instructor LEARN
+  tab now shows when you connected your LEARN account ("connected since …") and,
+  when a course's designated grade-sync instructor has **disconnected**, flags it
+  **"needs reconnect"** — making the deferred (grades-paused) state visible rather
+  than silent. Another connected instructor can take the course over with "Use my
+  account for this course". `docs/brightspace-setup.md` Step 4 updated for the
+  instructor self-serve binding + the disconnected-identity behaviour.

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -43,9 +43,9 @@ instructor connects their own LEARN account:
 2. **Designate / reassign.** Each course pushes grades as one designated
    instructor (`courses.brightspace_sync_user_id`). Any connected co-instructor
    can take over with "Use my account for this course".
-3. **Bind + map as usual.** Org-unit binding (admin, course page), grade-item
-   mapping, and student matching (Steps 4–6) are unchanged — they just run as the
-   course's designated instructor's key.
+3. **Bind + map.** Link the course to its org unit from the LEARN tab
+   ("Link course"), then map grade items and match students (Steps 4–6) — all
+   run as the course's designated instructor's key.
 
 A course whose designated instructor hasn't connected yet **defers**: its results
 stay pending and push automatically once someone connects, so nothing is lost. If
@@ -230,16 +230,28 @@ fastest auth smoke test — a bad key pair fails here, before any grade is at
 risk. (The helper in Step 1 already runs the same check, so if that passed
 this should too.)
 
-## Step 4 — Bind the course to its org unit (admin only)
+## Step 4 — Bind the course to its org unit
 
 A grade lands in a D2L **course**, identified by its **org unit ID** — the
 number in the course URL: `…/d2l/home/1106038` → org unit `1106038`.
 
-As an **admin**, on the Chickadee **course page**, set the BrightSpace
-org-unit ID. The server verifies it on save (`getOrgUnit`) and caches the D2L
-course name back into the page — **confirm that name matches** the course you
-intended. This is admin-only because the service account can usually write to
-many courses; instructors are then locked to their bound course.
+**Per-instructor (UW):** on the instructor **LEARN** tab, the **"Link course"**
+form sets the org-unit ID. The server verifies it with *your* connected LEARN
+key (`getOrgUnit`) and caches the D2L course name — **confirm that name matches**
+the course you intended. Binding also makes you the course's grade-sync identity.
+If your key can't see the org unit, verification fails at bind time (a clear
+signal you're not enrolled / it's the wrong ID) rather than silently at
+grade-push time.
+
+**Admin override:** an admin can still set the org-unit ID on the Chickadee
+**course page** (verified with the deployment-wide identity), e.g. for the
+shared-service-account model.
+
+> **Disconnected sync identity.** If the instructor a course syncs as later
+> disconnects their LEARN account, the LEARN tab flags the course **"needs
+> reconnect"** and grades **defer** (results stay pending, nothing is lost) until
+> they reconnect — or another connected instructor takes it over with "Use my
+> account for this course".
 
 ## Step 5 — Map each assignment to a grade item
 


### PR DESCRIPTION
## Why

Phase 4 (final code phase) of the per-instructor BrightSpace rollout (builds on #975/#976). Phase 1 made a course **defer** grade sync when its designated instructor has no connected key — correct, but **silent**. This surfaces that state so an instructor isn't left wondering why grades aren't flowing.

## What changed

On the instructor **LEARN** tab:
- **"connected since …"** on your own account line (from the credential's `captured_at`).
- A **"needs reconnect"** warning when a course's designated grade-sync instructor has **disconnected** — it says grades are **paused** until they reconnect, or a co-instructor takes over with "Use my account for this course".

Driven by new context fields `accountConnectedSince` / `syncIdentityConnected` / `syncIdentityNeedsReconnect`. The sync-identity display resolution is factored into `resolveSyncIdentityDisplay` (keeps `buildBrightspaceContext` under the body-length limit).

`docs/brightspace-setup.md` Step 4 rewritten for the instructor self-serve binding + the disconnected-identity behaviour.

## Tests

- The LEARN tab flags **"needs reconnect"** + "paused" when a course designates a disconnected identity.
- 43 BrightSpace tests green post-rebase; `swift-format` + SwiftLint `--strict` + style/CSS checks clean.

## Note on LeafKit

The "(since …)" suffix is pre-rendered server-side and the identity states use flat sibling conditionals — both deliberately avoid LeafKit 1.14.2 mis-parsing an inline/nested `#if` (an inline `#if` missing its `:` colon, or an `#if` nested inside an `#if/#else`, throws an `else`/`else` match error template-wide).

## Rollout status — done

- **Phase 1** ✅ merged (#975) — per-instructor credentials + identity-aware sync (Phase 3 folded in).
- **Phase 2** ✅ merged (#976) — instructor self-serve org-unit binding.
- **Phase 4** ← this PR — sync-identity health visibility + docs.
- **Phase 5** is operational: connect your LEARN account on `learntest`, bind 1106038, map an assignment, push end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_