### PR TITLE
In-iframe kernel-boot diagnostics: close the cross-process telemetry blind spot

### DIFF
--- a/Public/jl-kernel-diagnostics.js
+++ b/Public/jl-kernel-diagnostics.js
@@ -1,0 +1,181 @@
+// Public/jl-kernel-diagnostics.js
+//
+// Passive kernel-boot diagnostics, injected into the JupyterLite editor
+// documents (notebooks/repl index.html) so it runs INSIDE the editor iframe —
+// the same context as the Pyodide kernel, where the boot actually happens and
+// where errors are visible. The parent notebook page cannot read across the
+// cross-process iframe boundary (the Safari/iPad problem), which is exactly why
+// kernel hangs were invisible: a hung kernel still left the parent reporting a
+// green `editor_ready`. From the inside we can see the truth.
+//
+// It is a PURE OBSERVER: fully try/catch-guarded, fire-and-forget, never touches
+// the kernel or the page. It `postMessage`s two things to the parent window,
+// which forwards them through the normal client-diagnostics pipeline (the parent
+// holds the session + CSRF token — see the bridge in notebook.js):
+//
+//   • kernel_phase breadcrumbs (boot_start → app_ready → kernel_starting →
+//     kernel_idle) — the boot funnel; the drop-off point shows WHERE a boot
+//     stalls. `kernel_idle` is the reliable "the kernel actually came up"
+//     signal the parent-side probe could never get.
+//   • kernel_error — the actual failure: a CSP worker block (the data:-worker
+//     case), an IndexedDB / Drive exception, a blocked/404 asset, a dead/unknown
+//     kernel, or a boot-stall watchdog — the WHY.
+//
+// Capture is scoped to the BOOT window (it stops once the kernel is idle), so it
+// never records student-code execution — infrastructure breadcrumbs only, same
+// PII contract as the rest of client-diagnostics.
+
+(function () {
+    'use strict';
+
+    var KERNEL_BOOT_DEADLINE_MS = 75000;  // generous; a healthy kernel idles in seconds
+    var MAX_ERRORS = 8;
+
+    var origin;
+    try { origin = window.location.origin; } catch (_) { origin = '*'; }
+
+    var reportedPhases = {};
+    var seenErrors = {};
+    var errorCount = 0;
+    var done = false;                 // true once idle/stalled — stops the boot-window capture
+    var lastPhase = 'boot_start';
+
+    // Always posts to window.parent: in the editor that is the notebook page
+    // (which forwards it); loaded top-level (the editor-smoke REPL) parent is
+    // self, so a top-level listener can still observe it for testing.
+    function post(kind, source, message) {
+        try {
+            var payload = { ck: 'kernel-diag', kind: kind, source: String(source).slice(0, 64) };
+            if (message != null) payload.message = String(message).slice(0, 1000);
+            window.parent.postMessage(payload, origin);
+        } catch (_) { /* never throw */ }
+    }
+
+    function reportPhase(phase) {
+        if (reportedPhases[phase]) return;
+        reportedPhases[phase] = true;
+        lastPhase = phase;
+        post('kernel_phase', phase);
+    }
+
+    function reportError(source, message) {
+        try {
+            if (done) return;                 // boot window only — never student execution
+            if (errorCount >= MAX_ERRORS) return;
+            var key = source + '|' + (message || '');
+            if (seenErrors[key]) return;
+            seenErrors[key] = true;
+            errorCount += 1;
+            post('kernel_error', source, message);
+        } catch (_) { /* never throw */ }
+    }
+
+    // ---- error capture (the WHY) ---------------------------------------
+
+    try {
+        // CSP violations — e.g. the data:-worker block ("worker-src 'self' blob:").
+        window.addEventListener('securitypolicyviolation', function (e) {
+            try {
+                reportError(
+                    'csp_violation',
+                    (e.violatedDirective || 'csp') + ' blocked ' + String(e.blockedURI || '').slice(0, 200));
+            } catch (_) { /* ignore */ }
+        }, true);
+    } catch (_) { /* ignore */ }
+
+    try {
+        // Capture phase: resource-load failures (blocked/404 kernel worker chunk,
+        // wheel) don't bubble to a non-capturing listener.
+        window.addEventListener('error', function (e) {
+            try {
+                var target = e && e.target;
+                if (target && target !== window && (target.src || target.href)) {
+                    reportError('resource_error',
+                        'failed to load ' + String(target.src || target.href).slice(0, 200));
+                } else if (e && e.message) {
+                    reportError('onerror', e.message);
+                }
+            } catch (_) { /* ignore */ }
+        }, true);
+    } catch (_) { /* ignore */ }
+
+    try {
+        window.addEventListener('unhandledrejection', function (e) {
+            try {
+                var reason = e && e.reason;
+                reportError('unhandledrejection', (reason && reason.message) || String(reason || 'unhandledrejection'));
+            } catch (_) { /* ignore */ }
+        });
+    } catch (_) { /* ignore */ }
+
+    // ---- boot-phase detection (the WHERE) ------------------------------
+    //
+    // Reliable IN-CONTEXT (unlike the parent across the iframe boundary): a
+    // running kernel's execution_state/status via the ServiceManager, with the
+    // status-bar text as a fallback.
+    function kernelStatus() {
+        try {
+            var app = window.jupyterapp;
+            var sm = app && app.serviceManager;
+            if (sm) {
+                var managers = [sm.kernels, sm.sessions];
+                for (var m = 0; m < managers.length; m++) {
+                    var mgr = managers[m];
+                    if (mgr && typeof mgr.running === 'function') {
+                        var running = Array.from(mgr.running() || []);
+                        for (var i = 0; i < running.length; i++) {
+                            var k = running[i];
+                            var status = (k && (k.execution_state || k.status))
+                                || (k && k.kernel && (k.kernel.execution_state || k.kernel.status));
+                            if (status) return status;
+                        }
+                    }
+                }
+            }
+        } catch (_) { /* fall through */ }
+        try {
+            var txt = (document.body && document.body.textContent) || '';
+            if (txt.indexOf('| Idle') !== -1 || txt.indexOf('| Busy') !== -1) return 'idle';
+            if (txt.indexOf('Kernel Unknown') !== -1) return 'unknown';
+        } catch (_) { /* fall through */ }
+        return null;
+    }
+
+    var startedAt = Date.now();
+
+    function poll() {
+        if (done) return;
+        try {
+            if (!reportedPhases.app_ready && window.jupyterapp) reportPhase('app_ready');
+            var status = kernelStatus();
+            if (status) {
+                if (!reportedPhases.kernel_starting) reportPhase('kernel_starting');
+                if (status === 'idle' || status === 'busy') {
+                    reportPhase('kernel_idle');   // SUCCESS — the missing signal
+                    done = true;
+                    return;
+                }
+                if (status === 'dead' || status === 'unknown') {
+                    reportError('kernel_' + status, 'kernel status ' + status);
+                    // keep watching — a recovery may still reach idle
+                }
+            }
+        } catch (_) { /* ignore */ }
+        if (Date.now() - startedAt >= KERNEL_BOOT_DEADLINE_MS) {
+            reportError('boot_stalled',
+                'last_phase=' + lastPhase + ';elapsed_ms=' + (Date.now() - startedAt));
+            done = true;     // stop; the funnel drop-off + captured errors tell the story
+            return;
+        }
+        setTimeout(poll, 1000);
+    }
+
+    reportPhase('boot_start');
+    setTimeout(poll, 500);
+
+    // Test seam (Node vm): exercise detection + reporting without a browser.
+    try {
+        var hooks = (typeof globalThis !== 'undefined') && globalThis.__CK_KERNEL_DIAG_TEST_HOOKS__;
+        if (hooks) hooks.exports = { kernelStatus: kernelStatus, reportPhase: reportPhase, reportError: reportError };
+    } catch (_) { /* ignore */ }
+})();

