### PR TITLE
Add type-in user ID enrolment to instructor CSV page

### DIFF
--- a/Resources/Views/instructor-enroll-csv.leaf
+++ b/Resources/Views/instructor-enroll-csv.leaf
@@ -13,10 +13,10 @@ Enrol from CSV — #(courseCode)
 #endif
 
 <section class="admin-section">
-    <h2>Upload enrollment list</h2>
+    <h2>Add students</h2>
     <p class="enroll-csv-intro">
-        Upload a CSV or text file containing one username per line. The first column is used, and a header row like
-        <code>username</code> is ignored automatically.
+        Upload a CSV file, type user IDs directly, or both — supplied IDs are merged. Unknown IDs are recorded as
+        pending enrolments and resolved when the student first signs in.
     </p>
     <form method="post"
           action="/courses/#(courseID)/enroll-csv"
@@ -24,8 +24,16 @@ Enrol from CSV — #(courseCode)
           class="enroll-csv-form">
         #csrfFormField()
         <label class="form-label">
-            Enrollment CSV
-            <input class="form-input enroll-csv-file-input" type="file" name="file" accept=".csv,.txt" required>
+            Upload a CSV
+            <input class="form-input enroll-csv-file-input" type="file" name="file" accept=".csv,.txt">
+            <span class="enroll-csv-hint">One username per line. The first column is used, and a header row like
+                <code>username</code> is ignored automatically.</span>
+        </label>
+        <label class="form-label">
+            Or type user IDs
+            <textarea class="form-input enroll-csv-textarea" name="usernames" rows="5"
+                      placeholder="alice&#10;bob&#10;carol"></textarea>
+            <span class="enroll-csv-hint">Separate IDs with new lines, commas, or spaces.</span>
         </label>
         <div class="enroll-csv-form-buttons">
             <button class="btn btn-primary" type="submit">Enrol</button>
@@ -39,6 +47,8 @@ Enrol from CSV — #(courseCode)
 .enroll-csv-intro { margin-bottom: 1rem; color: var(--text-secondary); font-size: .9rem; }
 .enroll-csv-form { display: flex; flex-direction: column; gap: 1rem; max-width: 480px; }
 .enroll-csv-file-input { display: block; margin-top: .25rem; }
+.enroll-csv-textarea { display: block; margin-top: .25rem; width: 100%; font-family: var(--font-mono); resize: vertical; }
+.enroll-csv-hint { display: block; margin-top: .25rem; color: var(--text-secondary); font-size: .8rem; }
 .enroll-csv-form-buttons { display: flex; gap: .75rem; }
 </style>
 #endexport

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -24,14 +24,6 @@ extension CourseAdminRoutes {
             throw WebAssignmentError.noActiveCourse(action: "managing enrollments")
         }
 
