### PR TITLE
Per-course roles: seed role on new enrollments (multi-course-roles Phase 4a)

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -99,3 +99,29 @@ func enrolledCoursesWithRoles(
         .sorted { $0.course.code < $1.course.code }
         .map { (course: $0.course, role: $0.role) }
 }
+
+// MARK: - Enrollment creation (role seeding)
+
+/// Creates and saves a new enrollment for `user` in `courseID`, seeding the
+/// per-course role from the user's current global role: a global instructor or
+/// admin becomes a per-course instructor, everyone else a student. The single
+/// place the creation-time seeding rule lives (Phase 4a of
+/// docs/multi-course-roles.md), so moving authorization onto the per-course
+/// role later doesn't drop anyone's existing access — the roster can override
+/// afterward. Callers handle their own "already enrolled?" dedup.
+func saveSeededEnrollment(for user: APIUser, courseID: UUID, on db: Database) async throws {
+    try await APICourseEnrollment(
+        userID: try user.requireID(), courseID: courseID,
+        role: user.isInstructor ? .instructor : .student
+    ).save(on: db)
+}
+
+/// `saveSeededEnrollment` for callers that hold only the user's ID; loads the
+/// user to read its global role. A missing user falls back to `.student`.
+func saveSeededEnrollment(userID: UUID, courseID: UUID, on db: Database) async throws {
+    let isInstructor = try await APIUser.find(userID, on: db)?.isInstructor ?? false
+    try await APICourseEnrollment(
+        userID: userID, courseID: courseID,
+        role: isInstructor ? .instructor : .student
+    ).save(on: db)
+}

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -264,8 +264,7 @@ extension Request {
             guard let courseID = course.id else { continue }
             let alreadyEnrolled = enrolledContexts.contains { $0.id == courseID.uuidString }
             if !alreadyEnrolled {
-                let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
-                try? await enrollment.save(on: db)
+                try? await saveSeededEnrollment(for: user, courseID: courseID, on: db)
                 didEnroll = true
             }
         }

