### PR TITLE
Add self-service /reset-editor page (Clear-Site-Data) for wedged kernels

### DIFF
--- a/Public/notebook-preflight.js
+++ b/Public/notebook-preflight.js
@@ -106,6 +106,18 @@
         if (submit)   submit.style.display = 'none';
         if (fallback) fallback.hidden = false;
 
+        // Point the "reset the notebook editor" link back at THIS assignment, so
+        // after clearing site data the student lands on the same page (which now
+        // boots a clean kernel) instead of the dashboard.  The static href in the
+        // template ("/reset-editor") is the no-JS fallback.
+        const resetLink = document.getElementById('nb-reset-editor-link');
+        if (resetLink) {
+            try {
+                resetLink.href = '/reset-editor?next=' +
+                    encodeURIComponent(location.pathname + location.search);
+            } catch (_) { /* keep the static href */ }
+        }
+
         if (details) {
             const lines = [
                 'Failure: ' + info.kind,

--- a/Resources/Views/editor-reset.leaf
+++ b/Resources/Views/editor-reset.leaf
@@ -1,0 +1,55 @@
+#extend("base"):
+#export("title"):
+Reset notebook editor
+#endexport
+#export("content"):
+<style>
+/* Narrow utility page; the global .main caps at 900px, trim further. */
+.reset-panel { max-width: 36rem; margin: 2rem auto; }
+.reset-panel h1 { margin: 0 0 .75rem; }
+.reset-lead { color: var(--gray-700); }
+.reset-actions { display: flex; flex-wrap: wrap; gap: .75rem; align-items: center; margin-top: 1.25rem; }
+.reset-note { color: var(--gray-600); font-size: .85rem; margin-top: 1rem; }
+</style>
+<div class="reset-panel">
+#if(done):
+    <div class="notice-box" role="status">
+        <h1>Editor reset</h1>
+        <p class="reset-lead">
+            Your browser&rsquo;s cached notebook-editor data has been cleared.
+            Reopen your assignment and the Python kernel will start from a clean
+            slate. Your submitted work is safe &mdash; only unsaved local edits
+            sitting in this browser were cleared, and you are still logged in.
+        </p>
+    </div>
+    <div class="reset-actions">
+        <a class="btn btn-primary" href="#(next)">Reopen your assignment</a>
+        <a class="btn" href="/">Return to dashboard</a>
+    </div>
+#else:
+    <h1>Reset the notebook editor</h1>
+    <p class="reset-lead">
+        If the in-browser notebook editor keeps spinning and the Python kernel
+        never finishes loading, resetting clears the editor&rsquo;s cached data
+        in <strong>this browser</strong> so it can boot from a clean slate. It is
+        the same as &ldquo;Clear site data&rdquo; in your browser settings, scoped
+        to Chickadee.
+    </p>
+    <p class="reset-lead">
+        Your submitted work is safe and you stay logged in. Only unsaved local
+        edits sitting in this browser&rsquo;s editor cache are cleared.
+    </p>
+    <form method="post" action="/reset-editor" class="reset-actions">
+        #csrfFormField()
+        <input type="hidden" name="next" value="#(next)">
+        <button type="submit" class="btn btn-primary">Reset editor</button>
+        <a class="btn" href="#(next)">Cancel</a>
+    </form>
+    <p class="reset-note">
+        If the editor still won&rsquo;t load afterward, you can submit your
+        <code>.ipynb</code> file directly from the assignment page.
+    </p>
+#endif
+</div>
+#endexport
+#endextend

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -93,6 +93,12 @@ Notebook
     <p class="nb-fallback-text">
         <input type="file" id="nb-upload-file" accept=".ipynb,application/json">
     </p>
+    <p class="nb-fallback-text">
+        Still stuck? You can
+        <a id="nb-reset-editor-link" href="/reset-editor">reset the notebook editor</a>
+        &mdash; this clears cached editor data in your browser (your submitted
+        work is safe) so the kernel can start fresh.
+    </p>
     <details class="nb-fallback-diagnostic">
         <summary>Diagnostic details</summary>
         <pre id="nb-fallback-details" class="nb-fallback-pre"></pre>

--- a/Sources/APIServer/Routes/Web/WebRoutes+EditorReset.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+EditorReset.swift
@@ -1,0 +1,92 @@
+// APIServer/Routes/Web/WebRoutes+EditorReset.swift
+//
+// Student self-service "reset the notebook editor" page.
+//
+// When the in-browser JupyterLite editor wedges — a Python kernel that spins
+// forever and never finishes loading — the cause is usually persisted browser
+// state for our origin: a stale service worker, a corrupted IndexedDB-backed
+// JupyterLite Drive, or a cached asset.  notebook.js already unregisters stale
+// service workers and the `?v=#appVersion()` cache-buster refreshes JS/CSS on
+// each release, but neither touches IndexedDB — the most likely culprit for a
+// kernel that won't boot even after a plain reload.
+//
+// This route is the server-side equivalent of "Clear site data", scoped to
+// Chickadee and handed to a stuck student (or a TA) as a one-click fix: the
+// POST response carries `Clear-Site-Data: "cache", "storage"`, which clears the
+// origin's cache storage, IndexedDB, and service-worker registrations in one
+// shot.  It deliberately does NOT clear "cookies", so the student stays logged
+// in — they land back in the editor with a clean slate, not a login page.
+//
+// It is a two-step, CSRF-protected flow so a cross-origin page can't silently
+// wipe a student's in-progress notebook: GET renders a confirmation page, and
+// the POST (carrying the session's CSRF token, enforced by the auth group's
+// CSRF middleware) performs the clear.
+
+import Core
+import Foundation
+import Vapor
+
+extension WebRoutes {
+
+    /// Leaf context for `editor-reset.leaf` (confirm + done states).
+    struct EditorResetContext: Encodable {
+        let done: Bool
+        let next: String
+        let currentUser: CurrentUserContext?
+    }
+
+    // MARK: - GET /reset-editor
+
+    @Sendable
+    func editorResetPage(req: Request) async throws -> Response {
+        struct ResetQuery: Content { var next: String? }
+        let next = safeEditorResetReturnPath((try? req.query.decode(ResetQuery.self))?.next)
+        return try await req.view.render(
+            "editor-reset",
+            EditorResetContext(done: false, next: next, currentUser: req.currentUserContext)
+        ).encodeResponse(for: req)
+    }
+
+    // MARK: - POST /reset-editor
+
+    @Sendable
+    func performEditorReset(req: Request) async throws -> Response {
+        struct ResetForm: Content { var next: String? }
+        let next = safeEditorResetReturnPath((try? req.content.decode(ResetForm.self))?.next)
+        let response = try await req.view.render(
+            "editor-reset",
+            EditorResetContext(done: true, next: next, currentUser: req.currentUserContext)
+        ).encodeResponse(for: req)
+        // Clear cached editor assets, the IndexedDB-backed JupyterLite Drive, and
+        // any stale service-worker registration for this origin so the next load
+        // boots the kernel clean.  Deliberately omit "cookies": the session must
+        // survive so the student stays signed in.
+        response.headers.replaceOrAdd(name: "Clear-Site-Data", value: "\"cache\", \"storage\"")
+        if let userID = req.auth.get(APIUser.self)?.id {
+            req.logger.info("editor_reset_cleared_site_data student=\(userID.uuidString)")
+        }
+        return response
+    }
+}
+
+/// Sanitizes a caller-supplied `next` into a safe same-origin redirect path,
+/// defaulting to "/".  Rejects protocol-relative ("//host") and absolute
+/// ("https://host") URLs so the page can't be abused as an open redirect, and
+/// rejects whitespace / control characters so the value is safe to embed in an
+/// HTML attribute.  Mirrors the same-origin check in `postLoginRedirect`.
+func safeEditorResetReturnPath(_ raw: String?) -> String {
+    guard let candidate = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !candidate.isEmpty,
+        candidate.count <= 512,
+        candidate.hasPrefix("/"),
+        !candidate.hasPrefix("//"),
+        !candidate.contains("://"),
+        !candidate.contains("\\"),
+        candidate.unicodeScalars.allSatisfy({
+            $0 != " " && !CharacterSet.controlCharacters.contains($0)
+        })
+    else {
+        return "/"
+    }
+    return candidate
+}

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -30,6 +30,10 @@ struct WebRoutes: RouteCollection {
         routes.get("testsetups", ":testSetupID", "notebook", use: notebookPage)
         routes.get("testsetups", ":testSetupID", "notebook", "source", use: notebookSource)
         routes.post("testsetups", ":testSetupID", "reset-notebook", use: resetOwnNotebook)
+        // Self-service "clear cached editor data" page for a wedged kernel
+        // (Clear-Site-Data: cache + storage; see WebRoutes+EditorReset.swift).
+        routes.get("reset-editor", use: editorResetPage)
+        routes.post("reset-editor", use: performEditorReset)
         routes.get("submissions", ":submissionID", use: submissionPage)
     }
 

--- a/Tests/APITests/EditorResetReturnPathTests.swift
+++ b/Tests/APITests/EditorResetReturnPathTests.swift
@@ -1,0 +1,57 @@
+import Testing
+
+@testable import APIServer
+
+// Unit coverage for `safeEditorResetReturnPath`, the same-origin sanitizer that
+// keeps the /reset-editor "next" parameter from becoming an open redirect (and
+// safe to embed in an HTML attribute).  Pure function — no app needed.
+@Suite struct EditorResetReturnPathTests {
+
+    @Test func keepsPlainSameOriginPath() {
+        #expect(safeEditorResetReturnPath("/testsetups/abc123/notebook") == "/testsetups/abc123/notebook")
+    }
+
+    @Test func keepsSameOriginPathWithQuery() {
+        #expect(
+            safeEditorResetReturnPath("/testsetups/abc/notebook?submissionID=s1")
+                == "/testsetups/abc/notebook?submissionID=s1")
+    }
+
+    @Test func trimsSurroundingWhitespace() {
+        #expect(safeEditorResetReturnPath("  /dashboard  ") == "/dashboard")
+    }
+
+    @Test(arguments: [
+        // protocol-relative → would navigate off-origin
+        "//evil.example.com/phish",
+        // absolute URLs of various schemes
+        "https://evil.example.com",
+        "http://evil.example.com",
+        "javascript:alert(1)",
+        "data:text/html,hi",
+        // backslash tricks some URL parsers into treating it as a host sep
+        "/\\evil.example.com",
+        // not rooted at "/" (relative) — could resolve against the wrong base
+        "evil.example.com",
+        "testsetups/x/notebook",
+        // whitespace / control chars (attribute-injection / header-splitting)
+        "/a b",
+        "/a\nb",
+        "/a\tb",
+        // empty / missing
+        "",
+        "   ",
+    ])
+    func rejectsUnsafeValuesToRoot(_ raw: String) {
+        #expect(safeEditorResetReturnPath(raw) == "/", "expected \(raw.debugDescription) to sanitize to /")
+    }
+
+    @Test func rejectsNilToRoot() {
+        #expect(safeEditorResetReturnPath(nil) == "/")
+    }
+
+    @Test func rejectsOverlongValueToRoot() {
+        let long = "/" + String(repeating: "a", count: 600)
+        #expect(safeEditorResetReturnPath(long) == "/")
+    }
+}

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -1089,6 +1089,97 @@ import VaporTesting
         }
     }
 
