### PR TITLE
Harden nightly clean-build canary against connection-pool flakes

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -69,11 +69,30 @@ jobs:
         # and an occasional "Index out of range" crash that kills the whole
         # test process.  This job is the worst case: it runs *all* targets in
         # one process (no --filter split) with code coverage, so it's the most
-        # pool-pressured run we have, yet it was the only one missing the cap
-        # that swift-tests.yml already applies.  Match that cap here.
+        # pool-pressured run we have — strictly more so than any single
+        # --filter'd swift-tests.yml job.  So it gets a *tighter* cap than the
+        # per-PR jobs (2 vs. 4) to halve the concurrent-pool count.
+        #
+        # Second layer: the test step is retried once.  A lone transient
+        # pool-pressure flake should not redden the canary or auto-file a
+        # tracking issue — but a *real* break fails both attempts and still
+        # reports failure (the canary's signal for deterministic breaks is
+        # preserved).  A flaky first attempt is surfaced as a ::warning:: so
+        # the flakiness stays visible instead of being silently swallowed.
         env:
-          SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "4"
-        run: swift test --enable-code-coverage
+          SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "2"
+        run: |
+          run_tests() { swift test --enable-code-coverage; }
+          if run_tests; then
+            exit 0
+          fi
+          echo "::warning::Nightly clean-build tests failed on attempt 1; retrying once to distinguish a transient pool-pressure flake from a real break."
+          if run_tests; then
+            echo "::warning::Nightly clean-build tests passed on retry — attempt 1 was a flake. Investigate if this recurs (consider lowering parallelism further or raising the AsyncKit pool timeout)."
+            exit 0
+          fi
+          echo "::error::Nightly clean-build tests failed on both attempts — treating as a real failure."
+          exit 1
 
       - name: Export coverage to lcov
         run: |

--- a/changelog.d/nightly-flake-hardening.md
+++ b/changelog.d/nightly-flake-hardening.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **Nightly clean-build canary hardened against connection-pool-pressure flakes.**
+  `test-coverage.yml` runs every target in one process under code coverage —
+  the most pool-pressured run in CI — and was intermittently reddening on
+  transient AsyncKit "Connection request timed out" failures rather than real
+  breaks. The Swift Testing parallelism cap is now tightened to width 2 (from
+  4, half the concurrent test-app DB pools) and the test step is retried once:
+  a lone flake no longer reddens the canary or auto-files a tracking issue,
+  while a genuine break fails both attempts and still reports failure. A flaky
+  first attempt is surfaced as a CI `::warning::` so flakiness stays visible.


### PR DESCRIPTION
## Problem

The nightly clean-build canary (`test-coverage.yml`) runs **every target in one process under code coverage** — the most connection-pool-pressured run in CI. The job's own comment already documents the failure mode: at high parallelism the combined per-test-app DB connection pools exhaust and AsyncKit reports `Connection request timed out`, surfacing as spurious test failures (empty query results, validation stuck "pending") or the occasional load-induced `Index out of range` crash.

The **06-23 scheduled run** ([`28017342358`](https://github.com/JimWallace/Chickadee/actions/runs/28017342358), at v0.4.511 / `ac568a8`) was one such flake: it failed ~11m30s in (i.e. at the *end* of the test phase, one test going red late under load), yet a **faithful local clean-build repro of the exact same commit passed deterministically — 2230 tests in 241 suites, exit 0** (same `--enable-code-coverage`, same `WIDTH=4` cap, 4 cores). So the red was transient infrastructure pressure, not a code break. (This is unrelated to — and downstream of — the python3 fix in #997, which is merged and green.)

## Change

Two layers of hardening, both scoped to this one job:

| | Before | After |
|---|---|---|
| `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `4` | **`2`** — halves the concurrent test-app pool count; this run is strictly more pool-pressured than any single `--filter`'d `swift-tests.yml` job, so it warrants a tighter cap than the per-PR jobs |
| Test step | single `swift test` | **retry once** — a lone transient flake passes on attempt 2; a real break fails both attempts and still reports failure |

**The canary's signal is preserved.** A deterministic break fails both attempts → the job reddens and `report-failure` opens its tracking issue exactly as before. Only a *single* transient flake is forgiven, and even then it is surfaced as a CI `::warning::` so flakiness stays visible rather than being silently swallowed.

## Verification

- YAML parses; the embedded retry shell passes `bash -n`.
- The nightly only runs on `schedule` / `workflow_dispatch`, so this PR's own CI does not exercise the file — the change is config, validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014PobMDeK91fAWbM55p8i4X)_