### PR TITLE
Fix: app Web Workers (grading, freeze failover) blocked under editor cross-origin isolation

### DIFF
--- a/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
+++ b/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
@@ -7,6 +7,12 @@
 // giving the kernel `SharedArrayBuffer` for synchronous execution.
 // `COEPMiddleware` isolates the parent notebook page.
 //
+// It ALSO stamps COEP on the app's own Web Worker scripts that an isolated page
+// spawns (`/grading-worker.js`, `/freeze-watchdog-worker.js`) — see
+// `isolatedWorkerScripts`. Without COEP on the worker script, a `require-corp`
+// page cannot spawn the worker at all (Chrome `ERR_BLOCKED_BY_RESPONSE`), which
+// would break browser grading + the freeze failover on the notebook page.
+//
 // NOTE on coverage: the vendored asset *trees* (`/jupyterlite/build/`,
 // `/jupyterlite/extensions/` — including the Pyodide kernel WORKER chunk — plus
 // `/pyodide/` and `/vendor/`) are served by `EditorAssetFastPathMiddleware`,
@@ -33,12 +39,32 @@ struct NotebookAssetIsolationMiddleware: AsyncMiddleware {
     /// middleware does nothing.
     let enabled: Bool
 
+    /// App-owned Web Worker scripts (served from the Public root, NOT under the
+    /// fast path) that are spawned via `new Worker(...)` from a cross-origin-
+    /// ISOLATED page (the student notebook page `/testsetups/:id/notebook`). A
+    /// dedicated worker created by a `require-corp` document must ITSELF be served
+    /// with COEP `require-corp`, or Chrome refuses the worker script with
+    /// `ERR_BLOCKED_BY_RESPONSE` — the same rule that blocked the kernel worker
+    /// chunk, but for our own workers. The global `SecurityHeadersMiddleware`
+    /// gives them CORP but never COEP, so without this they are blocked.
+    ///
+    /// Deliberately EXCLUDES `/pyodide-worker.js`: it is spawned only by the
+    /// assignment-editor pages, which are NOT cross-origin isolated, so it must
+    /// not be forced `require-corp`. If an isolated page is ever made to spawn it,
+    /// add it here — the editor-smoke worker-spawn probe will flag the regression.
+    static let isolatedWorkerScripts: Set<String> = [
+        "/grading-worker.js",  // browser submission grader (browser-runner.js)
+        "/freeze-watchdog-worker.js",  // main-thread freeze failover (notebook.js)
+    ]
+
     func respond(
         to request: Request,
         chainingTo next: any AsyncResponder
     ) async throws -> Response {
         let response = try await next.respond(to: request)
-        guard enabled, request.url.path.hasPrefix("/jupyterlite/") else { return response }
+        let path = request.url.path
+        guard enabled, path.hasPrefix("/jupyterlite/") || Self.isolatedWorkerScripts.contains(path)
+        else { return response }
 
         response.setCrossOriginIsolationHeaders()
         return response

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -16,6 +16,9 @@ import XCTVapor
         app.get("testsetups", ":testSetupID", "notebook") { _ in "notebook" }
         app.get("instructor", ":assignmentID", "validate") { _ in "validate" }
         app.get("jupyterlite", "notebooks", "index.html") { _ in "iframe" }
+        app.get("grading-worker.js") { _ in "// grading worker" }
+        app.get("freeze-watchdog-worker.js") { _ in "// freeze worker" }
+        app.get("pyodide-worker.js") { _ in "// pyodide worker" }
         app.get("plain") { _ in "plain" }
 
         return app
@@ -83,6 +86,47 @@ import XCTVapor
             try await app.testable().test(.GET, "/plain") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+            }
+        }
+    }
+
+    // MARK: - App Web Worker scripts spawned by the isolated notebook page
+    //
+    // A dedicated worker created by a require-corp page must itself be served
+    // with COEP, or the browser blocks the worker (ERR_BLOCKED_BY_RESPONSE) —
+    // which silently broke browser grading + the freeze failover.
+
+    @Test func isolatedPageWorkerScriptsReceiveCOEPWhenEnabled() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            for path in ["/grading-worker.js", "/freeze-watchdog-worker.js"] {
+                try await app.testable().test(.GET, path) { res async in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp",
+                        "\(path) must carry COEP so an isolated page can spawn the worker")
+                    #expect(
+                        res.headers.first(name: "Cross-Origin-Resource-Policy") == "same-origin")
+                }
+            }
+        }
+    }
+
+    @Test func pyodideWorkerScriptIsNotForcedIsolated() async throws {
+        // /pyodide-worker.js is spawned only by the (non-isolated) assignment
+        // editor pages, so it must NOT be forced require-corp.
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            try await app.testable().test(.GET, "/pyodide-worker.js") { res async in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+            }
+        }
+    }
+
+    @Test func workerScriptsAreNotIsolatedWhenDisabled() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testable().test(.GET, "/grading-worker.js") { res async in
+                #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
             }
         }

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -229,6 +229,48 @@ async function main() {
       );
     }
 
