### PR TITLE
Per-course roles: authorization chokepoint (multi-course-roles Phase 3)

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -16,17 +16,48 @@ import Core
 import Fluent
 import Vapor
 
+/// Throws `.forbidden` unless `caller` is an admin or holds an enrollment in
+/// `courseID` whose per-course role is at least `minimum`. Admins bypass (they
+/// administer the whole deployment and can grant themselves enrollment anyway).
+/// This is the role-aware chokepoint for course access (Phase 3 of
+/// docs/multi-course-roles.md); `requireCourseEnrollment` is its `.student`
+/// case.
+///
+/// Authority is purely per-course here — there is no "global instructor"
+/// bypass. Today the only production callers pass `.student` (via
+/// `requireCourseEnrollment`), and every enrolled user is at least a student,
+/// so behaviour is identical to the prior enrollment-only check. The
+/// `.instructor` bar is wired into the authoring surfaces in Phase 4, once
+/// per-course roles are authorable; until then it is exercised only by tests.
+func requireCourseRole(
+    caller: APIUser, courseID: UUID, atLeast minimum: CourseRole, db: Database
+) async throws {
+    guard !caller.isAdmin else { return }
+    guard let callerID = caller.id else { throw Abort(.unauthorized) }
+    guard let role = try await courseRole(of: callerID, inCourse: courseID, db: db) else {
+        throw Abort(.forbidden)
+    }
+    guard role >= minimum else { throw Abort(.forbidden) }
+}
+
 /// Throws `.forbidden` unless `caller` is an admin or is enrolled in the
 /// course identified by `courseID`. Instructors get no bypass: historically
 /// any instructor account could fetch another course's content — including
 /// test setups carrying secret tests and reference solutions — by URL, even
-/// though the dashboard never showed it to them.
+/// though the dashboard never showed it to them. Now the `.student` case of
+/// `requireCourseRole`.
 func requireCourseEnrollment(caller: APIUser, courseID: UUID, db: Database) async throws {
-    guard !caller.isAdmin else { return }
-    guard let callerID = caller.id else { throw Abort(.unauthorized) }
-    guard try await userIsEnrolled(userID: callerID, inCourse: courseID, db: db) else {
-        throw Abort(.forbidden)
-    }
+    try await requireCourseRole(caller: caller, courseID: courseID, atLeast: .student, db: db)
+}
+
+/// The caller's per-course role in `courseID`, or nil if they hold no
+/// enrollment there. The single role read behind `requireCourseRole`.
+func courseRole(of userID: UUID, inCourse courseID: UUID, db: Database) async throws -> CourseRole? {
+    try await APICourseEnrollment.query(on: db)
+        .filter(\.$userID == userID)
+        .filter(\.$course.$id == courseID)
+        .first()?
+        .role
 }
 
 /// True when the user holds an enrollment row in course `courseID`. The single

--- a/Sources/Core/CourseRole.swift
+++ b/Sources/Core/CourseRole.swift
@@ -13,9 +13,24 @@
 // to a future `ta` rung between `student` and `instructor` without a schema
 // change — the column is a string; only the vocabulary grows.
 
