### PR TITLE
Per-course roles: Core + schema + read path (multi-course-roles Phases 1–2)

### DIFF
--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -32,7 +32,7 @@
     </a>
 
     #if(currentUser):
-        #if(currentUser.isInstructor && currentUser.activeCourse):
+        #if(currentUser.isInstructorInActiveCourse):
             <a class="nav-link" href="/instructor">#(currentUser.activeCourse.code)</a>
         #endif
         #if(currentUser.isAdmin):

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -12,6 +12,7 @@
 // are still enrollment-scoped (see ToolContext.authorizeCourseAccess), which
 // keeps agent scope ⊆ human scope for every role.
 
+import Core
 import Fluent
 import Vapor
 
@@ -44,15 +45,26 @@ func userIsEnrolled(userID: UUID, inCourse courseID: UUID, db: Database) async t
 /// resolver behind the web tab strip (`resolveActiveCourse`) and the MCP
 /// listing surface (`list_courses`, `resources/list`). No role widens this
 /// set: admins see — and their agents may act on — exactly what they are
-/// enrolled in.
+/// enrolled in. Defined in terms of `enrolledCoursesWithRoles` so the two
+/// can't drift on which courses are visible or in what order.
 func enrolledCourses(for userID: UUID, on db: Database) async throws -> [APICourse] {
+    try await enrolledCoursesWithRoles(for: userID, on: db).map(\.course)
+}
+
+/// Like `enrolledCourses`, but pairs each course with the caller's per-course
+/// role from the enrollment row (Phase 2 of docs/multi-course-roles.md). The
+/// web read path carries this into the nav; the role is web-only and never
+/// widens the visible set, and MCP keeps using the role-free `enrolledCourses`.
+func enrolledCoursesWithRoles(
+    for userID: UUID, on db: Database
+) async throws -> [(course: APICourse, role: CourseRole)] {
     let enrollments = try await APICourseEnrollment.query(on: db)
         .filter(\.$userID == userID)
         .with(\.$course)
         .all()
     return
         enrollments
-        .map(\.course)
-        .filter { !$0.isArchived }
-        .sorted { $0.code < $1.code }
+        .filter { !$0.course.isArchived }
+        .sorted { $0.course.code < $1.course.code }
+        .map { (course: $0.course, role: $0.role) }
 }

--- a/Sources/APIServer/Migrations/AddCourseEnrollmentRole.swift
+++ b/Sources/APIServer/Migrations/AddCourseEnrollmentRole.swift
@@ -1,0 +1,68 @@
+// APIServer/Migrations/AddCourseEnrollmentRole.swift
+//
+// Phase 1 of per-course roles (docs/multi-course-roles.md): adds the `role`
+// column to `course_enrollments` so a user's capability can become
+// course-scoped instead of deriving solely from the single global
+// `APIUser.role`.
+//
+// Migration shape mirrors AddUrlTokenToUsers:
+//   1. Add `role` as a nullable column (Fluent / SQLite can't add NOT NULL to
+//      an existing table cleanly; a nullable column plus the model-side `init`
+//      default is the established pattern here).
+//   2. Backfill behaviour-preservingly: each existing enrollment's role is
+//      seeded from the enrolled user's *current* global role — `.instructor`
+//      when the user is a global instructor or admin, else `.student`. So a
+//      current global instructor becomes an instructor in every course they
+//      are already enrolled in, students stay students, and day-one behaviour
+//      is unchanged.
+//
+// Nothing reads the column yet (later phases wire it into the nav, access
+// checks, and the enroll/roster UI), so applying this migration is observably
+// a no-op.
+
+import Fluent
+import Vapor
+
+struct AddCourseEnrollmentRole: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("course_enrollments")
+            .field("role", .string)
+            .update()
+
+        try await backfillRoles(on: database)
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("course_enrollments")
+            .deleteField("role")
+            .update()
+    }
+
+    /// Seeds every still-unset enrollment role from the enrolled user's global
+    /// role. Split out from `prepare` (which adds the column) so it can be
+    /// exercised directly in tests without re-running the column add.
+    /// Idempotent — only NULL roles are touched, so re-running is safe.
+    func backfillRoles(on database: Database) async throws {
+        let enrollments = try await APICourseEnrollment.query(on: database).all()
+
+        // Distinct users that still need a role, fetched in one IN-query
+        // rather than a lookup per enrollment row.
+        let pendingUserIDs = Set(enrollments.compactMap { $0.roleRaw == nil ? $0.userID : nil })
+        guard !pendingUserIDs.isEmpty else { return }
+
+        let users = try await APIUser.query(on: database)
+            .filter(\.$id ~~ pendingUserIDs)
+            .all()
+        var isInstructorByUserID: [UUID: Bool] = [:]
+        for user in users {
+            guard let id = user.id else { continue }
+            isInstructorByUserID[id] = user.isInstructor
+        }
+
+        for enrollment in enrollments where enrollment.roleRaw == nil {
+            let isInstructor = isInstructorByUserID[enrollment.userID] ?? false
+            enrollment.role = isInstructor ? .instructor : .student
+            try await enrollment.save(on: database)
+        }
+    }
+}