--- a/Public/jupyterlite/notebooks/index.html
+++ b/Public/jupyterlite/notebooks/index.html
@@ -111,6 +111,7 @@
         100% { opacity: 0; }
       }
     </style>
+  <script src="/jl-kernel-diagnostics.js"></script>
   </head>
   <body class="jp-ThemedContainer" data-notebook="notebooks">
     <div id="jupyterlite-loading-indicator" class="hidden">

--- a/Public/jupyterlite/repl/index.html
+++ b/Public/jupyterlite/repl/index.html
@@ -111,6 +111,7 @@
         100% { opacity: 0; }
       }
     </style>
+  <script src="/jl-kernel-diagnostics.js"></script>
   </head>
   <body class="jp-ThemedContainer" data-notebook="repl">
     <div id="jupyterlite-loading-indicator" class="hidden">

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -195,6 +195,57 @@
         });
     }
 
+    // --- In-iframe kernel-boot diagnostics bridge --------------------
+    //
+    // The JupyterLite editor document loads jl-kernel-diagnostics.js, which
+    // observes the Pyodide kernel boot from INSIDE the iframe — the one place
+    // the boot is actually visible — and postMessages kernel_phase breadcrumbs
+    // (boot_start → app_ready → kernel_starting → kernel_idle) and kernel_error
+    // reports out to us. We cannot read the cross-process iframe's kernel state
+    // directly (the Safari/iPad blind spot that made hung kernels look healthy:
+    // the shell mounts → editor_ready fires green → the kernel silently never
+    // starts), but postMessage crosses that boundary, and THIS page holds the
+    // session + CSRF token to forward them through the normal client-diagnostics
+    // pipeline (kernelBootFunnel in get_browser_diagnostics).
+    //
+    // Trust: accept only same-origin messages (our editor iframe is same-origin)
+    // carrying our `ck` tag and one of the two expected kinds. We deliberately do
+    // NOT check event.source — it is unreliable across a cross-process iframe in
+    // Safari, the engine we most need to hear from. The kind allowlist + origin
+    // check + server-side per-(user,setup,kind,source) rate limit bound the blast
+    // radius of a misbehaving sender.
+    let kernelDiagForwarded = 0;
+    const KERNEL_DIAG_MAX = 24;   // the collector self-caps; this bounds POSTs
+
+    // Validate + forward one postMessage from the in-iframe collector. Returns
+    // true if it was forwarded (test seam). Accepts only same-origin messages
+    // carrying our `ck` tag and one of the two expected kinds; event.source is
+    // deliberately NOT checked (unreliable across a cross-process iframe in
+    // Safari, the engine we most need to hear from).
+    function handleKernelDiagMessage(e) {
+        try {
+            if (!failures || !failures.reportEvent) return false;
+            if (!e || e.origin !== window.location.origin) return false;
+            const d = e.data;
+            if (!d || d.ck !== 'kernel-diag') return false;
+            if (d.kind !== 'kernel_phase' && d.kind !== 'kernel_error') return false;
+            if (kernelDiagForwarded >= KERNEL_DIAG_MAX) return false;
+            kernelDiagForwarded += 1;
+            failures.reportEvent({
+                kind:    d.kind,
+                source:  d.source ? String(d.source).slice(0, 64) : undefined,
+                message: d.message ? String(d.message).slice(0, 1000) : undefined
+            });
+            return true;
+        } catch (_) {
+            return false;   // telemetry must never break the page
+        }
+    }
+
+    if (failures && failures.reportEvent) {
+        window.addEventListener('message', handleKernelDiagMessage);
+    }
+
     const preflightPromise = failures
         ? failures.runPreflight()
         : Promise.resolve({ ok: true, failed: [] });
@@ -1907,6 +1958,7 @@
             planKernelFailureResponse,
             shouldForceReseed,
             reseedPlan,
+            handleKernelDiagMessage,
         };
     }
 })();

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
@@ -60,6 +60,14 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         /// phases shows where in-browser submissions are lost to a freeze — the
         /// last phase a frozen student reaches has no successor record.
         let submitFunnel: [CountEntry]
+        /// Kernel-boot funnel: `kernel_phase` breadcrumb counts in phase order
+        /// (boot_start → app_ready → kernel_starting → kernel_idle), forwarded by
+        /// the in-iframe collector. The drop-off localizes WHERE a kernel boot
+        /// stalls — a kernel that spins forever reaches some phase and stops, so
+        /// `kernel_idle` far below `boot_start` is the hung-kernel signature the
+        /// parent page could never see across the iframe boundary. Pair with the
+        /// `kernel_error` rows in bySource/recentSamples for the WHY.
+        let kernelBootFunnel: [CountEntry]
         let recentSamples: [Sample]
     }
 
