### PR TITLE
fix(notebook-editor): restore kernel-boot fallback + make hung kernels visible

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -218,17 +218,184 @@
         mountEditor();
     });
 
+    // ----------------------------------------------------------------
+    // Editor delivery hardening (kernel boot)
+    // ----------------------------------------------------------------
+    //
+    // The editor is served cross-origin isolated so the Pyodide kernel runs on
+    // SharedArrayBuffer with no service worker
+    // (docs/notebook-editor-kernel-boot.md). Two failure modes can still leave
+    // the kernel spinning forever; these helpers detect and route around them
+    // — and beacon them, so a hung kernel is no longer invisible to the admin
+    // diagnostics (it used to be logged only as a successful editor_ready).
+
+    // True when the per-client compat cookie is set (the server then serves the
+    // editor NON-isolated; see EditorCompatMode.swift).
+    function isEditorCompatMode() {
+        try { return document.cookie.indexOf('ck-editor-compat=1') !== -1; }
+        catch (_) { return false; }
+    }
+
+    // #1 — Remove a stale, now-redundant JupyterLite service worker. The
+    // SAB-only architecture disabled the SW manager, but a SW registered by a
+    // pre-SAB build stays registered and keeps controlling /jupyterlite/* — it
+    // can serve stale/uncontrolled responses that break the kernel boot, and a
+    // plain refresh never clears it. Drop any we find (never in compat mode,
+    // where the SW IS the intended sync path) and reload once if one was
+    // actually controlling this load.
+    function cleanupRedundantServiceWorker() {
+        if (isEditorCompatMode()) return;
+        if (typeof navigator === 'undefined' || !navigator.serviceWorker ||
+            !navigator.serviceWorker.getRegistrations) return;
+        navigator.serviceWorker.getRegistrations().then(function (regs) {
+            var removedControlling = false;
+            (regs || []).forEach(function (reg) {
+                var scope = (reg && reg.scope) || '';
+                if (scope.indexOf('/jupyterlite/') === -1) return;
+                if (navigator.serviceWorker.controller) removedControlling = true;
+                try { reg.unregister(); } catch (_) { /* best effort */ }
+            });
+            if (typeof caches !== 'undefined' && caches.delete) {
+                try { caches.delete('precache'); } catch (_) { /* best effort */ }
+            }
+            // A SW only stops controlling already-loaded clients on reload, so
+            // if one was controlling we reload once (guarded) for a clean,
+            // SW-free boot.
+            if (removedControlling && !staleSwReloadUsed()) {
+                markStaleSwReloadUsed();
+                try { window.location.reload(); } catch (_) { /* nothing else to try */ }
+            }
+        }).catch(function () { /* best effort */ });
+    }
+
+    function staleSwReloadUsed() {
+        try { return sessionStorage.getItem('chickadee:sw-cleanup:' + setupID) === '1'; }
+        catch (_) { return false; }
+    }
+    function markStaleSwReloadUsed() {
+        try { sessionStorage.setItem('chickadee:sw-cleanup:' + setupID, '1'); }
+        catch (_) { /* sessionStorage unavailable — reload simply won't be re-gated */ }
+    }
+
+    // #2 — The pyodide-kernel polyfills Atomics.waitAsync with a `data:` worker
+    // when the engine lacks it natively; `data:` workers are BLOCKED under COEP
+    // require-corp, so a cross-origin-isolated page on such an engine (older
+    // Safari / iPadOS) hangs the kernel with no fallback. Detect that exact
+    // combination and switch to a non-isolated, service-worker-backed boot.
+    function browserNeedsDataWorkerCompat() {
+        if (typeof crossOriginIsolated === 'undefined' || !crossOriginIsolated) return false;
+        if (typeof Atomics === 'undefined') return false;
+        return typeof Atomics.waitAsync !== 'function';
+    }
+
+    function compatAlreadyTried() {
+        try { return sessionStorage.getItem('chickadee:editor-compat:' + setupID) === '1'; }
+        catch (_) { return false; }
+    }
+    function markCompatTried() {
+        try { sessionStorage.setItem('chickadee:editor-compat:' + setupID, '1'); }
+        catch (_) { /* sessionStorage unavailable */ }
+    }
+
+    // Returns true if it kicked off a compat switch (a reload), so the caller
+    // stops the normal isolated mount.
+    function maybeEnterDataWorkerCompat() {
+        if (isEditorCompatMode()) return false;        // already non-isolated
+        if (!browserNeedsDataWorkerCompat()) return false;
+        if (compatAlreadyTried()) return false;        // never loop
+        markCompatTried();
+        try {
+            document.cookie = 'ck-editor-compat=1; path=/; max-age=86400; SameSite=Lax';
+        } catch (_) { /* cookies blocked — fall through; boot-timeout will catch it */ }
+        setStatus('loading', 'Preparing the notebook for your browser…');
+        try { window.location.reload(); return true; }
+        catch (_) { return false; }
+    }
+
+    // In compat (non-isolated) mode the SAB sync path is unavailable, so the
+    // kernel needs the JupyterLite service worker. The SW manager is disabled,
+    // so register it ourselves and wait for it to control /jupyterlite/ before
+    // the iframe mounts. Best-effort: on failure the boot-timeout path routes
+    // the student to the runner.
+    function ensureCompatServiceWorker() {
+        if (!isEditorCompatMode()) return Promise.resolve();
+        if (typeof navigator === 'undefined' || !navigator.serviceWorker) return Promise.resolve();
+        try {
+            return navigator.serviceWorker
+                .register('/jupyterlite/service-worker.js', { scope: '/jupyterlite/' })
+                .then(function () { return whenServiceWorkerActive(5000); })
+                .catch(function () { /* best effort */ });
+        } catch (_) {
+            return Promise.resolve();
+        }
+    }
+
+    // Isolation/engine context appended to kernel beacons so the admin
+    // diagnostics can tell WHY a kernel hung: coi=false → isolation not
+    // delivered (e.g. stale SW); waitasync=false under coi=true → the
+    // data:-worker block; compat=true → already on the service-worker fallback.
+    function isolationBeaconSuffix() {
+        var coi = (typeof crossOriginIsolated !== 'undefined') ? !!crossOriginIsolated : false;
+        var wa  = (typeof Atomics !== 'undefined' && typeof Atomics.waitAsync === 'function');
+        return 'coi=' + coi + ';waitasync=' + wa + ';compat=' + isEditorCompatMode();
+    }
+
+    // The kernel reached idle/busy — the success NUMERATOR (paired with
+    // editor_ready, the shell denominator).
+    function reportKernelReady(elapsedMs) {
+        if (failures && failures.reportEvent) {
+            failures.reportEvent({
+                kind: 'kernel_ready',
+                message: 'elapsed_ms=' + Math.round(elapsedMs) + ';' + isolationBeaconSuffix()
+            });
+        }
+    }
+
+    // The kernel never reached ready within the observation window. Beacon it
+    // (so the hang is finally visible) and surface the runner path — but do NOT
+    // tear down the iframe: it may merely be slow, and hiding it would kill a
+    // still-loading kernel.
+    function reportKernelBootTimeout() {
+        setStatus('error',
+            'The Python kernel is taking unusually long to start. You can keep ' +
+            'waiting, or click Submit to grade your work on the server.');
+        reenableSubmit();
+        if (failures && failures.reportEvent) {
+            failures.reportEvent({
+                kind: 'watchdog_timeout',
+                failedChecks: ['kernel-boot-timeout'],
+                source: 'kernel',
+                message: isolationBeaconSuffix()
+            });
+        }
+    }
+
     function mountEditor() {
+        // #1: drop any stale, redundant JupyterLite service worker before
+        // booting (no-op in compat mode, where the SW is the intended path).
+        cleanupRedundantServiceWorker();
+
+        // #2: engines that would hit the COEP data:-worker block switch to a
+        // non-isolated, service-worker-backed boot (this reloads).
+        if (maybeEnterDataWorkerCompat()) return;
+
         // The template renders the same URL into the iframe's src, so the
         // editor is already loading by the time the preflight resolves.
         // Re-assigning src aborts that in-flight navigation and starts it
         // over — only navigate when the attribute is missing or different
-        // (an older cached copy of the page).
-        if (frame.getAttribute('src') !== editorURL) {
-            frame.src = editorURL;
+        // (an older cached copy of the page). In compat mode we deliberately
+        // (re)mount AFTER the service worker is controlling /jupyterlite/.
+        var mountFrame = function () {
+            if (frame.getAttribute('src') !== editorURL) {
+                frame.src = editorURL;
+            }
+            scheduleServiceWorkerStateBeacon();
+        };
+        if (isEditorCompatMode()) {
+            ensureCompatServiceWorker().then(mountFrame);
+        } else {
+            mountFrame();
         }
-
-        scheduleServiceWorkerStateBeacon();
 
         // Quick reachability check helps explain blank/failed editor loads.
         fetch(notebookURL, { method: 'GET' }).then((res) => {
@@ -370,6 +537,8 @@
         // reloaded shell comes back up.
         let kernelRecoveryAttempted = false;
         let recovering              = false;
+        // The positive kernel-ready beacon is emitted at most once.
+        let kernelReadyReported     = false;
 
         function tick() {
             if (cancelled) return;
@@ -399,6 +568,16 @@
                     return;
                 }
                 setTimeout(tick, 500);
+                return;
+            }
+
+            // Positive kernel-ready: the kernel (not just the shell) reached
+            // idle/busy. This is the success numerator AND the signal that
+            // distinguishes a healthy boot from a hung one — once seen, stop.
+            if (probe.kernelReady && !kernelReadyReported) {
+                kernelReadyReported = true;
+                reportKernelReady(Date.now() - startedAt);
+                cancelled = true;
                 return;
             }
 
@@ -460,11 +639,15 @@
                 return;
             }
 
-            // No failure evidence + shell loaded.  Stop watching after
-            // a generous observation window — the user has a working
-            // editor and we shouldn't keep polling forever.
+            // Shell up, but we never saw the kernel reach idle/busy AND never
+            // saw positive failure evidence. We used to silently assume healthy
+            // here — which made a kernel that spins forever (e.g. the COEP
+            // data:-worker block) completely invisible (logged only as a
+            // successful editor_ready). Now we beacon it and surface the runner
+            // path, without tearing down the iframe in case it is merely slow.
             if (Date.now() - shellLoadedAt >= kernelMaxObserveMs) {
-                cancelled = true; // silent give-up; assume healthy
+                cancelled = true;
+                if (!kernelReadyReported) reportKernelBootTimeout();
                 return;
             }
             setTimeout(tick, 1000);
@@ -493,6 +676,7 @@
     // fires when we're sure something has broken.
     function probeIframeReadiness(frame) {
         let shellReady = false;
+        let kernelReady = false;
         let kernelInFailureState = false;
         let kernelEvidence = null;
         let win = null;
@@ -541,7 +725,13 @@
             } catch (_) { /* fall through */ }
         }
 
-        return { shellReady, kernelInFailureState, kernelEvidence };
+        // Positive kernel liveness (independent of failure evidence): a running
+        // session in idle/busy, or the "| Idle"/"| Busy" status text. Absence
+        // is "unknown", never "ready" — so kernel_ready never false-positives.
+        if (shellReady) {
+            kernelReady = kernelLivenessReady(win, doc);
+        }
+        return { shellReady, kernelReady, kernelInFailureState, kernelEvidence };
     }
 
     function reenableSubmit() {
@@ -664,6 +854,33 @@
         } catch (_) { /* fall through */ }
 
         return null;
+    }
+
+    // Returns true iff we have POSITIVE evidence the kernel is ALIVE — a running
+    // session reporting idle/busy, or the "| Idle"/"| Busy" status text in the
+    // iframe DOM. Absence is "unknown" (still booting, or an unprobeable
+    // cross-process Safari iframe), never "ready" — so the kernel_ready success
+    // signal never false-positives on a working-but-unprobeable editor.
+    function kernelLivenessReady(win, doc) {
+        try {
+            const app = win && win.jupyterapp;
+            const sm  = app && app.serviceManager;
+            if (sm && sm.sessions && typeof sm.sessions.running === 'function') {
+                const running = sm.sessions.running();
+                if (running) {
+                    const sessions = Array.from(running);
+                    for (let i = 0; i < sessions.length; i++) {
+                        const status = sessions[i] && sessions[i].kernel && sessions[i].kernel.status;
+                        if (status === 'idle' || status === 'busy') return true;
+                    }
+                }
+            }
+        } catch (_) { /* fall through */ }
+        try {
+            const text = (doc && doc.body && doc.body.textContent) || '';
+            if (text.indexOf('| Idle') !== -1 || text.indexOf('| Busy') !== -1) return true;
+        } catch (_) { /* fall through */ }
+        return false;
     }
 
     // Decides how the watchdog reacts to POSITIVE EVIDENCE that the kernel is