--- a/Sources/APIServer/Models/APICourseEnrollment.swift
+++ b/Sources/APIServer/Models/APICourseEnrollment.swift
@@ -2,9 +2,16 @@
 //
 // Join table: a user is enrolled in a course.
 // Both students and instructors enroll via the same mechanism.
-// The user's global role (student/instructor/admin) determines what they can do;
-// enrollment determines which courses they can see.
+//
+// Each enrollment carries a per-course `role` (CourseRole) — the foundation
+// for course-scoped capability, i.e. instructor in one course and student in
+// another (see docs/multi-course-roles.md). Phase 1 only *stores* this role:
+// the `AddCourseEnrollmentRole` migration adds it and seeds it
+// behaviour-preservingly from each user's global role, but nothing reads it
+// yet — the global `APIUser.role` still governs what a user can do. Later
+// phases move the nav, access checks, and roster UI onto the per-course role.
 
+import Core
 import Fluent
 import Vapor
 
@@ -27,11 +34,35 @@ final class APICourseEnrollment: Model, Content, @unchecked Sendable {
     @Timestamp(key: "enrolled_at", on: .create)
     var enrolledAt: Date?
 
+    /// The user's role *within this course* (`CourseRole`, stored as its raw
+    /// string).  Declared optional only because Fluent + SQLite can't add a
+    /// NOT NULL column to an existing table post-hoc — the same constraint
+    /// that keeps `APIUser.url_token` nullable.  Every row carries a value in
+    /// practice: fresh enrollments get one from `init` (defaulting to
+    /// `.student`) and the `AddCourseEnrollmentRole` migration backfills
+    /// pre-existing rows.  Read it through the typed `role` accessor below,
+    /// never this raw column.
+    @OptionalField(key: "role")
+    var roleRaw: String?
+
     init() {}
 
-    init(id: UUID? = nil, userID: UUID, courseID: UUID) {
+    init(id: UUID? = nil, userID: UUID, courseID: UUID, role: CourseRole = .student) {
         self.id = id
         self.userID = userID
         self.$course.id = courseID
+        self.roleRaw = role.rawValue
+    }
+}
+
+// MARK: - Per-course role
+
+extension APICourseEnrollment {
+    /// The enrollment's typed per-course role.  Falls back to `.student` for a
+    /// missing or unrecognised stored value — defensive, since every row is
+    /// expected to carry a valid role once `AddCourseEnrollmentRole` has run.
+    var role: CourseRole {
+        get { roleRaw.flatMap(CourseRole.init(rawValue:)) ?? .student }
+        set { roleRaw = newValue.rawValue }
     }
 }

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -289,18 +289,23 @@ extension Request {
 
         let activeCourseUUID = UUID(uuidString: activeCourseID)
         let markedCourses = enrolledContexts.map {
-            CourseContext(id: $0.id, code: $0.code, name: $0.name, isActive: $0.id == activeCourseID)
+            CourseContext(
+                id: $0.id, code: $0.code, name: $0.name,
+                isActive: $0.id == activeCourseID, role: $0.role)
         }
         let active = markedCourses.first(where: \.isActive)
         return ResolvedCourseState(active: active, all: markedCourses, activeCourseUUID: activeCourseUUID)
     }
 
     private func loadEnrolledCourseContexts(userID: UUID) async throws -> [CourseContext] {
-        // Delegates to the shared visibility resolver so the tab strip and the
-        // MCP listing surface stay in lockstep by construction.
-        try await enrolledCourses(for: userID, on: db).compactMap { course in
-            guard let id = course.id else { return nil }
-            return CourseContext(id: id.uuidString, code: course.code, name: course.name, isActive: false)
+        // Delegates to the shared visibility resolver (role-augmented) so the
+        // tab strip and the MCP listing surface stay in lockstep on which
+        // courses are visible; the per-course role rides along for the nav.
+        try await enrolledCoursesWithRoles(for: userID, on: db).compactMap { pair in
+            guard let id = pair.course.id else { return nil }
+            return CourseContext(
+                id: id.uuidString, code: pair.course.code, name: pair.course.name,
+                isActive: false, role: pair.role)
         }
     }
 }
@@ -313,6 +318,12 @@ struct CourseContext: Encodable {
     let code: String
     let name: String
     var isActive: Bool
+    /// The caller's per-course role in this course (Phase 2 of
+    /// docs/multi-course-roles.md). Carried so the nav can decide instructor
+    /// surfaces from the *active course's* role rather than the global one.
+    /// Behaviour-neutral today — every enrollment's role mirrors the global
+    /// role (Phase 1 backfill).
+    let role: CourseRole
 }
 
 /// The result of resolving which course is "active" for the current request.
@@ -337,6 +348,16 @@ struct CurrentUserContext: Encodable {
     let enrolledCourses: [CourseContext]
     /// True when the user is enrolled in more than one course (tab strip should show).
     let showCourseTabs: Bool
+    /// True when the user acts as an instructor *in the active course*: that
+    /// course's per-course role is `.instructor`, or the user is a global
+    /// instructor/admin (the transitional fallback, kept until the global role
+    /// is shrunk in Phase 5). The nav's Instructor tab keys off this instead
+    /// of the bare global `isInstructor`, so once per-course roles are
+    /// authorable (Phase 4) switching the active course switches the same
+    /// account between instructor and student views. Behaviour-neutral today:
+    /// every enrollment's role mirrors the global role, so this equals the
+    /// previous `isInstructor && activeCourse != nil`.
+    let isInstructorInActiveCourse: Bool
 
     init(user: APIUser, activeCourse: CourseContext? = nil, enrolledCourses: [CourseContext] = []) {
         let normalizedPreferredName = user.preferredName?
@@ -359,5 +380,7 @@ struct CurrentUserContext: Encodable {
         self.activeCourse = activeCourse
         self.enrolledCourses = enrolledCourses
         self.showCourseTabs = enrolledCourses.count > 1
+        self.isInstructorInActiveCourse =
+            activeCourse != nil && (activeCourse?.role == .instructor || user.isInstructor)
     }
 }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -329,4 +329,11 @@ func registerMigrations(on app: Application) {
     // Error-detail columns on client_diagnostics (message/stack/source) so
     // browser-side failures carry diagnosable signal.
     app.migrations.add(AddClientDiagnosticErrorDetail())
+
+    // Per-course role on each enrollment (Phase 1 of
+    // docs/multi-course-roles.md). Behaviour-preserving: backfills role from
+    // each user's current global role; nothing reads it yet. Runs after
+    // CreateCourseEnrollments (the table) and CreateUsers (the backfill reads
+    // users).
+    app.migrations.add(AddCourseEnrollmentRole())
 }

--- a/Sources/Core/CourseRole.swift
+++ b/Sources/Core/CourseRole.swift
@@ -1,0 +1,21 @@
+// Core/CourseRole.swift
+//
+// A user's role *within a single course*, carried on the enrollment join row
+// (`course_enrollments.role`).
+//
+// Distinct from the deployment-global `UserRole` (student/instructor/admin/mcp)
+// stored on the user: that one governs deployment administration, while
+// `CourseRole` governs participation in one specific course. Modelling role
+// per-enrollment is what lets a single account be an instructor in one course
+// and a student in another. See docs/multi-course-roles.md.
+//
+// Two rungs ship initially. The type is `String`-backed and deliberately open
+// to a future `ta` rung between `student` and `instructor` without a schema
+// change — the column is a string; only the vocabulary grows.
+
+public enum CourseRole: String, Codable, Sendable {
+    /// Submits to the course's assignments and views their own results.
+    case student
+    /// Authors and manages the course's assignments, suites, and content.
+    case instructor
+}

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -1,0 +1,132 @@
+// Tests/APITests/CourseEnrollmentRoleMigrationTests.swift
+//
+// Phase 1 of per-course roles (docs/multi-course-roles.md): the
+// `course_enrollments.role` column, its typed accessor, and the
+// behaviour-preserving backfill that seeds each enrollment's role from the
+// enrolled user's global role.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct CourseEnrollmentRoleTests {
+
+    // MARK: - Core type + model accessor (no DB)
+
+    @Test func courseRoleRawValuesRoundTrip() {
+        #expect(CourseRole.student.rawValue == "student")
+        #expect(CourseRole.instructor.rawValue == "instructor")
+        #expect(CourseRole(rawValue: "instructor") == .instructor)
+        #expect(CourseRole(rawValue: "ta") == nil)  // not a rung yet
+    }
+
+    @Test func roleAccessorDefaultsToStudentForMissingOrUnknownRaw() {
+        let enrollment = APICourseEnrollment(userID: UUID(), courseID: UUID())
+        // init default
+        #expect(enrollment.role == .student)
+        #expect(enrollment.roleRaw == "student")
+
+        // explicit nil → defensive default
+        enrollment.roleRaw = nil
+        #expect(enrollment.role == .student)
+
+        // unknown stored value → defensive default
+        enrollment.roleRaw = "wizard"
+        #expect(enrollment.role == .student)
+
+        // setter writes the raw string
+        enrollment.role = .instructor
+        #expect(enrollment.roleRaw == "instructor")
+    }
+
+    @Test func initStoresInstructorRole() {
+        let enrollment = APICourseEnrollment(userID: UUID(), courseID: UUID(), role: .instructor)
+        #expect(enrollment.role == .instructor)
+        #expect(enrollment.roleRaw == "instructor")
+    }
+
+    // MARK: - Backfill (DB)
+
+    /// The backfill seeds each still-unset enrollment role from the enrolled
+    /// user's *global* role: a global instructor (or admin, which implies
+    /// instructor) becomes a per-course instructor; everyone else a student.
+    /// This is what makes applying the migration behaviour-preserving.
+    @Test func backfillSeedsRoleFromGlobalRole() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let course = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            // One user per global role.
+            let instructor = makeUser(role: .instructor)
+            let admin = makeUser(role: .admin)
+            let student = makeUser(role: .student)
+            for user in [instructor, admin, student] { try await user.save(on: app.db) }
+
+            // Enrollments with a NULL role, simulating pre-migration rows.
+            for user in [instructor, admin, student] {
+                let enrollment = APICourseEnrollment(userID: try user.requireID(), courseID: courseID)
+                enrollment.roleRaw = nil
+                try await enrollment.save(on: app.db)
+            }
+
+            try await AddCourseEnrollmentRole().backfillRoles(on: app.db)
+
+            #expect(try await courseRole(of: instructor, on: app.db) == .instructor)
+            #expect(try await courseRole(of: admin, on: app.db) == .instructor, "admin implies instructor")
+            #expect(try await courseRole(of: student, on: app.db) == .student)
+        }
+    }
+
+    /// The backfill only touches NULL roles — an enrollment already carrying a
+    /// role is left alone, so re-running it is safe.
+    @Test func backfillLeavesExistingRolesUntouched() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let course = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            // A *student* global role, but the enrollment is explicitly an
+            // instructor (the shape a future TA / co-instructor takes).
+            let user = makeUser(role: .student)
+            try await user.save(on: app.db)
+            let enrollment = APICourseEnrollment(
+                userID: try user.requireID(), courseID: courseID, role: .instructor)
+            try await enrollment.save(on: app.db)
+
+            try await AddCourseEnrollmentRole().backfillRoles(on: app.db)
+
+            let reloaded = try #require(try await APICourseEnrollment.find(enrollment.id, on: app.db))
+            #expect(reloaded.role == .instructor, "a non-null role must not be overwritten by the global role")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeUser(role: UserRole) -> APIUser {
+        APIUser(
+            username: "\(role.rawValue)_\(UUID().uuidString.prefix(8))",
+            passwordHash: "x",
+            role: role.rawValue
+        )
+    }
+
+    private func courseRole(of user: APIUser, on db: Database) async throws -> CourseRole {
+        let enrollment = try #require(
+            try await APICourseEnrollment.query(on: db)
+                .filter(\.$userID == user.requireID())
+                .first()
+        )
+        return enrollment.role
+    }
+}

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -111,6 +111,70 @@ import Vapor
         }
     }
 
