### PR TITLE
Stamp kernel-boot elapsed_ms on the editor diagnostics breadcrumbs

### DIFF
--- a/Public/jl-kernel-diagnostics.js
+++ b/Public/jl-kernel-diagnostics.js
@@ -52,11 +52,11 @@
         } catch (_) { /* never throw */ }
     }
 
-    function reportPhase(phase) {
+    function reportPhase(phase, message) {
         if (reportedPhases[phase]) return;
         reportedPhases[phase] = true;
         lastPhase = phase;
-        post('kernel_phase', phase);
+        post('kernel_phase', phase, message);
     }
 
     function reportError(source, message) {
@@ -178,12 +178,21 @@
     function poll() {
         if (done) return;
         try {
-            if (!reportedPhases.app_ready && shellReady()) reportPhase('app_ready');
+            // Each phase carries elapsed_ms since boot_start, so the parent gets
+            // a phase-localized boot-time breakdown (shell vs kernel) and we can
+            // see the distribution — is a 2-min boot a freak or a fat tail?
+            if (!reportedPhases.app_ready && shellReady()) {
+                reportPhase('app_ready', 'elapsed_ms=' + (Date.now() - startedAt));
+            }
             var status = kernelStatus();
             if (status) {
-                if (!reportedPhases.kernel_starting) reportPhase('kernel_starting');
+                if (!reportedPhases.kernel_starting) {
+                    reportPhase('kernel_starting', 'elapsed_ms=' + (Date.now() - startedAt));
+                }
                 if (status === 'idle' || status === 'busy') {
-                    reportPhase('kernel_idle');   // SUCCESS — the missing signal
+                    // SUCCESS — the missing signal. elapsed_ms is the total kernel
+                    // boot time (boot_start → idle).
+                    reportPhase('kernel_idle', 'elapsed_ms=' + (Date.now() - startedAt));
                     done = true;
                     return;
                 }

--- a/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+++ b/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
@@ -104,6 +104,20 @@ test('collector reportPhase de-duplicates a phase', () => {
   assert.equal(appReady.length, 1);
 });
 
+test('collector reportPhase forwards an optional elapsed_ms message', () => {
+  const { posted, exports } = loadCollector();
+  exports.reportPhase('kernel_idle', 'elapsed_ms=1234');
+  const idle = posted.filter(p => p.payload.source === 'kernel_idle');
+  assert.equal(idle.length, 1);
+  assert.deepEqual({ ...idle[0].payload }, {
+    ck: 'kernel-diag', kind: 'kernel_phase', source: 'kernel_idle', message: 'elapsed_ms=1234',
+  });
+  // boot_start (posted on load) carries no message — the boot clock is reported
+  // from app_ready onward, so the boot_start payload stays message-free.
+  const bootStart = posted.find(p => p.payload.source === 'boot_start');
+  assert.equal('message' in bootStart.payload, false);
+});
+
 test('collector reportError forwards source + message and de-dupes', () => {
   const { posted, exports } = loadCollector();
   exports.reportError('csp_violation', "worker-src blocked data:");
@@ -214,6 +228,15 @@ test('bridge forwards a same-origin kernel_phase', () => {
   assert.equal(ok, true);
   assert.deepEqual(kernelEvents().map(e => ({ ...e })),
     [{ kind: 'kernel_phase', source: 'kernel_idle', message: undefined }]);
+});
+
+test('bridge forwards a kernel_phase elapsed_ms message to the server', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  handleKernelDiagMessage(msg({
+    ck: 'kernel-diag', kind: 'kernel_phase', source: 'kernel_idle', message: 'elapsed_ms=1500',
+  }));
+  assert.deepEqual(kernelEvents().map(e => ({ ...e })),
+    [{ kind: 'kernel_phase', source: 'kernel_idle', message: 'elapsed_ms=1500' }]);
 });
 
 test('bridge forwards a kernel_error with source + message', () => {

--- a/changelog.d/kernel-boot-timing.md
+++ b/changelog.d/kernel-boot-timing.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Kernel-boot timing in the in-browser editor diagnostics.** The in-iframe
+  collector now stamps `elapsed_ms` (since `boot_start`) on the `app_ready`,
+  `kernel_starting`, and `kernel_idle` phases, so the browser-diagnostics
+  funnel carries a phase-localized boot-time breakdown (shell vs. kernel) and a
+  boot-time distribution — making it possible to tell a one-off slow boot from a
+  fat tail, and to localize where a slow boot spends its time. No new event
+  kinds; the parent bridge already forwards a `kernel_phase` message.


### PR DESCRIPTION
## Why

We've been diagnosing slow in-browser editor kernel boots — including one **~158s** cold boot on an older Edge/macOS client. The boot funnel (`boot_start → app_ready → kernel_starting → kernel_idle`) shows *where* a boot drops off, but **not how long each phase takes**, so a slow boot was only visible by manually subtracting `createdAt` timestamps across samples. That makes it impossible to tell a one-off freak from a fat tail, or to localize *which* phase ate the time.

## What

Stamp `elapsed_ms` (since `boot_start`) on the `app_ready`, `kernel_starting`, and `kernel_idle` phase breadcrumbs in the in-iframe collector (`Public/jl-kernel-diagnostics.js`):

- `app_ready` → time to interactive shell
- `kernel_starting` → time to kernel handshake
- `kernel_idle` → **total kernel boot time**

This gives the browser-diagnostics funnel a phase-localized boot-time breakdown (shell vs. kernel) and a boot-time distribution.

`reportPhase()` gains an optional `message` arg. No new event kinds, and **no bridge or server change needed**: the parent bridge (`notebook.js handleKernelDiagMessage`) already forwards a `kernel_phase` `message` (clamped to 1000 chars), and the server already persists it on `client_diagnostics` rows / returns it in `get_browser_diagnostics` recent samples. `boot_start` stays message-free (it's the t=0 reference).

## Tests

`Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs` (+2, 16/16 green via `node --test`):
- collector `reportPhase` forwards an optional `elapsed_ms` message; `boot_start` stays message-free.
- bridge forwards a `kernel_phase` `elapsed_ms` message end-to-end to the server reporter.

## Follow-up (not in this PR)

Once this is deployed and timing samples accumulate, the distribution tells us whether to pursue the next levers (immutable `/pyodide` caching for repeat boots; per-assignment boot-package audit; Brotli). Measure first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_