@@ -68,6 +76,12 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
     static let submitPhaseOrder = [
         "grading_start", "runtime_loaded", "setup_unpacked",
         "suite_started", "suite_done", "result_posting", "result_posted",
+    ]
+
+    /// Canonical order of the kernel-boot breadcrumbs (emitted by the in-iframe
+    /// collector Public/jl-kernel-diagnostics.js, forwarded by notebook.js).
+    static let kernelPhaseOrder = [
+        "boot_start", "app_ready", "kernel_starting", "kernel_idle",
     ]
 
     static let name = "get_browser_diagnostics"
@@ -82,8 +96,13 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         + "(grading_start → runtime_loaded → setup_unpacked → suite_started → suite_done → "
         + "result_posting → result_posted) — the drop-off between consecutive phases shows where "
         + "in-browser submissions are lost to a freeze (a frozen student's last reached phase has no "
-        + "successor). Optionally filter by testSetupID. Read-only; reports infrastructure breadcrumbs "
-        + "only and never includes a student identifier."
+        + "successor). And kernelBootFunnel: the kernel_phase breadcrumb counts in phase order "
+        + "(boot_start → app_ready → kernel_starting → kernel_idle), forwarded by the in-iframe "
+        + "collector — the drop-off localizes WHERE a kernel boot stalls (a kernel that spins forever "
+        + "reaches some phase and stops, so kernel_idle far below boot_start is the hung-kernel "
+        + "signature); pair it with the kernel_error rows (in bySource / recentSamples: csp_violation, "
+        + "resource_error, kernel_dead, boot_stalled, …) for the WHY. Optionally filter by testSetupID. "
+        + "Read-only; reports infrastructure breadcrumbs only and never includes a student identifier."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -143,6 +162,18 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         let knownPhases = Set(Self.submitPhaseOrder)
         submitFunnel += Self.sortedCounts(submitPhaseCounts.filter { !knownPhases.contains($0.key) })
 
+        // Kernel-boot funnel from the `kernel_phase` breadcrumbs, in phase order
+        // (then any unknown phases by count). The drop-off pinpoints where a boot
+        // stalls — the in-iframe collector's view of the cross-process kernel.
+        let kernelPhaseCounts = rows.reduce(into: [String: Int]()) { acc, row in
+            if row.kind == "kernel_phase", let source = row.source { acc[source, default: 0] += 1 }
+        }
+        var kernelBootFunnel = Self.kernelPhaseOrder.compactMap { phase -> CountEntry? in
+            kernelPhaseCounts[phase].map { CountEntry(key: phase, count: $0) }
+        }
+        let knownKernelPhases = Set(Self.kernelPhaseOrder)
+        kernelBootFunnel += Self.sortedCounts(kernelPhaseCounts.filter { !knownKernelPhases.contains($0.key) })
+
         let samples = rows.prefix(sampleLimit).map { row in
             Sample(
                 kind: row.kind,
@@ -163,6 +194,7 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
             byFailedCheck: Self.sortedCounts(byCheck),
             byBrowser: Self.sortedCounts(byBrowser),
             submitFunnel: submitFunnel,
+            kernelBootFunnel: kernelBootFunnel,
             recentSamples: Array(samples))
     }
 

--- a/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
+++ b/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
@@ -70,10 +70,22 @@ struct ClientDiagnosticsRoutes: RouteCollection {
         // distinct subtype from the positive-evidence "kernel-unhealthy" one.
         // sw_state reports service-worker registration + cross-origin-isolation
         // state ("supported=…;registrations=…;coi=…;sab=…;waitasync=…").
+        // "kernel_phase" / "kernel_error" are forwarded by the parent page from
+        // the IN-IFRAME collector (jl-kernel-diagnostics.js): the editor document
+        // observes the Pyodide kernel boot from inside the cross-process iframe —
+        // the one context where it is visible — and postMessages breadcrumbs out.
+        // kernel_phase carries the phase name in `source`
+        // (boot_start → app_ready → kernel_starting → kernel_idle), the boot
+        // funnel whose drop-off point localizes WHERE a boot stalls; kernel_error
+        // carries the failure (source = csp_violation / resource_error /
+        // kernel_dead / boot_stalled / …, message = detail) — the WHY the parent
+        // could never see across the iframe boundary. Infrastructure breadcrumbs
+        // only (capture stops once the kernel idles), never student-code output.
         let allowedKinds: Set<String> = [
             "preflight_fail", "watchdog_timeout", "editor_error",
             "submit_phase", "submit_error", "page_unresponsive",
             "editor_ready", "kernel_ready", "sw_state",
+            "kernel_phase", "kernel_error",
         ]
         guard allowedKinds.contains(body.kind) else {
             throw AppError.badRequest(reason: "Unknown kind")

--- a/Tests/APITests/ClientDiagnosticsRoutesTests.swift
+++ b/Tests/APITests/ClientDiagnosticsRoutesTests.swift
@@ -166,6 +166,34 @@ import VaporTesting
         }
     }
 
+    @Test func acceptsInIframeKernelPhaseAndErrorTelemetry() async throws {
+        try await withApp(app) { _ in
+            // The in-iframe collector (jl-kernel-diagnostics.js), forwarded by
+            // notebook.js, reports the kernel boot from inside the cross-process
+            // iframe: kernel_phase breadcrumbs (phase name in `source`) and
+            // kernel_error (failure source + detail). Both are accepted and feed
+            // get_browser_diagnostics (kernelBootFunnel / bySource).
+            let auth = try await loginAsStudent()
+            try await insertSetup(id: "setup_kphase")
+            let bodies = [
+                #"{"kind":"kernel_phase","testSetupID":"setup_kphase","source":"boot_start"}"#,
+                #"{"kind":"kernel_phase","testSetupID":"setup_kphase","source":"kernel_idle"}"#,
+                #"{"kind":"kernel_error","testSetupID":"setup_kphase","source":"csp_violation","message":"worker-src blocked data:"}"#,
+            ]
+            for body in bodies {
+                let res = try await postJSON(body, auth: auth, userAgent: "Mozilla/5.0 (TestRunner)")
+                #expect(res.status == .accepted)
+            }
+
+            let records = try await APIClientDiagnostic.query(on: app.db).all()
+            let kinds = records.map(\.kind).sorted()
+            #expect(kinds == ["kernel_error", "kernel_phase", "kernel_phase"])
+            let err = try #require(records.first { $0.kind == "kernel_error" })
+            #expect(err.source == "csp_violation")
+            #expect(err.message == "worker-src blocked data:")
+        }
+    }
+
     @Test func persistsKernelBootTimeoutSubtype() async throws {
         try await withApp(app) { _ in
             // A kernel that mounts the shell but never reaches ready is reported

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -98,6 +98,51 @@ import VaporTesting
         }
     }
 
