### PR TITLE
Per-test time limit for pattern families and notebook checks (via MCP)

### DIFF
--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -171,8 +171,11 @@ enum MCPServerInstructions {
         preview_personalization to see the name→value map and starter-notebook placeholder audit a \
         student (or a given seed) would get.
         3. Edit: update_assignment (metadata), set_grading_mode (worker vs browser grading), \
-        set_time_limit (the assignment's default per-test timeout in seconds; a hand-written script \
-        can override it per-test via author_script / update_suite timeLimitSeconds), \
+        set_time_limit (the assignment's default per-test timeout in seconds; a per-test \
+        timeLimitSeconds override, 1–600s, can be set on a hand-written script via author_script / \
+        update_suite, on a pattern family via create_pattern_family / update_pattern_family \
+        (family-wide defaultTimeLimitSeconds and/or per-case timeLimitSeconds), and on a notebook \
+        check via author_notebook_check — 0 clears an override), \
         update_suite (script metadata). To add or change a GRADED test, prefer Chickadee's native \
         check types — update_pattern_family (edit a family's defaults/cases) / create_pattern_family \
         (add a new family) and author_notebook_check (create/replace a notebook check) — over a \

--- a/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
@@ -45,6 +45,9 @@ struct AuthorNotebookCheckTool: ContentTool {
         /// replace, keep its current section).
         let sectionID: String?
         let hint: String?
+        /// Check-level per-test execution time limit (seconds), in `1...600`,
+        /// overriding the assignment default. 0 / omitted = inherit the default.
+        let timeLimitSeconds: Int?
 
         // Per-kind config (the validator enforces which are required per kind).
         let variable: String?
@@ -72,6 +75,7 @@ struct AuthorNotebookCheckTool: ContentTool {
             assignmentPublicID: String, id: String, kind: String,
             name: String? = nil, tier: String? = nil, points: Int? = nil,
             dependsOn: [String]? = nil, sectionID: String? = nil, hint: String? = nil,
+            timeLimitSeconds: Int? = nil,
             variable: String? = nil, expectedRows: Int? = nil, expectedCols: Int? = nil,
             expectedColumns: [String]? = nil, columnMatch: String? = nil, expectedCSV: String? = nil,
             checkDtype: Bool? = nil, checkLike: Bool? = nil, rtol: Double? = nil, atol: Double? = nil,
@@ -88,6 +92,7 @@ struct AuthorNotebookCheckTool: ContentTool {
             self.dependsOn = dependsOn
             self.sectionID = sectionID
             self.hint = hint
+            self.timeLimitSeconds = timeLimitSeconds
             self.variable = variable
             self.expectedRows = expectedRows
             self.expectedCols = expectedCols
@@ -134,8 +139,9 @@ struct AuthorNotebookCheckTool: ContentTool {
         + "function_exists / variable_exists / ast_structure), and that kind's config fields — e.g. "
         + "data_frame_shape needs variable + expectedRows + expectedCols; figure_count needs minFigures; "
         + "cell_contains needs containsText; ast_structure needs requiredConstructs. Optional tier "
-        + "(public/release/secret/student, default public), points, dependsOn, sectionID, and a \"💡 "
-        + "Hint\" shown on failure. Saving renders the check's script, validates it synchronously "
+        + "(public/release/secret/student, default public), points, dependsOn, sectionID, a \"💡 "
+        + "Hint\" shown on failure, and a per-test timeLimitSeconds (1–600s, overriding the assignment "
+        + "default; 0 inherits it). Saving renders the check's script, validates it synchronously "
         + "(rejecting missing/!malformed kind fields), closes the assignment if it was open (reported as "
         + "`assignmentClosed`), and re-runs validation. Read existing checks (and their exact specs) "
         + "from get_suite; remove one with delete_suite_item."
@@ -183,6 +189,12 @@ struct AuthorNotebookCheckTool: ContentTool {
             "hint": .object([
                 "type": .string("string"),
                 "description": .string("\"💡 Hint\" shown to the student only when this check fails."),
+            ]),
+            "timeLimitSeconds": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Per-test execution time limit (seconds, 1–600) for this check, overriding the "
+                        + "assignment default. Omit / 0 to inherit the default."),
             ]),
             "variable": .object([
                 "type": .string("string"),
@@ -312,8 +324,9 @@ struct AuthorNotebookCheckTool: ContentTool {
             requestedSection
             ?? (existingIndex.flatMap { payload.items[$0].sectionID })
 
-        let check = Self.buildCheck(
-            input, id: checkID, kind: kind, tier: tier, columnMatch: columnMatch, sectionID: sectionID)
+        let check = try Self.buildCheck(
+            input, id: checkID, kind: kind, tier: tier, columnMatch: columnMatch,
+            sectionID: sectionID)
         let row = SuiteItemDTO(
             kind: "check", script: nil, family: nil, check: check,
             dependsOn: nil, sectionID: sectionID)
@@ -359,12 +372,20 @@ struct AuthorNotebookCheckTool: ContentTool {
         return mode
     }
 
+    /// Normalizes the check-level time limit: nil/0 → nil (inherit the default),
+    /// any non-zero value bound-checked to `1...600`.
+    private static func normalizedTimeLimit(_ raw: Int?) throws -> Int? {
+        guard let raw, raw != 0 else { return nil }
+        return try validateTimeLimitSeconds(raw, tool: name, field: "timeLimitSeconds")
+    }
+
     /// Builds the `NotebookCheck` from the input; per-kind field legality is left
-    /// to the validator that runs inside applySuiteEdit.
+    /// to the validator that runs inside applySuiteEdit. The time limit is
+    /// normalized here (0/nil → nil; non-zero bound-checked to 1...600).
     private static func buildCheck(
         _ input: Input, id: String, kind: NotebookCheckKind, tier: TestTier,
         columnMatch: ColumnMatchMode?, sectionID: String?
-    ) -> NotebookCheck {
+    ) throws -> NotebookCheck {
         NotebookCheck(
             id: id,
             name: input.name.flatMap { $0.isEmpty ? nil : $0 },
@@ -374,6 +395,7 @@ struct AuthorNotebookCheckTool: ContentTool {
             dependsOn: input.dependsOn ?? [],
             sectionID: sectionID,
             hint: input.hint.flatMap { $0.isEmpty ? nil : $0 },
+            timeLimitSeconds: try normalizedTimeLimit(input.timeLimitSeconds),
             variable: input.variable,
             expectedRows: input.expectedRows,
             expectedCols: input.expectedCols,

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -45,12 +45,16 @@ struct CreatePatternFamilyTool: ContentTool {
         let hint: String?
         let points: Int?
         let tier: String?
+        /// Per-case execution time limit (seconds), in `1...600`, overriding the
+        /// family default. 0 / omitted = no per-case override.
+        let timeLimitSeconds: Int?
         let enabled: Bool?
 
         init(
             key: String, label: String? = nil, args: [JSONValue]? = nil, expected: JSONValue? = nil,
             argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil, expectedVarRef: String? = nil,
-            hint: String? = nil, points: Int? = nil, tier: String? = nil, enabled: Bool? = nil
+            hint: String? = nil, points: Int? = nil, tier: String? = nil,
+            timeLimitSeconds: Int? = nil, enabled: Bool? = nil
         ) {
             self.key = key
             self.label = label
@@ -62,6 +66,7 @@ struct CreatePatternFamilyTool: ContentTool {
             self.hint = hint
             self.points = points
             self.tier = tier
+            self.timeLimitSeconds = timeLimitSeconds
             self.enabled = enabled
         }
     }
@@ -87,6 +92,10 @@ struct CreatePatternFamilyTool: ContentTool {
         let defaultPoints: Int?
         /// Family-wide "💡 Hint" applied to any case that has no per-case `hint`.
         let defaultHint: String?
+        /// Family-level per-test execution time limit (seconds), in `1...600`,
+        /// applied to every generated entry (cases + existence guard) without a
+        /// per-case override. 0 / omitted = inherit the assignment default.
+        let defaultTimeLimitSeconds: Int?
         let tolerance: Double?
         /// Existing section id to place the family in; nil = ungrouped.
         let sectionID: String?
@@ -98,6 +107,7 @@ struct CreatePatternFamilyTool: ContentTool {
             assignmentPublicID: String, id: String, name: String, kind: String,
             function: String? = nil, paramNames: [String]? = nil,
             defaultTier: String? = nil, defaultPoints: Int? = nil, defaultHint: String? = nil,
+            defaultTimeLimitSeconds: Int? = nil,
             tolerance: Double? = nil, sectionID: String? = nil, dependsOn: [String]? = nil,
             variables: [VariableInput]? = nil, cases: [CaseInput]
         ) {
@@ -110,6 +120,7 @@ struct CreatePatternFamilyTool: ContentTool {
             self.defaultTier = defaultTier
             self.defaultPoints = defaultPoints
             self.defaultHint = defaultHint
+            self.defaultTimeLimitSeconds = defaultTimeLimitSeconds
             self.tolerance = tolerance
             self.sectionID = sectionID
             self.dependsOn = dependsOn
@@ -145,6 +156,8 @@ struct CreatePatternFamilyTool: ContentTool {
         + "the cases skip — you don't need a separate function_exists check. "
         + "Set a `defaultHint` (family-wide) and/or per-case `hint` to give the student a \"💡 Hint\" "
         + "shown only when that test fails (per-case overrides the family default). "
+        + "Set a family-level `defaultTimeLimitSeconds` and/or per-case `timeLimitSeconds` "
+        + "(per-test execution time limit, 1–600s, overriding the assignment default). "
         + "Saving renders the family's scripts and runs validation synchronously, rejecting a wrong arg "
         + "count, an expected of the wrong shape for the kind, an unknown $ref, or a duplicate id. It "
         + "also closes the assignment if it was open (reported as `assignmentClosed`; re-open with "
@@ -192,6 +205,12 @@ struct CreatePatternFamilyTool: ContentTool {
                 "description": .string(
                     "Family-wide \"💡 Hint\" shown to the student on any failing case that has no "
                         + "per-case hint."),
+            ]),
+            "defaultTimeLimitSeconds": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Family-level per-test execution time limit (seconds, 1–600) for every generated "
+                        + "entry without a per-case override. Omit / 0 to inherit the assignment default."),
             ]),
             "tolerance": .object([
                 "type": .string("number"),
@@ -260,6 +279,12 @@ struct CreatePatternFamilyTool: ContentTool {
                                 .string("public"), .string("release"), .string("secret"),
                                 .string("student"),
                             ]),
+                        ]),
+                        "timeLimitSeconds": .object([
+                            "type": .string("integer"),
+                            "description": .string(
+                                "Per-case execution time limit (seconds, 1–600), overriding the family "
+                                    + "default. Omit / 0 for no per-case override."),
                         ]),
                         "enabled": .object(["type": .string("boolean")]),
                     ]),
@@ -369,7 +394,9 @@ struct CreatePatternFamilyTool: ContentTool {
             tier: try parseOptionalTier(input.defaultTier, tool: Self.name) ?? .pub,
             points: input.defaultPoints ?? 1,
             hint: normalizedHint(input.defaultHint),
-            tolerance: input.tolerance)
+            tolerance: input.tolerance,
+            timeLimitSeconds: try normalizedTimeLimit(
+                input.defaultTimeLimitSeconds, tool: Self.name, field: "defaultTimeLimitSeconds"))
         let cases = try input.cases.map { try patternCase(from: $0, tool: Self.name) }
         return PatternFamily(
             id: id, name: input.name, kind: kind, functionName: input.function ?? "",
@@ -398,6 +425,8 @@ struct CreatePatternFamilyTool: ContentTool {
             argsProvided: provided, argVarRefs: refs, expectedVarRef: ref,
             hint: normalizedHint(c.hint), tier: try parseOptionalTier(c.tier, tool: tool),
             points: c.points,
+            timeLimitSeconds: try normalizedTimeLimit(
+                c.timeLimitSeconds, tool: tool, field: "cases[\(c.key)].timeLimitSeconds"),
             enabled: c.enabled ?? true)
     }
 
@@ -440,5 +469,14 @@ struct CreatePatternFamilyTool: ContentTool {
     static func normalizedHint(_ raw: String?) -> String? {
         guard let raw, !raw.isEmpty else { return nil }
         return raw
+    }
+
+    /// Normalizes a create-path time limit: nil/0 → nil (no override), and any
+    /// non-zero value is bound-checked to `1...600` (mirroring 0 as the "clear"
+    /// sentinel used on the update path). Shared by the family default and the
+    /// per-case create path so a malformed value is rejected here, not shipped.
+    static func normalizedTimeLimit(_ raw: Int?, tool: String, field: String) throws -> Int? {
+        guard let raw, raw != 0 else { return nil }
+        return try validateTimeLimitSeconds(raw, tool: tool, field: field)
     }
 }

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -46,11 +46,16 @@ struct UpdatePatternFamilyTool: ContentTool {
         /// `defaultHint`). nil leaves the existing hint untouched; an empty
         /// string clears it.
         let hint: String?
+        /// Per-case execution time limit (seconds), in `1...600`. nil leaves
+        /// the existing value untouched; `0` clears it (the case reverts to the
+        /// family default / assignment-wide default).
+        let timeLimitSeconds: Int?
 
         init(
             key: String, args: [JSONValue]? = nil, expected: JSONValue? = nil,
             argVarRefs: [String?]? = nil, argsProvided: [Bool]? = nil,
-            expectedVarRef: String? = nil, hint: String? = nil
+            expectedVarRef: String? = nil, hint: String? = nil,
+            timeLimitSeconds: Int? = nil
         ) {
             self.key = key
             self.args = args
@@ -59,6 +64,7 @@ struct UpdatePatternFamilyTool: ContentTool {
             self.argsProvided = argsProvided
             self.expectedVarRef = expectedVarRef
             self.hint = hint
+            self.timeLimitSeconds = timeLimitSeconds
         }
     }
 
@@ -70,6 +76,11 @@ struct UpdatePatternFamilyTool: ContentTool {
         /// Family-wide "💡 Hint" applied to cases without their own hint. nil
         /// leaves it untouched; an empty string clears it.
         let defaultHint: String?
+        /// Family-level per-test execution time limit (seconds), in `1...600`,
+        /// applied to every generated entry (cases + existence guard) that has
+        /// no per-case override. nil leaves it untouched; `0` clears it (revert
+        /// to the assignment-wide default).
+        let defaultTimeLimitSeconds: Int?
         let enableCases: [String]?
         let disableCases: [String]?
         /// Per-case `args` / `expected` edits (the test logic).
@@ -87,7 +98,8 @@ struct UpdatePatternFamilyTool: ContentTool {
 
         init(
             assignmentPublicID: String, familyID: String, defaultTier: String? = nil,
-            defaultPoints: Int? = nil, defaultHint: String? = nil, enableCases: [String]? = nil,
+            defaultPoints: Int? = nil, defaultHint: String? = nil,
+            defaultTimeLimitSeconds: Int? = nil, enableCases: [String]? = nil,
             disableCases: [String]? = nil, cases: [CaseEdit]? = nil,
             addCases: [CreatePatternFamilyTool.CaseInput]? = nil, dependsOn: [String]? = nil
         ) {
@@ -96,6 +108,7 @@ struct UpdatePatternFamilyTool: ContentTool {
             self.defaultTier = defaultTier
             self.defaultPoints = defaultPoints
             self.defaultHint = defaultHint
+            self.defaultTimeLimitSeconds = defaultTimeLimitSeconds
             self.enableCases = enableCases
             self.disableCases = disableCases
             self.cases = cases
@@ -126,7 +139,9 @@ struct UpdatePatternFamilyTool: ContentTool {
         + "family's default tier (public/release/secret/student) and/or points, enable/disable cases "
         + "by key (enableCases / disableCases), set the family-wide `defaultHint` and/or per-case "
         + "`hint` (the \"💡 Hint\" shown to the student only when that test fails; empty string clears "
-        + "it), and/or edit individual cases' test logic via `cases` "
+        + "it), set the family-level `defaultTimeLimitSeconds` and/or a per-case `timeLimitSeconds` "
+        + "(per-test execution time limit, 1–600s, overriding the assignment default; 0 clears it), "
+        + "and/or edit individual cases' test logic via `cases` "
         + "(each { key, args?, expected? }). args/expected are raw JSON values (a list of args in "
         + "parameter order, and the expected return). Append brand-new cases with `addCases` (each a "
         + "full { key, args, expected, ... } spec like create_pattern_family takes; keys must not "
@@ -161,6 +176,13 @@ struct UpdatePatternFamilyTool: ContentTool {
                 "description": .string(
                     "Family-wide \"💡 Hint\" shown on a failing case that has no per-case hint. "
                         + "Empty string clears it."),
+            ]),
+            "defaultTimeLimitSeconds": .object([
+                "type": .string("integer"),
+                "description": .string(
+                    "Family-level per-test execution time limit (seconds, 1–600) for every "
+                        + "generated entry without its own override. 0 clears it (revert to the "
+                        + "assignment default); omit to leave unchanged."),
             ]),
             "enableCases": .object([
                 "type": .string("array"), "items": .object(["type": .string("string")]),
@@ -206,6 +228,12 @@ struct UpdatePatternFamilyTool: ContentTool {
                             "description": .string(
                                 "Per-case \"💡 Hint\" shown when this case fails (overrides defaultHint). "
                                     + "Empty string clears it."),
+                        ]),
+                        "timeLimitSeconds": .object([
+                            "type": .string("integer"),
+                            "description": .string(
+                                "Per-case execution time limit (seconds, 1–600), overriding the family "
+                                    + "default. 0 clears it; omit to leave unchanged."),
                         ]),
                     ]),
                     "required": .array([.string("key")]),
@@ -256,6 +284,12 @@ struct UpdatePatternFamilyTool: ContentTool {
                                 .string("public"), .string("release"), .string("secret"),
                                 .string("student"),
                             ]),
+                        ]),
+                        "timeLimitSeconds": .object([
+                            "type": .string("integer"),
+                            "description": .string(
+                                "Per-case execution time limit (seconds, 1–600), overriding the family "
+                                    + "default. 0 means no override."),
                         ]),
                         "enabled": .object(["type": .string("boolean")]),
                     ]),
@@ -310,18 +344,31 @@ struct UpdatePatternFamilyTool: ContentTool {
         let addCases = input.addCases ?? []
         guard
             newTier != nil || input.defaultPoints != nil || input.defaultHint != nil
+                || input.defaultTimeLimitSeconds != nil
                 || !enable.isEmpty || !disable.isEmpty || !caseEdits.isEmpty
                 || !addCases.isEmpty || input.dependsOn != nil
         else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name,
                 detail:
-                    "Specify at least one of: defaultTier, defaultPoints, defaultHint, enableCases, "
-                    + "disableCases, cases, addCases, dependsOn.")
+                    "Specify at least one of: defaultTier, defaultPoints, defaultHint, "
+                    + "defaultTimeLimitSeconds, enableCases, disableCases, cases, addCases, dependsOn.")
         }
         guard enable.isDisjoint(with: disable) else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "A case key cannot be in both enableCases and disableCases.")
+        }
+        // Bound-check any provided time limit (0 is allowed here as the "clear"
+        // sentinel; non-zero values must fall in 1...600). addCases time limits
+        // are validated by patternCase(from:) on the shared create path.
+        if let dtl = input.defaultTimeLimitSeconds, dtl != 0 {
+            try validateTimeLimitSeconds(dtl, tool: Self.name, field: "defaultTimeLimitSeconds")
+        }
+        for edit in caseEdits {
+            if let tl = edit.timeLimitSeconds, tl != 0 {
+                try validateTimeLimitSeconds(
+                    tl, tool: Self.name, field: "cases[\(edit.key)].timeLimitSeconds")
+            }
         }
         let editsByKey = try Self.indexCaseEdits(caseEdits)
         try CreatePatternFamilyTool.assertUniqueCaseKeys(addCases, tool: Self.name)
