### PR TITLE
Adjustable per-test execution time limit (assignment default + per-script override, via MCP)

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -272,6 +272,22 @@
             points: typeof entry.points === 'number' ? entry.points : 1,
         }));
 
+        // Per-script execution time-limit overrides (script name -> seconds).
+        // Resolved here, in the browser executor, NOT inside the shared
+        // RunnerCore wasm `executeSuites` loop — which is the wasm-pinned shared
+        // implementation and keeps receiving only the assignment default. The
+        // effective limit for a script is `perEntryTimeLimit[name] ?? limit`
+        // (mirrors the worker's NativeScriptExecutor.resolveTimeLimit). Only a
+        // positive number counts as an override; anything else inherits the
+        // assignment default.
+        const perEntryTimeLimit = {};
+        for (const entry of (manifest.testSuites || [])) {
+            if (entry && typeof entry.script === 'string'
+                && typeof entry.timeLimitSeconds === 'number' && entry.timeLimitSeconds > 0) {
+                perEntryTimeLimit[entry.script] = entry.timeLimitSeconds;
+            }
+        }
+
         // Section metadata, so the inline results can be grouped per section
         // exactly like the server-rendered submission view. Kept as a parallel
         // array (never stamped onto the outcomes, which must stay the canonical
@@ -296,7 +312,10 @@
         const executor = makeExecutor(files, assignmentSeed, runnerCore);
         try {
             const scriptExists = (name) => executor.scriptExists(name);
-            const runScript    = (name, limit) => executor.run(name, limit);
+            // Apply the per-script override before handing the limit to the
+            // executor. `limit` is the assignment default the wasm loop passes;
+            // a per-entry override (when present) wins for that one script.
+            const runScript    = (name, limit) => executor.run(name, perEntryTimeLimit[name] ?? limit);
 
             // Shared RunnerCore (wasm): the SAME Swift `executeSuites` loop the
             // native worker runs. Dependency gating, the "Skipped: prerequisite…"

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -171,6 +171,8 @@ enum MCPServerInstructions {
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \
+        set_time_limit (the assignment's default per-test timeout in seconds; a hand-written script \
+        can override it per-test via author_script / update_suite timeLimitSeconds), \
         update_suite (script metadata). To add or change a GRADED test, prefer Chickadee's native \
         check types — update_pattern_family (edit a family's defaults/cases) / create_pattern_family \
         (add a new family) and author_notebook_check (create/replace a notebook check) — over a \
@@ -226,8 +228,8 @@ enum MCPServerInstructions {
         you can see which check failed and why before fixing the suite or solution. It is \
         validation-only: it resolves the instructor's own reference-solution run and never exposes a \
         student submission, identity, or grade. \
-        Metadata-only edits (update_assignment, set_grading_mode, update_achievements, the \
-        section-organization tools) never trigger a regrade or a close.
+        Metadata-only edits (update_assignment, set_grading_mode, set_time_limit, \
+        update_achievements, the section-organization tools) never trigger a regrade or a close.
         - update_notebook replaces only the starter notebook; students keep their in-progress copies \
         and pick up the new notebook when their copy is next reset. Call get_notebook first and edit \
         the returned JSON.

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -44,6 +44,11 @@ struct AuthorScriptTool: ContentTool {
         let displayName: String?
         let dependsOn: [String]?
         let sectionID: String?
+        /// Per-test execution time limit override (seconds) for a test tier. A
+        /// value in 1...600 sets the override; 0 clears it (revert to the
+        /// assignment default); absent/null leaves an existing script's
+        /// override unchanged and a new script on the assignment default.
+        let timeLimitSeconds: Int?
     }
 
     struct Output: Encodable, Sendable {
@@ -82,7 +87,9 @@ struct AuthorScriptTool: ContentTool {
         + "\"support\" for a helper file that tests or personalization expressions can import but that "
         + "is not itself graded; omit tier to keep an existing file's kind (new files default to a "
         + "public test). For test tiers you may also set points, displayName, dependsOn (prerequisite "
-        + "script names or family:<id> tokens), and sectionID (an existing section). Cannot edit "
+        + "script names or family:<id> tokens), sectionID (an existing section), and timeLimitSeconds "
+        + "(a per-test execution time-limit override in seconds, 1–600; 0 clears it so the script uses "
+        + "the assignment default). Cannot edit "
         + "pattern-family or notebook-check generated scripts — edit the family/check instead. Saving "
         + "re-runs the assignment's validation and closes the assignment if it was open (re-open with "
         + "update_assignment once validation passes)."
@@ -144,6 +151,14 @@ struct AuthorScriptTool: ContentTool {
                 "description": .string(
                     "Existing section id to place a test row into (test tiers only); "
                         + "an unknown id is treated as ungrouped."),
+            ]),
+            "timeLimitSeconds": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Per-test execution time-limit override in seconds for a test tier "
+                        + "(\(mcpTimeLimitRange.lowerBound)–\(mcpTimeLimitRange.upperBound)); 0 clears the "
+                        + "override (revert to the assignment default set by set_time_limit). Ignored for "
+                        + "support files."),
             ]),
         ]),
         // content/sourceUrl are a one-of (validated in execute), so neither is