+    @Test func getBrowserDiagnosticsBuildsKernelBootFunnelInPhaseOrder() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "kb-admin", role: "admin")
+            let student = try await makeTestUser(on: app, username: "kb-student", role: "student")
+            let studentID = try student.requireID()
+            // kernel_phase breadcrumbs from the in-iframe collector, inserted out
+            // of order. The funnel must come back in canonical boot-phase order so
+            // the drop-off (where the kernel stalled) reads top-to-bottom: here
+            // boot_start=6 → app_ready=6 → kernel_starting=5 → kernel_idle=2, i.e.
+            // 4 of 6 boots never reached idle (the silent-spinner signature).
+            let phaseSeeds: [(String, Int)] = [
+                ("kernel_idle", 2),
+                ("boot_start", 6),
+                ("kernel_starting", 5),
+                ("app_ready", 6),
+            ]
+            for (phase, count) in phaseSeeds {
+                for _ in 0..<count {
+                    try await APIClientDiagnostic(
+                        userID: studentID, testSetupID: nil, kind: "kernel_phase",
+                        failedChecks: nil, userAgent: "UA", message: nil,
+                        stack: nil, source: phase
+                    ).save(on: app.db)
+                }
+            }
+            // A kernel_error must NOT leak into the phase funnel (different kind).
+            try await APIClientDiagnostic(
+                userID: studentID, testSetupID: nil, kind: "kernel_error",
+                failedChecks: nil, userAgent: "UA", message: "blocked",
+                stack: nil, source: "csp_violation"
+            ).save(on: app.db)
+
+            let output = try await GetBrowserDiagnosticsTool().execute(
+                .init(), context(subject: "kb-admin"))
+
+            #expect(
+                output.kernelBootFunnel.map(\.key) == [
+                    "boot_start", "app_ready", "kernel_starting", "kernel_idle",
+                ])
+            #expect(output.kernelBootFunnel.map(\.count) == [6, 6, 5, 2])
+            // The error shows up by source, not in the boot funnel.
+            #expect(output.bySource.contains { $0.key == "csp_violation" && $0.count == 1 })
+        }
+    }
+
     @Test func getHealthAlertsRejectsNonAdmin() async throws {
         try await withApp(app) { app in
             _ = try await makeTestUser(on: app, username: "ha-student", role: "student")

--- a/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+++ b/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
@@ -1,0 +1,235 @@
+// Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+//
+// Unit guards for the in-iframe kernel-boot diagnostics:
+//
+//   * Public/jl-kernel-diagnostics.js — the passive collector that runs INSIDE
+//     the JupyterLite editor iframe, detects the kernel boot phase, and
+//     postMessages kernel_phase / kernel_error breadcrumbs to the parent. Driven
+//     here via its __CK_KERNEL_DIAG_TEST_HOOKS__ seam.
+//   * Public/notebook.js handleKernelDiagMessage — the parent-side bridge that
+//     validates those messages (same-origin, our `ck` tag, allowed kind, cap)
+//     before forwarding them through the client-diagnostics pipeline.
+//
+// Together these pin the contract that closes the cross-process-iframe blind
+// spot: the parent can't read the kernel's state, but the collector can, and the
+// bridge only trusts a same-origin sender.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const collectorSource = await fs.readFile(
+  path.resolve('Public/jl-kernel-diagnostics.js'), 'utf8');
+const notebookSource = await fs.readFile(
+  path.resolve('Public/notebook.js'), 'utf8');
+
+// ----------------------------------------------------------------
+// Collector (jl-kernel-diagnostics.js)
+// ----------------------------------------------------------------
+
+function loadCollector({ jupyterapp, bodyText = '' } = {}) {
+  const posted = [];
+  const hooks = {};
+  const win = {
+    location: { origin: 'https://example.test' },
+    parent: { postMessage(payload, origin) { posted.push({ payload, origin }); } },
+    addEventListener() {},
+    jupyterapp,
+  };
+  const document = { body: { textContent: bodyText }, addEventListener() {} };
+  const context = {
+    console, JSON, Error,
+    setTimeout: () => 0,   // don't auto-run the poll loop; we drive via hooks
+    clearTimeout: () => {},
+    window: win,
+    document,
+    __CK_KERNEL_DIAG_TEST_HOOKS__: hooks,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(collectorSource, context, { filename: 'jl-kernel-diagnostics.js' });
+  return { posted, exports: hooks.exports };
+}
+
+test('collector posts boot_start to the parent on load, same-origin', () => {
+  const { posted } = loadCollector();
+  assert.equal(posted.length, 1);
+  // Spread into a test-realm object: the payload is built inside the vm context,
+  // so its prototype differs and deepStrictEqual would reject it cross-realm.
+  assert.deepEqual({ ...posted[0].payload }, {
+    ck: 'kernel-diag', kind: 'kernel_phase', source: 'boot_start',
+  });
+  assert.equal(posted[0].origin, 'https://example.test');
+});
+
+test('collector kernelStatus reads execution_state from the ServiceManager', () => {
+  const jupyterapp = {
+    serviceManager: {
+      kernels: { running() { return [{ execution_state: 'idle' }]; } },
+      sessions: { running() { return []; } },
+    },
+  };
+  const { exports } = loadCollector({ jupyterapp });
+  assert.equal(exports.kernelStatus(), 'idle');
+});
+
+test('collector kernelStatus falls back to the status-bar text', () => {
+  const idle = loadCollector({ bodyText: 'Python (Pyodide) | Idle' });
+  assert.equal(idle.exports.kernelStatus(), 'idle');
+  const unknown = loadCollector({ bodyText: 'Kernel Unknown' });
+  assert.equal(unknown.exports.kernelStatus(), 'unknown');
+  const nothing = loadCollector({ bodyText: '' });
+  assert.equal(nothing.exports.kernelStatus(), null);
+});
+
+test('collector reportPhase de-duplicates a phase', () => {
+  const { posted, exports } = loadCollector();   // posted already has boot_start
+  exports.reportPhase('app_ready');
+  exports.reportPhase('app_ready');
+  const appReady = posted.filter(p => p.payload.source === 'app_ready');
+  assert.equal(appReady.length, 1);
+});
+
+test('collector reportError forwards source + message and de-dupes', () => {
+  const { posted, exports } = loadCollector();
+  exports.reportError('csp_violation', "worker-src blocked data:");
+  exports.reportError('csp_violation', "worker-src blocked data:");   // dup
+  const errs = posted.filter(p => p.payload.kind === 'kernel_error');
+  assert.equal(errs.length, 1);
+  assert.deepEqual({ ...errs[0].payload }, {
+    ck: 'kernel-diag', kind: 'kernel_error',
+    source: 'csp_violation', message: 'worker-src blocked data:',
+  });
+});
+
+test('collector reportError caps at MAX_ERRORS distinct errors', () => {
+  const { posted, exports } = loadCollector();
+  for (let i = 0; i < 12; i++) exports.reportError('src' + i, 'msg' + i);
+  const errs = posted.filter(p => p.payload.kind === 'kernel_error');
+  assert.equal(errs.length, 8);   // MAX_ERRORS
+});
+
+// ----------------------------------------------------------------
+// Parent bridge (notebook.js handleKernelDiagMessage)
+// ----------------------------------------------------------------
+
+function loadBridge() {
+  const events = [];
+  const hooks = {};
+  const elements = new Map();
+  const frame = {
+    dataset: {
+      setupId: 'setup_123', gradingMode: 'browser',
+      notebookUrl: '/api/v1/testsetups/setup_123/assignment',
+      editorUrl: '/jupyterlite/notebooks/index.html?path=assignment.ipynb',
+    },
+    addEventListener() {},
+    getAttribute(name) { return name === 'src' ? this.dataset.editorUrl : null; },
+    contentWindow: null, contentDocument: null, src: '',
+  };
+  elements.set('jl-frame', frame);
+  elements.set('nb-status', { textContent: '', className: '' });
+  elements.set('nb-results', { hidden: true, innerHTML: '', appendChild() {}, scrollIntoView() {} });
+  const document = {
+    getElementById(id) { return elements.get(id) ?? null; },
+    createElement() { return { className: '', textContent: '', innerHTML: '', appendChild() {} }; },
+    addEventListener() {},
+    head: { appendChild() {} },
+  };
+  const fetch = async () => ({ ok: true, async json() { return { cells: [] }; } });
+  const failures = {
+    runPreflight: async () => ({ ok: true, failed: [] }),
+    reportEvent: (info) => { events.push(info); },
+    reportEditorError() {},
+    showFailure() {},
+  };
+  const context = {
+    console, document, fetch,
+    // No-op timers: the bridge installs synchronously at load, so we never need
+    // a real tick — and a real one would fire mountEditor's deferred sw_state
+    // beacon (which touches an undefined `navigator`) after the test ended.
+    setTimeout: () => 0, clearTimeout: () => {},
+    setInterval: () => 1, clearInterval: () => {},
+    URL, JSON, Error, Promise,
+    window: {
+      location: { origin: 'https://example.test' },
+      addEventListener() {},
+      matchMedia: null,
+      ChickadeeNotebookFailures: failures,
+    },
+    __CHICKADEE_NOTEBOOK_TEST_HOOKS__: hooks,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(notebookSource, context, { filename: 'notebook.js' });
+  // Drop any non-kernel telemetry emitted during load (e.g. sw_state).
+  const kernelEvents = () => events.filter(
+    e => e.kind === 'kernel_phase' || e.kind === 'kernel_error');
+  return { handleKernelDiagMessage: hooks.exports.handleKernelDiagMessage, kernelEvents };
+}
+
+function msg(data, origin = 'https://example.test') {
+  return { origin, data };
+}
+
+test('bridge forwards a same-origin kernel_phase', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  const ok = handleKernelDiagMessage(msg({ ck: 'kernel-diag', kind: 'kernel_phase', source: 'kernel_idle' }));
+  assert.equal(ok, true);
+  assert.deepEqual(kernelEvents().map(e => ({ ...e })),
+    [{ kind: 'kernel_phase', source: 'kernel_idle', message: undefined }]);
+});
+
+test('bridge forwards a kernel_error with source + message', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  handleKernelDiagMessage(msg({
+    ck: 'kernel-diag', kind: 'kernel_error', source: 'boot_stalled', message: 'last_phase=app_ready',
+  }));
+  assert.deepEqual(kernelEvents().map(e => ({ ...e })),
+    [{ kind: 'kernel_error', source: 'boot_stalled', message: 'last_phase=app_ready' }]);
+});
+
+test('bridge rejects a cross-origin message', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  const ok = handleKernelDiagMessage(
+    msg({ ck: 'kernel-diag', kind: 'kernel_phase', source: 'kernel_idle' }, 'https://evil.example.com'));
+  assert.equal(ok, false);
+  assert.equal(kernelEvents().length, 0);
+});
+
+test('bridge rejects a message without the ck tag', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  assert.equal(handleKernelDiagMessage(msg({ kind: 'kernel_phase', source: 'x' })), false);
+  assert.equal(handleKernelDiagMessage(msg({ ck: 'something-else', kind: 'kernel_phase', source: 'x' })), false);
+  assert.equal(kernelEvents().length, 0);
+});
+
+test('bridge rejects a disallowed kind', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  assert.equal(handleKernelDiagMessage(msg({ ck: 'kernel-diag', kind: 'editor_ready' })), false);
+  assert.equal(handleKernelDiagMessage(msg({ ck: 'kernel-diag', kind: 'evil' })), false);
+  assert.equal(kernelEvents().length, 0);
+});
+
+test('bridge caps forwarded messages', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  let forwarded = 0;
+  for (let i = 0; i < 30; i++) {
+    if (handleKernelDiagMessage(msg({ ck: 'kernel-diag', kind: 'kernel_error', source: 's' + i, message: 'm' }))) {
+      forwarded += 1;
+    }
+  }
+  assert.equal(forwarded, 24);            // KERNEL_DIAG_MAX
+  assert.equal(kernelEvents().length, 24);
+});
+
+test('bridge clamps oversized source and message', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  handleKernelDiagMessage(msg({
+    ck: 'kernel-diag', kind: 'kernel_error',
+    source: 'x'.repeat(200), message: 'y'.repeat(5000),
+  }));
+  const [e] = kernelEvents();
+  assert.equal(e.source.length, 64);
+  assert.equal(e.message.length, 1000);
+});