@@ -366,7 +413,9 @@ struct UpdatePatternFamilyTool: ContentTool {
             tier: newTier ?? family.defaults.tier,
             points: input.defaultPoints ?? family.defaults.points,
             hint: Self.resolveHintEdit(input.defaultHint, existing: family.defaults.hint),
-            tolerance: family.defaults.tolerance)
+            tolerance: family.defaults.tolerance,
+            timeLimitSeconds: Self.resolveTimeLimitEdit(
+                input.defaultTimeLimitSeconds, existing: family.defaults.timeLimitSeconds))
         let updatedFamily = try Self.rebuild(
             family, defaults: newDefaults,
             changes: CaseChanges(
@@ -478,7 +527,9 @@ struct UpdatePatternFamilyTool: ContentTool {
             key: caseSpec.key, label: caseSpec.label, args: finalArgs, expected: finalExpected,
             argsProvided: finalProvided, argVarRefs: finalVarRefs, expectedVarRef: finalExpectedVarRef,
             hint: resolveHintEdit(edit.hint, existing: caseSpec.hint),
-            tier: caseSpec.tier, points: caseSpec.points, enabled: enabled)
+            tier: caseSpec.tier, points: caseSpec.points,
+            timeLimitSeconds: resolveTimeLimitEdit(edit.timeLimitSeconds, existing: caseSpec.timeLimitSeconds),
+            enabled: enabled)
     }
 
     /// Resolves a hint edit against the existing value, matching the
