### PR TITLE
CI: make editor-smoke a requireable merge gate (P2a)

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -17,39 +17,21 @@ name: Editor smoke test
 # check shipped blind (spurious phase-1 timeouts; the Atomics.waitAsync
 # data:-worker blocked under COEP).
 #
-# Runs two ways:
-#   • nightly (schedule) — always-on insurance across the whole editor stack;
-#   • per-PR but PATH-FILTERED — only when a notebook/editor/middleware/asset
-#     file changes, so the PRs that can actually break the editor get the gate
-#     without burdening every unrelated PR.
-#
-# Advisory for now (do NOT mark it a required check while it's path-filtered: a
-# required check that is skipped on most PRs blocks their merge). Promote to
-# required once it has proven stable — see docs/notebook-editor-smoke-test.md.
+# REQUIRED-GATE DESIGN. The trigger is intentionally NOT path-filtered: a path-
+# filtered workflow is *skipped* on unrelated PRs, and a required status check
+# that is skipped blocks those merges forever. Instead the workflow runs on every
+# PR, a `changes` job decides whether the editor surface was touched (fail-safe:
+# any uncertainty runs the smoke), the expensive `smoke` matrix runs only when it
+# was, and an always-running `editor-smoke-gate` job reports the single status to
+# require in branch protection: green when the smoke passed OR was skipped, red
+# only when it actually failed. To enforce it, mark **editor-smoke-gate** as a
+# required status check (see docs/notebook-editor-smoke-test.md).
 
 on:
   schedule:
     # ~03:30 America/Toronto (07:30 UTC) — off the nightly coverage slot.
     - cron: "30 7 * * *"
   pull_request:
-    paths:
-      - "Public/notebook*.js"
-      - "Public/browser-runner.js"
-      - "Public/pyodide-worker.js"
-      - "Public/assignment-validate.js"
-      - "Public/freeze-watchdog-worker.js"
-      - "Public/jupyterlite/**"
-      - "Public/pyodide/**"
-      - "Public/vendor/**"
-      - "Sources/APIServer/Middleware/COEPMiddleware.swift"
-      - "Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift"
-      - "Sources/APIServer/Middleware/SecurityHeadersMiddleware.swift"
-      - "Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift"
-      - "Sources/APIServer/Bootstrap/AppMiddleware.swift"
-      - "Sources/APIServer/Configuration/SecurityConfig.swift"
-      - "Tools/jupyterlite/**"
-      - "Tools/editor-smoke-test/**"
-      - ".github/workflows/editor-smoke.yml"
   workflow_dispatch:
 
 concurrency:
@@ -57,7 +39,59 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Decide whether this PR touches any editor / grading / isolation surface.
+  # Filtering here (rather than at the trigger) keeps the workflow running on
+  # every PR so `editor-smoke-gate` always reports a status — while still
+  # skipping the expensive smoke when nothing relevant changed. Fail-safe: a
+  # non-PR event, a missing base commit, or an empty diff all run the smoke.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      editor: ${{ steps.detect.outputs.editor }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "editor=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::non-PR event ($EVENT) — running editor smoke."
+            exit 0
+          fi
+          git fetch --no-tags --quiet origin "$BASE_REF" || true
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "editor=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::base sha unavailable — running editor smoke (fail-safe)."
+            exit 0
+          fi
+          changed="$(git diff --name-only "$BASE_SHA" HEAD)"
+          if [ -z "$changed" ]; then
+            echo "editor=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::no diff computed — running editor smoke (fail-safe)."
+            exit 0
+          fi
+          # Editor / grading / cross-origin-isolation surface. Keep in sync with
+          # the assets the editor actually loads and the middlewares that isolate
+          # them. Over-matching is safe (it just runs the smoke); under-matching
+          # is the dangerous direction.
+          pattern='^(Public/notebook[^/]*\.js|Public/browser-runner\.js|Public/grading-worker\.js|Public/pyodide-worker\.js|Public/assignment-validate\.js|Public/freeze-watchdog-worker\.js|Public/jupyterlite/|Public/pyodide/|Public/vendor/|Sources/APIServer/Middleware/COEPMiddleware\.swift|Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware\.swift|Sources/APIServer/Middleware/CrossOriginIsolationHeaders\.swift|Sources/APIServer/Middleware/SecurityHeadersMiddleware\.swift|Sources/APIServer/Middleware/EditorAssetFastPathMiddleware\.swift|Sources/APIServer/Bootstrap/AppMiddleware\.swift|Sources/APIServer/Configuration/SecurityConfig\.swift|Tools/jupyterlite/|Tools/editor-smoke-test/|\.github/workflows/editor-smoke\.yml)'
+          if echo "$changed" | grep -qE "$pattern"; then
+            echo "editor=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::editor-relevant files changed — running editor smoke."
+          else
+            echo "editor=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::no editor-relevant changes — skipping editor smoke."
+          fi
+
   smoke:
+    needs: changes
+    if: ${{ needs.changes.outputs.editor == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # Run the editor against BOTH engines we ship to: Chromium (Chrome/Edge) and
@@ -129,3 +163,32 @@ jobs:
       # editor regressions in CI rather than in front of a student.
       - name: Run editor smoke selftest (${{ matrix.browser }}; both sync paths + freeze detector)
         run: SMOKE_BROWSER=${{ matrix.browser }} Tools/editor-smoke-test/selftest.sh
+
+  # Always-running required status. Green when the smoke passed OR was skipped
+  # (no editor-relevant changes), red only when the smoke actually failed — so
+  # this one check can be marked required without blocking unrelated PRs. Mark
+  # THIS job ("editor-smoke-gate") required in branch protection.
+  editor-smoke-gate:
+    needs: [changes, smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on editor smoke result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          SMOKE_RESULT: ${{ needs.smoke.result }}
+          EDITOR_CHANGED: ${{ needs.changes.outputs.editor }}
+        run: |
+          echo "changes job: ${CHANGES_RESULT}; editor-relevant: ${EDITOR_CHANGED}; smoke: ${SMOKE_RESULT}"
+          # If we couldn't even determine what changed, fail closed.
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error::change-detection job did not succeed (${CHANGES_RESULT}) — failing closed."
+            exit 1
+          fi
+          # smoke is 'skipped' when no editor files changed (pass), 'success'
+          # when it ran green, 'failure'/'cancelled' when it broke.
+          if [ "$SMOKE_RESULT" = "failure" ] || [ "$SMOKE_RESULT" = "cancelled" ]; then
+            echo "::error::Editor smoke test failed — see the smoke job."
+            exit 1
+          fi
+          echo "Editor smoke gate passed (smoke: ${SMOKE_RESULT})."

--- a/changelog.d/editor-smoke-required-gate.md
+++ b/changelog.d/editor-smoke-required-gate.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **The editor-smoke CI workflow is now a requireable merge gate.** Previously it
+  was advisory and path-filtered at the trigger, so it couldn't be marked required
+  (a path-filtered check is *skipped* on unrelated PRs, and a required-but-skipped
+  check blocks those merges). It now runs on every PR: a fail-safe `changes` job
+  decides whether the editor / grading / cross-origin-isolation surface was touched,
+  the expensive Chromium + WebKit `smoke` matrix runs only when it was, and an
+  always-running **`editor-smoke-gate`** job reports a single status — green when the
+  smoke passed or was skipped, red only when it actually failed (or when change
+  detection itself failed, i.e. fail-closed). Enforcing it is now one repo setting:
+  add `editor-smoke-gate` to `main`'s required status checks (see
+  `docs/notebook-editor-smoke-test.md`). The change-detection set also gained
+  `grading-worker.js` and `CrossOriginIsolationHeaders.swift`.

--- a/docs/notebook-editor-smoke-test.md
+++ b/docs/notebook-editor-smoke-test.md
@@ -36,24 +36,28 @@ SMOKE_SIMULATE_NO_SYNC=1 (no SW/SAB):  crossOriginIsolated=false  SMOKE FAIL  (i
 The decisions below were resolved as: **Chromium + WebKit** (CI runs the selftest
 under both engines via a matrix — `SMOKE_BROWSER`; WebKit is the Safari engine and
 is what catches the Safari-class regressions a Chromium-only check shipped blind);
-**advisory** (not a required check — it is path-filtered, so a required check would
-block the merge of every PR that skips it; promote to required after it proves
-stable — see "Make it a required gate" below); **full app** harness (it drives the
-real `/jupyterlite/repl` through the real middleware chain, no course seeding). The
-original proposal follows for context.
+**requireable** (the always-runs gate is now in place — see below); **full app**
+harness (it drives the real `/jupyterlite/repl` through the real middleware chain,
+no course seeding). The original proposal follows for context.
 
-## Make it a required gate (recommended)
+## Make it a required gate — IMPLEMENTED (one setting left)
 
-The smoke job is still *advisory* — a red run does not block merge. Given how many
-editor regressions have reached students, promote it to a **required** check. The
-GitHub gotcha: a path-filtered workflow is *skipped* on PRs that don't touch
-editor files, and a required check that is "skipped" blocks those merges forever.
-The fix is the standard always-runs gate: add a tiny companion job that has **no**
-path filter, `needs:` the smoke matrix, and passes iff every smoke leg succeeded
-**or was skipped** — then mark *that* job required in branch protection. That makes
-"editor changed ⇒ both engines must pass" enforceable without blocking unrelated
-PRs. (Branch protection itself is a repo setting, applied in GitHub, not in this
-file.)
+The always-runs gate is now built into `editor-smoke.yml`. The workflow no longer
+path-filters at the trigger; instead:
+
+1. a **`changes`** job decides whether the PR touched the editor/grading/isolation
+   surface (git-diff against the base; fail-safe — any uncertainty runs the smoke);
+2. the expensive **`smoke`** matrix (Chromium + WebKit) runs only when it did;
+3. an always-running **`editor-smoke-gate`** job reports the single status: green
+   when the smoke passed **or was skipped** (no editor changes), red only when the
+   smoke actually failed — and red if change-detection itself failed (fail closed).
+
+So every PR reports `editor-smoke-gate`, and it never spuriously blocks an unrelated
+PR. The **one remaining step is a repo setting** (not in this file): in branch
+protection for `main`, add **`editor-smoke-gate`** to the required status checks.
+Do NOT require the matrix legs (`smoke (chromium)` / `smoke (webkit)`) directly —
+they are skipped on non-editor PRs and would block those merges; require only the
+gate.
 
 ## Why
 


### PR DESCRIPTION
## What & why (P2a)

The editor-smoke workflow was **advisory + path-filtered**, so it could not be made a required check — a path-filtered workflow is *skipped* on unrelated PRs, and a required-but-skipped check blocks those merges forever. This is the recurring "we ship buggy editor builds because the one test that would catch it doesn't gate merges" problem.

Restructured so it's requireable **without** that trap:
- **Drop the trigger-level `paths:` filter** → the workflow runs on every PR (so the gate always reports).
- **New `changes` job** — git-diff against the base (house style; no new action dependency) decides if the editor/grading/isolation surface was touched. **Fail-safe**: non-PR events, a missing base SHA, or an empty diff all *run* the smoke. Over-matching is safe; under-matching is the dangerous direction, so I biased toward running. The detection set also now includes `grading-worker.js` and `CrossOriginIsolationHeaders.swift` (introduced by the recent isolation work).
- **`smoke` matrix** (Chromium + WebKit) runs only when `changes.editor == true`.
- **New `editor-smoke-gate` job** (`if: always()`, `needs: [changes, smoke]`) reports the single requireable status: green when smoke **passed or was skipped**, red only when smoke **failed/cancelled** — and red if change-detection itself failed (**fail closed**).

## The one step left (a repo setting, not in-repo)
In branch protection for `main`, add **`editor-smoke-gate`** to required status checks. **Do not** require the matrix legs (`smoke (chromium)` / `smoke (webkit)`) — they're skipped on non-editor PRs and would block those merges; require only the gate. (Documented in `docs/notebook-editor-smoke-test.md`.)

## Verification
- YAML parses; job wiring confirmed (`smoke needs changes` + `if editor==true`; `gate needs [changes, smoke]` + `if always()`).
- Logic walked through for all four states: editor PR pass → green; editor PR fail → red; non-editor PR → smoke skipped → gate green; change-detection error → fail closed.
- ⚠️ GitHub Actions control-flow can't be executed locally — this is config; the proof is the next editor-touching PR (this one touches `editor-smoke.yml`, so the `changes` job will match and the full matrix will run here, exercising the new structure end-to-end).

Independent of the P1 (notebook-page e2e) and P3 (disable redundant SW) work, which are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT)_