@@ -345,6 +360,11 @@ struct AuthorScriptTool: ContentTool {
         let normalizedSection = input.sectionID.flatMap { $0.isEmpty ? nil : $0 }
         let displayName = input.displayName.flatMap { $0.isEmpty ? nil : $0 }
         let points = max(0, input.points ?? 1)
+        // Resolve the override: a value in 1...600 sets it; 0 clears it; nil
+        // means "leave unchanged on replace / default on create".
+        let validatedLimit: Int? = try input.timeLimitSeconds.map { limit in
+            limit == 0 ? 0 : try validateTimeLimitSeconds(limit, tool: Self.name, field: "timeLimitSeconds")
+        }
 
         if let idx = payload.items.firstIndex(where: { $0.kind == "script" && $0.script?.script == filename }) {
             // Replace an existing hand-written script. Content + tier always
@@ -355,6 +375,9 @@ struct AuthorScriptTool: ContentTool {
             if let dn = input.displayName { payload.items[idx].script?.displayName = dn.isEmpty ? nil : dn }
             if let deps = input.dependsOn { payload.items[idx].script?.dependsOn = deps }
             if input.sectionID != nil { payload.items[idx].sectionID = normalizedSection }
+            if let validatedLimit {
+                payload.items[idx].script?.timeLimitSeconds = validatedLimit == 0 ? nil : validatedLimit
+            }
         } else {
             // Create a new hand-written script. Insert it adjacent to its
             // section's existing block (or the ungrouped block) so the
@@ -362,7 +385,8 @@ struct AuthorScriptTool: ContentTool {
             let dto = ScriptDTO(
                 script: filename, tier: tier, points: points,
                 displayName: displayName, dependsOn: input.dependsOn ?? [],
-                content: content, hint: nil)
+                content: content, hint: nil,
+                timeLimitSeconds: (validatedLimit == 0 ? nil : validatedLimit))
             let item = SuiteItemDTO(
                 kind: "script", script: dto, family: nil, check: nil,
                 dependsOn: nil, sectionID: normalizedSection)

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -62,6 +62,12 @@ struct GetSuiteTool: ContentTool {
             let content: String?
             /// Instructor hint for a hand-written script (`kind == "script"`).
             let hint: String?
+            /// Per-test execution time-limit override (seconds) for a
+            /// hand-written script (`kind == "script"`), when one is set; nil
+            /// means the script inherits the assignment default
+            /// (`timeLimitSeconds` at the top level). Generated family/check
+            /// rows always inherit the default, so this is nil for them.
+            let timeLimitSeconds: Int?
             /// Full pattern-family spec — function, kind, paramNames, defaults
             /// (including the family `hint`), variables, and every case's
             /// args/expected/hint — for `kind == "family"` items. This is the
@@ -74,6 +80,9 @@ struct GetSuiteTool: ContentTool {
         let assignmentPublicID: String
         let sections: [Section]
         let items: [Item]
+        /// The assignment-wide default per-test execution time limit (seconds).
+        /// Every item without its own `timeLimitSeconds` override uses this.
+        let timeLimitSeconds: Int
     }
 
     static let name = "get_suite"
@@ -86,9 +95,11 @@ struct GetSuiteTool: ContentTool {
         + "(`family`) with every case's args and expected value; notebook checks include their "
         + "spec (`check`). For hand-written scripts, `filename` is the exact value to pass to "
         + "`author_script` / `update_suite`; generated rows list the file(s) they produce in "
-        + "`generatedFilenames` (read-only — edit the family/check instead). Read-only — use this "
-        + "to inspect exactly what each test checks (e.g. to explain why a submission lost points) "
-        + "before editing the suite."
+        + "`generatedFilenames` (read-only — edit the family/check instead). The response also "
+        + "reports the assignment's default per-test execution time limit (`timeLimitSeconds` at the "
+        + "top level) and any per-script override (`timeLimitSeconds` on a script item). Read-only — "
+        + "use this to inspect exactly what each test checks (e.g. to explain why a submission lost "
+        + "points) before editing the suite."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -104,6 +115,12 @@ struct GetSuiteTool: ContentTool {
         "type": .string("object"),
         "properties": .object([
             "assignmentPublicID": .object(["type": .string("string")]),
+            "timeLimitSeconds": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "The assignment-wide default per-test execution time limit (seconds); every item "
+                        + "without its own override uses this."),
+            ]),
             "sections": .object([
                 "type": .string("array"),
                 "items": .object([
@@ -157,6 +174,12 @@ struct GetSuiteTool: ContentTool {
                             "type": .string("string"),
                             "description": .string("Instructor hint for a hand-written script."),
                         ]),
+                        "timeLimitSeconds": .object([
+                            "type": .string("integer"),
+                            "description": .string(
+                                "Per-test execution time-limit override (seconds) for a hand-written "
+                                    + "script; absent means it inherits the assignment default."),
+                        ]),
                         "family": .object([
                             "type": .string("object"),
                             "description": .string(
@@ -179,6 +202,7 @@ struct GetSuiteTool: ContentTool {
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("sections"), .string("items"),
+            .string("timeLimitSeconds"),
         ]),
     ])
     static let requiredScopes: Set<ContentScope> = [.read]
@@ -224,7 +248,12 @@ struct GetSuiteTool: ContentTool {
         let items = payload.items.map {
             Self.item(from: $0, generatedByFamily: generatedByFamily, generatedByCheck: generatedByCheck)
         }
-        return Output(assignmentPublicID: assignment.publicID, sections: sections, items: items)
+        // The assignment-wide default every override-less item inherits.
+        // Falls back to the model default (10) for an undecodable manifest.
+        let defaultTimeLimit = manifest?.timeLimitSeconds ?? 10
+        return Output(
+            assignmentPublicID: assignment.publicID, sections: sections, items: items,
+            timeLimitSeconds: defaultTimeLimit)
     }
 
     private static func item(
@@ -248,6 +277,7 @@ struct GetSuiteTool: ContentTool {
                 familyID: family?.id,
                 content: nil,
                 hint: nil,
+                timeLimitSeconds: nil,
                 family: family,
                 check: nil)
         case "check":
@@ -265,6 +295,7 @@ struct GetSuiteTool: ContentTool {
                 familyID: nil,
                 content: nil,
                 hint: nil,
+                timeLimitSeconds: nil,
                 family: nil,
                 check: check)
         default:
@@ -282,6 +313,7 @@ struct GetSuiteTool: ContentTool {
                 familyID: nil,
                 content: script?.content,
                 hint: script?.hint,
+                timeLimitSeconds: script?.timeLimitSeconds,
                 family: nil,
                 check: nil)
         }

--- a/Sources/APIServer/MCP/Tools/MCPTimeLimitValidation.swift
+++ b/Sources/APIServer/MCP/Tools/MCPTimeLimitValidation.swift
@@ -1,0 +1,30 @@
+// APIServer/MCP/Tools/MCPTimeLimitValidation.swift
+//
+// Shared bound check for the execution time-limit MCP inputs — the
+// assignment-wide default (set_time_limit) and the per-script override
+// (author_script / update_suite). A limit is an integer number of seconds in
+// `1...600`; rejecting 0/negative/huge values with one consistent message keeps
+// the three call sites honest.
+
+import Core
+
+/// The accepted closed range (seconds) for any execution time limit set over
+/// MCP — both the assignment-wide default and a per-test override.
+let mcpTimeLimitRange: ClosedRange<Int> = 1...600
+
+/// Validates that `seconds` is an integer in `mcpTimeLimitRange`, throwing
+/// `invalidArguments` otherwise. `field` names the offending argument in the
+/// error message. Returns the validated value for convenient inlining.
+@discardableResult
+func validateTimeLimitSeconds(
+    _ seconds: Int, tool: String, field: String = "seconds"
+) throws -> Int {
+    guard mcpTimeLimitRange.contains(seconds) else {
+        throw MCPToolError.invalidArguments(
+            tool: tool,
+            detail:
+                "\(field) must be an integer between \(mcpTimeLimitRange.lowerBound) and "
+                + "\(mcpTimeLimitRange.upperBound) seconds (got \(seconds)).")
+    }
+    return seconds
+}

--- a/Sources/APIServer/MCP/Tools/SetTimeLimitTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetTimeLimitTool.swift
@@ -1,0 +1,100 @@
+// APIServer/MCP/Tools/SetTimeLimitTool.swift
+//
+// Write tool: set an assignment's default per-test execution time limit (the
+// number of seconds a single test script may run before it is killed and
+// recorded as a timeout), by assignment public ID. content:write,
+// course-scoped.
+//
+// The default lives in the test setup's manifest (`timeLimitSeconds`). A
+// per-script override can be set on a hand-written script via author_script /
+// update_suite; this tool sets the assignment-wide fallback that every test
+// without an override uses. Like set_grading_mode, this is metadata-style: it
+// changes a grading-environment knob, not what the tests check, so it does NOT
+// re-grade existing submissions, re-run validation, or close the assignment.
+
+import Core
+import Fluent
+import Foundation
+
+struct SetTimeLimitTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// Default per-test time limit in seconds (integer, 1...600).
+        let seconds: Int
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        let timeLimitSeconds: Int
+    }
+
+    static let name = "set_time_limit"
+    static let description =
+        "Set an assignment's default per-test execution time limit (seconds) by its public ID — the "
+        + "number of seconds one test script may run before it is killed and recorded as a timeout. "
+        + "This is the assignment-wide fallback; a hand-written script can override it per-test via "
+        + "author_script / update_suite (timeLimitSeconds), and get_suite reports both the default and "
+        + "any per-script overrides. seconds must be an integer between 1 and 600. Changing the limit "
+        + "is a grading-environment knob, not a change to what the tests check, so it does NOT "
+        + "re-grade existing submissions, re-run validation, or change the open/closed state (matching "
+        + "set_grading_mode)."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object([
+                "type": .string("string"),
+                "description": .string("The assignment's 6-character public ID."),
+            ]),
+            "seconds": .object([
+                "type": .string("integer"),
+                "minimum": .int(mcpTimeLimitRange.lowerBound),
+                "maximum": .int(mcpTimeLimitRange.upperBound),
+                "description": .string(
+                    "Default per-test time limit in seconds (integer, "
+                        + "\(mcpTimeLimitRange.lowerBound)–\(mcpTimeLimitRange.upperBound))."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("seconds")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": .object(["type": .string("string")]),
+            "timeLimitSeconds": .object(["type": .string("integer")]),
+        ]),
+        "required": .array([.string("assignmentPublicID"), .string("timeLimitSeconds")]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        let seconds = try validateTimeLimitSeconds(input.seconds, tool: Self.name)
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+            publicID: input.assignmentPublicID, tool: Self.name)
+        let effective = try await setManifestTimeLimitSeconds(setup: setup, to: seconds, on: context.db)
+        return Output(assignmentPublicID: assignment.publicID, timeLimitSeconds: effective)
+    }
+}
+
+/// Sets the test setup's default `timeLimitSeconds` to `seconds` when it
+/// differs, mutating only that JSON field (so unknown fields the runner doesn't
+/// model survive — matching `setManifestGradingMode`). Returns the effective
+/// value.
+func setManifestTimeLimitSeconds(
+    setup: APITestSetup, to seconds: Int, on db: any Database
+) async throws -> Int {
+    guard var dict = (try? JSONSerialization.jsonObject(with: Data(setup.manifest.utf8))) as? [String: Any]
+    else { return seconds }
+    if (dict["timeLimitSeconds"] as? Int) != seconds {
+        dict["timeLimitSeconds"] = seconds
+        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+            let json = String(data: data, encoding: .utf8)
+        {
+            setup.manifest = json
+            try await setup.save(on: db)
+        }
+    }
+    return seconds
+}

--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -26,6 +26,27 @@ struct UpdateSuiteTool: ContentTool {
         /// Section id to move the script into; empty string ungroups it; absent
         /// leaves it unchanged.
         let sectionID: String?
+        /// Per-test execution time limit override (seconds). A value in 1...600
+        /// sets the override; 0 clears it (the script reverts to the assignment
+        /// default); absent/null leaves it unchanged.
+        let timeLimitSeconds: Int?
+
+        // Explicit init so `timeLimitSeconds` can default to nil — keeps the
+        // older positional/labelled call sites (which predate the field)
+        // compiling without threading nil through each one.
+        init(
+            script: String, tier: String? = nil, points: Int? = nil,
+            displayName: String? = nil, dependsOn: [String]? = nil,
+            sectionID: String? = nil, timeLimitSeconds: Int? = nil
+        ) {
+            self.script = script
+            self.tier = tier
+            self.points = points
+            self.displayName = displayName
+            self.dependsOn = dependsOn
+            self.sectionID = sectionID
+            self.timeLimitSeconds = timeLimitSeconds
+        }
     }
 
     struct Input: Decodable, Sendable {
@@ -47,7 +68,9 @@ struct UpdateSuiteTool: ContentTool {
     static let description =
         "Edit test-suite script metadata for an assignment, by its public ID. For each named "
         + "script provide any of: tier (public/release/secret/student), points, displayName, "
-        + "dependsOn (prerequisite script names), and sectionID (\"\" to ungroup). Does NOT change "
+        + "dependsOn (prerequisite script names), sectionID (\"\" to ungroup), and timeLimitSeconds "
+        + "(a per-test execution time limit override in seconds, 1–600; 0 clears the override so the "
+        + "script reverts to the assignment default set by set_time_limit). Does NOT change "
         + "script content or pattern families. Saving re-runs the assignment's validation and closes "
         + "the assignment if it was open (re-open with update_assignment once validation passes)."
     static let inputSchema: JSONValue = .object([
@@ -81,6 +104,13 @@ struct UpdateSuiteTool: ContentTool {
                         "sectionID": .object([
                             "type": .string("string"),
                             "description": .string("Section id, or \"\" to ungroup."),
+                        ]),
+                        "timeLimitSeconds": .object([
+                            "type": .string("integer"),
+                            "description": .string(
+                                "Per-test time-limit override in seconds "
+                                    + "(\(mcpTimeLimitRange.lowerBound)–\(mcpTimeLimitRange.upperBound)); "
+                                    + "0 clears the override (revert to the assignment default)."),
                         ]),
                     ]),
                     "required": .array([.string("script")]),
@@ -137,6 +167,16 @@ struct UpdateSuiteTool: ContentTool {
             if let dependsOn = edit.dependsOn { payload.items[idx].script?.dependsOn = dependsOn }
             if let sectionID = edit.sectionID {
                 payload.items[idx].sectionID = sectionID.isEmpty ? nil : sectionID
+            }
+            if let limit = edit.timeLimitSeconds {
+                // 0 clears the override (revert to the assignment default); any
+                // other value is validated to the accepted range.
+                if limit == 0 {
+                    payload.items[idx].script?.timeLimitSeconds = nil
+                } else {
+                    payload.items[idx].script?.timeLimitSeconds =
+                        try validateTimeLimitSeconds(limit, tool: Self.name, field: "timeLimitSeconds")
+                }
             }
             updated.append(edit.script)
         }

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -32,6 +32,7 @@ enum MCPToolCatalog {
             GetValidationResultTool().erased(),
             UpdateAssignmentTool().erased(),
             SetGradingModeTool().erased(),
+            SetTimeLimitTool().erased(),
             UpdateSuiteTool().erased(),
             UpdateGlobalInputsTool().erased(),
             UpdateAchievementsTool().erased(),

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -71,7 +71,8 @@ func updateManifestAddingScript(
             generatedBy: e.generatedBy,
             generatedByCheck: e.generatedByCheck,
             sectionID: e.sectionID,
-            hint: e.hint
+            hint: e.hint,
+            timeLimitSeconds: e.timeLimitSeconds
         )
     }
     let nextOrder = (existing.map(\.order).max() ?? 0) + 1
@@ -85,13 +86,15 @@ func updateManifestAddingScript(
         generatedBy: entry.generatedBy,
         generatedByCheck: entry.generatedByCheck,
         sectionID: entry.sectionID,
-        hint: entry.hint
+        hint: entry.hint,
+        timeLimitSeconds: entry.timeLimitSeconds
     )
     let updated = existing + [newEntry]
     return try? makeWorkerManifestJSON(
         testSuites: updated,
         includeMakefile: props.makefile != nil,
         gradingMode: props.gradingMode.rawValue,
+        timeLimitSeconds: props.timeLimitSeconds,
         starterNotebook: props.starterNotebook,
         patternFamilies: props.patternFamilies,
         notebookChecks: props.notebookChecks,
@@ -128,13 +131,15 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
                 generatedBy: e.generatedBy,
                 generatedByCheck: e.generatedByCheck,
                 sectionID: e.sectionID,
-                hint: e.hint
+                hint: e.hint,
+                timeLimitSeconds: e.timeLimitSeconds
             )
         }
     return try? makeWorkerManifestJSON(
         testSuites: updated,
         includeMakefile: props.makefile != nil,
         gradingMode: props.gradingMode.rawValue,
+        timeLimitSeconds: props.timeLimitSeconds,
         starterNotebook: props.starterNotebook,
         patternFamilies: props.patternFamilies,
         notebookChecks: props.notebookChecks,
@@ -148,6 +153,7 @@ func makeWorkerManifestJSON(
     testSuites: [ConfiguredSuiteEntry],
     includeMakefile: Bool,
     gradingMode: String = "worker",
+    timeLimitSeconds: Int = 10,
     starterNotebook: String? = "assignment.ipynb",
     patternFamilies: [PatternFamily] = [],
     notebookChecks: [NotebookCheck] = [],
@@ -168,7 +174,7 @@ func makeWorkerManifestJSON(
         "gradingMode": gradingMode,
         "requiredFiles": [],
         "testSuites": testSuiteJSON,
-        "timeLimitSeconds": 10,
+        "timeLimitSeconds": timeLimitSeconds,
         "makefile": includeMakefile ? ["target": NSNull()] : NSNull(),
     ]
     if let starterNotebook {
@@ -267,6 +273,12 @@ private func testSuiteEntryToDict(_ entry: ConfiguredSuiteEntry) -> [String: Any
     }
     if let hint = entry.hint, !hint.isEmpty {
         dict["hint"] = hint
+    }
+    // Per-test execution time limit override (seconds). Absent = inherit the
+    // assignment-wide default. Only positive values are meaningful; a nil/0
+    // value is omitted so the decoder falls back to the default.
+    if let limit = entry.timeLimitSeconds, limit > 0 {
+        dict["timeLimitSeconds"] = limit
     }
     return dict
 }

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Suite.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Suite.swift
@@ -161,7 +161,8 @@ func buildSuitePayload(fromManifest manifest: String, zipPath: String? = nil) ->
                         points: entry.points,
                         displayName: entry.name,
                         dependsOn: collapseDeps(entry.dependsOn),
-                        hint: entry.hint
+                        hint: entry.hint,
+                        timeLimitSeconds: entry.timeLimitSeconds
                     ),
                     family: nil,
                     check: nil,

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -112,7 +112,8 @@ func applySuiteEdit(
                         dependsOn: s.dependsOn,
                         sectionID: item.sectionID,
                         content: s.content,
-                        hint: s.hint
+                        hint: s.hint,
+                        timeLimitSeconds: s.timeLimitSeconds
                     )))
         case "family":
             guard var f = item.family else {

--- a/Sources/APIServer/Routes/Web/SuitePayloadDTOs.swift
+++ b/Sources/APIServer/Routes/Web/SuitePayloadDTOs.swift
@@ -51,6 +51,11 @@ struct ScriptDTO: Content {
     /// the manifest entry; on `PUT /suite` it's persisted onto the entry.
     /// Omitted by older clients, which keeps decoding.
     var hint: String?
+    /// Optional per-test execution time limit (seconds). nil = inherit the
+    /// assignment-wide default. On `GET /suite` it's read from the manifest
+    /// entry; on `PUT /suite` it's persisted onto the entry. Omitted by older
+    /// clients, which keeps decoding.
+    var timeLimitSeconds: Int?
 }
 
 /// Name + opaque id of a single section.  Order of `SuitePayload.sections`

--- a/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteRowHelpers.swift
@@ -47,12 +47,14 @@ struct ConfiguredSuiteEntry {
     let generatedByCheck: String?  // notebook check id; nil otherwise
     let sectionID: String?  // id into TestProperties.sections; nil = ungrouped
     let hint: String?  // instructor hint for raw scripts; nil for generated/no-hint
+    let timeLimitSeconds: Int?  // per-test override; nil = inherit assignment default
 
     init(
         script: String, tier: String, order: Int,
         dependsOn: [String], points: Int, displayName: String?,
         generatedBy: String? = nil, generatedByCheck: String? = nil,
-        sectionID: String? = nil, hint: String? = nil
+        sectionID: String? = nil, hint: String? = nil,
+        timeLimitSeconds: Int? = nil
     ) {
         self.script = script
         self.tier = tier
@@ -64,6 +66,7 @@ struct ConfiguredSuiteEntry {
         self.generatedByCheck = generatedByCheck
         self.sectionID = sectionID
         self.hint = hint
+        self.timeLimitSeconds = timeLimitSeconds
     }
 }
 

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -43,11 +43,16 @@ struct AuthoredRawScript: Equatable {
     /// `TestSuiteEntry.hint` so it surfaces as a "💡 Hint" callout on failure
     /// (PR2's display-time join). nil = no hint.
     let hint: String?
+    /// Optional per-test execution time limit (seconds), persisted onto the
+    /// generated `TestSuiteEntry.timeLimitSeconds`. nil = inherit the
+    /// assignment-wide default. Only meaningful for hand-written raw scripts;
+    /// generated family / notebook-check entries currently inherit the default.
+    let timeLimitSeconds: Int?
 
     init(
         script: String, tier: TestTier, points: Int,
         displayName: String?, dependsOn: [String], sectionID: String? = nil,
-        content: String? = nil, hint: String? = nil
+        content: String? = nil, hint: String? = nil, timeLimitSeconds: Int? = nil
     ) {
         self.script = script
         self.tier = tier
@@ -57,6 +62,7 @@ struct AuthoredRawScript: Equatable {
         self.sectionID = sectionID
         self.content = content
         self.hint = hint
+        self.timeLimitSeconds = timeLimitSeconds
     }
 }
 
@@ -223,7 +229,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                     dependsOn: s.dependsOn,
                     sectionID: normaliseSectionID(s.sectionID),
                     content: s.content,
-                    hint: s.hint
+                    hint: s.hint,
+                    timeLimitSeconds: s.timeLimitSeconds
                 )
             }
             return nil
@@ -240,7 +247,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                         dependsOn: s.dependsOn,
                         sectionID: normaliseSectionID(s.sectionID),
                         content: s.content,
-                        hint: s.hint
+                        hint: s.hint,
+                        timeLimitSeconds: s.timeLimitSeconds
                     ))
             case .family(let id, let sid):
                 return .family(id: id, sectionID: normaliseSectionID(sid))
@@ -259,7 +267,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                     displayName: e.name,
                     dependsOn: e.dependsOn,
                     sectionID: normaliseSectionID(e.sectionID),
-                    hint: e.hint
+                    hint: e.hint,
+                    timeLimitSeconds: e.timeLimitSeconds
                 )
             }
         // Reconstruct authored ordering from the existing manifest: walk
@@ -308,7 +317,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                             displayName: entry.name,
                             dependsOn: entry.dependsOn,
                             sectionID: normaliseSectionID(entry.sectionID),
-                            hint: entry.hint
+                            hint: entry.hint,
+                            timeLimitSeconds: entry.timeLimitSeconds
                         )))
             }
         }