-        struct EnrollCSVFormContext: Encodable {
-            let currentUser: CurrentUserContext?
-            let courseID: String
-            let courseCode: String
-            let courseName: String
-            let error: String?
-        }
-
         return try await req.view.render(
             "instructor-enroll-csv",
             EnrollCSVFormContext(
@@ -67,7 +59,13 @@ extension CourseAdminRoutes {
 
     @Sendable
     func instructorBulkEnrollCSV(req: Request) async throws -> View {
-        struct BulkEnrollForm: Content { var file: Data }
+        // Both inputs are optional: the instructor can upload a CSV, type
+        // user IDs into the textarea, or both.  Usernames from both sources
+        // are merged (and deduplicated by `enrollUsernamesInCourse`).
+        struct BulkEnrollForm: Content {
+            var file: Data?
+            var usernames: String?
+        }
 
         guard
             let idString = req.parameters.get("courseID"),
@@ -83,7 +81,26 @@ extension CourseAdminRoutes {
 
         let form = try req.content.decode(BulkEnrollForm.self)
 
-        let rawUsernames = parseUsernamesFromCSV(form.file)
+        var rawUsernames: [String] = []
+        if let file = form.file, !file.isEmpty {
+            rawUsernames += parseUsernamesFromCSV(file)
+        }
+        if let typed = form.usernames {
+            rawUsernames += parseUsernamesFromText(typed)
+        }
+
+        guard !rawUsernames.isEmpty else {
+            return try await req.view.render(
+                "instructor-enroll-csv",
+                EnrollCSVFormContext(
+                    currentUser: req.currentUserContext,
+                    courseID: idString,
+                    courseCode: course.code,
+                    courseName: course.name,
+                    error: "Upload a CSV file or type at least one user ID to enrol."
+                ))
+        }
+
         let result = try await enrollUsernamesInCourse(
             rawUsernames,
             courseID: courseID,

--- a/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
+++ b/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
@@ -119,6 +119,35 @@ func parseUsernamesFromCSV(_ data: Data) -> [String] {
     }
 }
 
+/// Parses a flat list of usernames from a free-text field — the typed-in
+/// alternative to a CSV upload.  Splits on any common separator (newlines,
+/// commas, semicolons, and surrounding whitespace) so an instructor can
+/// paste one-per-line, comma-separated, or space-separated user IDs.  Each
+/// token is trimmed of surrounding whitespace and quotes; blanks are
+/// dropped.  Shape validation (and pre-enrollment recording) happens later
+/// in `enrollUsernamesInCourse`, exactly as for the CSV path.
+func parseUsernamesFromText(_ text: String) -> [String] {
+    let separators = CharacterSet(charactersIn: ",;\n\r\t ")
+    return
+        text
+        .components(separatedBy: separators)
+        .map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        }
+        .filter { !$0.isEmpty }
+}
+
+/// Context for the `instructor-enroll-csv` upload form (GET render + the
+/// "nothing supplied" re-render of the POST handler).
+struct EnrollCSVFormContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let courseID: String
+    let courseCode: String
+    let courseName: String
+    let error: String?
+}
+
 /// Context for the shared `admin-enroll-csv-result` view, rendered by both
 /// admin and instructor CSV enrollment handlers.
 struct EnrollCSVResultContext: Encodable {

--- a/Tests/APITests/AssignmentEnrollmentTests.swift
+++ b/Tests/APITests/AssignmentEnrollmentTests.swift
@@ -263,6 +263,80 @@ import VaporTesting
         }
     }
 
+    @Test func bulkEnroll_enrollsTypedUsernamesWithoutFile() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "CSV_TYPED1")
+            _ = try await makeStudent(username: "typed_alice")
+            _ = try await makeStudent(username: "typed_bob")
+            let cookie = try await loginInstructor("typed_instructor1", in: course)
+            let courseID = try course.requireID().uuidString
+            let (token, newCookie) = try await csrfFields(for: "/enroll", cookie: cookie, on: app)
+
+            // No `file` part at all — only the typed `usernames` textarea.
+            let typed = "typed_alice, typed_bob"
+            let boundary = "----TypedBoundary1"
+            let part =
+                "--\(boundary)\r\nContent-Disposition: form-data; name=\"usernames\"\r\n\r\n\(typed)\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"_csrf\"\r\n\r\n\(token)\r\n--\(boundary)--\r\n"
+
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID)/enroll-csv",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    var body = ByteBufferAllocator().buffer(capacity: 256)
+                    body.writeString(part)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data",
+                        parameters: ["boundary": boundary])
+                    req.body = .init(buffer: body)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                })
+
+            let enrollments = try await APICourseEnrollment.query(on: app.db)
+                .filter(\.$course.$id == course.requireID())
+                .filter(\.$roleRaw == CourseRole.student.rawValue)
+                .all()
+            #expect(enrollments.count == 2, "Both typed users should be enrolled")
+        }
+    }
+
+    @Test func bulkEnroll_rendersErrorWhenNothingSupplied() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "CSV_EMPTY1")
+            let cookie = try await loginInstructor("empty_instructor1", in: course)
+            let courseID = try course.requireID().uuidString
+            let (token, newCookie) = try await csrfFields(for: "/enroll", cookie: cookie, on: app)
+
+            // Empty textarea, no file.
+            let boundary = "----EmptyBoundary1"
+            let part =
+                "--\(boundary)\r\nContent-Disposition: form-data; name=\"usernames\"\r\n\r\n   \r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"_csrf\"\r\n\r\n\(token)\r\n--\(boundary)--\r\n"
+
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID)/enroll-csv",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    var body = ByteBufferAllocator().buffer(capacity: 256)
+                    body.writeString(part)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data",
+                        parameters: ["boundary": boundary])
+                    req.body = .init(buffer: body)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("type at least one user ID"))
+                })
+
+            let enrollments = try await APICourseEnrollment.query(on: app.db)
+                .filter(\.$course.$id == course.requireID())
+                .filter(\.$roleRaw == CourseRole.student.rawValue)
+                .all()
+            #expect(enrollments.isEmpty, "Nothing supplied should enroll no one")
+        }
+    }
+
     // MARK: - Pre-enrollment (no APIUser yet)
 
     @Test func bulkEnrollCSV_recordsPreEnrollmentForUnknownUsernames() async throws {

--- a/Tests/APITests/EnrollCSVHelperTests.swift
+++ b/Tests/APITests/EnrollCSVHelperTests.swift
@@ -38,6 +38,29 @@ import Testing
         #expect(parseUsernamesFromCSV(Data(csv.utf8)) == ["alice", "bob"])
     }
 
