### PR TITLE
Import LEARN roster + sync override-only (non-submitter) grades

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -47,6 +47,12 @@ LEARN
             #csrfFormField()
             <button class="btn action-btn" type="submit">Retry failed</button>
         </form>
+        <form method="post" action="/instructor/brightspace/import-roster" class="inline-form"
+              onsubmit="return confirm('Create Chickadee student accounts for everyone in the LEARN classlist? Intended for test accounts that won’t log in.')">
+            #csrfFormField()
+            <button class="btn action-btn" type="submit"
+                    title="Create enrolled Chickadee accounts from the LEARN roster so you can grade students who haven’t logged in">Import students from LEARN</button>
+        </form>
     </div>
     #endif
 </section>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -48,7 +48,7 @@ LEARN
             <button class="btn action-btn" type="submit">Retry failed</button>
         </form>
         <form method="post" action="/instructor/brightspace/import-roster" class="inline-form"
-              onsubmit="return confirm('Create Chickadee student accounts for everyone in the LEARN classlist? Intended for test accounts that won’t log in.')">
+              onsubmit="return confirm('Create Chickadee student accounts for everyone in the LEARN classlist? They adopt their account when they first log in.')">
             #csrfFormField()
             <button class="btn action-btn" type="submit"
                     title="Create enrolled Chickadee accounts from the LEARN roster so you can grade students who haven’t logged in">Import students from LEARN</button>

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -354,9 +354,10 @@ extension InstructorDashboardRoutes {
     /// but backfilled + ensured enrolled.
     ///
     /// Provisioned accounts carry `authProvider = "learn-roster"` and no
-    /// `externalSubject`. Until SSO-adoption-on-login ships (Phase 2), a real
-    /// student who later logs in via SSO would collide on the unique username —
-    /// so this is for test accounts that won't log in, not yet a live class.
+    /// `externalSubject`. When the real student later logs in via SSO they adopt
+    /// this account in place (`adoptRosterShadowAccount`), inheriting its cached
+    /// ids + grades — no duplicate or unique-username collision. Safe on a live
+    /// class.
     @Sendable
     func brightspaceImportRoster(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -344,11 +344,65 @@ extension InstructorDashboardRoutes {
         return req.redirect(to: "/instructor/brightspace")
     }
 
+    // MARK: - POST /instructor/brightspace/import-roster
+
+    /// Imports the bound course's LEARN classlist as real, enrolled,
+    /// passwordless Chickadee student accounts so their grades can be entered
+    /// and synced before they ever log in. Each member's D2L UserId +
+    /// OrgDefinedId are cached up front (from the classlist), so sync resolves
+    /// with no lookup. Existing users (matched by username) are left in place
+    /// but backfilled + ensured enrolled.
+    ///
+    /// Provisioned accounts carry `authProvider = "learn-roster"` and no
+    /// `externalSubject`. Until SSO-adoption-on-login ships (Phase 2), a real
+    /// student who later logs in via SSO would collide on the unique username —
+    /// so this is for test accounts that won't log in, not yet a live class.
+    @Sendable
+    func brightspaceImportRoster(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db),
+            let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty,
+            let client = try await req.application.brightSpaceClient(forCourse: course)
+        else {
+            req.session.data["bs_flash_error"] =
+                "Link the course to its LEARN org unit first, then import the roster."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        let classlist: [BrightSpaceClasslistEntry]
+        do {
+            classlist = try await client.fetchClasslist(orgUnitID: orgUnitID, on: req.application)
+        } catch {
+            req.session.data["bs_flash_error"] =
+                "Couldn't read the LEARN classlist: \(error.localizedDescription)"
+            return req.redirect(to: "/instructor/brightspace")
+        }
+
+        let result = try await provisionStudentsFromClasslist(
+            classlist, courseID: courseUUID, on: req.db)
+        req.session.data["bs_flash_success"] =
+            "Imported \(classlist.count) LEARN roster member(s): \(result.created) new account(s), "
+            + "\(result.enrolled) newly enrolled. Enter grades for them, then Sync now."
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
     // MARK: - POST /instructor/brightspace/sync-now
 
     @Sendable
     func brightspaceSyncNow(req: Request) async throws -> Response {
         await runImmediateBrightspaceSweep(req: req)
+        // Also push override-only (no-submission) students for the active course —
+        // the result-based sweep can't see them (its queue is submission results).
+        if let user = req.auth.get(APIUser.self),
+            let courseUUID = try? await req.resolveActiveCourse(for: user).activeCourseUUID
+        {
+            _ = try? await pushOverrideOnlyGrades(
+                courseID: courseUUID,
+                resolveClient: { course in try await req.application.brightSpaceClient(forCourse: course) },
+                db: req.db, application: req.application, logger: req.logger)
+        }
         return req.redirect(to: "/instructor/brightspace")
     }
 
@@ -677,4 +731,62 @@ extension InstructorDashboardRoutes {
 struct BrightspaceTestResult: Content {
     let ok: Bool
     let message: String
+}
+
+/// Provisions (or backfills) Chickadee student accounts + course enrollments
+/// from a LEARN classlist. Returns `(created, enrolled)` counts. New accounts
+/// are passwordless `learn-roster` students with their D2L UserId +
+/// OrgDefinedId cached from the classlist; an existing user (by lowercased
+/// username) is left in place but gets those ids backfilled and is ensured
+/// enrolled. Extracted from the import route so the creation logic is
+/// unit-testable without a live D2L client.
+func provisionStudentsFromClasslist(
+    _ classlist: [BrightSpaceClasslistEntry], courseID: UUID, on db: Database
+) async throws -> (created: Int, enrolled: Int) {
+    var created = 0
+    var enrolledNow = 0
+    for entry in classlist {
+        guard
+            let rawUsername = entry.username?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawUsername.isEmpty
+        else { continue }
+        let username = rawUsername.lowercased()
+
+        let existing = try await APIUser.query(on: db).filter(\.$username == username).first()
+        let student: APIUser
+        if let existing {
+            if (existing.brightspaceUserID ?? "").isEmpty, let uid = entry.userID, !uid.isEmpty {
+                existing.brightspaceUserID = uid
+            }
+            if (existing.studentID ?? "").isEmpty, let org = entry.orgDefinedID, !org.isEmpty {
+                existing.studentID = org
+            }
+            try await existing.save(on: db)
+            student = existing
+        } else {
+            let newUser = APIUser(
+                username: username,
+                passwordHash: "",
+                role: UserRole.student.rawValue,
+                authProvider: "learn-roster",
+                studentID: entry.orgDefinedID
+            )
+            newUser.brightspaceUserID = entry.userID
+            try await newUser.save(on: db)
+            student = newUser
+            created += 1
+        }
+
+        guard let studentID = student.id else { continue }
+        let alreadyEnrolled =
+            try await APICourseEnrollment.query(on: db)
+            .filter(\.$userID == studentID)
+            .filter(\.$course.$id == courseID)
+            .first() != nil
+        if !alreadyEnrolled {
+            try await saveSeededEnrollment(userID: studentID, courseID: courseID, on: db)
+            enrolledNow += 1
+        }
+    }
+    return (created, enrolledNow)
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -52,6 +52,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post("brightspace", "bind-org-unit", use: brightspaceBindOrgUnit)
         r.get("brightspace", "grade-objects", use: brightspaceGradeObjects)
         r.post("brightspace", "auto-map", use: brightspaceAutoMap)
+        r.post("brightspace", "import-roster", use: brightspaceImportRoster)
         r.post("brightspace", "sync-now", use: brightspaceSyncNow)
         r.post("brightspace", "retry-failed", use: brightspaceRetryFailed)
         r.get("grades.csv", use: exportGradesCSV)

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -250,6 +250,11 @@ struct SSOAuthRoutes: RouteCollection {
             )
         )
 
+        let profile = SSOResolvedProfile(
+            username: username, subject: subject, preferredName: preferredName,
+            userIdentifier: userIdentifier, studentID: studentID, email: email,
+            displayName: displayName, mappedRole: mappedRole)
+
         if let existing = try await APIUser.query(on: req.db)
             .filter(\.$authProvider == "duo-oidc")
             .filter(\.$externalSubject == subject)
@@ -289,18 +294,46 @@ struct SSOAuthRoutes: RouteCollection {
             return existing
         }
 
+        // Adopt a roster-imported shadow account (provisioned from the LEARN
+        // classlist, `learn-roster`, never logged in) for its rightful owner —
+        // matched by the IdP-authoritative username — instead of creating a
+        // duplicate that would collide on the unique username. Only
+        // `learn-roster` accounts with no SSO subject are eligible, so real
+        // local/SSO accounts are never claimed.
+        if let adopted = try await adoptRosterShadowAccount(profile, on: req.db) {
+            await AuditLogger.record(
+                action: .userProvisioned,
+                targetType: .user,
+                targetID: adopted.id?.uuidString,
+                metadata: [
+                    "username": adopted.username,
+                    "role": adopted.role,
+                    "provider": "duo-oidc",
+                    "source": "adopted_learn_roster_account",
+                ],
+                actorUsernameOverride: "sso",
+                on: req
+            )
+            return adopted
+        }
+
+        return try await createSSOUser(profile, on: req)
+    }
+
+    /// Creates a fresh SSO-provisioned user from the resolved profile + audits it.
+    private func createSSOUser(_ profile: SSOResolvedProfile, on req: Request) async throws -> APIUser {
         let now = Date()
         let newUser = APIUser(
-            username: username,
+            username: profile.username,
             passwordHash: "",  // SSO users have no local password
-            role: mappedRole ?? UserRole.student.rawValue,
+            role: profile.mappedRole ?? UserRole.student.rawValue,
             authProvider: "duo-oidc",
-            externalSubject: subject,
-            email: email,
-            preferredName: preferredName,
-            userIdentifier: userIdentifier,
-            studentID: studentID,
-            displayName: displayName,
+            externalSubject: profile.subject,
+            email: profile.email,
+            preferredName: profile.preferredName,
+            userIdentifier: profile.userIdentifier,
+            studentID: profile.studentID,
+            displayName: profile.displayName,
             lastLoginAt: now,
             lastSeenAt: now
         )
@@ -460,4 +493,58 @@ private extension String {
     func normalizedIdentityKey() -> String? {
         nilIfBlank()?.lowercased()
     }
+}
+
+// MARK: - Roster-account adoption
+
+/// Adopts a roster-imported shadow account — provisioned from the LEARN
+/// classlist (`authProvider == "learn-roster"`, no `externalSubject`, never
+/// logged in) — for the SSO user identified by `username` / `subject`, if one
+/// exists, converting it to a real SSO account in place. Returns the adopted
+/// user, or nil when there's no shadow to claim.
+///
+/// This is what makes roster import safe on a live class: when an imported
+/// student logs in via SSO for the first time, they take over their existing
+/// account (and its cached BrightSpace ids + any grades) instead of hitting the
+/// unique-username constraint. Match is by the IdP-authoritative username
+/// (lowercased, as import stores it); only `learn-roster` shells are eligible,
+/// so real local/SSO accounts are never claimed.
+/// The SSO identity fields resolved from the IdP claims, bundled so the
+/// upsert / adopt / create paths share one parameter.
+struct SSOResolvedProfile {
+    let username: String
+    let subject: String
+    let preferredName: String?
+    let userIdentifier: String
+    let studentID: String?
+    let email: String?
+    let displayName: String?
+    let mappedRole: String?
+}
+
+func adoptRosterShadowAccount(
+    _ profile: SSOResolvedProfile, on db: Database
+) async throws -> APIUser? {
+    guard
+        let shadow = try await APIUser.query(on: db)
+            .filter(\.$authProvider == "learn-roster")
+            .filter(\.$externalSubject == nil)
+            .filter(\.$username == profile.username.lowercased())
+            .first()
+    else { return nil }
+
+    shadow.authProvider = "duo-oidc"
+    shadow.externalSubject = profile.subject
+    shadow.preferredName = profile.preferredName ?? shadow.preferredName
+    shadow.userIdentifier = profile.userIdentifier
+    // Keep the classlist-cached OrgDefinedId when the IdP sends no student_id.
+    shadow.studentID = profile.studentID ?? shadow.studentID
+    shadow.email = profile.email ?? shadow.email
+    shadow.displayName = profile.displayName ?? shadow.displayName
+    if let mappedRole = profile.mappedRole { shadow.role = mappedRole }
+    let now = Date()
+    shadow.lastLoginAt = now
+    shadow.lastSeenAt = now
+    try await shadow.save(on: db)
+    return shadow
 }

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -508,6 +508,91 @@ private func resolvedBrightSpaceUserID(
     return bsUserID
 }
 
+// MARK: - Override-only push (no-submission students)
+
+/// Pushes LEARN grades for students who have an instructor **override but no
+/// submission** for an assignment — the no-submission case the result-based
+/// sweep never sees (its queue is submission `APIResult` rows). Used by the
+/// manual "Sync now" action for the active course, so an instructor can grade
+/// students who never submitted (e.g. roster-imported, not-yet-logged-in
+/// students). Students who *do* have a submission are skipped here — the
+/// result-based sweep already pushes them (incorporating their override).
+/// Best-effort per student; returns the number pushed.
+@discardableResult
+func pushOverrideOnlyGrades(
+    courseID: UUID,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
+    db: Database,
+    application: Application,
+    logger: Logger
+) async throws -> Int {
+    guard let course = try await APICourse.find(courseID, on: db),
+        let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty
+    else { return 0 }
+
+    let assignments = try await APIAssignment.query(on: db)
+        .filter(\.$courseID == courseID)
+        .all()
+        .filter { !($0.brightspaceGradeObjectID ?? "").isEmpty }
+    guard !assignments.isEmpty, let client = try await resolveClient(course) else { return 0 }
+
+    let classlistCache = ClasslistUserIDCache()
+    let identityMap =
+        (try? await classlistCache.identityMap(
+            orgUnitID: orgUnitID, client: client, application: application)) ?? [:]
+
+    var pushed = 0
+    for assignment in assignments {
+        guard let gradeObjectID = assignment.brightspaceGradeObjectID, !gradeObjectID.isEmpty,
+            let total = try await suiteTotalPoints(testSetupID: assignment.testSetupID, db: db)
+        else { continue }
+        let overrides = try await APIGradeOverride.query(on: db)
+            .filter(\.$testSetupID == assignment.testSetupID)
+            .all()
+        for override in overrides {
+            // Students with a submission are handled by the result-based sweep.
+            let hasSubmission =
+                try await APISubmission.query(on: db)
+                .filter(\.$userID == override.userID)
+                .filter(\.$testSetupID == assignment.testSetupID)
+                .filter(\.$kind == APISubmission.Kind.student)
+                .first() != nil
+            if hasSubmission { continue }
+            guard let user = try await APIUser.find(override.userID, on: db) else { continue }
+            let points = Double(override.overridePercent) / 100.0 * total
+
+            func log(_ status: APIBrightSpaceSyncLog.Status, _ detail: String?) async {
+                let entry = APIBrightSpaceSyncLog(
+                    courseID: course.id, testSetupID: assignment.testSetupID,
+                    assignmentTitle: assignment.title, userID: override.userID,
+                    username: user.username, orgUnitID: orgUnitID, gradeObjectID: gradeObjectID,
+                    points: points, status: status, detail: detail)
+                try? await entry.save(on: db)
+            }
+
+            guard
+                let bsUserID = try await resolvedBrightSpaceUserID(
+                    for: user, identityMap: identityMap, db: db, client: client,
+                    application: application)
+            else {
+                await log(.skipped, "No LEARN account match (username / student number)")
+                continue
+            }
+            do {
+                try await client.pushGrade(
+                    orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, bsUserID: bsUserID,
+                    earnedPoints: points, on: application)
+                await log(.success, nil)
+                pushed += 1
+            } catch {
+                await log(.error, error.localizedDescription)
+                logger.warning("BrightSpace override-only push failed for \(user.username): \(error)")
+            }
+        }
+    }
+    return pushed
+}
+
 // MARK: - Monitor
 
 final class BrightSpaceGradeSyncMonitor: @unchecked Sendable {

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -218,6 +218,42 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
+    @Test func adoptRosterShadowAccountClaimsImportedStudentOnFirstLogin() async throws {
+        try await withApp(app) { _ in
+            // A roster-imported shadow: learn-roster, no SSO subject, cached ids.
+            let shadow = APIUser(
+                username: "jdoe", passwordHash: "", role: UserRole.student.rawValue,
+                authProvider: "learn-roster", studentID: "20850001")
+            shadow.brightspaceUserID = "d2l-1"
+            try await shadow.save(on: app.db)
+            let shadowID = try shadow.requireID()
+
+            // Owner logs in via SSO (username arrives mixed-case, no student_id claim).
+            let adopted = try await adoptRosterShadowAccount(
+                SSOResolvedProfile(
+                    username: "JDoe", subject: "oidc-sub-123", preferredName: "Jane",
+                    userIdentifier: "jdoe", studentID: nil, email: "jdoe@uw.ca",
+                    displayName: "Jane Doe", mappedRole: nil), on: app.db)
+            let user = try #require(adopted)
+            #expect(user.id == shadowID)  // same account, not a duplicate
+            #expect(user.authProvider == "duo-oidc")
+            #expect(user.externalSubject == "oidc-sub-123")
+            #expect(user.studentID == "20850001")  // cached OrgDefinedId kept (no claim)
+            #expect(user.brightspaceUserID == "d2l-1")  // cached LEARN UserId preserved
+
+            // No duplicate account exists for the username.
+            let count = try await APIUser.query(on: app.db).filter(\.$username == "jdoe").count()
+            #expect(count == 1)
+
+            // A username with no shadow is not adopted (returns nil → caller creates fresh).
+            let none = try await adoptRosterShadowAccount(
+                SSOResolvedProfile(
+                    username: "nobody", subject: "x", preferredName: nil, userIdentifier: "nobody",
+                    studentID: nil, email: nil, displayName: nil, mappedRole: nil), on: app.db)
+            #expect(none == nil)
+        }
+    }
+
     // MARK: - Roster import + override-only push
 
     @Test func provisionStudentsFromClasslistCreatesEnrolledGradeableAccounts() async throws {

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -218,6 +218,87 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
+    // MARK: - Roster import + override-only push
+
+    @Test func provisionStudentsFromClasslistCreatesEnrolledGradeableAccounts() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeTestCourse(on: app, code: "BS200")
+            let courseID = try course.requireID()
+            let classlist = [
+                BrightSpaceClasslistEntry(orgDefinedID: "20850001", username: "JDoe", userID: "d2l-1"),
+                BrightSpaceClasslistEntry(orgDefinedID: "20850002", username: "asmith", userID: "d2l-2"),
+                // No username → skipped.
+                BrightSpaceClasslistEntry(orgDefinedID: "x", username: nil, userID: "d2l-x"),
+            ]
+            let result = try await provisionStudentsFromClasslist(
+                classlist, courseID: courseID, on: app.db)
+            #expect(result.created == 2)
+            #expect(result.enrolled == 2)
+
+            // Username lowercased; D2L ids cached; passwordless student.
+            let jdoe = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "jdoe").first())
+            #expect(jdoe.brightspaceUserID == "d2l-1")
+            #expect(jdoe.studentID == "20850001")
+            #expect(jdoe.roleValue == .student)
+            #expect(jdoe.passwordHash.isEmpty)
+            let enrolled =
+                try await APICourseEnrollment.query(on: app.db)
+                .filter(\.$userID == jdoe.requireID())
+                .filter(\.$course.$id == courseID)
+                .first() != nil
+            #expect(enrolled)
+
+            // Re-running is idempotent — no duplicate accounts or enrollments.
+            let again = try await provisionStudentsFromClasslist(
+                classlist, courseID: courseID, on: app.db)
+            #expect(again.created == 0)
+            #expect(again.enrolled == 0)
+        }
+    }
+
+    @Test func pushOverrideOnlyGradesPushesNoSubmissionStudent() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeTestCourse(on: app, code: "BS300")
+            course.brightspaceOrgUnitID = "ou-300"
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            let setupID = "ts_\(UUID().uuidString.lowercased().prefix(8))"
+            let manifest =
+                #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"t.sh","points":10}],"timeLimitSeconds":10,"makefile":null}"#
+            _ = try await makeTestSetup(on: app, id: setupID, courseID: courseID, manifest: manifest)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: setupID, courseID: courseID, title: "Lab")
+            assignment.brightspaceGradeObjectID = "go-300"
+            try await assignment.save(on: app.db)
+
+            // A student with an override but NO submission.
+            let student = try await makeTestUser(
+                on: app, username: "ovr_\(UUID().uuidString.lowercased().prefix(6))")
+            let studentID = try student.requireID()
+            try await applyGradeOverride(
+                testSetupID: setupID, studentUserID: studentID, percent: 90, note: nil,
+                grantedByUserID: nil, on: app.db)
+
+            // Classlist resolves the student's username → D2L UserId.
+            let fake = FakeBrightSpaceGrading(classlist: [
+                BrightSpaceClasslistEntry(
+                    orgDefinedID: nil, username: student.username, userID: "d2l-555")
+            ])
+            let pushed = try await pushOverrideOnlyGrades(
+                courseID: courseID, resolveClient: { _ in fake }, db: app.db,
+                application: app, logger: app.logger)
+
+            #expect(pushed == 1)
+            let pushes = await fake.pushes
+            #expect(pushes.count == 1)
+            #expect(pushes.first?.bsUserID == "d2l-555")
+            #expect(pushes.first?.gradeObjectID == "go-300")
+            #expect(pushes.first?.earnedPoints == 9)  // 90% of 10
+        }
+    }
+
     @Test func resolvesByUsernameFromClasslistWhenNoStudentID() async throws {
         try await withApp(app) { _ in
             // SSO-typical: the student has a username but no student number.

--- a/changelog.d/brightspace-roster-import.md
+++ b/changelog.d/brightspace-roster-import.md
@@ -6,12 +6,12 @@
   enrolled, passwordless Chickadee student accounts — caching each member's D2L
   UserId + student number from the classlist so grade sync resolves with no
   lookup. Combined with a new override-only push wired into **"Sync now"**, an
-  instructor can now set a grade override on a student with **no submission** and
+  instructor can set a grade override on a student with **no submission** and
   have it sync to LEARN (the result-based sweep only ever saw submitters). This
-  makes it possible to grade non-submitters, and to exercise grade sync without a
-  student ever logging in.
+  enables grading non-submitters and exercising grade sync end to end.
 
-  Caveat (Phase 2 pending): provisioned accounts carry `authProvider
-  "learn-roster"` and no SSO subject, so until SSO-adoption-on-login ships, a
-  real student who later logs in via SSO would collide on the unique username —
-  intended for test accounts that won't log in, not yet a live class.
+  Safe on a live class: when an imported student later logs in via SSO they
+  **adopt** their provisioned account in place (matched by the IdP-authoritative
+  username), inheriting its cached BrightSpace ids and any grades, instead of
+  colliding on the unique username or creating a duplicate. Only never-logged-in
+  `learn-roster` shells are adoptable; real local/SSO accounts are never claimed.

--- a/changelog.d/brightspace-roster-import.md
+++ b/changelog.d/brightspace-roster-import.md
@@ -1,0 +1,17 @@
+### Added
+
+- **Grade students who haven't logged into Chickadee yet (LEARN roster import +
+  override-only sync).** A new **"Import students from LEARN"** action on the
+  instructor LEARN tab provisions the bound course's classlist as real,
+  enrolled, passwordless Chickadee student accounts — caching each member's D2L
+  UserId + student number from the classlist so grade sync resolves with no
+  lookup. Combined with a new override-only push wired into **"Sync now"**, an
+  instructor can now set a grade override on a student with **no submission** and
+  have it sync to LEARN (the result-based sweep only ever saw submitters). This
+  makes it possible to grade non-submitters, and to exercise grade sync without a
+  student ever logging in.
+
+  Caveat (Phase 2 pending): provisioned accounts carry `authProvider
+  "learn-roster"` and no SSO subject, so until SSO-adoption-on-login ships, a
+  real student who later logs in via SSO would collide on the unique username —
+  intended for test accounts that won't log in, not yet a live class.

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -307,9 +307,11 @@ or to test sync without anyone logging in):
    override), then **Sync now** — override-only (no-submission) students push
    to LEARN alongside the submitters.
 