-public enum CourseRole: String, Codable, Sendable {
+public enum CourseRole: String, Codable, Sendable, Comparable {
     /// Submits to the course's assignments and views their own results.
     case student
     /// Authors and manages the course's assignments, suites, and content.
     case instructor
+
+    /// Privilege rank for `atLeast`-style comparisons (higher = more
+    /// privilege). The gap leaves room to slot a future `ta` rung between
+    /// `student` and `instructor` without renumbering, so an
+    /// `enrollment.role >= .instructor` check keeps reading naturally.
+    private var rank: Int {
+        switch self {
+        case .student: return 0
+        case .instructor: return 20
+        }
+    }
+
+    public static func < (lhs: CourseRole, rhs: CourseRole) -> Bool {
+        lhs.rank < rhs.rank
+    }
 }

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -1,9 +1,12 @@
-// Tests/APITests/CourseEnrollmentRoleMigrationTests.swift
+// Tests/APITests/CourseEnrollmentRoleTests.swift
 //
-// Phase 1 of per-course roles (docs/multi-course-roles.md): the
-// `course_enrollments.role` column, its typed accessor, and the
-// behaviour-preserving backfill that seeds each enrollment's role from the
-// enrolled user's global role.
+// Per-course roles (docs/multi-course-roles.md):
+//   Phase 1 — the `course_enrollments.role` column, its typed accessor, and the
+//     behaviour-preserving backfill from each enrolled user's global role.
+//   Phase 2 — the read path: `enrolledCoursesWithRoles` and the nav predicate
+//     `isInstructorInActiveCourse`.
+//   Phase 3 — the auth chokepoint: `CourseRole` ordering and
+//     `requireCourseRole(atLeast:)`.
 
 import Core
 import Fluent
@@ -172,6 +175,70 @@ import Vapor
             // Archived course excluded; the rest sorted by code, role carried through.
             #expect(pairs.map(\.course.code) == ["CS101", "CS246"])
             #expect(pairs.map(\.role) == [.student, .instructor])
+        }
+    }
+
+    // MARK: - Auth path (Phase 3)
+
+    @Test func courseRoleLadderOrdersByPrivilege() {
+        #expect(CourseRole.student < CourseRole.instructor)
+        #expect(CourseRole.instructor >= .instructor)
+        #expect(CourseRole.student >= .student)
+        #expect(!(CourseRole.instructor < CourseRole.student))
+    }
+
+    /// `requireCourseRole` authorizes by the *per-course* role: a global student
+    /// enrolled as a per-course instructor passes the `.instructor` bar, while a
+    /// global student enrolled as a student does not. Admins bypass; an
+    /// unenrolled non-admin is forbidden even at `.student`.
+    @Test func requireCourseRoleEnforcesPerCourseRole() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let course = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            // All non-admins are global *students* — proving authority is per-course.
+            let asStudent = makeUser(role: .student)
+            let asInstructor = makeUser(role: .student)
+            let unenrolled = makeUser(role: .student)
+            let admin = makeUser(role: .admin)  // not enrolled anywhere
+            for user in [asStudent, asInstructor, unenrolled, admin] { try await user.save(on: app.db) }
+
+            try await APICourseEnrollment(
+                userID: try asStudent.requireID(), courseID: courseID, role: .student
+            ).save(on: app.db)
+            try await APICourseEnrollment(
+                userID: try asInstructor.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
+
+            // Per-course student: meets .student, not .instructor.
+            try await requireCourseRole(caller: asStudent, courseID: courseID, atLeast: .student, db: app.db)
+            await #expect(throws: Abort.self) {
+                try await requireCourseRole(
+                    caller: asStudent, courseID: courseID, atLeast: .instructor, db: app.db)
+            }
+
+            // Per-course instructor (a global student!): meets .instructor.
+            try await requireCourseRole(
+                caller: asInstructor, courseID: courseID, atLeast: .instructor, db: app.db)
+
+            // Admin bypasses without an enrollment.
+            try await requireCourseRole(caller: admin, courseID: courseID, atLeast: .instructor, db: app.db)
+
+            // Unenrolled non-admin is forbidden even at the student bar.
+            await #expect(throws: Abort.self) {
+                try await requireCourseRole(
+                    caller: unenrolled, courseID: courseID, atLeast: .student, db: app.db)
+            }
+
+            // requireCourseEnrollment still behaves as the `.student` case.
+            try await requireCourseEnrollment(caller: asStudent, courseID: courseID, db: app.db)
+            await #expect(throws: Abort.self) {
+                try await requireCourseEnrollment(caller: unenrolled, courseID: courseID, db: app.db)
+            }
         }
     }
 

