### PR TITLE
feat(notebook-editor): self-heal post-idle kernel hangs + recovery KPI telemetry

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -229,6 +229,13 @@
             const d = e.data;
             if (!d || d.ck !== 'kernel-diag') return false;
             if (d.kind !== 'kernel_phase' && d.kind !== 'kernel_error') return false;
+            // Self-heal: a post-idle exec_hang means the kernel booted then wedged
+            // on execute (the boot-failure watchdog doesn't cover it). Trigger the
+            // one-shot work-preserving editor reload — independent of the telemetry
+            // cap below, so a flood of breadcrumbs can't gate recovery.
+            if (d.kind === 'kernel_error' && d.source === 'exec_hang') {
+                recoverHungKernelOnce();
+            }
             if (kernelDiagForwarded >= KERNEL_DIAG_MAX) return false;
             kernelDiagForwarded += 1;
             failures.reportEvent({
@@ -935,6 +942,56 @@
             } catch (_) {
                 resolve(false);
             }
+        });
+    }
+
+    // Self-heal for a post-idle EXECUTION hang (the collector's `exec_hang`): the
+    // kernel booted to idle, then wedged on a cell. The watchdog's reload ladder
+    // only covers kernels that never *registered*, so nothing recovers this case
+    // today — students just sit on `[*]`. One work-preserving iframe reload (the
+    // same mechanism the watchdog uses; JupyterLite restores the student's saved
+    // copy from IndexedDB on boot, so edits survive), guarded to once per page so
+    // a persistently-deadlocking kernel can't reload-loop — a second hang points
+    // the student at the heavier /reset-editor clear instead. The flag is
+    // module-scoped so it survives the iframe reload (only the iframe reloads,
+    // not this page).
+    let kernelHangRecoverUsed = false;
+    // Recovery telemetry so the self-heal's usage IS the bug's KPI: `recover_attempt`
+    // (the self-heal fired) and `recover_failed` (the rebooted kernel hung AGAIN).
+    // Success ≈ attempts − failures; both should fall toward zero once the
+    // underlying kernel deadlock is actually fixed, so a drop is the signal the
+    // root-cause fix worked. Reuses the kernel_error kind (free-form source), so no
+    // server change and it never inflates the instructor error card (which counts
+    // only preflight_fail / watchdog_timeout / page_unresponsive).
+    function reportRecovery(source) {
+        if (!failures || !failures.reportEvent) return;
+        try { failures.reportEvent({ kind: 'kernel_error', source: source }); }
+        catch (_) { /* telemetry must never break recovery */ }
+    }
+    function recoverHungKernelOnce() {
+        // Don't fight a reset/reload that just happened (watchdog or locked-path).
+        if (forcedEditorResetAt && Date.now() - forcedEditorResetAt < 20000) return;
+        if (kernelHangRecoverUsed) {
+            // The reboot's kernel hung again — the self-heal didn't take.
+            reportRecovery('recover_failed');
+            try {
+                setStatus('error',
+                    'The notebook kernel is still not responding. Open /reset-editor '
+                    + 'for a clean restart, or try a different browser.');
+            } catch (_) { /* status is cosmetic */ }
+            return;
+        }
+        kernelHangRecoverUsed = true;
+        reportRecovery('recover_attempt');
+        try {
+            setStatus('loading',
+                'The notebook kernel stopped responding — reloading the editor…');
+        } catch (_) { /* status is cosmetic; recover regardless */ }
+        // Wait for the SW to settle, stamp forcedEditorResetAt so the locked-path
+        // enforcer doesn't fight the navigation, then re-point the iframe.
+        whenServiceWorkerActive(5000).then(() => {
+            forcedEditorResetAt = Date.now();
+            try { frame.src = editorURL; } catch (_) { /* nothing else to try */ }
         });
     }
 

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
@@ -104,7 +104,11 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         + "resource_error, kernel_dead, boot_stalled, exec_hang, …) for the WHY. exec_hang is the "
         + "POST-IDLE hang the boot funnel can't see: the kernel booted to idle (counted as success) "
         + "then wedged on execute, so cells sit busy forever; its count is distinct students who hit a "