@@ -487,6 +538,17 @@ struct UpdatePatternFamilyTool: ContentTool {
     private static func resolveHintEdit(_ edit: String?, existing: String?) -> String? {
         guard let edit else { return existing }
         return edit.isEmpty ? nil : edit
+    }
+
+    /// Resolves a time-limit edit against the existing value, mirroring the
+    /// hint convention with `0` as the sentinel for "clear": nil (omitted)
+    /// preserves the existing override, `0` clears it (revert to inherit), and
+    /// any other value sets it. Provided values are bound-checked by the caller
+    /// (`validateTimeLimitSeconds`) before this runs, so an out-of-range value
+    /// never reaches here.
+    private static func resolveTimeLimitEdit(_ edit: Int?, existing: Int?) -> Int? {
+        guard let edit else { return existing }
+        return edit == 0 ? nil : edit
     }
 
     /// Resolves a parallel array (argVarRefs / argsProvided) for an edited case:
@@ -518,6 +580,7 @@ extension PatternCase {
         PatternCase(
             key: key, label: label, args: args, expected: expected,
             argsProvided: argsProvided, argVarRefs: argVarRefs, expectedVarRef: expectedVarRef,
-            hint: hint, tier: tier, points: points, enabled: enabled)
+            hint: hint, tier: tier, points: points, timeLimitSeconds: timeLimitSeconds,
+            enabled: enabled)
     }
 }

