### PR TITLE
Add distribution sparklines to assignment-submissions statistics

### DIFF
--- a/Resources/Views/_diagnostic-cards.leaf
+++ b/Resources/Views/_diagnostic-cards.leaf
@@ -1,21 +1,31 @@
 <!--
-    Diagnostic-cards loop shared by the instructor dashboard
-    (`assignments.leaf`) and the per-assignment submissions drilldown
-    (`assignment-submissions.leaf`).  Expects a `metrics` array in
-    scope, each entry shaped `{ label, value }`.  The outer `<section>`
-    wrapper stays in the caller so the caller can scope styling via
-    its own section class (`instructor-diagnostics`,
-    `assignment-diagnostics`, …).
+    Diagnostic-cards loop for the per-assignment submissions drilldown
+    (`assignment-submissions.leaf`).  Expects a `metrics` array in scope, each
+    entry an `AssignmentStatCard` shaped `{ label, value, hasSpark,
+    sparkSummary, bars[] }`.  When `hasSpark` is true the card also draws a
+    server-rendered distribution sparkline (grade spread, attempts, or
+    submissions-over-time) from pre-normalized bar heights — no JS needed.
+    The outer `<section>` wrapper stays in the caller so it can scope styling
+    via its own section class (`assignment-diagnostics`).
 
-    `admin.leaf` keeps its own hardcoded 5-card structure — those
-    cards have JS-targeted `id="diag-…"` attributes filled in by
-    polling, not a Swift-side `metrics` array.
+    The instructor dashboard (`assignments.leaf`) and admin dashboard
+    (`admin.leaf`) keep their own card markup — their sparklines poll a
+    `/metrics/cards` endpoint and cycle the time window, rather than rendering
+    a fixed distribution server-side.
 -->
 <div class="diagnostics-cards">
     #for(metric in metrics):
     <article class="diagnostic-card">
         <div class="diagnostic-label">#(metric.label)</div>
         <div class="diagnostic-value">#(metric.value)</div>
+        #if(metric.hasSpark):
+        <div class="diagnostic-spark" aria-hidden="true">
+            #for(bar in metric.bars):
+            <div class="spark-slot" title="#(bar.title)"><span class="spark-fill" style="--bar-h:#(bar.heightPercent)%"></span></div>
+            #endfor
+        </div>
+        <span class="visually-hidden">#(metric.sparkSummary)</span>
+        #endif
     </article>
     #endfor
 </div>

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -150,6 +150,32 @@ struct InstructorDashboardMetric: Encodable {
     let value: String
 }
 