--- a/Sources/APIServer/Routes/Web/AccountRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AccountRoutes.swift
@@ -98,8 +98,7 @@ struct AccountRoutes: RouteCollection {
             .count()
 
         if existing == 0 {
-            let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
-            try await enrollment.save(on: req.db)
+            try await saveSeededEnrollment(userID: userID, courseID: courseID, on: req.db)
         }
 
         return req.redirect(to: "/account")

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -534,8 +534,7 @@ extension AdminRoutes {
             .count()
 
         if existing == 0 {
-            let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
-            try await enrollment.save(on: req.db)
+            try await saveSeededEnrollment(userID: userID, courseID: courseID, on: req.db)
         }
 
         return req.redirect(to: "/admin/users/\(idString)")

--- a/Sources/APIServer/Routes/Web/AdminRoutes+MCP.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+MCP.swift
@@ -201,7 +201,7 @@ extension AdminRoutes {
             .filter(\.$course.$id == courseID)
             .count() > 0
         if !already {
-            try await APICourseEnrollment(userID: userID, courseID: courseID).save(on: req.db)
+            try await saveSeededEnrollment(userID: userID, courseID: courseID, on: req.db)
             await AuditLogger.record(
                 action: .mcpAccountEnrolled, targetType: .user, targetID: user.id?.uuidString,
                 metadata: ["username": user.username, "course": course.code], on: req)

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -439,8 +439,7 @@ func postLoginRedirect(for user: APIUser, req: Request) async throws -> Response
             .filter(\.$course.$id == courseID)
             .count()
         if existing == 0 {
-            let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
-            try await enrollment.save(on: req.db)
+            try await saveSeededEnrollment(userID: userID, courseID: courseID, on: req.db)
         }
     }
 

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
@@ -343,8 +343,7 @@ private func importBundledEnrollments(
             .filter(\.$course.$id == courseID)
             .first()
         if alreadyEnrolled == nil {
-            let enrollment = APICourseEnrollment(userID: uid, courseID: courseID)
-            try await enrollment.save(on: db)
+            try await saveSeededEnrollment(userID: uid, courseID: courseID, on: db)
         }
     }
 }

--- a/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
+++ b/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
@@ -212,8 +212,7 @@ func enrollUsernamesInCourse(
             if alreadyEnrolledUserIDs.contains(userID) {
                 alreadyEnrolledCount += 1
             } else {
-                let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
-                try await enrollment.save(on: db)
+                try await saveSeededEnrollment(for: user, courseID: courseID, on: db)
                 enrolledCount += 1
             }
             continue
@@ -272,9 +271,8 @@ func resolvePendingPreEnrollments(
         for row in pending {
             let courseID = row.$course.id
             if !existingCourseIDs.contains(courseID) {
-                let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
                 do {
-                    try await enrollment.save(on: db)
+                    try await saveSeededEnrollment(for: user, courseID: courseID, on: db)
                 } catch {
                     logger.warning("Pre-enrollment resolve: failed to enroll \(username) in \(courseID): \(error)")
                     continue

--- a/Sources/APIServer/Routes/Web/EnrollmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/EnrollmentRoutes.swift
@@ -86,8 +86,7 @@ struct EnrollmentRoutes: RouteCollection {
                 .filter(\.$course.$id == courseID)
                 .count()
             if existing == 0 {
-                let enrollment = APICourseEnrollment(userID: userID, courseID: courseID)
-                try await enrollment.save(on: req.db)
+                try await saveSeededEnrollment(userID: userID, courseID: courseID, on: req.db)
             }
         }
 

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -7,6 +7,8 @@
 //     `isInstructorInActiveCourse`.
 //   Phase 3 — the auth chokepoint: `CourseRole` ordering and
 //     `requireCourseRole(atLeast:)`.
+//   Phase 4a — `saveSeededEnrollment`: new enrollments seed their role from the
+//     user's global role.
 
 import Core
 import Fluent
@@ -239,6 +241,35 @@ import Vapor
             await #expect(throws: Abort.self) {
                 try await requireCourseEnrollment(caller: unenrolled, courseID: courseID, db: app.db)
             }
+        }
+    }
+
+    // MARK: - Enrollment seeding (Phase 4a)
+
+    /// New enrollments seed their per-course role from the user's global role,
+    /// so moving authorization onto the per-course role doesn't drop anyone's
+    /// access. Exercises both the `for:` overload and the userID overload.
+    @Test func saveSeededEnrollmentSeedsRoleFromGlobalRole() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let course = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            let instructor = makeUser(role: .instructor)
+            let admin = makeUser(role: .admin)
+            let student = makeUser(role: .student)
+            for user in [instructor, admin, student] { try await user.save(on: app.db) }
+
+            try await saveSeededEnrollment(for: instructor, courseID: courseID, on: app.db)
+            try await saveSeededEnrollment(userID: try admin.requireID(), courseID: courseID, on: app.db)
+            try await saveSeededEnrollment(userID: try student.requireID(), courseID: courseID, on: app.db)
+
+            #expect(try await courseRole(of: instructor, on: app.db) == .instructor)
+            #expect(try await courseRole(of: admin, on: app.db) == .instructor, "admin implies instructor")
+            #expect(try await courseRole(of: student, on: app.db) == .student)
         }
     }
 

--- a/changelog.d/course-role-enrollment-seeding.md
+++ b/changelog.d/course-role-enrollment-seeding.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Per-course role seeding for new enrollments (multi-course-roles Phase 4a).**
+  Every enrollment-creation path now seeds the new enrollment's per-course role
+  from the user's current global role (a global instructor/admin becomes a
+  per-course instructor, everyone else a student) via a single
+  `saveSeededEnrollment` helper. **No observable behavior change** — the
+  per-course role still mirrors the global role; this keeps it accurate for new
+  enrollments so a later phase can move authorization onto the per-course role
+  without dropping anyone's access. See `docs/multi-course-roles.md`.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -4,10 +4,14 @@
 **Phases 1–3 have landed** — Core `CourseRole` + the `course_enrollments.role`
 column + the behaviour-preserving backfill (Phase 1), the read-path wiring that
 carries the per-course role into the nav (Phase 2), and the role-aware
-authorization chokepoint `requireCourseRole(atLeast:)` (Phase 3). Companion to
-the earlier fix that scoped the home dashboard and the "Instructor" nav tab to
-course enrollment (PR #972) — that fix was the first concrete step toward the
-model described here.
+authorization chokepoint `requireCourseRole(atLeast:)` (Phase 3). Phase 4 is
+split: **4a** seeds each new enrollment's role from the user's global role (so
+no current instructor loses access when authorization moves onto the per-course
+role); **4b** (held for review) adds the editable roster role control and flips
+authoring authorization onto the per-course role. Companion to the earlier fix
+that scoped the home dashboard and the "Instructor" nav tab to course
+enrollment (PR #972) — that fix was the first concrete step toward the model
+described here.
 
 The owner's design decisions are recorded in [§6](#6-decisions) and are
 settled; they shape Phases 4–5 (the behaviour-changing ones). Theme 2
@@ -174,8 +178,16 @@ representable and creatable.
    Behaviour-neutral (only `.student` is called in production). Flipping
    authoring handlers / `RoleMiddleware` / MCP to `.instructor` is folded into
    Phase 4 — see §3.4.
-4. **Authoring UI.** Per-course role on enroll/roster. **This is where
-   "instructor here, student there" goes live.**
+4. **Authoring UI (split).**
+   - **4a. ✓ Done.** Enrollment creation seeds each new enrollment's role from
+     the user's global role (`saveSeededEnrollment`), so the per-course role
+     stays accurate and nobody loses access when 4b flips authorization.
+   - **4b (held for review).** The editable roster role control **plus** the
+     access-control flip (relax `RoleMiddleware(.instructor)` to a coarse gate,
+     authoring handlers → `atLeast: .instructor`, MCP role-aware) — shipped
+     together so promoting a student to per-course instructor works end-to-end
+     with no broken interim. **This is where "instructor here, student there"
+     goes live.**
 5. **Shrink the global role.** Collapse `APIUser.role` to `admin`-only (per
    [§6](#6-decisions) the global `instructor` goes away entirely). Revisit SSO
    role mapping here — per [§6](#6-decisions) `SSO_INSTRUCTOR_USERS` keeps its


### PR DESCRIPTION
## What

Phase 4a of the per-course roles work (`docs/multi-course-roles.md`), following #994 (Phase 3). The **additive, behaviour-neutral** half of Phase 4: seed each new enrollment's per-course role from the user's global role. Nothing observable changes — this keeps the per-course role accurate for new enrollments so the **4b** access-control flip (held for your review) doesn't drop anyone's authoring access.

## Why split (4a here, 4b for review)

You chose *roster dropdown* + *split: additive now, auth flip for review*. There's a hard coupling: an **editable** role dropdown and the `RoleMiddleware(.instructor)` relaxation are inseparable — promoting a global `student` to per-course instructor only *works* once that gate is relaxed (otherwise they get an "Instructor" tab that 403s). So:

- **4a (this PR, autonomous):** role **seeding** at enrollment creation. Safe/additive.
- **4b (separate PR, held for your review):** the **editable** roster dropdown shipped *with* the gate relaxation + authoring/MCP auth flip, so it works end-to-end with no broken interim.

(The roster already shows a "Role" column; it reads the global role today, which equals the per-course role — so it stays accurate. 4b switches it to the per-course role alongside the editable control.)

## Changes

- **`CourseAccessHelpers`:** `saveSeededEnrollment(for:courseID:on:)` and a `(userID:courseID:on:)` overload — seed the per-course role from the user's global role (instructor/admin → `.instructor`, else `.student`). The single place the creation-time seeding rule lives.
- Routed **all nine** enrollment-creation sites through it: self-enroll, account enroll, login auto-enroll, `.auto` auto-enroll, CSV bulk, pre-enrollment resolve, admin enroll, bundle import, MCP-account enroll.

## Tests

- `saveSeededEnrollment` seeds instructor/admin → `.instructor` and student → `.student` (both overloads).
- Full enrollment/auth/bundle suites green (auto-enroll, bundle import, self-enroll all exercise the seeded path): 86 tests across 6 suites.

Local: clean build, `swift-format` / `lint.sh`, SwiftLint `--strict` (0 violations), `no-new-xctest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK)_