### PR TITLE
Gate release-tier result visibility on the effective (extension-aware) deadline

### DIFF
--- a/Sources/APIServer/Helpers/TierFilter.swift
+++ b/Sources/APIServer/Helpers/TierFilter.swift
@@ -84,15 +84,22 @@ extension TestOutcomeCollection {
 /// - Students see `public` always, `release` after the deadline passes
 ///   (or immediately when there is no deadline), and never `secret`.
 ///
+/// `effectiveDueAt` is the deadline that actually applies to the student whose
+/// submission is being viewed — the *later* of the assignment-wide due date and
+/// that student's per-student extension (see `effectiveDueAt(for:user:on:)`).
+/// Gating on the effective deadline rather than the bare assignment due date
+/// means an accommodated student does not get the hidden release tests revealed
+/// while their own extended window is still open.
+///
 /// The student *web* view is more nuanced — it lists release tests by name
 /// before the deadline but redacts their output — so it uses `itemizedTiers`
 /// and `releaseOutputVisible` instead.
-func visibleTiers(for user: APIUser, assignment: APIAssignment?) -> Set<String> {
+func visibleTiers(for user: APIUser, effectiveDueAt: Date?, now: Date = Date()) -> Set<String> {
     if user.isInstructor {
         return ["public", "release", "secret"]
     }
-    // nil dueAt → no deadline → release is immediately visible.
-    let releaseVisible = assignment?.dueAt.map { $0 <= Date() } ?? true
+    // nil effectiveDueAt → no deadline → release is immediately visible.
+    let releaseVisible = effectiveDueAt.map { $0 <= now } ?? true
     return releaseVisible ? ["public", "release"] : ["public"]
 }
 
@@ -111,9 +118,14 @@ func itemizedTiers(for user: APIUser) -> Set<String> {
 /// is shown to `user`.  Release rows are always listed by name for students,
 /// but their detailed output stays hidden until the deadline passes so students
 /// can't read the expected/actual values early.  Instructors always see it.
-func releaseOutputVisible(for user: APIUser, assignment: APIAssignment?) -> Bool {
+///
+/// `effectiveDueAt` is the deadline that applies to the viewing student — the
+/// later of the assignment due date and their own extension — so a student with
+/// an active extension keeps release output hidden until *their* deadline
+/// passes, not the (earlier) class-wide one.
+func releaseOutputVisible(for user: APIUser, effectiveDueAt: Date?, now: Date = Date()) -> Bool {
     if user.isInstructor { return true }
-    return assignment?.dueAt.map { $0 <= Date() } ?? true
+    return effectiveDueAt.map { $0 <= now } ?? true
 }
 
 /// Decodes a stored collection JSON with no tier filtering — the full,

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -99,11 +99,20 @@ struct SubmissionQueryRoutes: RouteCollection {
 
         // `fullCollection` carries the real grade across every tier.  The caller
         // may only *inspect* certain outcomes: secret never, release after the
-        // deadline (instructors see all tiers).
+        // deadline (instructors see all tiers).  Release is gated on the
+        // *effective* deadline — the later of the assignment due date and the
+        // caller's own per-student extension — so an accommodated student does
+        // not get release output revealed while their extended window is still
+        // open.  A non-instructor caller can only reach their own submission
+        // (`canViewSubmission`), so the caller is the submission owner; for
+        // instructors the deadline is unused (they see every tier).
         let assignment = try await APIAssignment.query(on: req.db)
             .filter(\.$testSetupID == submission.testSetupID)
             .first()
-        let visible = fullCollection.filtering(tiers: visibleTiers(for: caller, assignment: assignment))
+        let releaseDeadline = try await releaseVisibilityDeadline(
+            for: assignment, user: caller, on: req.db)
+        let visible = fullCollection.filtering(
+            tiers: visibleTiers(for: caller, effectiveDueAt: releaseDeadline))
 
         let responseCollection: TestOutcomeCollection
         if let tiersParam = req.query[String.self, at: "tiers"] {

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -271,8 +271,17 @@ extension WebRoutes {
         // on the deadline); secret is never itemized.  The grade itself spans
         // every tier — see `processDisplayResult` — so it is stable across the
         // deadline and matches the dashboard.
+        //
+        // Release *output* is gated on the *effective* deadline — the later of
+        // the assignment due date and the viewer's own per-student extension —
+        // so a student with an active extension keeps the hidden release output
+        // redacted until their extended window closes.  A non-instructor may
+        // only view their own submission (guarded above), so `user` is the
+        // submission owner; instructors see release output regardless.
         let itemized = itemizedTiers(for: user)
-        let releaseOutput = releaseOutputVisible(for: user, assignment: submissionAssignment)
+        let releaseDeadline = try await releaseVisibilityDeadline(
+            for: submissionAssignment, user: user, on: req.db)
+        let releaseOutput = releaseOutputVisible(for: user, effectiveDueAt: releaseDeadline)
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -191,6 +191,21 @@ func isAssignmentEffectivelyOpen(
     )
 }
 
+/// The deadline that gates release-tier *result visibility* for `user` viewing
+/// `assignment`'s results: the effective (extension-aware) deadline, or nil when
+/// there is no assignment or no deadline at all (release then visible
+/// immediately).  A non-instructor may only view their own submission, so the
+/// viewer is the submission owner and their extension is the right one to honour;
+/// instructors see every tier regardless, so the value is unused for them.
+func releaseVisibilityDeadline(
+    for assignment: APIAssignment?,
+    user: APIUser,
+    on db: Database
+) async throws -> Date? {
+    guard let assignment else { return nil }
+    return try await effectiveDueAt(for: assignment, user: user, on: db)
+}
+
 @discardableResult
 func closeAssignmentIfExpired(
     _ assignment: APIAssignment,

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -655,6 +655,105 @@ import VaporTesting
         }
     }
 
+    /// A student with an *active* per-student extension keeps `release` output
+    /// hidden even after the class-wide deadline has passed — release is gated on
+    /// their *effective* (extended) deadline, so they cannot read the hidden
+    /// tests early while their own submission window is still open.
+    @Test func getResultsHidesReleaseForStudentWithActiveExtension() async throws {
+        try await withApp(app) { _ in
+            let setupID = "setup_ext_active"
+            let username = "student_ext_active"
+            let cookie = try await loginAsStudent(username: username)
+            let student = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == username).first())
+            // Class deadline already passed…
+            let assignment = try await ensureAssignment(
+                setupID: setupID,
+                dueAt: Date().addingTimeInterval(-3600))  // 1 hr ago
+            // …but this student's extension is still in the future.
+            try await APIAssignmentExtension(
+                assignmentID: try assignment.requireID(),
+                userID: try student.requireID(),
+                extendedDueAt: Date().addingTimeInterval(86_400)  // 1 day out
+            ).save(on: app.db)
+            try await insertSubmission(
+                id: "sub_ext_active", testSetupID: setupID,
+                userID: student.id)
+            let collection = makeCollection(
+                submissionID: "sub_ext_active",
+                outcomes: [
+                    makeOutcome(name: "test_pub", tier: .pub, status: .pass),
+                    makeOutcome(name: "test_release", tier: .release, status: .fail),
+                    makeOutcome(name: "test_secret", tier: .secret, status: .pass),
+                ]
+            )
+            try await insertResult(submissionID: "sub_ext_active", collection: collection)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_ext_active/results",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try self.decodeCollection(from: res.body)
+                    #expect(
+                        body.outcomes.count == 1,
+                        "an active extension keeps release hidden past the class deadline")
+                    #expect(body.outcomes[0].testName == "test_pub")
+                    #expect(body.outcomes.contains { $0.tier == .release } == false)
+                    #expect(body.outcomes.contains { $0.tier == .secret } == false)
+                })
+
+        }
+    }
+
+    /// Once a student's extension has *also* lapsed, `release` is revealed just
+    /// like any other student past the deadline — the extension only postpones
+    /// the reveal, it does not suppress it forever.
+    @Test func getResultsShowsReleaseAfterLapsedExtension() async throws {
+        try await withApp(app) { _ in
+            let setupID = "setup_ext_lapsed"
+            let username = "student_ext_lapsed"
+            let cookie = try await loginAsStudent(username: username)
+            let student = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == username).first())
+            let assignment = try await ensureAssignment(
+                setupID: setupID,
+                dueAt: Date().addingTimeInterval(-7200))  // 2 hr ago
+            // Extension granted but already in the past.
+            try await APIAssignmentExtension(
+                assignmentID: try assignment.requireID(),
+                userID: try student.requireID(),
+                extendedDueAt: Date().addingTimeInterval(-3600)  // 1 hr ago
+            ).save(on: app.db)
+            try await insertSubmission(
+                id: "sub_ext_lapsed", testSetupID: setupID,
+                userID: student.id)
+            let collection = makeCollection(
+                submissionID: "sub_ext_lapsed",
+                outcomes: [
+                    makeOutcome(name: "test_pub", tier: .pub, status: .pass),
+                    makeOutcome(name: "test_release", tier: .release, status: .fail),
+                    makeOutcome(name: "test_secret", tier: .secret, status: .pass),
+                ]
+            )
+            try await insertResult(submissionID: "sub_ext_lapsed", collection: collection)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_ext_lapsed/results",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try self.decodeCollection(from: res.body)
+                    #expect(
+                        body.outcomes.count == 2,
+                        "a lapsed extension behaves like any past-deadline student")
+                    #expect(body.outcomes.contains { $0.tier == .release })
+                    #expect(body.outcomes.contains { $0.tier == .secret } == false)
+                })
+
+        }
+    }
+
     /// `secret` outcomes are never visible to students, even after the deadline.
     @Test func getResultsAlwaysHidesSecretFromStudent() async throws {
         try await withApp(app) { _ in

--- a/Tests/APITests/TierFilterTests.swift
+++ b/Tests/APITests/TierFilterTests.swift
@@ -1,0 +1,102 @@
+// Tests/APITests/TierFilterTests.swift
+//
+// Pure-logic coverage for the tier-visibility gates in TierFilter.swift.
+// These pin the contract that release-tier visibility is gated on the
+// *effective* (per-student, extension-aware) deadline rather than the bare
+// assignment due date — the integration-level proof lives in
+// SubmissionQueryRoutesTests / WebRoutesSubmissionPageTests.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+@testable import Core
+
+@Suite struct TierFilterTests {
+
+    private func student() -> APIUser {
+        APIUser(username: "s", passwordHash: "x", role: UserRole.student.rawValue)
+    }
+
+    private func instructor() -> APIUser {
+        APIUser(username: "i", passwordHash: "x", role: UserRole.instructor.rawValue)
+    }
+
+    // MARK: - visibleTiers
+
+    @Test func visibleTiersInstructorAlwaysSeesEveryTier() {
+        let now = Date()
+        // Deadline far in the future — an instructor still sees all three tiers.
+        let tiers = visibleTiers(
+            for: instructor(), effectiveDueAt: now.addingTimeInterval(86_400), now: now)
+        #expect(tiers == ["public", "release", "secret"])
+    }
+
+    @Test func visibleTiersStudentHidesReleaseBeforeEffectiveDeadline() {
+        let now = Date()
+        let tiers = visibleTiers(
+            for: student(), effectiveDueAt: now.addingTimeInterval(3600), now: now)
+        #expect(tiers == ["public"])
+    }
+
+    @Test func visibleTiersStudentShowsReleaseAfterEffectiveDeadline() {
+        let now = Date()
+        let tiers = visibleTiers(
+            for: student(), effectiveDueAt: now.addingTimeInterval(-3600), now: now)
+        #expect(tiers == ["public", "release"])
+    }
+
+    @Test func visibleTiersStudentShowsReleaseWhenNoDeadline() {
+        // nil effective deadline → no deadline → release immediately visible.
+        let tiers = visibleTiers(for: student(), effectiveDueAt: nil)
+        #expect(tiers == ["public", "release"])
+    }
+
+    /// The crux of the extension intersection: when the class deadline has
+    /// passed but the student's effective (extended) deadline has not, release
+    /// stays hidden.  The caller supplies the *effective* deadline, so the gate
+    /// only has to compare against it.
+    @Test func visibleTiersStudentHidesReleaseWhileExtensionActive() {
+        let now = Date()
+        // Effective deadline = the student's future extension, not the past
+        // class-wide due date.
+        let extended = now.addingTimeInterval(86_400)
+        let tiers = visibleTiers(for: student(), effectiveDueAt: extended, now: now)
+        #expect(tiers == ["public"], "release stays hidden until the student's own deadline passes")
+    }
+
+    // MARK: - releaseOutputVisible
+
+    @Test func releaseOutputInstructorAlwaysVisible() {
+        let now = Date()
+        #expect(
+            releaseOutputVisible(
+                for: instructor(), effectiveDueAt: now.addingTimeInterval(86_400), now: now))
+    }
+
+    @Test func releaseOutputStudentHiddenBeforeEffectiveDeadline() {
+        let now = Date()
+        #expect(
+            releaseOutputVisible(
+                for: student(), effectiveDueAt: now.addingTimeInterval(3600), now: now) == false)
+    }
+
+    @Test func releaseOutputStudentVisibleAfterEffectiveDeadline() {
+        let now = Date()
+        #expect(
+            releaseOutputVisible(
+                for: student(), effectiveDueAt: now.addingTimeInterval(-3600), now: now))
+    }
+
+    @Test func releaseOutputStudentVisibleWhenNoDeadline() {
+        #expect(releaseOutputVisible(for: student(), effectiveDueAt: nil))
+    }
+
+    @Test func releaseOutputStudentHiddenWhileExtensionActive() {
+        let now = Date()
+        let extended = now.addingTimeInterval(86_400)
+        #expect(
+            releaseOutputVisible(for: student(), effectiveDueAt: extended, now: now) == false,
+            "an active extension keeps release output redacted past the class deadline")
+    }
+}