@@ -664,6 +674,12 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                 guard seen.insert(d).inserted else { continue }
                 combined.append(d)
             }
+            // TODO(per-test timeout): generated pattern-family entries inherit
+            // the assignment-wide default for now. A family-level (or per-case)
+            // override would thread through here as
+            // `timeLimitSeconds: family.timeLimitSeconds` (and a per-case
+            // value from `generated`), once those fields are added to
+            // `PatternFamily` / `PatternCase`.
             newConfigured.append(
                 ConfiguredSuiteEntry(
                     script: generated.filename,
@@ -692,7 +708,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                     displayName: s.displayName,
                     generatedBy: nil,
                     sectionID: s.sectionID,
-                    hint: s.hint
+                    hint: s.hint,
+                    timeLimitSeconds: s.timeLimitSeconds
                 ))
 
         case .family(let fid, let familySection):
@@ -708,6 +725,10 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
             emittedCheckIDs.insert(cid)
             order += 1
             let inherited = expandDeps(check.dependsOn)
+            // TODO(per-test timeout): generated notebook-check entries inherit
+            // the assignment-wide default for now. A check-level override would
+            // thread through here as `timeLimitSeconds: check.timeLimitSeconds`
+            // once that field is added to `NotebookCheck`.
             newConfigured.append(
                 ConfiguredSuiteEntry(
                     script: generated.filename,
@@ -755,6 +776,7 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         testSuites: newConfigured,
         includeMakefile: props.makefile != nil,
         gradingMode: props.gradingMode.rawValue,
+        timeLimitSeconds: props.timeLimitSeconds,
         starterNotebook: props.starterNotebook,
         patternFamilies: nextFamilies,
         notebookChecks: resolvedChecks,

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -50,6 +50,15 @@ public struct TestSuiteEntry: Codable, Equatable, Sendable {
     // hint comes from the family case / notebook check spec instead; this
     // field carries the hint for hand-written raw scripts. nil = none.
     public let hint: String?
+    // Optional per-test execution time limit (seconds). When nil the entry
+    // inherits the assignment-wide default `TestProperties.timeLimitSeconds`.
+    // Resolution happens in each executor (the worker's NativeScriptExecutor,
+    // the browser runner's JS) rather than in RunnerCore's `executeSuites`,
+    // which is the wasm-pinned shared loop and still receives the assignment
+    // default as the fallback timeLimit. Effective limit for a script is
+    // `entry.timeLimitSeconds ?? manifest.timeLimitSeconds`. Back-compat:
+    // absent in JSON decodes to nil (inherit the default).
+    public let timeLimitSeconds: Int?
 
     public init(
         tier: TestTier, script: String, name: String? = nil,
@@ -57,7 +66,8 @@ public struct TestSuiteEntry: Codable, Equatable, Sendable {
         generatedBy: String? = nil,
         generatedByCheck: String? = nil,
         sectionID: String? = nil,
-        hint: String? = nil
+        hint: String? = nil,
+        timeLimitSeconds: Int? = nil
     ) {
         self.tier = tier
         self.script = script
@@ -68,6 +78,7 @@ public struct TestSuiteEntry: Codable, Equatable, Sendable {
         self.generatedByCheck = generatedByCheck
         self.sectionID = sectionID
         self.hint = hint
+        self.timeLimitSeconds = timeLimitSeconds
     }
 
     public init(from decoder: Decoder) throws {
@@ -81,6 +92,7 @@ public struct TestSuiteEntry: Codable, Equatable, Sendable {
         generatedByCheck = try c.decodeIfPresent(String.self, forKey: .generatedByCheck)
         sectionID = try c.decodeIfPresent(String.self, forKey: .sectionID)
         hint = try c.decodeIfPresent(String.self, forKey: .hint)
+        timeLimitSeconds = try c.decodeIfPresent(Int.self, forKey: .timeLimitSeconds)
     }
 
     /// True if this entry was produced by a pattern family or a notebook

--- a/Sources/Worker/NativeScriptExecutor.swift
+++ b/Sources/Worker/NativeScriptExecutor.swift
@@ -29,6 +29,23 @@ struct NativeScriptExecutor: ScriptExecutor, Sendable {
     /// Environment overrides merged into every script run (e.g. the
     /// `CHICKADEE_ASSIGNMENT_SEED`). Empty = inherit the parent env verbatim.
     let env: [String: String]
+    /// Per-script execution time-limit overrides (script name → seconds). A
+    /// script listed here runs with its own limit; everything else uses the
+    /// `timeLimitSeconds` that the shared `executeSuites` loop passes (the
+    /// assignment default). This is resolved here, in the executor, rather than
+    /// in RunnerCore's `executeSuites` — that loop is the wasm-pinned shared
+    /// implementation and must keep receiving only the assignment default.
+    let overrides: [String: Int]
+
+    init(
+        runner: any ScriptRunner, workDir: URL,
+        env: [String: String] = [:], overrides: [String: Int] = [:]
+    ) {
+        self.runner = runner
+        self.workDir = workDir
+        self.env = env
+        self.overrides = overrides
+    }
 
     func scriptExists(_ name: String) async -> Bool {
         FileManager.default.fileExists(atPath: workDir.appendingPathComponent(name).path)
@@ -38,8 +55,16 @@ struct NativeScriptExecutor: ScriptExecutor, Sendable {
         await runner.run(
             script: workDir.appendingPathComponent(script),
             workDir: workDir,
-            timeLimitSeconds: timeLimitSeconds,
+            timeLimitSeconds: resolveTimeLimit(
+                script: script, default: timeLimitSeconds, overrides: overrides),
             env: env
         )
     }
+}
+
+/// Resolves the effective per-test time limit for `script`: its override when
+/// present, otherwise the assignment `default`. Pure (no I/O) so the resolution
+/// rule can be unit-tested without a real subprocess.
+func resolveTimeLimit(script: String, default defaultLimit: Int, overrides: [String: Int]) -> Int {
+    overrides[script] ?? defaultLimit
 }

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -599,7 +599,18 @@ extension WorkerDaemon {
                 atomically: true, encoding: .utf8)
         }
 
-        let executor = NativeScriptExecutor(runner: runner, workDir: testSetupDir, env: scriptEnv)
+        // Per-test time-limit overrides resolved in the executor (the shared
+        // `executeSuites` loop still receives the assignment default below as
+        // the fallback). Only entries carrying an explicit positive override
+        // are mapped; everything else inherits `manifest.timeLimitSeconds`.
+        var timeLimitOverrides: [String: Int] = [:]
+        for entry in manifest.testSuites {
+            if let limit = entry.timeLimitSeconds, limit > 0 {
+                timeLimitOverrides[entry.script] = limit
+            }
+        }
+        let executor = NativeScriptExecutor(
+            runner: runner, workDir: testSetupDir, env: scriptEnv, overrides: timeLimitOverrides)
         let items = manifest.testSuites.map { entry in
             SuiteItem(
                 script: entry.script,

--- a/Tests/APITests/MCP/AuthorScriptToolTests.swift
+++ b/Tests/APITests/MCP/AuthorScriptToolTests.swift
@@ -76,12 +76,14 @@ import Vapor
         _ assignment: APIAssignment, filename: String, content: String? = nil,
         sourceUrl: String? = nil,
         tier: String? = nil, points: Int? = nil, displayName: String? = nil,
-        dependsOn: [String]? = nil, sectionID: String? = nil
+        dependsOn: [String]? = nil, sectionID: String? = nil,
+        timeLimitSeconds: Int? = nil
     ) -> AuthorScriptTool.Input {
         AuthorScriptTool.Input(
             assignmentPublicID: assignment.publicID, filename: filename, content: content,
             sourceUrl: sourceUrl,
-            tier: tier, points: points, displayName: displayName, dependsOn: dependsOn, sectionID: sectionID)
+            tier: tier, points: points, displayName: displayName, dependsOn: dependsOn,
+            sectionID: sectionID, timeLimitSeconds: timeLimitSeconds)
     }
 
     @Test func createsNewTestScriptWithMetadata() async throws {
@@ -109,6 +111,38 @@ import Vapor
             // The body landed in the zip verbatim.
             let body = try #require(readScriptFromZip(zipPath: reloaded.zipPath, filename: "secrettest_marker.py"))
             #expect(body.contains("print('ok')"))
+        }
+    }
+
+    @Test func createsTestScriptWithPerTestTimeLimitOverride() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await AuthorScriptTool().execute(
+                input(
+                    assignment, filename: "secrettest_slow.py",
+                    content: "#!/usr/bin/env python3\nprint('ok')\n",
+                    tier: "secret", timeLimitSeconds: 45),
+                context(app))
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest, zipPath: reloaded.zipPath).items
+            let row = try #require(items.first { $0.script?.script == "secrettest_slow.py" })
+            #expect(row.script?.timeLimitSeconds == 45)
+        }
+    }
+
+    @Test func rejectsOutOfRangePerTestTimeLimit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await AuthorScriptTool().execute(
+                    input(
+                        assignment, filename: "secrettest_huge.py",
+                        content: "#!/usr/bin/env python3\nprint('ok')\n",
+                        tier: "secret", timeLimitSeconds: 9999),
+                    context(app))
+            }
         }
     }
 

