### PR TITLE
Resolve LEARN grade-sync students by username via the classlist

### DIFF
--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -128,6 +128,8 @@ struct BrightSpaceGradeObject: Content, Sendable {
 struct BrightSpaceClasslistEntry: Content, Sendable {
     let orgDefinedID: String?
     let username: String?
+    /// D2L internal user id (`Identifier`) — the key a grade push targets.
+    let userID: String?
 }
 
 // MARK: - Paged list envelope
@@ -167,6 +169,10 @@ struct ValencePagedEnvelope<Element: Decodable>: Decodable {
 /// caching logic can be exercised without a live D2L endpoint.
 protocol BrightSpaceGrading: Sendable {
     func lookupUserID(orgDefinedId: String, on application: Application) async throws -> String?
+    func fetchClasslist(
+        orgUnitID: String, on application: Application
+    ) async throws
+        -> [BrightSpaceClasslistEntry]
     func pushGrade(
         orgUnitID: String,
         gradeObjectID: String,
@@ -510,12 +516,14 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         // The non-paged /classlist/ can truncate on large courses; /classlist/paged/
         // returns a bookmark-paged envelope we walk to completion (see fetchAllPages).
         let rawURL = "\(config.baseURL)/d2l/api/le/\(leVersion)/\(encoded)/classlist/paged/"
-        // D2L returns ClasslistUser objects; we keep only the two identity fields
-        // we match on.
+        // D2L returns ClasslistUser objects; we keep the identity fields we
+        // match on plus `Identifier`, the internal user id a grade push targets.
         struct ClasslistUserResponse: Decodable {
+            let identifier: String?
             let orgDefinedId: String?
             let username: String?
             enum CodingKeys: String, CodingKey {
+                case identifier = "Identifier"
                 case orgDefinedId = "OrgDefinedId"
                 case username = "Username"
             }
@@ -526,7 +534,8 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
             .classlistFetchFailed(orgUnitID: orgUnitID, status: status)
         }
         return rows.map {
-            BrightSpaceClasslistEntry(orgDefinedID: $0.orgDefinedId, username: $0.username)
+            BrightSpaceClasslistEntry(
+                orgDefinedID: $0.orgDefinedId, username: $0.username, userID: $0.identifier)
         }
     }
 }

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -48,6 +48,9 @@ func sweepBrightSpaceGradeSync(
 
     var processed = 0
 
+    // One classlist read per course is shared across all of this sweep's pushes.
+    let classlistCache = ClasslistUserIDCache()
+
     // Group pushable results by (student, test setup).  Results whose
     // submission is missing or isn't a student submission are no-ops handled
     // row-by-row, exactly as before.
@@ -87,8 +90,8 @@ func sweepBrightSpaceGradeSync(
         )
         do {
             let pushed = try await pushGrade(
-                for: target, db: db, resolveClient: resolveClient, logger: logger,
-                application: application)
+                for: target, db: db, resolveClient: resolveClient,
+                classlistCache: classlistCache, logger: logger, application: application)
             if pushed { processed += results.count }
         } catch {
             await recordSweepFailure(results, error: error, db: db, logger: logger)
@@ -230,6 +233,7 @@ private func pushGrade(
     for target: GradePushTarget,
     db: Database,
     resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
+    classlistCache: ClasslistUserIDCache,
     logger: Logger,
     application: Application
 ) async throws -> Bool {
@@ -294,8 +298,19 @@ private func pushGrade(
     }
 
     // Resolve D2L user ID (cached on APIUser, looked up on first sync).
+    // The course's classlist identity map (username/student-number → D2L UserId),
+    // fetched once per org unit per sweep. A read failure degrades to the
+    // org-level OrgDefinedId fallback rather than aborting the push.
+    var identityMap: [String: String] = [:]
+    do {
+        identityMap = try await classlistCache.identityMap(
+            orgUnitID: orgUnitID, client: client, application: application)
+    } catch {
+        logger.warning("BrightSpace classlist resolve failed for org unit \(orgUnitID): \(error)")
+    }
     let bsUserID = try await resolvedBrightSpaceUserID(
         for: target.user,
+        identityMap: identityMap,
         db: db,
         client: client,
         application: application
@@ -421,11 +436,48 @@ private func suiteTotalPoints(testSetupID: String, db: Database) async throws ->
     return total > 0 ? Double(total) : nil
 }
 
-/// Returns the cached D2L user ID for `user`, looking it up via studentID if
-/// not yet cached.  Takes the already batch-loaded `APIUser?` (nil when the
-/// sweep found no such user — same outcome as the old per-result `find`).
+/// Per-sweep cache of each course's LEARN classlist, reduced to an identity →
+/// D2L UserId map. The classlist carries both the student's login username and
+/// their student number (OrgDefinedId), so a Chickadee user is resolved by
+/// whichever identity is on file — username first (always present for SSO/local
+/// logins, == the LEARN username at UW), student number second. Fetched once
+/// per org unit per sweep.
+private actor ClasslistUserIDCache {
+    private var mapsByOrgUnit: [String: [String: String]] = [:]
+
+    /// The org unit's classlist as an identity → D2L UserId map, keyed by both
+    /// lowercased username and lowercased OrgDefinedId. Fetched once per org
+    /// unit per sweep; subsequent calls return the cached map.
+    func identityMap(
+        orgUnitID: String, client: any BrightSpaceGrading, application: Application
+    ) async throws -> [String: String] {
+        if let cached = mapsByOrgUnit[orgUnitID] { return cached }
+        let classlist = try await client.fetchClasslist(orgUnitID: orgUnitID, on: application)
+        var map: [String: String] = [:]
+        for entry in classlist {
+            guard let userID = entry.userID, !userID.isEmpty else { continue }
+            for identity in [entry.username, entry.orgDefinedID] {
+                let key = identity?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                if let key, !key.isEmpty { map[key] = userID }
+            }
+        }
+        mapsByOrgUnit[orgUnitID] = map
+        return map
+    }
+}
+
+/// Returns the cached D2L user ID for `user`, resolving it on first sync. Takes
+/// the already batch-loaded `APIUser?` (nil when the sweep found no such user)
+/// and the course's pre-built classlist identity map.
+///
+/// Resolution matches the classlist by **username first, student number
+/// second** — the username is the identity Chickadee always has (SSO or local)
+/// and equals the LEARN username at UW, so grade sync works without a
+/// student-number claim. Falls back to the org-level `users/?orgDefinedId=`
+/// lookup only when the classlist match misses but a student number is on file.
 private func resolvedBrightSpaceUserID(
     for user: APIUser?,
+    identityMap: [String: String],
     db: Database,
     client: any BrightSpaceGrading,
     application: Application
@@ -436,12 +488,18 @@ private func resolvedBrightSpaceUserID(
         return cached
     }
 
-    // Look up by studentID (= BrightSpace OrgDefinedId).
-    guard let orgDefinedId = user.studentID, !orgDefinedId.isEmpty else {
-        return nil
+    var bsUserID: String?
+    for key in [user.username, user.studentID].compactMap({ $0 }) {
+        let normalized = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if !normalized.isEmpty, let resolved = identityMap[normalized] {
+            bsUserID = resolved
+            break
+        }
     }
-
-    let bsUserID = try await client.lookupUserID(orgDefinedId: orgDefinedId, on: application)
+    // Fallback: the legacy org-level OrgDefinedId lookup (needs a student number).
+    if bsUserID == nil, let orgDefinedId = user.studentID, !orgDefinedId.isEmpty {
+        bsUserID = try await client.lookupUserID(orgDefinedId: orgDefinedId, on: application)
+    }
 
     if let bsUserID {
         user.brightspaceUserID = bsUserID

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -27,6 +27,7 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
     }
 
     private let userIDsByOrgDefinedId: [String: String]
+    private let classlist: [BrightSpaceClasslistEntry]
     private let lookupError: (any Error)?
     private let pushError: (any Error)?
     private(set) var pushes: [RecordedPush] = []
@@ -34,10 +35,12 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
 
     init(
         userIDsByOrgDefinedId: [String: String] = [:],
+        classlist: [BrightSpaceClasslistEntry] = [],
         lookupError: (any Error)? = nil,
         pushError: (any Error)? = nil
     ) {
         self.userIDsByOrgDefinedId = userIDsByOrgDefinedId
+        self.classlist = classlist
         self.lookupError = lookupError
         self.pushError = pushError
     }
@@ -46,6 +49,12 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         lookupCount += 1
         if let lookupError { throw lookupError }
         return userIDsByOrgDefinedId[orgDefinedId]
+    }
+
+    func fetchClasslist(
+        orgUnitID: String, on application: Application
+    ) async throws -> [BrightSpaceClasslistEntry] {
+        classlist
     }
 
     func pushGrade(
@@ -206,6 +215,37 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             #expect(user?.brightspaceUserID == "d2l-999")
             let lookupCount = await fake.lookupCount
             #expect(lookupCount == 1)
+        }
+    }
+
+    @Test func resolvesByUsernameFromClasslistWhenNoStudentID() async throws {
+        try await withApp(app) { _ in
+            // SSO-typical: the student has a username but no student number.
+            let scenario = try await makeConfiguredScenario(studentID: nil)
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 7, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let user = try #require(try await APIUser.find(scenario.userID, on: app.db))
+            // Classlist carries the username (UPPER-cased to prove case-insensitive
+            // matching) + the D2L UserId; no OrgDefinedId, empty lookup table.
+            let fake = FakeBrightSpaceGrading(
+                classlist: [
+                    BrightSpaceClasslistEntry(
+                        orgDefinedID: nil, username: user.username.uppercased(), userID: "d2l-777")
+                ])
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)
+            let pushes = await fake.pushes
+            #expect(pushes.first?.bsUserID == "d2l-777")
+            // Resolved by username via the classlist — the org-level lookup never ran.
+            let lookupCount = await fake.lookupCount
+            #expect(lookupCount == 0)
+            let reloaded = try await APIUser.find(scenario.userID, on: app.db)
+            #expect(reloaded?.brightspaceUserID == "d2l-777")
         }
     }
 

--- a/Tests/APITests/LearnRosterReconcilerTests.swift
+++ b/Tests/APITests/LearnRosterReconcilerTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite struct LearnRosterReconcilerTests {
 
     private func entry(_ org: String?, _ user: String?) -> BrightSpaceClasslistEntry {
-        BrightSpaceClasslistEntry(orgDefinedID: org, username: user)
+        BrightSpaceClasslistEntry(orgDefinedID: org, username: user, userID: nil)
     }
 
     @Test func identitySetLowercasesBothFieldsAndDropsBlanks() {

--- a/changelog.d/brightspace-username-resolve.md
+++ b/changelog.d/brightspace-username-resolve.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **LEARN grade sync now matches students by username, not just student
+  number.** Grade pushes resolve a Chickadee student against the course LEARN
+  **classlist** by **username first** (the WatIAM id — present for both SSO and
+  local logins and equal to the LEARN username at UW), then fall back to the
+  student number (`OrgDefinedId`) and the legacy `users/?orgDefinedId=` lookup.
+  The classlist decode now keeps D2L's internal `Identifier`, so SSO students who
+  carry no student-number claim sync **without any manual data entry**. No schema
+  change — the resolved D2L user id still caches on the existing
+  `brightspace_user_id` field and is reused thereafter. Resolution does one
+  classlist read per course per sweep, which also sidesteps the org-level user
+  lookup a course-scoped API role may not be permitted to call.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -424,10 +424,13 @@ each request URL per call (HMAC-SHA256) — no token endpoint.
   item (column). Instructors map these on the BrightSpace tab, picking from a
   dropdown sourced from `listGradeObjects` (free-text fallback).
 
-**Student identity.** `users.student_id` is the D2L `OrgDefinedId`;
-`users.brightspace_user_id` caches the resolved internal D2L user ID
-(`lookupUserID`, looked up lazily on first sync). Students with no resolvable
-account surface in the BrightSpace tab's "unmapped students" list.
+**Student identity.** A Chickadee user is matched to a LEARN account against the
+course **classlist**, by `username` (the WatIAM id, primary) then `student_id`
+(the D2L `OrgDefinedId`, fallback — incl. the legacy `lookupUserID`
+`users/?orgDefinedId=` call). The resolved internal D2L user id caches on
+`users.brightspace_user_id` on first sync and is reused thereafter. Students
+with no resolvable account surface in the BrightSpace tab's "unmapped students"
+list.
 
 **Sync engine.** On a worker result save, `ResultRoutes` flags the `APIResult`
 row pending. `BrightSpaceGradeSyncMonitor` sweeps every 60 s and pushes the

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -262,12 +262,20 @@ each Chickadee assignment to the column it should write to.
 
 ## Step 6 — Match student identities
 
-Grades route by **student number**: a Chickadee user's `student_id` must equal
-the D2L **OrgDefinedId** of the matching LEARN account. Enroll the test
-students in your Chickadee course with their `learntest` org-defined IDs. The
-BrightSpace tab's **classlist reconcile** and **"unmapped students"** list flag
-anyone who can't be resolved (no student ID on file, or not found in
-BrightSpace).
+Grades route by matching a Chickadee user to a LEARN account, resolved against
+the course **classlist** by **username first, student number second**:
+
+- **Username** — a Chickadee user's `username` (the WatIAM id, set for both SSO
+  and local logins) matched against the LEARN classlist `Username`. This is the
+  primary path and needs no student number, so SSO students just work.
+- **Student number** — a user's `student_id` matched against the D2L
+  `OrgDefinedId`, used when the username doesn't match (or as the legacy
+  `users/?orgDefinedId=` fallback).
+
+The resolved internal D2L user id is cached on `users.brightspace_user_id` on
+first sync and reused thereafter. The **classlist reconcile** and **"unmapped
+students"** list flag anyone who can't be resolved by either key (username not
+in the LEARN classlist and no usable student number).
 
 ## Step 7 — End-to-end test
 
@@ -304,7 +312,9 @@ student-free).
 - **Org-unit save shows "unverified":** the ID is wrong, or D2L was
   unreachable (egress). Verification failures don't block the save — the
   cached name just stays empty.