--- a/Tools/editor-smoke-test/editor-check.mjs
+++ b/Tools/editor-smoke-test/editor-check.mjs
@@ -19,7 +19,11 @@
 //     this fails;
 //   • a dead kernel / "Kernel Unknown" (a cell never executes);
 //   • the "Page Unresponsive" freeze — input()/stdin hangs when the kernel has
-//     neither the service worker nor SharedArrayBuffer for synchronous stdin.
+//     neither the service worker nor SharedArrayBuffer for synchronous stdin;
+//   • a dropped / CSP-blocked in-iframe kernel-boot collector —
+//     jl-kernel-diagnostics.js must actually run in the editor document and
+//     postMessage kernel_phase=boot_start (proves it's injected AND executes
+//     under the real CSP/COEP, beyond the build-time tag check).
 //
 // It is deliberately auth-free: the REPL and the vendored Pyodide/JupyterLite
 // assets are public static content served through the SAME middleware chain
@@ -173,6 +177,25 @@ async function main() {
     });
   }
 
+  // Capture the in-iframe kernel-boot collector's breadcrumbs. jl-kernel-
+  // diagnostics.js (injected into the editor document) postMessages
+  // kernel_phase / kernel_error to window.parent — which is `self` for the
+  // top-level REPL here — so a window 'message' listener installed before any
+  // page script (addInitScript) sees them. Lets us assert end-to-end that the
+  // collector is injected and that its ServiceManager status detection actually
+  // fires against the real JupyterLite kernel.
+  await context.addInitScript(() => {
+    try {
+      window.__ckKernelDiag = [];
+      window.addEventListener("message", (e) => {
+        const d = e && e.data;
+        if (d && d.ck === "kernel-diag") {
+          window.__ckKernelDiag.push({ kind: d.kind, source: d.source, message: d.message });
+        }
+      });
+    } catch (_) { /* ignore */ }
+  });
+
   const page = await context.newPage();
 
   const blocked = [];