--- a/Sources/APIServer/Utilities/NotebookCheckRenderer.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckRenderer.swift
@@ -60,7 +60,11 @@ func renderNotebookCheck(_ check: NotebookCheck) -> GeneratedCheck {
         points: check.points,
         displayName: displayName,
         caseKey: "",  // unused for checks; one file per check
-        familyID: ""  // unused for checks; the route field is generatedByCheck
+        familyID: "",  // unused for checks; the route field is generatedByCheck
+        // The check's per-test limit (0/negative → nil = inherit the default).
+        // The apply path re-derives this from `check.timeLimitSeconds` when it
+        // builds the entry; carrying it here keeps GeneratedScript self-describing.
+        timeLimitSeconds: normalizedGeneratedTimeLimit(check.timeLimitSeconds)
     )
     return GeneratedCheck(script: script, sidecars: sidecars)
 }

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -648,7 +648,9 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                     points: guardScript.points,
                     displayName: guardScript.displayName,
                     generatedBy: guardScript.familyID,
-                    sectionID: familySection
+                    sectionID: familySection,
+                    // The guard inherits the family-level time limit.
+                    timeLimitSeconds: guardScript.timeLimitSeconds
                 ))
         }
         for generated in renderPatternFamily(
@@ -674,12 +676,9 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                 guard seen.insert(d).inserted else { continue }
                 combined.append(d)
             }
-            // TODO(per-test timeout): generated pattern-family entries inherit
-            // the assignment-wide default for now. A family-level (or per-case)
-            // override would thread through here as
-            // `timeLimitSeconds: family.timeLimitSeconds` (and a per-case
-            // value from `generated`), once those fields are added to
-            // `PatternFamily` / `PatternCase`.
+            // Per-test time limit is resolved by the renderer
+            // (`case.resolvedTimeLimit(defaults:)`, then normalised so a
+            // 0/negative becomes nil) and carried on `generated`.
             newConfigured.append(
                 ConfiguredSuiteEntry(
                     script: generated.filename,
@@ -689,7 +688,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                     points: generated.points,
                     displayName: generated.displayName,
                     generatedBy: generated.familyID,
-                    sectionID: familySection
+                    sectionID: familySection,
+                    timeLimitSeconds: generated.timeLimitSeconds
                 ))
         }
     }
@@ -725,10 +725,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
             emittedCheckIDs.insert(cid)
             order += 1
             let inherited = expandDeps(check.dependsOn)
-            // TODO(per-test timeout): generated notebook-check entries inherit
-            // the assignment-wide default for now. A check-level override would
-            // thread through here as `timeLimitSeconds: check.timeLimitSeconds`
-            // once that field is added to `NotebookCheck`.
+            // Per-test time limit comes from the check spec (0/negative → nil,
+            // i.e. inherit the assignment-wide default).
             newConfigured.append(
                 ConfiguredSuiteEntry(
                     script: generated.filename,
@@ -739,7 +737,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                     displayName: generated.displayName,
                     generatedBy: nil,
                     generatedByCheck: check.id,
-                    sectionID: checkSection
+                    sectionID: checkSection,
+                    timeLimitSeconds: normalizedGeneratedTimeLimit(check.timeLimitSeconds)
                 ))
         }
     }
@@ -768,7 +767,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
                 displayName: generated.displayName,
                 generatedBy: nil,
                 generatedByCheck: check.id,