+    // (0) Worker-spawn probe (only meaningful under cross-origin isolation).
+    // The app's OWN Web Workers — the browser grader and the freeze failover —
+    // are spawned via `new Worker(...)` from the isolated notebook page. Under
+    // COEP `require-corp`, a worker whose script lacks COEP is refused by the
+    // browser (ERR_BLOCKED_BY_RESPONSE), which silently breaks browser grading.
+    // This regressed once (the worker scripts are not on the fast path that
+    // stamps COEP); spawn them here so it can't regress unseen. These workers are
+    // message-driven and do nothing until posted to, so spawning is cheap.
+    if (isolated) {
+      const workerScripts = ["/grading-worker.js", "/freeze-watchdog-worker.js"];
+      const workerBlocked = [];
+      const onWorkerReqFail = (req) => {
+        const why = req.failure()?.errorText || "";
+        if (workerScripts.some((s) => req.url().includes(s)) &&
+            (looksBlocked(why) || /ERR_BLOCKED/i.test(why))) {
+          workerBlocked.push(`${req.url()} — ${why}`);
+        }
+      };
+      page.on("requestfailed", onWorkerReqFail);
+      // Spawn in-page to trigger each worker-script fetch; a COEP block fails the
+      // request (caught above). Synchronous SecurityErrors are returned too.
+      const spawnErrors = await page.evaluate(async (scripts) => {
+        const errs = [];
+        await Promise.all(scripts.map((s) => new Promise((resolve) => {
+          let w;
+          try { w = new Worker(s); }
+          catch (e) { errs.push(`${s} threw ${(e && e.message) || e}`); return resolve(); }
+          setTimeout(() => { try { w.terminate(); } catch (_) { /* ignore */ } resolve(); }, 3000);
+        })));
+        return errs;
+      }, workerScripts);
+      await page.waitForTimeout(200);
+      page.off("requestfailed", onWorkerReqFail);
+      if (workerBlocked.length || spawnErrors.length) {
+        return await fail(
+          "an app Web Worker was blocked under cross-origin isolation (its script needs " +
+            "COEP require-corp): " + [...workerBlocked, ...spawnErrors].join("; ")
+        );
+      }
+      console.log(`worker-spawn probe: ${workerScripts.join(", ")} spawned OK under isolation`);
+    }
+
     // (1) Liveness: a trivial cell executes. Execution submitted before the
     // kernel finishes booting is queued and runs once it is ready, so we don't
     // pre-wait on readiness.

