### PR TITLE
Rename remaining BrightSpace UI labels to LEARN

### DIFF
--- a/Resources/Views/admin-audit.leaf
+++ b/Resources/Views/admin-audit.leaf
@@ -9,7 +9,7 @@ Audit Log
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/admin-brightspace.leaf
+++ b/Resources/Views/admin-brightspace.leaf
@@ -64,7 +64,7 @@ LEARN
         #endif
         #if(keySource == "authorized"):
         <form method="post" action="/admin/brightspace/clear" class="inline-form"
-              onsubmit="return confirm('Clear the stored BrightSpace authorization? Grade sync reverts to the env key if set, otherwise it stops.');">
+              onsubmit="return confirm('Clear the stored LEARN authorization? Grade sync reverts to the env key if set, otherwise it stops.');">
             #csrfFormField()
             <button class="btn action-danger" type="submit">Clear authorization</button>
         </form>
@@ -72,15 +72,12 @@ LEARN
     </div>
 
     <div class="bs-manual">
-        <h3 class="bs-manual-heading">Set credentials manually</h3>
+        <h3 class="bs-manual-heading">Set the user key</h3>
         <p class="bs-muted">
-            If your institution registers a central credential service as the
-            app's Trusted URL (e.g. UW's
-            <code>d2l-api-cred.fast.uwaterloo.ca</code>) instead of this server's
-            callback, the "Authorize" button above can't work. Harvest the
-            <strong>User ID</strong> and <strong>User Key</strong> for your
-            service account there, then paste them here — they're verified
-            against D2L and stored live, no env change or restart.
+            Harvest the <strong>User ID</strong> and <strong>User Key</strong> for
+            your service account from your institution's credential service (e.g.
+            UW's <code>d2l-api-cred.fast.uwaterloo.ca</code>), then paste them here —
+            they're verified against D2L and stored live, no env change or restart.
         </p>
         <form method="post" action="/admin/brightspace/set-credentials" class="bs-manual-form">
             #csrfFormField()
@@ -96,7 +93,7 @@ LEARN
 
     <p class="bs-muted bs-footnote">
         Instructors map assignments to grade items and watch grades flow on
-        their course's BrightSpace tab; this page only sets the shared connection.
+        their course's LEARN tab; this page only sets the shared connection.
     </p>
     #endif
 </section>

--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -78,7 +78,7 @@
         </label>
         #if(course.brightspaceSyncEnabled):
         <label class="form-label course-field-bs">
-            BrightSpace Org Unit ID
+            LEARN Org Unit ID
             <input class="form-input course-input-block" type="text" name="brightspaceOrgUnitID"
                    value="#(course.brightspaceOrgUnitID)"
                    placeholder="e.g. 123456">
@@ -99,11 +99,11 @@
             (wrong ID, or D2L unreachable). Re-save to retry verification.
             #endif
         #else:
-            BrightSpace grade sync is active. Set the Org Unit ID to bind this course to its D2L
+            LEARN grade sync is active. Set the Org Unit ID to bind this course to its D2L
             grade book — it's verified against D2L on save.
         #endif
         Per-assignment grade item IDs are configured on the
-        <a href="/instructor/brightspace">BrightSpace</a> tab.
+        <a href="/instructor/brightspace">LEARN</a> tab.
     </p>
     #endif
 </section>

--- a/Resources/Views/admin-mcp.leaf
+++ b/Resources/Views/admin-mcp.leaf
@@ -9,7 +9,7 @@ MCP
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/admin-retention.leaf
+++ b/Resources/Views/admin-retention.leaf
@@ -9,7 +9,7 @@ Retention
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/admin-storage.leaf
+++ b/Resources/Views/admin-storage.leaf
@@ -9,7 +9,7 @@ Storage
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/admin-users.leaf
+++ b/Resources/Views/admin-users.leaf
@@ -9,7 +9,7 @@ Users
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -9,7 +9,7 @@ Admin
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -9,7 +9,7 @@ Server Health Alerts
     <a class="admin-tab" href="/admin/users"#if(activeAdminTab == "users"): aria-current="page"#endif>Users</a>
     <a class="admin-tab" href="/admin/storage"#if(activeAdminTab == "storage"): aria-current="page"#endif>Storage</a>
     <a class="admin-tab" href="/admin/retention"#if(activeAdminTab == "retention"): aria-current="page"#endif>Retention</a>
