### PR TITLE
Migrate APITests off XCTVapor to VaporTesting (fix flaky test reporting)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -126,7 +126,7 @@ let package = Package(
             name: "APITests",
             dependencies: [
                 .target(name: "APIServer"),
-                .product(name: "XCTVapor", package: "vapor"),
+                .product(name: "VaporTesting", package: "vapor"),
                 .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
                 .product(name: "CSRF", package: "CSRF"),

--- a/Tests/APITests/AccountRoutesTests.swift
+++ b/Tests/APITests/AccountRoutesTests.swift
@@ -14,7 +14,7 @@ import Crypto
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementAuthoringTests.swift
+++ b/Tests/APITests/AchievementAuthoringTests.swift
@@ -9,7 +9,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementBadgeTests.swift
+++ b/Tests/APITests/AchievementBadgeTests.swift
@@ -9,7 +9,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementBonusTests.swift
+++ b/Tests/APITests/AchievementBonusTests.swift
@@ -9,7 +9,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementDisplayTests.swift
+++ b/Tests/APITests/AchievementDisplayTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementEvaluationTests.swift
+++ b/Tests/APITests/AchievementEvaluationTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementKindPresentationTests.swift
+++ b/Tests/APITests/AchievementKindPresentationTests.swift
@@ -10,7 +10,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AchievementSeedTests.swift
+++ b/Tests/APITests/AchievementSeedTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/ActivityChartServiceTests.swift
+++ b/Tests/APITests/ActivityChartServiceTests.swift
@@ -8,7 +8,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AdminActivityRouteTests.swift
+++ b/Tests/APITests/AdminActivityRouteTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -2,7 +2,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -322,8 +322,8 @@ private struct PassthroughResponder: AsyncResponder {
                     let recentIndex = try #require(body.range(of: "recent_seen")?.lowerBound)
                     let olderIndex = try #require(body.range(of: "older_seen")?.lowerBound)
                     let neverIndex = try #require(body.range(of: "never_seen")?.lowerBound)
-                    XCTAssertLessThan(recentIndex, olderIndex)
-                    XCTAssertLessThan(olderIndex, neverIndex)
+                    #expect(recentIndex < olderIndex)
+                    #expect(olderIndex < neverIndex)
                 })
 
         }

--- a/Tests/APITests/AssignmentEnrollmentTests.swift
+++ b/Tests/APITests/AssignmentEnrollmentTests.swift
@@ -9,7 +9,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentExtensionsTests.swift
+++ b/Tests/APITests/AssignmentExtensionsTests.swift
@@ -13,7 +13,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -337,8 +337,8 @@ import XCTVapor
                     let recentIndex = try #require(html.range(of: "recent_seen_student")?.lowerBound)
                     let olderIndex = try #require(html.range(of: "older_seen_student")?.lowerBound)
                     let neverIndex = try #require(html.range(of: "never_seen_student")?.lowerBound)
-                    XCTAssertLessThan(recentIndex, olderIndex)
-                    XCTAssertLessThan(olderIndex, neverIndex)
+                    #expect(recentIndex < olderIndex)
+                    #expect(olderIndex < neverIndex)
                 })
 
         }

--- a/Tests/APITests/AssignmentRoutesEditorTests.swift
+++ b/Tests/APITests/AssignmentRoutesEditorTests.swift
@@ -15,7 +15,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentRoutesHelpers.swift
+++ b/Tests/APITests/AssignmentRoutesHelpers.swift
@@ -7,7 +7,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentRoutesLifecycleTests.swift
+++ b/Tests/APITests/AssignmentRoutesLifecycleTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentRoutesNotebookTests.swift
+++ b/Tests/APITests/AssignmentRoutesNotebookTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -101,8 +101,8 @@ import XCTVapor
             let mtimeAfter =
                 (try FileManager.default.attributesOfItem(atPath: workingCopyPath)[.modificationDate] as? Date)
                 ?? Date.distantPast
-            XCTAssertGreaterThan(
-                mtimeAfter, mtimeBefore,
+            #expect(
+                mtimeAfter > mtimeBefore,
                 "Reset must bump the working-copy file mtime so notebook.js force-reseeds the browser's local copy.")
 
         }

--- a/Tests/APITests/AssignmentRoutesPublishTests.swift
+++ b/Tests/APITests/AssignmentRoutesPublishTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentRoutesRetestTests.swift
+++ b/Tests/APITests/AssignmentRoutesRetestTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AssignmentSeedStoreTests.swift
+++ b/Tests/APITests/AssignmentSeedStoreTests.swift
@@ -5,7 +5,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AuditLogReaperServiceTests.swift
+++ b/Tests/APITests/AuditLogReaperServiceTests.swift
@@ -5,7 +5,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AuthModeGatingTests.swift
+++ b/Tests/APITests/AuthModeGatingTests.swift
@@ -8,7 +8,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/AuthRoutesTests.swift
+++ b/Tests/APITests/AuthRoutesTests.swift
@@ -5,7 +5,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -249,8 +249,8 @@ import XCTVapor
                     #expect(res.status == .seeOther)
                 })
             let elapsed = Date().timeIntervalSince(start)
-            XCTAssertGreaterThan(
-                elapsed, 0.05,
+            #expect(
+                elapsed > 0.05,
                 "User-not-found login completed in \(elapsed)s; bcrypt verify likely skipped (cost 12 is ≥100 ms).")
 
         }

--- a/Tests/APITests/BrightSpaceCredentialStoreTests.swift
+++ b/Tests/APITests/BrightSpaceCredentialStoreTests.swift
@@ -7,7 +7,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -10,7 +10,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -10,7 +10,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -14,7 +14,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/BuiltInAwardTogglesTests.swift
+++ b/Tests/APITests/BuiltInAwardTogglesTests.swift
@@ -9,7 +9,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -1,6 +1,6 @@
 import Fluent
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -28,7 +28,7 @@ import XCTVapor
 
     @Test func notebookPageIsNotIsolatedByDefault() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/testsetups/setup_123/notebook") { res async in
+            try await app.testing().test(.GET, "/testsetups/setup_123/notebook") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
@@ -38,7 +38,7 @@ import XCTVapor
 
     @Test func jupyterliteAssetsAreNotIsolatedByDefault() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
+            try await app.testing().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
                 #expect(res.headers.first(name: "Cross-Origin-Resource-Policy") == nil)