--- a/Tests/APITests/MCP/GetSuiteToolTests.swift
+++ b/Tests/APITests/MCP/GetSuiteToolTests.swift
@@ -62,6 +62,38 @@ import Vapor
         }
     }
 
+    /// Manifest with a non-default assignment time limit and one per-script
+    /// override; the other script inherits the default (no override surfaced).
+    private let timeLimitManifest = """
+        {"schemaVersion":1,"testSuites":[\
+        {"tier":"public","script":"slow.sh","points":1,"timeLimitSeconds":45},\
+        {"tier":"public","script":"fast.sh","points":1}\
+        ],"timeLimitSeconds":20}
+        """
+
+    @Test func surfacesDefaultAndPerScriptTimeLimit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_tl", courseID: courseID, manifest: timeLimitManifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_tl", courseID: courseID, title: "Lab")
+
+            let output = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), context(app))
+
+            // Assignment-wide default is reported at the top level.
+            #expect(output.timeLimitSeconds == 20)
+            let slow = try #require(output.items.first { $0.name == "slow.sh" })
+            #expect(slow.timeLimitSeconds == 45)
+            let fast = try #require(output.items.first { $0.name == "fast.sh" })
+            #expect(fast.timeLimitSeconds == nil, "No override surfaces as nil (inherits the default)")
+        }
+    }
+
     /// Manifest with a section carrying its own variables + expressions.
     private let sectionInputsManifest = #"""
         {"schemaVersion":1,"testSuites":[{"tier":"public","script":"test_a.sh","points":1,"sectionID":"sec1"}],"sections":[{"id":"sec1","name":"Part A","variables":[{"name":"cap","value":7}],"expressions":[{"name":"pick","expression":"seed % 4"}]}],"timeLimitSeconds":10}