-                sectionID: nil
+                sectionID: nil,
+                timeLimitSeconds: normalizedGeneratedTimeLimit(check.timeLimitSeconds)
             ))
     }
 

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer.swift
@@ -30,6 +30,11 @@ struct GeneratedScript: Equatable {
     let displayName: String
     let caseKey: String
     let familyID: String
+    /// The resolved per-test execution time limit (seconds) for this generated
+    /// entry, or nil to inherit the assignment-wide default. For a case it is
+    /// `case.resolvedTimeLimit(defaults:)`; for the existence guard it is the
+    /// family default. A non-positive resolved value is normalised to nil.
+    let timeLimitSeconds: Int?
 }
 
 /// Top-level entry point.  Returns one `GeneratedScript` per **enabled** case
@@ -151,7 +156,11 @@ func existenceGuard(
         points: 0,
         displayName: label,
         caseKey: patternExistenceGuardCaseKey,
-        familyID: family.id
+        familyID: family.id,
+        // The guard applies to all the family's generated entries, so it
+        // inherits the family-level limit (the cases inherit it too unless
+        // they set their own).
+        timeLimitSeconds: normalizedGeneratedTimeLimit(family.defaults.timeLimitSeconds)
     )
 }
 
@@ -206,6 +215,16 @@ private func renderCase(
         points: c.resolvedPoints(defaults: family.defaults),
         displayName: c.label,
         caseKey: c.key,
-        familyID: family.id
+        familyID: family.id,
+        timeLimitSeconds: normalizedGeneratedTimeLimit(c.resolvedTimeLimit(defaults: family.defaults))
     )
+}
+
+/// Maps a resolved generated-entry time limit to the value persisted on the
+/// manifest: a positive value passes through, while nil / 0 / negative collapse
+/// to nil ("no override — inherit the assignment-wide default"). Used at every
+/// generated `GeneratedScript` construction so a 0/negative never reaches the
+/// manifest.
+func normalizedGeneratedTimeLimit(_ value: Int?) -> Int? {
+    (value ?? 0) > 0 ? value : nil
 }

--- a/Sources/Core/Models/NotebookCheck.swift
+++ b/Sources/Core/Models/NotebookCheck.swift
@@ -147,6 +147,10 @@ public struct NotebookCheck: Codable, Equatable, Sendable {
     /// the generated script — see the `hintByFilename` join in
     /// `WebRoutes+Submission.swift`).  nil = no hint.
     public let hint: String?
+    /// Optional check-level per-test execution time limit (seconds), persisted
+    /// onto the generated `TestSuiteEntry.timeLimitSeconds`.  nil = inherit the
+    /// assignment-wide default.
+    public let timeLimitSeconds: Int?
 
     // MARK: Per-kind config (presence enforced by validator)
 
@@ -242,6 +246,7 @@ public struct NotebookCheck: Codable, Equatable, Sendable {
         tier: TestTier = .pub, points: Int = 1,
         dependsOn: [String] = [], sectionID: String? = nil,
         hint: String? = nil,
+        timeLimitSeconds: Int? = nil,
         variable: String? = nil,
         expectedRows: Int? = nil, expectedCols: Int? = nil,
         expectedColumns: [String]? = nil,
@@ -267,6 +272,7 @@ public struct NotebookCheck: Codable, Equatable, Sendable {
         self.dependsOn = dependsOn
         self.sectionID = sectionID
         self.hint = hint
+        self.timeLimitSeconds = timeLimitSeconds
         self.variable = variable
         self.expectedRows = expectedRows
         self.expectedCols = expectedCols
@@ -298,6 +304,7 @@ public struct NotebookCheck: Codable, Equatable, Sendable {
         dependsOn = try c.decodeIfPresent([String].self, forKey: .dependsOn) ?? []
         sectionID = try c.decodeIfPresent(String.self, forKey: .sectionID)
         hint = try c.decodeIfPresent(String.self, forKey: .hint)
+        timeLimitSeconds = try c.decodeIfPresent(Int.self, forKey: .timeLimitSeconds)
         variable = try c.decodeIfPresent(String.self, forKey: .variable)
         expectedRows = try c.decodeIfPresent(Int.self, forKey: .expectedRows)
         expectedCols = try c.decodeIfPresent(Int.self, forKey: .expectedCols)

--- a/Sources/Core/Models/PatternFamily.swift
+++ b/Sources/Core/Models/PatternFamily.swift
@@ -80,15 +80,21 @@ public struct PatternDefaults: Codable, Equatable, Sendable {
     /// still counts as a pass, for floating-point `.approximateEquality`
     /// families.  When nil the renderer uses a sensible default (1e-6).
     public let tolerance: Double?
+    /// Family-level per-test execution time limit (seconds) applied to every
+    /// generated entry in this family — the cases and the auto-existence
+    /// guard.  A case may override it (`PatternCase.timeLimitSeconds`); when
+    /// both are nil the entry inherits the assignment-wide default.
+    public let timeLimitSeconds: Int?
 
     public init(
         tier: TestTier = .pub, points: Int = 1, hint: String? = nil,
-        tolerance: Double? = nil
+        tolerance: Double? = nil, timeLimitSeconds: Int? = nil
     ) {
         self.tier = tier
         self.points = points
         self.hint = hint
         self.tolerance = tolerance
+        self.timeLimitSeconds = timeLimitSeconds
     }
 
     public init(from decoder: Decoder) throws {
@@ -97,6 +103,7 @@ public struct PatternDefaults: Codable, Equatable, Sendable {
         points = try c.decodeIfPresent(Int.self, forKey: .points) ?? 1
         hint = try c.decodeIfPresent(String.self, forKey: .hint)
         tolerance = try c.decodeIfPresent(Double.self, forKey: .tolerance)
+        timeLimitSeconds = try c.decodeIfPresent(Int.self, forKey: .timeLimitSeconds)
     }
 }
 
@@ -147,6 +154,10 @@ public struct PatternCase: Codable, Equatable, Sendable {
     public let tier: TestTier?
     /// Per-case points override.  When nil, `defaults.points` is used.
     public let points: Int?
+    /// Per-case execution time limit (seconds).  When nil, the family default
+    /// (`defaults.timeLimitSeconds`) applies; when both are nil the generated
+    /// entry inherits the assignment-wide default.
+    public let timeLimitSeconds: Int?
     /// Disabled cases remain in the spec but are not rendered into the zip.
     public let enabled: Bool
 
@@ -155,6 +166,7 @@ public struct PatternCase: Codable, Equatable, Sendable {
         argsProvided: [Bool] = [], argVarRefs: [String?] = [],
         expectedVarRef: String? = nil,
         hint: String? = nil, tier: TestTier? = nil, points: Int? = nil,
+        timeLimitSeconds: Int? = nil,
         enabled: Bool = true
     ) {
         self.key = key
@@ -167,6 +179,7 @@ public struct PatternCase: Codable, Equatable, Sendable {
         self.hint = hint
         self.tier = tier
         self.points = points
+        self.timeLimitSeconds = timeLimitSeconds
         self.enabled = enabled
     }
 
@@ -184,6 +197,7 @@ public struct PatternCase: Codable, Equatable, Sendable {
         hint = try c.decodeIfPresent(String.self, forKey: .hint)
         tier = try c.decodeIfPresent(TestTier.self, forKey: .tier)
         points = try c.decodeIfPresent(Int.self, forKey: .points)
+        timeLimitSeconds = try c.decodeIfPresent(Int.self, forKey: .timeLimitSeconds)
         enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
     }
 }
@@ -291,5 +305,12 @@ extension PatternCase {
     /// Points applied to this case: override if set, else family default.
     public func resolvedPoints(defaults: PatternDefaults) -> Int {
         points ?? defaults.points
+    }
+
+    /// Per-test time limit (seconds) applied to this case: the case's own
+    /// override if set, else the family default, else nil (inherit the
+    /// assignment-wide default).
+    public func resolvedTimeLimit(defaults: PatternDefaults) -> Int? {
+        timeLimitSeconds ?? defaults.timeLimitSeconds
     }
 }

--- a/Tests/APITests/MCP/AuthorNotebookCheckToolTests.swift
+++ b/Tests/APITests/MCP/AuthorNotebookCheckToolTests.swift
@@ -105,6 +105,43 @@ import Vapor
         }
     }
 
+    @Test func setsCheckTimeLimitAndSurfacesInGetSuite() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await AuthorNotebookCheckTool().execute(
+                .init(
+                    assignmentPublicID: assignment.publicID, id: "figs", kind: "figure_count",
+                    timeLimitSeconds: 45, minFigures: 2),
+                context(app))
+            let check = try await reloadCheck(assignment, id: "figs", on: app.db)
+            #expect(check.timeLimitSeconds == 45)
+
+            // get_suite returns the value on the check spec.
+            let readCtx = ToolContext(
+                request: Request(application: app, on: app.eventLoopGroup.any()),
+                subject: "tester", grantedScopes: [.read])
+            let suite = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), readCtx)
+            let row = try #require(suite.items.compactMap(\.check).first { $0.id == "figs" })
+            #expect(row.timeLimitSeconds == 45)
+        }
+    }
+
+    @Test func rejectsOutOfRangeCheckTimeLimit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await AuthorNotebookCheckTool().execute(
+                    .init(
+                        assignmentPublicID: assignment.publicID, id: "figs", kind: "figure_count",
+                        timeLimitSeconds: 601, minFigures: 1),
+                    context(app))
+            }
+        }
+    }
+
     @Test func rejectsUnknownKind() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/CreatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/CreatePatternFamilyToolTests.swift