+    // MARK: - Read path (Phase 2)
+
+    /// `isInstructorInActiveCourse` (which the nav keys off) is driven by the
+    /// active course's per-course role, with a transitional fallback to the
+    /// global role.
+    @Test func instructorInActiveCourseReflectsPerCourseRoleAndGlobalFallback() {
+        func context(globalRole: UserRole, active: CourseContext?) -> CurrentUserContext {
+            let user = APIUser(username: "u", passwordHash: "x", role: globalRole.rawValue)
+            return CurrentUserContext(
+                user: user, activeCourse: active, enrolledCourses: active.map { [$0] } ?? [])
+        }
+        func course(_ role: CourseRole) -> CourseContext {
+            CourseContext(id: UUID().uuidString, code: "CS101", name: "Intro", isActive: true, role: role)
+        }
+
+        // No active course → never instructor-in-course, whatever the global role.
+        #expect(context(globalRole: .instructor, active: nil).isInstructorInActiveCourse == false)
+        // Global student, per-course student → no instructor surfaces.
+        #expect(context(globalRole: .student, active: course(.student)).isInstructorInActiveCourse == false)
+        // The Phase 2 point: a global *student* with a per-course instructor role → yes.
+        #expect(context(globalRole: .student, active: course(.instructor)).isInstructorInActiveCourse == true)
+        // Transitional fallback: a global instructor keeps the tab even where the
+        // per-course role is still student (the fallback is removed in Phase 5).
+        #expect(context(globalRole: .instructor, active: course(.student)).isInstructorInActiveCourse == true)
+        // Admin keeps deployment-wide instructor surfaces.
+        #expect(context(globalRole: .admin, active: course(.student)).isInstructorInActiveCourse == true)
+    }
+
+    /// `enrolledCoursesWithRoles` returns each enrolled (non-archived) course
+    /// paired with the caller's per-course role, sorted by code — the resolver
+    /// the nav's active-course role is read from.
+    @Test func enrolledCoursesWithRolesCarriesPerCourseRole() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let user = makeUser(role: .student)
+            try await user.save(on: app.db)
+            let userID = try user.requireID()
+
+            let cs101 = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            let cs246 = APICourse(code: "CS246", name: "OOP", enrollmentMode: .closed)
+            let archived = APICourse(code: "CS999", name: "Retired", enrollmentMode: .closed)
+            archived.isArchived = true
+            for course in [cs101, cs246, archived] { try await course.save(on: app.db) }
+
+            try await APICourseEnrollment(
+                userID: userID, courseID: try cs101.requireID(), role: .student
+            ).save(on: app.db)
+            try await APICourseEnrollment(
+                userID: userID, courseID: try cs246.requireID(), role: .instructor
+            ).save(on: app.db)
+            try await APICourseEnrollment(
+                userID: userID, courseID: try archived.requireID(), role: .instructor
+            ).save(on: app.db)
+
+            let pairs = try await enrolledCoursesWithRoles(for: userID, on: app.db)
+
+            // Archived course excluded; the rest sorted by code, role carried through.
+            #expect(pairs.map(\.course.code) == ["CS101", "CS246"])
+            #expect(pairs.map(\.role) == [.student, .instructor])
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeUser(role: UserRole) -> APIUser {

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -583,4 +583,37 @@ import VaporTesting
                 })
         }
     }