@@ -1758,6 +1975,7 @@
             parseStructuredPayload,
             probeIframeReadiness,
             kernelFailureEvidence,
+            kernelLivenessReady,
             planKernelFailureResponse,
             shouldForceReseed,
             reseedPlan,

--- a/Sources/APIServer/Middleware/COEPMiddleware.swift
+++ b/Sources/APIServer/Middleware/COEPMiddleware.swift
@@ -42,7 +42,16 @@ struct COEPMiddleware: AsyncMiddleware {
         chainingTo next: any AsyncResponder
     ) async throws -> Response {
         let response = try await next.respond(to: request)
-        guard needsCOEP(path: request.url.path) else { return response }
+        let path = request.url.path
+        guard needsCOEP(path: path) else { return response }
+        // Editor compat mode: a client that hit the COEP `data:`-worker block
+        // (cross-origin isolated but no native `Atomics.waitAsync`) opted out of
+        // isolation so the kernel can use the service-worker sync path instead.
+        // Scoped to the student notebook editor only — never the instructor
+        // validate page, a separate Pyodide surface that is not affected.
+        if request.editorCompatModeRequested, isStudentNotebookEditor(path: path) {
+            return response
+        }
         response.headers.replaceOrAdd(
             name: "Cross-Origin-Opener-Policy",
             value: "same-origin"
@@ -52,6 +61,12 @@ struct COEPMiddleware: AsyncMiddleware {
             value: "require-corp"
         )
         return response
+    }
+
+    /// True for the student notebook editor page (`/testsetups/:id/notebook`).
+    private func isStudentNotebookEditor(path: String) -> Bool {
+        let parts = path.split(separator: "/").map(String.init)
+        return parts.count == 3 && parts[0] == "testsetups" && parts.last == "notebook"
     }
 
     /// Returns true for paths whose pages opt into cross-origin isolation.

--- a/Sources/APIServer/Middleware/EditorCompatMode.swift
+++ b/Sources/APIServer/Middleware/EditorCompatMode.swift
@@ -1,0 +1,38 @@
+// APIServer/Middleware/EditorCompatMode.swift
+//
+// Per-client opt-out of the notebook editor's cross-origin isolation.
+//
+// The editor is served cross-origin isolated (COOP + COEP) so the Pyodide
+// kernel runs on `SharedArrayBuffer` with no service worker — the deterministic
+// "Kernel Unknown" fix (docs/notebook-editor-kernel-boot.md).  There is one
+// documented residual risk: the pyodide-kernel polyfills `Atomics.waitAsync`
+// (on engines that lack it natively, e.g. older Safari / iPadOS) with a
+// `new Worker("data:…")`, and `data:` workers are BLOCKED under COEP
+// `require-corp`, so on those engines the cross-origin-isolated kernel hangs
+// forever with no fallback.
+//
+// When notebook.js detects that exact combination (`crossOriginIsolated &&
+// !Atomics.waitAsync`) it sets the `ck-editor-compat` cookie and reloads.  The
+// isolation middlewares (`COEPMiddleware`, `NotebookAssetIsolationMiddleware`)
+// then DROP the COEP header for that client, so the editor page + iframe are no
+// longer cross-origin isolated.  Without SAB the kernel falls back to the
+// JupyterLite service-worker sync path (which notebook.js re-registers in
+// compat mode) — the pre-isolation path, which those engines can run.
+//
+// This is a per-client cookie, so the cross-origin-isolated majority is never
+// affected: the default (no cookie) path is unchanged.
+
+import Vapor
+
+enum EditorCompatMode {
+    /// Cookie set by notebook.js to request the non-isolated editor.
+    static let cookieName = "ck-editor-compat"
+}
+
+extension Request {
+    /// True when this client has opted into the non-isolated editor compat mode
+    /// (it hit, or would hit, the COEP `data:`-worker block).
+    var editorCompatModeRequested: Bool {
+        cookies[EditorCompatMode.cookieName]?.string == "1"
+    }
+}

--- a/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
+++ b/Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware.swift
@@ -65,6 +65,13 @@ struct NotebookAssetIsolationMiddleware: AsyncMiddleware {
         let path = request.url.path
         guard enabled, path.hasPrefix("/jupyterlite/") || Self.isolatedWorkerScripts.contains(path)
         else { return response }
+        // Editor compat mode: this client opted out of cross-origin isolation
+        // (the COEP `data:`-worker block), so leave its editor iframe documents
+        // and worker scripts non-isolated — the kernel uses the service-worker
+        // sync path that notebook.js re-registers in compat mode. The vendored
+        // asset trees on EditorAssetFastPathMiddleware keep their headers (a
+        // COEP-stamped worker script still loads fine from a non-isolated page).
+        if request.editorCompatModeRequested { return response }
 
         response.setCrossOriginIsolationHeaders()
         return response

--- a/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
+++ b/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
@@ -59,16 +59,21 @@ struct ClientDiagnosticsRoutes: RouteCollection {
         // service-worker sync path) and a dedicated worker — which keeps running
         // while the page is frozen — reported it. Such freezes are otherwise
         // invisible: the blocked main thread can't post anything itself.
-        // "editor_ready" and "sw_state" are non-failure telemetry: editor_ready
-        // is the success denominator (the editor shell came up, message
-        // "elapsed_ms=…") so we can compute a success RATE; sw_state reports
-        // whether JupyterLite's service worker registered (message
-        // "supported=…;registrations=…"), which diagnoses the "Kernel Unknown"
-        // failure mode per browser/device.
+        // "editor_ready", "kernel_ready" and "sw_state" are non-failure
+        // telemetry. editor_ready is the SHELL-up denominator (message
+        // "elapsed_ms=…"). kernel_ready is the stronger signal — the Pyodide
+        // KERNEL reached idle/busy — so a hung kernel is distinguishable from a
+        // healthy one (editor_ready alone over-counts success: the shell can
+        // mount while the kernel never starts, which is exactly the spinning-
+        // forever symptom). A kernel that never reaches ready is reported as a
+        // "watchdog_timeout" with failedChecks ["kernel-boot-timeout"] — a
+        // distinct subtype from the positive-evidence "kernel-unhealthy" one.
+        // sw_state reports service-worker registration + cross-origin-isolation
+        // state ("supported=…;registrations=…;coi=…;sab=…;waitasync=…").
         let allowedKinds: Set<String> = [
             "preflight_fail", "watchdog_timeout", "editor_error",
             "submit_phase", "submit_error", "page_unresponsive",
-            "editor_ready", "sw_state",
+            "editor_ready", "kernel_ready", "sw_state",
         ]
         guard allowedKinds.contains(body.kind) else {
             throw AppError.badRequest(reason: "Unknown kind")

--- a/Tests/APITests/COEPMiddlewareTests.swift
+++ b/Tests/APITests/COEPMiddlewareTests.swift
@@ -131,4 +131,56 @@ import VaporTesting
             }
         }
     }
+
+    // MARK: - Editor compat mode (per-client COEP opt-out)
+    //
+    // A client that hit the COEP `data:`-worker block (cross-origin isolated but
+    // no native Atomics.waitAsync — older Safari/iPadOS) sets the
+    // `ck-editor-compat` cookie; the isolation middlewares then DROP COEP for
+    // that client so the kernel can use the service-worker sync path.
+
+    @Test func compatCookieDropsCOEPOnNotebookPage() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            let res = try await app.asyncSendRequest(
+                .GET, "/testsetups/setup_123/notebook",
+                headers: ["cookie": "\(EditorCompatMode.cookieName)=1"])
+            #expect(res.status == .ok)
+            #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+        }
+    }
+
+    @Test func compatCookieDropsIsolationOnJupyterliteIframe() async throws {
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            let res = try await app.asyncSendRequest(
+                .GET, "/jupyterlite/notebooks/index.html",
+                headers: ["cookie": "\(EditorCompatMode.cookieName)=1"])
+            #expect(res.status == .ok)
+            #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == nil)
+            #expect(res.headers.first(name: "Cross-Origin-Resource-Policy") == nil)
+        }
+    }
+
+    @Test func compatCookieDoesNotAffectValidatePage() async throws {
+        // The compat opt-out is scoped to the student notebook editor; the
+        // instructor validate page must stay isolated regardless of the cookie.
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            let res = try await app.asyncSendRequest(
+                .GET, "/instructor/assignment_123/validate",
+                headers: ["cookie": "\(EditorCompatMode.cookieName)=1"])
+            #expect(res.status == .ok)
+            #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
+        }
+    }
+
+    @Test func absentCompatCookieKeepsNotebookIsolated() async throws {
+        // Regression guard for the majority path: no cookie → full isolation,
+        // byte-for-byte the pre-compat behaviour.
+        try await withApp(try await makeApp(isolateNotebook: true)) { app in
+            let res = try await app.asyncSendRequest(
+                .GET, "/testsetups/setup_123/notebook",
+                headers: ["cookie": "\(EditorCompatMode.cookieName)=0"])
+            #expect(res.status == .ok)
+            #expect(res.headers.first(name: "Cross-Origin-Embedder-Policy") == "require-corp")
+        }
+    }
 }