--- a/changelog.d/editor-worker-coep.md
+++ b/changelog.d/editor-worker-coep.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **Browser grading + the freeze failover are no longer blocked under the
+  notebook editor's cross-origin isolation.** Making the editor unconditionally
+  isolated meant the `/testsetups/:id/notebook` page is served `COEP: require-corp`
+  — and a `require-corp` page cannot spawn a dedicated `Worker` whose script
+  lacks COEP (Chrome `ERR_BLOCKED_BY_RESPONSE`). The app's own worker scripts
+  (`/grading-worker.js`, `/freeze-watchdog-worker.js`) are served from the Public
+  root, not the fast path that stamps COEP, so the global headers gave them CORP
+  but never COEP — which would have silently broken in-browser grading and the
+  main-thread freeze failover on deploy. `NotebookAssetIsolationMiddleware` now
+  stamps the isolation trio on those two worker scripts as well.
+  (`/pyodide-worker.js` is intentionally excluded — it is spawned only by the
+  non-isolated assignment-editor pages.) Guarded going forward by a new
+  worker-spawn probe in the editor-smoke harness — it spawns these workers from
+  the isolated page under **both Chromium and WebKit** and fails if either is
+  blocked — plus `COEPMiddlewareTests` coverage of the worker-script headers.


### PR DESCRIPTION
## The bug (a regression I introduced in #985, caught before dev deploy)

Making the notebook editor **unconditionally** cross-origin isolated means `/testsetups/:id/notebook` is served `COEP: require-corp`. A `require-corp` document **cannot spawn a dedicated `Worker` whose script lacks COEP** — Chrome refuses it with `net::ERR_BLOCKED_BY_RESPONSE` (the same rule that blocked the *kernel* worker, which #984 fixed for the fast-path assets).

But the app's **own** worker scripts — `/grading-worker.js` (browser submission grader) and `/freeze-watchdog-worker.js` (main-thread freeze failover) — are served from the Public root, **not** the fast path that stamps COEP. The global `SecurityHeadersMiddleware` gave them CORP but **never COEP**. So on deploy this would have **silently broken in-browser grading and the freeze failover** on the notebook page.

This was surfaced by the "how do we handle infinite loops now?" question — **not** by the smoke test, which proved the *kernel* worker but never spawned *our* workers under isolation. Credit where due: the maintainer caught it.

### Reproduced, then fixed (empirically)
```
# before: isolated page → new Worker('/grading-worker.js')
worker outcome = WORKER_ERROR:blocked
requestfailed: /grading-worker.js — net::ERR_BLOCKED_BY_RESPONSE
# after:
worker outcome = WORKER_OK  (worker loaded, booted Pyodide, replied)
```

## The fix (minimal)

`NotebookAssetIsolationMiddleware` now stamps the COOP/COEP/CORP trio on an explicit allowlist of app worker scripts spawned by isolated pages: `/grading-worker.js`, `/freeze-watchdog-worker.js`.

**`/pyodide-worker.js` is deliberately excluded** — it's spawned only by the assignment-editor pages, which are *not* isolated, so forcing it `require-corp` would needlessly alter a working path. (All three are verified same-origin-only, so the choice is about not changing working code, not safety.)

## Regression guards (so this can't recur)
1. **editor-smoke worker-spawn probe** — on the isolated page the harness now does `new Worker('/grading-worker.js')` + `/freeze-watchdog-worker.js` and **fails on `ERR_BLOCKED`**. Runs under **both Chromium and WebKit**. Verified: passes post-fix, and the pre-fix state was blocked.
2. **`COEPMiddlewareTests`** — asserts COEP present on the two isolated-page workers, absent on `/pyodide-worker.js`, and absent on all when isolation is disabled.

## Verification
- Header check: `grading-worker.js` / `freeze-watchdog-worker.js` → `COEP: require-corp`; `pyodide-worker.js` → none.
- Playwright repro: isolated-page worker spawn blocked before, OK after.
- `selftest.sh` under **chromium** and **webkit** → SELFTEST PASS, worker-spawn probe green in both.
- `swift test` (COEP / fast-path / HTTPS middleware) → 31/31.
- `swift build`, `swift format lint --strict`, `scripts/swiftlint.sh` → clean (0 violations).

## Note on what's still not covered
The smoke harness drives `/jupyterlite/repl` (isolated) and spawns the workers from there — a faithful proxy for the notebook page's isolation, but still not the full authenticated `/testsetups/:id/notebook` page end-to-end. That broader test remains the recommended follow-up. **This fix should land before the dev deploy**, since the regression is in `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT)_