+
+    /// Phase 2 wiring, end-to-end: the nav's Instructor tab keys off the
+    /// *per-course* role. A global `student` whose enrollment in the active
+    /// course carries `.instructor` sees the Instructor tab there — the
+    /// "instructor here, student elsewhere" case the per-course role exists for.
+    @Test func studentWithPerCourseInstructorRoleSeesInstructorTab() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await loginUser(
+                username: "student_ic", password: "pass", role: "student", on: app)
+            let user = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "student_ic").first())
+
+            let course = APICourse(code: "CS301", name: "Lab", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            try await APICourseEnrollment(
+                userID: try user.requireID(), courseID: try course.requireID(), role: .instructor
+            ).save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(
+                        html.contains(#"href="/instructor""#),
+                        "A per-course instructor (global student) must see the Instructor tab")
+                    #expect(
+                        html.contains(">CS301</a>"),
+                        "The Instructor tab is labelled with the active course code")
+                })
+        }
+    }
 }

--- a/changelog.d/course-enrollment-role-phase1.md
+++ b/changelog.d/course-enrollment-role-phase1.md
@@ -1,10 +1,11 @@
 ### Added
 
-- **Per-course role groundwork (multi-course-roles Phase 1).** Each course
+- **Per-course role groundwork (multi-course-roles Phases 1–2).** Each course
   enrollment now carries a `role` (`student` / `instructor`) — the foundation