+/// One bar of a server-rendered sparkline.  `heightPercent` is already
+/// normalized to 0–100 against the series maximum, so the Leaf template
+/// needs no arithmetic and the chart renders without JavaScript.  A zero-count
+/// bin still draws the 2px baseline from `.spark-fill`'s `min-height`, so a
+/// gap reads as "zero here", not "no data".  `title` is the hover tooltip.
+struct SparklineBar: Encodable {
+    let heightPercent: Int
+    let title: String
+}
+
+/// A statistic card on the assignment-submissions page.  Carries the same
+/// `{label, value}` headline as `InstructorDashboardMetric`, plus an optional
+/// server-rendered distribution sparkline (`bars`) visualizing the spread
+/// behind the number — the grade distribution, the attempts-per-student
+/// distribution, or submissions-over-time.  `hasSpark` gates rendering (Leaf's
+/// `array.isEmpty` is unreliable) and `sparkSummary` is the screen-reader
+/// caption; a card with no sparkline renders as a plain number, exactly like
+/// the instructor-dashboard cards.
+struct AssignmentStatCard: Encodable {
+    let label: String
+    let value: String
+    let hasSpark: Bool
+    let sparkSummary: String
+    let bars: [SparklineBar]
+}
+
 struct EnrolledStudentRow: Content {
     let id: String
     let username: String
@@ -173,7 +199,7 @@ struct AssignmentSubmissionsContext: Encodable {
     let currentUser: CurrentUserContext?
     let assignmentID: String
     let assignmentTitle: String
-    let metrics: [InstructorDashboardMetric]
+    let metrics: [AssignmentStatCard]
     let rows: [AssignmentStudentRow]
 }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -172,9 +172,11 @@ extension InstructorDashboardRoutes {
         rows: [AssignmentStudentRow],
         submissions: [APISubmission],
         enrolledStudentRosterCount: Int
-    ) -> [InstructorDashboardMetric] {
-        let windowStart = Date().addingTimeInterval(-24 * 60 * 60)
-        let submittedCount = rows.filter { $0.submissionCount > 0 }.count
+    ) -> [AssignmentStatCard] {
+        let now = Date()
+        let windowStart = now.addingTimeInterval(-24 * 60 * 60)
+        let submittedRows = rows.filter { $0.submissionCount > 0 }
+        let submittedCount = submittedRows.count
         let submissions24h = submissions.filter { submission in
             guard let submittedAt = submission.submittedAt else { return false }
             return submittedAt >= windowStart
@@ -196,7 +198,6 @@ extension InstructorDashboardRoutes {
             let median = sorted.count % 2 == 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
             medianBestGrade = "\(median)%"
         }
-        let submittedRows = rows.filter { $0.submissionCount > 0 }
         let avgAttempts: String
         if submittedRows.isEmpty {
             avgAttempts = "—"
@@ -205,14 +206,119 @@ extension InstructorDashboardRoutes {
             let avg = Double(total) / Double(submittedRows.count)
             avgAttempts = String(format: "%.1f", avg)
         }
+
+        let attemptBars = attemptDistributionBars(submittedRows)
+        let timelineBars = submissionTimelineBars(submissions, now: now)
+        let gradeBars = gradeDistributionBars(gradedRows)
+
         return [
-            InstructorDashboardMetric(
-                label: "Students Submitted", value: "\(submittedCount)/\(enrolledStudentRosterCount)"),
-            InstructorDashboardMetric(label: "Avg Attempts/Student", value: avgAttempts),
-            InstructorDashboardMetric(label: "Submissions (24h)", value: "\(submissions24h)"),
-            InstructorDashboardMetric(label: "Queued Jobs", value: "\(pendingLatestCount)"),
-            InstructorDashboardMetric(label: "Median Grade", value: medianBestGrade),
+            AssignmentStatCard(
+                label: "Students Submitted",
+                value: "\(submittedCount)/\(enrolledStudentRosterCount)",
+                hasSpark: false, sparkSummary: "", bars: []),
+            AssignmentStatCard(
+                label: "Avg Attempts/Student", value: avgAttempts,
+                hasSpark: !attemptBars.isEmpty,
+                sparkSummary: "Submission attempts per student.", bars: attemptBars),
+            AssignmentStatCard(
+                label: "Submissions (24h)", value: "\(submissions24h)",
+                hasSpark: !timelineBars.isEmpty,
+                sparkSummary: "Submissions per day over the last 14 days.", bars: timelineBars),
+            AssignmentStatCard(
+                label: "Queued Jobs", value: "\(pendingLatestCount)",
+                hasSpark: false, sparkSummary: "", bars: []),
+            AssignmentStatCard(
+                label: "Median Grade", value: medianBestGrade,
+                hasSpark: !gradeBars.isEmpty,
+                sparkSummary: "Grade distribution across \(countNoun(gradedRows.count, "graded student")).",
+                bars: gradeBars),
         ]
+    }
+
+    // MARK: - Distribution sparklines
+
+    /// Best-grade distribution in ten 10-point bins (`0–9%` … `90–100%`); the
+    /// top bin absorbs 100.  Empty when no student has a graded result.
+    private func gradeDistributionBars(_ grades: [Int]) -> [SparklineBar] {
+        guard !grades.isEmpty else { return [] }
+        var counts = [Int](repeating: 0, count: 10)
+        for grade in grades {
+            let bin = min(min(max(grade, 0), 100) / 10, 9)
+            counts[bin] += 1
+        }
+        let titles = counts.indices.map { bin -> String in
+            let upper = bin == 9 ? 100 : bin * 10 + 9
+            return "\(bin * 10)–\(upper)%: \(countNoun(counts[bin], "student"))"
+        }
+        return sparklineBars(counts: counts, titles: titles)
+    }
+
+    /// Attempts-per-student distribution in buckets `1, 2, 3, 4, 5, 6+`.
+    /// Empty when no student has submitted.
+    private func attemptDistributionBars(_ submittedRows: [AssignmentStudentRow]) -> [SparklineBar] {
+        guard !submittedRows.isEmpty else { return [] }
+        let bucketCount = 6  // 1, 2, 3, 4, 5, 6+
+        var counts = [Int](repeating: 0, count: bucketCount)
+        for row in submittedRows {
+            counts[min(max(row.submissionCount, 1), bucketCount) - 1] += 1
+        }
+        let titles = counts.indices.map { bin -> String in
+            let attempts: String
+            if bin == bucketCount - 1 {
+                attempts = "\(bucketCount)+ attempts"
+            } else {
+                attempts = countNoun(bin + 1, "attempt")
+            }
+            return "\(attempts): \(countNoun(counts[bin], "student"))"
+        }
+        return sparklineBars(counts: counts, titles: titles)
+    }
+
+    /// Daily submission counts over the most recent 14 days (Waterloo days, to
+    /// match the rest of the UI).  Empty when there is no activity in the
+    /// window, so the card falls back to its plain headline number.
+    private func submissionTimelineBars(_ submissions: [APISubmission], now: Date) -> [SparklineBar] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/Toronto") ?? calendar.timeZone
+        let today = calendar.startOfDay(for: now)
+        let dayCount = 14
+        let dayStarts: [Date] = stride(from: dayCount - 1, through: 0, by: -1).compactMap {
+            calendar.date(byAdding: .day, value: -$0, to: today)
+        }
+        guard dayStarts.count == dayCount else { return [] }
+        var counts = [Int](repeating: 0, count: dayCount)
+        for submission in submissions {
+            guard let submittedAt = submission.submittedAt else { continue }
+            if let index = dayStarts.firstIndex(of: calendar.startOfDay(for: submittedAt)) {
+                counts[index] += 1
+            }
+        }
+        guard counts.contains(where: { $0 > 0 }) else { return [] }
+        let labelFormatter = DateFormatter()
+        labelFormatter.locale = Locale(identifier: "en_US_POSIX")
+        labelFormatter.timeZone = calendar.timeZone
+        labelFormatter.dateFormat = "MMM d"
+        let titles = dayStarts.indices.map { index in
+            "\(labelFormatter.string(from: dayStarts[index])): \(countNoun(counts[index], "submission"))"
+        }
+        return sparklineBars(counts: counts, titles: titles)
+    }
+
+    /// Normalizes a count series to `[SparklineBar]`, scaling each bar's height
+    /// to a 0–100 percentage of the series maximum (matching the JS
+    /// `ChickadeeUI.renderSparkline` path used on the dashboards).
+    private func sparklineBars(counts: [Int], titles: [String]) -> [SparklineBar] {
+        let maxValue = counts.max() ?? 0
+        return counts.indices.map { index in
+            let height = maxValue > 0 ? Int((Double(counts[index]) / Double(maxValue) * 100).rounded()) : 0
+            return SparklineBar(
+                heightPercent: height,
+                title: index < titles.count ? titles[index] : "")
+        }
+    }
+
+    private func countNoun(_ count: Int, _ singular: String) -> String {
+        "\(count) \(singular)\(count == 1 ? "" : "s")"
     }
 
 }

--- a/Tests/APITests/AssignmentSubmissionsSparklineTests.swift
+++ b/Tests/APITests/AssignmentSubmissionsSparklineTests.swift
@@ -1,0 +1,89 @@
+// Tests/APITests/AssignmentSubmissionsSparklineTests.swift
+//
+// Render tests for the server-rendered distribution sparklines on the
+// instructor assignment-submissions page (GET /instructor/:assignmentID/
+// submissions).  The three statistic cards with a distribution behind their
+// number — Avg Attempts/Student, Submissions (24h), Median Grade — draw a
+// `.diagnostic-spark` chart from pre-normalized bar heights; the remaining two
+// stay plain numbers, and the whole spark is omitted when there is no activity.
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized)
+struct AssignmentSubmissionsSparklineTests {
+
+    @Test func submissionsPageRendersDistributionSparklines() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            let student = try await arInsertStudent(username: "spark_student", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "spark_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "spark_setup", title: "Sparkline Lab", isOpen: true, on: app)
+            _ = try await arInsertSubmission(
+                id: "sub_spark", testSetupID: "spark_setup",
+                userID: try student.requireID(), on: app)
+            // 3/4 → 75% → lands in the 70–79% grade bin.
+            let result = APIResult(
+                id: "res_spark",
+                submissionID: "sub_spark",
+                collectionJSON: #"{"earnedPoints":3,"totalPoints":4,"passCount":3,"totalTests":4}"#
+            )
+            try await result.save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/submissions",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    // Server-rendered sparkline scaffolding (no JS needed).
+                    #expect(body.contains("diagnostic-spark"), "sparkline container must render")
+                    #expect(body.contains("--bar-h:"), "bars carry a normalized height")
+                    // Attempts distribution tooltip: one student, one attempt.
+                    #expect(body.contains("1 attempt: 1 student"), "attempts distribution bins by count")
+                    // Accessible captions for the three distribution cards.
+                    #expect(body.contains("Grade distribution across 1 graded student"))
+                    #expect(body.contains("Submission attempts per student"))
+                    #expect(body.contains("Submissions per day over the last 14 days"))
+                }
+            )
+        }
+    }
+
+    @Test func submissionsPageOmitsSparklineWithoutActivity() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+
+            let student = try await arInsertStudent(username: "spark_none", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            try await arInsertSetup(id: "spark_none_setup", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "spark_none_setup", title: "No Subs Lab", isOpen: true, on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(assignment.publicID)/submissions",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    // The headline cards still render…
+                    #expect(body.contains("Median Grade"))
+                    #expect(body.contains("Avg Attempts/Student"))
+                    // …but with no submissions there is no distribution to chart.
+                    #expect(!body.contains("diagnostic-spark"), "no sparkline without activity")
+                }
+            )
+        }
+    }
+}