--- a/Tests/APITests/ClientDiagnosticsRoutesTests.swift
+++ b/Tests/APITests/ClientDiagnosticsRoutesTests.swift
@@ -147,6 +147,46 @@ import VaporTesting
         }
     }
 
+    @Test func acceptsKernelReadyTelemetry() async throws {
+        try await withApp(app) { _ in
+            // kernel_ready is the stronger success signal — the Pyodide kernel
+            // (not just the shell) reached idle/busy — so a hung kernel is
+            // distinguishable from a healthy boot. Accepted + persisted.
+            let auth = try await loginAsStudent()
+            try await insertSetup(id: "setup_kready")
+            let body = #"""
+                {"kind":"kernel_ready","testSetupID":"setup_kready","message":"elapsed_ms=4200;coi=true;waitasync=true;compat=false"}
+                """#
+            let res = try await postJSON(body, auth: auth, userAgent: "Mozilla/5.0 (TestRunner)")
+            #expect(res.status == .accepted)
+
+            let rec = try #require(try await APIClientDiagnostic.query(on: app.db).first())
+            #expect(rec.kind == "kernel_ready")
+            #expect(rec.testSetupID == "setup_kready")
+        }
+    }
+
+    @Test func persistsKernelBootTimeoutSubtype() async throws {
+        try await withApp(app) { _ in
+            // A kernel that mounts the shell but never reaches ready is reported
+            // as watchdog_timeout with the distinct failedChecks
+            // ["kernel-boot-timeout"] subtype (vs the positive-evidence
+            // "kernel-unhealthy" one), so the silent spinner is finally counted.
+            let auth = try await loginAsStudent()
+            try await insertSetup(id: "setup_boot_timeout")
+            let body = #"""
+                {"kind":"watchdog_timeout","testSetupID":"setup_boot_timeout","failedChecks":["kernel-boot-timeout"],"source":"kernel","message":"coi=true;waitasync=false;compat=false"}
+                """#
+            let res = try await postJSON(body, auth: auth, userAgent: "TestUA/5.0")
+            #expect(res.status == .accepted)
+
+            let rec = try #require(try await APIClientDiagnostic.query(on: app.db).first())
+            #expect(rec.kind == "watchdog_timeout")
+            #expect(rec.failedChecks == "kernel-boot-timeout")
+            #expect(rec.source == "kernel")
+        }
+    }
+
     @Test func persistsPreflightFailRecord() async throws {
         try await withApp(app) { _ in
             let auth = try await loginAsStudent()

--- a/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
+++ b/Tests/BrowserRunnerJSTests/watchdog-probe.test.mjs
@@ -386,6 +386,66 @@ test('probeIframeReadiness: kernel failure surfaces evidence string', async () =
 });
 
 // ----------------------------------------------------------------
+// Kernel liveness — the positive kernel_ready signal (success numerator),
+// distinct from shell readiness. Its presence drives the kernel_ready beacon;
+// its ABSENCE at the deadline drives the new kernel-boot-timeout beacon, so a
+// kernel that spins forever is no longer logged only as a successful shell.
+// ----------------------------------------------------------------
+
+test('probeIframeReadiness: shell up, kernel idle session → kernelReady true', async () => {
+  const { probeIframeReadiness } = await loadHarness();
+  const fakeApp = {
+    serviceManager: { sessions: { running() { return [{ kernel: { status: 'idle' } }]; } } },
+  };
+  const frame = makeFrame({
+    winFactory: () => ({ jupyterapp: fakeApp, document: makeDoc() }),
+    docFactory: () => makeDoc(),
+  });
+  const r = probeIframeReadiness(frame);
+  assert.equal(r.shellReady, true);
+  assert.equal(r.kernelReady, true);
+});
+
+test('probeIframeReadiness: shell up via DOM, "| Idle" status text → kernelReady true', async () => {
+  const { probeIframeReadiness } = await loadHarness();
+  const frame = makeFrame({
+    winFactory: () => null,
+    docFactory: () => makeDoc({ classList: ['jp-Toolbar'], bodyText: 'Python (Pyodide) | Idle' }),
+  });
+  const r = probeIframeReadiness(frame);
+  assert.equal(r.shellReady, true);
+  assert.equal(r.kernelReady, true);
+});
+
+test('probeIframeReadiness: shell up but kernel still starting → kernelReady false', async () => {
+  // The hung-kernel case: the shell mounted (editor_ready fires) but the kernel
+  // never reached idle/busy, so kernel_ready must NOT fire — this is exactly
+  // the gap that let a spinning kernel be recorded as a success.
+  const { probeIframeReadiness } = await loadHarness();
+  const frame = makeFrame({
+    winFactory: () => null,
+    docFactory: () => makeDoc({ classList: ['jp-Toolbar'], bodyText: 'Python (Pyodide) | Starting' }),
+  });
+  const r = probeIframeReadiness(frame);
+  assert.equal(r.shellReady, true);
+  assert.equal(r.kernelReady, false, 'a kernel that has not reached idle/busy is not ready');
+});
+
+test('kernelLivenessReady: busy session → true; dead session → false', async () => {
+  const { kernelLivenessReady } = await loadHarness();
+  const busy = { jupyterapp: { serviceManager: { sessions: { running() { return [{ kernel: { status: 'busy' } }]; } } } } };
+  const dead = { jupyterapp: { serviceManager: { sessions: { running() { return [{ kernel: { status: 'dead' } }]; } } } } };
+  assert.equal(kernelLivenessReady(busy, makeDoc()), true);
+  assert.equal(kernelLivenessReady(dead, makeDoc()), false);
+});
+
+test('kernelLivenessReady: access throws → false (never a false positive)', async () => {
+  const { kernelLivenessReady } = await loadHarness();
+  const win = { get jupyterapp() { throw new Error('cross-origin'); } };
+  assert.equal(kernelLivenessReady(win, null), false);
+});
+
+// ----------------------------------------------------------------
 // Kernel recovery ladder — iframe reload, then full-page reload, then give up
 // (the full-page rung was added to fix "persisted after auto-reload" cases,
 // where the in-place iframe reset re-raced the service-worker control).

--- a/changelog.d/notebook-kernel-boot-fallback.md
+++ b/changelog.d/notebook-kernel-boot-fallback.md
@@ -1,0 +1,25 @@
+### Fixed
+
+- **Notebook editor: restore a kernel-boot fallback and stop hung kernels from
+  hiding.** After the SAB-only switch (cross-origin isolation, service worker
+  removed) some students hit a Pyodide kernel that never finished loading. Two
+  causes: (1) a stale, now-redundant JupyterLite service worker left registered
+  by a pre-SAB build kept controlling `/jupyterlite/*` and broke the boot — it is
+  now proactively unregistered on load; (2) engines that lack native
+  `Atomics.waitAsync` (older Safari / iPadOS) hit the kernel's `data:`-worker
+  polyfill, which COEP `require-corp` blocks, hanging the kernel with no
+  fallback. notebook.js now detects that exact case (`crossOriginIsolated &&
+  !Atomics.waitAsync`), opts the client out of isolation via the
+  `ck-editor-compat` cookie (the isolation middlewares drop COEP for that
+  client only), and re-registers the JupyterLite service worker so the kernel
+  uses the SW sync path — the cross-origin-isolated majority is unchanged.
+
+### Added
+
+- **Kernel-liveness telemetry so a hung kernel is visible.** The editor now
+  beacons `kernel_ready` when the Pyodide kernel actually reaches idle/busy (not
+  just the shell mounting, which `editor_ready` already counted), and a
+  `watchdog_timeout` / `kernel-boot-timeout` diagnostic when it never does —
+  tagged with `coi` / `waitasync` / `compat` so the admin browser-diagnostics
+  surface shows which kernels are hanging and why, instead of recording a hung
+  kernel as a successful load.


### PR DESCRIPTION
## Problem

After the SAB-only switch (unconditional cross-origin isolation + JupyterLite service worker removed, #989), some students hit a Pyodide kernel that **never finishes loading** — the editor shell mounts but `Python (Pyodide)` spins forever and no cell runs. It was invisible on the admin dashboard because shell-up was logged as a success.

Root cause is two compounding failure modes, both consequences of removing the SW with no fallback:

1. **Stale service worker.** A SW registered by a pre-SAB build stays registered and keeps controlling `/jupyterlite/*`, breaking the boot. Disabling the SW *manager* stops new registrations but never removes an existing one, and a plain refresh doesn't clear it. (Most likely the returning-Chrome case.)
2. **COEP `data:`-worker block.** On engines without native `Atomics.waitAsync` (older Safari / iPadOS), the pyodide-kernel polyfills it with `new Worker("data:…")`, and `data:` workers are blocked under COEP `require-corp`. The kernel hangs with no fallback. This is the residual risk already documented in `docs/notebook-editor-kernel-boot.md` ("verify on Safari before promoting to production") — CI's Chromium/WebKit both have native `waitAsync`, so the headless matrix never exercises the failing path.

## Fix

1. **Unregister the stale, redundant SW** on notebook load (skipped in compat mode); reload once if one was controlling.
2. **Conditional compat fallback.** notebook.js detects `crossOriginIsolated && !Atomics.waitAsync`, sets the `ck-editor-compat` cookie and reloads; `COEPMiddleware` + `NotebookAssetIsolationMiddleware` drop COEP **for that client only**, so the page is non-isolated and the kernel uses the re-registered JupyterLite service-worker sync path. The cross-origin-isolated majority is byte-for-byte unchanged.
3. **Kernel-liveness telemetry.** Emit `kernel_ready` when the kernel actually reaches idle/busy (distinct from the shell-up `editor_ready`), and a `watchdog_timeout` / `kernel-boot-timeout` beacon when it never does — tagged with `coi`/`waitasync`/`compat` — so a hung kernel surfaces as a *failure* with a reason instead of a silent success.

## Tests

- `COEPMiddlewareTests`: compat-cookie drops COEP on the notebook page + iframe, leaves the validate page isolated, and (regression guard) keeps the default path fully isolated.
- `ClientDiagnosticsRoutesTests`: `kernel_ready` and `kernel-boot-timeout` acceptance/persistence.
- `watchdog-probe.test.mjs`: `kernelReady` liveness probe (idle/busy → ready; still-starting → not ready; never false-positives).

## Follow-up (durable test gap)

CI still can't reach the failing engine cohort. The right guard is a `SMOKE_SIMULATE_NO_WAITASYNC` knob in `Tools/editor-smoke-test/` that deletes `Atomics.waitAsync` before boot and asserts the editor still comes up via the compat path. Happy to add it here or as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_