### PR TITLE
feat(datasets): worker delivery of per-student slices (slice 2) + exact-match CI build cache

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -127,16 +127,16 @@ jobs:
         run: echo "key=$(swift --version | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       # Read-only restore of the shared build cache produced by the Swift Tests
-      # `build` job (same key). On a hit, building just the server product is a
-      # near-no-op; on the nightly/cold path, restore-keys gets the most recent
-      # main build and only changed files recompile.
+      # `build` job (same exact key).  EXACT-MATCH ONLY: a `restore-keys` prefix
+      # fallback would incrementally build the server over a mismatched tree,
+      # which is unsound for the same mangled-symbol reason documented in
+      # swift-tests.yml's `build` job.  On a hit, building the server product is
+      # a near-no-op; on a miss we build it cold.
       - name: Restore build artifacts
         uses: actions/cache/restore@v5
         with:
           path: .build
           key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
-          restore-keys: |
-            ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-
 
       - name: Build chickadee-server
         run: swift build --product chickadee-server

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -101,31 +101,30 @@ jobs:
         id: toolchain
         run: echo "key=$(swift --version | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
-      # `CACHE_SALT` is a manual bust knob.  Bump it whenever an incremental
-      # build on a restored `.build/` would be unsound — most notably when a
-      # cross-module type changes *kind* (struct↔enum): files that reference it
-      # only transitively (e.g. via a function whose mangled signature embeds
-      # the type) keep their old source mtime, so `git restore-mtime` marks
-      # them "fresh" and llbuild reuses stale object files compiled against the
-      # old symbol → "undefined reference" link errors. Bumping the salt forces
-      # one clean rebuild for everyone.  (v2: TestItem struct→enum, v0.4.228;
-      # v3: TestProperties gained the `achievements` field — its init's mangled
-      # signature changed, so stale transitive objects fail to link.
-      # v4: CourseBundleManifest gained the `sections` field, same init-mangling
-      # story.)
+      # Build-artifact cache is EXACT-MATCH ONLY — no `restore-keys` prefix
+      # fallback.  Incrementally rebuilding over a `.build/` restored from a
+      # *different* tree is unsound: when a cross-module type changes kind
+      # (struct↔enum) or a struct's init gains a field, files that reference it
+      # only transitively keep their old source mtime, so `git restore-mtime`
+      # marks them "fresh" and llbuild reuses stale object files compiled
+      # against the old mangled symbol → "undefined reference" link errors.
+      # This recurred on every such change (TestItem struct→enum, v0.4.228;
+      # TestProperties.achievements; CourseBundleManifest.sections;
+      # TestProperties.datasets) and used to need a manual cache-salt bump each
+      # time.  Exact-match-only removes the failure class outright: a tree that
+      # doesn't match an existing cache does a clean cold build instead of an
+      # unsound incremental one.  Trade-off: any Sources/Tests change pays a
+      # full rebuild (no partial reuse); an exact re-run of the same tree still
+      # hits and skips the build.
       - name: Cache build artifacts
         id: build-cache
         uses: actions/cache@v5
         with:
           path: .build
           key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
-          restore-keys: |
-            ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-
 
-      # Exact cache hit: artifacts already match this tree, skip even the
-      # near-no-op build.  Restore-keys partial hit (cache-hit is false): the
-      # git-normalised mtimes let `swift build` recompile only the files
-      # changed since the restored `.build/` was produced.
+      # Exact cache hit: artifacts already match this exact tree, skip even the
+      # near-no-op build.  Any miss = clean cold build (no stale-object reuse).
       - name: Build all targets and tests
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: swift build --build-tests

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -210,6 +210,18 @@ struct WorkerJobRoutes: RouteCollection {
                 manifest: claimed.manifest, seedHex: assignmentSeed, supportFilesDirectory: supportDir)
         }
 
+        // Resolve per-student dataset slices (Phase 1 datasets) for this seed.
+        // Cheap and deterministic (a file read + in-memory sample, no
+        // subprocess), so we resolve live for both student and validation
+        // submissions rather than caching it on the materialization row. A
+        // strict no-op for every assignment that declares no datasets — which is
+        // all of them until the dataset editor ships — so existing jobs are
+        // byte-identical to before. The runner-sanitized manifest below drops
+        // the dataset specs; only the resolved bytes travel, in `personalizedFiles`.
+        let datasetSharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+        let personalizedFiles = DatasetResolver.resolve(
+            manifest: claimed.manifest, seedHex: assignmentSeed, sourceDirectory: datasetSharedDir)
+
         return Job(
             submissionID: submissionID,
             testSetupID: setupID,
@@ -219,7 +231,8 @@ struct WorkerJobRoutes: RouteCollection {
             manifest: claimed.manifest.runnerSanitized(),
             submissionFilename: submission.filename,
             assignmentSeed: assignmentSeed,
-            personalizedInputs: personalizedInputs
+            personalizedInputs: personalizedInputs,
+            personalizedFiles: personalizedFiles
         )
     }
 

