### PR TITLE
feat(datasets): grader-only file foundation + train/test split design

### DIFF
--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -267,6 +267,21 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// `patternFamilies` / `globalExpressions`).
     public let datasets: [DatasetSpec]
 
+    /// Filenames the instructor has designated as **grader-only** (option B —
+    /// see docs/datasets.md): bundled in the test setup so the native worker's
+    /// grading scripts can read them, but withheld from every student-facing
+    /// path (editor symlinks, browser-runner download, student support-file
+    /// download).  This is the reserved holdout / secret test set.  A
+    /// grader-only entry is otherwise an ordinary support file; this list just
+    /// flags it as student-hidden.  Server-side only — the worker receives the
+    /// file via the test-setup zip and needs no marker — so `runnerSanitized()`
+    /// strips it via the memberwise default (like `datasets`).
+    public let graderOnlyFiles: [String]
+
+    /// The grader-only filenames as a set, for unioning into the student-facing
+    /// `reservedNames` filters at each delivery point.
+    public var graderOnlyFileSet: Set<String> { Set(graderOnlyFiles) }
+
     /// True when the manifest declares any per-student `=` expression, global
     /// or section-scoped.  Expressions are the only personalization inputs
     /// that need a per-(student, assignment) seed to resolve — use this to
@@ -316,6 +331,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         globalVariables: [FamilyVariable] = [],
         globalExpressions: [PersonalizationExpression] = [],
         datasets: [DatasetSpec] = [],
+        graderOnlyFiles: [String] = [],
         achievements: [Achievement] = [],
         disabledBuiltInAwardIDs: [String] = [],
         builtInAchievementsSeeded: Bool = false,
@@ -339,6 +355,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         self.globalVariables = globalVariables
         self.globalExpressions = globalExpressions
         self.datasets = datasets
+        self.graderOnlyFiles = graderOnlyFiles
         self.achievements = achievements
         self.disabledBuiltInAwardIDs = disabledBuiltInAwardIDs
         self.builtInAchievementsSeeded = builtInAchievementsSeeded
@@ -373,6 +390,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
                 [PersonalizationExpression].self,
                 forKey: .globalExpressions) ?? []
         datasets = try c.decodeIfPresent([DatasetSpec].self, forKey: .datasets) ?? []
+        graderOnlyFiles = try c.decodeIfPresent([String].self, forKey: .graderOnlyFiles) ?? []
         achievements = try c.decodeIfPresent([Achievement].self, forKey: .achievements) ?? []
         disabledBuiltInAwardIDs =
             try c.decodeIfPresent([String].self, forKey: .disabledBuiltInAwardIDs) ?? []
@@ -399,6 +417,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         case globalVariables
         case globalExpressions
         case datasets
+        case graderOnlyFiles
         case achievements
         case disabledBuiltInAwardIDs
         case builtInAchievementsSeeded
@@ -422,6 +441,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         try c.encode(globalVariables, forKey: .globalVariables)
         try c.encode(globalExpressions, forKey: .globalExpressions)
         try c.encode(datasets, forKey: .datasets)
+        try c.encode(graderOnlyFiles, forKey: .graderOnlyFiles)
         try c.encode(achievements, forKey: .achievements)
         try c.encode(disabledBuiltInAwardIDs, forKey: .disabledBuiltInAwardIDs)
         try c.encode(builtInAchievementsSeeded, forKey: .builtInAchievementsSeeded)
@@ -463,9 +483,10 @@ public struct TestProperties: Codable, Equatable, Sendable {
             },
             globalVariables: globalVariables,
             globalExpressions: [],
-            // `datasets` is dropped via the memberwise default: the runner
-            // receives the materialized per-student file (delivered with the
-            // job, like `_ck_inputs.py`), never the slice spec.
+            // `datasets` and `graderOnlyFiles` are dropped via the memberwise
+            // default: the runner receives the materialized per-student file
+            // (delivered with the job, like `_ck_inputs.py`) and the grader-only
+            // file (via the test-setup zip) directly — never the specs/markers.
             achievements: []
         )
     }

