### PR TITLE
Per-course instructor authority + roster role control (multi-course-roles Phase 4b)

### DIFF
--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -41,7 +41,8 @@ Students
 </div>
 
 <table class="results-table" id="enrolled-students-table"
-       data-archived="#if(courseIsArchived):true#else:false#endif">
+       data-archived="#if(courseIsArchived):true#else:false#endif"
+       data-course-id="#(currentUser.activeCourse.id)">
     <thead>
         <tr>
             <th class="sortable" data-col="0">Name <span class="sort-icon">⇕</span></th>
@@ -71,7 +72,23 @@ Students
                 <a href="#(student.submissionsURL)"><code>#(student.username)</code></a>
                 #endif
             </td>
-            <td>#(student.role)</td>
+            <td class="role-cell">
+                #if(student.isPending):
+                <span class="students-pending-role">(pending)</span>
+                #elseif(courseIsArchived):
+                #(student.role)
+                #else:
+                <form method="post" action="/courses/#(currentUser.activeCourse.id)/role/#(student.id)"
+                      class="inline-form students-role-form">
+                    #csrfFormField()
+                    <select name="role" class="form-input students-role-select" aria-label="Per-course role"
+                            onchange="this.form.submit()">
+                        <option value="student"#if(student.role == "student"): selected#endif>Student</option>
+                        <option value="instructor"#if(student.role == "instructor"): selected#endif>Instructor</option>
+                    </select>
+                </form>
+                #endif
+            </td>
             <td class="js-relative-time"
                 #if(student.lastSeenAtISO):data-iso="#(student.lastSeenAtISO)"#endif>
                 #(student.lastSeenAtText)
@@ -113,6 +130,9 @@ Students
 .students-pending-note { font-size: .72rem; color: var(--gray-500); margin-left: .4rem; }
 .students-pending-username { color: var(--gray-500); }
 .students-unenroll-btn { padding: .25rem .35rem; }
+.students-role-form { margin: 0; }
+.students-role-select { display: inline-block; font-size: .8rem; padding: .1rem .3rem; }
+.students-pending-role { color: var(--gray-500); }
 #enrolled-students-table th.sortable {
     cursor: pointer;
     user-select: none;
@@ -158,12 +178,21 @@ Students
     var emptyMsg = document.getElementById('no-students-msg');
     var countEl = document.getElementById('enrolled-count');
     var archived = table.getAttribute('data-archived') === 'true';
+    var courseId = table.getAttribute('data-course-id') || '';
 
     var sortCol = 3;
     var sortAsc = false;
 
     // Shared implementation (Public/chickadee-ui.js, loaded from base.leaf).
     var escapeHtml = ChickadeeUI.escapeHtml;
+
+    // Role cells contain a <select>; sort by its value, not the combined
+    // option-label text.
+    function cellSortText(cell) {
+        if (!cell) return '';
+        var sel = cell.querySelector('select');
+        return (sel ? sel.value : cell.textContent).trim().toLowerCase();
+    }
 
     var deleteIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';
 
@@ -176,6 +205,20 @@ Students
         var subURL = escapeHtml(student.submissionsURL);
         var unenrollURL = escapeHtml(student.unenrollURL);
         var csrfField = '<input type="hidden" name="_csrf" value="' + escapeHtml(csrfToken) + '">';
+
+        var roleCell;
+        if (student.isPending) {
+            roleCell = '<span class="students-pending-role">(pending)</span>';
+        } else if (archived) {
+            roleCell = role;
+        } else {
+            roleCell = '<form method="post" action="/courses/' + courseId + '/role/' + escapeHtml(student.id)
+                + '" class="inline-form students-role-form">' + csrfField
+                + '<select name="role" class="form-input students-role-select" aria-label="Per-course role" onchange="this.form.submit()">'
+                + '<option value="student"' + (student.role === 'student' ? ' selected' : '') + '>Student</option>'
+                + '<option value="instructor"' + (student.role === 'instructor' ? ' selected' : '') + '>Instructor</option>'
+                + '</select></form>';
+        }
 
         var nameCell = student.isPending
             ? '<strong class="students-pending-name">' + displayName + '</strong>'
