### PR TITLE
feat(browser-runner): bound + instrument grading-worker init (JupyterLite 0.8 groundwork)

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -309,7 +309,7 @@
         //    fallback path is preserved for environments with no Worker (and for
         //    the Node test harness, which has neither Worker nor a factory
         //    override, so it deterministically exercises the fallback).
-        const executor = makeExecutor(files, assignmentSeed, runnerCore);
+        const executor = makeExecutor(files, assignmentSeed, runnerCore, options.reportPhase);
         try {
             const scriptExists = (name) => executor.scriptExists(name);
             // Apply the per-script override before handing the limit to the
@@ -357,9 +357,9 @@
         return null;
     }
 
-    function makeExecutor(files, assignmentSeed, runnerCore) {
+    function makeExecutor(files, assignmentSeed, runnerCore, reportPhase) {
         const factory = gradingWorkerFactory();
-        if (factory) return new GradingWorkerExecutor(files, assignmentSeed, runnerCore, factory);
+        if (factory) return new GradingWorkerExecutor(files, assignmentSeed, runnerCore, factory, reportPhase);
         return new MainThreadExecutor(files, assignmentSeed, runnerCore);
     }
 
@@ -462,12 +462,31 @@
     // provide against a synchronous CPU-bound loop.
     // -------------------------------------------------------------------------
 
+    // Bounded init: how long to wait for a grading worker to finish loadPyodide +
+    // env-config before declaring it wedged, terminating it, and retrying once on
+    // a fresh worker. The init path used to be UNBOUNDED — unlike run(), which
+    // races a timer — so a Pyodide load/boot that never completed (observed
+    // intermittently when the editor kernel boots a SECOND Pyodide beside the
+    // grader under cross-origin isolation) hung the whole grade forever, with no
+    // telemetry, since the per-test timer only covers the 'run' message. A real
+    // cold init is seconds, so a generous default never trips a healthy boot; it
+    // only converts an infinite hang into a bounded, observable, self-healing
+    // failure. Overridable for tests via __CHICKADEE_GRADING_INIT_TIMEOUT_MS__.
+    const GRADING_INIT_TIMEOUT_MS =
+        (typeof globalThis !== 'undefined' && Number(globalThis.__CHICKADEE_GRADING_INIT_TIMEOUT_MS__) > 0)
+            ? Number(globalThis.__CHICKADEE_GRADING_INIT_TIMEOUT_MS__)
+            : 120000;
+
     class GradingWorkerExecutor {
-        constructor(files, assignmentSeed, runnerCore, factory) {
+        constructor(files, assignmentSeed, runnerCore, factory, reportPhase) {
             this.files = files;
             this.assignmentSeed = assignmentSeed ?? null;
             this.runnerCore = runnerCore;
             this.factory = factory;
+            // Submit-phase breadcrumb sink (student submit path only). Undefined
+            // on the instructor-validation path, so init telemetry stays silent
+            // there, matching the existing reportPhase scoping.
+            this.reportPhase = (typeof reportPhase === 'function') ? reportPhase : function () {};
             this.worker = null;
             this._initPromise = null;
             this._nextID = 1;
@@ -476,6 +495,12 @@
             // we terminated (a fresh spawn after a timeout proves the kill path).
             this.spawnCount = 0;
             this.terminateCount = 0;
+        }
+
+        // Forward a diagnostic breadcrumb to the submit-phase telemetry. Best
+        // effort: never let telemetry break grading.
+        _report(phase, detail) {
+            try { this.reportPhase(phase, detail); } catch (_) { /* telemetry is best-effort */ }
         }
 
         scriptExists(name) {
@@ -487,6 +512,14 @@
             this.spawnCount += 1;
             worker.onmessage = (e) => {
                 const msg = (e && e.data) || {};
+                // Diagnostic breadcrumbs (no `id`) emitted from inside the worker
+                // during init — forward to submit-phase telemetry so an init hang
+                // is localizable to the loadPyodide vs env-config step. Never
+                // grading state; ignored if telemetry is unwired.
+                if (msg.type === 'phase') {
+                    this._report(msg.phase, (msg.ms != null) ? ('ms=' + msg.ms) : undefined);
+                    return;
+                }
                 const entry = this._pending.get(msg.id);
                 if (!entry) return;
                 this._pending.delete(msg.id);
@@ -504,16 +537,24 @@
             return worker;
         }
 
-        _killWorker() {
+        // Terminate the current worker process and reject its in-flight calls,
+        // but LEAVE _initPromise intact — used by the init retry loop, which owns
+        // and manages _initPromise across attempts itself.
+        _terminateWorker() {
             if (this.worker) {
                 try { this.worker.terminate(); } catch (_) { /* best-effort */ }
                 this.terminateCount += 1;
                 this.worker = null;
             }
-            this._initPromise = null;
             // Reject any still-pending calls so they don't hang forever.
             for (const [, entry] of this._pending) entry.reject(new Error('grading worker terminated'));
             this._pending.clear();
+        }
+
+        _killWorker() {
+            this._terminateWorker();
+            // Drop the init cache so the NEXT run rebuilds a fresh worker.
+            this._initPromise = null;
         }
 
         _post(message) {
@@ -529,24 +570,67 @@
             });
         }
 
+        // Post a message and race the reply against a REAL timer. Resolves to
+        // { __timedOut: true } if the worker doesn't answer within timeoutMs; the
+        // timer is always cleared. Used for both init (bounded) and run (per-test
+        // limit) so neither path can hang the grade indefinitely.
+        _postWithTimeout(message, timeoutMs) {
+            let timer = null;
+            const timeoutPromise = new Promise((resolve) => {
+                timer = setTimeout(() => resolve({ __timedOut: true }), timeoutMs);
+            });
+            return Promise.race([this._post(message), timeoutPromise])
+                .finally(() => { if (timer !== null) clearTimeout(timer); });
+        }
+
         // Spawn (if needed) and init the worker with the file map + seed. Cached
         // so concurrent/repeated runs share one init; cleared by _killWorker so
         // the NEXT run after a terminate rebuilds from scratch.
         _ensureWorker() {
             if (this._initPromise) return this._initPromise;
-            this._spawn();
-            this._initPromise = (async () => {
-                const reply = await this._post({ type: 'init', files: this.files, seed: this.assignmentSeed });
-                if (!reply || !reply.ok) {
-                    throw new Error('Failed to configure Python environment: '
-                        + ((reply && reply.error) || 'grading worker init failed'));
+            const p = this._initWithRetry();
+            this._initPromise = p;
+            // On ultimate failure, drop the cache so a later run can try fresh.
+            p.catch(() => { if (this._initPromise === p) this._initPromise = null; });
+            return p;
+        }
+
+        // Init the worker, bounded by GRADING_INIT_TIMEOUT_MS and retried once on
+        // a fresh worker. A wedged loadPyodide/env-config (e.g. two Pyodides
+        // contending at boot under cross-origin isolation) terminates + respawns
+        // instead of hanging the whole grade forever; a second failure surfaces
+        // as a clear error (matching the old throw-on-init-failure contract),
+        // never an infinite hang. Each attempt is breadcrumbed so a future hang
+        // is visible server-side via the keepalive submit-phase telemetry.
+        async _initWithRetry() {
+            const attempts = 2;
+            let lastErr = null;
+            for (let attempt = 1; attempt <= attempts; attempt++) {
+                const startMs = Date.now();
+                this._report('grading_init_start', 'attempt=' + attempt);
+                this._spawn();
+                try {
+                    const reply = await this._postWithTimeout(
+                        { type: 'init', files: this.files, seed: this.assignmentSeed },
+                        GRADING_INIT_TIMEOUT_MS);
+                    if (reply && reply.__timedOut) {
+                        throw new Error('grading worker init timed out after ' + GRADING_INIT_TIMEOUT_MS + 'ms');
+                    }
+                    if (!reply || !reply.ok) {
+                        throw new Error('Failed to configure Python environment: '
+                            + ((reply && reply.error) || 'grading worker init failed'));
+                    }
+                    this._report('grading_init_done', 'attempt=' + attempt + ';ms=' + (Date.now() - startMs));
+                    return;  // success — worker is live, _initPromise stays cached
+                } catch (e) {
+                    lastErr = e;
+                    // Drop the wedged/failed worker but keep _initPromise (this
+                    // loop owns it); a fresh worker is spawned on the next attempt.
+                    this._terminateWorker();
+                    this._report('grading_init_failed', 'attempt=' + attempt + ';' + toMessage(e));
                 }
-            })().catch((e) => {
-                // A failed init kills the worker so a later retry can rebuild.
-                this._killWorker();
-                throw e;
-            });
-            return this._initPromise;
+            }
+            throw lastErr || new Error('grading worker init failed');
         }
 
         async run(name, limitSeconds) {
@@ -576,18 +660,8 @@
             // Race the worker reply against a REAL timer. Because the worker runs
             // Pyodide on its own thread, the timer always fires even when student
             // code is in a synchronous CPU-bound loop — so terminate() can kill it.
-            let timer = null;
-            const timeoutPromise = new Promise((resolve) => {
-                timer = setTimeout(() => resolve({ __timedOut: true }), limitSeconds * 1000);
-            });
-            const runPromise = this._post({ type: 'run', script: name, limit: limitSeconds });
-
-            let reply;
-            try {
-                reply = await Promise.race([runPromise, timeoutPromise]);
-            } finally {
-                if (timer !== null) clearTimeout(timer);
-            }
+            const reply = await this._postWithTimeout(
+                { type: 'run', script: name, limit: limitSeconds }, limitSeconds * 1000);
 
             if (reply && reply.__timedOut) {
                 // Kill the run-away worker; the next run rebuilds a fresh one.

--- a/Public/grading-worker.js
+++ b/Public/grading-worker.js
@@ -16,9 +16,16 @@
 // real setTimeout and, on timeout, calls `Worker.terminate()` to kill the
 // worker mid-execution, then spins up a fresh one for the next script.
 //
-// Why not SharedArrayBuffer interrupt:  that needs cross-origin isolation
-// (COOP/COEP), which the submit/validate pages don't carry (require-corp would
-// block CodeMirror / JupyterLite content).  Worker isolation needs no headers.
+// Why not SharedArrayBuffer interrupt:  worker isolation + Worker.terminate()
+// kills run-away code on ANY page regardless of headers, whereas a SAB interrupt
+// needs cross-origin isolation (COOP/COEP).  NOTE (corrected — the old comment
+// claimed "the submit/validate pages don't carry COOP/COEP", which is stale
+// since #574): the notebook editor page that hosts this grader
+// (/testsetups/:id/notebook) now IS cross-origin isolated, unconditionally
+// (Sources/APIServer/Middleware/COEPMiddleware.swift), so SharedArrayBuffer IS
+// available here — and the JupyterLite editor kernel runs a SECOND Pyodide
+// beside this one.  We keep worker-terminate anyway: it's the portable kill path
+// and avoids SAB-interrupt complexity.
 //
 // Protocol (postMessage from main thread → worker; every reply carries the
 // originating `id`):
@@ -83,7 +90,15 @@ self.onmessage = async function (e) {
     var id = msg.id;
     try {
         if (msg.type === 'init') {
+            var _initT0 = Date.now();
             var py = await getPyodide();
+            // Diagnostic breadcrumb (no `id`): tells the main thread the heavy
+            // loadPyodide() step finished, so a 314 init hang is localizable —
+            // if this never arrives the wedge is in Pyodide load; if it arrives
+            // but `env_configured` never does, the wedge is in env setup.
+            // browser-runner.js's GradingWorkerExecutor forwards these `phase`
+            // messages to the keepalive submit-phase telemetry.
+            self.postMessage({ type: 'phase', phase: 'pyodide_loaded', ms: Date.now() - _initT0 });
             _workDir = '/chickadee_work_' + Date.now();
             try { py.FS.mkdir(_workDir); } catch (err) { /* fresh worker; ignore */ }
             writeFilesToPyFS(py, _workDir, msg.files || {});
@@ -93,6 +108,7 @@ self.onmessage = async function (e) {
             // Add working directory to the path and wire builtins — the SAME
             // block browser-runner.js runs (drift-guarded).
             await py.runPythonAsync(envConfigPython(_workDir));
+            self.postMessage({ type: 'phase', phase: 'env_configured', ms: Date.now() - _initT0 });
             self.postMessage({ id: id, ok: true });
             return;
         }

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -415,6 +415,10 @@ function makeFakeGradingWorkerFactory(options) {
       if (msg.type === 'init') {
         this.files = msg.files || {};
         this.seed = msg.seed ?? null;
+        // `initPending` simulates a worker whose loadPyodide()/env-config never
+        // completes (the intermittent Pyodide-314 init hang) — it NEVER replies,
+        // so the executor's bounded-init timeout must terminate + retry it.
+        if (options.initPending) return;
         this._reply({ id: msg.id, ok: true });
         return;
       }
@@ -598,6 +602,12 @@ async function loadRunnerHarness(options = {}) {
     context.__CHICKADEE_GRADING_WORKER_FACTORY__ = gradingWorkerFactory;
   }
 
+  // Optional override for the GradingWorkerExecutor's bounded-init budget (read
+  // once at module-eval from globalThis), so a timeout test runs in milliseconds.
+  if (options.gradingInitTimeoutMs != null) {
+    context.__CHICKADEE_GRADING_INIT_TIMEOUT_MS__ = options.gradingInitTimeoutMs;
+  }
+
   context.window = {
     document,
     fetch: fetchImpl,
@@ -722,6 +732,9 @@ test('runAndSubmit emits ordered submit-phase breadcrumbs; validation stays sile
 
   // The breadcrumb funnel must cover the whole grading flow, in order, so a
   // freeze in any phase leaves a server-visible "last reached" record.
+  // This case runs on the MAIN-THREAD executor (no useGradingWorker), so the
+  // GradingWorkerExecutor's bounded-init breadcrumbs do not appear here; they are
+  // covered by the worker-path test below.
   assert.deepEqual(
     harness.breadcrumbs.map(b => b.source),
     [
@@ -929,6 +942,86 @@ test('GradingWorkerExecutor kills a CPU-bound run-away via terminate() and respa
   // The fresh worker was re-initialized with the same workspace before running.
   assert.ok(workers[1].postedTypes.includes('init'), 'respawned worker must be re-init()ed');
   assert.ok(workers[1].postedTypes.includes('run'), 'respawned worker must run the next script');
+});
+
+test('GradingWorkerExecutor brackets the worker init with start/done breadcrumbs', async () => {
+  // The init path (loadPyodide + env-config) used to be awaited with NO timer, so
+  // a wedged boot hung the whole grade with zero telemetry. It is now bracketed
+  // by grading_init_start/grading_init_done breadcrumbs (and bounded — see the
+  // timeout test below) so a future init hang is localizable server-side via the
+  // keepalive submit-phase funnel. Only the student submit path emits them
+  // (runAndSubmit wires reportPhase; instructor validation stays silent).
+  const harness = await loadRunnerHarness({
+    useGradingWorker: true,
+    zipFiles: { 'tests/test_pass.py': '# pass\nJSON_RESULT_PASS\n' },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 5,
+      testSuites: [{ script: 'tests/test_pass.py', tier: 'public' }],
+    },
+    scriptBehaviors: {
+      'tests/test_pass.py': {
+        stdout: `${JSON.stringify({ shortResult: 'ok', status: 'pass' })}\n`,
+        stderr: '',
+        exitCode: 0,
+      },
+    },
+  });
+
+  await harness.window.BrowserRunner.runAndSubmit(
+    new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+    'setup_init_bc',
+  );
+
+  const sources = harness.breadcrumbs.map(b => b.source);
+  // Exactly one start/done pair (init is cached across the suite's scripts).
+  assert.deepEqual(
+    sources.filter(s => s.startsWith('grading_init')),
+    ['grading_init_start', 'grading_init_done'],
+  );
+  // …and it brackets the run, between suite_started and suite_done.
+  const ordered = ['suite_started', 'grading_init_start', 'grading_init_done', 'suite_done']
+    .map(s => sources.indexOf(s));
+  assert.ok(ordered.every((idx, i) => idx >= 0 && (i === 0 || idx > ordered[i - 1])),
+    `init breadcrumbs out of order in ${JSON.stringify(sources)}`);
+});
+
+test('GradingWorkerExecutor bounds a wedged worker init: times out, retries once, then fails instead of hanging', async () => {
+  // A worker whose init never replies (loadPyodide that never resolves — the
+  // intermittent Pyodide-314 init hang) must NOT hang the grade forever. With a
+  // tiny init budget the executor times out, terminates, retries once on a fresh
+  // worker, and — when that also hangs — surfaces a bounded failure. Two
+  // grading_init_start breadcrumbs (the attempts) prove the retry; the run never
+  // exceeds the budget. This is the safety net the old unbounded init lacked.
+  const harness = await loadRunnerHarness({
+    useGradingWorker: true,
+    initPending: true,          // fake worker never replies to 'init'
+    gradingInitTimeoutMs: 25,   // tiny budget so the test is fast
+    zipFiles: { 'tests/test_pass.py': '# pass\nJSON_RESULT_PASS\n' },
+    manifest: {
+      gradingMode: 'browser',
+      timeLimitSeconds: 5,
+      testSuites: [{ script: 'tests/test_pass.py', tier: 'public' }],
+    },
+  });
+
+  await assert.rejects(
+    harness.window.BrowserRunner.runAndSubmit(
+      new TextEncoder().encode('{"nbformat":4,"metadata":{},"cells":[]}'),
+      'setup_init_hang',
+    ),
+    /init|configure Python/i,
+  );
+
+  const sources = harness.breadcrumbs.map(b => b.source);
+  assert.equal(sources.filter(s => s === 'grading_init_start').length, 2, 'two init attempts');
+  assert.equal(sources.filter(s => s === 'grading_init_failed').length, 2, 'both attempts reported failed');
+  assert.ok(!sources.includes('grading_init_done'), 'init must not report done when it never succeeds');
+
+  // Both spawned workers were terminated (the kill path on a wedged init).
+  const workers = harness.gradingWorkerFactory.created;
+  assert.equal(workers.length, 2, `expected two init attempts, saw ${workers.length}`);
+  assert.ok(workers.every(w => w.terminated), 'every wedged init worker must be terminated');
 });
 
 test('GradingWorkerExecutor grades pass/fail through one worker and classifies non-python on the main thread', async () => {

--- a/changelog.d/grading-worker-bounded-init.md
+++ b/changelog.d/grading-worker-bounded-init.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Browser grader: bounded, instrumented worker init.** The in-browser
+  submission grader's worker init (loadPyodide + env-config) used to be awaited
+  with no timeout — unlike the per-test `run` path — so a wedged boot could hang
+  a whole grade forever with no server-side trace. Init is now bounded
+  (`GRADING_INIT_TIMEOUT_MS`, default 120 s), terminates-and-retries once on a
+  fresh worker, and is bracketed by `grading_init_start` / `grading_init_done` /
+  `grading_init_failed` submit-phase breadcrumbs (plus `pyodide_loaded` /
+  `env_configured` from inside the worker), so a stalled init is localizable
+  instead of invisible. Healthy boots (seconds) are unaffected. Groundwork for
+  the JupyterLite 0.8 / Pyodide 314 upgrade, where a second editor-kernel Pyodide
+  boots beside the grader under cross-origin isolation; also corrects the stale
+  "the submit/validate pages don't carry COOP/COEP" comment in `grading-worker.js`
+  (that page has been cross-origin isolated since #574).


### PR DESCRIPTION
## What

Hardens the in-browser submission grader's **worker init** path, on `main` (JupyterLite 0.7.6 / Pyodide 0.29.3), as **groundwork for the JupyterLite 0.8 / Pyodide 314 upgrade** (PR #1028). Safe and useful today; lands the diagnostics + safety net the 0.8 blocker needs *before* rebasing 0.8 on top.

## Why

The grader's `GradingWorkerExecutor` awaited worker init (`loadPyodide` + env-config) with **no timeout** — unlike the per-test `run` path, which carefully races a timer. So a wedged boot hangs the *entire* grade forever, and it's **invisible**: the only un-timed `await` in the executor is init, and a worker-thread stall doesn't trip the main-thread freeze watchdog or emit any telemetry.

That is exactly the failure mode the 0.8 work hits intermittently (~1/6): under cross-origin isolation a **second** Pyodide — the JupyterLite editor kernel — boots beside the grader, and the grader's init occasionally stalls. (The notebook editor page has been cross-origin isolated since #574; the in-file comment claiming otherwise was stale and is corrected here.)

## Changes (all JS + tests — no Swift, no server, no bundle rebuild)

- **Bounded init** (`GRADING_INIT_TIMEOUT_MS`, default 120 s, test-overridable): on timeout, terminate the worker and **retry once** on a fresh one; a second failure surfaces as a clear error (preserving the prior throw-on-init-failure contract) instead of an infinite hang. A healthy cold init is seconds, so this never trips a good boot.
- **Instrumented init**: `grading_init_start` / `grading_init_done` / `grading_init_failed` submit-phase breadcrumbs from the main thread (they survive a wedged worker via the existing `keepalive` fetch), plus `pyodide_loaded` / `env_configured` breadcrumbs from inside the worker — so a future stall is localizable to *loadPyodide vs env-config* rather than disappearing. All use the already-allowlisted `submit_phase` diagnostic kind (no server change).
- **Refactor**: factor the run-path timer into a shared `_postWithTimeout`; split `_killWorker` into `_terminateWorker` (process only) + `_killWorker` (also drops the init cache) so the retry loop can respawn without clobbering its own cached init promise.
- **Comment fix**: correct the stale "the submit/validate pages don't carry COOP/COEP" note in `grading-worker.js`.

## Note on "single-thread loadPyodide"

The 0.8 investigation floated forcing the grader's Pyodide single-threaded. Confirmed against the vendored `pyodide.d.ts`: **`loadPyodide` has no thread/SAB runtime option** (threading is build-time). So that lever isn't implementable as a runtime flag — bounding + self-healing the init is the portable mitigation, and it's what makes the eventual 0.8 grading hang non-fatal and diagnosable.

## Tests

Two new `BrowserRunnerJSTests` cover the worker-path init breadcrumbs and the bounded timeout+retry (wedged-init fake worker + tiny budget). Full suite **126/126 green**; the grading-worker drift guard is unaffected (changes sit outside the fenced Python-snippet regions).

## Next

Rebase PR #1028 (JupyterLite 0.8) onto a `main` carrying this, then reproduce + fix the grading hang with these breadcrumbs in hand. See `docs/jupyterlite-0.8-integration-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm)_