### PR TITLE
fix(ci): editor-smoke gate no longer skips smoke on large editor PRs

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -81,7 +81,14 @@ jobs:
           # them. Over-matching is safe (it just runs the smoke); under-matching
           # is the dangerous direction.
           pattern='^(Public/notebook[^/]*\.js|Public/browser-runner\.js|Public/grading-worker\.js|Public/pyodide-worker\.js|Public/assignment-validate\.js|Public/freeze-watchdog-worker\.js|Public/jupyterlite/|Public/pyodide/|Public/vendor/|Sources/APIServer/Middleware/COEPMiddleware\.swift|Sources/APIServer/Middleware/NotebookAssetIsolationMiddleware\.swift|Sources/APIServer/Middleware/CrossOriginIsolationHeaders\.swift|Sources/APIServer/Middleware/SecurityHeadersMiddleware\.swift|Sources/APIServer/Middleware/EditorAssetFastPathMiddleware\.swift|Sources/APIServer/Bootstrap/AppMiddleware\.swift|Sources/APIServer/Configuration/SecurityConfig\.swift|Tools/jupyterlite/|Tools/editor-smoke-test/|\.github/workflows/editor-smoke\.yml)'
-          if echo "$changed" | grep -qE "$pattern"; then
+          # Use a here-string, NOT `echo "$changed" | grep -qE`: with a large
+          # changed-file list (e.g. a full JupyterLite bundle re-vendor) grep -q
+          # matches early and closes the pipe, echo takes SIGPIPE, and the
+          # `set -o pipefail` above then makes the pipeline exit non-zero EVEN ON
+          # A MATCH — silently misclassifying the PR as "no editor changes" and
+          # skipping the required smoke (a falsely-green gate). A here-string has
+          # no upstream writer process to receive SIGPIPE, so the match stands.
+          if grep -qE "$pattern" <<< "$changed"; then
             echo "editor=true" >> "$GITHUB_OUTPUT"
             echo "::notice::editor-relevant files changed — running editor smoke."
           else

--- a/changelog.d/fix-editor-smoke-gate-sigpipe.md
+++ b/changelog.d/fix-editor-smoke-gate-sigpipe.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Editor-smoke gate no longer skips the browser grading check on large editor
+  PRs.** The required `editor-smoke-gate`'s change-detection step ran
+  `set -o pipefail; echo "$changed" | grep -qE "$pattern"`; on a big changed-file
+  list (e.g. a full JupyterLite bundle re-vendor) `grep -q` closed the pipe
+  early, `echo` took SIGPIPE, and `pipefail` made the pipeline exit non-zero even
+  on a match — so the PR was misclassified as "no editor changes" and the smoke
+  was skipped, turning the required gate green without ever running the editor /
+  in-browser grading check. Switched to a here-string (`grep -qE … <<< "$changed"`)
+  which has no upstream writer to receive SIGPIPE.


### PR DESCRIPTION
## What

Fixes a gate-evasion bug in the required `editor-smoke-gate`'s change-detection.

## The bug

The `changes` job in `.github/workflows/editor-smoke.yml` ran:

```sh
set -o pipefail
...
if echo "$changed" | grep -qE "$pattern"; then
```

On a **large** changed-file list (e.g. a full JupyterLite bundle re-vendor — the in-flight 0.8 PR #1028 touches **1894 files**), `grep -q` matches early and closes the pipe, `echo` takes **SIGPIPE**, and `set -o pipefail` then makes the whole pipeline exit non-zero **even though grep matched**. The detect step falls through to the `else` branch, emits `editor=false`, the expensive `smoke` matrix is skipped, and the always-green `editor-smoke-gate` reports success **without ever running the editor / in-browser grading check** — exactly the "under-matching is the dangerous direction" failure the job's own comment warns about.

Observed live on #1028: `##[notice]no editor-relevant changes — skipping editor smoke.` preceded by `echo: write error: Broken pipe`, despite the PR re-vendoring the entire bundle.

## The fix

Switch to a here-string — `grep -qE "$pattern" <<< "$changed"`. A here-string has no upstream writer process to receive SIGPIPE, so `grep -q`'s early exit is harmless and a match is reported correctly.

Reproduced deterministically:

```
echo "$big" | grep -qE p   (set -o pipefail)  → exit 141  (skip — bug)
grep -qE p <<< "$big"       (set -o pipefail)  → exit 0    (run  — fixed)
```

Workflow-only change; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm)_