--- a/Tests/APITests/MCP/SetTimeLimitToolTests.swift
+++ b/Tests/APITests/MCP/SetTimeLimitToolTests.swift
@@ -1,0 +1,110 @@
+// Tests for SetTimeLimitTool (set an assignment's default per-test execution
+// time limit), backed by a real test database.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct SetTimeLimitToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.write]
+        )
+    }
+
+    private let manifest =
+        #"{"schemaVersion":1,"gradingMode":"worker","testSuites":[],"timeLimitSeconds":10}"#
+
+    private func fixture(on app: Application, enroll: Bool = true) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        if enroll {
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        }
+        try await makeTestSetup(on: app, id: "setup_tl", courseID: courseID, manifest: manifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_tl", courseID: courseID, title: "Lab")
+    }
+
+    @Test func setsDefaultTimeLimitWithoutClosing() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            #expect(assignment.visibility == .open)
+
+            let out = try await SetTimeLimitTool().execute(
+                .init(assignmentPublicID: assignment.publicID, seconds: 30), context(app))
+            #expect(out.timeLimitSeconds == 30)
+
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(setup.decodedManifest()?.timeLimitSeconds == 30)
+            // Metadata-style edit: the assignment stays open, not closed.
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(reloaded.visibility == .open)
+        }
+    }
+
+    @Test func rejectsZero() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetTimeLimitTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, seconds: 0), context(app))
+            }
+        }
+    }
+
+    @Test func rejectsNegative() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetTimeLimitTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, seconds: -5), context(app))
+            }
+        }
+    }
+
+    @Test func rejectsAboveMax() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetTimeLimitTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, seconds: 601), context(app))
+            }
+        }
+    }
+
+    @Test func acceptsBoundaryValues() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let low = try await SetTimeLimitTool().execute(
+                .init(assignmentPublicID: assignment.publicID, seconds: 1), context(app))
+            #expect(low.timeLimitSeconds == 1)
+            let high = try await SetTimeLimitTool().execute(
+                .init(assignmentPublicID: assignment.publicID, seconds: 600), context(app))
+            #expect(high.timeLimitSeconds == 600)
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, enroll: false)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetTimeLimitTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, seconds: 30), context(app))
+            }
+        }
+    }
+}