-> **Not yet for live classes.** Imported accounts have no SSO subject, so until
-> SSO-adoption-on-login ships, a real student who later logs in via SSO would
-> collide on the unique username. Use this for test accounts that won't log in.
+> **Safe on a live class.** When an imported student later logs in via SSO, they
+> **adopt** their provisioned account in place (matched by username), inheriting
+> its cached BrightSpace ids and any grades — no duplicate, no username
+> collision. Only never-logged-in roster shells are adoptable; real local/SSO
+> accounts are never claimed.
 
 ## Troubleshooting
 

--- a/docs/brightspace-setup.md
+++ b/docs/brightspace-setup.md
@@ -292,6 +292,25 @@ For ops-level diagnosis, the admin diagnostic MCP surface exposes
 `get_brightspace_sync_status` (counts by status + recent D2L error detail,
 student-free).
 
+## Grading students who haven't logged into Chickadee
+
+Grades attach to a real Chickadee user with a submission or an instructor
+override; a manual enrolment is only a placeholder until that student first logs
+in. To grade students who never used Chickadee (e.g. for a participation mark,
+or to test sync without anyone logging in):
+
+1. Bind the course to its LEARN org unit and connect the service key.
+2. On the LEARN tab, click **Import students from LEARN** — this provisions the
+   classlist as real, enrolled, passwordless student accounts, caching each
+   one's D2L UserId + student number so sync resolves immediately.
+3. Set a grade override for each student (per-assignment submissions page →
+   override), then **Sync now** — override-only (no-submission) students push
+   to LEARN alongside the submitters.
+
+> **Not yet for live classes.** Imported accounts have no SSO subject, so until
+> SSO-adoption-on-login ships, a real student who later logs in via SSO would
+> collide on the unique username. Use this for test accounts that won't log in.
+
 ## Troubleshooting
 
 - **"This application is not authorized on this LMS instance" (Step 1):** the