-  for a user being an instructor in one course and a student in another. The
-  `AddCourseEnrollmentRole` migration adds the column and backfills it
-  behaviour-preservingly from each user's current global role, so this release
-  has **no observable behavior change**: nothing reads the per-course role yet
-  (the global role still governs what a user can do). See
-  `docs/multi-course-roles.md`.
+  for a user being an instructor in one course and a student in another. A
+  migration adds the column and backfills it behaviour-preservingly from each
+  user's current global role (Phase 1), and the home/nav read path now derives
+  the "Instructor" tab from the *active course's* role rather than the global
+  one (Phase 2). **No observable behavior change yet:** every enrollment's role
+  mirrors the global role until per-course roles become authorable in a later
+  phase. See `docs/multi-course-roles.md`.

--- a/changelog.d/course-enrollment-role-phase1.md
+++ b/changelog.d/course-enrollment-role-phase1.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Per-course role groundwork (multi-course-roles Phase 1).** Each course
+  enrollment now carries a `role` (`student` / `instructor`) — the foundation
+  for a user being an instructor in one course and a student in another. The
+  `AddCourseEnrollmentRole` migration adds the column and backfills it
+  behaviour-preservingly from each user's current global role, so this release
+  has **no observable behavior change**: nothing reads the per-course role yet
+  (the global role still governs what a user can do). See
+  `docs/multi-course-roles.md`.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -1,13 +1,15 @@
 # Multi-course roles & university-scale organization
 