--- a/Tests/APITests/MCP/UpdateSuiteToolTests.swift
+++ b/Tests/APITests/MCP/UpdateSuiteToolTests.swift
@@ -113,6 +113,61 @@ import Vapor
         }
     }
 
+    @Test func setsPerTestTimeLimitOverride() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [UpdateSuiteTool.ScriptEdit(script: "test_a.sh", timeLimitSeconds: 30)]),
+                context(app))
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest).items
+            let a = try #require(items.first { $0.script?.script == "test_a.sh" })
+            #expect(a.script?.timeLimitSeconds == 30)
+            // The untouched script keeps no override (inherits the default).
+            let b = try #require(items.first { $0.script?.script == "test_b.sh" })
+            #expect(b.script?.timeLimitSeconds == nil)
+        }
+    }
+
+    @Test func clearsPerTestTimeLimitWithZero() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Set, then clear with 0.
+            _ = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [UpdateSuiteTool.ScriptEdit(script: "test_a.sh", timeLimitSeconds: 30)]),
+                context(app))
+            _ = try await UpdateSuiteTool().execute(
+                UpdateSuiteTool.Input(
+                    assignmentPublicID: assignment.publicID,
+                    edits: [UpdateSuiteTool.ScriptEdit(script: "test_a.sh", timeLimitSeconds: 0)]),
+                context(app))
+            let reloaded = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let items = buildSuitePayload(fromManifest: reloaded.manifest).items
+            let a = try #require(items.first { $0.script?.script == "test_a.sh" })
+            #expect(a.script?.timeLimitSeconds == nil)
+        }
+    }
+
+    @Test func rejectsOutOfRangePerTestTimeLimit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdateSuiteTool().execute(
+                    UpdateSuiteTool.Input(
+                        assignmentPublicID: assignment.publicID,
+                        edits: [UpdateSuiteTool.ScriptEdit(script: "test_a.sh", timeLimitSeconds: 1000)]),
+                    context(app))
+            }
+        }
+    }
+
     @Test func closesOpenAssignmentOnEdit() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/PatternFamilyApplyTests.swift