--- a/Tests/CoreTests/GraderOnlyFilesTests.swift
+++ b/Tests/CoreTests/GraderOnlyFilesTests.swift
@@ -1,0 +1,39 @@
+// Tests/CoreTests/GraderOnlyFilesTests.swift
+//
+// Pins the grader-only-files manifest marker (option B foundation — see
+// docs/datasets.md): Codable back-compat (a manifest without the key decodes
+// to empty), the round-trip, the runnerSanitized() strip (the runner gets the
+// file via the zip, never the marker), and the set helper used to union into
+// the student-facing reservedNames filters.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct GraderOnlyFilesTests {
+
+    @Test func manifestWithoutGraderOnlyKeyDecodesEmpty() throws {
+        let json = #"{"schemaVersion":1}"#
+        let decoded = try JSONDecoder().decode(TestProperties.self, from: Data(json.utf8))
+        #expect(decoded.graderOnlyFiles.isEmpty)
+        #expect(decoded.graderOnlyFileSet.isEmpty)
+    }
+
+    @Test func graderOnlyFilesRoundTrip() throws {
+        let manifest = TestProperties(graderOnlyFiles: ["test.csv", "answers.json"])
+        let data = try JSONEncoder().encode(manifest)
+        let decoded = try JSONDecoder().decode(TestProperties.self, from: data)
+        #expect(decoded.graderOnlyFiles == ["test.csv", "answers.json"])
+        #expect(decoded.graderOnlyFileSet == Set(["test.csv", "answers.json"]))
+    }
+
+    @Test func runnerSanitizedStripsGraderOnlyFiles() {
+        let manifest = TestProperties(graderOnlyFiles: ["test.csv"])
+        #expect(manifest.runnerSanitized().graderOnlyFiles.isEmpty)
+    }
+
+    @Test func emptyByDefault() {
+        #expect(TestProperties().graderOnlyFiles.isEmpty)
+    }
+}

