### PR TITLE
fix(notebook-editor): stop kernel-boot-timeout false positives on healthy kernels

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -351,24 +351,16 @@
         }
     }
 
-    // The kernel never reached ready within the observation window. Beacon it
-    // (so the hang is finally visible) and surface the runner path — but do NOT
-    // tear down the iframe: it may merely be slow, and hiding it would kill a
-    // still-loading kernel.
-    function reportKernelBootTimeout() {
-        setStatus('error',
-            'The Python kernel is taking unusually long to start. You can keep ' +
-            'waiting, or click Submit to grade your work on the server.');
-        reenableSubmit();
-        if (failures && failures.reportEvent) {
-            failures.reportEvent({
-                kind: 'watchdog_timeout',
-                failedChecks: ['kernel-boot-timeout'],
-                source: 'kernel',
-                message: isolationBeaconSuffix()
-            });
-        }
-    }
+    // NOTE: we intentionally do NOT report a "kernel-boot-timeout" on mere
+    // absence of a positive ready signal. In production the parent frequently
+    // cannot read the kernel's state inside the (cross-process) iframe, so
+    // `kernelLivenessReady` returns false even for HEALTHY kernels — which made
+    // a deadline-based beacon false-positive on Chrome AND Safari and show a
+    // spurious "kernel taking long" message over working editors. The genuine
+    // no-SAB hang (the data:-worker block) is pre-empted up front by the compat
+    // switch (browserNeedsDataWorkerCompat), not by watching for absence here.
+    // Restoring a positive kernel-boot-timeout needs a liveness probe validated
+    // against real JupyterLite in the editor-smoke harness first.
 
     function mountEditor() {
         // #1: drop any stale, redundant JupyterLite service worker before
@@ -639,15 +631,14 @@
                 return;
             }
 
-            // Shell up, but we never saw the kernel reach idle/busy AND never
-            // saw positive failure evidence. We used to silently assume healthy
-            // here — which made a kernel that spins forever (e.g. the COEP
-            // data:-worker block) completely invisible (logged only as a
-            // successful editor_ready). Now we beacon it and surface the runner
-            // path, without tearing down the iframe in case it is merely slow.
+            // Shell up, no positive failure evidence, and we could not confirm
+            // kernel-ready within the window. Stop watching SILENTLY — do not
+            // treat "couldn't confirm ready" as "hung": the parent often can't
+            // read the kernel state in a cross-process iframe, so a beacon here
+            // false-positives on healthy kernels (observed on Chrome + Safari in
+            // prod). Genuine no-SAB hangs are pre-empted by the compat switch.
             if (Date.now() - shellLoadedAt >= kernelMaxObserveMs) {
                 cancelled = true;
-                if (!kernelReadyReported) reportKernelBootTimeout();
                 return;
             }
             setTimeout(tick, 1000);
@@ -782,7 +773,12 @@
             if (!failures || !failures.reportEvent) return;
             var coi = (typeof crossOriginIsolated !== 'undefined') ? !!crossOriginIsolated : false;
             var sab = (typeof SharedArrayBuffer !== 'undefined');
-            var isolation = ';coi=' + coi + ';sab=' + sab;
+            // waitasync: native Atomics.waitAsync. coi=true with waitasync=false
+            // is the exact cohort the COEP data:-worker block hits (older
+            // Safari/iPadOS) — a reliable, probe-free way to size the at-risk
+            // population and confirm the compat switch is engaging.
+            var wa = (typeof Atomics !== 'undefined' && typeof Atomics.waitAsync === 'function');
+            var isolation = ';coi=' + coi + ';sab=' + sab + ';waitasync=' + wa;
             if (!('serviceWorker' in navigator)) {
                 failures.reportEvent({ kind: 'sw_state', message: 'supported=false' + isolation });
                 return;

--- a/changelog.d/kernel-boot-timeout-falsepos.md
+++ b/changelog.d/kernel-boot-timeout-falsepos.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Notebook editor: stop the new kernel-boot watchdog from false-alarming on
+  healthy kernels.** The v0.4.500 `kernel-boot-timeout` beacon fired on mere
+  *absence* of a positive kernel-ready signal, but the parent page often cannot
+  read the kernel's state inside the cross-process editor iframe — so it
+  false-positived on healthy Chrome **and** Safari kernels (a spurious "kernel
+  taking unusually long" message plus phantom kernel errors on the dashboard).
+  The watchdog deadline now stops watching silently instead of beaconing;
+  genuine no-`SharedArrayBuffer` hangs are still pre-empted up front by the
+  cross-origin-isolation compat switch. The `sw_state` beacon now also reports
+  `waitasync`, so the at-risk `coi=true; waitasync=false` cohort is visible
+  without any iframe probing.


### PR DESCRIPTION
## Problem (found live in production telemetry, v0.4.500)

The `kernel-boot-timeout` beacon added in #999 fires when the editor watchdog can't confirm the kernel reached idle/busy within its 120s window. But the parent page frequently **cannot read the kernel's state inside the cross-process editor iframe**, so `kernelLivenessReady` returns `false` even for **healthy** kernels.

Observed within minutes of the v0.4.500 deploy: **4 `kernel-boot-timeout` events on Chrome 148/149 + Safari 26.5**, all tagged `coi=true; waitasync=true; compat=false` (healthy modern browsers — *not* the `data:`-worker cohort), with **zero `kernel_ready` beacons ever firing**. That combination means these were **false positives in our own telemetry, not student kernel failures** — real browser submissions were completing end-to-end on the same setups, and `registrations` was trending to 0 (the #999 SW cleanup working). Student-facing impact: a spurious "kernel taking unusually long" message shown over a working editor.

## Fix

- The watchdog deadline now **stops watching silently** instead of beaconing on "couldn't confirm ready" — restoring the deliberate "don't report on mere absence of evidence" contract the original watchdog held. Genuine no-`SharedArrayBuffer` hangs are still pre-empted **up front** by the cross-origin-isolation **compat switch** (`browserNeedsDataWorkerCompat`), which is positive feature detection, not iframe probing.
- `sw_state` now reports **`waitasync`**, so the at-risk `coi=true; waitasync=false` cohort (older Safari / iPadOS — the only engines the `data:`-worker block affects) is visible **without any iframe probing**.

The `kernel_ready` positive signal stays in place, but it won't fire reliably until the liveness probe is validated against real JupyterLite in the editor-smoke harness — tracked as a follow-up (the `SMOKE_SIMULATE_NO_WAITASYNC` guard + a real liveness probe).

## Scope

JS-only (`Public/notebook.js`) + one changelog fragment. **No Swift changes.** The #999 server-side pieces (compat-cookie COEP opt-out, stale-SW cleanup) are unchanged and confirmed working in production telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_