### PR TITLE
Disable the redundant JupyterLite service worker — SAB only, no fallback (P3)

### DIFF
--- a/Public/jupyterlite/jupyter-lite.json
+++ b/Public/jupyterlite/jupyter-lite.json
@@ -5,7 +5,9 @@
     "appVersion": "0.7.6-chickadee.1",
     "baseUrl": "./",
     "defaultKernelName": "python",
-    "disabledExtensions": [],
+    "disabledExtensions": [
+      "@jupyterlite/application-extension:service-worker-manager"
+    ],
     "faviconUrl": "./lab/favicon.ico",
     "federated_extensions": [
       {

--- a/Tests/APITests/JupyterLiteConfigTests.swift
+++ b/Tests/APITests/JupyterLiteConfigTests.swift
@@ -1,32 +1,29 @@
 // Tests/APITests/JupyterLiteConfigTests.swift
 //
 // Regression guard for the JupyterLite bundle config (`Public/jupyterlite/
-// jupyter-lite.json`).  Asserts the service-worker-manager plugin is ENABLED
-// (i.e. NOT in disabledExtensions).
+// jupyter-lite.json`).  Asserts the service-worker-manager plugin is DISABLED
+// (i.e. listed in disabledExtensions).
 //
-// History — this guard was INVERTED:
+// History — this guard has flipped twice, tracking the kernel's sync mechanism:
 //
-//   * v0.4.150 (PR #467) DISABLED the service-worker-manager plugin because
-//     students saw 404s on `/jupyterlite/api/drive` and the kernel stuck in
-//     "Unknown".  Root cause was a never-fully-understood SW registration/
-//     controller race.  Disabling forced `mountDrive=false` and avoided it.
-//   * BUT disabling the SW also removed the kernel's ONLY synchronous-execution
-//     mechanism (the SW intercepts `/api/drive` AND `/api/stdin/` and broadcasts
-//     to the kernel).  With no SW and no SharedArrayBuffer, a synchronous kernel
-//     op (`input()`) hard-freezes the page — the "Page Unresponsive" freeze.
-//     v0.4.150's own changelog flagged this: "no stdin … input() in cells will
-//     hang."
-//   * Re-enabling the SW restores that sync mechanism and fixes the freeze. The
-//     vended SW already does `self.skipWaiting()` + `self.clients.claim()`
-//     (see Public/jupyterlite/service-worker.js), the standard lifecycle that
-//     addresses the original controller race.
+//   * v0.4.150 (PR #467) DISABLED the SW (kernel stuck "Unknown" from an SW
+//     registration/controller race) — but that removed the kernel's only
+//     synchronous-execution path, so `input()` hard-froze the page (#959).
+//   * v0.4.467 RE-ENABLED the SW to restore sync and kill the freeze — at the
+//     cost of reintroducing the SW-control "Kernel Unknown" race on devices
+//     where the SW failed to control the page in time.
+//   * Now: cross-origin isolation is unconditional, so the kernel uses
+//     `SharedArrayBuffer` for synchronous stdin/Drive and no longer needs the
+//     SW at all.  The SW is therefore DISABLED again — but this time there is no
+//     freeze (SAB carries sync) AND no control race (no SW to race).  This is
+//     the deterministic end state: one sync path, no fallback.
 //
-// ⚠️ Re-enabling reverses a guarded decision and reintroduces the risk of the
-// "Kernel Unknown" race on devices where the SW fails to control the page.
-// This MUST be browser-verified (Chrome + Safari + a managed device) before it
-// ships — CI cannot test it.  If Kernel Unknown recurs, the next step is a
-// kernel-wheel patch that gates `mountDrive` on the SW actually controlling the
-// page (graceful degradation), not re-disabling the SW.
+// This is browser-verified by the editor-smoke harness
+// (`Tools/editor-smoke-test`): the selftest boots the editor with no SW and
+// asserts the kernel + `input()` work over SAB, and the authenticated
+// notebook-page e2e loads the student's notebook from the Drive and grades a
+// real submission — both under Chromium AND WebKit (Safari engine).  If you ever
+// re-ENABLE the SW, restore the old "must be enabled" assertion and rationale.
 
 import Foundation
 import Testing
@@ -46,7 +43,7 @@ import Testing
     private static let serviceWorkerManager =
         "@jupyterlite/application-extension:service-worker-manager"
 
-    @Test func sourceConfigEnablesServiceWorkerManager() throws {
+    @Test func sourceConfigDisablesServiceWorkerManager() throws {
         let url = URL(fileURLWithPath: sourceConfigPath)
         let data = try Data(contentsOf: url)
         let root = try #require(
@@ -57,16 +54,16 @@ import Testing
 
         let disabled = cfg["disabledExtensions"] as? [String] ?? []
         let sourceMsg: Comment = """
-            Expected source JupyterLite config (\(sourceConfigPath)) to ENABLE the \
-            service-worker-manager plugin (not in disabledExtensions) so the kernel \
-            regains its SW-based stdin/Drive sync and the input()-freeze is fixed. \
-            Got disabledExtensions=\(disabled). Do not re-disable without restoring \
-            another sync mechanism — disabling alone reintroduces the freeze.
+            Expected source JupyterLite config (\(sourceConfigPath)) to DISABLE the \
+            service-worker-manager plugin (listed in disabledExtensions): the kernel \
+            now syncs stdin/Drive over SharedArrayBuffer (cross-origin isolation), so \
+            the SW is redundant. Got disabledExtensions=\(disabled). Do not re-enable \
+            without reverting the editor to the SW sync path — see the file header.
             """
-        #expect(!disabled.contains(Self.serviceWorkerManager), sourceMsg)
+        #expect(disabled.contains(Self.serviceWorkerManager), sourceMsg)
     }
 
-    @Test func bundleEnablesServiceWorkerManager() throws {
+    @Test func bundleDisablesServiceWorkerManager() throws {
         let url = URL(fileURLWithPath: configPath)
         let data = try Data(contentsOf: url)
         let root = try #require(
@@ -77,12 +74,12 @@ import Testing
 
         let disabled = cfg["disabledExtensions"] as? [String] ?? []
         let bundleMsg: Comment = """
-            Expected built JupyterLite bundle to ENABLE the service-worker-manager \
-            plugin (not in disabledExtensions). Got disabledExtensions=\(disabled). \
-            Remove it from Tools/jupyterlite/jupyter-lite.json and re-run \
-            scripts/build-jupyterlite.sh (or sync the served config).
+            Expected built JupyterLite bundle to DISABLE the service-worker-manager \
+            plugin (listed in disabledExtensions); the kernel uses SharedArrayBuffer \
+            now. Got disabledExtensions=\(disabled). Add it to \
+            Tools/jupyterlite/jupyter-lite.json and sync the served config.
             """
-        #expect(!disabled.contains(Self.serviceWorkerManager), bundleMsg)
+        #expect(disabled.contains(Self.serviceWorkerManager), bundleMsg)
     }
 
     @Test func bundleAppVersionMatchesRequirementsPin() throws {

--- a/Tools/editor-smoke-test/notebook-page-check.mjs
+++ b/Tools/editor-smoke-test/notebook-page-check.mjs
@@ -42,8 +42,12 @@ const COURSE = { code: `E2E${STAMP}`.slice(0, 12), name: "E2E Browser Course" };
 // Budgets — the real page boots TWO Pyodide instances (editor kernel + grader),
 // both local but large, so be generous.
 const PAGE_LOAD_MS = 30_000;
-const KERNEL_BOOT_MS = parseInt(process.env.SMOKE_KERNEL_MS || "90000", 10);
-const SUBMIT_RESULT_MS = parseInt(process.env.SMOKE_SUBMIT_MS || "120000", 10);
+const KERNEL_BOOT_MS = parseInt(process.env.SMOKE_KERNEL_MS || "120000", 10);
+// Generous: the real page boots TWO Pyodides (editor kernel + grader). Without
+// the JupyterLite service worker's asset cache (disabled now that the kernel
+// syncs over SharedArrayBuffer) that double load is heavier — measurably so
+// under WebKit — so grading-to-result can take a few minutes on a cold runner.
+const SUBMIT_RESULT_MS = parseInt(process.env.SMOKE_SUBMIT_MS || "240000", 10);
 
 function fail(reason, extra) {
   console.log(`E2E FAIL — ${reason}`);
@@ -218,32 +222,14 @@ async function main() {
 
     // (2) Our app Web Workers must spawn from the real isolated page (the #986
     // regression: a require-corp page can't spawn a worker whose script lacks
-    // COEP). This is the same probe as editor-check, but on the REAL page.
-    const workerScripts = ["/grading-worker.js", "/freeze-watchdog-worker.js"];
-    const workerBlocked = [];
-    const onWorkerReqFail = (req) => {
-      const why = req.failure()?.errorText || "";
-      if (workerScripts.some((s) => req.url().includes(s)) && /ERR_BLOCKED/i.test(why)) {
-        workerBlocked.push(`${req.url()} — ${why}`);
-      }
-    };
-    page.on("requestfailed", onWorkerReqFail);
-    const spawnErrors = await page.evaluate(async (scripts) => {
-      const errs = [];
-      await Promise.all(scripts.map((s) => new Promise((resolve) => {
-        let w;
-        try { w = new Worker(s); } catch (e) { errs.push(`${s} threw ${(e && e.message) || e}`); return resolve(); }
-        setTimeout(() => { try { w.terminate(); } catch (_) { /* ignore */ } resolve(); }, 3000);
-      })));
-      return errs;
-    }, workerScripts);
-    await page.waitForTimeout(200);
-    page.off("requestfailed", onWorkerReqFail);
-    if (workerBlocked.length || spawnErrors.length) {
-      return fail("an app Web Worker was blocked under isolation on the real notebook page",
-        [...workerBlocked, ...spawnErrors].join("\n"));
-    }
-    console.log(`worker-spawn probe: ${workerScripts.join(", ")} spawned OK on the real page`);
+    // COEP). We do NOT spawn a synthetic probe worker here — that would start a
+    // second Pyodide load (grading-worker.js importScripts pyodide at startup)
+    // and contend with the real grading. Instead the page exercises the workers
+    // for us: notebook.js spawns /freeze-watchdog-worker.js on load and
+    // browser-runner.js spawns /grading-worker.js on Submit. A COEP block of
+    // either surfaces as an ERR_BLOCKED request, captured in `blocked` and
+    // asserted below (and the Submit step would also fail). Editor-check.mjs
+    // keeps the active probe for the standalone case.
 
     // (3) The editor iframe must boot the JupyterLite shell AND load the
     // student's notebook from the Drive. We probe the same-origin iframe's DOM
@@ -295,21 +281,27 @@ async function main() {
     }
     await submit.click();
     const results = page.locator("#nb-results");
+    // Wait for the grader to render a terminal result line ("N / M passed …").
     const gotResults = await page.waitForFunction(
       () => {
         const el = document.getElementById("nb-results");
         if (!el || el.hidden) return false;
-        const t = el.innerText || "";
-        return /passed|✓|fail|error/i.test(t);
+        return /\d+\s*\/\s*\d+\s*passed/i.test(el.innerText || "");
       },
       null, { timeout: SUBMIT_RESULT_MS }
     ).then(() => true).catch(() => false);
-    if (blocked.length) return fail("blocked resources during submit/grading", blocked.join("\n"));
+    if (blocked.length) return fail("blocked resources during submit/grading (a worker was COEP-blocked)", blocked.join("\n"));
     if (!gotResults) return fail(`no grading result rendered within ${SUBMIT_RESULT_MS}ms`);
     const resultText = (await results.innerText()).replace(/\s+/g, " ").trim().slice(0, 200);
     console.log(`grading result rendered: "${resultText}"`);
+    // The fixture's one public test (`print(...)`, exit 0) must PASS — a
+    // result of "1 / 1 passed" proves grading-worker.js spawned under isolation,
+    // loaded Pyodide, ran the test, and posted a correct outcome end-to-end.
+    if (!/1\s*\/\s*1\s*passed/i.test(resultText)) {
+      return fail(`grading did not pass cleanly (expected "1 / 1 passed"): ${resultText}`);
+    }
 
-    console.log(`E2E PASS — real notebook page isolated, workers spawned, kernel booted, submit graded (engine=${browserName})`);
+    console.log(`E2E PASS — real notebook page isolated, workers spawned, kernel booted, submit graded 1/1 (engine=${browserName})`);
     await finish(0);
   } catch (err) {
     return fail(`exception: ${(err && err.stack) || err}`, blocked.length ? blocked.join("\n") : undefined);

--- a/Tools/jupyterlite/jupyter-lite.json
+++ b/Tools/jupyterlite/jupyter-lite.json
@@ -3,7 +3,9 @@
     "appVersion": "0.7.6-chickadee.1",
     "defaultKernelName": "python",
     "fullLabextensionsUrl": "./extensions",
-    "disabledExtensions": [],
+    "disabledExtensions": [
+      "@jupyterlite/application-extension:service-worker-manager"
+    ],
     "federated_extensions": [
       {
         "name": "@jupyterlite/pyodide-kernel-extension",

--- a/changelog.d/disable-redundant-sw.md
+++ b/changelog.d/disable-redundant-sw.md
@@ -1,0 +1,20 @@
+### Changed
+
+- **Disabled the now-redundant JupyterLite service worker — the editor runs on
+  SharedArrayBuffer alone, no fallback.** With cross-origin isolation
+  unconditional, the kernel syncs stdin/Drive over `SharedArrayBuffer`, so the
+  service worker (`@jupyterlite/application-extension:service-worker-manager`) is
+  no longer needed and is now in `disabledExtensions` (source + served config).
+  This is the deterministic end state: one sync path, no fallback — which also
+  removes the SW-control "Kernel Unknown" race entirely (no SW to race).
+  `JupyterLiteConfigTests` now asserts the SW manager is disabled. Verified by
+  the editor-smoke selftest (kernel + `input()` over SAB with no SW) and the
+  authenticated notebook-page e2e (the real editor loads the notebook from the
+  Drive and grades a real submission with no SW), both under **Chromium and
+  WebKit**. Trade-off: without the SW asset cache the page's two Pyodide loads
+  are heavier, so grading-to-result is somewhat slower (noticeably under WebKit)
+  but still completes — the notebook-page e2e's submit budget was widened
+  accordingly. Its redundant active worker-spawn probe (which started a second
+  Pyodide and could perturb the real grading) was removed in favour of asserting
+  no COEP-blocked resources plus a clean `1 / 1 passed`, making the e2e
+  deterministic across engines.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -172,10 +172,27 @@ Harder to do cleanly here than the nb_mypy wheel patch
 content-hash-named webpack chunks rather than a fixed-name Python member.
 Prefer plan C; this is a per-browser safety net only.
 
+### Service worker disabled (no safety net)
+
+Now that cross-origin isolation is unconditional and `SharedArrayBuffer` carries
+the kernel's synchronous stdin/Drive, the JupyterLite **service worker is
+redundant and has been disabled** (`@jupyterlite/application-extension:service-worker-manager`
+in `disabledExtensions`, both `Tools/jupyterlite/jupyter-lite.json` and the served
+`Public/jupyterlite/jupyter-lite.json`). This is the deterministic end state:
+**one sync path (SAB), no fallback** — which also removes the SW-control race
+entirely (no SW to race) and the redundant SW asset cache. Guarded by
+`JupyterLiteConfigTests` (now asserts the SW manager *is* disabled) and proven by
+the editor-smoke selftest (editor boots + `input()` over SAB with no SW) and the
+authenticated notebook-page e2e (the real editor loads the notebook from the
+Drive and grades a real submission with no SW) — both under Chromium *and*
+WebKit. One observed trade-off: without the SW asset cache, the page's two
+Pyodide loads (editor kernel + grader) are heavier, so grading-to-result is
+somewhat slower (noticeably under WebKit); it still completes.
+
 ## Quick reference
 
 | | Sync path | SW-control race? | Status |
 |---|---|---|---|
 | Before | JupyterLite service worker | **yes** | the bug; recovery ladder A mitigates it |
-| Now (unconditional) | `SharedArrayBuffer` (cross-origin isolation) | **no** | shipped + headless-proven; SW kept as harmless fallback |
-| Fallback | SW, gated on `serviceWorker.controller` | removed | per-browser safety net only |
+| Now | `SharedArrayBuffer` (cross-origin isolation) | **no** | shipped + headless-proven (both engines); **SW disabled** — one sync path, no fallback |
+| Removed | SW, gated on `serviceWorker.controller` | n/a | the never-built fallback; unnecessary once SAB is the sole path |


### PR DESCRIPTION
## What & why (P3)

With cross-origin isolation now unconditional, the Pyodide kernel syncs stdin/Drive over **`SharedArrayBuffer`**, so the JupyterLite service worker is redundant. This disables it (`@jupyterlite/application-extension:service-worker-manager` in `disabledExtensions`, both the source `Tools/jupyterlite/jupyter-lite.json` and the served `Public/jupyterlite/jupyter-lite.json`).

**No safety net, by design** — one sync path (SAB), no fallback. This is the deterministic end state and also removes the SW-control "Kernel Unknown" race *entirely* (there's no SW left to race).

`JupyterLiteConfigTests` is flipped: it now asserts the SW manager **is** disabled (source + built bundle), with the rationale rewritten.

## Verified with no SW — both engines
- **editor-smoke selftest**: kernel boots and `input()` round-trips over SAB (the default config is now the no-SW path); the freeze detector still fires.
- **authenticated notebook-page e2e**: the real editor **loads the student's notebook from the Drive** and a real **Submit grades `1 / 1`** — proving the Drive + grading paths work on SAB alone.
- `verify-jupyterlite.sh` still passes.

Ran Chromium ×N and **WebKit ×2** locally — all green.

## e2e hardening (discovered while verifying)
- **Removed the redundant active worker-spawn probe.** Spawning `/grading-worker.js` runs `importScripts('/pyodide/pyodide.js')` immediately (a real Pyodide load) that the probe terminated mid-flight — contention that intermittently produced a spurious `1 error`. The page already spawns the real freeze/grading workers itself, so a COEP block still surfaces (via the no-blocked-resources assertion or a grading failure). Result: deterministic across engines.
- **Strict assertion**: grading must render `1 / 1 passed`.
- **Wider submit budget**: without the SW asset cache, the page's two Pyodide loads (editor kernel + grader) are heavier — noticeably slower under WebKit — but grading still completes.

## Trade-off worth flagging
Disabling the SW removes its asset cache, so grading is somewhat slower (most visible on WebKit / cold loads). It still completes; this is a minor perf cost for removing the race and the redundant machinery. (Relevant to the earlier Lab 4 "grading feels slow" note — the real per-test grading-speed work is separate.)

## Deliberately kept
The recovery ladder (#983) and the freeze-failover worker are **not** removed — they guard a genuinely dead kernel / a main-thread grading freeze, which are distinct from the SW sync path. Say the word and I'll remove those too.

Completes the P1 → P2a → P3 series (P2a #987, P1 #988 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT)_