@@ -50,7 +50,7 @@ import XCTVapor
 
     @Test func notebookPageIsIsolatedWhenEnabled() async throws {
         try await withApp(try await makeApp(isolateNotebook: true)) { app in
-            try await app.testable().test(.GET, "/testsetups/setup_123/notebook") { res async in
+            try await app.testing().test(.GET, "/testsetups/setup_123/notebook") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
@@ -60,7 +60,7 @@ import XCTVapor
 
     @Test func jupyterliteAssetsAreIsolatedWhenEnabled() async throws {
         try await withApp(try await makeApp(isolateNotebook: true)) { app in
-            try await app.testable().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
+            try await app.testing().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
@@ -73,7 +73,7 @@ import XCTVapor
 
     @Test func validatePageAlwaysReceivesCOEPHeaders() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/instructor/assignment_123/validate") { res async in
+            try await app.testing().test(.GET, "/instructor/assignment_123/validate") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == "same-origin")
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
@@ -83,7 +83,7 @@ import XCTVapor
 
     @Test func unrelatedPageNeverReceivesCOEPHeaders() async throws {
         try await withApp(try await makeApp(isolateNotebook: true)) { app in
-            try await app.testable().test(.GET, "/plain") { res async in
+            try await app.testing().test(.GET, "/plain") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Opener-Policy") == nil)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
@@ -100,7 +100,7 @@ import XCTVapor
     @Test func isolatedPageWorkerScriptsReceiveCOEPWhenEnabled() async throws {
         try await withApp(try await makeApp(isolateNotebook: true)) { app in
             for path in ["/grading-worker.js", "/freeze-watchdog-worker.js"] {
-                try await app.testable().test(.GET, path) { res async in
+                try await app.testing().test(.GET, path) { res async in
                     #expect(res.status == .ok)
                     #expect(
                         res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp",
@@ -116,7 +116,7 @@ import XCTVapor
         // /pyodide-worker.js is spawned only by the (non-isolated) assignment
         // editor pages, so it must NOT be forced require-corp.
         try await withApp(try await makeApp(isolateNotebook: true)) { app in
-            try await app.testable().test(.GET, "/pyodide-worker.js") { res async in
+            try await app.testing().test(.GET, "/pyodide-worker.js") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
             }
@@ -125,7 +125,7 @@ import XCTVapor
 
     @Test func workerScriptsAreNotIsolatedWhenDisabled() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/grading-worker.js") { res async in
+            try await app.testing().test(.GET, "/grading-worker.js") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
             }

--- a/Tests/APITests/CSRFTests.swift
+++ b/Tests/APITests/CSRFTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/ClassRecordManifestTests.swift
+++ b/Tests/APITests/ClassRecordManifestTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/ClientDiagnosticsRoutesTests.swift
+++ b/Tests/APITests/ClientDiagnosticsRoutesTests.swift
@@ -8,7 +8,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -54,7 +54,7 @@ import XCTVapor
         _ body: String,
         auth: (cookie: String, csrf: String),
         userAgent: String? = nil
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(.POST, "/api/v1/client-diagnostics") { req in
             req.headers.add(name: .cookie, value: auth.cookie)
             req.headers.add(name: "x-csrf-token", value: auth.csrf)

--- a/Tests/APITests/CourseBundleTests.swift
+++ b/Tests/APITests/CourseBundleTests.swift
@@ -11,7 +11,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -425,7 +425,7 @@ import XCTVapor
                 let course = try await APICourse.query(on: app.db)
                     .filter(\.$code == "IMP_RECORDS").first()
             else {
-                XCTFail("Imported course should exist in DB")
+                Issue.record("Imported course should exist in DB")
                 return
             }
             let courseID = try course.requireID()
@@ -470,7 +470,7 @@ import XCTVapor
                 .filter(\.$code == "USERMATCH_CB").first()
             #expect(course != nil)
             guard let courseID2 = try course?.requireID() else {
-                XCTFail("Imported course USERMATCH_CB not found in DB")
+                Issue.record("Imported course USERMATCH_CB not found in DB")
                 return
             }
             let enrollment = try await APICourseEnrollment.query(on: app.db)
@@ -544,7 +544,7 @@ import XCTVapor
                     .filter(\.$isArchived == false)
                     .first()
             else {
-                XCTFail("Imported course should exist and be active")
+                Issue.record("Imported course should exist and be active")
                 return
             }
             let importedID = try imported.requireID()

--- a/Tests/APITests/DraftSuiteSectionRoutesTests.swift
+++ b/Tests/APITests/DraftSuiteSectionRoutesTests.swift
@@ -16,7 +16,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/DraftSupportFilesTests.swift
+++ b/Tests/APITests/DraftSupportFilesTests.swift
@@ -14,7 +14,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -178,7 +178,7 @@ import XCTVapor
             guard let setup = try await APITestSetup.find(draftID, on: app.db),
                 let data = setup.manifest.data(using: .utf8),
                 let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else { return XCTFail("manifest load failed") }
+            else { Issue.record("manifest load failed"); return }
             let entries = dict["testSuites"] as? [[String: Any]] ?? []
             #expect(entries.isEmpty, "Support file uploads must not add a testSuites entry")
 

--- a/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
+++ b/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
@@ -1,5 +1,5 @@
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -64,7 +64,7 @@ import XCTVapor
 
     @Test func hashedBuildChunkIsServedWithImmutableCaching() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/jupyterlite/build/100.5a28c9e.js") { res async in
+            try await app.testing().test(.GET, "/jupyterlite/build/100.5a28c9e.js") { res async in
                 #expect(res.status == .ok)
                 #expect(res.body.string == "hashed-chunk")
                 #expect(
@@ -76,7 +76,7 @@ import XCTVapor
 
     @Test func hashedExtensionAssetIsServedWithImmutableCaching() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/jupyterlite/extensions/@jupyterlite/kernel/static/154.377fd2862adcf65a4294.js"
             ) { res async in
                 #expect(res.status == .ok)
@@ -89,14 +89,14 @@ import XCTVapor
 
     @Test func unhashedBundleFilenameKeepsRevalidating() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/jupyterlite/build/MathJax_Main-Regular.woff"
             ) { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: .cacheControl) == nil)
                 #expect(res.headers.first(name: .eTag) != nil)
             }
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/jupyterlite/extensions/@jupyterlite/kernel/install.json"
             ) { res async in
                 #expect(res.status == .ok)
@@ -108,7 +108,7 @@ import XCTVapor
     @Test func pyodideAndVendorAreFastPathedWithoutImmutableCaching() async throws {
         try await withApp(try await makeApp()) { app in
             for path in ["/pyodide/pyodide-lock.json", "/vendor/jszip.min.js"] {
-                try await app.testable().test(.GET, path) { res async in
+                try await app.testing().test(.GET, path) { res async in
                     #expect(res.status == .ok)
                     #expect(res.headers.first(name: .cacheControl) == nil)
                     #expect(res.headers.first(name: .eTag) != nil)
@@ -119,7 +119,7 @@ import XCTVapor
 
     @Test func userNamespaceFilesStillRequireAuthentication() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET,
                 "/jupyterlite/files/users/5f1c0b9a-0000-0000-0000-000000000000/work.ipynb"
             ) { res async in
@@ -135,7 +135,7 @@ import XCTVapor
                 "/jupyterlite/build/../../secret.txt",
                 "/jupyterlite/build/%2e%2e/%2e%2e/secret.txt",
             ] {
-                try await app.testable().test(.GET, path) { res async in
+                try await app.testing().test(.GET, path) { res async in
                     #expect(res.status != .ok)
                     #expect(res.body.string.contains("top-secret") == false)
                 }
@@ -145,7 +145,7 @@ import XCTVapor
 
     @Test func missingFastPathFileFallsThroughToTheNormalChain() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/jupyterlite/build/absent.js") { res async in
+            try await app.testing().test(.GET, "/jupyterlite/build/absent.js") { res async in
                 #expect(res.status == .notFound)
             }
         }
@@ -160,7 +160,7 @@ import XCTVapor
                 "/jupyterlite/extensions/@jupyterlite/kernel/static/154.377fd2862adcf65a4294.js",
                 "/pyodide/pyodide-lock.json",
             ] {
-                try await app.testable().test(.GET, path) { res async in
+                try await app.testing().test(.GET, path) { res async in
                     #expect(res.status == .ok)
                     #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
                 }
@@ -181,7 +181,7 @@ import XCTVapor
                 "/pyodide/pyodide-lock.json",
                 "/vendor/jszip.min.js",
             ] {
-                try await app.testable().test(.GET, path) { res async in
+                try await app.testing().test(.GET, path) { res async in
                     #expect(res.status == .ok)
                     #expect(
                         res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp",

--- a/Tests/APITests/EnrollmentRoutesTests.swift
+++ b/Tests/APITests/EnrollmentRoutesTests.swift
@@ -13,7 +13,7 @@ import Crypto
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/ExtensionCSRFTokenTests.swift
+++ b/Tests/APITests/ExtensionCSRFTokenTests.swift
@@ -22,7 +22,7 @@
 // a *streaming* body, and the CSRF token retrieval used to read `_csrf` with
 // a synchronous `content.get` — nil for a streaming body — so the request
 // 403'd "No CSRF token provided." even though the field was on the wire.
-// XCTVapor's in-memory transport always delivers pre-collected bodies, so
+// VaporTesting's in-memory transport always delivers pre-collected bodies, so
 // that path needs a real socket: the test boots the server on a loopback
 // port and POSTs the extension form with `Transfer-Encoding: chunked`, which
 // the decoder deterministically dispatches as a stream.
@@ -31,7 +31,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -181,7 +181,7 @@ import Glibc
 /// Sends raw bytes to 127.0.0.1:`port` and returns the full response read
 /// until the server closes the connection (`Connection: close` request).
 /// Plain blocking POSIX sockets — the point is to exercise the real server
-/// pipeline, which XCTVapor's in-memory transport bypasses.
+/// pipeline, which VaporTesting's in-memory transport bypasses.
 private func rawLoopbackHTTPExchange(port: Int, request: String) throws -> String {
     #if os(Linux)
     let sockStream = Int32(SOCK_STREAM.rawValue)

--- a/Tests/APITests/GradeOverridesTests.swift
+++ b/Tests/APITests/GradeOverridesTests.swift
@@ -17,7 +17,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
+++ b/Tests/APITests/HTTPSRedirectMiddlewareTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -41,7 +41,7 @@ import XCTVapor
 
     @Test func noRedirectWhenEnforcementDisabled() async throws {
         try await withApp(try await makeApp(enforceHTTPS: false)) { app in
-            try await app.testable().test(.GET, "/test") { res async in
+            try await app.testing().test(.GET, "/test") { res async in
                 #expect(res.status == .ok)
                 #expect(res.body.string == "ok")
             }
@@ -52,7 +52,7 @@ import XCTVapor
 
     @Test func httpsRequestPassesThrough() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: "X-Forwarded-Proto", value: "https")
@@ -67,7 +67,7 @@ import XCTVapor
 
     @Test func getRedirectsToHTTPS() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: .host, value: "example.com")
@@ -86,7 +86,7 @@ import XCTVapor
 
     @Test func postReturns426() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/submit",
                 beforeRequest: { req async in
                     req.headers.add(name: .host, value: "example.com")
@@ -101,7 +101,7 @@ import XCTVapor
 
     @Test func workerPostPassesThroughOverPlainHTTP() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/api/v1/worker/request",
                 beforeRequest: { req async in
                     req.headers.add(name: .host, value: "example.com")
@@ -115,7 +115,7 @@ import XCTVapor
 
     @Test func healthGetPassesThroughOverPlainHTTP() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/health",
                 beforeRequest: { req async in
                     req.headers.add(name: .host, value: "example.com")
@@ -131,7 +131,7 @@ import XCTVapor
 
     @Test func forwardedProtoHTTPSPassesThrough() async throws {
         try await withApp(try await makeApp(trustForwardedProto: true)) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: "X-Forwarded-Proto", value: "https")
@@ -144,7 +144,7 @@ import XCTVapor
 
     @Test func forwardedProtoHTTPRedirects() async throws {
         try await withApp(try await makeApp(trustForwardedProto: true)) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: "X-Forwarded-Proto", value: "http")
@@ -160,7 +160,7 @@ import XCTVapor
 
     @Test func redirectUsesForwardedHost() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: "X-Forwarded-Host", value: "public.example.com")
@@ -180,7 +180,7 @@ import XCTVapor
 
     @Test func redirectUsesPublicBaseURL() async throws {
         try await withApp(try await makeApp(publicBaseURL: "https://chickadee.example.edu")) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: .host, value: "internal.local")
@@ -199,7 +199,7 @@ import XCTVapor
 
     @Test func redirectFallsBackToLocalhost() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/test",
                 afterResponse: { res async in
                     #expect(res.status == .temporaryRedirect)
@@ -213,7 +213,7 @@ import XCTVapor
 
     @Test func headRedirectsLikeGET() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .HEAD, "/test",
                 beforeRequest: { req async in
                     req.headers.add(name: .host, value: "example.com")

--- a/Tests/APITests/JupyterLiteContentsRoutesTests.swift
+++ b/Tests/APITests/JupyterLiteContentsRoutesTests.swift
@@ -2,7 +2,7 @@ import Fluent
 import Foundation
 import Testing
 import Vapor
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/MCP/AdminMCPBearerTests.swift
+++ b/Tests/APITests/MCP/AdminMCPBearerTests.swift
@@ -7,7 +7,7 @@ import Core
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -33,7 +33,7 @@ import XCTVapor
 
     private func post(
         _ app: Application, body: String, bearer: String?
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(.POST, "/admin-mcp") { req in
             req.headers.contentType = .json
             if let bearer { req.headers.add(name: .authorization, value: "Bearer \(bearer)") }

--- a/Tests/APITests/MCP/AdminMCPDispatcherTests.swift
+++ b/Tests/APITests/MCP/AdminMCPDispatcherTests.swift
@@ -11,7 +11,7 @@ import Core
 import Fluent
 import Testing
 import Vapor
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/MCP/AdminMCPEndpointTests.swift
+++ b/Tests/APITests/MCP/AdminMCPEndpointTests.swift
@@ -4,7 +4,7 @@
 // AdminMCPBearerAuthMiddleware (the auth path is covered in AdminMCPBearerTests).
 
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -33,7 +33,7 @@ import XCTVapor
     @Test func postInitializeReturnsToolsOnlyResult() async throws {
         try await withApp(try await makeApp()) { app in
             let body = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/admin-mcp", headers: jsonHeaders, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .ok)
@@ -47,7 +47,7 @@ import XCTVapor
     @Test func postNotificationReturns202() async throws {
         try await withApp(try await makeApp()) { app in
             let body = #"{"jsonrpc":"2.0","method":"notifications/initialized"}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/admin-mcp", headers: jsonHeaders, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .accepted)
@@ -58,7 +58,7 @@ import XCTVapor
 
     @Test func unparseableBodyReturns400() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/admin-mcp", headers: jsonHeaders, body: ByteBuffer(string: "not json")
             ) { res async in
                 #expect(res.status == .badRequest)
@@ -69,7 +69,7 @@ import XCTVapor
 
     @Test func getReturns405() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/admin-mcp") { res async in
+            try await app.testing().test(.GET, "/admin-mcp") { res async in
                 #expect(res.status == .methodNotAllowed)
             }
         }
@@ -82,7 +82,7 @@ import XCTVapor
                 "Content-Type": "application/json", "Origin": "https://evil.example",
             ]
             let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/admin-mcp", headers: headers, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .forbidden)

--- a/Tests/APITests/MCP/AdminMCPOAuthTests.swift
+++ b/Tests/APITests/MCP/AdminMCPOAuthTests.swift
@@ -11,7 +11,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -83,7 +83,7 @@ import XCTVapor
         return String(tail[..<end])
     }
 
-    private func submitConsent(_ app: Application, token: String) async throws -> XCTHTTPResponse {
+    private func submitConsent(_ app: Application, token: String) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/authorize",
             beforeRequest: { req in
@@ -92,7 +92,7 @@ import XCTVapor
             })
     }
 
-    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> XCTHTTPResponse {
+    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/token",
             beforeRequest: { req in try req.content.encode(fields, as: .urlEncodedForm) })
@@ -103,7 +103,7 @@ import XCTVapor
         return components.queryItems?.first(where: { $0.name == name })?.value
     }
 
-    private func jsonField(_ name: String, in res: XCTHTTPResponse) -> String? {
+    private func jsonField(_ name: String, in res: TestingHTTPResponse) -> String? {
         let object = try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8)) as? [String: Any]
         return object?[name] as? String
     }

--- a/Tests/APITests/MCP/AdminMCPRoutesTests.swift
+++ b/Tests/APITests/MCP/AdminMCPRoutesTests.swift
@@ -7,7 +7,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -49,7 +49,7 @@ import XCTVapor
     /// cookie through in case the GET rotates it.
     private func adminCSRFPost(
         _ app: Application, to path: String, cookie: inout String, fields: [String: String]
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         let (token, bound) = try await csrfFields(for: "/admin/mcp", cookie: cookie, on: app)
         cookie = bound
         var body = fields

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -7,7 +7,7 @@ import Fluent
 import Logging
 import Testing
 import Vapor
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/MCP/MCPBearerAuthMiddlewareTests.swift
+++ b/Tests/APITests/MCP/MCPBearerAuthMiddlewareTests.swift
@@ -3,7 +3,7 @@
 
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -38,7 +38,7 @@ import XCTVapor
     @Test func missingTokenReturns401WithChallenge() async throws {
         let (app, _) = try await makeGuardedApp()
         try await withApp(app) { app in
-            try await app.testable().test(.GET, "/guarded") { res async in
+            try await app.testing().test(.GET, "/guarded") { res async in
                 #expect(res.status == .unauthorized)
                 #expect(res.headers.first(name: .wwwAuthenticate)?.contains("resource_metadata=") == true)
             }
@@ -51,7 +51,7 @@ import XCTVapor
             let token = try await authority.mint(
                 subject: "agent", scopes: [.read, .write],
                 issuer: issuer, audience: resource, ttlSeconds: 3600)
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/guarded", headers: ["Authorization": "Bearer \(token)"]
             ) { res async in
                 #expect(res.status == .ok)
@@ -66,7 +66,7 @@ import XCTVapor
             let token = try await authority.mint(
                 subject: "a", scopes: [.read],
                 issuer: issuer, audience: "https://evil.example/mcp", ttlSeconds: 3600)
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/guarded", headers: ["Authorization": "Bearer \(token)"]
             ) { res async in
                 #expect(res.status == .unauthorized)
@@ -80,7 +80,7 @@ import XCTVapor
             let token = try await authority.mint(
                 subject: "a", scopes: [],
                 issuer: issuer, audience: resource, ttlSeconds: 3600)
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/guarded", headers: ["Authorization": "Bearer \(token)"]
             ) { res async in
                 #expect(res.status == .forbidden)

--- a/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
+++ b/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
@@ -6,7 +6,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -25,13 +25,13 @@ import XCTVapor
         return app
     }
 
-    private func register(_ app: Application, body: String) async throws -> XCTHTTPResponse {
+    private func register(_ app: Application, body: String) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/register",
             headers: ["Content-Type": "application/json"], body: ByteBuffer(string: body))
     }
 
-    private func jsonObject(_ res: XCTHTTPResponse) -> [String: Any]? {
+    private func jsonObject(_ res: TestingHTTPResponse) -> [String: Any]? {
         (try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8))) as? [String: Any]
     }
 

--- a/Tests/APITests/MCP/MCPEndToEndTests.swift
+++ b/Tests/APITests/MCP/MCPEndToEndTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -29,7 +29,7 @@ import XCTVapor
         return (app, authority)
     }
 
-    private func post(_ app: Application, body: String, token: String) async throws -> XCTHTTPResponse {
+    private func post(_ app: Application, body: String, token: String) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/mcp",
             headers: ["Content-Type": "application/json", "Authorization": "Bearer \(token)"],
@@ -154,7 +154,7 @@ import XCTVapor
     @Test func discoveryMetadataIsReachableWithoutAToken() async throws {
         let (app, _) = try await makeMCPApp()
         try await withApp(app) { app in
-            try await app.testable().test(.GET, "/.well-known/oauth-protected-resource") { res async in
+            try await app.testing().test(.GET, "/.well-known/oauth-protected-resource") { res async in
                 #expect(res.status == .ok)
                 let body = String(buffer: res.body)
                 #expect(body.contains("\"resource\""))

--- a/Tests/APITests/MCP/MCPEndpointTests.swift
+++ b/Tests/APITests/MCP/MCPEndpointTests.swift
@@ -6,7 +6,7 @@
 // MCPBearerAuthMiddlewareTests and MCPEndToEndTests for the auth path.
 
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -35,7 +35,7 @@ import XCTVapor
     @Test func postInitializeReturnsJSONResult() async throws {
         try await withApp(try await makeApp()) { app in
             let body = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/mcp", headers: jsonHeaders, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .ok)
@@ -48,7 +48,7 @@ import XCTVapor
     @Test func postNotificationReturns202WithNoBody() async throws {
         try await withApp(try await makeApp()) { app in
             let body = #"{"jsonrpc":"2.0","method":"notifications/initialized"}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/mcp", headers: jsonHeaders, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .accepted)
@@ -59,7 +59,7 @@ import XCTVapor
 
     @Test func unparseableBodyReturns400ParseError() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/mcp", headers: jsonHeaders, body: ByteBuffer(string: "not json")
             ) { res async in
                 #expect(res.status == .badRequest)
@@ -70,7 +70,7 @@ import XCTVapor
 
     @Test func getReturns405() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/mcp") { res async in
+            try await app.testing().test(.GET, "/mcp") { res async in
                 #expect(res.status == .methodNotAllowed)
             }
         }
@@ -82,7 +82,7 @@ import XCTVapor
                 var headers = jsonHeaders
                 headers.add(name: "MCP-Protocol-Version", value: version)
                 let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
-                try await app.testable().test(
+                try await app.testing().test(
                     .POST, "/mcp", headers: headers, body: ByteBuffer(string: body)
                 ) { res async in
                     #expect(res.status == .ok)
@@ -99,7 +99,7 @@ import XCTVapor
             var headers = jsonHeaders
             headers.add(name: "MCP-Protocol-Version", value: "1999-01-01")
             let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/mcp", headers: headers, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .badRequest)
@@ -120,7 +120,7 @@ import XCTVapor
                 "Origin": "https://some-client.example",
             ]
             let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/mcp", headers: headers, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .ok)
@@ -136,7 +136,7 @@ import XCTVapor
                 "Origin": "https://evil.example",
             ]
             let body = #"{"jsonrpc":"2.0","id":1,"method":"ping"}"#
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/mcp", headers: headers, body: ByteBuffer(string: body)
             ) { res async in
                 #expect(res.status == .forbidden)

--- a/Tests/APITests/MCP/MCPMetadataRoutesTests.swift
+++ b/Tests/APITests/MCP/MCPMetadataRoutesTests.swift
@@ -4,7 +4,7 @@
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -26,7 +26,7 @@ import XCTVapor
         return app
     }
 
-    private func scopesSupported(_ res: XCTHTTPResponse) -> [String]? {
+    private func scopesSupported(_ res: TestingHTTPResponse) -> [String]? {
         let object =
             (try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8))) as? [String: Any]
         return object?["scopes_supported"] as? [String]
@@ -34,7 +34,7 @@ import XCTVapor
 
     @Test func protectedResourceMetadataAdvertisesServerAndScopes() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/.well-known/oauth-protected-resource") { res async in
+            try await app.testing().test(.GET, "/.well-known/oauth-protected-resource") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.contentType == .json)
                 let body = String(buffer: res.body)
@@ -51,7 +51,7 @@ import XCTVapor
     /// request a scope the server then refused, breaking the connect flow.
     @Test func protectedResourceMetadataReadOnlyAdvertisesOnlyRead() async throws {
         try await withApp(try await makeApp(advertisedScopes: MCPMode.readOnly.advertisedScopes)) { app in
-            try await app.testable().test(.GET, "/.well-known/oauth-protected-resource") { res async in
+            try await app.testing().test(.GET, "/.well-known/oauth-protected-resource") { res async in
                 #expect(res.status == .ok)
                 #expect(self.scopesSupported(res) == ["content:read"])
             }
@@ -60,7 +60,7 @@ import XCTVapor
 
     @Test func authorizationServerMetadataAdvertisesEndpoints() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/.well-known/oauth-authorization-server") { res async in
+            try await app.testing().test(.GET, "/.well-known/oauth-authorization-server") { res async in
                 #expect(res.status == .ok)
                 // Decode rather than substring-match: Linux's JSONEncoder escapes
                 // "/" as "\/", so a raw `contains("/oauth/authorize")` would miss.
@@ -80,7 +80,7 @@ import XCTVapor
     /// advertises only `content:read`.
     @Test func authorizationServerMetadataReadOnlyAdvertisesOnlyRead() async throws {
         try await withApp(try await makeApp(advertisedScopes: MCPMode.readOnly.advertisedScopes)) { app in
-            try await app.testable().test(.GET, "/.well-known/oauth-authorization-server") { res async in
+            try await app.testing().test(.GET, "/.well-known/oauth-authorization-server") { res async in
                 #expect(res.status == .ok)
                 #expect(self.scopesSupported(res) == ["content:read"])
             }
@@ -89,7 +89,7 @@ import XCTVapor
 
     @Test func jwksExportsTheSigningKey() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/.well-known/jwks.json") { res async in
+            try await app.testing().test(.GET, "/.well-known/jwks.json") { res async in
                 #expect(res.status == .ok)
                 let body = String(buffer: res.body)
                 #expect(body.contains("\"kty\":\"EC\""))
@@ -108,7 +108,7 @@ import XCTVapor
                 endpoints: MCPEndpoints(issuer: issuer, resource: resource, metadataOrigin: issuer),
                 advertisedScopes: MCPMode.readWrite.advertisedScopes))
         try await withApp(app) { app in
-            try await app.testable().test(.GET, "/.well-known/jwks.json") { res async in
+            try await app.testing().test(.GET, "/.well-known/jwks.json") { res async in
                 #expect(res.status == .ok)
                 #expect(String(buffer: res.body).contains("\"keys\":[]"))
             }

--- a/Tests/APITests/MCP/MCPModeScopeContractTests.swift
+++ b/Tests/APITests/MCP/MCPModeScopeContractTests.swift
@@ -12,7 +12,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -48,7 +48,7 @@ import XCTVapor
 
     // MARK: - Request helpers (mirror the real client handshake)
 
-    private func register(_ app: Application) async throws -> XCTHTTPResponse {
+    private func register(_ app: Application) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/register",
             headers: ["Content-Type": "application/json"],
@@ -74,7 +74,7 @@ import XCTVapor
     /// (cookie-less, like the cross-site connector POST) and returns the 303.
     private func consent(
         _ app: Application, cookie: String, clientID: String, scope: String
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         var html = ""
         try await app.asyncTest(
             .GET, authorizePath(clientID: clientID, scope: scope),
@@ -93,7 +93,7 @@ import XCTVapor
             })
     }
 
-    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> XCTHTTPResponse {
+    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/token",
             beforeRequest: { req in try req.content.encode(fields, as: .urlEncodedForm) })
@@ -104,12 +104,12 @@ import XCTVapor
         return components.queryItems?.first(where: { $0.name == name })?.value
     }
 
-    private func jsonField(_ name: String, in res: XCTHTTPResponse) -> String? {
+    private func jsonField(_ name: String, in res: TestingHTTPResponse) -> String? {
         let object = try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8)) as? [String: Any]
         return object?[name] as? String
     }
 
-    private func scopesSupported(_ res: XCTHTTPResponse) -> [String]? {
+    private func scopesSupported(_ res: TestingHTTPResponse) -> [String]? {
         let object =
             (try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8))) as? [String: Any]
         return object?["scopes_supported"] as? [String]
@@ -127,7 +127,7 @@ import XCTVapor
         try await withApp(app) { app in
             // 1. Discovery: both well-known docs advertise exactly the mode's scopes.
             for path in ["/.well-known/oauth-protected-resource", "/.well-known/oauth-authorization-server"] {
-                try await app.testable().test(.GET, path) { res async in
+                try await app.testing().test(.GET, path) { res async in
                     #expect(res.status == .ok)
                     #expect(self.scopesSupported(res) == expectedScopes)
                 }

--- a/Tests/APITests/MCP/MCPOAuthFlowTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthFlowTests.swift
@@ -10,7 +10,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -91,7 +91,7 @@ import XCTVapor
     /// is the whole point (Safari/ITP drops the cookie on this cross-site hop).
     private func submitConsent(
         _ app: Application, token: String, decision: String, cookie: String? = nil
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/authorize",
             beforeRequest: { req in
@@ -105,7 +105,7 @@ import XCTVapor
     /// returns the POST response (a 303 to the client).
     private func consent(
         _ app: Application, cookie: String, scope: String, decision: String
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         let token = try await mintConsentToken(app, cookie: cookie, scope: scope)
         return try await submitConsent(app, token: token, decision: decision)
     }
@@ -115,13 +115,13 @@ import XCTVapor
         return components.queryItems?.first(where: { $0.name == name })?.value
     }
 
-    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> XCTHTTPResponse {
+    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/token",
             beforeRequest: { req in try req.content.encode(fields, as: .urlEncodedForm) })
     }
 
-    private func jsonField(_ name: String, in res: XCTHTTPResponse) -> String? {
+    private func jsonField(_ name: String, in res: TestingHTTPResponse) -> String? {
         let object = try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8)) as? [String: Any]
         return object?[name] as? String
     }

--- a/Tests/APITests/MCP/MCPOAuthModelsTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthModelsTests.swift
@@ -5,7 +5,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/MCP/MCPOAuthReaperTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthReaperTests.swift
@@ -4,7 +4,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/MCP/MCPProgressStreamTests.swift
+++ b/Tests/APITests/MCP/MCPProgressStreamTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -43,7 +43,7 @@ import XCTVapor
 
     private func post(
         _ app: Application, body: String, token: String, accept: String
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/mcp",
             headers: [

--- a/Tests/APITests/MCP/MCPReadOnlyModeTests.swift
+++ b/Tests/APITests/MCP/MCPReadOnlyModeTests.swift
@@ -7,7 +7,7 @@
 import Fluent
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -29,7 +29,7 @@ import XCTVapor
         return (app, authority)
     }
 
-    private func post(_ app: Application, body: String, token: String) async throws -> XCTHTTPResponse {
+    private func post(_ app: Application, body: String, token: String) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/mcp",
             headers: ["Content-Type": "application/json", "Authorization": "Bearer \(token)"],
@@ -101,7 +101,7 @@ import XCTVapor
     @Test func discoveryMetadataIsReachableInReadOnly() async throws {
         let (app, _) = try await makeReadOnlyApp()
         try await withApp(app) { app in
-            try await app.testable().test(.GET, "/.well-known/oauth-protected-resource") { res async in
+            try await app.testing().test(.GET, "/.well-known/oauth-protected-resource") { res async in
                 #expect(res.status == .ok)
                 #expect(String(buffer: res.body).contains("\"resource\""))
             }

--- a/Tests/APITests/MCP/MCPSSETransportTests.swift
+++ b/Tests/APITests/MCP/MCPSSETransportTests.swift
@@ -7,7 +7,7 @@
 import Fluent
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -29,7 +29,7 @@ import XCTVapor
 
     private func post(
         _ app: Application, body: String, token: String, accept: String
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/mcp",
             headers: [

--- a/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
+++ b/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
@@ -12,7 +12,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -81,7 +81,7 @@ import XCTVapor
     private func consent(
         _ app: Application, cookie: String, clientID: String, redirectURI: String,
         scope: String, decision: String
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         // GET the consent screen (authenticated) to mint the single-use token,
         // then submit it. The POST carries no cookie — the token alone guards it.
         var html = ""
@@ -102,7 +102,7 @@ import XCTVapor
             })
     }
 
-    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> XCTHTTPResponse {
+    private func tokenPost(_ app: Application, fields: [String: String]) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/oauth/token",
             beforeRequest: { req in try req.content.encode(fields, as: .urlEncodedForm) })
@@ -131,7 +131,7 @@ import XCTVapor
         #expect(tokenRes.status == .ok)
     }
 
-    private func mcpPost(_ app: Application, token: String) async throws -> XCTHTTPResponse {
+    private func mcpPost(_ app: Application, token: String) async throws -> TestingHTTPResponse {
         try await app.asyncSendRequest(
             .POST, "/mcp",
             headers: ["Content-Type": "application/json", "Authorization": "Bearer \(token)"],

--- a/Tests/APITests/MCP/MCPTokenAttributionTests.swift
+++ b/Tests/APITests/MCP/MCPTokenAttributionTests.swift
@@ -5,7 +5,7 @@
 
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -41,7 +41,7 @@ import XCTVapor
                 subject: "instructor-jane", scopes: [.read, .write],
                 issuer: issuer, audience: resource, ttlSeconds: 3600,
                 clientID: "agent-xyz", agentName: "Claude Course Bot")
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/whoami", headers: ["Authorization": "Bearer \(token)"]
             ) { res async in
                 #expect(res.status == .ok)
@@ -56,7 +56,7 @@ import XCTVapor
             let token = try await authority.mint(
                 subject: "service-bot", scopes: [.read],
                 issuer: issuer, audience: resource, ttlSeconds: 3600)
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/whoami", headers: ["Authorization": "Bearer \(token)"]
             ) { res async in
                 #expect(res.status == .ok)

--- a/Tests/APITests/MetricsCardSeriesTests.swift
+++ b/Tests/APITests/MetricsCardSeriesTests.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 @testable import Core

--- a/Tests/APITests/NewAssignmentDraftServiceTests.swift
+++ b/Tests/APITests/NewAssignmentDraftServiceTests.swift
@@ -21,7 +21,7 @@ import Fluent
 import Foundation
 import Testing
 import Vapor
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -10,7 +10,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/NotebookScanRoutesTests.swift
+++ b/Tests/APITests/NotebookScanRoutesTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -239,9 +239,9 @@ import XCTVapor
                         let valueRange = Range(match.range(at: 1), in: html),
                         let mtime = Int(html[valueRange])
                     else {
-                        XCTFail("Expected data-working-copy-mtime=\"<int>\" attribute on iframe"); return
+                        Issue.record("Expected data-working-copy-mtime=\"<int>\" attribute on iframe"); return
                     }
-                    XCTAssertGreaterThan(mtime, 0, "Working-copy mtime should be a positive Unix-epoch timestamp")
+                    #expect(mtime > 0, "Working-copy mtime should be a positive Unix-epoch timestamp")
                 })
 
             let workingCopy = try String(

--- a/Tests/APITests/OIDCTests.swift
+++ b/Tests/APITests/OIDCTests.swift
@@ -1,7 +1,7 @@
 import Fluent
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 @testable import Core
@@ -327,7 +327,7 @@ import XCTVapor
                 afterResponse: { response in
                     #expect(response.status == .ok)
                     let payload = try response.content.decode(InternalMetricsResponse.self)
-                    XCTAssertGreaterThanOrEqual(payload.activeRunners, 1)
+                    #expect(payload.activeRunners >= 1)
                     #expect(payload.jobsProcessed24h == 1)
                     #expect(payload.queueWait.averageMs != nil)
                     #expect(payload.jobStatusCounts.first(where: { $0.status == "passed" })?.count == 1)
@@ -446,16 +446,16 @@ import XCTVapor
             // the 210ms queueWait. The summed formula yields 311ms.
             #expect(metric?.totalProcessingMs == 311)
             if let total = metric?.totalProcessingMs, let queue = metric?.queueWaitMs {
-                XCTAssertGreaterThanOrEqual(total, queue)
+                #expect(total >= queue)
             } else {
-                XCTFail("expected queueWaitMs and totalProcessingMs to be populated")
+                Issue.record("expected queueWaitMs and totalProcessingMs to be populated")
             }
 
             // Same invariant on APISubmissionDiagnostics.turnaroundMs.
             let diag = try await APISubmissionDiagnostics.find("sub_clock_skew", on: app.db)
             #expect(diag?.turnaroundMs == 311)
             if let turnaround = diag?.turnaroundMs, let queue = diag?.queueWaitMs {
-                XCTAssertGreaterThanOrEqual(turnaround, queue)
+                #expect(turnaround >= queue)
             }
 
         }

--- a/Tests/APITests/PersonalizationGradingParityTests.swift
+++ b/Tests/APITests/PersonalizationGradingParityTests.swift
@@ -12,7 +12,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/ResponseCompressionTests.swift
+++ b/Tests/APITests/ResponseCompressionTests.swift
@@ -4,7 +4,7 @@
 // tests bypass the compressor entirely.
 
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -33,7 +33,7 @@ import XCTVapor
 
     @Test func compressibleAssetIsGzippedOverTheWire() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+            try await app.testing(method: .running(hostname: "localhost", port: 0)).test(
                 .GET, "/styles.css",
                 headers: ["Accept-Encoding": "gzip"]
             ) { res async in
@@ -45,7 +45,7 @@ import XCTVapor
 
     @Test func htmlIsExcludedFromCompression() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+            try await app.testing(method: .running(hostname: "localhost", port: 0)).test(
                 .GET, "/page",
                 headers: ["Accept-Encoding": "gzip"]
             ) { res async in
@@ -59,7 +59,7 @@ import XCTVapor
 
     @Test func clientWithoutAcceptEncodingGetsIdentity() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+            try await app.testing(method: .running(hostname: "localhost", port: 0)).test(
                 .GET, "/styles.css"
             ) { res async in
                 #expect(res.status == .ok)

--- a/Tests/APITests/ResultRoutesTests.swift
+++ b/Tests/APITests/ResultRoutesTests.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 @testable import Core
@@ -332,7 +332,7 @@ import XCTVapor
             try await ensureSubmissionExists(submissionID: collection.submissionID, testSetupID: collection.testSetupID)
             let body = try bodyData(for: collection)
 
-            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+            try await app.testing(method: .running(hostname: "localhost", port: 0)).test(
                 .POST,
                 self.resultsPath,
                 headers: workerHMACHeaders(
@@ -348,7 +348,7 @@ import XCTVapor
                     let response = try res.content.decode(ReportResponse.self)
                     #expect(response.received)
                 } catch {
-                    XCTFail("Failed to decode ReportResponse: \(error)")
+                    Issue.record("Failed to decode ReportResponse: \(error)")
                 }
             }
 

--- a/Tests/APITests/RoleMiddlewareTests.swift
+++ b/Tests/APITests/RoleMiddlewareTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/RunnerCompatibilityTests.swift
+++ b/Tests/APITests/RunnerCompatibilityTests.swift
@@ -1,7 +1,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 @testable import Core
@@ -230,7 +230,7 @@ import XCTVapor
     private func requestJob(
         workerID: String,
         profile: RunnerCapabilityProfile?
-    ) async throws -> XCTHTTPResponse {
+    ) async throws -> TestingHTTPResponse {
         let path = "/api/v1/worker/request"
         let payload = WorkerActivityPayload(
             workerID: workerID,
@@ -284,7 +284,7 @@ import XCTVapor
 
     private func makeAssignment(setupID: String, title: String) async throws -> APIAssignment {
         guard let courseID = try await APITestSetup.find(setupID, on: app.db)?.courseID else {
-            throw XCTSkip("missing course for setup")
+            throw IssueRecorded("missing course for setup")
         }
         let assignment = APIAssignment(testSetupID: setupID, title: title, isOpen: true, courseID: courseID)
         try await assignment.save(on: app.db)

--- a/Tests/APITests/RunnerWasmCacheMiddlewareTests.swift
+++ b/Tests/APITests/RunnerWasmCacheMiddlewareTests.swift
@@ -1,6 +1,6 @@
 import Fluent
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -18,7 +18,7 @@ import XCTVapor
 
     @Test func hashedWasmIsImmutableAndApplicationWasm() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/runner-wasm/RunnerWasm.deadbeef.wasm") { res async in
+            try await app.testing().test(.GET, "/runner-wasm/RunnerWasm.deadbeef.wasm") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: .contentType) == "application/wasm")
                 #expect(
@@ -29,7 +29,7 @@ import XCTVapor
 
     @Test func loaderRevalidates() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/runner-wasm/runner-core.js") { res async in
+            try await app.testing().test(.GET, "/runner-wasm/runner-core.js") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: .cacheControl) == "no-cache")
             }
@@ -38,7 +38,7 @@ import XCTVapor
 
     @Test func unrelatedAssetIsUntouched() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/styles.css") { res async in
+            try await app.testing().test(.GET, "/styles.css") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: .cacheControl) == nil)
             }

--- a/Tests/APITests/SSOAuthFlowTests.swift
+++ b/Tests/APITests/SSOAuthFlowTests.swift
@@ -11,7 +11,7 @@ import Fluent
 import Foundation
 import JWT
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -160,7 +160,7 @@ import XCTVapor
         try await app.asyncBoot()
         try await app.startup()
         guard let port = app.http.server.shared.localAddress?.port else {
-            throw XCTSkip("mock provider failed to bind a port")
+            throw IssueRecorded("mock provider failed to bind a port")
         }
         return (app, port, tokenEndpoint)
     }
@@ -193,7 +193,7 @@ import XCTVapor
         return mergedCookie(existing: existing, setCookieHeader: setCookie)
     }
 
-    private func mergedCookie(existing: String, from response: XCTHTTPResponse) -> String {
+    private func mergedCookie(existing: String, from response: TestingHTTPResponse) -> String {
         guard let setCookie = response.headers.first(name: .setCookie), !setCookie.isEmpty else {
             return existing
         }

--- a/Tests/APITests/ScanModeMiddlewareTests.swift
+++ b/Tests/APITests/ScanModeMiddlewareTests.swift
@@ -1,6 +1,6 @@
 import Fluent
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -39,7 +39,7 @@ import XCTVapor
                 (.POST, "/testsetups/setup_42/submit"),
             ]
             for (method, path) in gated {
-                try await app.testable().test(method, path) { res async in
+                try await app.testing().test(method, path) { res async in
                     #expect(
                         res.status == .serviceUnavailable,
                         "expected 503 for \(method.rawValue) \(path), got \(res.status)"
@@ -52,10 +52,10 @@ import XCTVapor
 
     @Test func nonGatedRoutesStillWorkWhenEnabled() async throws {
         try await withApp(try await makeApp(scanEnabled: true)) { app in
-            try await app.testable().test(.POST, "/login") { res async in
+            try await app.testing().test(.POST, "/login") { res async in
                 #expect(res.status == .ok)
             }
-            try await app.testable().test(.GET, "/dashboard") { res async in
+            try await app.testing().test(.GET, "/dashboard") { res async in
                 #expect(res.status == .ok)
             }
         }
@@ -63,10 +63,10 @@ import XCTVapor
 
     @Test func gatedRoutesPassThroughWhenDisabled() async throws {
         try await withApp(try await makeApp(scanEnabled: false)) { app in
-            try await app.testable().test(.POST, "/api/v1/submissions") { res async in
+            try await app.testing().test(.POST, "/api/v1/submissions") { res async in
                 #expect(res.status == .ok)
             }
-            try await app.testable().test(.POST, "/admin/users/x/delete") { res async in
+            try await app.testing().test(.POST, "/admin/users/x/delete") { res async in
                 #expect(res.status == .ok)
             }
         }

--- a/Tests/APITests/ScriptEditRoutesTests.swift
+++ b/Tests/APITests/ScriptEditRoutesTests.swift
@@ -10,7 +10,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -67,7 +67,7 @@ import XCTVapor
     /// Skips the test if Python 3 is unavailable (same pattern as ZipArchiverTests).
     private func makeZipAt(zipPath: String, entries: [(name: String, content: String)]) throws {
         guard FileManager.default.fileExists(atPath: "/usr/bin/env") else {
-            throw XCTSkip("env not available")
+            throw IssueRecorded("env not available")
         }
         // An empty zip can be made with a dummy entry then deleted, but it's easier
         // to always include a placeholder if no entries are given.
@@ -91,7 +91,7 @@ import XCTVapor
         try proc.run()
         proc.waitUntilExit()
         guard proc.terminationStatus == 0 else {
-            throw XCTSkip("python3 not available or failed to create zip")
+            throw IssueRecorded("python3 not available or failed to create zip")
         }
     }
 
@@ -102,7 +102,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             try await insertSetup(
@@ -134,7 +134,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             try await insertSetup(id: "sc_get2", withEntries: [("test_a.py", "pass\n")])
@@ -159,7 +159,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsStudent()
             try await insertSetup(id: "sc_get3", withEntries: [("test_a.py", "pass\n")])
@@ -204,7 +204,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -237,7 +237,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -266,7 +266,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsStudent()
             try await insertSetup(id: "sc_put3", withEntries: [("test_a.py", "pass\n")])
@@ -295,7 +295,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -334,7 +334,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -374,7 +374,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -403,7 +403,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -432,7 +432,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsStudent()
             try await insertSetup(id: "sc_post5", withEntries: [])
@@ -461,7 +461,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -499,7 +499,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -545,7 +545,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -588,7 +588,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsInstructor()
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
@@ -615,7 +615,7 @@ import XCTVapor
             guard FileManager.default.fileExists(atPath: "/usr/bin/unzip"),
                 FileManager.default.fileExists(atPath: "/usr/bin/zip")
             else {
-                throw XCTSkip("zip/unzip not available")
+                throw IssueRecorded("zip/unzip not available")
             }
             let cookie = try await loginAsStudent()
             try await insertSetup(id: "sc_del5", withEntries: [("test_a.py", "pass\n")])

--- a/Tests/APITests/SectionRoutesTests.swift
+++ b/Tests/APITests/SectionRoutesTests.swift
@@ -11,7 +11,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -2,7 +2,7 @@ import Fluent
 import Foundation
 import Testing
 import Vapor
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/SessionIdleTimeoutMiddlewareTests.swift
+++ b/Tests/APITests/SessionIdleTimeoutMiddlewareTests.swift
@@ -8,7 +8,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -56,7 +56,7 @@ import XCTVapor
     @Test func activeBrowserRequestPassesThrough() async throws {
         let user = makeUser(lastSeenAt: Date().addingTimeInterval(-60))  // 1 min ago
         try await withApp(try await makeApp(user: user, idleTimeoutSeconds: 30 * 60)) { app in
-            try await app.testable().test(.GET, "/page") { res async in
+            try await app.testing().test(.GET, "/page") { res async in
                 #expect(res.status == .ok)
                 #expect(res.body.string == "ok")
             }
@@ -66,7 +66,7 @@ import XCTVapor
     @Test func idleBrowserRequestRedirectsToLoginWithTimeoutError() async throws {
         let user = makeUser(lastSeenAt: Date().addingTimeInterval(-31 * 60))  // 31 min ago
         try await withApp(try await makeApp(user: user, idleTimeoutSeconds: 30 * 60)) { app in
-            try await app.testable().test(.GET, "/page") { res async in
+            try await app.testing().test(.GET, "/page") { res async in
                 #expect(res.status == .seeOther)
                 #expect(res.headers.first(name: .location) == "/login?error=timeout")
             }
@@ -78,7 +78,7 @@ import XCTVapor
     @Test func idleAPIRequestReturns401() async throws {
         let user = makeUser(lastSeenAt: Date().addingTimeInterval(-31 * 60))
         try await withApp(try await makeApp(user: user, idleTimeoutSeconds: 30 * 60)) { app in
-            try await app.testable().test(.GET, "/api/v1/thing") { res async in
+            try await app.testing().test(.GET, "/api/v1/thing") { res async in
                 #expect(res.status == .unauthorized)
             }
         }
@@ -87,7 +87,7 @@ import XCTVapor
     @Test func activeAPIRequestPassesThrough() async throws {
         let user = makeUser(lastSeenAt: Date())
         try await withApp(try await makeApp(user: user, idleTimeoutSeconds: 30 * 60)) { app in
-            try await app.testable().test(.GET, "/api/v1/thing") { res async in
+            try await app.testing().test(.GET, "/api/v1/thing") { res async in
                 #expect(res.status == .ok)
                 #expect(res.body.string == "ok-api")
             }
@@ -100,7 +100,7 @@ import XCTVapor
         // Even an ancient lastSeenAt should pass through when disabled.
         let user = makeUser(lastSeenAt: Date.distantPast)
         try await withApp(try await makeApp(user: user, idleTimeoutSeconds: 0)) { app in
-            try await app.testable().test(.GET, "/page") { res async in
+            try await app.testing().test(.GET, "/page") { res async in
                 #expect(res.status == .ok)
             }
         }
@@ -112,7 +112,7 @@ import XCTVapor
         // so the gate must not lock the user out before they get a signal.
         let user = makeUser(lastSeenAt: nil)
         try await withApp(try await makeApp(user: user, idleTimeoutSeconds: 30 * 60)) { app in
-            try await app.testable().test(.GET, "/page") { res async in
+            try await app.testing().test(.GET, "/page") { res async in
                 #expect(res.status == .ok)
             }
         }

--- a/Tests/APITests/SessionKeepAliveRoutesTests.swift
+++ b/Tests/APITests/SessionKeepAliveRoutesTests.swift
@@ -7,7 +7,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/SessionReaperServiceTests.swift
+++ b/Tests/APITests/SessionReaperServiceTests.swift
@@ -13,7 +13,7 @@ import Fluent
 import Foundation
 import Testing
 import Vapor
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/SpaceCourseCodeCSRFTests.swift
+++ b/Tests/APITests/SpaceCourseCodeCSRFTests.swift
@@ -11,7 +11,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/StaticAssetCacheMiddlewareTests.swift
+++ b/Tests/APITests/StaticAssetCacheMiddlewareTests.swift
@@ -1,6 +1,6 @@
 import Core
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -30,7 +30,7 @@ import XCTVapor
 
     @Test func versionedAssetGetsImmutableCacheControl() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/styles.css?v=\(ChickadeeVersion.current)"
             ) { res async in
                 #expect(res.status == .ok)
@@ -41,7 +41,7 @@ import XCTVapor
 
     @Test func unversionedAssetKeepsDefaultRevalidation() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/styles.css") { res async in
+            try await app.testing().test(.GET, "/styles.css") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: .cacheControl) == nil)
             }
@@ -50,7 +50,7 @@ import XCTVapor
 
     @Test func staleVersionIsNotStamped() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(.GET, "/styles.css?v=0.0.0-stale") { res async in
+            try await app.testing().test(.GET, "/styles.css?v=0.0.0-stale") { res async in
                 #expect(res.status == .ok)
                 #expect(res.headers.first(name: .cacheControl) == nil)
             }
@@ -59,7 +59,7 @@ import XCTVapor
 
     @Test func existingCacheControlIsPreserved() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/runner-core.js?v=\(ChickadeeVersion.current)"
             ) { res async in
                 #expect(res.headers.first(name: .cacheControl) == "no-cache")
@@ -69,7 +69,7 @@ import XCTVapor
 
     @Test func nonAssetPathIsNotStamped() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .GET, "/page?v=\(ChickadeeVersion.current)"
             ) { res async in
                 #expect(res.status == .ok)

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -9,7 +9,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 @testable import Core

--- a/Tests/APITests/SubmissionRetentionTests.swift
+++ b/Tests/APITests/SubmissionRetentionTests.swift
@@ -2,7 +2,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/SubmissionRoutesTests.swift
+++ b/Tests/APITests/SubmissionRoutesTests.swift
@@ -6,7 +6,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 @testable import Core

--- a/Tests/APITests/SuiteRouteTests.swift
+++ b/Tests/APITests/SuiteRouteTests.swift
@@ -12,7 +12,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/SuiteSectionRoutesTests.swift
+++ b/Tests/APITests/SuiteSectionRoutesTests.swift
@@ -16,7 +16,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -81,7 +81,7 @@ import XCTVapor
         guard let setup = try await APITestSetup.find(setupID, on: app.db),
             let data = setup.manifest.data(using: .utf8),
             let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { throw XCTSkip("manifest load failed") }
+        else { throw IssueRecorded("manifest load failed") }
         return dict
     }
 

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -12,7 +12,7 @@ import Leaf
 import LeafKit
 import SQLKit
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -288,18 +288,22 @@ extension Application {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        afterResponse: (XCTHTTPResponse) throws -> Void
-    ) async throws -> XCTApplicationTester {
+        fileID: String = #fileID,
+        filePath: String = #filePath,
+        line: Int = #line,
+        column: Int = #column,
+        afterResponse: (TestingHTTPResponse) throws -> Void
+    ) async throws -> TestingApplicationTester {
         try await self.asyncTest(
             method: runnerMethod,
             method,
             path,
             headers: headers,
             body: body,
-            file: file,
+            fileID: fileID,
+            filePath: filePath,
             line: line,
+            column: column,
             beforeRequest: { _ in },
             afterResponse: afterResponse
         )
@@ -312,19 +316,23 @@ extension Application {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        beforeRequest: (inout XCTHTTPRequest) throws -> Void = { _ in },
-        afterResponse: (XCTHTTPResponse) throws -> Void = { _ in }
-    ) async throws -> XCTApplicationTester {
-        let tester = try self.testable(method: runnerMethod)
+        fileID: String = #fileID,
+        filePath: String = #filePath,
+        line: Int = #line,
+        column: Int = #column,
+        beforeRequest: (inout TestingHTTPRequest) throws -> Void = { _ in },
+        afterResponse: (TestingHTTPResponse) throws -> Void = { _ in }
+    ) async throws -> TestingApplicationTester {
+        let tester = try self.testing(method: runnerMethod)
         return try await tester.test(
             method,
             path,
             headers: headers,
             body: body,
-            file: file,
+            fileID: fileID,
+            filePath: filePath,
             line: line,
+            column: column,
             beforeRequest: { request async throws in
                 try beforeRequest(&request)
             },
@@ -341,9 +349,9 @@ extension Application {
         _ path: String,
         headers: HTTPHeaders = [:],
         body: ByteBuffer? = nil,
-        beforeRequest: (inout XCTHTTPRequest) throws -> Void = { _ in }
-    ) async throws -> XCTHTTPResponse {
-        var captured: XCTHTTPResponse?
+        beforeRequest: (inout TestingHTTPRequest) throws -> Void = { _ in }
+    ) async throws -> TestingHTTPResponse {
+        var captured: TestingHTTPResponse?
         try await self.asyncTest(
             method, path,
             headers: headers,

--- a/Tests/APITests/TestSetupEditTests.swift
+++ b/Tests/APITests/TestSetupEditTests.swift
@@ -9,7 +9,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/UnifiedAchievementsTests.swift
+++ b/Tests/APITests/UnifiedAchievementsTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/VanityURLRoutesTests.swift
+++ b/Tests/APITests/VanityURLRoutesTests.swift
@@ -5,7 +5,7 @@
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -95,7 +95,7 @@ import XCTVapor
             let user = try await APIUser.query(on: app.db)
                 .filter(\.$username == username).first()
         else {
-            XCTFail("Expected user \(username) to exist")
+            Issue.record("Expected user \(username) to exist")
             return
         }
         try await APICourseEnrollment(

--- a/Tests/APITests/WebRoutesBadgeTests.swift
+++ b/Tests/APITests/WebRoutesBadgeTests.swift
@@ -7,7 +7,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/WebRoutesHelpers.swift
+++ b/Tests/APITests/WebRoutesHelpers.swift
@@ -12,7 +12,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -7,7 +7,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/WebRoutesSubmissionPageTests.swift
+++ b/Tests/APITests/WebRoutesSubmissionPageTests.swift
@@ -7,7 +7,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/WebRoutesSubmitHistoryTests.swift
+++ b/Tests/APITests/WebRoutesSubmitHistoryTests.swift
@@ -8,7 +8,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
+++ b/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
@@ -1,7 +1,7 @@
 import Crypto
 import Fluent
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -62,7 +62,7 @@ import XCTVapor
         )
 
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, path,
                 beforeRequest: { req async in
                     req.headers = headers
@@ -76,7 +76,7 @@ import XCTVapor
 
     @Test func rejectsMissingHeaders() async throws {
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, "/internal/worker/ping",
                 beforeRequest: { req async in
                     req.headers.contentType = .json
@@ -101,7 +101,7 @@ import XCTVapor
         )
 
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, path,
                 beforeRequest: { req async in
                     req.headers = headers
@@ -127,7 +127,7 @@ import XCTVapor
         )
 
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, path,
                 beforeRequest: { req async in
                     req.headers = headers
@@ -137,7 +137,7 @@ import XCTVapor
                     #expect(res.status == .ok)
                 })
 
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, path,
                 beforeRequest: { req async in
                     req.headers = headers
@@ -163,7 +163,7 @@ import XCTVapor
         headers.replaceOrAdd(name: "X-Worker-Signature", value: "deadbeef")
 
         try await withApp(try await makeApp()) { app in
-            try await app.testable().test(
+            try await app.testing().test(
                 .POST, path,
                 beforeRequest: { req async in
                     req.headers = headers
@@ -191,7 +191,7 @@ import XCTVapor
         )
 
         try await withApp(try await makeApp()) { app in
-            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+            try await app.testing(method: .running(hostname: "localhost", port: 0)).test(
                 .POST,
                 path,
                 headers: headers,
@@ -216,7 +216,7 @@ import XCTVapor
         )
 
         try await withApp(try await makeApp()) { app in
-            try await app.testable(method: .running(hostname: "localhost", port: 0)).test(
+            try await app.testing(method: .running(hostname: "localhost", port: 0)).test(
                 .POST,
                 path,
                 headers: headers,

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -9,7 +9,7 @@ import Core
 import Fluent
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 
@@ -101,7 +101,7 @@ import XCTVapor
 
     private func makeAssignment(setupID: String, title: String = "Assignment") async throws -> APIAssignment {
         guard let courseID = try await APITestSetup.find(setupID, on: app.db)?.courseID else {
-            throw XCTSkip("setup missing course")
+            throw IssueRecorded("setup missing course")
         }
         let assignment = APIAssignment(testSetupID: setupID, title: title, isOpen: true, courseID: courseID)
         try await assignment.save(on: app.db)
@@ -458,8 +458,8 @@ import XCTVapor
             let secret = workerSecret  // String — Sendable
             let testApp = app  // Application — @unchecked Sendable
 
-            var responses: [XCTHTTPResponse] = []
-            try await withThrowingTaskGroup(of: XCTHTTPResponse.self) { group in
+            var responses: [TestingHTTPResponse] = []
+            try await withThrowingTaskGroup(of: TestingHTTPResponse.self) { group in
                 for workerID in ["w1", "w2"] {
                     // Compute per-worker values outside the task so the closure
                     // captures only Sendable types and avoids capturing `self`.

--- a/Tests/APITests/ZipUploadValidationTests.swift
+++ b/Tests/APITests/ZipUploadValidationTests.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 import Testing
-import XCTVapor
+import VaporTesting
 
 @testable import APIServer
 

--- a/changelog.d/api-tests-vaportesting.md
+++ b/changelog.d/api-tests-vaportesting.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **api-tests flakiness: migrated the HTTP-test surface off XCTVapor to Vapor's
+  Swift-Testing-native `VaporTesting`.** The `APITests` target drove requests
+  through XCTVapor (`app.testable().test(...)`), which reports a thrown
+  request/decoding error via `XCTFail`. Called from a Swift Testing `@Test`,
+  `XCTFail` is mis-attributed and intermittently dropped — surfacing as
+  unattributed "issues" and the "test failures not being reported" CI warning.
+  All 102 `APITests` files now `import VaporTesting` and use `app.testing()`,
+  so request-execution failures are recorded with `Issue.record(sourceLocation:)`
+  and attributed to the right test. The central `Application.asyncTest` /
+  `asyncSendRequest` helpers thread the new `fileID`/`filePath`/`line`/`column`
+  source location through. Incidental XCTest assertions in the migrated files
+  (`XCTFail`, `XCTAssert{Greater,Less}Than*`, `XCTSkip`) were converted to
+  `Issue.record` / `#expect` / `IssueRecorded`. `scripts/no-new-xctest.sh` now
+  also blocks `import XCTVapor` so the flaky bridge can't return. No production
+  code changed.

--- a/scripts/no-new-xctest.sh
+++ b/scripts/no-new-xctest.sh
@@ -2,7 +2,15 @@
 set -euo pipefail
 
 # Migration complete: every test file is on Swift Testing.  This guard
-# now simply asserts that no file under `Tests/` imports XCTest.
+# asserts that no file under `Tests/` imports XCTest or XCTVapor.
+#
+# XCTVapor re-exports XCTest and reports request-execution failures via
+# `XCTFail`, which is mis-attributed (and intermittently dropped, with a
+# "test failures not being reported" warning) when called from a Swift
+# Testing `@Test`.  The HTTP-test surface is on Vapor's Swift-Testing-native
+# `VaporTesting` module (`app.testing()` + `Issue.record`) instead — see
+# Tests/APITests/TestHelpers.swift.  Re-introducing XCTVapor brings the
+# flaky bridge back, so it's blocked here too.
 #
 # If you ever genuinely need XCTest (e.g. measure blocks not yet
 # available in Swift Testing), discuss in CLAUDE.md before adding.
@@ -10,13 +18,13 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-actual=$(grep -rl "^import XCTest" Tests/ 2>/dev/null | sort || true)
+actual=$(grep -rlE "^import (XCTest|XCTVapor)$" Tests/ 2>/dev/null | sort || true)
 
 if [ -n "$actual" ]; then
-  echo "ERROR: New file(s) import XCTest. Use Swift Testing for new tests:"
+  echo "ERROR: New file(s) import XCTest/XCTVapor. Use Swift Testing + VaporTesting:"
   echo "$actual" | sed 's/^/  /'
   exit 1
 fi
 
 count=$(grep -rl "^import Testing" Tests/ 2>/dev/null | wc -l | tr -d ' ')
-echo "no-new-xctest: OK ($count file(s) on Swift Testing; 0 on XCTest)"
+echo "no-new-xctest: OK ($count file(s) on Swift Testing; 0 on XCTest/XCTVapor)"


### PR DESCRIPTION
## What & why

The `APITests` target drove HTTP requests through **XCTVapor**
(`app.testable().test(...)`). XCTVapor reports a thrown request/decoding
error via `XCTFail`. When that `XCTFail` fires inside a Swift Testing
`@Test`, it is **mis-attributed and intermittently dropped** — which is
exactly the api-tests flakiness: unattributed "issues" (e.g. 3/1793 with no
owning test) and the CI **"test failures not being reported"** warning.

This migrates the HTTP-test surface to Vapor's Swift-Testing-native
[`VaporTesting`](https://docs.vapor.codes) module, where request-execution
failures are recorded with `Issue.record(sourceLocation:)` and attributed to
the right test.

## Changes

- **`Package.swift`** — `APITests` depends on `VaporTesting` instead of `XCTVapor`.
- **All 102 `APITests` files** — `import VaporTesting`; `app.testing()`
  instead of `app.testable()`; `TestingHTTPResponse` / `TestingHTTPRequest` /
  `TestingApplicationTester` instead of the `XCT*` aliases.
- **`TestHelpers.swift`** — `asyncTest` / `asyncSendRequest` thread the new
  `fileID`/`filePath`/`line`/`column` source location through `app.testing().test(...)`
  so failures inside the wrapper still point at the calling test, not the helper.
- **Incidental XCTest assertions** in the migrated files converted to the
  Swift Testing idioms the codebase already uses: `XCTFail` → `Issue.record`,
  `XCTAssert{Greater,Less}Than*` → `#expect(a > b)`, `XCTSkip` → `IssueRecorded`.
- **`scripts/no-new-xctest.sh`** now also blocks `import XCTVapor`, so the
  flaky bridge can't be reintroduced.

**No production code changed** — this is test-infrastructure only.

## Verification

- `swift build --build-tests` — clean.
- **Full `APITests` suite: 1793 tests in 206 suites pass** locally, with no
  "test failures not being reported" warning and no unattributed issues.
- `scripts/lint.sh` (swift-format), `scripts/swiftlint.sh --strict`
  (0 violations), and `scripts/no-new-xctest.sh` all green.

## Honest scope note

This fixes the **reporting** path that produced the flaky/unattributed
failures — thrown errors now attribute correctly instead of being dropped by
the XCTVapor→XCTest→Swift-Testing bridge. It does not change the underlying
request execution or DB layer, so it is not a claim about any *separate*
genuinely-racy test (if one exists, it will now fail loudly and attributably
instead of as a phantom "issue").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT

---
_Generated by [Claude Code](https://claude.ai/code/session_019uzMTefpeQiQuHWn5j6ZXT)_