-**Status:** Design / planning. No implementation yet. Companion to the fix
-that scoped the home dashboard and the "Instructor" nav tab to course
-enrollment (PR #972) — that fix is the first concrete step toward the model
-described here.
+**Status:** Active. Theme 1 (per-course roles) is being implemented in phases;
+**Phase 1 (Core `CourseRole` + the `course_enrollments.role` column + the
+behaviour-preserving backfill) has landed.** Companion to the earlier fix that
+scoped the home dashboard and the "Instructor" nav tab to course enrollment
+(PR #972) — that fix was the first concrete step toward the model described
+here.
 
-This document is a starting point for "thinking on paper," not a committed
-plan. The decisions in [Open questions](#open-questions-for-the-owner) are
-the owner's to make.
+The owner's design decisions are recorded in [§6](#6-decisions) and are
+settled; they shape Phases 4–5 (the behaviour-changing ones). Theme 2
+(university-scale organization) remains design-only.
 
 ---
 
@@ -50,7 +52,7 @@ same way it is already *visibility*-scoped to a course.
 | Concern | Where | Shape |
 |---|---|---|
 | Global role | `Sources/APIServer/Models/APIUser.swift` — `UserRole` enum, `role` field, `isInstructor`/`isAdmin` | One string column on the user. `isInstructor == (role == .instructor \|\| role == .admin)`. |
-| Enrollment | `Sources/APIServer/Models/APICourseEnrollment.swift` | Join row `(user_id, course_id)` — **role-agnostic**. Its own header comment: *"The user's global role determines what they can do; enrollment determines which courses they can see."* |
+| Enrollment | `Sources/APIServer/Models/APICourseEnrollment.swift` | Join row `(user_id, course_id)`. As of Phase 1 it also carries a per-course `role` (`CourseRole`), seeded behaviour-preservingly from the global role and **not yet read** — the global role still governs capability until Phases 2–4 wire this in. |
 | Access policy | `Sources/APIServer/Helpers/CourseAccessHelpers.swift` — `requireCourseEnrollment`, `userIsEnrolled`, `enrolledCourses` | The single chokepoint both the web routes and MCP tools resolve course access through. Admin is the one bypass. |
 | Active-course resolution | `APIUser.swift` — `resolveActiveCourse`, `CourseContext`, `ResolvedCourseState` | Picks the active course from session/DB, auto-enrolls `.auto` courses, returns the enrolled set. |
 | View context | `APIUser.swift` — `CurrentUserContext` | Carries `isAdmin`, `isInstructor`, `activeCourse`, `enrolledCourses` into Leaf. The nav (`Resources/Views/base.leaf`) reads these. |
@@ -76,20 +78,28 @@ representable and creatable.
 ### 3.1 Data model
 
 - Add `role` to `course_enrollments` — a new `CourseRole` enum in `Core/`
-  (`Codable`, `Sendable`), mirroring `UserRole`: `student`, `instructor`
-  (and, when wanted, `ta` — see open questions). Default `student`.
+  (`Codable`, `Sendable`). Per [§6](#6-decisions) it ships with two rungs,
+  `student` and `instructor`; `ta` is deferred (the type is string-backed, so
+  adding it later needs no schema change). Default `student`. **(Implemented —
+  `Sources/Core/CourseRole.swift`.)**
 - Reinterpret `APIUser.role`:
   - `admin` stays a **deployment** super-user (manages courses, users,
     runners; bypasses course checks).
   - For everyone else the global role stops carrying course capability —
-    capability comes from the enrollment row. (Whether a vestigial global
-    `instructor` survives as a "may create a course" capability is an open
-    question; today instructors don't create courses, admins do.)
+    capability comes from the enrollment row. Per [§6](#6-decisions) course
+    creation stays **admin-only**, so the global `instructor` role collapses
+    entirely into "instructor on some enrollment" — there is no surviving
+    deployment-level `instructor`. (That collapse is Phase 5 work; the global
+    role is untouched through Phases 1–4.)
 
-### 3.2 Migration / backfill (behavior-preserving)
+### 3.2 Migration / backfill (behavior-preserving) — **implemented**
 
-- New migration adds `role` to `course_enrollments` (add nullable →
-  backfill → enforce default `student`, the SQLite-friendly three-step).
+- `AddCourseEnrollmentRole` adds `role` as a **nullable** column and backfills
+  it. It deliberately does not add a DB-level NOT NULL/default: Fluent +
+  SQLite can't add a NOT NULL column to an existing table post-hoc, so — like
+  `AddUrlTokenToUsers` — the column stays nullable and the "every row has a
+  role" invariant is held by the model-side `init` default plus the typed
+  accessor (which falls back to `.student` for a missing value).
 - **Backfill rule:** for each existing enrollment, set
   `role = (user.isInstructor ? .instructor : .student)`. A current global
   instructor therefore becomes instructor in *every course they're already
@@ -143,17 +153,20 @@ representable and creatable.
 
 ### 3.6 Suggested phasing
 
-1. **Core + schema.** `CourseRole`, the migration, the backfill. No reads of
-   the new column yet → zero behavior change.
+1. **Core + schema. ✓ Done.** `CourseRole`, the `AddCourseEnrollmentRole`
+   migration, the backfill. No reads of the new column yet → zero behavior
+   change.
 2. **Read path.** `CourseContext.role`, nav keyed off active-course role.
    Still identical behavior (backfill mirrors the global role).
 3. **Auth path.** Helper + handler/middleware switch to role checks. Still
    identical (same reason).
 4. **Authoring UI.** Per-course role on enroll/roster. **This is where
    "instructor here, student there" goes live.**
-5. **Shrink the global role.** Collapse `APIUser.role` toward `admin`-only;
-   revisit SSO role mapping (`SSO_INSTRUCTOR_USERS` currently sets the *global*
-   role — see open questions). Longest tail; can lag well behind 1–4.
+5. **Shrink the global role.** Collapse `APIUser.role` to `admin`-only (per
+   [§6](#6-decisions) the global `instructor` goes away entirely). Revisit SSO
+   role mapping here — per [§6](#6-decisions) `SSO_INSTRUCTOR_USERS` keeps its
+   current global-role behavior until this phase. Longest tail; can lag well
+   behind 1–4.
 
 ---
 
@@ -194,20 +207,27 @@ machinery cleanly rather than inventing a parallel one.
 
 ---
 
-## 6. Open questions (for the owner)
+## 6. Decisions
 
-1. **Does a global `instructor` survive at all?** Today instructors don't
-   create courses (admins do). If that stays true, global `instructor` may
-   collapse entirely into "instructor on some enrollment," leaving only
-   `admin` as a global role. If instructors should self-serve course
-   creation, we need a deployment-level "may create courses" capability —
-   which is itself a small scoped-admin question (Theme 2).
-2. **TA as a distinct `CourseRole` now or later?** A `ta` between `student`
-   and `instructor` (e.g. can view submissions + grade, cannot edit the
-   suite) is a natural third rung but adds policy surface.
-3. **SSO role mapping.** `SSO_INSTRUCTOR_USERS` / `SSO_ADMIN_USERS` currently
-   set the *global* role at login. Under per-course roles, does an SSO
-   "instructor" become instructor only in courses they're enrolled in, or
-   does it seed a course-creation capability? (Ties to Q1.)
+The Theme 1 questions were settled with the owner (2026-06-22). They shape the
+behaviour-changing Phases 4–5, not the behaviour-neutral Phases 1–3.
+
+1. **Course creation stays admin-only → the global `instructor` role
+   collapses.** Instructors do not self-serve course creation (admins do, as
+   today), so there is no deployment-level "may create courses" capability to
+   model. `instructor` becomes purely a per-course role; the only global role
+   that survives the Phase 5 shrink is `admin`.
+2. **`CourseRole` ships as `student` + `instructor` only; `ta` is deferred.**
+   A TA rung (view/grade submissions, no suite edits) is a natural future
+   addition but carries extra policy surface; the enum is string-backed, so it
+   can be added later without a schema change.
+3. **SSO mapping is deferred to Phase 5.** `SSO_INSTRUCTOR_USERS` /
+   `SSO_ADMIN_USERS` keep their current global-role behavior through
+   Phases 1–4 (which don't touch SSO). How an SSO "instructor" maps under the
+   collapsed model is decided when the global role is shrunk.
+
+### Still open (Theme 2)
+
 4. **Term model depth.** Is a lightweight `Term` label enough, or do we want
    term-scoped enrollment (re-enroll each term) and cross-term analytics?
+   Deferred with the rest of Theme 2.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -1,11 +1,12 @@
 # Multi-course roles & university-scale organization
 
 **Status:** Active. Theme 1 (per-course roles) is being implemented in phases;
-**Phase 1 (Core `CourseRole` + the `course_enrollments.role` column + the
-behaviour-preserving backfill) has landed.** Companion to the earlier fix that
-scoped the home dashboard and the "Instructor" nav tab to course enrollment
-(PR #972) — that fix was the first concrete step toward the model described
-here.
+**Phases 1–2 have landed** — Core `CourseRole` + the `course_enrollments.role`
+column + the behaviour-preserving backfill (Phase 1), and the read-path wiring
+that carries the per-course role into the nav (Phase 2). Companion to the
+earlier fix that scoped the home dashboard and the "Instructor" nav tab to
+course enrollment (PR #972) — that fix was the first concrete step toward the
+model described here.
 
 The owner's design decisions are recorded in [§6](#6-decisions) and are
 settled; they shape Phases 4–5 (the behaviour-changing ones). Theme 2
@@ -110,16 +111,21 @@ representable and creatable.
   The behavior change only arrives when someone *authors* a mixed role
   (Phase 4).
 
-### 3.3 Read path (visibility / nav)
+### 3.3 Read path (visibility / nav) — **implemented**
 
-- `CourseContext` gains `role: CourseRole`; `resolveActiveCourse` /
-  `enrolledCourses` populate it from the enrollment row (it's already loaded —
-  one extra column, no extra query).
-- `CurrentUserContext` exposes the active course's role (e.g. a derived
-  `isInstructorInActiveCourse`). `base.leaf` keys the Instructor tab off
-  *that* instead of the global `isInstructor`. Switching the course tab then
-  switches the same account between instructor and student views — which is
-  exactly the desired UX for a TA-who-is-also-a-student.
+- `CourseContext` carries `role: CourseRole`, populated by a new
+  `enrolledCoursesWithRoles` resolver (the enrollment row is already loaded —
+  no extra query). `enrolledCourses` is now defined in terms of it, so the
+  role-free MCP visibility set can't drift from the web one.
+- `CurrentUserContext` exposes `isInstructorInActiveCourse`, and `base.leaf`
+  keys the Instructor tab off *that* instead of the global `isInstructor`. It
+  is `true` when the active course's role is `.instructor` **or** (a
+  transitional fallback) the user is a global instructor/admin — so today's
+  behaviour is identical (every enrollment's role mirrors the global role),
+  while a future global-student-who-is-instructor-here already lights up the
+  tab. The fallback is dropped in Phase 5 when the global role shrinks.
+  Switching the course tab then switches the same account between instructor
+  and student views — the desired UX for a TA-who-is-also-a-student.
 
 ### 3.4 Auth path (permissions)
 
@@ -156,8 +162,9 @@ representable and creatable.
 1. **Core + schema. ✓ Done.** `CourseRole`, the `AddCourseEnrollmentRole`
    migration, the backfill. No reads of the new column yet → zero behavior
    change.
-2. **Read path.** `CourseContext.role`, nav keyed off active-course role.
-   Still identical behavior (backfill mirrors the global role).
+2. **Read path. ✓ Done.** `CourseContext.role`, nav keyed off
+   `isInstructorInActiveCourse`. Still identical behavior (the role mirrors the
+   global role, plus a transitional global-role fallback in the nav predicate).
 3. **Auth path.** Helper + handler/middleware switch to role checks. Still
    identical (same reason).
 4. **Authoring UI.** Per-course role on enroll/roster. **This is where


### PR DESCRIPTION
## What

Phases 1–2 of the per-course roles work (`docs/multi-course-roles.md`) — the **behaviour-neutral foundation** for course-scoped capability, so a single account can be an instructor in one course and a student in another. Follows the dashboard / Instructor-tab scoping fix in #972.

**No observable behaviour change yet.** Every enrollment's role is seeded to mirror the global role, and the nav keeps a transitional fallback to the global role, so existing users see exactly what they did before. The change goes live when per-course roles become *authorable* (Phase 4).

## Phase 1 — Core + schema + backfill

- **Core:** new `CourseRole` enum (`student`, `instructor`) — string-backed, open to a future `ta` rung with no schema change.
- **`APICourseEnrollment`:** nullable `role` column + typed `role` accessor defaulting to `.student` (the `AddUrlTokenToUsers` nullable pattern).
- **`AddCourseEnrollmentRole` migration:** adds the column and backfills each enrollment's role from the enrolled user's current global role (`instructor`/`admin` → `.instructor`, else `.student`). Backfill split out (`backfillRoles`) for testability; idempotent.

## Phase 2 — Read path (nav)

- **`CourseContext`** carries `role: CourseRole`, populated by a new `enrolledCoursesWithRoles` resolver. `enrolledCourses` is now defined in terms of it, so the role-free MCP visibility set can't drift from the web one.
- **`CurrentUserContext`** exposes `isInstructorInActiveCourse` — true when the active course's role is `.instructor` **or** (transitional) the user is a global instructor/admin. **`base.leaf`** keys the Instructor tab off that instead of the bare global `isInstructor`. The fallback preserves today's behaviour and is dropped in Phase 5.

## Decisions baked in (settled with the owner)

| Question | Decision |
|---|---|
| Course creation | Admins only → global `instructor` collapses into per-course |
| TA rung | Deferred; ship `student` + `instructor` only |
| SSO instructor mapping | Deferred to Phase 5 |

## Not in scope (later phases)

`requireCourseRole(atLeast:)` in `CourseAccessHelpers` + handler/middleware swaps (Phase 3); per-course role on the enroll/roster UI, where mixed roles become *creatable* (Phase 4); shrinking the global role to `admin`-only (Phase 5).

## Tests

- `CourseRole` round-trip; the accessor's defensive `.student` default; init storing `.instructor`.
- Backfill: instructor/admin → `.instructor`, student → `.student`; already-set role not overwritten (idempotent).
- `isInstructorInActiveCourse` predicate (per-course role, global fallback, admin, no-active-course); `enrolledCoursesWithRoles` (role carried, archived excluded, sorted by code).
- End-to-end render: a global **student** with a per-course `.instructor` role sees the Instructor tab; the #972 nav tests still pass (behaviour-neutral).

Local: clean build (sources + tests), the role + `WebRoutesIndexTests` suites (25 tests), `swift-format` / `lint.sh`, SwiftLint `--strict` (0 violations), and the style / CSS / no-XCTest guards all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK