### PR TITLE
Post-idle kernel exec-hang telemetry (exec_hang)

### DIFF
--- a/Public/jl-kernel-diagnostics.js
+++ b/Public/jl-kernel-diagnostics.js
@@ -19,11 +19,18 @@
 //     signal the parent-side probe could never get.
 //   • kernel_error — the actual failure: a CSP worker block (the data:-worker
 //     case), an IndexedDB / Drive exception, a blocked/404 asset, a dead/unknown
-//     kernel, or a boot-stall watchdog — the WHY.
+//     kernel, a boot-stall watchdog, or a post-idle execution hang
+//     (source `exec_hang`) — the WHY.
 //
-// Capture is scoped to the BOOT window (it stops once the kernel is idle), so it
-// never records student-code execution — infrastructure breadcrumbs only, same
-// PII contract as the rest of client-diagnostics.
+// Boot-window error capture (CSP / resource / unhandledrejection / dead-unknown /
+// boot-stall) stops the instant the kernel reaches idle, so it never records
+// student-code execution. AFTER idle, ONE narrow watcher remains: it polls only
+// the kernel's busy/idle status indicator (never the notebook content) and emits
+// a single `exec_hang` when a cell sits `busy` past EXEC_HANG_MS — the post-idle
+// hang the boot funnel goes blind on (the kernel booted fine, then wedged on
+// execute, so `kernel_idle` already reported "success"). It transmits a duration
+// only (`busy_ms=…`), never code or output — same PII contract as the rest of
+// client-diagnostics.
 
 (function () {
     'use strict';
@@ -31,6 +38,8 @@
     var KERNEL_BOOT_DEADLINE_MS = 75000;  // generous; a healthy kernel idles in seconds
     var SUSTAINED_UNHEALTHY_MS = 10000;   // ignore transient mid-boot dead/unknown blips
     var MAX_ERRORS = 8;
+    var EXEC_HANG_MS = 45000;     // a cell BUSY this long post-idle is a hang, not a slow cell
+    var POST_IDLE_MAX_MS = 900000;  // watch the post-idle exec window this long, then stop (hygiene)
 
     var origin;
     try { origin = window.location.origin; } catch (_) { origin = '*'; }
@@ -172,8 +181,64 @@
         return { unhealthySince: 0, report: false };
     }
 
+    // Raw execution-indicator status for the post-idle watcher: ONLY the
+    // structured data-status (idle/busy/starting/…), never the body-text fallback
+    // — after idle the page body holds the student's code/output, and this watcher
+    // must read infrastructure state only. Returns null when the indicator is
+    // absent (the watcher then reports nothing: graceful, no false positive, no
+    // content scan).
+    function executionStatusRaw() {
+        try {
+            var ind = document.querySelector('.jp-Notebook-ExecutionIndicator[data-status]');
+            if (ind) return ind.getAttribute('data-status');
+        } catch (_) { /* ignore */ }
+        return null;
+    }
+
+    // Decide whether the kernel has been continuously BUSY long enough to be a
+    // hang rather than a slow cell. PURE, mirrors trackUnhealthy. Start a clock on
+    // the first busy poll; flag once busy has held for EXEC_HANG_MS; any non-busy
+    // status (idle/starting/null — a finished cell or none running) resets it.
+    //   status        — raw execution-indicator status (may be null)
+    //   execBusySince — ms timestamp the current busy run began, or 0 if none
+    //   now           — current time in ms
+    // returns { execBusySince, hang }.
+    function trackExecHang(status, execBusySince, now) {
+        if (status === 'busy') {
+            var since = execBusySince || now;
+            return { execBusySince: since, hang: now - since >= EXEC_HANG_MS };
+        }
+        return { execBusySince: 0, hang: false };
+    }
+
     var startedAt = Date.now();
     var unhealthySince = 0;   // ms timestamp the current dead/unknown streak began; 0 = healthy
+    var execBusySince = 0;        // ms timestamp the current post-idle busy run began; 0 = idle
+    var execHangReported = false; // de-dupe: one exec_hang per page
+    var execWatchStartedAt = 0;
+
+    // Post-idle execution-hang watcher. Starts the instant the kernel reaches idle
+    // (handed off from poll, which has stopped). Reads ONLY the busy/idle indicator
+    // and reports a SINGLE `exec_hang` (duration only — never student content) when
+    // a cell hangs busy past EXEC_HANG_MS: the post-idle case the boot funnel can't
+    // see. Stops after the first report or POST_IDLE_MAX_MS, whichever is first.
+    function watchExec() {
+        try {
+            var now = Date.now();
+            if (now - execWatchStartedAt >= POST_IDLE_MAX_MS) return;
+            var tracked = trackExecHang(executionStatusRaw(), execBusySince, now);
+            execBusySince = tracked.execBusySince;
+            if (tracked.hang && !execHangReported) {
+                execHangReported = true;
+                // PII-safe: kernel busy-duration only — never student code/output.
+                // Reuses the kernel_error kind so the existing parent bridge +
+                // server forward it unchanged; source `exec_hang` distinguishes it.
+                post('kernel_error', 'exec_hang', 'busy_ms=' + (now - tracked.execBusySince));
+                return;   // one report per page; stop watching
+            }
+        } catch (_) { /* never throw */ }
+        setTimeout(watchExec, 2000);
+    }
 
     function poll() {
         if (done) return;
@@ -194,6 +259,11 @@
                     // boot time (boot_start → idle).
                     reportPhase('kernel_idle', 'elapsed_ms=' + (Date.now() - startedAt));
                     done = true;
+                    // Boot capture stops here; hand off to the post-idle hang
+                    // watcher (status-only, PII-safe) so the blind spot after idle
+                    // — a kernel that booted then wedged on execute — is covered.
+                    execWatchStartedAt = Date.now();
+                    setTimeout(watchExec, 2000);
                     return;
                 }
             }
