### PR TITLE
Fix admin Max Load card headline leaking the 30-day peak into every window

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+CardSeries.swift
@@ -132,12 +132,19 @@ extension OperationalDiagnosticsService {
     ) -> (series: [Int?], peakActive: Int?, peakMax: Int?) {
         var series = [Int?](repeating: nil, count: grid.bucketCount)
 
+        // `points` is the full longest-window fetch shared across every card
+        // window, so the headline peak must be restricted to the points that
+        // actually land in this grid — otherwise the 24h / 7d headline reports
+        // a peak drawn from up to 30 days of data while its sparkline only
+        // spans the displayed window.
+        var inWindow: [RunnerLoadPoint] = []
         for point in points {
             guard point.totalMax > 0, let index = grid.bucketIndex(for: point.bucketStart) else { continue }
+            inWindow.append(point)
             let utilization = Int((Double(point.totalActive) / Double(point.totalMax) * 100).rounded())
             series[index] = series[index].map { Swift.max($0, utilization) } ?? utilization
         }
-        let peak = peakLoadPoint(from: points)
+        let peak = peakLoadPoint(from: inWindow)
         return (series, peak?.active, peak?.max)
     }
 

--- a/Tests/APITests/MetricsCardSeriesTests.swift
+++ b/Tests/APITests/MetricsCardSeriesTests.swift
@@ -242,6 +242,39 @@ import VaporTesting
         try await snapshot.save(on: app.db)
     }
 
+    /// The Max Load headline must be scoped to each card's own window.  The
+    /// load points are fetched once for the longest (30-day) window and reused
+    /// across windows, so a peak that lands outside the 24h window must not
+    /// leak into the 24h headline (regression: every window showed the 30-day
+    /// peak, e.g. a stale 13/13).
+    @Test func loadHeadlineScopedToEachWindow() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            // A saturated peak (13/13) two days ago: inside 7d / 30d, outside 24h.
+            try await saveSnapshot(
+                runner: "lhs_old", at: now.addingTimeInterval(-2 * 86400), active: 13, max: 13)
+            // A quieter, recent sample (2/13) ten minutes ago: inside every window.
+            try await saveSnapshot(
+                runner: "lhs_recent", at: now.addingTimeInterval(-600), active: 2, max: 13)
+
+            let response = try await app.diagnostics.metricsCardSeries(on: app.db, now: now)
+
+            let day = try #require(response.windows.first { $0.window == "24h" })
+            // 24h sees only the recent 2/13 — not the two-day-old saturation.
+            #expect(day.load.activeJobs == 2)
+            #expect(day.load.capacity == 13)
+
+            let week = try #require(response.windows.first { $0.window == "1w" })
+            // 7d (and 30d) include the saturated peak.
+            #expect(week.load.activeJobs == 13)
+            #expect(week.load.capacity == 13)
+
+            let month = try #require(response.windows.first { $0.window == "1m" })
+            #expect(month.load.activeJobs == 13)
+            #expect(month.load.capacity == 13)
+        }
+    }
+
     @Test func cardsEndpointRequiresAuthentication() async throws {
         try await withApp(app) { _ in
             try await app.asyncTest(

--- a/changelog.d/max-load-card-window-scope.md
+++ b/changelog.d/max-load-card-window-scope.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Admin "Max Load" card headline now scoped to its own window.** The load
+  points feeding the diagnostic cards are fetched once for the longest
+  (30-day) window and reused across the 24h / 7d / 30d cards, but the
+  headline peak was computed over that whole fetch instead of the displayed
+  window — so every card reported the 30-day peak (e.g. a stale `13/13`) even
+  when its sparkline never reached it. The peak is now restricted to the load
+  points that fall inside each card's grid, matching the sparkline.


### PR DESCRIPTION
## Problem

On `/admin`, the **Max Load** diagnostic card always showed a saturated headline (e.g. `13/13`) even when its sparkline never reached that level — an aggregation bug where the headline didn't match the displayed window.

## Root cause

`metricsCardSeries` fetches runner load points **once** for the longest (30-day) window and derives all three cards (24h / 7d / 30d) from that shared set. In `loadSeriesAndPeak`:

- The **sparkline series** correctly drops out-of-window points — `grid.bucketIndex(for:)` returns `nil` for anything outside the displayed window.
- The **headline peak**, however, was computed via `peakLoadPoint(from: points)` over the *entire* 30-day fetch.

So if load ever hit 13/13 in the last 30 days, the 24h and 7d cards reported `13/13` as the headline while their sparklines only spanned (and never reached) that peak.

## Fix

Restrict the headline peak to the load points that actually land in each card's grid window, so the headline matches the displayed window and its sparkline. `peakLoadPoint` itself is unchanged — the `/admin/metrics` snapshot already fetches load points scoped to its window, so it's unaffected.

## Test

Adds `loadHeadlineScopedToEachWindow`: seeds a saturated `13/13` peak two days ago (inside 7d/30d, outside 24h) plus a quiet `2/13` ten minutes ago, and asserts the 24h headline reports `2/13` while 7d/30d report `13/13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZZnyHp5TLhrAD5cefzsEF)_