--- a/changelog.d/assignment-submissions-sparklines.md
+++ b/changelog.d/assignment-submissions-sparklines.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Distribution sparklines on the assignment-submissions statistics.** The
+  instructor `/instructor/:assignmentID/submissions` stat cards now draw a
+  compact sparkline behind three of their headline numbers: the grade
+  distribution (ten 10-point bins) under *Median Grade*, the
+  attempts-per-student distribution (1–6+) under *Avg Attempts/Student*, and
+  daily submissions over the last 14 days (Waterloo days) under *Submissions
+  (24h)*. Bars are rendered server-side from pre-normalized heights — reusing
+  the existing `.diagnostic-spark` styling, no JavaScript or polling endpoint —
+  so they work without scripts; per-bar tooltips and a screen-reader caption
+  describe each chart. Cards with no distribution stay plain numbers, and the
+  sparkline is omitted entirely when an assignment has no submissions yet.


### PR DESCRIPTION
## What

The instructor assignment-submissions page (`GET /instructor/:assignmentID/submissions`, e.g. `/instructor/F3XkAG/submissions`) shows five statistic cards. Three of them now draw a compact **sparkline** behind their headline number, so an instructor can see the *shape* of the data, not just the summary:

| Card | Sparkline |
|------|-----------|
| **Median Grade** | grade distribution — ten 10-point bins (`0–9%` … `90–100%`) |
| **Avg Attempts/Student** | attempts-per-student distribution (`1, 2, 3, 4, 5, 6+`) |
| **Submissions (24h)** | daily submissions over the last 14 days (Waterloo days) |