@@ -225,6 +295,7 @@
         if (hooks) hooks.exports = {
             kernelStatus: kernelStatus, reportPhase: reportPhase,
             reportError: reportError, trackUnhealthy: trackUnhealthy,
+            trackExecHang: trackExecHang, executionStatusRaw: executionStatusRaw,
         };
     } catch (_) { /* ignore */ }
 })();

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
@@ -101,7 +101,10 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         + "collector — the drop-off localizes WHERE a kernel boot stalls (a kernel that spins forever "
         + "reaches some phase and stops, so kernel_idle far below boot_start is the hung-kernel "
         + "signature); pair it with the kernel_error rows (in bySource / recentSamples: csp_violation, "
-        + "resource_error, kernel_dead, boot_stalled, …) for the WHY. Optionally filter by testSetupID. "
+        + "resource_error, kernel_dead, boot_stalled, exec_hang, …) for the WHY. exec_hang is the "
+        + "POST-IDLE hang the boot funnel can't see: the kernel booted to idle (counted as success) "
+        + "then wedged on execute, so cells sit busy forever; its count is distinct students who hit a "
+        + "sustained-busy hang, message busy_ms=… the hang duration. Optionally filter by testSetupID. "
         + "Read-only; reports infrastructure breadcrumbs only and never includes a student identifier."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),

--- a/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+++ b/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
@@ -160,6 +160,33 @@ test('collector trackUnhealthy ignores a transient unknown but flags a sustained
   }
 });
 
+test('collector executionStatusRaw reads only the data-status indicator', () => {
+  assert.equal(loadCollector({ executionStatus: 'busy' }).exports.executionStatusRaw(), 'busy');
+  assert.equal(loadCollector({ executionStatus: 'idle' }).exports.executionStatusRaw(), 'idle');
+  // No data-status indicator → null (watcher reports nothing; never scans body text).
+  assert.equal(loadCollector({ bodyText: 'Kernel status: Busy' }).exports.executionStatusRaw(), null);
+});
+
+test('collector trackExecHang flags a sustained-busy cell but not a quick one', () => {
+  const { exports } = loadCollector();
+  const t = exports.trackExecHang;
+  // First busy poll starts the clock; nothing flagged yet.
+  const first = t('busy', 0, 1000);
+  assert.equal(first.execBusySince, 1000);
+  assert.equal(first.hang, false);
+  // Still busy but under EXEC_HANG_MS (45s): clock preserved, no hang.
+  const held = t('busy', 1000, 20000);
+  assert.equal(held.execBusySince, 1000);
+  assert.equal(held.hang, false);
+  // Busy held continuously past EXEC_HANG_MS: now a hang.
+  assert.equal(t('busy', 1000, 46000).hang, true);
+  // Any non-busy status (finished cell or none running) resets the clock — a
+  // quick cell, or an idle kernel, is never a hang.
+  for (const status of ['idle', 'starting', null]) {
+    assert.deepEqual({ ...t(status, 1000, 46000) }, { execBusySince: 0, hang: false });
+  }
+});
+
 // ----------------------------------------------------------------
 // Parent bridge (notebook.js handleKernelDiagMessage)
 // ----------------------------------------------------------------