### PR DESCRIPTION
## Why

You can't add students to LEARN (Registrar owns it), can't log in as the test accounts, and have no grade row yourself — so there was no way to get a gradeable student into Chickadee. This is also a real instructor need: **manually grade a student who never submitted**. Both come down to "grade students who haven't logged into Chickadee yet."

## What's in it

**1. Import students from LEARN** (`POST /instructor/brightspace/import-roster`, button on the LEARN tab)
`provisionStudentsFromClasslist` turns the bound course's classlist into **real, enrolled, passwordless** student accounts — caching each member's **D2L UserId + student number** from the classlist, so grade sync resolves with no lookup. Existing users (by lowercased username) are backfilled + ensured enrolled; re-running is idempotent.

**2. Override-only push** (wired into **Sync now**)
`pushOverrideOnlyGrades` pushes the override grade for students who have an instructor override but **no submission** — the case the result-based sweep never sees. Submitters are skipped here (the sweep handles them).

**3. SSO adoption on first login — live-class safe**
`adoptRosterShadowAccount`: when an imported student logs in via SSO for the first time, they **adopt** their provisioned account in place (matched by the IdP-authoritative username), inheriting its cached BrightSpace ids + any grades — no duplicate, no unique-username collision. Only never-logged-in `learn-roster` shells are adoptable; real local/SSO accounts are never claimed.

So the flow is: **Import from LEARN → set a grade override → Sync now → it pushes** — and when the real students show up, they seamlessly take over their accounts. This is also the first thing that exercises grade **write** end to end.

## Tests

- `provisionStudentsFromClasslist`: enrolled gradeable accounts (lowercased username, cached d2l ids, passwordless student, skips no-username entries, idempotent).
- `pushOverrideOnlyGrades`: a no-submission student's 90%-of-10 override resolves by classlist username and pushes 9 pts.
- `adoptRosterShadowAccount`: imported shell is adopted on first login (same row → duo-oidc + subject, ids preserved, no duplicate); non-shells return nil.
- 258 BrightSpace/SSO/Auth/Enrollment tests green; `swift-format` + SwiftLint `--strict` + style checks clean.

## Try it

Import from LEARN on 1106038 → set an override on a student (per-assignment submissions page) → Auto-map the assignment → **Sync now** → ping me and I'll read the sync status (the grade-**write** check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi