### PR TITLE
Make notebook-editor cross-origin isolation actually work (the real "Kernel Unknown" fix)

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -8,6 +8,11 @@ name: Editor smoke test
 # blocks the kernel worker (the COEP cross-origin-isolation attempt) or leaves a
 # dead kernel ("Kernel Unknown") passes CI and only fails in front of a student.
 #
+# Runs the selftest, which exercises BOTH editor sync paths against one build —
+# the default service-worker path AND the cross-origin-isolation /
+# SharedArrayBuffer path — plus a known-broken (frozen) config to prove the
+# detector is discriminating. See Tools/editor-smoke-test/selftest.sh.
+#
 # Runs two ways:
 #   • nightly (schedule) — always-on insurance across the whole editor stack;
 #   • per-PR but PATH-FILTERED — only when a notebook/editor/middleware/asset
@@ -101,5 +106,13 @@ jobs:
           # --with-deps installs the browser's system libraries via apt.
           npx playwright install --with-deps chromium
 
-      - name: Run editor smoke test
-        run: Tools/editor-smoke-test/run-smoke.sh
+      # selftest.sh drives the editor THREE ways against this one build:
+      #   • default (service-worker path) — must PASS, crossOriginIsolated=false;
+      #   • NOTEBOOK_CROSS_ORIGIN_ISOLATION=true (SharedArrayBuffer path) — must
+      #     PASS, crossOriginIsolated=true (the fast-path-isolation fix; this is
+      #     also the live guard against the COEP kernel-worker block regressing);
+      #   • SMOKE_SIMULATE_FROZEN=1 — must FAIL (proves the freeze detector works).
+      # Using selftest (not the single-config run-smoke) means CI guards BOTH
+      # editor sync paths, not just the default one.
+      - name: Run editor smoke selftest (both sync paths + freeze detector)
+        run: Tools/editor-smoke-test/selftest.sh

--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -48,6 +48,11 @@ import Vapor
 func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     let securityConfiguration = appConfig.security
     let scanModeConfiguration = appConfig.scanMode
+    // Cross-origin isolation for the notebook editor (NOTEBOOK_CROSS_ORIGIN_ISOLATION,
+    // default off).  Read once here because it is needed in two places in the
+    // chain: the fast path (which serves — and must isolate — the editor asset
+    // trees) and the slow-path asset / page middlewares below.
+    let isolateNotebook = securityConfiguration.notebookCrossOriginIsolation
 
     // MARK: - Storage seeding for auth/security configs
 
@@ -94,8 +99,16 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     }
     // Vendored editor assets short-circuit here, before any session work.
     // See EditorAssetFastPathMiddleware for the whitelist + cache policy.
