### PR TITLE
Only report sustained kernel unknown/dead, not transient mid-boot blips

### DIFF
--- a/Public/jl-kernel-diagnostics.js
+++ b/Public/jl-kernel-diagnostics.js
@@ -29,6 +29,7 @@
     'use strict';
 
     var KERNEL_BOOT_DEADLINE_MS = 75000;  // generous; a healthy kernel idles in seconds
+    var SUSTAINED_UNHEALTHY_MS = 10000;   // ignore transient mid-boot dead/unknown blips
     var MAX_ERRORS = 8;
 
     var origin;
@@ -151,7 +152,28 @@
         return null;
     }
 
+    // Decide whether a dead/unknown kernel status has persisted long enough to
+    // report. PURE (no globals beyond the constant) so it unit-tests cleanly.
+    // A healthy boot routinely flashes "Kernel Unknown" for a beat before it
+    // reaches idle, so a single unhealthy poll is noise — reporting it produced
+    // a false kernel_unknown on most *successful* boots. So: start a clock on
+    // the first unhealthy poll, report only once the state has held continuously
+    // for SUSTAINED_UNHEALTHY_MS, and reset the clock the instant the status is
+    // anything else (idle/busy/starting/null).
+    //   status         — current kernelStatus() value (may be null)
+    //   unhealthySince — ms timestamp the current streak began, or 0 if none
+    //   now            — current time in ms
+    // returns { unhealthySince, report }.
+    function trackUnhealthy(status, unhealthySince, now) {
+        if (status === 'dead' || status === 'unknown') {
+            var since = unhealthySince || now;   // first unhealthy poll starts the clock
+            return { unhealthySince: since, report: now - since >= SUSTAINED_UNHEALTHY_MS };
+        }
+        return { unhealthySince: 0, report: false };
+    }
+
     var startedAt = Date.now();
+    var unhealthySince = 0;   // ms timestamp the current dead/unknown streak began; 0 = healthy
 
     function poll() {
         if (done) return;
@@ -165,10 +187,15 @@
                     done = true;
                     return;
                 }
-                if (status === 'dead' || status === 'unknown') {
-                    reportError('kernel_' + status, 'kernel status ' + status);
-                    // keep watching — a recovery may still reach idle
-                }
+            }
+            // Report dead/unknown only when it PERSISTS — runs every poll
+            // (including status === null) so a momentary unknown that flips back
+            // resets the clock and never reports.
+            var tracked = trackUnhealthy(status, unhealthySince, Date.now());
+            unhealthySince = tracked.unhealthySince;
+            if (tracked.report) {
+                reportError('kernel_' + status, 'kernel status ' + status);
+                // keep watching — a recovery may still reach idle
             }
         } catch (_) { /* ignore */ }
         if (Date.now() - startedAt >= KERNEL_BOOT_DEADLINE_MS) {
@@ -186,6 +213,9 @@
     // Test seam (Node vm): exercise detection + reporting without a browser.
     try {
         var hooks = (typeof globalThis !== 'undefined') && globalThis.__CK_KERNEL_DIAG_TEST_HOOKS__;
-        if (hooks) hooks.exports = { kernelStatus: kernelStatus, reportPhase: reportPhase, reportError: reportError };
+        if (hooks) hooks.exports = {
+            kernelStatus: kernelStatus, reportPhase: reportPhase,
+            reportError: reportError, trackUnhealthy: trackUnhealthy,
+        };
     } catch (_) { /* ignore */ }
 })();

--- a/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+++ b/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
@@ -123,6 +123,29 @@ test('collector reportError caps at MAX_ERRORS distinct errors', () => {
   assert.equal(errs.length, 8);   // MAX_ERRORS
 });
 
+test('collector trackUnhealthy ignores a transient unknown but flags a sustained one', () => {
+  const { exports } = loadCollector();
+  const t = exports.trackUnhealthy;
+  // First unhealthy poll starts the clock; nothing reported yet.
+  const first = t('unknown', 0, 1000);
+  assert.equal(first.unhealthySince, 1000);
+  assert.equal(first.report, false);
+  // Still unhealthy but under the threshold (passing the streak start back in):
+  // the start is preserved and no report fires.
+  const held = t('unknown', 1000, 5000);
+  assert.equal(held.unhealthySince, 1000);
+  assert.equal(held.report, false);
+  // Held continuously past SUSTAINED_UNHEALTHY_MS (10s): now report. 'dead'
+  // behaves identically.
+  assert.equal(t('unknown', 1000, 11000).report, true);
+  assert.equal(t('dead', 1000, 11000).report, true);
+  // Any healthy/indeterminate poll resets the clock — no report, streak cleared —
+  // so a momentary unknown that flips back to idle/null never reports.
+  for (const status of ['idle', 'busy', 'starting', null]) {
+    assert.deepEqual({ ...t(status, 1000, 11000) }, { unhealthySince: 0, report: false });
+  }
+});
+
 // ----------------------------------------------------------------
 // Parent bridge (notebook.js handleKernelDiagMessage)
 // ----------------------------------------------------------------

--- a/changelog.d/kernel-unknown-noise.md
+++ b/changelog.d/kernel-unknown-noise.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **In-iframe kernel diagnostics no longer report a transient "Kernel
+  Unknown".** A healthy JupyterLite boot routinely flashes a momentary
+  `unknown`/`dead` kernel status for a beat before it reaches idle, and the
+  collector was emitting a `kernel_error` on the first such poll — a false
+  positive on most *successful* boots (observed where 11/11 real boots reached
+  `kernel_idle`). It now starts a clock on the first unhealthy poll and reports
+  only once the state has held continuously for ~10s, resetting the instant the
+  status is anything else.


### PR DESCRIPTION
## Problem

The in-iframe kernel-boot collector (`Public/jl-kernel-diagnostics.js`, shipped in #1010) was reporting a `kernel_error` on the **first** poll where the kernel status read `unknown` or `dead`. But a healthy JupyterLite boot routinely flashes a momentary "Kernel Unknown" for a beat before the kernel reaches idle — so the collector emitted a false `kernel_unknown` on most *successful* boots.

In real class traffic this fired on boots that went on to reach `kernel_idle` (11/11 reached idle in the window we looked at, yet `kernel_unknown` errors were still being posted). It's noise that makes the browser diagnostics harder to read.

## Fix

Add a pure `trackUnhealthy(status, unhealthySince, now)` helper:

- Starts a clock on the **first** dead/unknown poll.
- Reports only once the unhealthy state has held **continuously** for `SUSTAINED_UNHEALTHY_MS` (10s).
- Resets the clock the instant the status is anything else (`idle`/`busy`/`starting`/`null`).

`poll()` now runs the tracker on **every** poll (including `status === null`), so a transient unknown that flips back never reports. The existing 75s `boot_stalled` watchdog still backstops a genuinely stuck boot, and a *sustained* unknown/dead now reports `kernel_unknown`/`kernel_dead` after 10s as a real signal.

Being a pure function with no globals (beyond the constant), it's unit-tested directly via the existing `__CK_KERNEL_DIAG_TEST_HOOKS__` seam.

## Tests

- New `collector trackUnhealthy ...` case in `Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs`: transient unknown → no report; streak start preserved across calls; sustained (≥10s) unknown/dead → report; any healthy/indeterminate poll resets the clock.
- `node --test` green (14/14).

No behaviour change to the boot funnel phases (`boot_start` → `app_ready` → `kernel_starting` → `kernel_idle`) or to `boot_stalled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_