### PR TITLE
chore(deps): bump SwiftLintPlugins 0.63.3 → 0.64.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c7f392d0bc090266c6128e117fbcce14d7731f25d6b0c0bf47c9965603201a0b",
+  "originHash" : "1fcda69a269bca152e9916c7d7274be2a793c1fa5b530b6939ecb2756c5e66ff",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -384,8 +384,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "18d8d2d18e1668006d1d209e0b5f5e06c1da7cb5",
-        "version" : "0.63.3"
+        "revision" : "61663f4b6c73824526f6429a4f77b1d18a19e4b3",
+        "version" : "0.64.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         // binary so CI / fresh checkouts don't pay a SwiftLint-from-source build.
         // Invoked on demand via `scripts/swiftlint.sh`; no `plugins:` entry on
         // any target, so `swift build` / `swift test` are unaffected.
-        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.63.3"),
+        .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", from: "0.64.0"),
     ],
     targets: [
         // MARK: - Runner core

--- a/changelog.d/swiftlint-0.64.md
+++ b/changelog.d/swiftlint-0.64.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **SwiftLint bumped 0.63.3 → 0.64.0** (`SwiftLintPlugins`). The codebase
+  stays at zero violations under the new version's `--strict` gate; no rule
+  baselines were touched. Every other Swift dependency (direct and transitive)
+  was already pinned to its latest release.


### PR DESCRIPTION
## What

Bumps `SimplyDanny/SwiftLintPlugins` from **0.63.3 → 0.64.0** (which pulls SwiftLint 0.64.0).

## Why

I audited the full dependency graph for available updates. The result:

- **Swift packages — fully current except this one.** Every package in `Package.resolved`, both direct and transitive (Vapor 4.121.4, Fluent, JWT, swift-crypto, swift-nio, postgres-nio, leaf-kit 1.14.2, etc.), is already pinned to its latest upstream release. SwiftLintPlugins was the only one with a newer version available.
- **Python / JupyterLite toolchain — current.** `jupyterlite==0.7.6`, `jupyterlite-pyodide-kernel==0.7.2` are both latest (the kernel pin deliberately drives the parity-locked vendored Pyodide version).
- **Vendored JS.** CodeMirror's `^6.0.0` range already resolves to the latest 6.x on re-vendor. `esbuild ^0.24.0` (build-tool only) could move to 0.28.x but was left out of this PR since it changes checked-in vendored bytes and needs a `setup-vendor.sh` re-run.

## Verification

- `swift package resolve` → SwiftLintPlugins at 0.64.0, SwiftLint binary 0.64.0 downloaded.
- `scripts/swiftlint.sh` (`--strict`) → **0 violations, 0 serious in 692 files.** No rule baselines in `.swiftlint.yml` were touched.

The plugin has no `plugins:` entry on any target, so `swift build` / `swift test` are unaffected by definition — this only changes which linter binary `scripts/swiftlint.sh` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVjpgMoZoHH7W1MSDRkvas)_