-    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>BrightSpace</a>
+    <a class="admin-tab" href="/admin/brightspace"#if(activeAdminTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     #if(mcpEnabled()):<a class="admin-tab" href="/admin/mcp"#if(activeAdminTab == "mcp"): aria-current="page"#endif>MCP</a>#endif
     <a class="admin-tab" href="/admin/audit"#if(activeAdminTab == "audit"): aria-current="page"#endif>Audit Log</a>
     <a class="admin-tab" href="/admin/alerts"#if(activeAdminTab == "alerts"): aria-current="page"#endif>Health Alerts</a>

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -190,19 +190,19 @@
 <!-- ── BrightSpace grade sync ─────────────────────────── -->
 <div class="editor-block">
     <details>
-        <summary class="bs-summary">BrightSpace Grade Sync</summary>
+        <summary class="bs-summary">LEARN Grade Sync</summary>
         <div class="bs-body">
             <form method="post" action="/instructor/#(assignmentID)/brightspace">
                 #csrfFormField()
                 <label class="form-label field-gap">
-                    BrightSpace Grade Item ID
+                    LEARN Grade Item ID
                     <input class="form-input input-block" type="text" name="gradeObjectID"
                            value="#(brightspaceGradeObjectID)"
                            placeholder="e.g. 78901">
                 </label>
                 <p class="card-meta bs-note">
                     Enter the D2L grade item (grade object) ID for this assignment.
-                    Find it in BrightSpace → Grades → hover the column → Properties → Grade Object ID in the URL.
+                    Find it in LEARN → Grades → hover the column → Properties → Grade Object ID in the URL.
                     Leave blank to disable sync for this assignment.
                 </p>
                 <button class="btn btn-primary" type="submit">Save grade item ID</button>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -113,7 +113,7 @@ LEARN
                     #if(!courseIsArchived):
                     <form method="post" action="/instructor/#(row.assignmentID)/brightspace/push-all"
                           class="inline-form"
-                          onsubmit="return confirm('Re-push every student’s best grade for #(row.title) to BrightSpace?')">
+                          onsubmit="return confirm('Re-push every student’s best grade for #(row.title) to LEARN?')">
                         #csrfFormField()
                         <button class="btn action-btn" type="submit"
                                 title="Re-push all grades for this assignment">Push all</button>
@@ -132,7 +132,7 @@ LEARN
 <section class="bs-section">
     <h2 class="bs-h2">Unmapped students (#(summary.unmapped))</h2>
     <p class="card-meta bs-section-note">
-        These students' grades can't sync because Chickadee can't resolve a BrightSpace account
+        These students' grades can't sync because Chickadee can't resolve a LEARN account
         for them. Fix the student number on file, or confirm they're enrolled in the D2L course.
     </p>
     <div class="table-scroll"><table class="results-table">

--- a/changelog.d/learn-rename-consistency.md
+++ b/changelog.d/learn-rename-consistency.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Finish renaming the BrightSpace UI to "LEARN".** The admin nav tab still
+  read "BrightSpace" on every admin page except the LEARN page itself; renamed
+  it across all of them, plus the remaining user-facing "BrightSpace" labels on
+  the admin LEARN page, the instructor LEARN tab, the assignment editor's
+  grade-sync section, and the admin course page. Also removed a stale reference
+  to the in-app "Authorize" button (dropped earlier) from the manual-credentials
+  help text.


### PR DESCRIPTION
## Why

Follow-up to #998: the admin nav tab is inlined per page, so renaming it only on the LEARN page left it reading **"BrightSpace"** on every *other* admin page (`/admin`, Users, Storage, Retention, MCP, Audit, Health Alerts). This finishes the rename consistently.

## What changed (user-facing labels → "LEARN")

- **Admin nav tab** on all 7 remaining admin pages.
- **Admin LEARN page:** "Clear authorization" confirm + footnote; reworded the manual-credentials help, which also still referenced the in-app **"Authorize"** button that #998 removed (stale).
- **Instructor LEARN tab:** push-all confirm dialog + unmapped-students copy.
- **Assignment editor:** grade-sync section heading, field label, instructions.
- **Admin course page:** org-unit field label, active-sync note, instructor-tab link.

## Left untouched (intentionally)

Code-level references that aren't UI labels: route paths (`/admin/brightspace`), env vars (`BRIGHTSPACE_*`), CSS class names (`bs-*`), one HTML comment, and backend error strings (e.g. the `no BrightSpace account` sync error, which is asserted by a test).

## Tests

Text-only template change. `check-styles` clean; 89 render tests across the 8 touched templates (admin pages, instructor LEARN, assignment editor, admin course) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_