+    // It serves the editor asset trees (/jupyterlite/build, /jupyterlite/extensions,
+    // /pyodide, /vendor) — including the Pyodide kernel WORKER chunk — and returns
+    // WITHOUT calling next, so the slow-path NotebookAssetIsolationMiddleware never
+    // sees them.  It must therefore carry the cross-origin-isolation headers itself
+    // when the flag is on, or the isolated editor page spawns a worker whose script
+    // lacks COEP and Chrome blocks it (ERR_BLOCKED_BY_RESPONSE).
     app.middleware.use(
-        EditorAssetFastPathMiddleware(publicDirectory: app.directory.publicDirectory))
+        EditorAssetFastPathMiddleware(
+            publicDirectory: app.directory.publicDirectory,
+            crossOriginIsolation: isolateNotebook))
     app.middleware.use(app.sessions.middleware)
     app.middleware.use(UserSessionAuthenticator())
     if securityConfiguration.sessionIdleTimeoutSeconds > 0 {
@@ -152,10 +165,11 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // dynamic notebook page, while NotebookAssetIsolationMiddleware (before it)
     // is needed to decorate the static /jupyterlite/* responses. By default the
     // JupyterLite assets get no COEP (long-standing behaviour). Cross-origin
-    // isolation for the editor — the fix for the Pyodide main-thread freeze when
-    // there's no SharedArrayBuffer and the service-worker sync fallback is
-    // disabled — is opt-in via NOTEBOOK_CROSS_ORIGIN_ISOLATION (see
-    // COEPMiddleware / NotebookAssetIsolationMiddleware).
+    // isolation for the editor — which gives the Pyodide kernel SharedArrayBuffer
+    // so it no longer depends on the service worker for synchronous stdin/Drive
+    // (fixing both the main-thread freeze and the SW-control "Kernel Unknown"
+    // race) — is opt-in via NOTEBOOK_CROSS_ORIGIN_ISOLATION (see COEPMiddleware /
+    // NotebookAssetIsolationMiddleware / EditorAssetFastPathMiddleware).
     // Registered just OUTSIDE FileMiddleware so it can set immutable cache +
     // application/wasm headers on the content-hashed wasm runner served from
     // Public/runner-wasm/ (FileMiddleware short-circuits, so a middleware after
@@ -167,11 +181,13 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     app.middleware.use(StaticAssetCacheMiddleware())
     app.middleware.use(RunnerWasmCacheMiddleware())
     // Cross-origin isolation for the notebook editor (gated by
-    // NOTEBOOK_CROSS_ORIGIN_ISOLATION, default off). The asset middleware runs
-    // BEFORE FileMiddleware so it can decorate the short-circuited /jupyterlite/*
-    // static responses; COEPMiddleware (after FileMiddleware) covers the dynamic
-    // notebook page itself. Both no-op when the flag is off.
-    let isolateNotebook = securityConfiguration.notebookCrossOriginIsolation
+    // NOTEBOOK_CROSS_ORIGIN_ISOLATION, default off). This middleware runs BEFORE
+    // FileMiddleware so it can decorate the SLOW-PATH /jupyterlite/* responses
+    // FileMiddleware serves (the editor HTML documents — repl/lab/notebooks
+    // index.html — which are NOT on the fast path); the fast path above isolates
+    // the vendored asset trees it serves itself, and COEPMiddleware (after
+    // FileMiddleware) covers the dynamic notebook page. All three no-op when the
+    // flag is off.
     app.middleware.use(NotebookAssetIsolationMiddleware(enabled: isolateNotebook))
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(COEPMiddleware(isolateNotebook: isolateNotebook))

--- a/Sources/APIServer/Configuration/SecurityConfig.swift
+++ b/Sources/APIServer/Configuration/SecurityConfig.swift
@@ -22,16 +22,21 @@ struct AppSecurityConfiguration: Sendable {
     /// timeout; zero (or a disabled gate) suppresses the warning so the
     /// client logs out straight at the ceiling.
     let sessionIdleWarningSeconds: TimeInterval
-    /// When true, the student notebook editor page AND the `/jupyterlite/*`
-    /// iframe assets are served with COOP + COEP (`require-corp`) so the page is
+    /// When true, the student notebook editor page AND every editor asset
+    /// (the `/jupyterlite/*` documents, plus the fast-path-served
+    /// `/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`, `/vendor`
+    /// trees) are served with COOP + COEP (`require-corp`) so the editor is
     /// cross-origin isolated and the Pyodide kernel can use `SharedArrayBuffer`
-    /// for synchronous execution — the fix for the main-thread freeze that
-    /// occurs when neither `SharedArrayBuffer` nor the (disabled) service-worker
-    /// sync fallback is available. Set via `NOTEBOOK_CROSS_ORIGIN_ISOLATION`,
-    /// default false: COEP on the editor page has broken the iframe before
-    /// (#574), so this is gated behind a flag — enable on staging, verify the
-    /// editor boots in each target browser, then enable in production, with
-    /// instant rollback by flipping the flag (no redeploy).
+    /// for synchronous execution. SAB removes the kernel's dependence on the
+    /// JupyterLite service worker for synchronous stdin/Drive — eliminating both
+    /// the main-thread freeze and the SW-control "Kernel Unknown" race (see
+    /// docs/notebook-editor-kernel-boot.md). Set via
+    /// `NOTEBOOK_CROSS_ORIGIN_ISOLATION`, default false: COEP on the editor page
+    /// has broken the iframe before (#574), so this is gated behind a flag —
+    /// enable on staging, verify the editor boots in each target browser
+    /// (Chromium is covered by the editor-smoke harness; Safari is not), then
+    /// enable in production, with instant rollback by flipping the flag (no
+    /// redeploy).
     let notebookCrossOriginIsolation: Bool
 
     static let `default` = AppSecurityConfiguration(

--- a/Sources/APIServer/Middleware/CrossOriginIsolationHeaders.swift
+++ b/Sources/APIServer/Middleware/CrossOriginIsolationHeaders.swift
@@ -1,0 +1,37 @@
+// APIServer/Middleware/CrossOriginIsolationHeaders.swift
+//
+// The COOP + COEP + CORP trio that makes a document, dedicated worker, or
+// subresource participate in a cross-origin-isolated context — which is what
+// gives the Pyodide kernel `SharedArrayBuffer` for synchronous execution.
+//
+// Shared by the two middlewares that serve the notebook editor's assets
+// (`NotebookAssetIsolationMiddleware` for the slow-path HTML documents,
+// `EditorAssetFastPathMiddleware` for the vendored asset trees) so the header
+// set cannot drift between them — a drift is exactly what broke the editor: the
+// fast-path-served kernel worker chunk was missing COEP, so the isolated editor
+// page spawned a worker Chrome then blocked with `ERR_BLOCKED_BY_RESPONSE`.
+
+import Vapor
+
+extension Response {
+    /// Stamps `Cross-Origin-Opener-Policy: same-origin`,
+    /// `Cross-Origin-Embedder-Policy: require-corp`, and
+    /// `Cross-Origin-Resource-Policy: same-origin` on this response.
+    ///
+    /// All three are required together:
+    ///   * COOP `same-origin` + COEP `require-corp` on the editor document make
+    ///     it cross-origin isolated (`self.crossOriginIsolated === true`).
+    ///   * A dedicated worker the isolated document spawns must ALSO be served
+    ///     with COEP `require-corp`, or the worker script load is blocked with
+    ///     `ERR_BLOCKED_BY_RESPONSE` — this is the failure the fast path hit.
+    ///   * CORP `same-origin` lets the `require-corp` embedder load the resource.
+    ///
+    /// Idempotent (`replaceOrAdd`): safe to call even though the outer
+    /// `SecurityHeadersMiddleware` already sets COOP + CORP globally — this only
+    /// adds the COEP the isolated editor paths additionally need.
+    func setCrossOriginIsolationHeaders() {
+        headers.replaceOrAdd(name: "Cross-Origin-Opener-Policy", value: "same-origin")
+        headers.replaceOrAdd(name: "Cross-Origin-Embedder-Policy", value: "require-corp")
+        headers.replaceOrAdd(name: "Cross-Origin-Resource-Policy", value: "same-origin")
+    }
+}

--- a/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
+++ b/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
@@ -49,8 +49,17 @@ struct EditorAssetFastPathMiddleware: AsyncMiddleware {
 
     private let publicDirectory: String
 
-    init(publicDirectory: String) {
+    /// When true, the editor asset trees this middleware serves are stamped with
+    /// the cross-origin-isolation headers (COOP/COEP/CORP).  Required because the
+    /// fast path short-circuits the chain BEFORE `NotebookAssetIsolationMiddleware`,
+    /// so without this the isolated editor page would load a kernel worker chunk
+    /// that lacks COEP and Chrome would block it.  Gated by
+    /// `NOTEBOOK_CROSS_ORIGIN_ISOLATION` (off by default).
+    private let crossOriginIsolation: Bool
+
+    init(publicDirectory: String, crossOriginIsolation: Bool = false) {
         self.publicDirectory = publicDirectory.hasSuffix("/") ? publicDirectory : publicDirectory + "/"
+        self.crossOriginIsolation = crossOriginIsolation
     }
 
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
@@ -74,6 +83,11 @@ struct EditorAssetFastPathMiddleware: AsyncMiddleware {
         if Self.isContentHashedBundleAsset(path: path) {
             response.headers.replaceOrAdd(
                 name: .cacheControl, value: "public, max-age=31536000, immutable")
+        }
+        // The slow-path NotebookAssetIsolationMiddleware never sees these
+        // short-circuited responses, so the fast path must isolate them itself.
+        if crossOriginIsolation {
+            response.setCrossOriginIsolationHeaders()
         }
         return response
     }

--- a/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
+++ b/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
@@ -1,14 +1,22 @@
 // APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
 //
-// Stamps cross-origin-isolation headers on the JupyterLite iframe assets so the
-// iframe document — where the Pyodide kernel and its worker actually run — is
-// cross-origin isolated, giving the kernel `SharedArrayBuffer` for synchronous
-// execution. `COEPMiddleware` isolates the parent notebook page; this isolates
-// the embedded `/jupyterlite/*` documents and assets so the chain is consistent
-// (a cross-origin-isolated iframe requires a cross-origin-isolated embedder and
-// its own COEP).
+// Stamps cross-origin-isolation headers on the SLOW-PATH `/jupyterlite/*`
+// responses — the JupyterLite editor HTML documents (`repl/`, `lab/`,
+// `notebooks/` index.html and the like) that FileMiddleware serves — so the
+// iframe document where the Pyodide kernel runs is cross-origin isolated,
+// giving the kernel `SharedArrayBuffer` for synchronous execution.
+// `COEPMiddleware` isolates the parent notebook page.
 //
-// Must be registered BEFORE `FileMiddleware`, which serves `/jupyterlite/*` and
+// NOTE on coverage: the vendored asset *trees* (`/jupyterlite/build/`,
+// `/jupyterlite/extensions/` — including the Pyodide kernel WORKER chunk — plus
+// `/pyodide/` and `/vendor/`) are served by `EditorAssetFastPathMiddleware`,
+// which short-circuits the chain UPSTREAM of this middleware. Those responses
+// never reach here, so the fast path isolates them itself (see
+// `setCrossOriginIsolationHeaders`). This middleware only catches the
+// `/jupyterlite/*` paths NOT on that whitelist (the HTML documents and the
+// per-student `/jupyterlite/files/...` copies).
+//
+// Must be registered BEFORE `FileMiddleware`, which serves the editor HTML and
 // short-circuits the responder chain (it returns without calling `next`), so a
 // middleware registered AFTER it never sees those static responses. Registered
 // before, this one decorates the response on the way back out.
@@ -17,11 +25,6 @@
 // is a pure pass-through, preserving the long-standing behaviour of serving the
 // JupyterLite assets without COEP. See `COEPMiddleware` for the rationale and
 // the #574 history.
-//
-// `Cross-Origin-Resource-Policy: same-origin` is added so the same-origin
-// parent can embed these documents/assets under its own COEP; `require-corp`
-// itself only constrains cross-origin subresources, which Chickadee does not
-// load (Pyodide / CodeMirror / jszip are vendored same-origin).
 
 import Vapor
 
@@ -37,9 +40,7 @@ struct NotebookAssetIsolationMiddleware: AsyncMiddleware {
         let response = try await next.respond(to: request)
         guard enabled, request.url.path.hasPrefix("/jupyterlite/") else { return response }
 
-        response.headers.replaceOrAdd(name: "Cross-Origin-Opener-Policy", value: "same-origin")
-        response.headers.replaceOrAdd(name: "Cross-Origin-Embedder-Policy", value: "require-corp")
-        response.headers.replaceOrAdd(name: "Cross-Origin-Resource-Policy", value: "same-origin")
+        response.setCrossOriginIsolationHeaders()
         return response
     }
 }

--- a/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
+++ b/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
@@ -50,11 +50,13 @@ import XCTVapor
         try? FileManager.default.removeItem(atPath: tempRoot)
     }
 
-    private func makeApp() async throws -> Application {
+    private func makeApp(crossOriginIsolation: Bool = false) async throws -> Application {
         let app = try await Application.make(.testing)
         // Production order: fast path runs before any session/auth work,
         // the user-namespace guard and FileMiddleware after it.
-        app.middleware.use(EditorAssetFastPathMiddleware(publicDirectory: publicDir))
+        app.middleware.use(
+            EditorAssetFastPathMiddleware(
+                publicDirectory: publicDir, crossOriginIsolation: crossOriginIsolation))
         app.middleware.use(UserFileNamespaceMiddleware())
         app.middleware.use(FileMiddleware(publicDirectory: publicDir))
         return app
@@ -145,6 +147,50 @@ import XCTVapor
         try await withApp(try await makeApp()) { app in
             try await app.testable().test(.GET, "/jupyterlite/build/absent.js") { res async in
                 #expect(res.status == .notFound)
+            }
+        }
+    }
+
+    // When cross-origin isolation is OFF (the default), the fast path must NOT
+    // add COEP — the long-standing non-isolated behaviour the editor relies on
+    // for its service-worker sync path.
+    @Test func fastPathOmitsCOEPWhenIsolationDisabled() async throws {
+        try await withApp(try await makeApp(crossOriginIsolation: false)) { app in
+            for path in [
+                "/jupyterlite/extensions/@jupyterlite/kernel/static/154.377fd2862adcf65a4294.js",
+                "/pyodide/pyodide-lock.json",
+            ] {
+                try await app.testable().test(.GET, path) { res async in
+                    #expect(res.status == .ok)
+                    #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+                }
+            }
+        }
+    }
+
+    // When cross-origin isolation is ON, the fast path must stamp the COOP +
+    // COEP + CORP trio on the vendored editor assets it serves — especially the
+    // Pyodide kernel WORKER chunk, whose missing COEP was the worker-block: an
+    // isolated editor page spawning a worker without COEP is blocked by Chrome.
+    @Test func fastPathIsolatesEditorAssetsWhenEnabled() async throws {
+        try await withApp(try await makeApp(crossOriginIsolation: true)) { app in
+            // The hashed extension chunk stands in for the kernel worker chunk.
+            for path in [
+                "/jupyterlite/extensions/@jupyterlite/kernel/static/154.377fd2862adcf65a4294.js",
+                "/jupyterlite/build/100.5a28c9e.js",
+                "/pyodide/pyodide-lock.json",
+                "/vendor/jszip.min.js",
+            ] {
+                try await app.testable().test(.GET, path) { res async in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp",
+                        "fast-path asset \(path) must carry COEP so the isolated worker can load")
+                    #expect(
+                        res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
+                    #expect(
+                        res.headers.first(name: "Cross-Origin-Resource-Policy") == "same-origin")
+                }
             }
         }
     }

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -9,8 +9,14 @@
 // they never put a browser in front of the editor.
 //
 // It catches the three editor breakages we shipped blind:
-//   • the COEP cross-origin-isolation attempt that BLOCKED the Pyodide kernel
-//     worker (the page loaded a kernel only to refuse its worker script);
+//   • the COEP cross-origin-isolation worker-block — when the editor page is
+//     cross-origin isolated but its Pyodide kernel worker script is served
+//     without COEP, Chrome refuses the worker (ERR_BLOCKED_BY_RESPONSE).  This
+//     is now a SUPPORTED config (the fast path isolates the worker chunk too);
+//     run with NOTEBOOK_CROSS_ORIGIN_ISOLATION=true + SMOKE_EXPECT_ISOLATED=1
+//     to assert the SharedArrayBuffer path boots, and the same config is the
+//     live regression guard — if the fix regresses the worker-block returns
+//     and this fails;
 //   • a dead kernel / "Kernel Unknown" (a cell never executes);
 //   • the "Page Unresponsive" freeze — input()/stdin hangs when the kernel has
 //     neither the service worker nor SharedArrayBuffer for synchronous stdin.
@@ -23,9 +29,13 @@
 // Usage:   node editor-check.mjs <baseURL>
 // Exit 0 = editor healthy; exit 1 = editor broken (details printed).
 //
-// Env: SMOKE_SIMULATE_FROZEN=1 rewrites jupyter-lite.json in-flight to disable
-// the service-worker manager, reproducing the #959 freeze config so the
-// selftest can prove the input() probe actually catches it.
+// Env:
+//   SMOKE_SIMULATE_FROZEN=1  rewrites jupyter-lite.json in-flight to disable the
+//     service-worker manager, reproducing the #959 freeze config so the selftest
+//     can prove the input() probe actually catches it.
+//   SMOKE_EXPECT_ISOLATED=1|0  asserts the page's crossOriginIsolated state so a
+//     config meant to exercise the SharedArrayBuffer path can't silently pass
+//     via the service-worker fallback (or vice versa).
 
 import { chromium } from "playwright";
 
@@ -35,6 +45,12 @@ const baseURL = (process.argv[2] || process.env.BASE_URL || "http://127.0.0.1:80
 );
 const replURL = `${baseURL}/jupyterlite/repl/index.html?kernel=python&toolbar=1`;
 const simulateFrozen = process.env.SMOKE_SIMULATE_FROZEN === "1";
+// Optional assertion on the page's cross-origin-isolation state, so a config
+// that is SUPPOSED to be isolated (SharedArrayBuffer path) can't quietly pass
+// via the service-worker fallback if isolation silently regresses — and vice
+// versa.  "1" ⇒ require crossOriginIsolated; "0" ⇒ require NOT isolated;
+// unset ⇒ don't assert (just report).
+const expectIsolated = process.env.SMOKE_EXPECT_ISOLATED;
 
 const SERVICE_WORKER_MANAGER = "@jupyterlite/application-extension:service-worker-manager";
 
@@ -163,6 +179,18 @@ async function main() {
 
     const isolated = await page.evaluate(() => globalThis.crossOriginIsolated === true);
     console.log(`crossOriginIsolated = ${isolated}`);
+    if (expectIsolated === "1" && !isolated) {
+      return await fail(
+        "expected cross-origin isolation (crossOriginIsolated=true) but the page was NOT isolated — " +
+          "the SharedArrayBuffer path is not active (isolation headers missing?)"
+      );
+    }
+    if (expectIsolated === "0" && isolated) {
+      return await fail(
+        "expected NO cross-origin isolation but the page WAS isolated — " +
+          "isolation headers applied unexpectedly"
+      );
+    }
 
     // (1) Liveness: a trivial cell executes. Execution submitted before the
     // kernel finishes booting is queued and runs once it is ready, so we don't

--- a/Tools/editor-smoke-test/selftest.sh
+++ b/Tools/editor-smoke-test/selftest.sh
@@ -1,30 +1,41 @@
 #!/usr/bin/env bash
 #
 # selftest.sh — prove the smoke test actually detects the regressions it exists
-# to catch. Runs the editor check three ways against the same server build:
+# to catch AND that both editor sync paths (service worker / SharedArrayBuffer)
+# are healthy. Runs the editor check three ways against the same server build:
 #
-#   1. default config (service worker, NO cross-origin isolation) — must PASS;
-#   2. NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — must FAIL, because COEP
-#      require-corp on the editor page blocks the fast-path-served Pyodide
-#      kernel worker (the COEP attempt's kernel-worker block);
+#   1. default config (service worker, NO cross-origin isolation) — must PASS,
+#      and must report crossOriginIsolated=false (SMOKE_EXPECT_ISOLATED=0): the
+#      kernel syncs stdin/Drive through the service worker;
+#   2. NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — must PASS, and must report
+#      crossOriginIsolated=true (SMOKE_EXPECT_ISOLATED=1): the editor boots
+#      cross-origin isolated and input() round-trips over SharedArrayBuffer,
+#      with no dependence on the service worker.  Before the fast-path-isolation
+#      fix this config FAILED, because COEP on the editor page blocked the
+#      fast-path-served Pyodide kernel worker (its script was missing COEP).
+#      This config is therefore ALSO the live worker-block guard: if the fix
+#      regresses the worker block returns and this flips to FAIL (and the
+#      SMOKE_EXPECT_ISOLATED=1 assertion catches a silent isolation regression
+#      that would otherwise pass via the service-worker fallback);
 #   3. SMOKE_SIMULATE_FROZEN=1 — must FAIL, because disabling the service worker
 #      (and with COEP off, no SAB) leaves input()/stdin no synchronous path and
-#      the editor goes "Page Unresponsive" (the #959 freeze).
+#      the editor goes "Page Unresponsive" (the #959 freeze).  Proves the
+#      input() probe is discriminating.
 #
-# If the good config fails or either bad config passes, the smoke test is not
-# discriminating and this exits non-zero — i.e. it guards the guard.
+# If a must-pass config fails or the must-fail config passes, the smoke test /
+# fix is not behaving and this exits non-zero — i.e. it guards the guard.
 
 set -uo pipefail
 cd "$(dirname "$0")"
 
-echo "=== selftest 1/3: default config — expect PASS ==="
-PORT="${PORT_GOOD:-8099}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false ./run-smoke.sh
+echo "=== selftest 1/3: default config — expect PASS (service-worker path) ==="
+PORT="${PORT_GOOD:-8099}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false SMOKE_EXPECT_ISOLATED=0 ./run-smoke.sh
 good_ok=$([ $? -eq 0 ] && echo 1 || echo 0)
 
 echo
-echo "=== selftest 2/3: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect FAIL (COEP worker-block) ==="
-PORT="${PORT_COEP:-8100}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=true ./run-smoke.sh
-coep_failed=$([ $? -ne 0 ] && echo 1 || echo 0)
+echo "=== selftest 2/3: NOTEBOOK_CROSS_ORIGIN_ISOLATION=true — expect PASS (SharedArrayBuffer path) ==="
+PORT="${PORT_COEP:-8100}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=true SMOKE_EXPECT_ISOLATED=1 ./run-smoke.sh
+coep_ok=$([ $? -eq 0 ] && echo 1 || echo 0)
 
 echo
 echo "=== selftest 3/3: SMOKE_SIMULATE_FROZEN=1 (no service worker) — expect FAIL (input freeze) ==="
@@ -32,12 +43,13 @@ PORT="${PORT_FROZEN:-8101}" NOTEBOOK_CROSS_ORIGIN_ISOLATION=false SMOKE_SIMULATE
 frozen_failed=$([ $? -ne 0 ] && echo 1 || echo 0)
 
 echo
-if [ "$good_ok" -eq 1 ] && [ "$coep_failed" -eq 1 ] && [ "$frozen_failed" -eq 1 ]; then
-  echo "SELFTEST PASS — passes on the good config and fails on both the COEP block and the freeze."
+if [ "$good_ok" -eq 1 ] && [ "$coep_ok" -eq 1 ] && [ "$frozen_failed" -eq 1 ]; then
+  echo "SELFTEST PASS — passes on the service-worker config, passes on the isolated"
+  echo "SharedArrayBuffer config, and fails on the input freeze."
   exit 0
 fi
 echo "SELFTEST FAIL — the smoke test is not discriminating:"
-echo "  good config passed?      $good_ok       (want 1)"
-echo "  COEP config failed?      $coep_failed   (want 1)"
-echo "  freeze config failed?    $frozen_failed (want 1)"
+echo "  default (SW) config passed?       $good_ok       (want 1)"
+echo "  isolated (SAB) config passed?     $coep_ok       (want 1)"
+echo "  freeze config failed?             $frozen_failed (want 1)"
 exit 1

--- a/changelog.d/editor-cross-origin-isolation-fix.md
+++ b/changelog.d/editor-cross-origin-isolation-fix.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **Cross-origin isolation now works for the notebook editor — the deterministic
+  fix for "Kernel Unknown".** Turning on `NOTEBOOK_CROSS_ORIGIN_ISOLATION` gives
+  the Pyodide kernel `SharedArrayBuffer` for synchronous stdin/Drive, removing
+  its dependence on the JupyterLite service worker and eliminating the
+  service-worker-control race that caused the "Kernel Unknown" boot failures
+  (the root cause behind the recovery-ladder mitigation). The flag had been
+  unusable because, under COEP `require-corp`, the editor's Pyodide **kernel
+  worker** is served by `EditorAssetFastPathMiddleware`, which short-circuits the
+  chain *before* the isolation middleware ran — so the worker script went out
+  with no `Cross-Origin-Embedder-Policy` header and Chrome blocked it
+  (`ERR_BLOCKED_BY_RESPONSE`). The fast path is now isolation-aware: when the
+  flag is on it stamps COOP/COEP/CORP on the vendored editor asset trees it
+  serves (`/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`,
+  `/vendor`), via a shared `Response.setCrossOriginIsolationHeaders()` so the
+  isolation middlewares can't drift. Proven end-to-end in the headless-browser
+  smoke harness (`Tools/editor-smoke-test/selftest.sh`): the isolated config now
+  boots the kernel with `crossOriginIsolated=true` and round-trips `input()` over
+  `SharedArrayBuffer` with no service worker, while the freeze detector stays
+  discriminating. The flag remains **default off** pending real-browser (esp.
+  Safari) rollout — see `docs/notebook-editor-kernel-boot.md`.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -77,81 +77,114 @@ behind no flag with instant rollback. Watch `get_browser_diagnostics`
 (`watchdog_timeout` count and `byBrowser`) after deploy to confirm the rate
 drops.
 
-## The durable fix (plan C): cross-origin isolation + `SharedArrayBuffer`
+## The durable fix (plan C): cross-origin isolation + `SharedArrayBuffer` — IMPLEMENTED
 
 The deterministic fix is to give the kernel a synchronous path that does **not
 depend on SW control timing at all**: `SharedArrayBuffer`, which requires the
 editor iframe to be **cross-origin isolated** (COOP `same-origin` + COEP
 `require-corp`). With SAB available the kernel never needs the SW for sync, so
-the race disappears. The plumbing already exists, gated off:
+the race disappears. Driven by `NOTEBOOK_CROSS_ORIGIN_ISOLATION` (still default
+off — see rollout below):
 
 - `COEPMiddleware` stamps COOP/COEP on the `/testsetups/:id/notebook` page.
-- `NotebookAssetIsolationMiddleware` stamps COOP/COEP + `Cross-Origin-Resource-Policy: same-origin`
-  on `/jupyterlite/*` iframe assets.
-- Both are driven by `NOTEBOOK_CROSS_ORIGIN_ISOLATION` (default off).
+- `NotebookAssetIsolationMiddleware` stamps COOP/COEP/CORP on the slow-path
+  `/jupyterlite/*` editor HTML documents.
+- **`EditorAssetFastPathMiddleware` stamps the same trio on the vendored asset
+  trees it serves (`/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`,
+  `/vendor`)** — the fast-path-isolation fix (see below).
 
-### Why it's still off — the blocker
+### Root cause of the historical worker-block (was: "why it's still off")
 
-This was tried unconditionally in v0.4.466 and reverted: under COEP
-`require-corp`, **the Pyodide kernel worker fails to start**. The v0.4.469
-editor-smoke *selftest* encodes this as a guarantee — it asserts the editor
-**passes** on the default config and **fails** under
-`NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` ("the COEP worker-block"). So we cannot
-just flip the flag; the worker-block must be fixed first.
+Cross-origin isolation was tried unconditionally in v0.4.466 and reverted
+because **the Pyodide kernel worker failed to start** under COEP. The actual
+mechanism, confirmed both statically and by reproducing it with the smoke
+selftest:
 
-### Leading hypothesis (to verify, not assume)
+`EditorAssetFastPathMiddleware` is registered **near the top** of the chain and
+serves `/jupyterlite/build`, `/jupyterlite/extensions` (**including the Pyodide
+kernel worker chunk** `…/pyodide-kernel-extension/static/620.*.js`), `/pyodide`
+and `/vendor` by short-circuiting the responder chain — *before*
+`NotebookAssetIsolationMiddleware` runs. So with isolation on, the editor HTML
+became cross-origin isolated (`require-corp`) but the kernel **worker script was
+served with no `Cross-Origin-Embedder-Policy` header**. Chrome requires a
+dedicated worker spawned by a `require-corp` document to itself be served with
+COEP `require-corp`, so it blocked the worker with `net::ERR_BLOCKED_BY_RESPONSE`
+— the "fast-path-served kernel worker block".
 
-Under COEP `require-corp` on the iframe document, a dedicated Worker inherits
-the policy and **every resource it pulls must be isolation-compatible**
-(`Cross-Origin-Resource-Policy`, or CORS). The Pyodide kernel worker loads the
-runtime + wheels from **`/pyodide/*`**, but only **`/jupyterlite/*`** is
-stamped with CORP today (`NotebookAssetIsolationMiddleware` matches that prefix
-only). `/pyodide/*` (and any other same-origin asset the isolated worker
-fetches) is served by `FileMiddleware` with **no** CORP header. That mismatch
-is the most likely cause of the worker-block.
+(The earlier hypothesis was missing CORP on `/pyodide/*`. That was wrong:
+`SecurityHeadersMiddleware` already sets COOP+CORP globally, and same-origin
+subresources don't need CORP anyway. The single missing header was **COEP on
+the worker chunk**, which only the bypassed isolation middleware would have
+added.)
 
-### Proposed steps
+### The fix (fast-path isolation)
 
-1. **Reproduce locally** with the smoke selftest
-   (`Tools/editor-smoke-test/selftest.sh`) and capture the *exact* console /
-   network error from the COEP run — confirm whether it's a CORP rejection on
-   `/pyodide/*`, the worker script itself, a `Blob:`/`importScripts` path, or
-   a credentials issue. Do not proceed on the hypothesis alone.
-2. **Stamp CORP on every same-origin asset the isolated worker loads** — at
-   minimum extend `NotebookAssetIsolationMiddleware` (or add a sibling) to add
-   `Cross-Origin-Resource-Policy: same-origin` to `/pyodide/*` and any other
-   prefix the error implicates, *only when isolation is enabled* (keep the
-   non-isolated path byte-identical).
-3. **Re-run the selftest.** Success criterion: the COEP run **flips to PASS**.
-   Update `selftest.sh` so the COEP config is now an *expected pass* (and keep a
-   regression case for whatever the real failing config is, so the guard can't
-   rot — e.g. isolation on but CORP deliberately withheld from `/pyodide/*`).
-4. **Verify in real browsers** (Chrome + Safari + a managed device) via the
-   smoke harness; this path is not fully CI-verifiable.
-5. **Flip the default / make unconditional**, then **disable the JupyterLite
-   service worker** again (it's only there for sync, which SAB now provides) —
-   removing the freeze risk *and* the control race together. Reverse the
-   `JupyterLiteConfigTests` SW guard accordingly.
-6. **Promote the editor-smoke workflow from advisory to a required gate** once
-   it reliably passes on the isolated config — that is what actually closes out
-   "all editor-load issues fixed".
+`EditorAssetFastPathMiddleware` is now isolation-aware: when
+`NOTEBOOK_CROSS_ORIGIN_ISOLATION` is on it stamps COOP `same-origin` + COEP
+`require-corp` + CORP `same-origin` on every asset it serves (shared with
+`NotebookAssetIsolationMiddleware` via `Response.setCrossOriginIsolationHeaders()`
+so the two can't drift). When the flag is off it's byte-identical to before.
 
-### Fallback if isolation can't be made to work
+**Proven via the headless-browser smoke harness** (`Tools/editor-smoke-test/`),
+which boots a real server and drives the real JupyterLite kernel in Chromium.
+`selftest.sh` now asserts three configs against one build:
 
-If the worker-block proves intractable, the v0.4.467-named alternative remains:
-patch the pyodide-kernel so `mountDrive` waits on
-`navigator.serviceWorker.controller` before using the SW sync path. This is
-harder to do cleanly here than the nb_mypy wheel patch
-(`scripts/patch-pyodide-kernel.py`), because the gating logic lives in
-**content-hash-named webpack chunks** (`Public/jupyterlite/.../static/620.*.js`,
-`644.*.js`) rather than a fixed-name Python member, so editing it is a
-rebuild-the-bundle / upstream-patch effort and is not CI-verifiable.
-Prefer plan C.
+1. default (service-worker path) → **PASS**, `crossOriginIsolated=false`;
+2. `NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (SAB path) → **PASS**,
+   `crossOriginIsolated=true`, and `input()` round-trips over `SharedArrayBuffer`
+   with no service worker involved. This config is *also* the live worker-block
+   guard — if the fast-path isolation regresses, the worker block returns and it
+   flips to FAIL (and the new `SMOKE_EXPECT_ISOLATED=1` assertion catches a
+   *silent* isolation regression that would otherwise pass via the SW fallback);
+3. `SMOKE_SIMULATE_FROZEN=1` (no SW, no SAB) → **FAIL** (input freeze), proving
+   the detector is still discriminating.
+
+Swift unit coverage: `EditorAssetFastPathMiddlewareTests` now asserts the trio
+is present with the flag on and absent with it off.
+
+### Rollout (the remaining, deploy-time work)
+
+The fix makes isolation *work*; turning it on in production is deliberately left
+as an operator step so it can be staged with instant rollback (the flag needs no
+redeploy):
+
+1. **Enable on staging** (`NOTEBOOK_CROSS_ORIGIN_ISOLATION=true`) and verify the
+   editor boots in each target browser — **Chrome and especially Safari** and a
+   managed/locked-down device. Chromium is covered by the headless harness;
+   Safari is not, and is the residual risk (see below).
+2. **Enable in production.** Roll back instantly by clearing the flag if anything
+   regresses.
+3. **Then** consider disabling the JupyterLite service worker (it's only there
+   for sync, which SAB now provides) to remove the freeze risk and the control
+   race together, and reversing the `JupyterLiteConfigTests` SW guard. Keep the
+   SW until isolation is default-on and verified everywhere — under isolation the
+   kernel prefers SAB, so the SW just sits as a harmless fallback.
+4. **Promote the editor-smoke workflow from advisory to a required gate** once it
+   reliably passes on the isolated config.
+
+### Residual risk: Safari + the `Atomics.waitAsync` `data:` worker
+
+The pyodide-kernel polyfills `Atomics.waitAsync` (when the engine lacks it) with
+a `new Worker("data:application/javascript,…")`. `data:` workers are blocked
+under COEP `require-corp`. Chromium has native `Atomics.waitAsync`, so the
+polyfill never runs there and the headless test passes; **Safari** is the one to
+watch on staging — if it falls into the polyfill, the isolated kernel could
+break. This is the main reason isolation stays opt-in until real-browser
+verification.
+
+### Fallback if isolation can't be made to work in some browser
+
+The v0.4.467-named alternative remains: patch the pyodide-kernel so `mountDrive`
+waits on `navigator.serviceWorker.controller` before using the SW sync path.
+Harder to do cleanly here than the nb_mypy wheel patch
+(`scripts/patch-pyodide-kernel.py`) because the gating logic lives in
+content-hash-named webpack chunks rather than a fixed-name Python member.
+Prefer plan C; this is a per-browser safety net only.
 
 ## Quick reference
 
 | | Sync path | SW-control race? | Status |
 |---|---|---|---|
-| Today | JupyterLite service worker | **yes** (the bug) | shipped; mitigated by recovery ladder A |
-| Plan C | `SharedArrayBuffer` (cross-origin isolation) | no | blocked on the COEP kernel-worker fix |
-| Fallback | SW, gated on `serviceWorker.controller` | removed | last resort; webpack-chunk patch |
+| Default (flag off) | JupyterLite service worker | **yes** | shipped; mitigated by recovery ladder A |
+| Flag on (plan C) | `SharedArrayBuffer` (cross-origin isolation) | **no** | implemented + headless-proven; opt-in pending real-browser rollout |
+| Fallback | SW, gated on `serviceWorker.controller` | removed | per-browser safety net only |


### PR DESCRIPTION
## What this is

The **deterministic root-cause fix** for the "Kernel Unknown" editor-boot failures (#983 shipped the recovery-ladder *mitigation*; this is the cure). It makes `NOTEBOOK_CROSS_ORIGIN_ISOLATION` actually work, giving the Pyodide kernel `SharedArrayBuffer` for synchronous stdin/Drive — so it no longer depends on the JupyterLite service worker and the **SW-control race that causes "Kernel Unknown" disappears entirely**.

## Root cause (confirmed statically *and* by reproduction)

With the flag on, the editor's Pyodide **kernel worker** chunk (`…/pyodide-kernel-extension/static/620.*.js`) is served by `EditorAssetFastPathMiddleware`, which is registered near the top of the chain and **short-circuits before `NotebookAssetIsolationMiddleware` runs**. So the editor HTML became cross-origin isolated (`require-corp`) but the worker script went out with **no `Cross-Origin-Embedder-Policy` header** — and Chrome blocks a dedicated worker spawned by a `require-corp` document if the worker script itself lacks COEP:

```
crossOriginIsolated = true
SMOKE FAIL — blocked resource detected while waiting for the kernel (COEP worker-block)
  requestfailed: …/pyodide-kernel-extension/static/620.*.js — net::ERR_BLOCKED_BY_RESPONSE
```

(Curl confirmed it: the REPL HTML had all of COOP/COEP/CORP; the worker chunk and `/pyodide/*` had COOP+CORP — from the global `SecurityHeadersMiddleware` — but were missing exactly **COEP**. The earlier "missing CORP on `/pyodide`" hypothesis was wrong; same-origin subresources don't need CORP.)

## The fix

`EditorAssetFastPathMiddleware` is now isolation-aware: when the flag is on it stamps COOP `same-origin` + COEP `require-corp` + CORP `same-origin` on the vendored editor asset trees it serves (`/jupyterlite/build`, `/jupyterlite/extensions`, `/pyodide`, `/vendor`), via a shared `Response.setCrossOriginIsolationHeaders()` so the isolation middlewares can't drift. **Off by default ⇒ byte-identical to today.**

## Proof — headless browser (your requirement)

`Tools/editor-smoke-test/selftest.sh` boots a real server and drives the real JupyterLite kernel in Chromium. All three configs green against one build:

| Config | Result | Notes |
|---|---|---|
| default (SW path) | **PASS** | `crossOriginIsolated=false`, kernel + `input()` work via service worker |
| `NOTEBOOK_CROSS_ORIGIN_ISOLATION=true` (SAB path) | **PASS** | `crossOriginIsolated=true`, `input()` round-trips over `SharedArrayBuffer`, **no service worker** |
| `SMOKE_SIMULATE_FROZEN=1` | **FAIL** (expected) | freeze/stdin detector still discriminating |

The selftest now **asserts** the isolation state (`SMOKE_EXPECT_ISOLATED`) so a silent isolation regression can't sneak through by falling back to the SW; the isolated config doubles as the live worker-block guard. Swift unit tests (`EditorAssetFastPathMiddlewareTests`) assert the header trio is present with the flag on and absent with it off.

## Verification done
- `selftest.sh` → SELFTEST PASS (exit 0), all 3 configs.
- `swift test --filter "EditorAssetFastPathMiddlewareTests|COEPMiddlewareTests"` → 16/16 pass.
- `swift build`, `swift format lint --strict`, `scripts/swiftlint.sh` → clean (0 violations).

## Scope / rollout (deliberately left to the operator)
The flag **stays default off**. It now *works*, but turning it on in prod is a staged decision with instant rollback (no redeploy):
1. Enable on staging, verify in real browsers — **Chrome and especially Safari** (Chromium is covered by the headless harness; Safari is the residual risk, see below) + a managed device;
2. enable in prod;
3. then optionally disable the now-redundant JupyterLite service worker and promote the editor-smoke workflow to a required gate.

**Residual risk:** the pyodide-kernel polyfills `Atomics.waitAsync` with a `data:` worker when the engine lacks it; `data:` workers are blocked under COEP. Chromium has it natively (so the headless test passes); Safari is the one to confirm on staging. Full write-up in `docs/notebook-editor-kernel-boot.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT)_