--- a/changelog.d/release-tests-extensions.md
+++ b/changelog.d/release-tests-extensions.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Release-tier results now respect per-student extensions.** Release-test
+  output is gated on the student's *effective* deadline — the later of the
+  assignment due date and their own extension — instead of the bare
+  assignment-wide due date. A student with an active extension no longer has
+  the hidden release tests revealed while their extended submission window is
+  still open; the reveal is only postponed to their own deadline, not
+  suppressed. Both the JSON results API
+  (`GET /api/v1/submissions/:id/results`) and the web submission page route
+  their tier-visibility decision through `effectiveDueAt(for:user:)`.


### PR DESCRIPTION
## Problem

Release-tier test results were being revealed to a student the moment the **assignment-wide** due date passed, ignoring any per-student extension.

A student with an active extension would therefore get the hidden `release` tests revealed while their own submission window was still open — exactly the feedback the release tier exists to withhold until the deadline. Concretely: assignment due Monday, student extended to Wednesday → between Monday and Wednesday the student can still submit *and* already sees the release results.

The two gates in `TierFilter.swift` (`visibleTiers` for `GET /api/v1/submissions/:id/results`, and `releaseOutputVisible` for the web submission page) both compared against the bare `assignment.dueAt`, never consulting the extension feature that already exists (`APIAssignmentExtension` / `effectiveDueAt(for:user:)`).

## Fix

Route both visibility gates through the student's **effective deadline** — the later of the assignment due date and that student's own extension — instead of `assignment.dueAt`.

- The two tier functions now take `effectiveDueAt: Date?` (plus an injectable `now`) rather than an `APIAssignment?`.
- A new `releaseVisibilityDeadline(for:user:on:)` helper (in `AssignmentDeadlineService.swift`) computes the gating deadline at both call sites. A non-instructor can only view their own submission, so the viewer is the submission owner and their extension is the right one to honour; instructors see every tier regardless.
- The reveal is **postponed, not suppressed**: once the student's extension also lapses, release results appear just as they do for any other past-deadline student.

## Tests

- New `Tests/APITests/TierFilterTests.swift` — pure-logic coverage of both gates, including the "extension active → release hidden past the class deadline" case.
- New integration tests in `SubmissionQueryRoutesTests`: active extension keeps `release` hidden past the class deadline; lapsed extension behaves like any past-deadline student.
- Existing `WebRoutesSubmissionPageTests` and `AssignmentExtensionsTests` still pass.

All affected suites green; `swift-format`, `lint.sh`, and `swiftlint.sh --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015FYg7BoNXo83W3C3TYdUZc)_