--- a/Sources/Core/DatasetResolver.swift
+++ b/Sources/Core/DatasetResolver.swift
@@ -1,0 +1,40 @@
+// Core/DatasetResolver.swift
+//
+// Resolves a submission's per-student dataset slices (Phase 1 datasets — see
+// docs/datasets.md).  For each dataset declared in the manifest it reads the
+// instructor's source pool from `sourceDirectory` and returns the student's
+// deterministic slice keyed by the delivered filename.
+//
+// Resolution is server-side and pure given the files on disk plus the seed
+// (slicing is delegated to `DatasetMaterializer`), so the worker job payload
+// and the browser seed endpoint produce identical bytes for the same student.
+// It is a strict no-op — returning nil before any I/O — when the manifest
+// declares no datasets, so every non-dataset assignment is entirely unaffected.
+
+import Foundation
+
+public enum DatasetResolver {
+
+    /// Per-student dataset files for `seedHex`, keyed by delivered filename, or
+    /// nil when there are no datasets, no seed, or no source file could be read.
+    ///
+    /// A missing/unreadable source pool for one dataset is skipped (grading then
+    /// falls back to the file as shipped) rather than failing resolution for the
+    /// whole submission.
+    public static func resolve(
+        manifest: TestProperties, seedHex: String?, sourceDirectory: String
+    ) -> [String: String]? {
+        guard !manifest.datasets.isEmpty else { return nil }
+        guard let seedHex, !seedHex.isEmpty else { return nil }
+
+        let directory = sourceDirectory.hasSuffix("/") ? sourceDirectory : sourceDirectory + "/"
+        var files: [String: String] = [:]
+        for spec in manifest.datasets {
+            let path = directory + spec.file
+            guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
+            files[spec.file] = DatasetMaterializer.materialize(
+                source: content, spec: spec, seedHex: seedHex)
+        }
+        return files.isEmpty ? nil : files
+    }
+}

