### PR TITLE
fix: retry browser-result writes on transient SQLite lock (intermittent 500)

### DIFF
--- a/Sources/APIServer/Helpers/SubmissionAttemptNumber.swift
+++ b/Sources/APIServer/Helpers/SubmissionAttemptNumber.swift
@@ -24,22 +24,76 @@ func saveSubmissionWithNextAttemptNumber(
     userID: UUID?,
     on db: Database
 ) async throws {
-    try await db.transaction { tx in
-        if let sql = tx as? SQLDatabase, sql.dialect.name == "postgresql" {
-            let scope = "chickadee.attempt:\(submission.testSetupID):\(userID?.uuidString ?? "-")"
-            try await sql.raw("SELECT pg_advisory_xact_lock(hashtext(\(bind: scope)))").run()
-        }
+    try await withTransientDatabaseLockRetry(on: db) {
+        try await db.transaction { tx in
+            if let sql = tx as? SQLDatabase, sql.dialect.name == "postgresql" {
+                let scope = "chickadee.attempt:\(submission.testSetupID):\(userID?.uuidString ?? "-")"
+                try await sql.raw("SELECT pg_advisory_xact_lock(hashtext(\(bind: scope)))").run()
+            }
 
-        let query = APISubmission.query(on: tx)
-            .filter(\.$testSetupID == submission.testSetupID)
-            .filter(\.$kind == APISubmission.Kind.student)
-        if let userID {
-            _ = query.filter(\.$userID == userID)
-        }
-        // max() on an optional field yields Int?? — flatten both levels.
-        let maxAttempt = (try await query.max(\.$attemptNumber)).flatMap { $0 } ?? 0
+            let query = APISubmission.query(on: tx)
+                .filter(\.$testSetupID == submission.testSetupID)
+                .filter(\.$kind == APISubmission.Kind.student)
+            if let userID {
+                _ = query.filter(\.$userID == userID)
+            }
+            // max() on an optional field yields Int?? — flatten both levels.
+            let maxAttempt = (try await query.max(\.$attemptNumber)).flatMap { $0 } ?? 0
 
-        submission.attemptNumber = maxAttempt + 1
-        try await submission.save(on: tx)
+            submission.attemptNumber = maxAttempt + 1
+            try await submission.save(on: tx)
+        }
     }
+}
+
+/// Retries a database write on a transient SQLite lock error (`SQLITE_BUSY` /
+/// "database is locked").
+///
+/// SQLite (even in WAL mode) allows only one writer at a time, and the app does
+/// not set a `busy_timeout`, so a contended write fails *immediately* rather than
+/// waiting. Worse, a deferred read-then-write transaction (e.g. the
+/// `MAX(attempt_number)` read above followed by the insert) can get
+/// `SQLITE_BUSY_SNAPSHOT` when another connection — a Fluent-backed session
+/// write, a background monitor — commits between this transaction's read and its
+/// write; that is a *stale snapshot* a `busy_timeout` could not absorb (waiting
+/// doesn't refresh the snapshot), so the only correct recovery is to re-run the
+/// whole transaction against a fresh snapshot. Without this, the contention
+/// surfaced to callers as an intermittent HTTP 500 (notably on
+/// `POST /submissions/browser-result`).
+///
+/// The transaction body is idempotent under retry: a failed transaction rolls
+/// back (no row committed, the model's create is not marked as existing), so a
+/// re-run recomputes the attempt number from a fresh `MAX` and inserts cleanly.
+/// Postgres serializes via the advisory lock instead and won't hit this; the
+/// retry is a harmless no-op there.
+func withTransientDatabaseLockRetry<T>(
+    on db: Database,
+    maxAttempts: Int = 6,
+    operation: () async throws -> T
+) async throws -> T {
+    var attempt = 0
+    while true {
+        attempt += 1
+        do {
+            return try await operation()
+        } catch {
+            guard attempt < maxAttempts, isTransientDatabaseLockError(error) else { throw error }
+            db.logger.warning(
+                "Transient DB lock on attempt \(attempt)/\(maxAttempts): \(error) — retrying")
+            // Escalating backoff: 10, 20, 40, 80, 160 ms.
+            try? await Task.sleep(nanoseconds: UInt64(10_000_000) << UInt64(attempt - 1))
+        }
+    }
+}
+
+/// Whether `error` looks like a transient SQLite lock (`SQLITE_BUSY` /
+/// `SQLITE_LOCKED` / "database is locked"). Matched on the error text so this
+/// helper needs no SQLiteNIO import and tolerates how the driver wraps the code.
+private func isTransientDatabaseLockError(_ error: Error) -> Bool {
+    let text = String(describing: error).lowercased()
+    return text.contains("database is locked")
+        || text.contains("database table is locked")
+        || text.contains("sqlite_busy")
+        || text.contains("sqlite_locked")
+        || text.contains("is busy")
 }

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -117,7 +117,12 @@ struct BrowserResultRoutes: RouteCollection {
             collectionJSON: collectionJSON,
             source: "browser"
         )
-        try await browserResult.save(on: req.db)
+        // Same transient-SQLite-lock guard as the submission insert above: this
+        // second write can also lose a race with a concurrent commit (session
+        // write / background monitor) and surface as a 500 otherwise.
+        try await withTransientDatabaseLockRetry(on: req.db) {
+            try await browserResult.save(on: req.db)
+        }
 
         req.logger.info("Browser result stored for \(subID)")
 

--- a/Tools/editor-smoke-test/run-smoke.sh
+++ b/Tools/editor-smoke-test/run-smoke.sh
@@ -84,4 +84,15 @@ if [ "$ready" -ne 1 ]; then
   exit 2
 fi
 
+# Run the check; on failure dump the server log tail BEFORE the EXIT trap wipes
+# the work dir, so a server-side 500 (e.g. a SQLite "database is locked") is
+# visible in CI instead of hiding behind the browser's generic "500" message.
+set +e
 node "${SMOKE_CHECK:-editor-check.mjs}" "http://127.0.0.1:$PORT"
+check_rc=$?
+set -e
+if [ "$check_rc" -ne 0 ]; then
+  echo "run-smoke: check failed (rc=$check_rc) — server log tail:" >&2
+  tail -40 "$LOG" >&2 || true
+fi
+exit "$check_rc"

--- a/changelog.d/fix-browser-result-sqlite-busy-500.md
+++ b/changelog.d/fix-browser-result-sqlite-busy-500.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Intermittent HTTP 500 when storing a browser-graded submission.** SQLite runs
+  in WAL mode but without a `busy_timeout`, so a contended write fails
+  immediately with `SQLITE_BUSY`; the `MAX(attempt_number)` read-then-insert in
+  `saveSubmissionWithNextAttemptNumber` could additionally hit
+  `SQLITE_BUSY_SNAPSHOT` when another connection (a Fluent session write, a
+  background monitor) committed between its read and its write. That surfaced as
+  an intermittent 500 on `POST /api/v1/submissions/browser-result` — the grade
+  computed fine in the browser, but ~1 submission in ~12 failed to store. The
+  submission insert and the result save now retry on transient SQLite lock errors
+  (re-running the transaction against a fresh snapshot, which a `busy_timeout`
+  alone can't fix). Postgres serializes via its advisory lock and is unaffected.
+  `run-smoke.sh` now also dumps the server log tail on a check failure so a
+  server-side 500 is diagnosable in CI.


### PR DESCRIPTION
## What

Fixes an **intermittent HTTP 500 when storing a browser-graded submission** (`POST /api/v1/submissions/browser-result`).

## How it was found

A CI rate-sweep (`grading-hang-probe`, added for the 0.8 work) looped the real notebook grading check 12×/engine with breadcrumb capture. The one failing chromium iteration (8/12) shows the grade **completed perfectly** and then the result POST 500'd:

```
… suite_started → grading_init_done [attempt=1, ms=1746] → suite_done [n=1]
   → result_posting → submit_failed [500 "Something went wrong on our end."]
```

So the long-suspected "Pyodide-314 grading hang" is **not** a grading hang at all — the grade runs fine (~1.9s); the *server* intermittently 500s storing the result. It is **version-independent** (this endpoint is plain Swift) — present on `main`/0.7.6 too, just rarely hit and previously masked by the gate skipping the smoke (fixed in #1032) and only running it once.

## Cause

SQLite runs in WAL mode but with **no `busy_timeout`** (`DatabaseConfiguration.swift`), so the default is 0 — any write contention fails *immediately* with `SQLITE_BUSY`. The **read-then-write** transaction in `saveSubmissionWithNextAttemptNumber` (`MAX(attempt_number)` then `INSERT`) can additionally hit `SQLITE_BUSY_SNAPSHOT` when another connection — a Fluent-backed session write, a background monitor — commits between its read and its write. That's a *stale snapshot* a `busy_timeout` could not absorb (waiting doesn't refresh it); only re-running the transaction recovers.

## Fix

`withTransientDatabaseLockRetry` wraps the submission insert and the result save, re-running on `SQLITE_BUSY`/locked with escalating backoff (10–160 ms). The transaction body is idempotent under retry (a rolled-back create is not marked existing, so it recomputes the attempt number and re-inserts cleanly). Postgres serializes via its advisory lock and is unaffected — the retry is a no-op there.

Also: `run-smoke.sh` now dumps the server log tail on a check failure, so a server-side 500 is diagnosable in CI rather than hidden behind the browser's generic message.

## Verification

The same fix is on #1028's branch; its `grading-hang-probe` rate-sweep (which reproduced the 500 at 1/12) must go to **0/N** to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm)_