### PR TITLE
Fix nightly coverage canary: install python3, harden python3-dependent tests

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -46,8 +46,15 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          # python3: the noble base image (unlike jammy) does not bundle it, and
+          # APITests run generated pattern-family cases / seed-expression grading
+          # that shell out to `#!/usr/bin/env python3`.  swift-tests.yml installs
+          # it in every test job for the same reason; this clean-build run executes
+          # *all* targets in one process, so it must match — without it the
+          # python3-dependent tests trap (broken pipe / leaked test Application →
+          # ServeCommand deinit assertion → SIGILL) and take down the whole run.
           for i in 1 2 3; do
-            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip curl file && break
+            apt-get update -qq && apt-get install -y --no-install-recommends zip unzip curl file python3 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
             sleep 15
           done

--- a/Tests/APITests/PatternFamilyFixtures.swift
+++ b/Tests/APITests/PatternFamilyFixtures.swift
@@ -191,6 +191,16 @@ func pfGuardFilename(_ familyID: String, tier: TestTier = .pub) -> String {
 }
 
 func pfAssertValidPythonSyntax(_ source: String, label: String) throws {
+    // python3 is required to parse-check the generated source.  On a host
+    // without it, skip silently rather than trapping: `/usr/bin/env python3`
+    // launches env, env exits 127, and a non-throwing write to the now-closed
+    // stdin pipe traps (broken pipe) → SIGILL, taking down the whole test
+    // process.  CI installs python3; this guard only protects bare dev hosts.
+    let python3Paths = ["/usr/bin/python3", "/usr/local/bin/python3", "/opt/homebrew/bin/python3"]
+    guard python3Paths.contains(where: { FileManager.default.fileExists(atPath: $0) }) else {
+        return  // python3 unavailable on this platform — skip the syntax check
+    }
+
     let p = Process()
     p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
     p.arguments = ["python3", "-c", "import ast, sys; ast.parse(sys.stdin.read())"]
@@ -200,7 +210,10 @@ func pfAssertValidPythonSyntax(_ source: String, label: String) throws {
     p.standardError = stderr
     p.standardOutput = Pipe()
     try p.run()
-    stdin.fileHandleForWriting.write(Data(source.utf8))
+    // Throwing write/close (not the non-throwing `write(_:)`, whose internal
+    // `try!` traps on a broken pipe) so a failed subprocess surfaces as a
+    // thrown error instead of a SIGILL.
+    try stdin.fileHandleForWriting.write(contentsOf: Data(source.utf8))
     try stdin.fileHandleForWriting.close()
     p.waitUntilExit()
     if p.terminationStatus != 0 {

--- a/Tests/APITests/WorkerRoutesTests.swift
+++ b/Tests/APITests/WorkerRoutesTests.swift
@@ -725,11 +725,16 @@ import VaporTesting
     // the same seed feeding `_ck_inputs.py`. Requires a real seed (→ user +
     // assignment) and `python3`.
     @Test func materializeValidation_resolvesExpressionForSeed() async throws {
-        let python3Paths = ["/usr/bin/python3", "/usr/local/bin/python3", "/opt/homebrew/bin/python3"]
-        guard python3Paths.contains(where: { FileManager.default.fileExists(atPath: $0) }) else {
-            return  // python3 unavailable on this platform — skip
-        }
         try await withApp(app) { _ in
+            // Keep the python3 skip-guard *inside* withApp so the test
+            // Application is always shut down.  An early `return` before withApp
+            // leaks the app, and its deinit then trips Vapor's
+            // `ServeCommand did not shutdown before deinit` assertion → SIGILL,
+            // which kills the whole test process (see TestHelpers.swift).
+            let python3Paths = ["/usr/bin/python3", "/usr/local/bin/python3", "/opt/homebrew/bin/python3"]
+            guard python3Paths.contains(where: { FileManager.default.fileExists(atPath: $0) }) else {
+                return  // python3 unavailable on this platform — skip
+            }
             let manifest = """
                 {"schemaVersion":1,"testSuites":[{"tier":"public","script":"test.sh"}],\
                 "timeLimitSeconds":10,\

--- a/changelog.d/nightly-coverage-python3.md
+++ b/changelog.d/nightly-coverage-python3.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Nightly clean-build coverage canary restored.** `test-coverage.yml` runs
+  every target in one process but never installed `python3`, so the
+  python3-dependent APITests (generated pattern-family syntax checks,
+  seed-expression validation grading) trapped — a broken-pipe write to a
+  never-spawned interpreter, and a test `Application` leaked past a python3-skip
+  guard tripping Vapor's `ServeCommand did not shutdown before deinit`
+  assertion — each SIGILLing the whole run. The container now installs `python3`
+  (matching `swift-tests.yml`); the skip guard in
+  `WorkerRoutesTests.materializeValidation_resolvesExpressionForSeed` moved
+  inside `withApp` so a skip can't leak the app; and `pfAssertValidPythonSyntax`
+  skips cleanly and uses a throwing write so a missing/failed interpreter
+  degrades to a skip instead of a process-killing trap.


### PR DESCRIPTION
## Problem

The **Nightly Clean Build & Coverage** canary (`test-coverage.yml`) has been red since **2026-06-17** (green through 06-16). It is **not flaky and not the documented pool-pressure timeout** — both nightly crashes are SIGILL (signal 4 / a Swift runtime trap), and they stem from one environmental gap.

**Root cause:** `test-coverage.yml` runs every target in one process but installs only `zip unzip curl file` — it **never installs `python3`**. The per-PR `swift-tests.yml` installs python3 in all three test jobs (*"the noble base image (unlike jammy) does not bundle it"*). So python3-dependent APITests pass on every PR and only ever run interpreter-less in the nightly full-suite run, where one uncaught trap SIGILLs the whole xctest process — taking down the run and the coverage step.

Two python3-dependent tests were crashing it on alternating nights:

| Night | Test | Mechanism |
|------|------|-----------|
| Jun 17 | `PatternFamilyRendererTests.renderer_familyVariable_…` → `pfAssertValidPythonSyntax` | non-throwing `FileHandle.write` to a `python3` subprocess that never spawned → **broken-pipe** `try!` trap (`FileHandle.swift:709`) |
| Jun 22 | `WorkerRoutesTests.materializeValidation_resolvesExpressionForSeed` | python3 skip-guard's `return` fires **before** `withApp(app)` → test `Application` leaked → `ServeCommand did not shutdown before deinit` assertion (the exact failure mode documented in `TestHelpers.swift:188-193`) |

## Fixes

1. **`test-coverage.yml` installs `python3`** — mirrors `swift-tests.yml`; directly restores the nightly. The previously-skipped tests now actually run, so coverage can only go up.
2. **`WorkerRoutesTests.materializeValidation_resolvesExpressionForSeed`** — the python3 skip-guard moves **inside** `withApp(app)` so a skip can never leak the app. Genuine latent bug: it would also crash any contributor running the suite without python3.
3. **`pfAssertValidPythonSyntax`** — guards python3 availability (skips cleanly on a bare host) and uses the throwing `write(contentsOf:)` instead of the non-throwing `write(_:)`, so a missing/failed interpreter degrades to a skip / thrown error instead of a process-killing trap.

## Verification

- `swift build --build-tests` ✅
- Both previously-crashing tests pass locally (python3 present): `materializeValidation_resolvesExpressionForSeed` and `renderer_familyVariable_prependedAndReferencedInCase` ✅
- `swift-format lint --strict` and SwiftLint `--strict` clean on the changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014PobMDeK91fAWbM55p8i4X)_