@@ -302,6 +325,37 @@ async function main() {
     if (!ran) {
       return await fail(`kernel did not execute ${PROBE_EXPR} → ${PROBE_RESULT} within ${KERNEL_RUN_MS}ms`);
     }
+
+    // (1b) In-iframe kernel-boot collector: jl-kernel-diagnostics.js is injected
+    // into the editor document and must actually RUN under the real CSP/COEP and
+    // postMessage its first breadcrumb (kernel_phase=boot_start) to the parent.
+    // This is distinct coverage from verify-jupyterlite.sh (which only checks the
+    // <script> tag is present in the built HTML): it proves the script isn't
+    // CSP-blocked or broken and that its postMessage reaches a listener. We assert
+    // boot_start, not kernel_idle, because this harness drives the REPL, which —
+    // unlike the production notebooks editor — does not expose the
+    // `window.jupyterapp.serviceManager` hook the collector reads (the same hook
+    // notebook.js's shipped watchdog uses). The kernel_idle detection itself is
+    // covered by the Node unit test (mocking that ServiceManager shape) and by the
+    // production hook the watchdog already relies on.
+    const sawBootStart = await (async () => {
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        const diag = await page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
+        if (diag.some((d) => d.kind === "kernel_phase" && d.source === "boot_start")) return true;
+        await page.waitForTimeout(500);
+      }
+      return false;
+    })();
+    if (!sawBootStart) {
+      const diag = await page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
+      return await fail(
+        "the in-iframe kernel-boot collector (jl-kernel-diagnostics.js) did not emit " +
+          "kernel_phase=boot_start — the script is not injected into the editor document, is " +
+          "CSP-blocked, or its postMessage bridge is broken. Observed: " + JSON.stringify(diag)
+      );
+    }
+    console.log("kernel-boot collector: observed kernel_phase=boot_start (collector running)");
 
     // (2) Freeze probe: input() must resolve without hanging the page. Needs
     // the service worker (or SAB) for synchronous stdin; without either, the

--- a/changelog.d/in-iframe-kernel-diagnostics.md
+++ b/changelog.d/in-iframe-kernel-diagnostics.md
@@ -1,0 +1,21 @@
+### Added
+
+- **In-iframe kernel-boot diagnostics — closing the cross-process blind spot.**
+  The parent notebook page can't read the Pyodide kernel's state across the
+  cross-process editor iframe (the Safari/iPad case where a hung kernel still
+  left the parent reporting a green `editor_ready`), so a spinning-forever kernel
+  was invisible to telemetry. A new passive collector
+  (`Public/jl-kernel-diagnostics.js`) is injected into the JupyterLite editor
+  documents and runs *inside* the iframe — the one context where the boot is
+  visible. It postMessages two breadcrumb kinds to the parent, which forwards
+  them through the existing client-diagnostics pipeline (session + CSRF):
+  `kernel_phase` (`boot_start → app_ready → kernel_starting → kernel_idle`, the
+  boot funnel whose drop-off localizes *where* a boot stalls) and `kernel_error`
+  (CSP worker block, blocked/404 asset, dead/unknown kernel, or boot-stall — the
+  *why*). Capture is scoped to the boot window, so no student-code execution is
+  ever recorded. `get_browser_diagnostics` gains a `kernelBootFunnel` over the
+  `kernel_phase` events (a `kernel_idle` count far below `boot_start` is the
+  hung-kernel signature). The collector is injected at build time
+  (`scripts/patch-jupyterlite-diagnostics.py`, run from `build-jupyterlite.sh`)
+  and asserted present by `verify-jupyterlite.sh`; the editor-smoke harness
+  asserts it actually runs in a real browser under the live CSP/COEP.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -200,6 +200,49 @@ WebKit. One observed trade-off: without the SW asset cache, the page's two
 Pyodide loads (editor kernel + grader) are heavier, so grading-to-result is
 somewhat slower (noticeably under WebKit); it still completes.
 
