### PR TITLE
feat(datasets): enforce grader-only files at every student-facing path

### DIFF
--- a/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSupportFilesTool.swift
@@ -111,9 +111,13 @@ struct GetSupportFilesTool: ContentTool {
         let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
             publicID: input.assignmentPublicID, tool: Self.name)
 
-        let suiteScripts = Set(setup.decodedManifest()?.testSuites.map(\.script) ?? [])
+        let manifest = setup.decodedManifest()
+        let suiteScripts = Set(manifest?.testSuites.map(\.script) ?? [])
+        // Grader-only files (option B — docs/datasets.md) are hidden from the
+        // support-file listing/read.
+        let graderOnly = manifest?.graderOnlyFileSet ?? []
         let supportNames = listZipEntries(zipPath: setup.zipPath).filter {
-            !suiteScripts.contains($0) && !Self.reservedNames.contains($0)
+            !suiteScripts.contains($0) && !Self.reservedNames.contains($0) && !graderOnly.contains($0)
         }
 
         guard let filename = input.filename else {

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -59,7 +59,19 @@ struct BrowserRunnerRoutes: RouteCollection {
         if try await requireOpenStudentAssignment(for: setupID, user: caller, on: req) == nil {
             try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
         }
-        return try await req.fileio.asyncStreamFile(at: setup.zipPath)
+
+        // Grader-only files (option B — docs/datasets.md) must never reach the
+        // student's browser. The canonical stored zip keeps them (the native
+        // worker downloads it over the HMAC route); here we stream a filtered
+        // copy with them removed. Strict no-op — stream the stored zip as-is —
+        // when none are declared, so non-grader-only assignments are unchanged.
+        let graderOnly = setup.decodedManifest()?.graderOnlyFileSet ?? []
+        guard !graderOnly.isEmpty else {
+            return try await req.fileio.asyncStreamFile(at: setup.zipPath)
+        }
+        let filtered = try filteredZipCopy(sourceZip: setup.zipPath, excluding: graderOnly)
+        defer { try? FileManager.default.removeItem(at: filtered.deletingLastPathComponent()) }
+        return buildFileResponse(data: try Data(contentsOf: filtered), filename: "\(setupID).zip")
     }
 
     // MARK: - GET /api/v1/browser-runner/testsetups/:id/manifest
@@ -88,11 +100,28 @@ struct BrowserRunnerRoutes: RouteCollection {
             try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
         }
 
+        // Strip grader-only filenames (option B — docs/datasets.md) from the
+        // student-facing manifest so their names don't leak here (their contents
+        // are already withheld at every download path). Targeted JSON-key edit —
+        // every other field is served exactly as stored. No-op when none.
+        var manifestBody = setup.manifest
+        if let data = setup.manifest.data(using: .utf8),
+            var obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            obj["graderOnlyFiles"] != nil
+        {
+            obj["graderOnlyFiles"] = [String]()
+            if let reencoded = try? JSONSerialization.data(withJSONObject: obj),
+                let stripped = String(data: reencoded, encoding: .utf8)
+            {
+                manifestBody = stripped
+            }
+        }
+
         var headers = HTTPHeaders()
         headers.add(name: .contentType, value: "application/json; charset=utf-8")
         return Response(
             status: .ok, headers: headers,
-            body: .init(string: setup.manifest))
+            body: .init(string: manifestBody))
     }
 
     // MARK: - GET /api/v1/browser-runner/testsetups/:id/seed

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -458,13 +458,13 @@ struct TestSetupRoutes: RouteCollection {
         let allEntries = listZipEntries(zipPath: setup.zipPath)
         guard allEntries.contains(filename) else { throw Abort(.notFound) }
 
-        let testScripts: Set<String> = {
-            guard let props = setup.decodedManifest()
-
-            else { return [] }
-            return Set(props.testSuites.map(\.script))
-        }()
-        let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+        let manifest = setup.decodedManifest()
+        let testScripts = Set(manifest?.testSuites.map(\.script) ?? [])
+        // Grader-only files (option B — docs/datasets.md) are never
+        // student-downloadable: union them into the reserved set alongside the
+        // canonical notebooks.
+        var reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+        reservedNames.formUnion(manifest?.graderOnlyFiles ?? [])
         guard !testScripts.contains(filename), !reservedNames.contains(filename) else {
             throw AppError.forbidden(action: "download '\(filename)' (not a support file)")
         }

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -303,6 +303,31 @@ func removeScriptFromZip(zipPath: String, filename: String) throws {
     try repackZipFromDirectory(zipPath: zipPath, sourceDir: tempDir)
 }
 
+/// Builds a NEW temp zip copy of `sourceZip` with `excluding` entries removed,
+/// leaving `sourceZip` itself untouched.  Returns the temp zip's URL; the caller
+/// must delete its parent directory (`url.deletingLastPathComponent()`) when
+/// done streaming it.
+///
+/// Used to serve a student-facing test-setup zip that withholds grader-only
+/// files (option B — docs/datasets.md) while the canonical stored zip — which
+/// the native worker downloads over the HMAC route — keeps them.
+func filteredZipCopy(sourceZip: String, excluding: Set<String>) throws -> URL {
+    let fm = FileManager.default
+    let workDir = fm.temporaryDirectory
+        .appendingPathComponent("chickadee_zip_filter_\(UUID().uuidString)")
+    let stageDir = workDir.appendingPathComponent("stage")
+    try fm.createDirectory(at: stageDir, withIntermediateDirectories: true)
+    for entry in listZipEntries(zipPath: sourceZip) where !excluding.contains(entry) {
+        guard let data = extractZipEntry(zipPath: sourceZip, entryName: entry) else { continue }
+        let dest = stageDir.appendingPathComponent(entry)
+        try fm.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: dest)
+    }
+    let outZip = workDir.appendingPathComponent("filtered.zip")
+    try repackZipFromDirectory(zipPath: outZip.path, sourceDir: stageDir)
+    return outZip
+}
+
 func extractZipEntry(zipPath: String, entryName: String) -> Data? {
     let result: (Int32, Data)? = try? withZipProcessLock {
         let process = Process()

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -453,7 +453,10 @@ func createSupportFileSymlinks(req: Request, setup: APITestSetup, studentDir: St
     else { return }
 
     let testScriptNames = Set(props.testSuites.map { $0.script })
-    let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+    // Grader-only files (option B — docs/datasets.md) are withheld from the
+    // student editor: union them into the reserved set so no symlink is created.
+    var reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+    reservedNames.formUnion(props.graderOnlyFiles)
     // Cached: this pass runs on every notebook visit (the symlinks are
     // idempotent), so listing the zip fresh each time would spawn a serialized
     // `unzip` subprocess per load. The cache busts when the zip's mtime/size

--- a/Tests/APITests/GraderOnlyEnforcementTests.swift
+++ b/Tests/APITests/GraderOnlyEnforcementTests.swift
@@ -1,0 +1,60 @@
+// Tests/APITests/GraderOnlyEnforcementTests.swift
+//
+// Grader-only files (option B — docs/datasets.md) must be withheld from every
+// student-facing path while the canonical stored zip (which the native worker
+// downloads) keeps them. The student-facing test-setup download serves a
+// filtered copy via `filteredZipCopy`; these tests pin that helper's contract
+// directly (it's the security-critical new logic):
+//   - the excluded entry is gone, every other entry + its bytes survive,
+//   - the SOURCE zip is left untouched (so the worker still gets the file),
+//   - excluding nothing yields a faithful copy.
+// The name-union exclusions at the other delivery points (editor symlink,
+// support-file download, MCP listing) reuse the existing reservedNames pattern.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct GraderOnlyFilteredZipTests {
+
+    /// Packs `files` (name → content) into a fresh zip and returns its path.
+    private func makeZip(_ files: [String: String]) throws -> String {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("go-src-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        for (name, content) in files {
+            try content.write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        let zipPath = fm.temporaryDirectory.appendingPathComponent("go-\(UUID().uuidString).zip").path
+        try repackZipFromDirectory(zipPath: zipPath, sourceDir: dir)
+        return zipPath
+    }
+
+    @Test func excludesGraderOnlyButKeepsOthersWithContent() throws {
+        let zip = try makeZip(["a.py": "print(1)", "data.csv": "id\n1\n", "test.csv": "ans\n42\n"])
+        let filtered = try filteredZipCopy(sourceZip: zip, excluding: ["test.csv"])
+        defer { try? FileManager.default.removeItem(at: filtered.deletingLastPathComponent()) }
+
+        let entries = Set(listZipEntries(zipPath: filtered.path))
+        #expect(!entries.contains("test.csv"), "grader-only file must be removed")
+        #expect(entries == ["a.py", "data.csv"])
+        let kept = try #require(extractZipEntry(zipPath: filtered.path, entryName: "data.csv"))
+        #expect(String(data: kept, encoding: .utf8) == "id\n1\n")
+    }
+
+    @Test func sourceZipIsLeftUntouched() throws {
+        let zip = try makeZip(["a.py": "x", "test.csv": "secret"])
+        let filtered = try filteredZipCopy(sourceZip: zip, excluding: ["test.csv"])
+        defer { try? FileManager.default.removeItem(at: filtered.deletingLastPathComponent()) }
+        // The worker still downloads the canonical stored zip — it must keep the file.
+        #expect(Set(listZipEntries(zipPath: zip)) == ["a.py", "test.csv"])
+    }
+
+    @Test func excludingNothingIsAFaithfulCopy() throws {
+        let zip = try makeZip(["a.py": "x", "data.csv": "y"])
+        let filtered = try filteredZipCopy(sourceZip: zip, excluding: [])
+        defer { try? FileManager.default.removeItem(at: filtered.deletingLastPathComponent()) }
+        #expect(Set(listZipEntries(zipPath: filtered.path)) == ["a.py", "data.csv"])
+    }
+}

--- a/changelog.d/datasets-grader-only-enforcement.md
+++ b/changelog.d/datasets-grader-only-enforcement.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Datasets: grader-only file enforcement.** A file listed in
+  `TestProperties.graderOnlyFiles` (option B — the reserved holdout / secret test
+  set, see `docs/datasets.md`) is now withheld from every student-facing path —
+  the JupyterLite editor symlinks, the student support-file download, the
+  browser-runner zip download (served as a filtered copy), the browser manifest
+  endpoint (the names), and the MCP support listing — while the native worker
+  still receives it via the test-setup zip so grading scripts can read it. A
+  strict no-op for assignments that declare none. Authoring (a UI/MCP way to
+  designate a file grader-only, plus the worker-grading lock) follows.


### PR DESCRIPTION
## What

**Enforcement** for option B — reserved grader-only files (the secret test set / reserved holdout). Builds on the merged foundation (#1020, `TestProperties.graderOnlyFiles`). A grader-only file is now **withheld from every student-facing path** while the native worker still receives it via the test-setup zip, so an instructor's grading scripts can read a held-out test set the student never sees. See `docs/datasets.md`.

This reuses the codebase's existing `solution.ipynb` `reservedNames` precedent — unioning the manifest's `graderOnlyFiles` in at each classification point.

## Exclusion points

| Path | Change |
|------|--------|
| Editor symlinks (`createSupportFileSymlinks`) | union → no symlink created |
| Student support-file download (`downloadSupportFile`) | union → blocked by name |
| MCP support listing/read (`GetSupportFilesTool`) | union → hidden |
| Browser-runner **zip** download | stream a **filtered copy** via new `filteredZipCopy` (extract → drop grader-only → repack); canonical stored zip untouched. No-op when none declared |
| Browser **manifest** endpoint | strip the `graderOnlyFiles` names from the student-facing JSON |
| **Worker** download (`WorkerArtifactRoutes`) | **unchanged** — it must keep the file |

## Tests / verification

- `filteredZipCopy` logic verified against **real `zip`/`unzip`**: drops the excluded entry, preserves every other entry and its bytes, and **leaves the source zip intact** (so the worker still gets the file).
- A unit test (`GraderOnlyEnforcementTests`) pins that contract.
- `swift format` clean. Full build can't run here (egress policy); CI is the oracle.

## Regression safety

- **Strict no-op** for assignments that declare no `graderOnlyFiles` — which is all of them (no authoring surface exists yet), so zero behavior change across the corpus.
- The worker delivery path is deliberately untouched.

## Not in scope (next)

- **Authoring** — the editor control + MCP to designate a file grader-only, plus the worker-grading lock (last, so a grader-only file can't be authored before it's enforced).
- Heavier endpoint-integration tests (asserting each route's exclusion against a live app) — fast follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx1g6pnZFeZMtKhbKcJCuS)_