--- a/changelog.d/kernel-exec-hang-telemetry.md
+++ b/changelog.d/kernel-exec-hang-telemetry.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Post-idle kernel execution-hang telemetry (`exec_hang`).** The in-iframe
+  kernel diagnostics collector previously stopped the instant the kernel reached
+  `kernel_idle` — so a kernel that booted fine and *then* wedged on cell execution
+  (the `[*]`-forever hang) was invisible to both the boot funnel and the
+  watchdog's recovery. The collector now keeps one narrow, PII-safe watcher alive
+  past idle: it polls only the busy/idle status indicator (never the notebook
+  content) and emits a single `kernel_error` with source `exec_hang` (message
+  `busy_ms=…`, a duration only) when a cell sits `busy` past a threshold
+  (`EXEC_HANG_MS`, 45s). It rides the existing parent-bridge / `kernel_error`
+  path, so no server change is needed; `get_browser_diagnostics` surfaces it in
+  `bySource`, where the count is the number of distinct students who hit a
+  post-idle hang. Boot-window error capture still stops at idle, preserving the
+  existing PII contract.


### PR DESCRIPTION
## Why

Students in the HLTH 230 Lab 5 section are hitting a **post-idle kernel hang**: the editor kernel boots fine, reaches idle, and *then* wedges on cell execution — `[*]` forever, surviving kernel restarts. The TA reported "quite a few" of these, but my telemetry read green.

The reason it's invisible: **both the collector and the watchdog stop at `kernel_idle`.** The boot funnel scores idle as success and quits; the parent watchdog's auto-recovery only fires for kernels that *never registered* ("Kernel Unknown"). A kernel that registers, idles, then hangs on execute gets neither telemetry nor recovery.

(Confirmed *not* a regression from the 0.4.520 deploy — the JupyterLite/Pyodide bundle and `notebook.js` are byte-identical to 0.4.511; only my collector changed. This is a pre-existing latent hang, likely an execution-time SharedArrayBuffer/`Atomics` deadlock on certain browsers.)

## What

Make the post-idle hang **visible** so we can measure scope and which browsers (recovery is a deliberate follow-up — it needs care not to false-positive on legitimately long cells).

`Public/jl-kernel-diagnostics.js` now keeps **one narrow watcher** alive past idle:
- Handed off the instant the kernel reaches idle (the boot poll still stops there — boot-window error capture is unchanged).
- Reads **only** the busy/idle status indicator (`executionStatusRaw()` — the structured `data-status`, never the body-text fallback, so it never scans the student's notebook content).
- Emits a **single** `kernel_error` with source **`exec_hang`** (message `busy_ms=…`, a duration only) when a cell sits `busy` past `EXEC_HANG_MS` (45s) — a hang, not a slow cell.
- Stops after the first report or `POST_IDLE_MAX_MS` (15 min).

Pure `trackExecHang()` mirrors `trackUnhealthy()` and is unit-tested.

**No bridge or server change:** it reuses the `kernel_error` kind, and the server already accepts `kernel_error` with a free-form `source` (validated in `ClientDiagnosticsRoutes` — kind allow-list only, source is a dedup sub-key). `get_browser_diagnostics` surfaces `exec_hang` in `bySource`, where the **count is the number of distinct students who hit a post-idle hang**. The admin tool description was updated to document it.

### PII contract preserved
Boot-window error capture (CSP / resource / unhandledrejection / dead-unknown / boot-stall) still stops at idle. The post-idle watcher transmits a **duration only** — never code or output — and reads only the infrastructure status indicator.

## Tests

`Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs` (+2; 122/122 across the JS suite):
- `executionStatusRaw` reads only the `data-status` indicator (null — never body text — when absent)
- `trackExecHang` flags sustained-busy (≥45s) as a hang, resets on any non-busy status (a finished/quick cell is never a hang)

## Follow-up (not in this PR)
Post-idle **recovery** — let the watchdog notice a sustained-busy hang and offer a one-click reload. Deferred because it must not false-positive on a genuinely long-running cell; this telemetry will tell us the right threshold + scope first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_