@@ -182,6 +182,63 @@ import Vapor
         }
     }
 
+    @Test func createsFamilyWithDefaultAndPerCaseTimeLimits() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await CreatePatternFamilyTool().execute(
+                CreatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, id: "timed", name: "Timed",
+                    kind: "boundary_equality", function: "f", paramNames: ["x"],
+                    defaultTimeLimitSeconds: 30,
+                    cases: [
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "01", args: [.int(1)], expected: .string("one"),
+                            timeLimitSeconds: 120),
+                        CreatePatternFamilyTool.CaseInput(
+                            key: "02", args: [.int(2)], expected: .string("two")),
+                    ]),
+                context(app))
+
+            let family = try await reloadFamily(assignment, id: "timed", on: app.db)
+            #expect(family.defaults.timeLimitSeconds == 30)
+            #expect(family.cases.first { $0.key == "01" }?.timeLimitSeconds == 120)
+            // Case 02 has no override → resolves to the family default.
+            let c2 = try #require(family.cases.first { $0.key == "02" })
+            #expect(c2.timeLimitSeconds == nil)
+            #expect(c2.resolvedTimeLimit(defaults: family.defaults) == 30)
+
+            // get_suite surfaces the values on the returned family spec.
+            let readCtx = ToolContext(
+                request: Request(application: app, on: app.eventLoopGroup.any()),
+                subject: "tester", grantedScopes: [.read])
+            let suite = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), readCtx)
+            let famRow = try #require(suite.items.compactMap(\.family).first { $0.id == "timed" })
+            #expect(famRow.defaults.timeLimitSeconds == 30)
+            #expect(famRow.cases.first { $0.key == "01" }?.timeLimitSeconds == 120)
+        }
+    }
+
+    @Test func rejectsOutOfRangeTimeLimitOnCreate() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreatePatternFamilyTool().execute(
+                    CreatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, id: "bad", name: "Bad",
+                        kind: "boundary_equality", function: "f", paramNames: ["x"],
+                        defaultTimeLimitSeconds: 9999,
+                        cases: [
+                            CreatePatternFamilyTool.CaseInput(
+                                key: "01", args: [.int(1)], expected: .string("one"))
+                        ]),
+                    context(app))
+            }
+        }
+    }
+
     @Test func blankPerCaseHintIsStoredAsNil() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
+++ b/Tests/APITests/MCP/UpdatePatternFamilyToolTests.swift
@@ -167,6 +167,71 @@ import Vapor
         }
     }
 
+    @Test func setsAndClearsFamilyAndPerCaseTimeLimits() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // Set a family default and a per-case override on case 01.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultTimeLimitSeconds: 30,
+                    cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", timeLimitSeconds: 120)]),
+                context(app))
+            var family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.defaults.timeLimitSeconds == 30)
+            #expect(family.cases.first { $0.key == "01" }?.timeLimitSeconds == 120)
+            // Case 02 has no override → resolves to the family default.
+            let c2 = try #require(family.cases.first { $0.key == "02" })
+            #expect(c2.timeLimitSeconds == nil)
+            #expect(c2.resolvedTimeLimit(defaults: family.defaults) == 30)
+
+            // get_suite surfaces the values on the family spec.
+            let readCtx = ToolContext(
+                request: Request(application: app, on: app.eventLoopGroup.any()),
+                subject: "tester", grantedScopes: [.read])
+            let suite = try await GetSuiteTool().execute(
+                GetSuiteTool.Input(assignmentPublicID: assignment.publicID), readCtx)
+            let famRow = try #require(suite.items.compactMap(\.family).first { $0.id == "bmi_category" })
+            #expect(famRow.defaults.timeLimitSeconds == 30)
+            #expect(famRow.cases.first { $0.key == "01" }?.timeLimitSeconds == 120)
+
+            // 0 clears both the family default and the per-case override.
+            _ = try await UpdatePatternFamilyTool().execute(
+                UpdatePatternFamilyTool.Input(
+                    assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                    defaultTimeLimitSeconds: 0,
+                    cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", timeLimitSeconds: 0)]),
+                context(app))
+            family = try await reloadFamily(assignment, on: app.db)
+            #expect(family.defaults.timeLimitSeconds == nil)
+            #expect(family.cases.first { $0.key == "01" }?.timeLimitSeconds == nil)
+        }
+    }
+
+    @Test func rejectsOutOfRangeTimeLimit() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            // 601 is above the 1...600 ceiling.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        defaultTimeLimitSeconds: 601),
+                    context(app))
+            }
+            // A per-case value below the floor is rejected too.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await UpdatePatternFamilyTool().execute(
+                    UpdatePatternFamilyTool.Input(
+                        assignmentPublicID: assignment.publicID, familyID: "bmi_category",
+                        cases: [UpdatePatternFamilyTool.CaseEdit(key: "01", timeLimitSeconds: -5)]),
+                    context(app))
+            }
+        }
+    }
+
     @Test func setsPerStudentExpectedVarRefAndClearsOnLiteralEdit() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/PatternFamilyApplyTests.swift
