### PR TITLE
Harden in-browser editor recovery from "Kernel Unknown" boots

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -403,15 +403,18 @@
             }
 
             // Shell loaded.  Phase 2 fires ONLY on positive evidence the
-            // kernel has hit a known failure state.  The first time we see
-            // it we reload the editor once (recovery); only a SECOND failure
-            // surfaces the fallback UI + diagnostic.
+            // kernel has hit a known failure state.  We escalate through two
+            // reload rungs (iframe, then whole page) before surfacing the
+            // fallback UI + diagnostic — see planKernelFailureResponse.  Every
+            // reload first waits for the service worker to settle, so we don't
+            // just re-create the SW-control race that caused the failure.
             if (probe.kernelInFailureState) {
                 const plan = planKernelFailureResponse({
-                    recoveryAlreadyAttempted: kernelRecoveryAttempted,
-                    evidence: probe.kernelEvidence
+                    iframeReloadAttempted: kernelRecoveryAttempted,
+                    pageReloadAttempted:   kernelPageReloadUsed(),
+                    evidence:              probe.kernelEvidence
                 });
-                if (plan.action === 'recover') {
+                if (plan.action === 'reload-iframe') {
                     kernelRecoveryAttempted = true;
                     recovering = true;
                     setStatus('loading',
@@ -422,13 +425,33 @@
                     // IndexedDB on boot and the reseed preservation logic keeps
                     // their work, so this reboots the kernel without discarding
                     // edits.  `forcedEditorResetAt` keeps the locked-path
-                    // enforcer from fighting our navigation.
+                    // enforcer from fighting our navigation.  Wait for the SW to
+                    // settle first so the fresh boot doesn't re-race it.
                     forcedEditorResetAt = Date.now();
-                    try { frame.src = editorURL; } catch (_) { /* retry on next tick */ }
-                    // Re-arm both phases for the fresh boot.
-                    startedAt     = Date.now();
-                    shellLoadedAt = null;
-                    setTimeout(tick, 2000);
+                    whenServiceWorkerActive(5000).then(() => {
+                        if (cancelled) return;
+                        try { frame.src = editorURL; } catch (_) { /* retry on next tick */ }
+                        // Re-arm both phases for the fresh boot.
+                        startedAt     = Date.now();
+                        shellLoadedAt = null;
+                        setTimeout(tick, 2000);
+                    });
+                    return;
+                }
+                if (plan.action === 'reload-page') {
+                    // The iframe reload re-raced; a full-tab reload is the only
+                    // thing that re-bootstraps the SW→client control from
+                    // scratch.  Done at most once per tab session (guarded) so
+                    // it can never loop.  Stop this watchdog; the reloaded page
+                    // arms a fresh one.
+                    markKernelPageReloadUsed();
+                    recovering = true;
+                    cancelled  = true;
+                    setStatus('loading',
+                        'The notebook kernel didn’t start — reloading the page…');
+                    whenServiceWorkerActive(5000).then(() => {
+                        try { window.location.reload(); } catch (_) { /* nothing else to try */ }
+                    });
                     return;
                 }
                 cancelled = true;
@@ -633,18 +656,33 @@
     // badge).  Pure so it's unit-testable; the caller performs the reload /
     // showFailure side effects.
     //
-    //   * First failure  → 'recover': reload the editor once.  A dead/unknown
-    //                      kernel is usually a transient cold-boot race that a
-    //                      fresh load clears, so we retry before giving up.
-    //   * Second failure → 'fail': the reload didn't help.  Surface the upload
+    // The Pyodide kernel's synchronous-execution path (Drive + stdin) is served
+    // by the JupyterLite service worker, so a kernel that boots while the SW is
+    // registered-but-not-yet-*controlling* lands in "Kernel Unknown".  That race
+    // is usually transient, so we escalate through two reload rungs before
+    // giving up:
+    //
+    //   * First failure  → 'reload-iframe': reload just the editor iframe.  The
+    //                      cheapest recovery; clears most cold-boot races.
+    //   * Second failure → 'reload-page': the iframe reload re-raced.  Reload
+    //                      the whole tab once — only a full document load
+    //                      re-bootstraps the SW→client control relationship from
+    //                      scratch (an in-place iframe `src` reset cannot), which
+    //                      is what was missing when failures "persisted after
+    //                      auto-reload".  Guarded by the caller (one per tab
+    //                      session) so it can't loop.
+    //   * Third failure  → 'fail': neither reload helped.  Surface the upload
     //                      fallback and report the diagnostic, with the message
     //                      annotated so telemetry can distinguish a persistent
     //                      kernel failure from a first-try one.  The kind /
     //                      failedChecks / source are unchanged so the admin
     //                      browser-diagnostics breakdown keeps classifying it.
-    function planKernelFailureResponse({ recoveryAlreadyAttempted, evidence }) {
-        if (!recoveryAlreadyAttempted) {
-            return { action: 'recover' };
+    function planKernelFailureResponse({ iframeReloadAttempted, pageReloadAttempted, evidence }) {
+        if (!iframeReloadAttempted) {
+            return { action: 'reload-iframe' };
+        }
+        if (!pageReloadAttempted) {
+            return { action: 'reload-page' };
         }
         const reason = evidence || 'kernel in failure state';
         return {
@@ -656,6 +694,61 @@
                 message:      reason + ' (persisted after auto-reload)'
             }
         };
+    }
+
+    // Resolves once the service worker has activated (and ideally is controlling
+    // the page), or after `timeoutMs`.  The kernel's sync path is served by the
+    // JupyterLite service worker, so reloading *before* the SW has settled just
+    // re-creates the "Kernel Unknown" race — waiting first is what turns a
+    // re-racing reload into a real recovery.  Best-effort and never rejects: a
+    // missing/blocked SW resolves false after the timeout so recovery still
+    // proceeds (the reload itself may yet help).  Note the iframe's kernel SW is
+    // a different scope from this page, so `controller` here is a proxy for "the
+    // SW subsystem has settled", not a guarantee of control — hence the bound.
+    function whenServiceWorkerActive(timeoutMs) {
+        return new Promise((resolve) => {
+            try {
+                if (!('serviceWorker' in navigator)) { resolve(false); return; }
+                if (navigator.serviceWorker.controller) { resolve(true); return; }
+                let settled = false;
+                const finish = (value) => {
+                    if (settled) return;
+                    settled = true;
+                    try {
+                        navigator.serviceWorker.removeEventListener('controllerchange', onController);
+                    } catch (_) { /* ignore */ }
+                    resolve(value);
+                };
+                const onController = () => finish(true);
+                try {
+                    navigator.serviceWorker.addEventListener('controllerchange', onController);
+                } catch (_) { /* ignore */ }
+                navigator.serviceWorker.ready.then(() => {
+                    if (navigator.serviceWorker.controller) finish(true);
+                }).catch(() => { /* fall through to timeout */ });
+                setTimeout(() => {
+                    finish(!!(navigator.serviceWorker && navigator.serviceWorker.controller));
+                }, timeoutMs);
+            } catch (_) {
+                resolve(false);
+            }
+        });
+    }
+
+    // One full-page reload per (tab session, setup): the flag survives the
+    // reload (sessionStorage is per-tab), so the escalation ladder can't loop
+    // into a reload storm.  A fresh tab starts with a clean flag, so a later
+    // genuine retry still gets the full ladder.
+    function kernelPageReloadStorageKey() {
+        return 'chickadee:kernel-page-reload:' + setupID;
+    }
+    function kernelPageReloadUsed() {
+        try { return sessionStorage.getItem(kernelPageReloadStorageKey()) === '1'; }
+        catch (_) { return false; }
+    }
+    function markKernelPageReloadUsed() {
+        try { sessionStorage.setItem(kernelPageReloadStorageKey(), '1'); }
+        catch (_) { /* sessionStorage unavailable — page reload simply won't be re-gated */ }
     }
 
     // Hard fallback: if the notebook hasn't synced within 15 seconds (e.g. the

--- a/Sources/APIServer/Middleware/COEPMiddleware.swift
+++ b/Sources/APIServer/Middleware/COEPMiddleware.swift
@@ -18,8 +18,14 @@
 //
 // COEP require-corp only restricts CROSS-origin subresources; same-origin ones
 // (Chickadee vendors Pyodide / CodeMirror / jszip same-origin) load unchanged.
-// The historical objection — that JupyterLite's service-worker synthesised
-// responses lacked CORP — no longer applies: that service worker is disabled.
+//
+// NOTE: this flag is OFF by default. The JupyterLite service worker (re-enabled
+// in v0.4.467) is currently the kernel's synchronous-execution path, so the
+// editor runs without cross-origin isolation today. Turning this on is the
+// SharedArrayBuffer route (see docs/notebook-editor-kernel-boot.md): it is
+// still gated because COEP require-corp blocks the fast-path-served Pyodide
+// kernel worker (the v0.4.469 editor-smoke selftest pins exactly that), so it
+// cannot be enabled until that worker is served CORP-clean.
 
 import Vapor
 

--- a/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
+++ b/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
@@ -386,24 +386,41 @@ test('probeIframeReadiness: kernel failure surfaces evidence string', async () =
 });
 
 // ----------------------------------------------------------------
-// One-shot kernel recovery — first failure reloads, second gives up
+// Kernel recovery ladder — iframe reload, then full-page reload, then give up
+// (the full-page rung was added to fix "persisted after auto-reload" cases,
+// where the in-place iframe reset re-raced the service-worker control).
 // ----------------------------------------------------------------
 
-test('planKernelFailureResponse: first failure → recover (reload once)', async () => {
+test('planKernelFailureResponse: first failure → reload the iframe', async () => {
   const { planKernelFailureResponse } = await loadHarness();
   const plan = planKernelFailureResponse({
-    recoveryAlreadyAttempted: false,
+    iframeReloadAttempted: false,
+    pageReloadAttempted: false,
     evidence: 'kernel status: dead',
   });
-  assert.equal(plan.action, 'recover');
+  assert.equal(plan.action, 'reload-iframe');
   assert.equal(plan.diagnostic, undefined,
     'a recovery does not post a diagnostic — the editor gets one more chance');
 });
 
-test('planKernelFailureResponse: second failure → fail with annotated diagnostic', async () => {
+test('planKernelFailureResponse: iframe reload failed → reload the whole page', async () => {
   const { planKernelFailureResponse } = await loadHarness();
   const plan = planKernelFailureResponse({
-    recoveryAlreadyAttempted: true,
+    iframeReloadAttempted: true,
+    pageReloadAttempted: false,
+    evidence: 'kernel status: dead',
+  });
+  assert.equal(plan.action, 'reload-page',
+    'a same-document iframe reset cannot re-bootstrap SW control; the full-page reload can');
+  assert.equal(plan.diagnostic, undefined,
+    'the page reload is still a recovery — no diagnostic yet');
+});
+
+test('planKernelFailureResponse: both reloads failed → fail with annotated diagnostic', async () => {
+  const { planKernelFailureResponse } = await loadHarness();
+  const plan = planKernelFailureResponse({
+    iframeReloadAttempted: true,
+    pageReloadAttempted: true,
     evidence: 'kernel status: dead',
   });
   assert.equal(plan.action, 'fail');
@@ -421,10 +438,11 @@ test('planKernelFailureResponse: second failure → fail with annotated diagnost
     'annotates that recovery was attempted so persistent failures are distinguishable');
 });
 
-test('planKernelFailureResponse: second failure with no evidence → safe default message', async () => {
+test('planKernelFailureResponse: exhausted recovery with no evidence → safe default message', async () => {
   const { planKernelFailureResponse } = await loadHarness();
   const plan = planKernelFailureResponse({
-    recoveryAlreadyAttempted: true,
+    iframeReloadAttempted: true,
+    pageReloadAttempted: true,
     evidence: null,
   });
   assert.equal(plan.action, 'fail');

--- a/changelog.d/editor-kernel-recovery-ladder.md
+++ b/changelog.d/editor-kernel-recovery-ladder.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **Hardened the in-browser editor's recovery from "Kernel Unknown" boots.**
+  When the Pyodide kernel registers `dead`/`unknown` at startup — the
+  service-worker control race (the SW the kernel needs for its sync path is
+  *registered* but not yet *controlling the page* when the kernel mounts its
+  Drive) — the watchdog previously did a single in-place iframe reload and
+  then gave up, so failures showed up annotated "persisted after auto-reload":
+  the reset just re-raced the same SW startup. Recovery is now a three-rung
+  ladder, and each reload first waits (bounded) for the service worker to
+  settle: reload the iframe → reload the whole tab (a full document load is the
+  only thing that re-bootstraps the SW → client *control* relationship; guarded
+  by a per-(tab, setup) `sessionStorage` flag so it happens at most once and
+  can't loop) → only then surface the upload fallback and the unchanged
+  `watchdog_timeout` / `kernel-unhealthy` diagnostic. Mitigation, not a cure
+  (it still depends on the SW eventually controlling); the deterministic
+  root-cause fix (cross-origin isolation + `SharedArrayBuffer`, and why it's
+  still blocked) is written up in `docs/notebook-editor-kernel-boot.md`. Also
+  corrects a stale `COEPMiddleware` comment that claimed the JupyterLite service
+  worker was disabled — it was re-enabled in v0.4.467.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -1,0 +1,157 @@
+# Notebook editor kernel boot — "Kernel Unknown" and the path to a deterministic fix
+
+This note captures the in-browser editor's kernel-boot failure mode
+("Kernel Unknown"), the mitigation shipped now, and the plan for the
+durable root-cause fix (cross-origin isolation / `SharedArrayBuffer`).
+
+It is the companion to [`docs/notebook-editor-smoke-test.md`](notebook-editor-smoke-test.md)
+(the Playwright harness that gates this code) and the inline rationale in
+`Sources/APIServer/Middleware/COEPMiddleware.swift` +
+`NotebookAssetIsolationMiddleware.swift`.
+
+## Symptom
+
+A small, steady fraction of in-browser editor loads land on JupyterLite's
+**"Kernel Unknown"** badge — the Pyodide kernel session never registers, so
+the student can't run or (for browser-graded assignments) submit from the
+editor. It surfaces in the admin diagnostics as
+`watchdog_timeout` / `failedChecks: ["kernel-unhealthy"]`
+(`get_browser_diagnostics`), and historically clustered on specific
+browser/OS classes rather than being uniform.
+
+## Root cause: the service-worker control race
+
+The editor's current architecture (after the v0.4.465 → v0.4.467 sequence)
+runs **without cross-origin isolation** (`NOTEBOOK_CROSS_ORIGIN_ISOLATION`
+defaults off — `SecurityConfig.swift`), so there is **no `SharedArrayBuffer`**.
+That leaves the **JupyterLite service worker** as the kernel's *only*
+synchronous-execution path: it intercepts `/api/drive` and `/api/stdin/` and
+broadcasts to the Pyodide kernel worker.
+
+The kernel boots cleanly only if that service worker is **controlling the
+page** when the kernel mounts its Drive. The vended SW does
+`skipWaiting()` + `clients.claim()`, but on some devices/loads the SW is
+**registered but not yet controlling** at kernel-mount time → the kernel
+can't establish its sync path → it registers `dead`/`unknown` → "Kernel
+Unknown".
+
+Telemetry corroborates this exactly: the `sw_state` beacon reports
+`registrations=1` (the SW *registered*) on loads that still hit
+`kernel-unhealthy` — registration is not the same as control.
+
+This is a **known, predicted recurrence**, not a new bug. The v0.4.467
+changelog entry (which re-enabled the SW to kill the "Page Unresponsive"
+freeze) names the follow-up verbatim: *"If it recurs, the follow-up is a
+kernel-wheel patch gating `mountDrive` on the SW actually controlling the
+page."*
+
+## What shipped now (mitigation A): a real recovery ladder
+
+The parent-side watchdog in `Public/notebook.js` (`armEditorWatchdog` /
+`planKernelFailureResponse`) previously did **one** in-place iframe `src`
+reset and then gave up — which is why failures showed up annotated
+"persisted after auto-reload": the reset re-raced the same SW startup it was
+trying to dodge.
+
+The recovery is now a three-rung ladder, and every reload first waits for the
+SW to settle:
+
+1. **First failure → reload the iframe** (cheapest; clears most cold-boot
+   races). But first `await whenServiceWorkerActive(5000)` so the fresh boot
+   doesn't re-race SW activation.
+2. **Second failure → reload the whole tab** (`window.location.reload()`).
+   Only a full document load re-bootstraps the SW → client *control*
+   relationship from scratch; an in-place iframe reset cannot. Guarded by a
+   per-(tab, setup) `sessionStorage` flag (`chickadee:kernel-page-reload:<id>`)
+   so it happens **at most once** and can never loop into a reload storm.
+3. **Third failure → fail**: surface the upload fallback + the same
+   `watchdog_timeout` / `kernel-unhealthy` diagnostic as before (classification
+   unchanged, so the admin breakdown keeps bucketing it).
+
+Pinned by `Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs`.
+
+This is a **mitigation, not a cure**: it still depends on the SW eventually
+controlling the page. It should cut the persisted-failure rate materially
+(most of these clear on a clean reload once the SW has settled), and it ships
+behind no flag with instant rollback. Watch `get_browser_diagnostics`
+(`watchdog_timeout` count and `byBrowser`) after deploy to confirm the rate
+drops.
+
+## The durable fix (plan C): cross-origin isolation + `SharedArrayBuffer`
+
+The deterministic fix is to give the kernel a synchronous path that does **not
+depend on SW control timing at all**: `SharedArrayBuffer`, which requires the
+editor iframe to be **cross-origin isolated** (COOP `same-origin` + COEP
+`require-corp`). With SAB available the kernel never needs the SW for sync, so
+the race disappears. The plumbing already exists, gated off:
+
+- `COEPMiddleware` stamps COOP/COEP on the `/testsetups/:id/notebook` page.
+- `NotebookAssetIsolationMiddleware` stamps COOP/COEP + `Cross-Origin-Resource-Policy: same-origin`
+  on `/jupyterlite/*` iframe assets.
+- Both are driven by `NOTEBOOK_CROSS_ORIGIN_ISOLATION` (default off).
+
+### Why it's still off — the blocker
+
+This was tried unconditionally in v0.4.466 and reverted: under COEP
+`require-corp`, **the Pyodide kernel worker fails to start**. The v0.4.469
+editor-smoke *selftest* encodes this as a guarantee — it asserts the editor
+**passes** on the default config and **fails** under
+`NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` ("the COEP worker-block"). So we cannot
+just flip the flag; the worker-block must be fixed first.
+
+### Leading hypothesis (to verify, not assume)
+
+Under COEP `require-corp` on the iframe document, a dedicated Worker inherits
+the policy and **every resource it pulls must be isolation-compatible**
+(`Cross-Origin-Resource-Policy`, or CORS). The Pyodide kernel worker loads the
+runtime + wheels from **`/pyodide/*`**, but only **`/jupyterlite/*`** is
+stamped with CORP today (`NotebookAssetIsolationMiddleware` matches that prefix
+only). `/pyodide/*` (and any other same-origin asset the isolated worker
+fetches) is served by `FileMiddleware` with **no** CORP header. That mismatch
+is the most likely cause of the worker-block.
+
+### Proposed steps
+
+1. **Reproduce locally** with the smoke selftest
+   (`Tools/editor-smoke-test/selftest.sh`) and capture the *exact* console /
+   network error from the COEP run — confirm whether it's a CORP rejection on
+   `/pyodide/*`, the worker script itself, a `Blob:`/`importScripts` path, or
+   a credentials issue. Do not proceed on the hypothesis alone.
+2. **Stamp CORP on every same-origin asset the isolated worker loads** — at
+   minimum extend `NotebookAssetIsolationMiddleware` (or add a sibling) to add
+   `Cross-Origin-Resource-Policy: same-origin` to `/pyodide/*` and any other
+   prefix the error implicates, *only when isolation is enabled* (keep the
+   non-isolated path byte-identical).
+3. **Re-run the selftest.** Success criterion: the COEP run **flips to PASS**.
+   Update `selftest.sh` so the COEP config is now an *expected pass* (and keep a
+   regression case for whatever the real failing config is, so the guard can't
+   rot — e.g. isolation on but CORP deliberately withheld from `/pyodide/*`).
+4. **Verify in real browsers** (Chrome + Safari + a managed device) via the
+   smoke harness; this path is not fully CI-verifiable.
+5. **Flip the default / make unconditional**, then **disable the JupyterLite
+   service worker** again (it's only there for sync, which SAB now provides) —
+   removing the freeze risk *and* the control race together. Reverse the
+   `JupyterLiteConfigTests` SW guard accordingly.
+6. **Promote the editor-smoke workflow from advisory to a required gate** once
+   it reliably passes on the isolated config — that is what actually closes out
+   "all editor-load issues fixed".
+
+### Fallback if isolation can't be made to work
+
+If the worker-block proves intractable, the v0.4.467-named alternative remains:
+patch the pyodide-kernel so `mountDrive` waits on
+`navigator.serviceWorker.controller` before using the SW sync path. This is
+harder to do cleanly here than the nb_mypy wheel patch
+(`scripts/patch-pyodide-kernel.py`), because the gating logic lives in
+**content-hash-named webpack chunks** (`Public/jupyterlite/.../static/620.*.js`,
+`644.*.js`) rather than a fixed-name Python member, so editing it is a
+rebuild-the-bundle / upstream-patch effort and is not CI-verifiable.
+Prefer plan C.
+
+## Quick reference
+
+| | Sync path | SW-control race? | Status |
+|---|---|---|---|
+| Today | JupyterLite service worker | **yes** (the bug) | shipped; mitigated by recovery ladder A |
+| Plan C | `SharedArrayBuffer` (cross-origin isolation) | no | blocked on the COEP kernel-worker fix |
+| Fallback | SW, gated on `serviceWorker.controller` | removed | last resort; webpack-chunk patch |


### PR DESCRIPTION
## Why

Today's browser diagnostics still show a small, steady trickle of editor-load failures: 2 `watchdog_timeout` / `kernel-unhealthy` events over 24h, both macOS Chrome, both **"Kernel Unknown badge (iframe dom) (persisted after auto-reload)"**. This is the last big item for the online labs.

### Root cause (confirmed in code + telemetry)
Cross-origin isolation is off (`NOTEBOOK_CROSS_ORIGIN_ISOLATION` defaults false), so there's no `SharedArrayBuffer` — the **JupyterLite service worker** is the kernel's only synchronous-execution path. The kernel boots cleanly only if that SW is *controlling the page* when it mounts its Drive. On some loads the SW is **registered but not yet controlling** at mount time → session registers `dead`/`unknown` → "Kernel Unknown". Telemetry corroborates: `sw_state` reports `registrations=1` on loads that still fail. This is the recurrence v0.4.467 explicitly predicted when it re-enabled the SW.

## What this PR does (mitigation "A")

The watchdog previously did **one** in-place iframe `src` reset, then gave up — which just re-raced the same SW startup (hence "persisted after auto-reload"). Recovery is now a three-rung ladder, and **each reload first waits (bounded) for the SW to settle**:

1. **iframe reload** — cheapest; clears most cold-boot races.
2. **full-tab reload** (`window.location.reload()`) — only a full document load re-bootstraps the SW → client *control* relationship; an in-place iframe reset cannot. Guarded by a per-(tab, setup) `sessionStorage` flag so it runs **at most once** and can't loop.
3. **fail** — surface the upload fallback + the unchanged `watchdog_timeout` / `kernel-unhealthy` diagnostic (classification untouched, so the admin breakdown keeps bucketing it).

This is a **mitigation, not a cure** — it still depends on the SW eventually controlling — but it should materially cut the persisted-failure rate, and ships behind no flag with instant rollback.

## Plan for the deterministic fix ("C")

`docs/notebook-editor-kernel-boot.md` (new) writes up the root cause, this mitigation, and the durable fix: **cross-origin isolation + `SharedArrayBuffer`**, which removes the SW-timing dependency entirely. It's blocked because COEP `require-corp` currently breaks the Pyodide kernel worker (the v0.4.469 editor-smoke selftest pins this). The doc lays out the leading hypothesis (only `/jupyterlite/*` is CORP-stamped today, not `/pyodide/*`), concrete steps to unblock + verify via the smoke harness, and the fallback if isolation proves intractable.

## Changes
- `Public/notebook.js` — three-rung recovery ladder + `whenServiceWorkerActive()` + `sessionStorage` page-reload guard.
- `Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs` — updated `planKernelFailureResponse` contract (iframe → page → fail), all 99 JS tests pass.
- `Sources/APIServer/Middleware/COEPMiddleware.swift` — corrected stale comment (SW was re-enabled in v0.4.467) + pointer to the new doc.
- `docs/notebook-editor-kernel-boot.md` — root-cause + plan-C write-up.
- `changelog.d/` fragment.

## Verification
- `node --test Tests/BrowserRunnerJSTests/*.test.mjs` → 99 pass.
- ⚠️ This path is not fully CI-verifiable. Before un-drafting, worth running the v0.4.469 Playwright smoke harness and a real macOS Chrome check, and watching `get_browser_diagnostics` (`watchdog_timeout` count + `byBrowser`) after deploy to confirm the rate drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT)_