-        + "sustained-busy hang, message busy_ms=… the hang duration. Optionally filter by testSetupID. "
+        + "sustained-busy hang, message busy_ms=… the hang duration. recover_attempt / recover_failed "
+        + "track the editor's self-heal for that hang (auto-reload the kernel): recover_attempt fired the "
+        + "reload, recover_failed means the rebooted kernel hung AGAIN — so success ≈ attempts − failures, "
+        + "and both should drop toward zero once the underlying deadlock is fixed (the headline KPI for it). "
+        + "Optionally filter by testSetupID. "
         + "Read-only; reports infrastructure breadcrumbs only and never includes a student identifier."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),

--- a/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
+++ b/Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs
@@ -242,12 +242,49 @@ function loadBridge() {
   // Drop any non-kernel telemetry emitted during load (e.g. sw_state).
   const kernelEvents = () => events.filter(
     e => e.kind === 'kernel_phase' || e.kind === 'kernel_error');
-  return { handleKernelDiagMessage: hooks.exports.handleKernelDiagMessage, kernelEvents };
+  return { handleKernelDiagMessage: hooks.exports.handleKernelDiagMessage, kernelEvents, frame };
 }
 
 function msg(data, origin = 'https://example.test') {
   return { origin, data };
 }
+
+test('bridge self-heals an exec_hang: one reload + a recover_attempt event', async () => {
+  const { handleKernelDiagMessage, frame, kernelEvents } = loadBridge();
+  const editorUrl = frame.dataset.editorUrl;
+  // First exec_hang → reload the editor iframe once. whenServiceWorkerActive
+  // resolves false synchronously (no navigator in the harness), so the reload
+  // .then() runs on a microtask we flush with two awaits.
+  frame.src = 'SENTINEL-A';
+  handleKernelDiagMessage(msg({
+    ck: 'kernel-diag', kind: 'kernel_error', source: 'exec_hang', message: 'busy_ms=45000',
+  }));
+  await Promise.resolve(); await Promise.resolve();
+  assert.equal(frame.src, editorUrl);
+  assert.equal(kernelEvents().filter(e => e.source === 'recover_attempt').length, 1);
+  // A second exec_hang must NOT reload again — guarded so a persistently
+  // deadlocking kernel can't reload-loop.
+  frame.src = 'SENTINEL-B';
+  handleKernelDiagMessage(msg({
+    ck: 'kernel-diag', kind: 'kernel_error', source: 'exec_hang', message: 'busy_ms=45000',
+  }));
+  await Promise.resolve(); await Promise.resolve();
+  assert.equal(frame.src, 'SENTINEL-B');
+});
+
+test('bridge reports recover_failed when the rebooted kernel hangs again', () => {
+  const { handleKernelDiagMessage, kernelEvents } = loadBridge();
+  // Two exec_hangs without yielding: the reload .then() hasn't run, so the
+  // reset-window guard is still open and the second hang reaches the
+  // persistent-hang branch — exactly the "self-heal didn't take" case.
+  const hang = () => handleKernelDiagMessage(msg({
+    ck: 'kernel-diag', kind: 'kernel_error', source: 'exec_hang', message: 'busy_ms=45000',
+  }));
+  hang();   // recover_attempt + schedules the reload
+  hang();   // already-recovered, guard still open → recover_failed
+  assert.equal(kernelEvents().filter(e => e.source === 'recover_attempt').length, 1);
+  assert.equal(kernelEvents().filter(e => e.source === 'recover_failed').length, 1);
+});
 
 test('bridge forwards a same-origin kernel_phase', () => {
   const { handleKernelDiagMessage, kernelEvents } = loadBridge();

--- a/changelog.d/kernel-hang-self-heal.md
+++ b/changelog.d/kernel-hang-self-heal.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Self-heal for post-idle kernel execution hangs, with KPI telemetry.** When
+  the in-iframe collector reports an `exec_hang` (the kernel booted to idle then
+  wedged on a cell — the `[*]`-forever deadlock), the editor now **auto-reloads
+  the kernel iframe once** via the existing work-preserving recovery path
+  (JupyterLite restores the student's saved copy from IndexedDB on boot), instead
+  of leaving the student stuck. Guarded to once per page so a persistently
+  deadlocking kernel can't reload-loop; a second hang surfaces the `/reset-editor`
+  fallback. The recovery emits two breadcrumbs — `recover_attempt` (the self-heal
+  fired) and `recover_failed` (the rebooted kernel hung again) — so success ≈
+  attempts − failures, and both fall toward zero once the underlying kernel
+  deadlock is actually fixed (the headline metric for that root-cause work).
+  Reuses the `kernel_error` pipeline (no server change); surfaced in
+  `get_browser_diagnostics` `bySource`.


### PR DESCRIPTION
## What

Two things, both keyed off the `exec_hang` signal shipped in 0.4.522 (#1023):

1. **Self-heal.** When the in-iframe collector reports an `exec_hang` (the kernel
   booted to idle, then wedged on a cell — the `[*]`-forever deadlock), the parent
   bridge now **auto-reloads the kernel iframe once** via the existing
   work-preserving reset path (`frame.src = editorURL` after
   `whenServiceWorkerActive`). JupyterLite restores the student's saved copy from
   IndexedDB on boot, so no work is lost. Guarded to **once per page** so a
   persistently-deadlocking kernel can't reload-loop; a second hang surfaces the
   `/reset-editor` fallback message instead of reloading again.

2. **Recovery KPI telemetry.** The self-heal emits two breadcrumbs through the
   existing `kernel_error` pipeline (no server change):
   - `recover_attempt` — the self-heal fired (auto-reloaded the kernel).
   - `recover_failed` — the rebooted kernel hung *again*.

   So **success ≈ attempts − failures**, and — the point of this PR — **both
   counts fall toward zero once the underlying SharedArrayBuffer/Atomics kernel
   deadlock is actually fixed.** `recover_attempt` is the headline KPI for that
   root-cause work: as long as it's nonzero, students are still hitting the hang
   (we're just papering over it); when the real fix lands, this number is how we
   prove it.

Surfaced in `get_browser_diagnostics` `bySource` alongside `exec_hang`; the tool
description documents the attempts−failures reading.

## Why

This morning's lab surfaced a post-idle kernel hang that the boot funnel and the
watchdog both miss by construction — the collector stops at `kernel_idle` and the
watchdog only escalates kernels that *never* register. `exec_hang` (0.4.522) made
the hang visible; this makes it *recoverable* for the student in the common case
(one reload clears it) and *measurable* so the eventual root-cause fix has a KPI.

This is a mitigation, not the root-cause fix. The SharedArrayBuffer/Atomics
execution deadlock itself is still to be diagnosed (deferred pending more data /
deeper comm-path breadcrumbs). `recover_attempt` trending to ~0 is the success
condition for that follow-up.

## Scope / safety

- `Public/notebook.js` — parent bridge only; reuses module-scoped reload
  primitives (`frame`, `editorURL`, `forcedEditorResetAt`,
  `whenServiceWorkerActive`, `setStatus`, `failures`). No watchdog refactor.
- `Public/jl-kernel-diagnostics.js` (the in-iframe collector) is **unchanged** —
  it already emits `exec_hang`.
- No server/schema change: `recover_attempt` / `recover_failed` ride the
  free-form `source` field on the existing `kernel_error` kind.
- Auto-reload is capped at once per page and respects the 20 s
  `forcedEditorResetAt` debounce, so it can't fight a manual reset or loop.

## Tests

`Tests/BrowserRunnerJSTests/kernel-diagnostics.test.mjs` (124/124 pass,
`node --test Tests/BrowserRunnerJSTests/*.mjs`):
- first `exec_hang` → one iframe reload + exactly one `recover_attempt`; a second
  `exec_hang` inside the reset window → no reload.
- two hangs with the reset window not yet open → one `recover_attempt` + one
  `recover_failed` (persistent-hang branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_