+## Observability: the in-iframe kernel-boot collector
+
+The mitigations above fix *known* failure modes. But the parent notebook page
+has a structural blind spot: it **cannot read the Pyodide kernel's state across
+the cross-process editor iframe**. The shell mounting fires a green
+`editor_ready`; if the kernel then silently never starts (the spinning-forever
+symptom), the parent has no signal — `kernelLivenessReady` returns false even
+for *healthy* kernels in that case, which is exactly why a deadline-based
+parent-side beacon false-positived and had to be removed (see the NOTE in
+`notebook.js`). So a hung kernel was invisible to telemetry.
+
+`Public/jl-kernel-diagnostics.js` closes that gap. It is a passive observer
+injected into the editor documents (`notebooks/` + `repl/index.html`) so it runs
+**inside** the iframe — the one context where the boot is actually visible. It
+`postMessage`s two breadcrumb kinds to the parent, which forwards them through
+the normal client-diagnostics pipeline (the parent holds the session + CSRF
+token — the bridge is `handleKernelDiagMessage` in `notebook.js`, which accepts
+only same-origin `ck:'kernel-diag'` messages of an allowed kind):
+
+- **`kernel_phase`** — `boot_start → app_ready → kernel_starting → kernel_idle`.
+  The boot funnel; the drop-off point shows *where* a boot stalls. `kernel_idle`
+  is the positive "the kernel actually came up" signal the parent could never
+  get. Detection reads `window.jupyterapp.serviceManager` (the same hook
+  `notebook.js`'s shipped watchdog uses), with the status-bar text as a fallback.
+- **`kernel_error`** — the *why*: a CSP worker block (the historical
+  `data:`-worker case), a blocked/404 asset, a dead/unknown kernel, or a
+  boot-stall watchdog.
+
+Capture is scoped to the **boot window** (it stops once the kernel idles), so it
+never records student-code execution — same PII contract as the rest of
+client-diagnostics. The admin tool `get_browser_diagnostics` aggregates the
+`kernel_phase` events into a **`kernelBootFunnel`**: a `kernel_idle` count far
+below `boot_start` is the hung-kernel signature, and the `kernel_error` rows
+(in `bySource` / `recentSamples`) say why.
+
+Wiring: the `<script>` tag is injected at build time by
+`scripts/patch-jupyterlite-diagnostics.py` (run from `build-jupyterlite.sh`,
+since `jupyter lite build` regenerates the index.html files) and asserted present
+by `verify-jupyterlite.sh`. The editor-smoke harness asserts the collector
+actually *runs* in a real browser under the live CSP/COEP (it must emit
+`kernel_phase=boot_start`), and the collector + bridge logic is unit-tested in
+`Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs`.
+
 ## Quick reference
 
 | | Sync path | SW-control race? | Status |

--- a/scripts/build-jupyterlite.sh
+++ b/scripts/build-jupyterlite.sh
@@ -78,5 +78,10 @@ PY
 # cross-origin isolated. Idempotent; fails if the upstream polyfill string drifts.
 python3 "$ROOT_DIR/scripts/patch-pyodide-waitasync-worker.py" "$OUTPUT_DIR"
 
+# Inject the in-iframe kernel-boot diagnostics collector (jl-kernel-diagnostics.js)
+# into the editor index.html documents. `jupyter lite build` regenerates those, so
+# this re-adds the <script> tag every build. Idempotent.
+python3 "$ROOT_DIR/scripts/patch-jupyterlite-diagnostics.py" "$OUTPUT_DIR"
+
 "$ROOT_DIR/scripts/verify-jupyterlite.sh" "$OUTPUT_DIR"
 echo "JupyterLite rebuilt at $OUTPUT_DIR"

--- a/scripts/patch-jupyterlite-diagnostics.py
+++ b/scripts/patch-jupyterlite-diagnostics.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Inject the in-iframe kernel-boot diagnostics collector into the JupyterLite
+editor documents.
+
+jl-kernel-diagnostics.js observes the Pyodide kernel boot from INSIDE the editor
+iframe — the one context where the boot is visible — and postMessages
+kernel_phase / kernel_error breadcrumbs out to the parent notebook page, which
+forwards them through the normal client-diagnostics pipeline. The parent cannot
+read the cross-process iframe's kernel state directly (the Safari/iPad blind spot
+that let a hung kernel report a green editor_ready), so the collector has to run
+in the iframe document — which means a <script> tag in the generated index.html.
+
+`jupyter lite build` regenerates those index.html files, so this patch re-injects
+the tag on every build (run from build-jupyterlite.sh) and the checked-in output
+carries it too. It is injected into the kernel-bearing editors only (notebooks,
+repl) — not consoles/edit/lab/tree — so non-kernel pages don't emit boot-stall
+noise.
+
+Idempotent: the tag is only added when absent. Fails loudly if an expected
+editor index.html is missing (an upstream layout change to re-examine).
+"""
+import pathlib
+import sys
+
+# Same-origin absolute path: the editor iframe is served by Chickadee from
+# /jupyterlite/..., so "/jl-kernel-diagnostics.js" resolves to Public/ at the
+# origin root, is allowed by the CSP (script-src 'self'), and — being same-origin
+# — loads cleanly under the editor's COEP require-corp isolation.
+SCRIPT_TAG = '<script src="/jl-kernel-diagnostics.js"></script>'
+
+# Anchor the injection right before </head> so the collector's error listeners
+# are installed as early as possible in the document, before the kernel boots.
+ANCHOR = "</head>"
+
+# Only the kernel-bearing editor entry points; the notebook page mounts
+# /jupyterlite/notebooks/index.html and the editor-smoke harness drives repl.
+EDITOR_INDEXES = [
+    "notebooks/index.html",
+    "repl/index.html",
+]
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("Public/jupyterlite")
+
+    injected = 0
+    already = 0
+    for rel in EDITOR_INDEXES:
+        path = root / rel
+        if not path.is_file():
+            print(
+                f"patch-jupyterlite-diagnostics: FAIL — expected editor document missing: {path}",
+                file=sys.stderr,
+            )
+            return 1
+        text = path.read_text()
+        if SCRIPT_TAG in text:
+            already += 1
+            continue
+        if ANCHOR not in text:
+            print(
+                f"patch-jupyterlite-diagnostics: FAIL — no {ANCHOR!r} anchor in {path}; "
+                "the JupyterLite index.html layout changed, re-examine.",
+                file=sys.stderr,
+            )
+            return 1
+        # Insert before the first </head>, preserving indentation of the anchor.
+        idx = text.index(ANCHOR)
+        line_start = text.rfind("\n", 0, idx) + 1
+        indent = text[line_start:idx]
+        patched = text[:line_start] + indent + SCRIPT_TAG + "\n" + text[line_start:]
+        path.write_text(patched)
+        injected += 1
+
+    if injected:
+        print(f"patch-jupyterlite-diagnostics: injected collector into {injected} editor document(s)")
+    if already:
+        print(f"patch-jupyterlite-diagnostics: already present in {already} editor document(s) — no-op")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-jupyterlite.sh
+++ b/scripts/verify-jupyterlite.sh
@@ -127,5 +127,22 @@ if data_worker_chunks:
         "run scripts/patch-pyodide-waitasync-worker.py (build-jupyterlite.sh does this)."
     )
 
+# The in-iframe kernel-boot diagnostics collector must be injected into the
+# kernel-bearing editor documents (scripts/patch-jupyterlite-diagnostics.py). A
+# `jupyter lite build` regenerates these index.html files and would drop the
+# <script> tag; without it the collector never runs and the kernel boot is
+# invisible again. Assert it's present so a rebuild that forgets the patch fails
+# here, not silently in front of a student.
+diag_tag = '<script src="/jl-kernel-diagnostics.js"></script>'
+for rel in ("notebooks/index.html", "repl/index.html"):
+    index_path = build_dir / rel
+    if not index_path.is_file():
+        fail(f"missing editor document: {index_path}")
+    if diag_tag not in index_path.read_text():
+        fail(
+            f"{rel} is missing the kernel-diagnostics collector tag — "
+            "run scripts/patch-jupyterlite-diagnostics.py (build-jupyterlite.sh does this)."
+        )
+
 print("JupyterLite verification passed.")
 PY


### PR DESCRIPTION
## Why

Some students on v0.4.502+ report the in-browser editor **spinning forever** — the Python (Pyodide) kernel never finishes loading. PR #1005 (`/reset-editor`) gives stuck students a fix; this PR builds the *diagnosis* lever so we can see which students hit it and **why**.

The core problem is a structural blind spot: the parent notebook page **cannot read the kernel's state across the cross-process editor iframe** (the Safari/iPad case). The shell mounts and fires a green `editor_ready`; if the kernel then silently never starts, the parent has no signal — `kernelLivenessReady` returns false even for *healthy* kernels there, which is exactly why an earlier deadline-based parent beacon false-positived and was removed. So a hung kernel was invisible to telemetry.

## What

A passive collector (`Public/jl-kernel-diagnostics.js`) is injected into the JupyterLite editor documents and runs **inside** the iframe — the one context where the boot is visible. It `postMessage`s two breadcrumb kinds to the parent, which forwards them through the existing client-diagnostics pipeline (session + CSRF):

- **`kernel_phase`** — `boot_start → app_ready → kernel_starting → kernel_idle`, the boot funnel whose drop-off localizes **where** a boot stalls. Detection reads `window.jupyterapp.serviceManager` — the *same* hook `notebook.js`'s shipped watchdog uses — with the status-bar text as a fallback.
- **`kernel_error`** — the **why**: a CSP worker block (the historical `data:`-worker case), a blocked/404 asset, a dead/unknown kernel, or a boot-stall watchdog.

`get_browser_diagnostics` gains a **`kernelBootFunnel`** over the `kernel_phase` events: a `kernel_idle` count far below `boot_start` is the hung-kernel signature, and the `kernel_error` rows (in `bySource` / `recentSamples`) say why.

## Safety / scope

- **PII**: capture is scoped to the **boot window** (stops once the kernel idles), so no student-code execution is ever recorded — same contract as the rest of client-diagnostics. `get_browser_diagnostics` stays user-id-free.
- **Trust boundary**: the parent bridge (`handleKernelDiagMessage`) accepts only **same-origin** `ck:'kernel-diag'` messages of an allowed kind, with a forward cap. `event.source` is deliberately not checked (unreliable across a cross-process iframe in Safari — the engine we most need to hear from).
- **Build wiring**: the `<script>` tag is injected at build time by `scripts/patch-jupyterlite-diagnostics.py` (run from `build-jupyterlite.sh`, since `jupyter lite build` regenerates the index.html files) and asserted present by `verify-jupyterlite.sh`.

## Tests (all green locally)

- **Node** (`Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs`, 13 cases): the collector's phase detection / dedup / error cap, and the bridge's origin + `ck` + kind validation, cap, and clamping.
- **Swift**: server accepts `kernel_phase` / `kernel_error`; `kernelBootFunnel` is built in canonical phase order (and a `kernel_error` doesn't leak into it).
- **editor-smoke**: asserts the collector actually **runs** in a real browser under the live CSP/COEP (emits `kernel_phase=boot_start`) — verified locally that the default config PASSes and the discriminating no-sync config still FAILs.
- `swift build`, full Node suite (117), `lint`, `swiftlint` (0 violations), `check-styles`, `check-css-vars`, `verify-jupyterlite` all pass.

One note on the smoke assertion: it checks `boot_start` (the collector running), not `kernel_idle`, because the harness drives the **REPL**, which — unlike the production notebooks editor — doesn't expose `window.jupyterapp.serviceManager`. `kernel_idle` detection is covered by the Node unit test (mocking that ServiceManager shape) and by the fact that it reads the identical hook the shipped production watchdog already relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_