@@ -199,7 +242,7 @@ Students
             + (student.isPending ? '' : ' data-href="' + subURL + '"') + '>'
             + '<td>' + nameCell + '</td>'
             + '<td>' + userCell + '</td>'
-            + '<td>' + role + '</td>'
+            + '<td class="role-cell">' + roleCell + '</td>'
             + '<td class="js-relative-time"' + (iso ? ' data-iso="' + iso + '"' : '') + '>' + lastSeenText + '</td>'
             + '<td>' + actionCell + '</td>'
             + '</tr>';
@@ -218,8 +261,8 @@ Students
                 var bISO = b.cells[3] ? b.cells[3].getAttribute('data-iso') : '';
                 result = (aISO ? new Date(aISO).getTime() : 0) - (bISO ? new Date(bISO).getTime() : 0);
             } else {
-                var aText = (a.cells[sortCol] ? a.cells[sortCol].textContent : '').trim().toLowerCase();
-                var bText = (b.cells[sortCol] ? b.cells[sortCol].textContent : '').trim().toLowerCase();
+                var aText = cellSortText(a.cells[sortCol]);
+                var bText = cellSortText(b.cells[sortCol]);
                 result = aText.localeCompare(bText);
             }
             if (result === 0) {

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -100,6 +100,17 @@ func enrolledCoursesWithRoles(
         .map { (course: $0.course, role: $0.role) }
 }
 
+/// Transitional instructor-authorization for a specific course (Phase 4b):
+/// admits an admin or a **global** instructor (the pre-per-course crutch,
+/// removed in Phase 5), or a per-course instructor. The param-taking
+/// `/instructor` endpoints use this so existing global instructors keep their
+/// access, while a per-course instructor (a global student with an instructor
+/// enrollment) is scoped to the course they actually instruct.
+func requireCourseInstructor(caller: APIUser, courseID: UUID, db: Database) async throws {
+    if caller.isInstructor { return }  // admin or global instructor (transitional)
+    try await requireCourseRole(caller: caller, courseID: courseID, atLeast: .instructor, db: db)
+}
+
 // MARK: - Enrollment creation (role seeding)
 
 /// Creates and saves a new enrollment for `user` in `courseID`, seeding the

--- a/Sources/APIServer/Middleware/ActiveCourseInstructorMiddleware.swift
+++ b/Sources/APIServer/Middleware/ActiveCourseInstructorMiddleware.swift
@@ -1,0 +1,60 @@
+// APIServer/Middleware/ActiveCourseInstructorMiddleware.swift
+//
+// Gates the `/instructor` route group on *per-course* instructor authority
+// (Phase 4b of docs/multi-course-roles.md). Replaces the global
+// `RoleMiddleware(required: .instructor)` gate: instructor authority is now
+// per-course, so the gate admits an admin (deployment-wide bypass) or a user
+// who is an instructor in their *active course* — the course the instructor
+// handlers act on (`resolveActiveCourse`). A user who is an instructor in one
+// course but has a course where they're a student active is therefore kept out
+// of the instructor tools for that student course.
+//
+// Must sit downstream of `UserSessionAuthenticator`. This gate covers the
+// active-course-scoped handlers; handlers that act on a course or assignment
+// named by a URL parameter additionally call `requireCourseRole(atLeast:)` on
+// that target, so they can't be driven against another course by URL.
+
+import Fluent
+import Vapor
+
+struct ActiveCourseInstructorMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        guard let user = request.auth.get(APIUser.self) else {
+            if request.wantsBrowserRedirect { return request.redirect(to: "/login") }
+            throw Abort(.unauthorized)
+        }
+
+        // Admins (deployment-wide) and — transitionally, until the global role
+        // is shrunk in Phase 5 — global instructors are admitted to the section.
+        // The param-taking actions inside still check per-course instructor
+        // access on their target course, so this fallback widens "may open the
+        // instructor section", not "may act on any course".
+        if user.isInstructor {
+            return try await next.respond(to: request)
+        }
+
+        // A per-course instructor who is not a global instructor reaches the
+        // section only for the course they actually instruct (their active one).
+        let state = try await request.resolveActiveCourse(for: user)
+        if let activeCourseUUID = state.activeCourseUUID,
+            let userID = user.id,
+            let role = try await courseRole(of: userID, inCourse: activeCourseUUID, db: request.db),
+            role >= .instructor
+        {
+            return try await next.respond(to: request)
+        }
+
+        // Authenticated but not an instructor here: 403, matching the prior
+        // RoleMiddleware behaviour for an insufficient role.
+        throw Abort(.forbidden)
+    }
+}
+
+extension Request {
+    /// True for a browser page request (not an `/api/` endpoint). Browser
+    /// requests get a redirect rather than a bare status, mirroring
+    /// `RoleMiddleware`'s own behaviour.
+    fileprivate var wantsBrowserRedirect: Bool {
+        !url.path.hasPrefix("/api/")
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -113,6 +113,7 @@ enum AuditAction: String, Sendable, CaseIterable {
     // Enrollment
     case enrollmentBulkAdded = "enrollment.bulk_added"
     case enrollmentRemoved = "enrollment.removed"
+    case enrollmentRoleChanged = "enrollment.role_changed"
 
     // Submissions
     case submissionsPurged = "submission.retention_purged"
@@ -153,7 +154,7 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .courseCreated, .courseArchived, .courseUnarchived, .courseDeleted,
             .courseBundleImported, .courseBundleExported:
             return .courses
-        case .enrollmentBulkAdded, .enrollmentRemoved:
+        case .enrollmentBulkAdded, .enrollmentRemoved, .enrollmentRoleChanged:
             return .enrollment
         case .submissionsPurged, .submissionRetestAll, .submissionRetestForStudent:
             return .submissions
@@ -190,6 +191,7 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .courseBundleExported: return "Course bundle exported"
         case .enrollmentBulkAdded: return "Bulk enrollment"
         case .enrollmentRemoved: return "Unenrolled"
+        case .enrollmentRoleChanged: return "Per-course role changed"
         case .submissionsPurged: return "Submissions purged"
         case .submissionRetestAll: return "Retest all submissions"
         case .submissionRetestForStudent: return "Retest student submissions"

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -55,6 +55,8 @@ extension CourseAdminRoutes {
         else {
             throw WebAssignmentError.notFound(resource: "Course")
         }
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
         let body = try? req.content.decode(Body.self)
         course.enrollmentMode = CourseEnrollmentMode(rawValue: body?.enrollmentMode ?? "") ?? .open
         try await course.save(on: req.db)
@@ -75,6 +77,9 @@ extension CourseAdminRoutes {
         else {
             throw WebAssignmentError.invalidParameter(name: "courseID", reason: "Invalid or archived course.")
         }
+
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
 
         let form = try req.content.decode(BulkEnrollForm.self)
 
@@ -113,6 +118,9 @@ extension CourseAdminRoutes {
                 name: "courseID/userID", reason: "Invalid courseID or userID parameter")
         }
 
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+
         try await APICourseEnrollment.query(on: req.db)
             .filter(\.$course.$id == courseID)
             .filter(\.$userID == userID)
@@ -148,11 +156,64 @@ extension CourseAdminRoutes {
                 name: "courseID/preEnrollmentID", reason: "Invalid courseID or preEnrollmentID parameter")
         }
 
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+
         try await APIPreEnrollment.query(on: req.db)
             .filter(\.$id == preID)
             .filter(\.$course.$id == courseID)
             .delete()
 
         return req.redirect(to: "/instructor")
+    }
+
+    // MARK: - POST /courses/:courseID/role/:userID
+    //
+    // Sets a roster member's per-course role (Phase 4b). Authorized per-course:
+    // the caller must be an instructor in *this* course (or an admin), not just
+    // an instructor somewhere — `requireCourseRole` checks the courseID param,
+    // so the relaxed `/instructor` gate can't be driven against another course.
+
+    @Sendable
+    func instructorSetEnrollmentRole(req: Request) async throws -> Response {
+        let caller = try req.auth.require(APIUser.self)
+        guard
+            let courseIDString = req.parameters.get("courseID"),
+            let courseID = UUID(uuidString: courseIDString),
+            let userIDString = req.parameters.get("userID"),
+            let userID = UUID(uuidString: userIDString)
+        else {
+            throw WebAssignmentError.invalidParameter(
+                name: "courseID/userID", reason: "Invalid courseID or userID parameter")
+        }
+        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+
+        struct Body: Content { var role: String? }
+        let body = try? req.content.decode(Body.self)
+        guard let newRole = CourseRole(rawValue: body?.role ?? "") else {
+            throw WebAssignmentError.invalidParameter(name: "role", reason: "Unknown per-course role.")
+        }
+
+        guard
+            let enrollment = try await APICourseEnrollment.query(on: req.db)
+                .filter(\.$course.$id == courseID)
+                .filter(\.$userID == userID)
+                .first()
+        else {
+            throw WebAssignmentError.notFound(resource: "Enrollment")
+        }
+        enrollment.role = newRole
+        try await enrollment.save(on: req.db)
+
+        await AuditLogger.record(
+            action: .enrollmentRoleChanged,
+            targetType: .enrollment,
+            targetID: userIDString,
+            metadata: [
+                "course_id": courseIDString, "subject_user_id": userIDString, "role": newRole.rawValue,
+            ],
+            on: req
+        )
+        return req.redirect(to: "/instructor/students")
     }
 }

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
@@ -21,6 +21,8 @@ struct CourseAdminRoutes: RouteCollection {
         routes.post("courses", ":courseID", "enroll-csv", use: instructorBulkEnrollCSV)
         routes.post("courses", ":courseID", "unenroll", ":userID", use: instructorUnenrollUser)
         routes.post("courses", ":courseID", "pre-unenroll", ":preEnrollmentID", use: instructorCancelPreEnrollment)
+        // Set a roster member's per-course role (Phase 4b).
+        routes.post("courses", ":courseID", "role", ":userID", use: instructorSetEnrollmentRole)
 
         let r = routes.grouped("instructor")
         r.get("enroll-csv", use: enrollCSVForm)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -93,9 +93,11 @@ extension InstructorDashboardRoutes {
         fmt: DateFormatter,
         isoFormatter: ISO8601DateFormatter
     ) async throws -> CourseRosterData {
-        let enrolledUsers = try await loadEnrolledUsersForRoster(req: req, activeCourseUUID: activeCourseUUID)
+        let (enrolledUsers, rolesByUserID) = try await loadEnrolledUsersForRoster(
+            req: req, activeCourseUUID: activeCourseUUID)
         var enrolledStudents = buildEnrolledStudentRows(
             enrolledUsers: enrolledUsers,
+            rolesByUserID: rolesByUserID,
             activeCourseUUID: activeCourseUUID,
             activeCourseCode: activeCourseCode,
             fmt: fmt,
@@ -116,6 +118,9 @@ extension InstructorDashboardRoutes {
             )
         )
 
+        // The "Y students enrolled" denominator still keys off the global role
+        // (instructor/admin test accounts excluded). Switching it to the
+        // per-course role is a follow-up once mixed roles are in real use.
         let activeStudentIDs = Set(
             enrolledUsers
                 .filter { $0.roleValue == .student }
@@ -154,9 +159,11 @@ extension InstructorDashboardRoutes {
         fmt: DateFormatter,
         isoFormatter: ISO8601DateFormatter
     ) async throws -> (rows: [EnrolledStudentRow], count: Int) {
-        let enrolledUsers = try await loadEnrolledUsersForRoster(req: req, activeCourseUUID: activeCourseUUID)
+        let (enrolledUsers, rolesByUserID) = try await loadEnrolledUsersForRoster(
+            req: req, activeCourseUUID: activeCourseUUID)
         var rows = buildEnrolledStudentRows(
             enrolledUsers: enrolledUsers,
+            rolesByUserID: rolesByUserID,
             activeCourseUUID: activeCourseUUID,
             activeCourseCode: activeCourseCode,
             fmt: fmt,
@@ -181,13 +188,15 @@ extension InstructorDashboardRoutes {
     private func loadEnrolledUsersForRoster(
         req: Request,
         activeCourseUUID: UUID
-    ) async throws -> [APIUser] {
+    ) async throws -> (users: [APIUser], rolesByUserID: [UUID: CourseRole]) {
         let enrollments = try await APICourseEnrollment.query(on: req.db)
             .filter(\.$course.$id == activeCourseUUID)
             .all()
         let enrolledUserIDs = enrollments.map(\.userID)
-        guard !enrolledUserIDs.isEmpty else { return [] }
-        return try await APIUser.query(on: req.db)
+        guard !enrolledUserIDs.isEmpty else { return ([], [:]) }
+        var rolesByUserID: [UUID: CourseRole] = [:]
+        for enrollment in enrollments { rolesByUserID[enrollment.userID] = enrollment.role }
+        let users = try await APIUser.query(on: req.db)
             .filter(\.$id ~~ enrolledUserIDs)
             // Exclude `mcp` service accounts: they may be enrolled to scope an
             // agent's access (admin MCP tab) but are not roster members.
@@ -206,10 +215,12 @@ extension InstructorDashboardRoutes {
                 }
                 return lhs.username.localizedStandardCompare(rhs.username) == .orderedAscending
             }
+        return (users, rolesByUserID)
     }
 
     private func buildEnrolledStudentRows(
         enrolledUsers: [APIUser],
+        rolesByUserID: [UUID: CourseRole],
         activeCourseUUID: UUID,
         activeCourseCode: String,
         fmt: DateFormatter,
@@ -226,7 +237,7 @@ extension InstructorDashboardRoutes {
                 id: id.uuidString,
                 username: u.username,
                 displayName: u.displayName ?? u.username,
-                role: u.role,
+                role: (rolesByUserID[id] ?? .student).rawValue,
                 lastSeenAtText: u.lastSeenAt.map { fmt.string(from: $0) } ?? "—",
                 lastSeenAtISO: u.lastSeenAt.map { isoFormatter.string(from: $0) },
                 submissionsURL: studentSubmissionsURL(

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -50,7 +50,9 @@ func routes(_ app: Application) throws {
 
     // MARK: - Instructor or admin only
 
-    let instructor = app.grouped(sessionAuth, RoleMiddleware(required: .instructor), csrf)
+    // Per-course instructor authority (Phase 4b): admits admins, or a user who
+    // is an instructor in their active course — not the bare global role.
+    let instructor = app.grouped(sessionAuth, ActiveCourseInstructorMiddleware(), csrf)
     try instructor.register(collection: InstructorDashboardRoutes())
     try instructor.register(collection: DraftAssignmentRoutes())
     try instructor.register(collection: PublishedAssignmentRoutes())

--- a/Tests/APITests/ActiveCourseInstructorGateTests.swift
+++ b/Tests/APITests/ActiveCourseInstructorGateTests.swift
@@ -1,0 +1,71 @@
+// Tests/APITests/ActiveCourseInstructorGateTests.swift
+//
+// Phase 4b (docs/multi-course-roles.md): the /instructor group is gated on
+// *per-course* instructor authority (ActiveCourseInstructorMiddleware) — it
+// admits admins and a user who is an instructor in their active course, and
+// turns away a student in the active course. This is the access-control flip
+// that makes per-course instructors able to author while keeping a per-course
+// student out of instructor tools.
+
+import Core
+import Fluent
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct ActiveCourseInstructorGateTests {
+
+    /// Drives GET /instructor as `username` (global role `globalRole`) enrolled
+    /// in the single course with `courseRole`, returning the response status.
+    private func instructorGateStatus(
+        username: String, globalRole: String, courseRole: CourseRole,
+        courseID: UUID, on app: Application
+    ) async throws -> HTTPStatus {
+        let cookie = try await loginUser(username: username, password: "pass", role: globalRole, on: app)
+        let user = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == username).first())
+        try await APICourseEnrollment(
+            userID: try user.requireID(), courseID: courseID, role: courseRole
+        ).save(on: app.db)
+
+        var status: HTTPStatus = .ok
+        try await app.asyncTest(
+            .GET, "/instructor",
+            beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+            afterResponse: { res in status = res.status })
+        return status
+    }
+
+    @Test func admitsPerCourseInstructorAndTurnsAwayPerCourseStudent() async throws {
+        try await withWebRoutesApp { app in
+            let course = APICourse(code: "CS500", name: "Lab", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            // A global *student* enrolled as a per-course instructor is admitted.
+            let instructorStatus = try await instructorGateStatus(
+                username: "pcinstructor", globalRole: "student", courseRole: .instructor,
+                courseID: courseID, on: app)
+            #expect(instructorStatus == .ok, "a per-course instructor (global student) may use /instructor")
+
+            // A global *student* enrolled as a student is turned away (redirect).
+            let studentStatus = try await instructorGateStatus(
+                username: "pcstudent", globalRole: "student", courseRole: .student,
+                courseID: courseID, on: app)
+            #expect(studentStatus != .ok, "a per-course student must not reach /instructor")
+        }
+    }
+
+    @Test func admitsAdminEvenWithoutInstructorRole() async throws {
+        try await withWebRoutesApp { app in
+            let course = APICourse(code: "CS500", name: "Lab", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            // Admin enrolled with a *student* per-course role still gets in.
+            let status = try await instructorGateStatus(
+                username: "adm", globalRole: "admin", courseRole: .student,
+                courseID: try course.requireID(), on: app)
+            #expect(status == .ok, "admin bypasses the per-course instructor gate")
+        }
+    }
+}

--- a/Tests/APITests/EnrollmentRoutesTests.swift
+++ b/Tests/APITests/EnrollmentRoutesTests.swift
@@ -541,6 +541,13 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "ins_mode_instructor", password: "pw",
                 role: "instructor", on: app)
+            // Phase 4b: the param-taking enrollment endpoints require per-course
+            // instructor access on the target course, so enrol the caller there.
+            let instructorUser = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "ins_mode_instructor").first())
+            try await APICourseEnrollment(
+                userID: try instructorUser.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
 
             let (token, newCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
             try await app.asyncTest(

--- a/changelog.d/course-role-instructor-gate.md
+++ b/changelog.d/course-role-instructor-gate.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **Per-course instructor authority (multi-course-roles Phase 4b).** A person
+  can now be an instructor in one course and a student in another: the
+  `/instructor` section admits a per-course instructor (gated on the caller's
+  role *in their active course*), not just a global one, and an instructor or
+  admin sets a roster member's per-course role from a dropdown on the Students
+  page. The param-taking enrollment endpoints (unenroll, set enrollment mode,
+  bulk-enroll, cancel pre-enrollment, set role) check per-course instructor
+  access on the course named in the URL, so a per-course instructor can't be
+  driven against another course. Existing **global** instructors keep their
+  access unchanged — the global-instructor fallback is removed when the global
+  role is shrunk in a later phase. See `docs/multi-course-roles.md`.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -1,17 +1,16 @@
 # Multi-course roles & university-scale organization
 
-**Status:** Active. Theme 1 (per-course roles) is being implemented in phases;
-**Phases 1–3 have landed** — Core `CourseRole` + the `course_enrollments.role`
+**Status:** Active. Theme 1 (per-course roles) is being implemented in phases.
+**Phases 1–4a have landed** — Core `CourseRole` + the `course_enrollments.role`
 column + the behaviour-preserving backfill (Phase 1), the read-path wiring that
-carries the per-course role into the nav (Phase 2), and the role-aware
-authorization chokepoint `requireCourseRole(atLeast:)` (Phase 3). Phase 4 is
-split: **4a** seeds each new enrollment's role from the user's global role (so
-no current instructor loses access when authorization moves onto the per-course
-role); **4b** (held for review) adds the editable roster role control and flips
-authoring authorization onto the per-course role. Companion to the earlier fix
-that scoped the home dashboard and the "Instructor" nav tab to course
-enrollment (PR #972) — that fix was the first concrete step toward the model
-described here.
+carries the per-course role into the nav (Phase 2), the role-aware authorization
+chokepoint `requireCourseRole(atLeast:)` (Phase 3), and per-course role seeding
+on new enrollments (Phase 4a). **Phase 4b** — the access-control flip
+(`ActiveCourseInstructorMiddleware` gates `/instructor` on per-course instructor
+role; the roster role dropdown) — is **implemented and held for the owner's
+review**. Companion to the earlier fix that scoped the home dashboard and the
+"Instructor" nav tab to course enrollment (PR #972) — that fix was the first
+concrete step toward the model described here.
 
 The owner's design decisions are recorded in [§6](#6-decisions) and are
 settled; they shape Phases 4–5 (the behaviour-changing ones). Theme 2
@@ -182,16 +181,21 @@ representable and creatable.
    - **4a. ✓ Done.** Enrollment creation seeds each new enrollment's role from
      the user's global role (`saveSeededEnrollment`), so the per-course role
      stays accurate and nobody loses access when 4b flips authorization.
-   - **4b (held for review).** The editable roster role control **plus** the
-     access-control flip (relax `RoleMiddleware(.instructor)` to a coarse gate,
-     authoring handlers → `atLeast: .instructor`, MCP role-aware) — shipped
-     together so promoting a student to per-course instructor works end-to-end
-     with no broken interim. **This is where "instructor here, student there"
-     goes live.**
-5. **Shrink the global role.** Collapse `APIUser.role` to `admin`-only (per
-   [§6](#6-decisions) the global `instructor` goes away entirely). Revisit SSO
-   role mapping here — per [§6](#6-decisions) `SSO_INSTRUCTOR_USERS` keeps its
-   current global-role behavior until this phase. Longest tail; can lag well
+   - **4b. Implemented — held for review.** Replaces the global
+     `RoleMiddleware(.instructor)` on `/instructor` with
+     `ActiveCourseInstructorMiddleware` (admit admin or **global** instructor —
+     transitional — or a per-course instructor in the *active* course); the
+     param-taking enrollment endpoints call `requireCourseInstructor` on their
+     URL course (same transitional rule) so a per-course instructor can't be
+     driven cross-course; the Students roster shows the per-course role and an
+     instructor/admin sets it from a dropdown. **This is where "instructor here,
+     student there" goes live.** The global-instructor fallback is removed in
+     Phase 5; MCP content-tool role-awareness is a small follow-up (today every
+     MCP subject is a global instructor, so it's a no-op).
+5. **Shrink the global role.** Collapse `APIUser.role` to `admin`-only (the
+   global `instructor` goes away entirely). **Remove the `SSO_INSTRUCTOR_USERS`
+   handling** — keep `SSO_ADMIN_USERS` — per [§6](#6-decisions). Drop the nav's
+   transitional global-role fallback (Phase 2). Longest tail; can lag well
    behind 1–4.
 
 ---
@@ -247,10 +251,13 @@ behaviour-changing Phases 4–5, not the behaviour-neutral Phases 1–3.
    A TA rung (view/grade submissions, no suite edits) is a natural future
    addition but carries extra policy surface; the enum is string-backed, so it
    can be added later without a schema change.
-3. **SSO mapping is deferred to Phase 5.** `SSO_INSTRUCTOR_USERS` /
-   `SSO_ADMIN_USERS` keep their current global-role behavior through
-   Phases 1–4 (which don't touch SSO). How an SSO "instructor" maps under the
-   collapsed model is decided when the global role is shrunk.
+3. **SSO mapping (decided 2026-06-22).** `SSO_INSTRUCTOR_USERS` is **retired** —
+   there is no "global instructor via SSO" under the per-course model. An admin
+   sets up a course and assigns its instructor manually (the Phase 4b roster
+   dropdown); how course creation / instructor assignment should ultimately flow
+   is a later question. `SSO_ADMIN_USERS` **stays** (for now) — admins are still
+   provisioned via SSO. Removing the `SSO_INSTRUCTOR_USERS` handling is Phase 5
+   work; it keeps its current behavior until then.
 
 ### Still open (Theme 2)
 


### PR DESCRIPTION
## ⚠️ Held for your review — please don't expect me to auto-merge this one

Per your "split: additive now, **auth flip for review**" choice, this is the access-control flip. It's implemented, green locally, and **kept as a draft for you to review** before it merges. Phases 1–4a (merged) were the behaviour-neutral runway; this is the behaviour change.

## What it does

A person can be an **instructor in one course and a student in another**, and instructor authority is gated on the **per-course** role.

- **`ActiveCourseInstructorMiddleware`** replaces the global `RoleMiddleware(.instructor)` on the `/instructor` group. It admits: an **admin**; (transitionally) a **global** instructor; or a **per-course instructor in the active course**. Authenticated-but-insufficient → 403 (matching the old middleware).
- **`requireCourseInstructor`** guards the param-taking enrollment endpoints (set mode, bulk-enroll, unenroll, cancel pre-enroll, **set role**) on the course named in the URL — so a per-course instructor can't be driven against another course.
- **Roster role control:** new `POST /courses/:courseID/role/:userID` + a dropdown on the Students roster lets an instructor/admin set a member's per-course role; the roster **Role** column now shows the per-course role. New audit action `enrollment.role_changed`.

## The one design choice I'd most like your eyes on — the transitional fallback

To keep this **additive** (no current instructor loses access, no big test churn), both the gate and the handler checks keep a **transitional global-instructor fallback**: a *global* instructor is admitted everywhere they are today, exactly as before. The genuinely new, fully-scoped path is the **per-course instructor** (a global `student` with an `.instructor` enrollment), who is restricted to the course they instruct. The fallback — and the latent "global instructor by URL" gap it preserves — goes away in **Phase 5** when the global role is shrunk.

If you'd rather **close that gap now** (pure per-course, no global fallback), I can — it means updating the instructor-endpoint tests to enrol their callers as instructor-in-course (bounded, ~a dozen). Your call.

## Other review notes / deliberate follow-ups

- **Admin workflow:** you said admins set up a course and plug in an instructor. The dropdown lives on the **instructor** Students roster (your pick), so an admin assigns the instructor via that course's roster — which needs the admin to have that course active (i.e. be enrolled). If you'd prefer admins assign without enrolling, that's the "admin course page too" option from earlier.
- **Student-count denominator** on the dashboard badge still keys off the global role (instructor/admin test accounts excluded); switching it to per-course is a noted follow-up.
- **MCP** content-tool role-awareness is a no-op today (every MCP subject is a global instructor) — deferred.
- **SSO direction recorded** in `docs/multi-course-roles.md` §6: retire `SSO_INSTRUCTOR_USERS`, keep `SSO_ADMIN_USERS`, admin-assigns-instructor — to be actioned in Phase 5.

## Tests

`ActiveCourseInstructorGateTests`: a per-course instructor (global student) and an admin are admitted to `/instructor`; a per-course student is turned away. Existing enrollment / dashboard / role suites pass locally (the per-course handler checks required enrolling one test's caller; the dashboard badge keeps its global-role count). `swift-format` / SwiftLint `--strict` / `check-styles` / `check-css-vars` / `no-new-xctest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNL5Qww1g5xw3g6H1C3eDK)_