### PR TITLE
Fix kernel-boot collector detection — was polling 75s on every editor open

### DIFF
--- a/Public/jl-kernel-diagnostics.js
+++ b/Public/jl-kernel-diagnostics.js
@@ -110,33 +110,43 @@
 
     // ---- boot-phase detection (the WHERE) ------------------------------
     //
-    // Reliable IN-CONTEXT (unlike the parent across the iframe boundary): a
-    // running kernel's execution_state/status via the ServiceManager, with the
-    // status-bar text as a fallback.
+    // This JupyterLite build (Notebook 7) does NOT expose window.jupyterapp, so
+    // we read the kernel state from the DOM the shell renders — verified against
+    // the real editor by the authenticated notebook-page smoke test. The notebook
+    // execution indicator carries a structured data-status (idle/busy/starting),
+    // with the "Kernel status: …" tooltip text as a secondary signal. (This is
+    // also why the parent-side watchdog could never read kernel state: the global
+    // it reaches for simply isn't there.) Cheap by design — a couple of
+    // querySelectors — so the per-second poll never competes with the kernel.
+    function shellReady() {
+        try {
+            if (document.querySelector('.jp-Notebook-ExecutionIndicator, .jp-NotebookPanel, .jp-Notebook')) {
+                return true;
+            }
+            return document.querySelectorAll('[class^="jp-"],[class*=" jp-"]').length > 20;
+        } catch (_) { return false; }
+    }
+
     function kernelStatus() {
         try {
-            var app = window.jupyterapp;
-            var sm = app && app.serviceManager;
-            if (sm) {
-                var managers = [sm.kernels, sm.sessions];
-                for (var m = 0; m < managers.length; m++) {
-                    var mgr = managers[m];
-                    if (mgr && typeof mgr.running === 'function') {
-                        var running = Array.from(mgr.running() || []);
-                        for (var i = 0; i < running.length; i++) {
-                            var k = running[i];
-                            var status = (k && (k.execution_state || k.status))
-                                || (k && k.kernel && (k.kernel.execution_state || k.kernel.status));
-                            if (status) return status;
-                        }
-                    }
-                }
+            // Primary: the execution indicator's data-status (idle/busy/starting/…).
+            var ind = document.querySelector('.jp-Notebook-ExecutionIndicator[data-status]');
+            if (ind) {
+                var s = ind.getAttribute('data-status');
+                if (s) return s;
             }
+            if (document.querySelector('.jp-KernelStatus-error')) return 'unknown';
         } catch (_) { /* fall through */ }
         try {
+            // Text fallback (console/REPL, or a layout change in a future build).
             var txt = (document.body && document.body.textContent) || '';
-            if (txt.indexOf('| Idle') !== -1 || txt.indexOf('| Busy') !== -1) return 'idle';
-            if (txt.indexOf('Kernel Unknown') !== -1) return 'unknown';
+            if (txt.indexOf('Kernel status: Idle') !== -1 || txt.indexOf('Kernel status: Busy') !== -1
+                || txt.indexOf('| Idle') !== -1 || txt.indexOf('| Busy') !== -1) {
+                return 'idle';
+            }
+            if (txt.indexOf('Kernel status: Unknown') !== -1 || txt.indexOf('Kernel Unknown') !== -1) {
+                return 'unknown';
+            }
         } catch (_) { /* fall through */ }
         return null;
     }
@@ -146,7 +156,7 @@
     function poll() {
         if (done) return;
         try {
-            if (!reportedPhases.app_ready && window.jupyterapp) reportPhase('app_ready');
+            if (!reportedPhases.app_ready && shellReady()) reportPhase('app_ready');
             var status = kernelStatus();
             if (status) {
                 if (!reportedPhases.kernel_starting) reportPhase('kernel_starting');

--- a/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+++ b/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
@@ -29,16 +29,36 @@ const notebookSource = await fs.readFile(
 // Collector (jl-kernel-diagnostics.js)
 // ----------------------------------------------------------------
 
-function loadCollector({ jupyterapp, bodyText = '' } = {}) {
+function loadCollector({ executionStatus, jpCount = 0, kernelError = false, bodyText = '' } = {}) {
   const posted = [];
   const hooks = {};
   const win = {
     location: { origin: 'https://example.test' },
     parent: { postMessage(payload, origin) { posted.push({ payload, origin }); } },
     addEventListener() {},
-    jupyterapp,
   };
-  const document = { body: { textContent: bodyText }, addEventListener() {} };
+  // Mock the JupyterLite shell DOM the collector reads (this build exposes no
+  // window.jupyterapp): the execution indicator's data-status, the kernel-status
+  // error class, and the jp-* shell-element count.
+  const document = {
+    body: { textContent: bodyText },
+    addEventListener() {},
+    querySelector(sel) {
+      if (/jp-Notebook-ExecutionIndicator\[data-status\]/.test(sel)) {
+        return executionStatus != null
+          ? { getAttribute: (a) => (a === 'data-status' ? executionStatus : null) }
+          : null;
+      }
+      if (/jp-KernelStatus-error/.test(sel)) return kernelError ? {} : null;
+      if (/jp-Notebook-ExecutionIndicator|jp-NotebookPanel|jp-Notebook/.test(sel)) {
+        return jpCount > 0 ? {} : null;
+      }
+      return null;
+    },
+    querySelectorAll(sel) {
+      return { length: /class\^=/.test(sel) ? jpCount : 0 };
+    },
+  };
   const context = {
     console, JSON, Error,
     setTimeout: () => 0,   // don't auto-run the poll loop; we drive via hooks
@@ -63,24 +83,17 @@ test('collector posts boot_start to the parent on load, same-origin', () => {
   assert.equal(posted[0].origin, 'https://example.test');
 });
 
-test('collector kernelStatus reads execution_state from the ServiceManager', () => {
-  const jupyterapp = {
-    serviceManager: {
-      kernels: { running() { return [{ execution_state: 'idle' }]; } },
-      sessions: { running() { return []; } },
-    },
-  };
-  const { exports } = loadCollector({ jupyterapp });
-  assert.equal(exports.kernelStatus(), 'idle');
+test('collector kernelStatus reads data-status from the execution indicator', () => {
+  assert.equal(loadCollector({ executionStatus: 'idle' }).exports.kernelStatus(), 'idle');
+  assert.equal(loadCollector({ executionStatus: 'busy' }).exports.kernelStatus(), 'busy');
+  assert.equal(loadCollector({ executionStatus: 'starting' }).exports.kernelStatus(), 'starting');
+  assert.equal(loadCollector({ kernelError: true }).exports.kernelStatus(), 'unknown');
 });
 
-test('collector kernelStatus falls back to the status-bar text', () => {
-  const idle = loadCollector({ bodyText: 'Python (Pyodide) | Idle' });
-  assert.equal(idle.exports.kernelStatus(), 'idle');
-  const unknown = loadCollector({ bodyText: 'Kernel Unknown' });
-  assert.equal(unknown.exports.kernelStatus(), 'unknown');
-  const nothing = loadCollector({ bodyText: '' });
-  assert.equal(nothing.exports.kernelStatus(), null);
+test('collector kernelStatus falls back to the kernel-status text', () => {
+  assert.equal(loadCollector({ bodyText: 'Python (Pyodide) Kernel status: Idle' }).exports.kernelStatus(), 'idle');
+  assert.equal(loadCollector({ bodyText: 'Kernel status: Unknown' }).exports.kernelStatus(), 'unknown');
+  assert.equal(loadCollector({ bodyText: '' }).exports.kernelStatus(), null);
 });
 
 test('collector reportPhase de-duplicates a phase', () => {

--- a/Tools/editor-smoke-test/notebook-page-check.mjs
+++ b/Tools/editor-smoke-test/notebook-page-check.mjs
@@ -198,6 +198,23 @@ async function main() {
       : { headless: true };
   const browser = await browserType.launch(launchOptions);
   const context = await browser.newContext({ storageState: seeded.storageState });
+  // Capture the in-iframe kernel-boot collector's breadcrumbs on the PARENT
+  // window (the collector posts to window.parent, which IS the notebook page
+  // here). Installed in every frame before any page script. Lets us assert the
+  // funnel advances past boot_start in the REAL notebooks editor — the surface
+  // editor-check.mjs (the REPL) can't exercise because the REPL has no
+  // window.jupyterapp for the collector's status detection.
+  await context.addInitScript(() => {
+    try {
+      window.__ckKernelDiag = window.__ckKernelDiag || [];
+      window.addEventListener("message", (e) => {
+        const d = e && e.data;
+        if (d && d.ck === "kernel-diag") {
+          window.__ckKernelDiag.push({ kind: d.kind, source: d.source, message: d.message });
+        }
+      });
+    } catch (_) { /* ignore */ }
+  });
   const page = await context.newPage();
 
   const blocked = [];
@@ -263,6 +280,50 @@ async function main() {
       return fail(`editor iframe did not load the notebook within ${KERNEL_BOOT_MS}ms`, dump);
     }
     console.log("editor iframe shell is up and the notebook loaded from the Drive");
+
+    // (3b) Kernel-boot collector: in the REAL notebooks editor the collector
+    // must actually advance past boot_start to kernel_idle. This both validates
+    // the kernelBootFunnel end-to-end (the gap editor-check.mjs leaves) AND
+    // proves the collector's poll loop terminates — if its status detection
+    // failed here it would never set done=true and would poll for the full 75s
+    // boot deadline, wasted main-thread work on every editor open. Probe the
+    // iframe's own ServiceManager too, so a failure says WHICH side broke.
+    const idleDeadline = Date.now() + 60_000;
+    let sawIdle = false;
+    while (Date.now() < idleDeadline) {
+      const diag = await page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
+      if (diag.some((d) => d.kind === "kernel_phase" && d.source === "kernel_idle")) { sawIdle = true; break; }
+      await page.waitForTimeout(1000);
+    }
+    if (!sawIdle) {
+      const diag = await page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
+      let smProbe = "(probe failed)";
+      try {
+        smProbe = await jlFrame.evaluate(() => {
+          const app = window.jupyterapp;
+          const sm = app && app.serviceManager;
+          const out = { hasJupyterapp: typeof app, hasServiceManager: !!sm };
+          // Hunt for the real kernel-status signal in the DOM.
+          out.dataStatus = Array.from(document.querySelectorAll("[data-status]"))
+            .map((el) => ({ tag: el.tagName, cls: el.className, status: el.getAttribute("data-status") }))
+            .slice(0, 10);
+          out.statusish = Array.from(document.querySelectorAll("*"))
+            .filter((el) => typeof el.className === "string" &&
+              /(ernelStatus|ExecutionIndicator|jp-KernelName|StatusBar)/.test(el.className))
+            .map((el) => ({ cls: el.className, title: el.getAttribute("title"), text: (el.textContent || "").slice(0, 40) }))
+            .slice(0, 12);
+          out.bodyTail = ((document.body && document.body.textContent) || "").replace(/\s+/g, " ").slice(-200);
+          return out;
+        }).then(JSON.stringify);
+      } catch { /* ignore */ }
+      return fail(
+        "the kernel-boot collector never reported kernel_idle in the real notebooks editor — " +
+          "its status detection does not match this app's ServiceManager, so the funnel is stuck at " +
+          "boot_start AND the collector polls the full boot deadline. " +
+          `Captured=${JSON.stringify(diag)} iframeServiceManager=${smProbe}`
+      );
+    }
+    console.log("kernel-boot collector: funnel reached kernel_idle in the real notebooks editor");
 
     // (4) Full submit: click Submit (enabled once the notebook syncs) and wait
     // for an inline result. This exercises in-browser grading end-to-end —

--- a/changelog.d/kernel-collector-detection-fix.md
+++ b/changelog.d/kernel-collector-detection-fix.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **Kernel-boot collector now actually detects the kernel (and stops polling).**
+  The in-iframe collector shipped in the previous diagnostics work read kernel
+  state from `window.jupyterapp.serviceManager` — but this JupyterLite build
+  (Notebook 7) does not expose `window.jupyterapp` at all (which is also why the
+  parent-side watchdog was blind). So the collector never advanced past
+  `boot_start`: the `kernelBootFunnel` was stuck, every healthy editor open
+  emitted a spurious `kernel_error: boot_stalled` after the 75 s deadline, and —
+  the user-visible part — the collector's 1 Hz poll (which walked the notebook
+  DOM via `document.body.textContent`) ran for the full 75 s on every open,
+  competing with the student's editing/execution. Detection now reads the shell
+  DOM the editor actually renders — the execution indicator's `data-status`
+  (`.jp-Notebook-ExecutionIndicator[data-status]`), with "Kernel status: …" text
+  as a fallback — so it reports the real funnel and terminates within seconds of
+  the kernel idling. The authenticated `notebook-page-check.mjs` smoke test
+  (chromium + webkit, in CI) now asserts the funnel reaches `kernel_idle` in the
+  real notebooks editor, so this can't silently regress.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -222,8 +222,15 @@ only same-origin `ck:'kernel-diag'` messages of an allowed kind):
 - **`kernel_phase`** — `boot_start → app_ready → kernel_starting → kernel_idle`.
   The boot funnel; the drop-off point shows *where* a boot stalls. `kernel_idle`
   is the positive "the kernel actually came up" signal the parent could never
-  get. Detection reads `window.jupyterapp.serviceManager` (the same hook
-  `notebook.js`'s shipped watchdog uses), with the status-bar text as a fallback.
+  get. This JupyterLite build (Notebook 7) does not expose `window.jupyterapp`
+  at all — which is *why* the parent-side watchdog could never read kernel state
+  — so detection reads the shell DOM instead: the notebook execution indicator's
+  `data-status` (`.jp-Notebook-ExecutionIndicator[data-status]`, idle/busy/…),
+  with the "Kernel status: …" text as a fallback. Cheap (a couple of
+  `querySelector`s) and verified against the real editor by the authenticated
+  `notebook-page-check.mjs` smoke test, which asserts the funnel reaches
+  `kernel_idle` — without that, a detection mismatch would silently stall the
+  funnel at `boot_start` and leave the collector polling the full boot deadline.
 - **`kernel_error`** — the *why*: a CSP worker block (the historical
   `data:`-worker case), a blocked/404 asset, a dead/unknown kernel, or a
   boot-stall watchdog.


### PR DESCRIPTION
## Why (this answers "is Pyodide a little slower when running code, related to our changes?" — yes)

The in-iframe kernel-boot collector from the prior diagnostics work read kernel state from `window.jupyterapp.serviceManager` — but **this JupyterLite build (Notebook 7) does not expose `window.jupyterapp` at all** (which is also *why* the parent-side watchdog could never read kernel state). I confirmed this empirically against the real editor: inside the iframe, `window.jupyterapp` is `undefined`.

So the collector never advanced past `boot_start`, with three consequences:
1. **`kernelBootFunnel` stuck at `boot_start`** — the diagnostics didn't actually work.
2. **Every healthy editor open emitted a spurious `kernel_error: boot_stalled`** after the 75 s deadline — which would have made tomorrow's funnel data misleading (looks like everyone's kernel is stalling).
3. **The user-visible regression:** the 1 Hz poll walked the notebook DOM (`document.body.textContent`) for the full 75 s on *every* open — `done` never flipped — competing with the student's editing/execution on the main thread. That's the "feels a little slower when running code."

## Fix

Detection now reads the shell DOM the editor actually renders — the execution indicator's `data-status` (`.jp-Notebook-ExecutionIndicator[data-status]`, idle/busy/starting), with "Kernel status: …" text as a fallback (found by dumping the real editor's DOM). It's cheap (a couple of `querySelector`s) and **terminates within seconds of the kernel idling**, so the poll no longer lingers and the funnel reports the real phases.

## Verification

The authenticated `notebook-page-check.mjs` smoke test (chromium + webkit, **already in CI**) now asserts the funnel reaches `kernel_idle` in the *real* notebooks editor — closing the gap the REPL-based smoke couldn't cover (the REPL has no app global either). Run locally:
- **Before the fix:** E2E FAIL — `Captured=[{boot_start}] iframeServiceManager={hasJupyterapp:"undefined"}`
- **After the fix:** `kernel-boot collector: funnel reached kernel_idle in the real notebooks editor` → **E2E PASS**

Node unit tests updated to mock the DOM signal (13/13 pass). No Swift changed.

## Note
This is the run-time perf half. The **load-time** half (compressing the 8.6 MB uncompressed Pyodide wasm) is a separate PR I'm building next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_