--- a/changelog.d/course-role-auth-chokepoint.md
+++ b/changelog.d/course-role-auth-chokepoint.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Per-course role authorization chokepoint (multi-course-roles Phase 3).**
+  `CourseRole` is now ordered (`Comparable`), and `CourseAccessHelpers` gains
+  `requireCourseRole(caller:courseID:atLeast:db:)` — the role-aware
+  generalization of the existing enrollment check, which becomes its `.student`
+  case. Authorization is purely per-course (admin bypass only). **No observable
+  behavior change:** production callers use the `.student` bar, and every
+  enrolled user is at least a student. See `docs/multi-course-roles.md`.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -1,10 +1,11 @@
 # Multi-course roles & university-scale organization
 
 **Status:** Active. Theme 1 (per-course roles) is being implemented in phases;
-**Phases 1–2 have landed** — Core `CourseRole` + the `course_enrollments.role`
-column + the behaviour-preserving backfill (Phase 1), and the read-path wiring
-that carries the per-course role into the nav (Phase 2). Companion to the
-earlier fix that scoped the home dashboard and the "Instructor" nav tab to
+**Phases 1–3 have landed** — Core `CourseRole` + the `course_enrollments.role`
+column + the behaviour-preserving backfill (Phase 1), the read-path wiring that
+carries the per-course role into the nav (Phase 2), and the role-aware
+authorization chokepoint `requireCourseRole(atLeast:)` (Phase 3). Companion to
+the earlier fix that scoped the home dashboard and the "Instructor" nav tab to
 course enrollment (PR #972) — that fix was the first concrete step toward the
 model described here.
 
@@ -127,24 +128,27 @@ representable and creatable.
   Switching the course tab then switches the same account between instructor
   and student views — the desired UX for a TA-who-is-also-a-student.
 
-### 3.4 Auth path (permissions)
+### 3.4 Auth path (permissions) — **chokepoint implemented**
 
-- `CourseAccessHelpers` is the chokepoint: add
-  `requireCourseRole(caller:courseID:atLeast: CourseRole, db:)` alongside the
-  existing `requireCourseEnrollment` (which becomes the `atLeast: .student`
-  case). Admin bypass stays.
-- Authoring endpoints (test-setup CRUD, assignment CRUD, suite editor, MCP
-  content tools) switch from "enrolled" to `atLeast: .instructor`. Submit /
-  view endpoints stay at "enrolled" (`atLeast: .student`).
-- `RoleMiddleware(.instructor)` on the `/instructor` group
-  (`routes.swift`) can no longer be the *fine-grained* check, because the
-  middleware doesn't know the target course. It becomes a **coarse gate**
-  ("is the caller an instructor in *some* course, or admin?" — enough to enter
-  the section), with the authoritative per-course check moving into the
-  handlers, which already resolve the course. (Most instructor handlers
-  already call `requireCourseEnrollment`; this is a one-line swap there.)
-- MCP: `ToolContext.authorizeCourseAccess` becomes role-aware (content tools
-  require instructor-in-course), preserving agent scope ⊆ human scope.
+- `CourseAccessHelpers` is the chokepoint: `requireCourseRole(caller:courseID:
+  atLeast: CourseRole, db:)` is in, and `requireCourseEnrollment` is now its
+  `.student` case (a one-call delegation, so every existing caller is
+  unchanged). Authority is **purely per-course** — admin bypass only, no global
+  instructor bypass — and `CourseRole` is `Comparable`, so `role >= .instructor`
+  reads naturally. `courseRole(of:inCourse:db:)` is the single role read behind
+  it. **(Done.)**
+- *Deferred to Phase 4* (the tightening): an audit showed the web authoring
+  surfaces are gated by `RoleMiddleware(.instructor)` — a **global**-role group
+  guard in `routes.swift` — not by a per-course `requireCourseEnrollment`, which
+  is used on the student/content endpoints. So flipping authoring to
+  `atLeast: .instructor`, relaxing `RoleMiddleware` to a coarse "instructor in
+  *some* course, or admin" gate, and making `ToolContext.authorizeCourseAccess`
+  role-aware are sequenced with Phase 4, when per-course instructor enrollments
+  become *authorable* — that is when these checks first change a real outcome
+  (a global student authoring in a course they instruct) and become testable
+  end-to-end. Until then `requireCourseRole(atLeast: .instructor)` is exercised
+  only by unit tests.
+- Submit / view endpoints stay at "enrolled" (`atLeast: .student`).
 
 ### 3.5 UI touchpoints
 
@@ -165,8 +169,11 @@ representable and creatable.
 2. **Read path. ✓ Done.** `CourseContext.role`, nav keyed off
    `isInstructorInActiveCourse`. Still identical behavior (the role mirrors the
    global role, plus a transitional global-role fallback in the nav predicate).
-3. **Auth path.** Helper + handler/middleware switch to role checks. Still
-   identical (same reason).
+3. **Auth path. ✓ Done (chokepoint).** `requireCourseRole(atLeast:)` +
+   `CourseRole` ordering; `requireCourseEnrollment` is its `.student` case.
+   Behaviour-neutral (only `.student` is called in production). Flipping
+   authoring handlers / `RoleMiddleware` / MCP to `.instructor` is folded into
+   Phase 4 — see §3.4.
 4. **Authoring UI.** Per-course role on enroll/roster. **This is where
    "instructor here, student there" goes live.**
 5. **Shrink the global role.** Collapse `APIUser.role` to `admin`-only (per


### PR DESCRIPTION
## What

Phase 3 of the per-course roles work (`docs/multi-course-roles.md`), following #993 (Phases 1–2). Introduces the **role-aware authorization chokepoint** — the mechanism later phases tighten onto. **Behaviour-neutral.**

## Changes

- **Core:** `CourseRole` is now `Comparable` (ranked, with a gap left for a future `ta` rung), so `role >= .instructor` reads naturally.
- **`CourseAccessHelpers`:** new `requireCourseRole(caller:courseID:atLeast:db:)` — admin-bypass only, **purely per-course** (no global-instructor bypass). `requireCourseEnrollment` is now its `.student` case (a one-call delegation, so all 14 existing callers are unchanged). `courseRole(of:inCourse:db:)` is the single role read behind it.

## Why it's behaviour-neutral

The only production callers pass `.student` (via `requireCourseEnrollment`), and every enrolled user is at least a student — so authorization outcomes are identical to the prior enrollment check. `requireCourseRole(atLeast: .instructor)` is exercised only by tests for now.

## Audit finding → Phase 4 sequencing

An audit showed the **web authoring surfaces are gated by `RoleMiddleware(.instructor)`** — a *global*-role group guard in `routes.swift` — not by a per-course `requireCourseEnrollment` (which is used on the student/content endpoints). So the *tightening* the doc originally lumped into Phase 3 — flipping authoring to `atLeast: .instructor`, relaxing `RoleMiddleware` to a coarse "instructor in some course, or admin" gate, and making `ToolContext.authorizeCourseAccess` role-aware — is sequenced with **Phase 4**, when per-course instructor enrollments become *authorable* and those checks first change a real outcome (and are testable end-to-end). The doc's §3.4 / §3.6 are updated to reflect this.

## Tests

- `CourseRole` ordering (`student < instructor`, `>=` self).
- `requireCourseRole` enforces the **per-course** role: a global *student* enrolled as a per-course `.instructor` passes the `.instructor` bar; a per-course student fails it; an admin bypasses without enrollment; an unenrolled non-admin is forbidden even at `.student`. `requireCourseEnrollment` still behaves as the `.student` case.

Local: clean build (sources + tests), role suite (9 tests), `swift-format` / `lint.sh`, SwiftLint `--strict` (0 violations), `no-new-xctest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK)_