*Students Submitted* and *Queued Jobs* stay as plain numbers.

## How

- Bars are computed **server-side** in `buildAssignmentSubmissionsMetrics` — each bar's height is pre-normalized to a 0–100 percentage of the series max (the same math the JS `ChickadeeUI.renderSparkline` does on the dashboards), so the Leaf template needs no arithmetic and **the chart renders with no JavaScript and no polling endpoint**.
- Reuses the existing `.diagnostic-spark` / `.spark-slot` / `.spark-fill` CSS (no new styles). The shared `_diagnostic-cards.leaf` partial — used only by this page — now emits the spark when a card has one.
- The submissions-page metric model gains a small `SparklineBar` + `AssignmentStatCard` type; `InstructorDashboardMetric` (the instructor/admin dashboards) is untouched.
- **Accessibility:** each bar carries a hover `title` tooltip (e.g. `70–79%: 4 students`, `3 attempts: 5 students`, `Jun 12: 7 submissions`) and every spark a `.visually-hidden` screen-reader caption. The visual spark itself is `aria-hidden`.
- A card omits its sparkline entirely when there's no distribution to chart (no graded results / no submissions in the window), falling back to the plain headline number — verified by a test.

## Notes

- Headline labels and values are unchanged, so existing render tests stay green.
- Timeline buckets use an `America/Toronto` calendar, matching the rest of the UI.
- No `VERSION` / `CHANGELOG.md` / `ChickadeeVersion` edits — a fragment was added under `changelog.d/` per the release process.

## Testing

- New `AssignmentSubmissionsSparklineTests` (renders the spark for a graded submission; omits it when there's no activity).
- `GradeOverridesTests` + `SubmissionQueryRoutesTests` pass unchanged.
- `scripts/check-styles.sh`, `scripts/check-css-vars.sh`, `swift-format`, and `swiftlint --strict` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uycq6ZKNZDoG8Yzy26THkj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uycq6ZKNZDoG8Yzy26THkj)_