+++ b/Tests/APITests/PatternFamilyApplyTests.swift
@@ -362,6 +362,104 @@ import Vapor
         }
     }
 
+    /// A family with a `defaults.timeLimitSeconds` and one per-case override
+    /// threads the resolved value onto every generated entry: the override case
+    /// carries its own value, the others (and the existence guard) carry the
+    /// family default. The values survive an `authoredItems == nil` re-apply.
+    @Test func apply_familyAndPerCaseTimeLimitPropagateToGeneratedEntries() async throws {
+        try await withPatternFamilyFixture { fixture in
+
+            var cases = pfBMIFamily().cases
+            // Case "02" overrides the family default with a longer limit.
+            cases[1] = PatternCase(
+                key: cases[1].key, label: cases[1].label,
+                args: cases[1].args, expected: cases[1].expected,
+                timeLimitSeconds: 120)
+            let family = PatternFamily(
+                id: "bmi_category", name: "BMI", kind: .boundaryEquality,
+                functionName: "bmi_category", paramNames: ["bmi"],
+                defaults: PatternDefaults(tier: .pub, points: 1, hint: "x", timeLimitSeconds: 30),
+                cases: cases
+            )
+
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [family], on: fixture.app.db)
+
+            func assertLimits(_ props: TestProperties, label: String) throws {
+                let generated = props.testSuites.filter { $0.generatedBy != nil }
+                #expect(generated.count == 4, "\(label): 3 cases + guard")
+                let guardName = pfGuardFilename("bmi_category")
+                // Guard inherits the family default.
+                #expect(
+                    generated.first { $0.script == guardName }?.timeLimitSeconds == 30,
+                    "\(label): guard inherits the family default")
+                // Override case carries 120.
+                #expect(
+                    generated.first { $0.script == "publictest_bmi_category_02.py" }?
+                        .timeLimitSeconds == 120,
+                    "\(label): per-case override wins")
+                // The other two cases inherit the family default (30).
+                #expect(
+                    generated.first { $0.script == "publictest_bmi_category_01.py" }?
+                        .timeLimitSeconds == 30)
+                #expect(
+                    generated.first { $0.script == "publictest_bmi_category_03.py" }?
+                        .timeLimitSeconds == 30)
+            }
+
+            try assertLimits(try pfDecodeManifest(fixture.setup.manifest), label: "initial apply")
+
+            // Re-apply through the legacy (authoredItems == nil) path — the
+            // family-modal save — which reconstructs ordering from the manifest.
+            let existing = try pfDecodeManifest(fixture.setup.manifest).patternFamilies
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: existing, on: fixture.app.db)
+            try assertLimits(try pfDecodeManifest(fixture.setup.manifest), label: "re-apply")
+        }
+    }
+
+    /// A family with no time limits yields generated entries with nil
+    /// (absent) `timeLimitSeconds` — they inherit the assignment-wide default.
+    @Test func apply_familyWithoutTimeLimitsYieldsNilEntries() async throws {
+        try await withPatternFamilyFixture { fixture in
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [pfBMIFamily()], on: fixture.app.db)
+            let props = try pfDecodeManifest(fixture.setup.manifest)
+            for generated in props.testSuites where generated.generatedBy != nil {
+                #expect(
+                    generated.timeLimitSeconds == nil,
+                    "A family with no limits must leave generated entries inheriting the default")
+            }
+        }
+    }
+
+    /// A notebook check carrying `timeLimitSeconds` threads the value onto its
+    /// generated entry, including through the `authoredItems == nil` re-apply.
+    @Test func apply_notebookCheckTimeLimitPropagatesToGeneratedEntry() async throws {
+        try await withPatternFamilyFixture { fixture in
+            let check = NotebookCheck(
+                id: "figs", kind: .figureCount, tier: .pub, points: 1,
+                timeLimitSeconds: 45, minFigures: 2)
+
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [], nextChecks: [check],
+                authoredItems: [.check(id: "figs", sectionID: nil)], on: fixture.app.db)
+
+            func checkEntry(_ props: TestProperties) throws -> TestSuiteEntry {
+                try #require(props.testSuites.first { $0.generatedByCheck == "figs" })
+            }
+            #expect(try checkEntry(try pfDecodeManifest(fixture.setup.manifest)).timeLimitSeconds == 45)
+
+            // Re-apply via the legacy (authoredItems == nil) path.
+            let existing = try pfDecodeManifest(fixture.setup.manifest).notebookChecks
+            _ = try await applyPatternFamilies(
+                to: fixture.setup, nextFamilies: [], nextChecks: existing, on: fixture.app.db)
+            #expect(
+                try checkEntry(try pfDecodeManifest(fixture.setup.manifest)).timeLimitSeconds == 45,
+                "Check time limit must survive an authoredItems==nil re-apply")
+        }
+    }
+
     /// Family-level `dependsOn` propagates to every generated case, with
     /// family-ref tokens expanded to the referenced family's filenames.
     @Test func apply_familyLevelDepsExpandedAndInheritedByCases() async throws {

--- a/Tests/CoreTests/CoreCodableTests.swift
+++ b/Tests/CoreTests/CoreCodableTests.swift
@@ -758,6 +758,65 @@ struct CoreCodableTests {
         #expect(decoded.requiredConstructs?.count == 3)
     }
 
+    // MARK: - Per-test time-limit overrides (families + checks)
+
+    @Test func patternDefaultsTimeLimitRoundTrip() throws {
+        let defaults = PatternDefaults(timeLimitSeconds: 30)
+        let decoded = try decoder.decode(PatternDefaults.self, from: encoder.encode(defaults))
+        #expect(decoded.timeLimitSeconds == 30)
+    }
+
+    @Test func patternDefaultsWithoutTimeLimitDecodesNil() throws {
+        let json = #"{ "tier": "public", "points": 1 }"#
+        let decoded = try decoder.decode(PatternDefaults.self, from: Data(json.utf8))
+        #expect(decoded.timeLimitSeconds == nil)
+    }
+
+    @Test func patternCaseTimeLimitRoundTrip() throws {
+        let c = PatternCase(
+            key: "01", label: "slow", args: [.int(1)], expected: .int(1),
+            timeLimitSeconds: 120)
+        let decoded = try decoder.decode(PatternCase.self, from: encoder.encode(c))
+        #expect(decoded.timeLimitSeconds == 120)
+    }
+
+    @Test func patternCaseWithoutTimeLimitDecodesNil() throws {
+        let json = #"{ "key": "01", "label": "L", "args": [1], "expected": 2 }"#
+        let decoded = try decoder.decode(PatternCase.self, from: Data(json.utf8))
+        #expect(decoded.timeLimitSeconds == nil)
+    }
+
+    @Test func patternCaseResolvedTimeLimitPrecedence() {
+        let defaults30 = PatternDefaults(timeLimitSeconds: 30)
+        let defaultsNil = PatternDefaults()
+        // Case override wins over the family default.
+        let withOverride = PatternCase(
+            key: "01", label: "L", args: [.int(1)], expected: .int(1), timeLimitSeconds: 120)
+        #expect(withOverride.resolvedTimeLimit(defaults: defaults30) == 120)
+        // No case override → falls back to the family default.
+        let noOverride = PatternCase(key: "02", label: "L", args: [.int(1)], expected: .int(1))
+        #expect(noOverride.resolvedTimeLimit(defaults: defaults30) == 30)
+        // Neither set → nil (inherit the assignment-wide default).
+        #expect(noOverride.resolvedTimeLimit(defaults: defaultsNil) == nil)
+    }
+
+    @Test func notebookCheckTimeLimitRoundTrip() throws {
+        let check = NotebookCheck(
+            id: "df_shape", kind: .dataFrameShape, timeLimitSeconds: 45,
+            variable: "df", expectedRows: 1, expectedCols: 1)
+        let decoded = try decoder.decode(NotebookCheck.self, from: encoder.encode(check))
+        #expect(decoded == check)
+        #expect(decoded.timeLimitSeconds == 45)
+    }
+
+    @Test func notebookCheckWithoutTimeLimitDecodesNil() throws {
+        let json = #"""
+            { "id": "c", "kind": "figure_count", "tier": "public", "points": 1, "minFigures": 1 }
+            """#
+        let decoded = try decoder.decode(NotebookCheck.self, from: Data(json.utf8))
+        #expect(decoded.timeLimitSeconds == nil)
+    }
+
     @Test func notebookCheckEqualityLegacyManifestDecodesCleanly() throws {
         // Pre-equality manifests don't carry the new fields; decode must
         // leave them nil rather than throwing.

--- a/changelog.d/per-test-timeout-families-checks.md
+++ b/changelog.d/per-test-timeout-families-checks.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Per-test time-limit overrides for pattern families and notebook checks (MCP).**
+  A pattern family can now carry a family-wide `defaultTimeLimitSeconds` (applied
+  to every generated case and the auto-existence guard) and each case its own
+  `timeLimitSeconds`; a notebook check can carry a check-level `timeLimitSeconds`.
+  The resolved value (case override wins over the family default; nil = inherit
+  the assignment-wide default) is threaded onto the generated `TestSuiteEntry` so
+  the worker and browser graders already honor it. Settable over the MCP content
+  API via `create_pattern_family` / `update_pattern_family`
+  (`defaultTimeLimitSeconds` + per-case `timeLimitSeconds`) and
+  `author_notebook_check` (`timeLimitSeconds`); the range is 1–600 seconds and a
+  `0` over MCP clears an override. `get_suite` surfaces the values on each
+  family/check spec. The suite-editor UI for these stays deferred.


### PR DESCRIPTION
Fast-follow to #981. That PR made the per-test execution time limit adjustable for the **assignment default** (`set_time_limit`) and **hand-written scripts**; this extends per-test overrides to the remaining generated test types, all via the MCP content API.

## What
- **Pattern families:** a family-level default (`PatternDefaults.timeLimitSeconds`) applied to every generated entry (cases + the existence guard), plus a per-case override (`PatternCase.timeLimitSeconds`). Precedence: `case ?? family default ?? assignment-wide default` (`PatternCase.resolvedTimeLimit(defaults:)`).
- **Notebook checks:** a check-level override (`NotebookCheck.timeLimitSeconds`).

## MCP surface
- `create_pattern_family` / `update_pattern_family`: `defaultTimeLimitSeconds` (→ family default) and per-case `timeLimitSeconds`.
- `author_notebook_check`: `timeLimitSeconds`.
- On `update_*`: `0` clears (revert to inherit), `nil`/omitted leaves untouched, `1–600` sets — mirroring the existing `hint` clear-vs-leave convention. Out-of-range rejected by the shared `validateTimeLimitSeconds`.
- `get_suite` surfaces all of them (its item embeds the Core `PatternFamily` / `NotebookCheck` structs directly, so the fields appear via synthesized Codable — no DTO change needed).

## Why it's a small/low-risk diff
A payoff from #981's design: **no executor / `browser-runner.js` / RunnerCore / WASM changes**. Both runners already resolve `entry.timeLimitSeconds` for *every* suite entry, and `testSuiteEntryToDict` already emits the key when `> 0`. This PR only **populates** that field for generated family/check entries (at the four generation emit sites — guard, family cases, and both notebook-check paths). The renderer resolves and normalizes each value (`0`/negative → nil) so a non-positive limit never reaches the manifest — consistent end-to-end with #981.

## Tests / verification
- `swift build` clean; **240 tests in 15 suites** pass (Core codable round-trip + `resolvedTimeLimit` precedence; manifest application — family default vs per-case override vs guard, and the `authoredItems == nil` re-apply path; the three MCP tools incl. `0`-clears and out-of-range rejection).
- `swift-format --strict` and SwiftLint `--strict` clean.
- No `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` edits (a `changelog.d/` fragment is included); no `RunnerCore` / `runner-wasm` / `browser-runner.js` / executor / Leaf changes.

**UI remains deferred** — that's the separate "per-test override in the UI later" item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8NoBbU4P9TjoCtmVgpJAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8NoBbU4P9TjoCtmVgpJAq)_