-- **Student shows as unmapped:** missing `student_id` in Chickadee, or it
-  doesn't match the LEARN OrgDefinedId. Fix the enrollment record.
+- **Student shows as unmapped:** Chickadee couldn't find them in the LEARN
+  classlist by **username** (the WatIAM id) or by student number. Confirm their
+  Chickadee `username` matches their LEARN username, and that they're enrolled
+  in the D2L course.
 - **Grade pushed but not visible:** confirm the grade item is the right column
   and the assignment is mapped to it; check the sync log row's detail.


### PR DESCRIPTION
## Why

This is the one gap between "built" and "grades actually flow." The push pipeline was complete, but it resolved a student to a LEARN user **only** by `student_id → OrgDefinedId` (the org-level `users/?orgDefinedId=` lookup). UW SSO students carry no student-number claim, so `student_id` is empty → every push skipped as *"no BrightSpace account"* — even though their **username already matches the LEARN roster**.

## What changed (schema-free)

Resolution now matches the course **classlist** by **username first, student number second** — the username is the identity Chickadee always has (SSO or local) and equals the LEARN username at UW:

- `BrightSpaceClasslistEntry` keeps D2L's internal `Identifier` (UserId); the classlist decode captures it (it was being dropped).
- `BrightSpaceGrading` gains `fetchClasslist`; a per-sweep `ClasslistUserIDCache` builds each org unit's `identity → UserId` map **once** (keyed by lowercased username + OrgDefinedId) and shares it across that sweep's pushes.
- `resolvedBrightSpaceUserID` matches `user.username` then `user.studentID`, falling back to the legacy `lookupUserID(orgDefinedId:)` only on a miss. The resolved id still caches on the **existing** `brightspace_user_id` column — **no new field, no migration**.

As you put it: resolve once → store on the profile → reuse from then on. The only change is *how* the one-time resolution happens.

Side benefit: one classlist read per course per sweep instead of one `users/?orgDefinedId=` per student — and it avoids the org-level LP endpoint a course-scoped API role may not be allowed to call (the LP-vs-LE split we hit on org-unit verify).

## Tests

- **New:** a student with **no student number** resolves by classlist **username** (case-insensitive), pushes to the classlist UserId, and the org-level lookup never runs.
- **Existing** OrgDefinedId tests still pass via the fallback path.
- Full BrightSpace + roster suites (53 tests) green; `swift-format` + SwiftLint `--strict` + lint clean. Docs (`brightspace-setup.md`, `architecture.md`) updated.

## How to test end-to-end

One student in both LEARN course 1106038 and Chickadee under the **same username** → submit → Sync now / Push all → I read the sync status. No hand-entering student numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_