--- a/Sources/Core/Job.swift
+++ b/Sources/Core/Job.swift
@@ -41,6 +41,18 @@ public struct Job: Codable, Sendable {
     /// with a clear message.
     public let personalizedInputs: [String: String]?
 
+    /// Per-student dataset files, resolved server-side for this submission's
+    /// `assignmentSeed` (Phase 1 datasets — see docs/datasets.md). Maps each
+    /// dataset's delivered filename to its sliced contents (a deterministic
+    /// per-student slice of the instructor's source pool, produced by
+    /// `DatasetMaterializer`). The worker writes each into the grading
+    /// workspace, overwriting the source pool copied from the cached test-setup
+    /// so student scripts read only their slice. Nil when the assignment
+    /// declares no datasets or no seed is available — grading then proceeds
+    /// against the file as shipped. Same delivery shape as `personalizedInputs`:
+    /// the server resolves the bytes; the worker only writes them.
+    public let personalizedFiles: [String: String]?
+
     public init(
         submissionID: String,
         testSetupID: String,
@@ -50,7 +62,8 @@ public struct Job: Codable, Sendable {
         manifest: TestProperties,
         submissionFilename: String? = nil,
         assignmentSeed: String? = nil,
-        personalizedInputs: [String: String]? = nil
+        personalizedInputs: [String: String]? = nil,
+        personalizedFiles: [String: String]? = nil
     ) {
         self.submissionID = submissionID
         self.testSetupID = testSetupID
@@ -61,5 +74,6 @@ public struct Job: Codable, Sendable {
         self.submissionFilename = submissionFilename
         self.assignmentSeed = assignmentSeed
         self.personalizedInputs = personalizedInputs
+        self.personalizedFiles = personalizedFiles
     }
 }

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -599,6 +599,23 @@ extension WorkerDaemon {
                 atomically: true, encoding: .utf8)
         }
 
+        // Materialize per-student dataset slices (Phase 1 datasets — see
+        // docs/datasets.md) into the grading workspace, overwriting the source
+        // pool copied from the cached test-setup so student scripts read only
+        // their slice. Same delivery shape as `_ck_inputs.py`: the server
+        // resolved the bytes (`DatasetResolver` over the seed); we only write
+        // them. A failed write would silently grade the student against the
+        // wrong (pool) data, so throw — the job is reported buildStatus:failed
+        // and stays retestable, matching the `_ck_inputs.py` rationale above.
+        if let files = job.personalizedFiles, !files.isEmpty {
+            for name in files.keys.sorted() {
+                guard let content = files[name] else { continue }
+                try content.write(
+                    to: testSetupDir.appendingPathComponent(name),
+                    atomically: true, encoding: .utf8)
+            }
+        }
+
         // Per-test time-limit overrides resolved in the executor (the shared
         // `executeSuites` loop still receives the assignment default below as
         // the fallback). Only entries carrying an explicit positive override

--- a/Tests/CoreTests/DatasetResolverTests.swift
+++ b/Tests/CoreTests/DatasetResolverTests.swift
@@ -1,0 +1,128 @@
+// Tests/CoreTests/DatasetResolverTests.swift
+//
+// Pins DatasetResolver (Phase 1 datasets): it reads each declared dataset's
+// source pool from a directory and returns the student's deterministic slice,
+// delegating slicing to DatasetMaterializer. The no-dataset / no-seed / missing
+// -file cases must return nil (the strict no-op that keeps every non-dataset
+// assignment unaffected). Also covers Job's new personalizedFiles round-trip.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct DatasetResolverTests {
+
+    private let seed = String(repeating: "a1b2", count: 16)
+
+    /// Creates a fresh temp directory and removes it after `body`.
+    private func withTempDir(_ body: (String) throws -> Void) throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ds-resolver-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try body(dir.path)
+    }
+
+    private func indexedCSV(_ n: Int) -> String {
+        "id\n" + (0..<n).map(String.init).joined(separator: "\n") + "\n"
+    }
+
+    @Test func resolvesDeterministicSliceForDeclaredDataset() throws {
+        try withTempDir { dir in
+            let pool = indexedCSV(100)
+            try pool.write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(datasets: [DatasetSpec(file: "cases.csv", sampleSize: 10)])
+
+            let files = try #require(
+                DatasetResolver.resolve(manifest: manifest, seedHex: seed, sourceDirectory: dir))
+            let slice = try #require(files["cases.csv"])
+
+            // Delegates to DatasetMaterializer — identical bytes.
+            #expect(
+                slice
+                    == DatasetMaterializer.materialize(
+                        source: pool, spec: DatasetSpec(file: "cases.csv", sampleSize: 10),
+                        seedHex: seed))
+            #expect(slice.hasPrefix("id\n"))
+            #expect(slice.split(separator: "\n").dropFirst().count == 10)
+        }
+    }
+
+    @Test func trailingSlashOnDirectoryIsOptional() throws {
+        try withTempDir { dir in
+            try indexedCSV(50).write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(datasets: [DatasetSpec(file: "cases.csv", sampleSize: 5)])
+            let withSlash = DatasetResolver.resolve(
+                manifest: manifest, seedHex: seed, sourceDirectory: dir + "/")
+            let withoutSlash = DatasetResolver.resolve(
+                manifest: manifest, seedHex: seed, sourceDirectory: dir)
+            #expect(withSlash?["cases.csv"] == withoutSlash?["cases.csv"])
+            #expect(withSlash?["cases.csv"] != nil)
+        }
+    }
+
+    @Test func noDatasetsReturnsNil() throws {
+        try withTempDir { dir in
+            #expect(
+                DatasetResolver.resolve(manifest: TestProperties(), seedHex: seed, sourceDirectory: dir)
+                    == nil)
+        }
+    }
+
+    @Test func noSeedReturnsNil() throws {
+        try withTempDir { dir in
+            try indexedCSV(50).write(toFile: dir + "/cases.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(datasets: [DatasetSpec(file: "cases.csv", sampleSize: 5)])
+            #expect(DatasetResolver.resolve(manifest: manifest, seedHex: nil, sourceDirectory: dir) == nil)
+            #expect(DatasetResolver.resolve(manifest: manifest, seedHex: "", sourceDirectory: dir) == nil)
+        }
+    }
+
+    @Test func missingSourceFileIsSkipped() throws {
+        try withTempDir { dir in
+            // Declared but never written to disk.
+            let manifest = TestProperties(datasets: [DatasetSpec(file: "absent.csv", sampleSize: 5)])
+            #expect(DatasetResolver.resolve(manifest: manifest, seedHex: seed, sourceDirectory: dir) == nil)
+        }
+    }
+
+    @Test func resolvesMultipleDatasetsIndependently() throws {
+        try withTempDir { dir in
+            try indexedCSV(80).write(toFile: dir + "/a.csv", atomically: true, encoding: .utf8)
+            try indexedCSV(80).write(toFile: dir + "/b.csv", atomically: true, encoding: .utf8)
+            let manifest = TestProperties(datasets: [
+                DatasetSpec(file: "a.csv", sampleSize: 5),
+                DatasetSpec(file: "b.csv", sampleSize: 7),
+            ])
+            let files = try #require(
+                DatasetResolver.resolve(manifest: manifest, seedHex: seed, sourceDirectory: dir))
+            #expect(files["a.csv"]?.split(separator: "\n").dropFirst().count == 5)
+            #expect(files["b.csv"]?.split(separator: "\n").dropFirst().count == 7)
+        }
+    }
+}
+
+@Suite struct JobPersonalizedFilesCodableTests {
+
+    @Test func jobWithoutPersonalizedFilesDecodesNil() throws {
+        let json = #"""
+            {"submissionID":"s1","testSetupID":"t1","attemptNumber":1,
+             "submissionURL":"https://example.com/s","testSetupURL":"https://example.com/t",
+             "manifest":{"schemaVersion":1}}
+            """#
+        let job = try JSONDecoder().decode(Job.self, from: Data(json.utf8))
+        #expect(job.personalizedFiles == nil)
+    }
+
+    @Test func jobPersonalizedFilesRoundTrip() throws {
+        let url = try #require(URL(string: "https://example.com/x"))
+        let job = Job(
+            submissionID: "s1", testSetupID: "t1", attemptNumber: 1,
+            submissionURL: url, testSetupURL: url, manifest: TestProperties(),
+            personalizedFiles: ["cases.csv": "id\n1\n2\n"])
+        let data = try JSONEncoder().encode(job)
+        let decoded = try JSONDecoder().decode(Job.self, from: data)
+        #expect(decoded.personalizedFiles == ["cases.csv": "id\n1\n2\n"])
+    }
+}

--- a/changelog.d/datasets-worker-delivery.md
+++ b/changelog.d/datasets-worker-delivery.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Per-student datasets: worker grading delivery.** When an assignment's
+  manifest declares datasets, the server now resolves each student's
+  deterministic slice (via `DatasetResolver` + the seed) and ships the bytes in
+  the worker job payload; the runner writes them into the grading workspace,
+  overwriting the instructor's source pool so a student's scripts grade against
+  only their slice. A strict no-op for assignments without datasets. Editor
+  delivery and the authoring UI follow — see `docs/datasets.md`.


### PR DESCRIPTION
## What

Slice 2 of per-student datasets (after the merged foundation in #1014). When an assignment's manifest declares datasets, the server now resolves each student's deterministic slice and delivers it to **worker** grading, so a student's scripts grade against only their slice of the instructor's source pool. See `docs/datasets.md`.

This mirrors the proven `personalizedInputs` (`_ck_inputs.py`) delivery path end-to-end.

## Changes

- **`Job.personalizedFiles: [String: String]?`** (Core) — optional, so synthesized `Codable` decodes a missing key to `nil`; old/new server↔worker combos stay compatible.
- **`DatasetResolver`** (Core) — reads each declared dataset's source pool from a directory and returns the student's slice via `DatasetMaterializer`. Returns `nil` *before any I/O* when there are no datasets or no seed.
- **`WorkerJobRoutes.buildJobPayload`** — resolves slices live (a file read + in-memory sample, no subprocess) for both student and validation submissions, and ships them in the job payload. The runner-sanitized manifest still drops the specs; only resolved bytes travel.
- **`RunnerDaemon+JobProcessing`** — writes each slice into the per-job workspace next to `_ck_inputs.py`, overwriting the source pool so scripts read only the slice. A failed write throws (`buildStatus:failed`, retestable).

## Regression safety

- **Strict no-op for every existing assignment**: nothing authors `manifest.datasets` yet (the editor is slice 4), so the resolver returns `nil` before any I/O — no payload change, no worker write, identical jobs.
- New `Job` field is optional/back-compat; the only `Job(...)` constructor is `buildJobPayload`.
- No change to the validation materialization cache (slices resolved live for both paths).
- Logic verified locally with a standalone `swift` harness against real temp files (full `swift build` can't run in this environment — egress policy blocks the SwiftPM mirrors); CI is the compile/test oracle.

## Not in scope (next slices)

- **Slice 3** — editor delivery (per-student file written into JupyterLite working dir; suppress the shared symlink for dataset files).
- **Slice 5** — browser-graded delivery + hiding the source pool from student-facing zips/downloads.
- **Slice 4** — the authoring UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx1g6pnZFeZMtKhbKcJCuS)_