### PR TITLE
Dashboard stats polish: cyclable Submissions card, visible small bins, admin tidy-up

### DIFF
--- a/Resources/Views/_diagnostic-cards.leaf
+++ b/Resources/Views/_diagnostic-cards.leaf
@@ -2,30 +2,52 @@
     Diagnostic-cards loop for the per-assignment submissions drilldown
     (`assignment-submissions.leaf`).  Expects a `metrics` array in scope, each
     entry an `AssignmentStatCard` shaped `{ label, value, hasSpark,
-    sparkSummary, bars[] }`.  When `hasSpark` is true the card also draws a
-    server-rendered distribution sparkline (grade spread, attempts, or
-    submissions-over-time) from pre-normalized bar heights — no JS needed.
-    The outer `<section>` wrapper stays in the caller so it can scope styling
-    via its own section class (`assignment-diagnostics`).
+    sparkSummary, bars[], cyclable, windowChip, windows[] }`.
+
+      * `hasSpark`  → a fixed server-rendered distribution sparkline (grade
+                      spread, attempts) drawn from pre-normalized bar heights.
+      * `cyclable`  → the Submissions card: three pre-rendered windows
+                      (24h/7d/30d); the 24h view shows server-side and the
+                      page's click handler reveals the others (cycle.js inline).
+
+    Empty buckets carry `isEmpty` and render flat/transparent so a populated
+    bucket is always visibly distinct.  The outer `<section>` wrapper stays in
+    the caller so it can scope styling via its own section class
+    (`assignment-diagnostics`).
 
     The instructor dashboard (`assignments.leaf`) and admin dashboard
     (`admin.leaf`) keep their own card markup — their sparklines poll a
-    `/metrics/cards` endpoint and cycle the time window, rather than rendering
-    a fixed distribution server-side.
+    `/metrics/cards` endpoint, rather than rendering windows server-side.
 -->
 <div class="diagnostics-cards">
     #for(metric in metrics):
+    #if(metric.cyclable):
+    <article class="diagnostic-card diagnostic-card-cyclable" data-subm-trend
+             role="button" tabindex="0"
+             aria-label="Submissions over time. Press to change the time window between 24 hours, 7 days, and 30 days.">
+        <div class="diagnostic-label"><span class="diagnostic-window-chip" data-subm-chip>#(metric.windowChip)</span> #(metric.label)</div>
+        <div class="diagnostic-value" data-subm-value>#(metric.value)</div>
+        #for(win in metric.windows):
+        <div class="diagnostic-spark subm-trend-spark" data-subm-window="#(win.key)" data-subm-headline="#(win.headline)" aria-hidden="true"#if(win.initiallyHidden): hidden#endif>
+            #for(bar in win.bars):
+            <div class="spark-slot" title="#(bar.title)"><span class="spark-fill#if(bar.isEmpty): spark-fill-empty#endif" style="--bar-h:#(bar.heightPercent)%"></span></div>
+            #endfor
+        </div>
+        #endfor
+    </article>
+    #else:
     <article class="diagnostic-card">
         <div class="diagnostic-label">#(metric.label)</div>
         <div class="diagnostic-value">#(metric.value)</div>
         #if(metric.hasSpark):
         <div class="diagnostic-spark" aria-hidden="true">
             #for(bar in metric.bars):
-            <div class="spark-slot" title="#(bar.title)"><span class="spark-fill" style="--bar-h:#(bar.heightPercent)%"></span></div>
+            <div class="spark-slot" title="#(bar.title)"><span class="spark-fill#if(bar.isEmpty): spark-fill-empty#endif" style="--bar-h:#(bar.heightPercent)%"></span></div>
             #endfor
         </div>
         <span class="visually-hidden">#(metric.sparkSummary)</span>
         #endif
     </article>
+    #endif
     #endfor
 </div>

--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -16,11 +16,15 @@ Admin
 </nav>
 <section class="admin-section admin-diagnostics">
     <div class="diagnostics-cards" id="diagnostics-cards">
-        <article class="diagnostic-card diagnostic-card-cyclable" data-card="maxQueueDepth"
-                 role="button" tabindex="0" aria-label="Max queue depth, last 24 hours. Press to change time window.">
-            <div class="diagnostic-label"><span class="diagnostic-window-chip">24h</span> Max Queue</div>
-            <div class="diagnostic-value" id="diag-queue-depth">—</div>
-            <div class="diagnostic-spark" aria-hidden="true"></div>
+        <article class="diagnostic-card diagnostic-card-cyclable" data-activity-card
+                 role="button" tabindex="0" aria-label="Active users, last 24 hours. Press to change the time window.">
+            <div class="diagnostic-label"><span class="diagnostic-window-chip" id="activity-card-window">24h</span> Active Users</div>
+            <div class="diagnostic-value" id="activity-card-value">—</div>
+            <div class="diagnostic-spark" id="activity-card-spark" aria-hidden="true">
+            #for(bucket in activityChart.buckets):
+                <div class="spark-slot" data-count="#(bucket.count)" data-label="#(bucket.label)"><span class="spark-fill"></span></div>
+            #endfor
+            </div>
         </article>
         <article class="diagnostic-card diagnostic-card-cyclable" data-card="jobsProcessed"
                  role="button" tabindex="0" aria-label="Jobs processed, last 24 hours. Press to change time window.">
@@ -175,27 +179,6 @@ Admin
 
 </section>
 
-<!-- ── Active users over time ─────────────────────────── -->
-<section class="admin-section activity-section">
-    <div class="activity-header">
-        <h2>Active Users</h2>
-        <div class="activity-windows" role="group" aria-label="Activity time range">
-            <button type="button" class="activity-window-btn activity-window-active" data-window="24h" aria-pressed="true">24h</button>
-            <button type="button" class="activity-window-btn" data-window="1w" aria-pressed="false">1 week</button>
-            <button type="button" class="activity-window-btn" data-window="1m" aria-pressed="false">1 month</button>
-        </div>
-    </div>
-    <p class="activity-caption" id="activity-caption">&nbsp;</p>
-    <div class="activity-chart">
-        <div class="activity-bars" id="activity-bars" role="img" aria-label="Distinct active users per time bucket">
-        #for(bucket in activityChart.buckets):
-            <div class="activity-bar" data-count="#(bucket.count)" data-label="#(bucket.label)"><span class="activity-bar-fill"></span></div>
-        #endfor
-        </div>
-        <p class="activity-empty" id="activity-empty" hidden>No activity recorded in this window.</p>
-    </div>
-</section>
-
 <style>
 .admin-diagnostics {
     padding-bottom: 1rem;
@@ -259,90 +242,6 @@ Admin
 tr.runner-row-offline {
     opacity: .5;
 }
-/* ── Active-users activity chart ─────────────────────── */
-.activity-header h2 { margin: 0; }
-.activity-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: .5rem;
-    margin-bottom: .25rem;
-}
-.activity-windows {
-    display: inline-flex;
-    border: 1px solid var(--border);
-    border-radius: .375rem;
-    overflow: hidden;
-}
-.activity-window-btn {
-    padding: .3rem .7rem;
-    font-size: .8rem;
-    font-weight: 500;
-    background: var(--surface);
-    color: var(--gray-600);
-    border: none;
-    border-left: 1px solid var(--border);
-    cursor: pointer;
-    transition: background .12s, color .12s;
-}
-.activity-window-btn:first-child { border-left: none; }
-.activity-window-btn:hover { background: var(--hover-bg); color: var(--gray-900); }
-.activity-window-active,
-.activity-window-active:hover {
-    background: var(--health-teal-dark);
-    color: #fff;
-}
-.activity-caption {
-    margin: 0 0 .5rem;
-    font-size: .8rem;
-    color: var(--gray-600);
-}
-.activity-chart {
-    border: 1px solid var(--border);
-    border-radius: .5rem;
-    background: var(--surface);
-    padding: 1rem 1rem 1.9rem;
-}
-.activity-bars {
-    display: flex;
-    align-items: flex-end;
-    gap: 2px;
-    height: 180px;
-    margin-bottom: 1.4rem;
-}
-.activity-bar {
-    position: relative;
-    flex: 1 1 0;
-    height: 100%;
-    display: flex;
-    align-items: flex-end;
-}
-.activity-bar-fill {
-    width: 100%;
-    height: var(--bar-h, 0);
-    background: var(--health-teal);
-    border-radius: 3px 3px 0 0;
-    transition: height .25s ease;
-}
-.activity-bar:hover .activity-bar-fill { background: var(--health-teal-dark); }
-.activity-bar-label {
-    position: absolute;
-    bottom: -1.35rem;
-    left: -50%;
-    right: -50%;
-    text-align: center;
-    font-size: .65rem;
-    color: var(--gray-500);
-    white-space: nowrap;
-    pointer-events: none;
-}
-.activity-empty {
-    color: var(--gray-500);
-    font-size: .85rem;
-    text-align: center;
-    margin: -2.5rem 0 0;
-}
 </style>
 <script src="/relative-time.js?v=#appVersion()"></script>
 <script>
@@ -356,7 +255,6 @@ tr.runner-row-offline {
     var escapeHtml = ChickadeeUI.escapeHtml;
 
     var collator = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true });
-    var diagQueueDepth = document.getElementById('diag-queue-depth');
     var diagJobsProcessed = document.getElementById('diag-jobs-processed');
     var diagMaxLoad = document.getElementById('diag-max-load');
     var diagQueueP95 = document.getElementById('diag-queue-p95');
@@ -406,11 +304,6 @@ tr.runner-row-offline {
     var windowNouns = { '24h': 'last 24 hours', '1w': 'last 7 days', '1m': 'last 30 days' };
     var cardWindowIndex = {};
     var sparkCards = [
-        {
-            key: 'maxQueueDepth', name: 'Max queue depth', valueEl: diagQueueDepth,
-            headline: function (data) { return data.headline == null ? '—' : String(data.headline); },
-            point: function (v) { return v + (v === 1 ? ' job queued' : ' jobs queued'); }
-        },
         {
             key: 'jobsProcessed', name: 'Jobs processed', valueEl: diagJobsProcessed,
             headline: function (data) { return data.headline == null ? '—' : String(data.headline); },
@@ -748,49 +641,44 @@ tr.runner-row-offline {
     }, 5000);
     setInterval(refreshCards, 60000);
 
-    // ── Active-users activity chart ──────────────────────────────────
-    var activityBars = document.getElementById('activity-bars');
-    if (activityBars) {
-        var activityCaption = document.getElementById('activity-caption');
-        var activityEmpty = document.getElementById('activity-empty');
-        var activityButtons = Array.from(document.querySelectorAll('.activity-window-btn'));
+    // Active Users card: sparkline + click-cycle 24h/7d/30d.
+    // Reuses the GET /admin/activity endpoint (24h/1w/1m windows). The card's
+    // headline is the peak distinct active users in a single bucket; the spark
+    // shows the per-bucket trend. The 24h view is server-rendered into the card
+    // so there's no fetch-on-load flash; clicking the card cycles the window.
+    var activitySpark = document.getElementById('activity-card-spark');
+    if (activitySpark) {
+        var activityCard = document.querySelector('[data-activity-card]');
+        var activityValue = document.getElementById('activity-card-value');
+        var activityWindowChip = document.getElementById('activity-card-window');
+        var activityWindows = ['24h', '1w', '1m'];
+        var activityChipText = { '24h': '24h', '1w': '7d', '1m': '30d' };
         var activityWindow = '24h';
 
-        var windowCaptions = { '24h': 'last 24 hours', '1w': 'last 7 days', '1m': 'last 30 days' };
-
-        function renderActivity(buckets) {
+        function renderActivityCard(buckets) {
             buckets = Array.isArray(buckets) ? buckets : [];
             var max = buckets.reduce(function (m, b) { return Math.max(m, Number(b.count) || 0); }, 0);
-            // Thin the x-axis labels so 24/30 bars don't collide: aim for ~8.
-            var labelEvery = Math.max(1, Math.ceil(buckets.length / 8));
-
-            activityBars.innerHTML = buckets.map(function (b, i) {
+            activitySpark.innerHTML = buckets.map(function (b) {
                 var count = Number(b.count) || 0;
-                var pct = max > 0 ? (count / max) * 100 : 0;
-                var label = b.label || '';
-                var showLabel = (i % labelEvery === 0) || i === buckets.length - 1;
+                // Floor populated buckets so a lone active user shows a visible
+                // bar, not a 2px sliver indistinguishable from an empty bucket.
+                var pct = (max > 0 && count > 0) ? Math.max((count / max) * 100, 20) : 0;
                 var noun = count === 1 ? 'user' : 'users';
-                return '<div class="activity-bar" title="' + escapeHtml(label) + ': ' + count + ' active ' + noun + '">'
-                    + '<span class="activity-bar-fill" style="--bar-h:' + pct.toFixed(1) + '%"></span>'
-                    + (showLabel ? '<span class="activity-bar-label">' + escapeHtml(label) + '</span>' : '')
-                    + '</div>';
+                return '<div class="spark-slot" data-count="' + count + '" data-label="' + escapeHtml(b.label || '')
+                    + '" title="' + escapeHtml(b.label || '') + ': ' + count + ' active ' + noun + '">'
+                    + '<span class="spark-fill' + (count > 0 ? '' : ' spark-fill-empty')
+                    + '" style="--bar-h:' + pct.toFixed(1) + '%"></span></div>';
             }).join('');
-
-            if (activityEmpty) activityEmpty.hidden = max > 0;
-            if (activityCaption) {
-                activityCaption.textContent = max > 0
-                    ? ('Peak ' + max + ' active in a single bucket · ' + (windowCaptions[activityWindow] || ''))
-                    : ' ';
-            }
+            if (activityValue) activityValue.textContent = String(max);
         }
 
-        function bucketsFromDOM() {
-            return Array.from(activityBars.querySelectorAll('.activity-bar')).map(function (el) {
+        function activityBucketsFromDOM() {
+            return Array.from(activitySpark.querySelectorAll('.spark-slot')).map(function (el) {
                 return { count: Number(el.getAttribute('data-count')) || 0, label: el.getAttribute('data-label') || '' };
             });
         }
 
-        async function refreshActivity() {
+        async function refreshActivityCard() {
             try {
                 var res = await fetch('/admin/activity?window=' + encodeURIComponent(activityWindow), {
                     headers: { 'Accept': 'application/json', 'X-Background-Refresh': '1' },
@@ -798,29 +686,33 @@ tr.runner-row-offline {
                 });
                 if (!res.ok) return;
                 var data = await res.json();
-                renderActivity(data.buckets);
+                renderActivityCard(data.buckets);
             } catch (_) {
-                // Keep current chart on transient polling errors.
+                // Keep the current bars on transient polling errors.
             }
         }
 
-        activityButtons.forEach(function (btn) {
-            btn.addEventListener('click', function () {
-                if (btn.getAttribute('data-window') === activityWindow) return;
-                activityWindow = btn.getAttribute('data-window') || '24h';
-                activityButtons.forEach(function (other) {
-                    var active = other === btn;
-                    other.classList.toggle('activity-window-active', active);
-                    other.setAttribute('aria-pressed', active ? 'true' : 'false');
-                });
-                refreshActivity();
-            });
-        });
+        function cycleActivityWindow() {
+            var idx = activityWindows.indexOf(activityWindow);
+            activityWindow = activityWindows[(idx + 1) % activityWindows.length];
+            if (activityWindowChip) activityWindowChip.textContent = activityChipText[activityWindow] || activityWindow;
+            refreshActivityCard();
+        }
 
-        // Size the server-rendered bars immediately (no fetch, no flash), then
-        // keep them fresh on the same cadence as the runners table.
-        renderActivity(bucketsFromDOM());
-        setInterval(refreshActivity, 60000);
+        if (activityCard) {
+            activityCard.addEventListener('click', cycleActivityWindow);
+            activityCard.addEventListener('keydown', function (event) {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    cycleActivityWindow();
+                }
+            });
+        }
+
+        // Size the server-rendered 24h bars immediately (no fetch, no flash),
+        // then keep fresh on the runners-table cadence.
+        renderActivityCard(activityBucketsFromDOM());
+        setInterval(refreshActivityCard, 60000);
     }
 
     // ── Import course ────────────────────────────────────────────────

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -265,5 +265,35 @@
     }
 })();
 </script>
+<script>
+// Submissions stat card: cycle the pre-rendered 24h/7d/30d sparklines on
+// click/Enter/Space. Each window's bars are server-rendered (the 24h view is
+// the only one visible without JS); this just swaps which one shows and
+// updates the window chip + headline count to match.
+(function () {
+    var card = document.querySelector('[data-subm-trend]');
+    if (!card) return;
+    var sparks = Array.prototype.slice.call(card.querySelectorAll('.subm-trend-spark'));
+    if (sparks.length < 2) return;
+    var chip = card.querySelector('[data-subm-chip]');
+    var valueEl = card.querySelector('[data-subm-value]');
+    var index = 0;
+    function show(next) {
+        index = (next + sparks.length) % sparks.length;
+        for (var i = 0; i < sparks.length; i++) { sparks[i].hidden = (i !== index); }
+        var active = sparks[index];
+        if (chip) chip.textContent = active.getAttribute('data-subm-window') || '';
+        if (valueEl) valueEl.textContent = active.getAttribute('data-subm-headline') || '';
+    }
+    card.addEventListener('click', function () { show(index + 1); });
+    card.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            show(index + 1);
+        }
+    });
+    show(0);
+})();
+</script>
 #endexport
 #endextend

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -151,29 +151,48 @@ struct InstructorDashboardMetric: Encodable {
 }
 
 /// One bar of a server-rendered sparkline.  `heightPercent` is already
-/// normalized to 0–100 against the series maximum, so the Leaf template
-/// needs no arithmetic and the chart renders without JavaScript.  A zero-count
-/// bin still draws the 2px baseline from `.spark-fill`'s `min-height`, so a
-/// gap reads as "zero here", not "no data".  `title` is the hover tooltip.
+/// normalized to 0–100 against the series maximum, so the Leaf template needs
+/// no arithmetic and the chart renders without JavaScript.  Populated buckets
+/// are floored to a clearly visible height so a lone student/submission isn't a
+/// 2px sliver indistinguishable from an empty bin; `isEmpty` marks a zero-count
+/// bucket, which renders flat/transparent (`.spark-fill-empty`) so "no one
+/// here" reads differently from "a few here".  `title` is the hover tooltip.
 struct SparklineBar: Encodable {
     let heightPercent: Int
+    let isEmpty: Bool
     let title: String
+}
+
+/// One time-window of the cyclable submissions-over-time card.  `key` is the
+/// window-chip text (`24h` / `7d` / `30d`), `headline` the submission count in
+/// that window, and `bars` the per-bucket sparkline.  `initiallyHidden` is true
+/// for every window after the first, so the page renders the 24h view
+/// server-side (works without JS) and the click handler reveals the others.
+struct SubmissionsTrendWindow: Encodable {
+    let key: String
+    let headline: String
+    let initiallyHidden: Bool
+    let bars: [SparklineBar]
 }
 
 /// A statistic card on the assignment-submissions page.  Carries the same
 /// `{label, value}` headline as `InstructorDashboardMetric`, plus an optional
-/// server-rendered distribution sparkline (`bars`) visualizing the spread
-/// behind the number — the grade distribution, the attempts-per-student
-/// distribution, or submissions-over-time.  `hasSpark` gates rendering (Leaf's
-/// `array.isEmpty` is unreliable) and `sparkSummary` is the screen-reader
-/// caption; a card with no sparkline renders as a plain number, exactly like
-/// the instructor-dashboard cards.
+/// server-rendered distribution sparkline (`bars`, gated by `hasSpark`) — the
+/// grade distribution or the attempts-per-student distribution.  The
+/// Submissions card instead sets `cyclable` and carries three `windows`
+/// (24h/7d/30d) the browser cycles on click, like the dashboard cards.
+/// `sparkSummary` is the screen-reader caption; a card with neither a spark nor
+/// windows renders as a plain number, exactly like the instructor-dashboard
+/// cards.
 struct AssignmentStatCard: Encodable {
     let label: String
     let value: String
     let hasSpark: Bool
     let sparkSummary: String
     let bars: [SparklineBar]
+    let cyclable: Bool
+    let windowChip: String
+    let windows: [SubmissionsTrendWindow]
 }
 
 struct EnrolledStudentRow: Content {

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -208,30 +208,47 @@ extension InstructorDashboardRoutes {
         }
 
         let attemptBars = attemptDistributionBars(submittedRows)
-        let timelineBars = submissionTimelineBars(submissions, now: now)
+        let trendWindows = submissionTrendWindows(submissions, now: now)
         let gradeBars = gradeDistributionBars(gradedRows)
+
+        // The Submissions card is cyclable across 24h/7d/30d when there's been
+        // activity in the last 30 days; otherwise it falls back to a plain
+        // "Submissions (24h)" count, matching its pre-sparkline behaviour.
+        let submissionsCard: AssignmentStatCard
+        if let firstWindow = trendWindows.first {
+            submissionsCard = AssignmentStatCard(
+                label: "Submissions", value: firstWindow.headline,
+                hasSpark: false, sparkSummary: "", bars: [],
+                cyclable: true, windowChip: firstWindow.key, windows: trendWindows)
+        } else {
+            submissionsCard = AssignmentStatCard(
+                label: "Submissions (24h)", value: "\(submissions24h)",
+                hasSpark: false, sparkSummary: "", bars: [],
+                cyclable: false, windowChip: "", windows: [])
+        }
 
         return [
             AssignmentStatCard(
                 label: "Students Submitted",
                 value: "\(submittedCount)/\(enrolledStudentRosterCount)",
-                hasSpark: false, sparkSummary: "", bars: []),
+                hasSpark: false, sparkSummary: "", bars: [],
+                cyclable: false, windowChip: "", windows: []),
             AssignmentStatCard(
                 label: "Avg Attempts/Student", value: avgAttempts,
                 hasSpark: !attemptBars.isEmpty,
-                sparkSummary: "Submission attempts per student.", bars: attemptBars),
-            AssignmentStatCard(
-                label: "Submissions (24h)", value: "\(submissions24h)",
-                hasSpark: !timelineBars.isEmpty,
-                sparkSummary: "Submissions per day over the last 14 days.", bars: timelineBars),
+                sparkSummary: "Submission attempts per student.", bars: attemptBars,
+                cyclable: false, windowChip: "", windows: []),
+            submissionsCard,
             AssignmentStatCard(
                 label: "Queued Jobs", value: "\(pendingLatestCount)",
-                hasSpark: false, sparkSummary: "", bars: []),
+                hasSpark: false, sparkSummary: "", bars: [],
+                cyclable: false, windowChip: "", windows: []),
             AssignmentStatCard(
                 label: "Median Grade", value: medianBestGrade,
                 hasSpark: !gradeBars.isEmpty,
                 sparkSummary: "Grade distribution across \(countNoun(gradedRows.count, "graded student")).",
-                bars: gradeBars),
+                bars: gradeBars,
+                cyclable: false, windowChip: "", windows: []),
         ]
     }
 
@@ -274,45 +291,116 @@ extension InstructorDashboardRoutes {
         return sparklineBars(counts: counts, titles: titles)
     }
 
-    /// Daily submission counts over the most recent 14 days (Waterloo days, to
-    /// match the rest of the UI).  Empty when there is no activity in the
-    /// window, so the card falls back to its plain headline number.
-    private func submissionTimelineBars(_ submissions: [APISubmission], now: Date) -> [SparklineBar] {
+    // MARK: - Submissions-over-time (cyclable card)
+
+    /// The three time windows for the cyclable Submissions card — 24 hourly
+    /// buckets (24h), 7 daily buckets (7d), and 30 daily buckets (30d), all in
+    /// Waterloo time.  Empty when there's been no submission in the last 30
+    /// days, so the card falls back to a plain "Submissions (24h)" count.
+    private func submissionTrendWindows(
+        _ submissions: [APISubmission], now: Date
+    ) -> [SubmissionsTrendWindow] {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "America/Toronto") ?? calendar.timeZone
+
+        let (monthStarts, monthCounts) = dailyBuckets(submissions, dayCount: 30, calendar: calendar, now: now)
+        guard monthCounts.contains(where: { $0 > 0 }) else { return [] }
+        let (hourStarts, hourCounts) = hourlyBuckets(submissions, calendar: calendar, now: now)
+        let (weekStarts, weekCounts) = dailyBuckets(submissions, dayCount: 7, calendar: calendar, now: now)
+
+        let hourFormatter = DateFormatter()
+        hourFormatter.locale = Locale(identifier: "en_US_POSIX")
+        hourFormatter.timeZone = calendar.timeZone
+        hourFormatter.dateFormat = "h a"
+        let dayFormatter = DateFormatter()
+        dayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dayFormatter.timeZone = calendar.timeZone
+        dayFormatter.dateFormat = "MMM d"
+
+        return [
+            trendWindow(
+                key: "24h", starts: hourStarts, counts: hourCounts,
+                formatter: hourFormatter, initiallyHidden: false),
+            trendWindow(
+                key: "7d", starts: weekStarts, counts: weekCounts,
+                formatter: dayFormatter, initiallyHidden: true),
+            trendWindow(
+                key: "30d", starts: monthStarts, counts: monthCounts,
+                formatter: dayFormatter, initiallyHidden: true),
+        ]
+    }
+
+    private func trendWindow(
+        key: String, starts: [Date], counts: [Int], formatter: DateFormatter, initiallyHidden: Bool
+    ) -> SubmissionsTrendWindow {
+        let titles = starts.indices.map { index in
+            "\(formatter.string(from: starts[index])): \(countNoun(counts[index], "submission"))"
+        }
+        return SubmissionsTrendWindow(
+            key: key, headline: "\(counts.reduce(0, +))",
+            initiallyHidden: initiallyHidden,
+            bars: sparklineBars(counts: counts, titles: titles))
+    }
+
+    /// Buckets submissions into `dayCount` daily buckets ending today.
+    private func dailyBuckets(
+        _ submissions: [APISubmission], dayCount: Int, calendar: Calendar, now: Date
+    ) -> ([Date], [Int]) {
         let today = calendar.startOfDay(for: now)
-        let dayCount = 14
-        let dayStarts: [Date] = stride(from: dayCount - 1, through: 0, by: -1).compactMap {
+        let starts: [Date] = stride(from: dayCount - 1, through: 0, by: -1).compactMap {
             calendar.date(byAdding: .day, value: -$0, to: today)
         }
-        guard dayStarts.count == dayCount else { return [] }
-        var counts = [Int](repeating: 0, count: dayCount)
+        var counts = [Int](repeating: 0, count: starts.count)
         for submission in submissions {
             guard let submittedAt = submission.submittedAt else { continue }
-            if let index = dayStarts.firstIndex(of: calendar.startOfDay(for: submittedAt)) {
+            if let index = starts.firstIndex(of: calendar.startOfDay(for: submittedAt)) {
                 counts[index] += 1
             }
         }
-        guard counts.contains(where: { $0 > 0 }) else { return [] }
-        let labelFormatter = DateFormatter()
-        labelFormatter.locale = Locale(identifier: "en_US_POSIX")
-        labelFormatter.timeZone = calendar.timeZone
-        labelFormatter.dateFormat = "MMM d"
-        let titles = dayStarts.indices.map { index in
-            "\(labelFormatter.string(from: dayStarts[index])): \(countNoun(counts[index], "submission"))"
-        }
-        return sparklineBars(counts: counts, titles: titles)
+        return (starts, counts)
     }
 
-    /// Normalizes a count series to `[SparklineBar]`, scaling each bar's height
-    /// to a 0–100 percentage of the series maximum (matching the JS
-    /// `ChickadeeUI.renderSparkline` path used on the dashboards).
+    /// Buckets submissions into 24 hourly buckets ending at the current hour.
+    private func hourlyBuckets(
+        _ submissions: [APISubmission], calendar: Calendar, now: Date
+    ) -> ([Date], [Int]) {
+        let hourUnits: Set<Calendar.Component> = [.year, .month, .day, .hour]
+        let currentHour = calendar.date(from: calendar.dateComponents(hourUnits, from: now)) ?? now
+        let starts: [Date] = stride(from: 23, through: 0, by: -1).compactMap {
+            calendar.date(byAdding: .hour, value: -$0, to: currentHour)
+        }
+        var counts = [Int](repeating: 0, count: starts.count)
+        for submission in submissions {
+            guard let submittedAt = submission.submittedAt,
+                let bucket = calendar.date(from: calendar.dateComponents(hourUnits, from: submittedAt))
+            else { continue }
+            if let index = starts.firstIndex(of: bucket) {
+                counts[index] += 1
+            }
+        }
+        return (starts, counts)
+    }
+
+    /// Normalizes a count series to `[SparklineBar]`.  Each populated bucket is
+    /// scaled to a 0–100 percentage of the series maximum and floored to a
+    /// clearly visible height, so a single student/submission doesn't collapse
+    /// to a 2px sliver indistinguishable from an empty bin; empty buckets are
+    /// flagged so they render flat/transparent rather than at the `.spark-fill`
+    /// min-height (the floor that made small bins read as empty).
     private func sparklineBars(counts: [Int], titles: [String]) -> [SparklineBar] {
         let maxValue = counts.max() ?? 0
+        let minVisibleHeight = 20
         return counts.indices.map { index in
-            let height = maxValue > 0 ? Int((Double(counts[index]) / Double(maxValue) * 100).rounded()) : 0
+            let count = counts[index]
+            let height: Int
+            if count <= 0 || maxValue <= 0 {
+                height = 0
+            } else {
+                height = max(Int((Double(count) / Double(maxValue) * 100).rounded()), minVisibleHeight)
+            }
             return SparklineBar(
                 heightPercent: height,
+                isEmpty: count <= 0,
                 title: index < titles.count ? titles[index] : "")
         }
     }

--- a/Tests/APITests/AdminActivityRouteTests.swift
+++ b/Tests/APITests/AdminActivityRouteTests.swift
@@ -83,9 +83,12 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let body = String(buffer: res.body)
+                    // Active Users is now a cyclable diagnostic card (the old
+                    // standalone bar chart with 24h/1w/1m buttons was folded
+                    // into the metric-cards row, taking the Max Queue slot).
                     #expect(body.contains("Active Users"))
-                    #expect(body.contains("activity-bars"))
-                    #expect(body.contains("data-window=\"1m\""))
+                    #expect(body.contains("data-activity-card"))
+                    #expect(body.contains("activity-card-spark"))
                 })
         }
     }

--- a/Tests/APITests/AssignmentSubmissionsSparklineTests.swift
+++ b/Tests/APITests/AssignmentSubmissionsSparklineTests.swift
@@ -1,11 +1,11 @@
 // Tests/APITests/AssignmentSubmissionsSparklineTests.swift
 //
-// Render tests for the server-rendered distribution sparklines on the
-// instructor assignment-submissions page (GET /instructor/:assignmentID/
-// submissions).  The three statistic cards with a distribution behind their
-// number — Avg Attempts/Student, Submissions (24h), Median Grade — draw a
-// `.diagnostic-spark` chart from pre-normalized bar heights; the remaining two
-// stay plain numbers, and the whole spark is omitted when there is no activity.
+// Render tests for the server-rendered sparklines on the instructor
+// assignment-submissions page (GET /instructor/:assignmentID/submissions).
+// Avg Attempts/Student and Median Grade draw a fixed distribution chart;
+// Submissions is a cyclable card carrying pre-rendered 24h/7d/30d windows the
+// browser swaps on click.  All are server-rendered from pre-normalized bar
+// heights; the charts are omitted when there is no activity.
 
 import Fluent
 import Foundation
@@ -50,10 +50,14 @@ struct AssignmentSubmissionsSparklineTests {
                     #expect(body.contains("--bar-h:"), "bars carry a normalized height")
                     // Attempts distribution tooltip: one student, one attempt.
                     #expect(body.contains("1 attempt: 1 student"), "attempts distribution bins by count")
-                    // Accessible captions for the three distribution cards.
+                    // Accessible captions for the fixed distribution cards.
                     #expect(body.contains("Grade distribution across 1 graded student"))
                     #expect(body.contains("Submission attempts per student"))
-                    #expect(body.contains("Submissions per day over the last 14 days"))
+                    // Submissions card is cyclable: all three windows render server-side.
+                    #expect(body.contains("data-subm-trend"), "Submissions card is cyclable")
+                    #expect(body.contains("data-subm-window=\"24h\""))
+                    #expect(body.contains("data-subm-window=\"7d\""))
+                    #expect(body.contains("data-subm-window=\"30d\""))
                 }
             )
         }
@@ -80,8 +84,12 @@ struct AssignmentSubmissionsSparklineTests {
                     // The headline cards still render…
                     #expect(body.contains("Median Grade"))
                     #expect(body.contains("Avg Attempts/Student"))
-                    // …but with no submissions there is no distribution to chart.
+                    // …but with no submissions there is no distribution to chart,
+                    // and the Submissions card stays a plain number (not cyclable).
+                    // (`data-subm-trend` also appears in the always-present cycling
+                    // script, so key off the per-window markup the card alone emits.)
                     #expect(!body.contains("diagnostic-spark"), "no sparkline without activity")
+                    #expect(!body.contains("data-subm-window="), "Submissions card not cyclable without activity")
                 }
             )
         }

--- a/changelog.d/dashboard-stats-polish.md
+++ b/changelog.d/dashboard-stats-polish.md
@@ -1,0 +1,23 @@
+### Changed
+
+- **Submissions stat card is now cyclable (24h/7d/30d).** On the instructor
+  assignment-submissions page the *Submissions* card behaves like the dashboard
+  cards: click (or Enter/Space) cycles its sparkline through submissions-over-time
+  for the last 24 hours (hourly), 7 days, and 30 days (daily), updating the
+  window chip and count. All three windows are rendered server-side, so the 24h
+  view still shows without JavaScript. The grade and attempts charts stay
+  fixed distributions (they have no time axis).
+- **Admin dashboard: dropped the *Max Queue* card** (Max Load conveys the same
+  or more) and turned *Active Users* into a cyclable metric card in its place —
+  a compact sparkline of distinct active users that cycles 24h/7d/30d on click,
+  replacing the large standalone activity chart at the foot of the page.
+
+### Fixed
+
+- **Distribution sparklines hid small bins.** Bars were rendered at the
+  `.spark-fill` 2px floor for *every* bucket, so a grade bin with one or two
+  students looked identical to an empty bin and the chart appeared to undercount
+  (e.g. ~33 students shown for 37 graded). Empty buckets now render
+  flat/transparent and any populated bucket gets a clearly visible minimum
+  height, so every bin with students is distinct. (The data was always complete
+  — bin tooltips already summed correctly.)


### PR DESCRIPTION
Follow-ups to the assignment-submissions sparklines (#1009), plus two admin-dashboard tweaks.

## Instructor assignment-submissions page

**Submissions card is now cyclable (24h / 7d / 30d).** Like the instructor/admin dashboard cards, the *Submissions* card now cycles on click/Enter/Space through submissions-over-time — hourly buckets for 24h, daily for 7d and 30d — updating the window chip and headline count. All three windows are rendered **server-side** (the 24h view shows without JavaScript; the inline script just swaps which window is visible). The grade and attempts charts stay fixed distributions, since they have no time axis.

**Fix: small bins were invisible.** This is the bug behind "the grade chart shows ~33 but 37 submitted." Every bucket — including zero-count bins — was drawn at the `.spark-fill` 2px floor, so a grade bin with 1–2 students looked identical to an empty bin and the chart appeared to undercount. Now:
- empty buckets render flat/transparent (`.spark-fill-empty`),
- any populated bucket gets a clearly visible minimum height.

So every bin with students is visually distinct. The data was always complete — the bin tooltips already summed to the full graded count.

## Admin dashboard

- **Removed the *Max Queue* card** (and its JS wiring) — Max Load conveys the same or more.
- **Turned *Active Users* into a cyclable metric card** in the freed slot: a compact sparkline of distinct active users that cycles **24h/7d/30d on click** (reusing the `GET /admin/activity` endpoint; 24h is server-rendered so there's no load flash). This replaces the large standalone activity chart that sat at the foot of the page; its now-dead CSS is removed.

## Testing

- `AssignmentSubmissionsSparklineTests` updated: asserts the three cyclable Submissions windows render and that the card is absent (plain number) with no activity.
- `AdminActivityRouteTests` updated: the overview page now renders the Active Users **card** (`data-activity-card` / `activity-card-spark`) instead of the old bar chart; the `/admin/activity` JSON endpoint is unchanged.
- `AdminRoutesTests` (29) pass.
- `check-styles.sh`, `check-css-vars.sh`, `swift-format`, `swiftlint --strict` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uycq6ZKNZDoG8Yzy26THkj