+    @Test func editorResetPageRendersConfirmForm() async throws {
+        try await withApp(app) { _ in
+            // GET /reset-editor renders the confirmation form (no clearing yet),
+            // preserving a safe same-origin `next` and dropping an unsafe one.
+            let cookie = try await loginAsStudent()
+
+            try await app.asyncTest(
+                .GET, "/reset-editor?next=/testsetups/abc/notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains(#"action="/reset-editor""#))
+                    #expect(html.contains("Reset editor"))
+                    // Safe next echoed into the hidden field + Cancel link.
+                    #expect(html.contains(#"value="/testsetups/abc/notebook""#))
+                    // The confirm GET must NOT clear anything.
+                    #expect(res.headers.first(name: "Clear-Site-Data") == nil)
+                })
+        }
+    }
+
+    @Test func editorResetPageSanitizesOpenRedirectNext() async throws {
+        try await withApp(app) { _ in
+            // An off-origin `next` must be neutralised to "/" so the page can't be
+            // turned into an open redirect (or attribute injection).
+            let cookie = try await loginAsStudent()
+
+            try await app.asyncTest(
+                .GET, "/reset-editor?next=https://evil.example.com/phish",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("evil.example.com") == false)
+                    #expect(html.contains(#"value="/""#))
+                })
+        }
+    }
+
+    @Test func performEditorResetSetsClearSiteDataAndKeepsSession() async throws {
+        try await withApp(app) { _ in
+            // POST /reset-editor returns the "done" page AND a Clear-Site-Data
+            // header that drops cache + storage (IndexedDB / service worker) but
+            // NOT cookies — the student must stay logged in.
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/reset-editor",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": csrf, "next": "/testsetups/abc/notebook"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let clear = try #require(res.headers.first(name: "Clear-Site-Data"))
+                    #expect(clear.contains("\"cache\""))
+                    #expect(clear.contains("\"storage\""))
+                    #expect(clear.contains("cookies") == false, "must not log the student out")
+                    // The done page links back to the (safe) assignment.
+                    #expect(res.body.string.contains(#"href="/testsetups/abc/notebook""#))
+                })
+        }
+    }
+
+    @Test func performEditorResetRequiresCSRF() async throws {
+        try await withApp(app) { _ in
+            // Without a CSRF token the POST is rejected (the auth group's CSRF
+            // middleware) — a cross-origin page can't silently wipe a student's
+            // in-progress notebook.
+            let cookie = try await loginAsStudent()
+
+            try await app.asyncTest(
+                .POST, "/reset-editor",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                    try req.content.encode(["next": "/"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                    #expect(res.headers.first(name: "Clear-Site-Data") == nil)
+                })
+        }
+    }
+
     @Test func notebookSourceFallsBackToFirstNestedNotebookWhenZipOnlySetupHasNoManifestStarter() async throws {
         try await withApp(app) { _ in
             let cookie = try await loginAsStudent()

--- a/changelog.d/editor-reset-route.md
+++ b/changelog.d/editor-reset-route.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Self-service "reset the notebook editor" page (`/reset-editor`).** When the
+  in-browser editor wedges and the Python kernel spins forever — usually stale
+  persisted browser state (a corrupted IndexedDB-backed JupyterLite Drive, a
+  stale service worker, or cached assets) that a plain reload can't shift — a
+  stuck student (or a TA) can hit `/reset-editor` for a one-click fix. The
+  confirmation POST returns `Clear-Site-Data: "cache", "storage"`, the
+  server-side equivalent of "Clear site data" scoped to Chickadee: it drops
+  cache storage, IndexedDB, and service-worker registrations so the next load
+  boots the kernel from a clean slate. It deliberately omits `"cookies"`, so the
+  student stays logged in. Two-step and CSRF-protected so a cross-origin page
+  can't silently wipe in-progress work; the `next` return path is sanitized to a
+  same-origin path. The notebook fallback panel links to it (pre-filled with the
+  current assignment) when the editor fails to load.


### PR DESCRIPTION
## Why

Some students on v0.4.502+ report the in-browser notebook editor **spinning forever** — the Python (Pyodide) kernel never finishes loading, even after a hard refresh and across Safari/Chrome/iPad. For at least some of these (e.g. Chrome/macOS, which has native `Atomics.waitAsync` and so isn't the blob:-worker cohort fixed in #1003), the most likely cause is **persisted browser state for our origin**: a corrupted IndexedDB-backed JupyterLite Drive, a stale service worker, or cached assets.

The `?v=#appVersion()` cache-buster refreshes JS/CSS on each release and `notebook.js` already unregisters stale service workers, but **neither touches IndexedDB** — which a plain reload can't shift either. So "can we force their browser to reload some of the content?" needs a path that clears storage, not just cache.

## What

A two-step, CSRF-protected **`/reset-editor`** page — the server-side equivalent of "Clear site data", scoped to Chickadee and handed to a stuck student (or a TA) as a one-click fix:

- `GET /reset-editor` → confirmation page (no clearing).
- `POST /reset-editor` → returns the "done" page with **`Clear-Site-Data: "cache", "storage"`**, which drops cache storage, IndexedDB, and service-worker registrations so the next load boots the kernel from a clean slate.

Deliberately **omits `"cookies"`** so the student stays logged in — they land back in the editor with a clean slate, not a login page.

The notebook **fallback panel** links to it (pre-filled with the current assignment via `next=`) when the editor fails to load.

## Safety

- **CSRF-protected** (the auth group's CSRF middleware): a cross-origin page can't silently POST and wipe a student's in-progress notebook. Covered by `performEditorResetRequiresCSRF`.
- **Open-redirect hardened**: the `next` return path is sanitized to a same-origin path (`safeEditorResetReturnPath`) — rejects `//host`, `https://host`, `javascript:`, backslash tricks, relative paths, and whitespace/control chars → defaults to `/`. Unit-tested with 16 cases.
- **Bounded blast radius**: only the caller's own browser storage for our origin is cleared; server-side data (working copies, submissions) is untouched.

## Tests

- `EditorResetReturnPathTests` — sanitizer unit coverage (safe paths preserved; unsafe → `/`).
- `NotebookWebRoutesTests` — GET renders the confirm form and sanitizes `next`; POST sets `Clear-Site-Data` with cache+storage but **not** cookies; POST without CSRF → 403.

`swift build`, the new tests, `scripts/lint.sh`, `scripts/swiftlint.sh` (0 violations), `scripts/check-styles.sh`, and `scripts/check-css-vars.sh` all pass locally.

## Operator note

This is opt-in by design — a blanket `Clear-Site-Data: "storage"` on the notebook page would wipe **every** student's unsaved work, so it's gated behind a deliberate visit. Stuck students can be pointed at `chickadee.uwaterloo.ca/reset-editor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_