+    // MARK: - Free-text (typed-in) parsing
+
+    @Test func textParsesOnePerLine() {
+        #expect(parseUsernamesFromText("alice\nbob\ncarol\n") == ["alice", "bob", "carol"])
+    }
+
+    @Test func textParsesCommaSeparated() {
+        #expect(parseUsernamesFromText("alice, bob, carol") == ["alice", "bob", "carol"])
+    }
+
+    @Test func textParsesMixedSeparators() {
+        #expect(parseUsernamesFromText("alice bob,carol;dave\neve") == ["alice", "bob", "carol", "dave", "eve"])
+    }
+
+    @Test func textStripsQuotesAndWhitespace() {
+        #expect(parseUsernamesFromText("  \"alice\" , 'bob' ") == ["alice", "bob"])
+    }
+
+    @Test func textDropsBlanks() {
+        #expect(parseUsernamesFromText("alice,,  ,\n\nbob") == ["alice", "bob"])
+        #expect(parseUsernamesFromText("   \n  ").isEmpty)
+    }
+
     // MARK: - Header detection
 
     @Test func skipsUsernameHeader() {

--- a/changelog.d/manual-user-enrollment.md
+++ b/changelog.d/manual-user-enrollment.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Type-in enrolment on the instructor "Enrol from CSV" page.** Alongside the
+  CSV upload, instructors can now paste or type user IDs directly into a
+  textarea (separated by new lines, commas, or spaces). The file and the typed
+  IDs are merged and deduplicated; either input alone is enough, and submitting
+  both empty surfaces an inline error. Unknown IDs are still recorded as pending
+  pre-enrolments and resolved on first login, exactly as for an upload.


### PR DESCRIPTION
## What

On the instructor **Enrol from CSV** page (`/instructor/enroll-csv`), instructors can now type or paste user IDs directly instead of (or in addition to) uploading a CSV file.

## Changes

- **Form** (`instructor-enroll-csv.leaf`): the CSV file input is no longer `required`, and a new **"Or type user IDs"** textarea accepts IDs separated by new lines, commas, or spaces. Reworded the intro to explain both inputs.
- **Handler** (`instructorBulkEnrollCSV`): `BulkEnrollForm` now decodes an optional `file` *and* an optional `usernames` textarea. Usernames parsed from both sources are concatenated and deduplicated by the existing `enrollUsernamesInCourse`. If neither input yields any IDs, the page re-renders with an inline validation error.
- **Helper** (`EnrollCSVHelper.swift`): new shared `parseUsernamesFromText` splits free-text on common separators with the same trim/quote-strip behaviour as the CSV parser. The per-handler form context was hoisted to a shared `EnrollCSVFormContext` so the error path can re-render the form.

Unknown IDs continue to be recorded as pending pre-enrolments and resolved on first login — unchanged. The admin course page's compact CSV button is left as-is.

## Tests

- `EnrollCSVHelperTests`: 5 new cases for `parseUsernamesFromText` (one-per-line, comma, mixed separators, quote/whitespace stripping, blanks).
- `AssignmentEnrollmentTests`: typed-only enrolment (no file part) enrols matched users; empty submission re-renders with the inline error and enrols no one.
- swift-format, SwiftLint (`--strict`), `check-styles.sh`, and `check-css-vars.sh` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtfhQDtDCMP1AxBGmLuNLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtfhQDtDCMP1AxBGmLuNLV)_