+++ b/Tests/APITests/PatternFamilyApplyTests.swift
@@ -315,6 +315,53 @@ import Vapor
         }
     }
 
+    /// A raw script carrying a per-test `timeLimitSeconds` override persists it
+    /// onto the resulting `TestSuiteEntry`, and an `authoredItems == nil`
+    /// re-apply (the family/check-modal save path) preserves it.
+    @Test func apply_rawScriptTimeLimitPersistsAndSurvivesReapply() async throws {
+        try await withPatternFamilyFixture { fixture in
+
+            try updateScriptInZip(
+                zipPath: fixture.setup.zipPath,
+                filename: "publictest_slow.py",
+                content: "# slow\npassed('ok')\n"
+            )
+            let rawEntry = AuthoredRawScript(
+                script: "publictest_slow.py",
+                tier: .pub, points: 1, displayName: nil,
+                dependsOn: [], timeLimitSeconds: 45
+            )
+            _ = try await applyPatternFamilies(
+                to: fixture.setup,
+                nextFamilies: [pfBMIFamily()],
+                authoredItems: [.script(rawEntry), .family(id: "bmi_category")],
+                on: fixture.app.db
+            )
+
+            // The override is persisted onto the raw entry; generated entries
+            // inherit the default (nil).
+            let props = try pfDecodeManifest(fixture.setup.manifest)
+            let slow = try #require(props.testSuites.first { $0.script == "publictest_slow.py" })
+            #expect(slow.timeLimitSeconds == 45)
+            for generated in props.testSuites where generated.generatedBy != nil {
+                #expect(generated.timeLimitSeconds == nil, "Generated entries inherit the default")
+            }
+
+            // Re-apply through the legacy (authoredItems == nil) path — the
+            // family-modal save — which rebuilds AuthoredRawScript from the
+            // existing manifest. The override must survive.
+            let existingFamilies = props.patternFamilies
+            _ = try await applyPatternFamilies(
+                to: fixture.setup,
+                nextFamilies: existingFamilies,
+                on: fixture.app.db
+            )
+            let reapplied = try pfDecodeManifest(fixture.setup.manifest)
+            let slowAfter = try #require(reapplied.testSuites.first { $0.script == "publictest_slow.py" })
+            #expect(slowAfter.timeLimitSeconds == 45, "Override must survive an authoredItems==nil re-apply")
+        }
+    }
+
     /// Family-level `dependsOn` propagates to every generated case, with
     /// family-ref tokens expanded to the referenced family's filenames.
     @Test func apply_familyLevelDepsExpandedAndInheritedByCases() async throws {

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -377,6 +377,9 @@ function makeFakeGradingWorkerFactory(options) {
       this.terminated = false;
       this.postedTypes = [];
       this.files = {};
+      // Records every `run` message's { script, limit } so a test can assert
+      // the per-script time limit the executor handed down.
+      this.runCalls = [];
       created.push(this);
     }
 
@@ -416,6 +419,7 @@ function makeFakeGradingWorkerFactory(options) {
         return;
       }
       if (msg.type === 'run') {
+        this.runCalls.push({ script: msg.script, limit: msg.limit });
         const behavior = this._behaviorFor(msg.script);
         if (behavior.pending) return;  // never reply — simulates a real hang
         this._reply({
@@ -973,6 +977,39 @@ test('GradingWorkerExecutor grades pass/fail through one worker and classifies n
   const runCount = workers[0].postedTypes.filter(t => t === 'run').length;
   assert.equal(runCount, 2, 'only the two python scripts reached the worker (shell handled on main thread)');
   assert.equal(harness.postBodies.length, 1, 'results are still posted');
+});
+
+test('per-script timeLimitSeconds in the manifest overrides the assignment default for that script', async () => {
+  // The assignment default is 12s; `slow.py` carries a 3s per-test override.
+  // The override must be the limit handed to the executor for `slow.py`, while
+  // `fast.py` (no override) still gets the assignment default.
+  const harness = await loadRunnerHarness({
+    useGradingWorker: true,
+    zipFiles: {
+      'slow.py': '# slow\nJSON_RESULT_PASS\n',
+      'fast.py': '# fast\nJSON_RESULT_PASS\n',
+    },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 12,
+      testSuites: [
+        { script: 'slow.py', tier: 'public', timeLimitSeconds: 3 },
+        { script: 'fast.py', tier: 'public' },
+      ],
+    },
+  });
+
+  await harness.window.BrowserRunner.runAndSubmit(
+    new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+    'setup_per_test_limit',
+  );
+
+  // The happy path reuses one worker; its runCalls record the { script, limit }
+  // each script was launched with — the override is applied before executor.run.
+  const worker = harness.gradingWorkerFactory.created[0];
+  const limitFor = name => worker.runCalls.find(c => c.script === name)?.limit;
+  assert.equal(limitFor('slow.py'), 3, 'the per-script override is the limit for slow.py');
+  assert.equal(limitFor('fast.py'), 12, 'an override-less script keeps the assignment default');
 });
 
 test('extensionless Python test scripts dispatch via their shebang instead of failing as unsupported', async () => {

--- a/Tests/CoreTests/CoreCodableTests.swift
+++ b/Tests/CoreTests/CoreCodableTests.swift
@@ -794,6 +794,29 @@ struct CoreCodableTests {
         #expect(check.isGenerated == true)
     }
 
+    @Test func testSuiteEntryTimeLimitRoundTripsWhenPresent() throws {
+        let entry = TestSuiteEntry(tier: .pub, script: "slow.py", timeLimitSeconds: 45)
+        let data = try encoder.encode(entry)
+        // The synthesized encode must emit the field.
+        let text = try #require(String(data: data, encoding: .utf8))
+        #expect(text.contains("\"timeLimitSeconds\":45"))
+        let decoded = try decoder.decode(TestSuiteEntry.self, from: data)
+        #expect(decoded.timeLimitSeconds == 45)
+    }
+
+    @Test func testSuiteEntryTimeLimitAbsentDecodesToNil() throws {
+        // Back-compat: an entry with no timeLimitSeconds key decodes to nil
+        // (inherit the assignment default).
+        let entry = try decoder.decode(
+            TestSuiteEntry.self,
+            from: Data(#"{ "tier": "public", "script": "a.py" }"#.utf8))
+        #expect(entry.timeLimitSeconds == nil)
+        // And a round-trip of the nil case stays nil.
+        let reencoded = try encoder.encode(entry)
+        let decoded = try decoder.decode(TestSuiteEntry.self, from: reencoded)
+        #expect(decoded.timeLimitSeconds == nil)
+    }
+
     @Test func legacyManifestWithoutNotebookChecksDecodesAsEmpty() throws {
         // Pre-NotebookCheck manifests don't carry the notebookChecks field;
         // decoder must default to [].

--- a/Tests/WorkerTests/NativeScriptExecutorTimeLimitTests.swift
+++ b/Tests/WorkerTests/NativeScriptExecutorTimeLimitTests.swift
@@ -1,0 +1,64 @@
+// Tests/WorkerTests/NativeScriptExecutorTimeLimitTests.swift
+//
+// Unit tests for the per-test time-limit resolution in NativeScriptExecutor:
+// the pure `resolveTimeLimit` helper and the executor's `run`, which must apply
+// a per-script override when present and otherwise fall back to the assignment
+// default the shared `executeSuites` loop passes.
+
+import Foundation
+import RunnerCore
+import Testing
+
+@testable import chickadee_runner
+
+// Records the timeLimitSeconds each script.run was invoked with, so the
+// executor's resolution can be asserted without launching a real subprocess.
+private actor RecordingScriptRunner: ScriptRunner {
+    private(set) var limitByScript: [String: Int] = [:]
+
+    func run(script: URL, workDir: URL, timeLimitSeconds: Int, env: [String: String]) async -> ScriptOutput {
+        limitByScript[script.lastPathComponent] = timeLimitSeconds
+        return ScriptOutput(exitCode: 0, stdout: "", stderr: "", executionTimeMs: 0, timedOut: false)
+    }
+
+    func limit(for script: String) -> Int? { limitByScript[script] }
+}
+
+@Suite struct NativeScriptExecutorTimeLimitTests {
+
+    // MARK: - Pure resolution helper
+
+    @Test func resolveTimeLimitPrefersOverride() {
+        #expect(resolveTimeLimit(script: "a.py", default: 10, overrides: ["a.py": 3]) == 3)
+    }
+
+    @Test func resolveTimeLimitFallsBackToDefaultForUnlistedScript() {
+        #expect(resolveTimeLimit(script: "b.py", default: 10, overrides: ["a.py": 3]) == 10)
+    }
+
+    @Test func resolveTimeLimitFallsBackWithNoOverrides() {
+        #expect(resolveTimeLimit(script: "a.py", default: 7, overrides: [:]) == 7)
+    }
+
+    // MARK: - End-to-end through run()
+
+    @Test func runUsesOverrideForListedScript() async {
+        let recorder = RecordingScriptRunner()
+        let executor = NativeScriptExecutor(
+            runner: recorder,
+            workDir: URL(fileURLWithPath: "/tmp"),
+            overrides: ["a.py": 3])
+        _ = await executor.run(script: "a.py", timeLimitSeconds: 10)
+        #expect(await recorder.limit(for: "a.py") == 3)
+    }
+
+    @Test func runUsesDefaultForUnlistedScript() async {
+        let recorder = RecordingScriptRunner()
+        let executor = NativeScriptExecutor(
+            runner: recorder,
+            workDir: URL(fileURLWithPath: "/tmp"),
+            overrides: ["a.py": 3])
+        _ = await executor.run(script: "b.py", timeLimitSeconds: 10)
+        #expect(await recorder.limit(for: "b.py") == 10)
+    }
+}

--- a/changelog.d/per-test-timeout.md
+++ b/changelog.d/per-test-timeout.md
@@ -1,0 +1,17 @@
+### Added
+
+- **Adjustable per-test execution time limit.** The per-test timeout is now
+  editable two ways: an assignment-wide default (`TestProperties.timeLimitSeconds`,
+  set over MCP with the new `set_time_limit` tool) and a per-test override on a
+  hand-written script (`TestSuiteEntry.timeLimitSeconds`, settable via
+  `author_script` / `update_suite` `timeLimitSeconds` and readable in
+  `get_suite`). The effective limit for a script is
+  `entry.timeLimitSeconds ?? manifest.timeLimitSeconds`, resolved in each
+  executor (the worker's `NativeScriptExecutor` and the browser runner) rather
+  than in the shared wasm `executeSuites` loop, which still receives the
+  assignment default as the fallback. Both write paths validate the bound
+  (1–600 seconds). Per-family / per-notebook-check / per-case overrides are
+  deferred to a later change (TODOs mark the hook points); generated entries
+  inherit the assignment default for now. `set_time_limit` is metadata-style
+  (like `set_grading_mode`): it changes a grading-environment knob, not what the
+  tests check, so it does not re-grade, re-validate, or close the assignment.


### PR DESCRIPTION
Implements the backend + MCP half of #979 (UI deferred, per the plan). Lets instructors adjust the per-test execution time limit — both an editable per-assignment default and a per-test override on hand-written scripts — through the MCP content API.

## Why
The per-test limit was a single `TestProperties.timeLimitSeconds`, only settable as raw JSON on the new-test-setup page at creation — no edit-page field, no MCP tool — so once an assignment existed it was effectively baked. With the browser-grader freeze fix (#978) making the limit the bound on a runaway submission's grading time, tuning it now matters (e.g. dropping Labs 0-5 to ~2s; later ML labs needing a longer limit on specific tests).

## What
- **`set_time_limit` MCP tool** — sets the assignment-wide default. Metadata-style (like `set_grading_mode`): mutates only the manifest's `timeLimitSeconds`, **no** close / regrade / re-validate. Validated to an integer in 1–600.
- **`author_script` / `update_suite`** gain an optional per-script `timeLimitSeconds` (1–600; `0` clears) that persists onto the raw script's `TestSuiteEntry` via the existing suite-edit path. `get_suite` reports the assignment default and any per-script overrides.
- Shared 1–600 bound validator (`MCPTimeLimitValidation`).

## Design — no RunnerCore/WASM change
The effective limit (`entry.timeLimitSeconds ?? assignment default`) is resolved **in each executor**, never in `RunnerCore.executeSuites` — that loop is the wasm-pinned shared implementation and keeps receiving only the assignment default as the fallback. So the vendored WASM is untouched and **both runners ship the feature in the same release** (no re-vendor lag, no SwiftWasm rebuild):
- **Worker:** `NativeScriptExecutor` gains an `overrides` map + a pure `resolveTimeLimit` helper; `RunnerDaemon+JobProcessing` builds the map from manifest entries.
- **Browser:** `runScripts` builds a per-script map; the `runScript` wiring applies `perEntryTimeLimit[name] ?? limit` before `executor.run`.

## Latent bug fixed
`makeWorkerManifestJSON` hard-coded `"timeLimitSeconds": 10`, which would have **reset the assignment default to 10 on every suite rebuild** (any suite edit, add/remove script, family save). It now takes the value as a parameter; all three rebuild call sites pass `props.timeLimitSeconds`.

## Deferred (TODO hooks left at the family/check generation points)
Per-pattern-family, per-notebook-check, and per-case overrides, plus the suite-editor UI. Hand-written scripts cover the ML per-test case; the assignment default covers Labs 0-5.

## Tests / verification
- `swift build` clean; **161 Swift tests** (Core codable round-trip, manifest persistence incl. the `authoredItems == nil` reconstruction, native-executor resolution, MCP `set_time_limit`/`update_suite`/`author_script`/`get_suite`) pass.
- **98 `node --test`** browser-runner tests pass (incl. a new per-script-override case).
- `swift-format --strict` and SwiftLint `--strict` clean.
- No `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` edits (a `changelog.d/` fragment is included); `Sources/RunnerCore/` and `Public/runner-wasm/` untouched; no UI changes.

After this merges and deploys, `set_time_limit` lets me set Labs 0-5 → 2s (same deploy lag as the prior fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8NoBbU4P9TjoCtmVgpJAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8NoBbU4P9TjoCtmVgpJAq)_