--- a/changelog.d/datasets-grader-only-foundation.md
+++ b/changelog.d/datasets-grader-only-foundation.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Datasets: train/test split design + grader-only file foundation.** Documents
+  train/test splits in `docs/datasets.md` as two composable blocks — a
+  per-student served sample plus a *reserved grader-only file* (a holdout served
+  to no student, present only in the worker grader) — and adds the inert
+  `TestProperties.graderOnlyFiles` manifest marker for it. Enforcement
+  (withholding the file from every student-facing path) and authoring land in
+  follow-ups; the marker does nothing on its own yet.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -503,6 +503,84 @@ pool. Secrecy becomes load-bearing only for Phase 2 mystery answers.
    hatch (reuses `PersonalizationEvaluator`'s file-writing subprocess), the
    bridge to Phase 2.
 
+## Train/test splits & grader-only files (option B)
+
+The dataset feature also supports **train/test splits**, built from two
+composable building blocks (decided for v1; the auto-split and per-student
+complement variants are deferred):
+
+- **A — per-student served sample** (slices 1–2, shipped): each student is
+  served a deterministic random subset of the pool as their *training* data.
+- **B — reserved grader-only file** (this work): a bundled file served to
+  **no student** — present only in the native worker's grading workspace.
+
+Combined, **A + B** gives both the classic *shared-train / secret-test* split
+(a plain served file + a grader-only test file) and the stronger
+*random-train + reserved-holdout* (a per-student sample + a grader-only test
+file).
+
+### "Holdout" means nobody sees it — and which kind matters
+
+- **Reserved holdout (globally secret):** rows/files served to no student,
+  only in the worker workspace. Collusion-proof — the whole class pooling its
+  training data still can't reconstruct it. This is option B and the default
+  meaning of "holdout".
+- **Per-student complement (individually unseen only):** grading a student on
+  the rows that weren't in *their* sample. Cheap and uses all the data, but a
+  row in student A's "test" set was student B's *training* data, so two
+  students colluding can reconstruct it. **Not** secret — deferred (option D),
+  and named "complement" to keep it distinct from a true holdout.
+
+### Grader-only delivery matrix
+
+A grader-only file must reach the worker and nothing student-facing. The
+codebase already enforces exactly this shape for `solution.ipynb` via a
+`reservedNames` set; grader-only files union the manifest's
+`graderOnlyFiles` into that same set at each classification point:
+
+| Path | Handler | Student-facing? | Grader-only action |
+|------|---------|-----------------|--------------------|
+| Worker download | `WorkerArtifactRoutes.downloadTestSetup` (HMAC) | no (trusted) | **keep** — streams the full stored zip as-is |
+| Browser-runner download | `BrowserRunnerRoutes.downloadTestSetup` | **yes** | **filter** — stream a copy with grader-only entries removed (guarded no-op when none) |
+| Student support-file download | `TestSetupRoutes.downloadSupportFile` | **yes** | **block** — union into `reservedNames` (already gates by name) |
+| Editor symlinks | `NotebookWorkingCopyStore.createSupportFileSymlinks` | **yes** | **skip** — union into `reservedNames` |
+| shared/ extraction | `extractSupportFilesToSharedDirectory` | (symlink source) | **skip** — union into `reservedNames` |
+| MCP support listing | `GetSupportFilesTool` | yes (instructor) | **hide** — union into `reservedNames` |
+| Instructor zip download | `TestSetupRoutes.downloadTestSetup` | no (`isInstructor` gate) | keep |
+
+The stored zip keeps the grader-only file (so the worker gets it via its
+download); only the *student-facing* paths exclude it. The browser-runner path
+is the one that needs an active filter (it streams the whole zip); everything
+else is a name-set union.
+
+### Data model
+
+`TestProperties.graderOnlyFiles: [String]` (decoded with `decodeIfPresent`
+default `[]`; **stripped by `runnerSanitized()`** — the worker receives the
+file via the zip and needs no marker). A grader-only file is otherwise an
+ordinary support file; this list just flags it as student-hidden.
+
+### Trust boundary & worker-grading
+
+A grader-only file is a secret, so an assignment that declares one must be
+**worker-graded** — the browser path can't keep it from the student even with
+the download filter (a determined student controls their browser). The editor
+ships the grading-mode lock + the 🔒 cues described under the UI section.
+
+### Build order (safety)
+
+Implement in this order so a grader-only file can never be *authored* before
+it is *enforced*:
+
+1. **Foundation** — `graderOnlyFiles` on `TestProperties` + `runnerSanitized`
+   strip + tests. Inert: no authoring surface, so nothing can create one yet.
+2. **Enforcement** — union `graderOnlyFiles` into `reservedNames` at the four
+   student-facing classification points + the browser-runner filtered
+   download, with tests asserting the worker download *includes* and the
+   student/browser paths *exclude* a grader-only file.
+3. **Authoring (last)** — the editor control + MCP, plus the worker-grading
+   lock. Only after enforcement is in place.
+
 ## See also
 
 - `docs/personalization-phase1.md` — the per-student seed contract


### PR DESCRIPTION
## What

Foundation for **option B — reserved grader-only files** (the secret test set / reserved holdout) of the datasets feature, plus the finalized train/test split design in `docs/datasets.md`. Follows the merged slices 1–2 (per-student dataset model, materializer, worker delivery).

This is deliberately the **inert** first step — there's no authoring surface yet, so a grader-only file can't be created until enforcement lands. Safe ordering: **foundation → enforcement → authoring**.

## Changes

- **`TestProperties.graderOnlyFiles: [String]`** (Core) — marks bundled support files as grader-only: the native worker's grading scripts read them, but they're withheld from every student-facing path. Codable with `decodeIfPresent` back-compat; **stripped by `runnerSanitized()`** (the worker receives the file via the test-setup zip, never the marker), matching the `datasets` pattern. Plus a `graderOnlyFileSet` helper for unioning into the existing `reservedNames` filters.
- **`docs/datasets.md`** — finalized train/test design:
  - **reserved holdout** (globally secret, collusion-proof) vs **per-student complement** (individually unseen only) vocabulary,
  - the **A + B** v1 scope (per-student served sample + reserved grader-only file; C/D deferred),
  - the **grader-only delivery matrix** (worker download keeps it; editor symlinks / browser-runner download / student support-file download exclude it — reusing the existing `solution.ipynb` `reservedNames` precedent),
  - the safe build order.
- Tests pin Codable back-compat, round-trip, the `runnerSanitized()` strip, and the set helper.

## Regression safety

- The field is **inert**: `graderOnlyFiles` defaults to `[]`, nothing reads it yet, and there's no way to set it — so zero behavior change for any existing assignment.
- New field is optional/back-compat; `runnerSanitized()` strips it.
- Core logic verified locally (`swift format` clean; mirrors the CI-passed `datasets` Codable pattern). Full build can't run in this environment (egress policy); CI is the oracle.

## Not in scope (follow-ups)

- **Enforcement** — union `graderOnlyFiles` into `reservedNames` at the four student-facing classification points + a filtered browser-runner download, with tests asserting the worker download *includes* and student/browser paths *exclude* a grader-only file.
- **Authoring** — the editor control + MCP + the worker-grading lock (last, so a grader-only file can't be authored before it's enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx1g6pnZFeZMtKhbKcJCuS)_