### PR TITLE
feat(notebook-editor): route editor saves through the iframe command bridge

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1102,19 +1102,82 @@
         return looksLikeNotebook(notebook) ? notebook : null;
     }
 
+    // ── Editor command bridge (jupyter-iframe-commands) ──────────────
+    // Preferred channel for driving JupyterLab commands in the editor iframe.
+    // The `jupyter-iframe-commands` labextension (federated into the bundle)
+    // exposes the command registry over postMessage/comlink, and the vendored
+    // host (Public/vendor/iframe-commands-host.js) wraps it from this frame.
+    // This works even where `frame.contentWindow.jupyterapp` is not reachable:
+    // cross-origin-isolated WebKit can put the same-origin iframe in another
+    // process, making that JS-global poke flaky/absent (the reason the bridge
+    // exists). The poke is kept as a fallback.
+    //
+    // Created + readiness-awaited once, then cached; any build failure
+    // (missing/old extension, import error, never-ready) resolves to null so
+    // callers transparently fall back.
+    let _commandBridgePromise = null;
+    function getCommandBridge() {
+        if (_commandBridgePromise) return _commandBridgePromise;
+        _commandBridgePromise = (async () => {
+            try {
+                const mod = await import('/vendor/iframe-commands-host.js');
+                if (!mod || typeof mod.createBridge !== 'function') return null;
+                const bridge = mod.createBridge({ iframeId: 'jl-frame' });
+                // Bound the readiness wait so a never-ready extension can't pin
+                // the cached promise pending forever.
+                const ready = await Promise.race([
+                    Promise.resolve(bridge.ready).then(() => true).catch(() => false),
+                    new Promise((resolve) => setTimeout(() => resolve(false), 10000)),
+                ]);
+                if (!ready) { _commandBridgePromise = null; return null; }
+                return bridge;
+            } catch (_) {
+                _commandBridgePromise = null;
+                return null;
+            }
+        })();
+        return _commandBridgePromise;
+    }
+
+    // Execute a JupyterLab command in the editor, bridge-first with a
+    // same-origin `jupyterapp` fallback. Best-effort; never throws; returns
+    // true if either channel ran the command. A not-yet-ready bridge is raced
+    // against a short budget so a cold bridge never stalls a save — it keeps
+    // warming in the background for the next call.
+    async function executeEditorCommand(command, args) {
+        try {
+            const bridge = await Promise.race([
+                getCommandBridge(),
+                new Promise((resolve) => setTimeout(() => resolve(null), 2500)),
+            ]);
+            if (bridge) {
+                await bridge.execute(command, args);
+                return true;
+            }
+        } catch (_) {
+            // Bridge failed for this call; fall back to the direct poke.
+        }
+        try {
+            const app = frame.contentWindow && frame.contentWindow.jupyterapp;
+            if (app && app.commands && typeof app.commands.execute === 'function') {
+                await app.commands.execute(command, args);
+                return true;
+            }
+        } catch (_) {
+            // Best-effort only.
+        }
+        return false;
+    }
+
     // Exposed for idle-logout.js: flush the open notebook to JupyterLite's
     // storage before the inactivity watchdog signs the user out, so unsaved
     // cells survive. Best-effort and read-only-aware; never throws.
     window.chickadeeSaveNotebook = async function () {
         if (readOnly) return;
         try {
-            const childWindow = frame.contentWindow;
-            const app = childWindow && childWindow.jupyterapp;
-            if (app && app.commands && typeof app.commands.execute === 'function') {
-                try { await app.commands.execute('docmanager:save'); } catch (_) {}
-                try { await app.commands.execute('docmanager:save-all'); } catch (_) {}
-                await delay(150);
-            }
+            await executeEditorCommand('docmanager:save');
+            await executeEditorCommand('docmanager:save-all');
+            await delay(150);
         } catch (_) {
             // Saving is best-effort; swallow everything.
         }
@@ -1122,17 +1185,18 @@
 
     async function readNotebookFromJupyterFrame() {
         try {
+            // Best effort: flush edits to the notebook model/context before
+            // reading. Bridge-first (reliable under WebKit isolation), falling
+            // back to the jupyterapp poke. The deep model read below still needs
+            // direct `app` access, which comlink can't proxy.
+            await executeEditorCommand('docmanager:save');
+            await executeEditorCommand('docmanager:save-all');
+            // Allow save handlers to settle before reading back from contents.
+            await delay(125);
+
             const childWindow = frame.contentWindow;
             const app = childWindow && childWindow.jupyterapp;
             if (!app || !app.shell) return null;
-
-            // Best effort: flush edits to the notebook model/context before reading.
-            if (app.commands && typeof app.commands.execute === 'function') {
-                try { await app.commands.execute('docmanager:save'); } catch (_) {}
-                try { await app.commands.execute('docmanager:save-all'); } catch (_) {}
-            }
-            // Allow save handlers to settle before reading back from contents.
-            await delay(125);
 
             const widget = notebookWidgetFromShell(app.shell, lockedNotebookPath);
             const modelNotebook = notebookFromWidget(widget);

--- a/Tools/editor-smoke-test/notebook-bridge-check.mjs
+++ b/Tools/editor-smoke-test/notebook-bridge-check.mjs
@@ -1,6 +1,6 @@
 // notebook-bridge-check.mjs
 //
-// Headless PROTOTYPE probe for the jupyter-iframe-commands command bridge — the
+// Headless probe for the jupyter-iframe-commands command bridge — the
 // supported replacement for notebook.js's fragile
 // `frame.contentWindow.jupyterapp.commands.execute(...)` cross-frame poking.
 //
@@ -13,8 +13,9 @@
 //     /vendor/iframe-commands-host.js — runs in the PARENT frame and wraps the
 //     iframe's comlink endpoint.
 //
-// This probe proves the bridge end-to-end WITHOUT touching notebook.js's
-// production save path (that cutover is a follow-up decision). It:
+// This probe proves the bridge end-to-end AND that notebook.js's production
+// save path (window.chickadeeSaveNotebook, the idle-logout flush) is wired
+// through it. It:
 //
 //   1. Boots the editor on the real student page; the seeded starter cell
 //      renders and the kernel reaches idle.
@@ -23,12 +24,17 @@
 //   3. From the PARENT page, imports the vendored host bundle, builds the bridge
 //      against iframe#jl-frame, awaits `.ready`, asserts `listCommands()` RPCs
 //      back an array containing "docmanager:save" (a real round-trip that
-//      returns data), then `execute("docmanager:save")`.
-//   4. Reloads the same context and asserts the marker survived — i.e. the
-//      bridge-driven save actually wrote to the IndexedDB Drive.
+//      returns data), then `execute("docmanager:save")`. A regression here fails
+//      even if the jupyterapp fallback would have saved.
+//   4. Types a second marker (CKPROD_<stamp>) and calls the MIGRATED production
+//      helper window.chickadeeSaveNotebook() — the idle-logout flush now routed
+//      through the bridge in notebook.js.
+//   5. Reloads the same context and asserts BOTH markers survived — i.e. the
+//      direct bridge save AND the production save path wrote to the Drive.
 //
-// A PASS means the bridge can both READ (listCommands) and DRIVE (execute) the
-// in-iframe JupyterLab app from the parent frame on the 0.8 stack.
+// A PASS means the bridge can READ (listCommands) and DRIVE (execute) the
+// in-iframe JupyterLab app from the parent, and that the migrated production
+// save path persists through it on the 0.8 stack.
 //
 // Seeds through the real HTTP API exactly like notebook-lifecycle-check.mjs.
 //
@@ -54,6 +60,7 @@ const FRAME_ID = "jl-frame";
 const STAMP = Date.now().toString(36);
 const STARTER_MARKER = "CKSTARTER";
 const BRIDGE_MARKER = `CKBRIDGE_${STAMP}`;
+const PROD_MARKER = `CKPROD_${STAMP}`;
 const STARTER_SOURCE = `# ${STARTER_MARKER}\nx = 1\n`;
 
 const INSTRUCTOR = { username: `br_instr_${STAMP}`, password: "instructor-pw-123" };
@@ -273,6 +280,24 @@ async function driveSaveViaBridge(page) {
   }, { frameId: FRAME_ID, readyMs: BRIDGE_READY_MS });
 }
 
+// Drive the MIGRATED production save path: notebook.js's window.chickadeeSaveNotebook
+// (the idle-logout flush) now routes through executeEditorCommand → the bridge
+// (with a jupyterapp fallback). Calling it from the parent page proves the
+// production wiring, not just an ad-hoc bridge. Returns { ok, detail }.
+async function driveProductionSave(page) {
+  return await page.evaluate(async () => {
+    if (typeof window.chickadeeSaveNotebook !== "function") {
+      return { ok: false, detail: "window.chickadeeSaveNotebook is not defined (notebook.js not loaded / not wired)" };
+    }
+    try {
+      await window.chickadeeSaveNotebook();
+      return { ok: true, detail: "called window.chickadeeSaveNotebook()" };
+    } catch (e) {
+      return { ok: false, detail: "chickadeeSaveNotebook() threw: " + (e && e.message || e) };
+    }
+  });
+}
+
 async function main() {
   console.log(`Browser engine: ${browserName}`);
   console.log(`Seeding browser-graded assignment via ${baseURL} …`);
@@ -318,33 +343,46 @@ async function main() {
     if (typed !== "ok") return fail(`could not type the marker into the notebook: ${typed}`);
     console.log("step 2 ok: typed marker into cell 0 (unsaved)");
 
-    // ---- Step 3: drive docmanager:save THROUGH THE BRIDGE ----------------
+    // ---- Step 3: drive docmanager:save THROUGH THE BRIDGE directly -------
+    // Proves the bridge MECHANISM (a regression here fails even if the
+    // jupyterapp fallback would have saved).
     const bridge = await driveSaveViaBridge(page);
     if (!bridge.ok) return fail(`bridge could not drive the save: ${bridge.detail}`);
     console.log(`step 3 ok: ${bridge.detail} (listCommands → ${bridge.commandCount} commands)`);
 
-    // ---- Step 4: reload and assert the bridge save persisted -------------
+    // ---- Step 4: drive the MIGRATED production save path -----------------
+    // Dirty the doc again, then call window.chickadeeSaveNotebook() — the
+    // idle-logout flush now wired through the bridge in notebook.js.
+    const typed2 = await typeMarkerIntoCell(page, jlFrame, PROD_MARKER);
+    if (typed2 !== "ok") return fail(`could not type the production marker: ${typed2}`);
+    const prod = await driveProductionSave(page);
+    if (!prod.ok) return fail(`production save path failed: ${prod.detail}`);
+    console.log(`step 4 ok: ${prod.detail}`);
+
+    // ---- Step 5: reload and assert BOTH saves persisted ------------------
     await page.waitForTimeout(2000); // let the Drive write flush
-    console.log("step 4: reloading to confirm the bridge-driven save reached the Drive…");
+    console.log("step 5: reloading to confirm both saves reached the Drive…");
     await page.reload({ waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
     jlFrame = await findEditorFrame(page);
-    if (!jlFrame) return fail("editor iframe never re-attached after bridge save + reload");
+    if (!jlFrame) return fail("editor iframe never re-attached after save + reload");
     if (!(await waitForEditorWithSource(jlFrame, STARTER_MARKER))) {
-      return fail("editor did not re-render the notebook after bridge save + reload", (await bodyText(jlFrame)).slice(0, 300));
+      return fail("editor did not re-render the notebook after save + reload", (await bodyText(jlFrame)).slice(0, 300));
     }
-    const persisted = await jlFrame.waitForFunction(
-      (needle) => ((document.body && document.body.innerText) || "").includes(needle),
-      BRIDGE_MARKER, { timeout: 30_000 }
-    ).then(() => true).catch(() => false);
-    if (!persisted) {
-      return fail(
-        "marker did NOT survive reload — bridge execute(docmanager:save) did not actually persist to the Drive",
-        (await bodyText(jlFrame)).slice(0, 300)
-      );
+    for (const [label, marker, why] of [
+      ["bridge", BRIDGE_MARKER, "bridge execute(docmanager:save) did not persist to the Drive"],
+      ["production", PROD_MARKER, "window.chickadeeSaveNotebook() (migrated to the bridge) did not persist to the Drive"],
+    ]) {
+      const ok = await jlFrame.waitForFunction(
+        (needle) => ((document.body && document.body.innerText) || "").includes(needle),
+        marker, { timeout: 30_000 }
+      ).then(() => true).catch(() => false);
+      if (!ok) {
+        return fail(`${label} marker did NOT survive reload — ${why}`, (await bodyText(jlFrame)).slice(0, 300));
+      }
+      console.log(`step 5 ok: ${label} save persisted across reload`);
     }
-    console.log("step 4 ok: bridge-driven save persisted across reload");
 
-    console.log(`BRIDGE PASS — jupyter-iframe-commands bridge read + drove docmanager:save on the real 0.8 editor (engine=${browserName})`);
+    console.log(`BRIDGE PASS — jupyter-iframe-commands bridge drove docmanager:save directly AND via the migrated window.chickadeeSaveNotebook on the real 0.8 editor (engine=${browserName})`);
     await finish(0);
   } catch (err) {
     return fail(`exception: ${(err && err.stack) || err}`);

--- a/changelog.d/notebook-bridge-save-migration.md
+++ b/changelog.d/notebook-bridge-save-migration.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Notebook editor saves now route through the iframe command bridge.**
+  `notebook.js`'s save flushes — `window.chickadeeSaveNotebook` (the idle-logout
+  flush) and the pre-read flush in `readNotebookFromJupyterFrame` — now drive
+  `docmanager:save` through the `jupyter-iframe-commands` bridge
+  (`executeEditorCommand`, bridge-first with a `frame.contentWindow.jupyterapp`
+  fallback) instead of poking the cross-frame `jupyterapp` global directly. The
+  global is flaky/absent under WebKit's cross-origin-isolated process model, so
+  this hardens save persistence in Safari. The bridge probe
+  (`notebook-bridge-probe.yml`) now verifies the migrated production path end to
+  end. The remaining `jupyterapp` reads (notebook read-back, server reseed,
+  readiness probes) need a custom labextension to bridge and stay as-is for now —
+  see `docs/jupyterlite-0.8-integration-followups.md`.

--- a/docs/jupyterlite-0.8-integration-followups.md
+++ b/docs/jupyterlite-0.8-integration-followups.md
@@ -99,61 +99,58 @@ inject extra wheels; `check-pyodide-parity.sh` asserts they're present. After th
   don't hardcode it.
 - `Public/pyodide` is ~510 MB on 314 (down from ~1.4 GB on 0.28); checked in.
 
-## Robustness upgrade — the iframe command bridge (PROTOTYPED)
+## Robustness upgrade — the iframe command bridge
 
 0.8's ecosystem ships **`jupyter-iframe-commands`** — a supported replacement for
 `notebook.js`'s fragile `frame.contentWindow.jupyterapp.commands.execute(…)`
-poking (16 touch-points; the `jupyterapp` global is reachable in Chromium but
-flaky/absent in WebKit, which is why those sites are wrapped in defensive
+poking (the `jupyterapp` global is reachable in Chromium but flaky/absent in
+WebKit, which is why those sites are wrapped in defensive
 `if (win && win.jupyterapp)` guards and try/catch). It does **not** fix the
 grading work above; it's an independent durability win.
 
-**The prototype is on branch `claude/iframe-command-bridge` (additive, no change
-to `notebook.js`'s production save path):**
+**Shipped (#1035 — the bridge) + (this PR — save migration):**
 
-- `jupyter-iframe-commands==0.3.0` added to `Tools/jupyterlite/requirements.txt`
-  → federated into the 0.8 bundle (auto-discovered by `jupyter lite build`,
-  appears in `Public/jupyterlite/jupyter-lite.json`'s `federated_extensions`;
-  the labextension auto-starts inside the iframe and `expose`s the command
-  registry over comlink/postMessage).
-- `jupyter-iframe-commands-host` vendored to `Public/vendor/iframe-commands-host.js`
-  (ESM, comlink folded in; built by `scripts/setup-vendor.sh` from
-  `Tools/vendor/iframe-commands-host-entry.js`). `createBridge({ iframeId })`
-  returns `.ready`, `.execute(cmd, args)`, `.listCommands()`.
-- The editor iframe already carries `id="jl-frame"` — no template change needed.
+- `jupyter-iframe-commands==0.3.0` is in `Tools/jupyterlite/requirements.txt`,
+  federated into the bundle (auto-discovered by `jupyter lite build`, in
+  `Public/jupyterlite/jupyter-lite.json`'s `federated_extensions`; the
+  labextension auto-starts inside the iframe and `expose`s the command registry
+  over comlink/postMessage).
+- `jupyter-iframe-commands-host` is vendored to
+  `Public/vendor/iframe-commands-host.js` (ESM, comlink folded in; built by
+  `scripts/setup-vendor.sh` from `Tools/vendor/iframe-commands-host-entry.js`).
+  `createBridge({ iframeId })` → `.ready` / `.execute(cmd, args)` / `.listCommands()`.
+- `notebook.js` has a `getCommandBridge()` (lazy, cached, readiness-bounded) +
+  `executeEditorCommand(command, args)` helper: **bridge-first with a
+  `jupyterapp` poke fallback**. The save flushes — `window.chickadeeSaveNotebook`
+  (idle-logout) and the pre-read flush in `readNotebookFromJupyterFrame` — now
+  route through it, so they're reliable under WebKit isolation.
 - **CI probe:** `Tools/editor-smoke-test/notebook-bridge-check.mjs` +
   `.github/workflows/notebook-bridge-probe.yml` (chromium+webkit, non-required
-  diagnostic). Boots the real student editor, types an unsaved marker, then from
-  the PARENT frame builds the bridge, asserts `listCommands()` RPCs back
-  `docmanager:save`, drives `execute("docmanager:save")`, reloads, and asserts
-  the bridge-driven save persisted to the Drive.
+  diagnostic) drives `docmanager:save` directly through the bridge AND via the
+  migrated `window.chickadeeSaveNotebook()`, asserting both persist across reload.
 
-**Validated locally** against the freshly-built 0.8 bundle (server-free static
-harness, chromium): the extension activates, `bridge.ready` resolves,
-`listCommands()` returns 400 commands incl. `docmanager:save`, and
-`execute("notebook:create-new")` drives a real command. WebKit + save-persistence
-are left to the CI probe (WebKit isn't installable in the sandbox).
+**Still on the `jupyterapp` poke (NOT yet bridged) — needs a custom labextension:**
 
-**Cutover assessment (for the full `notebook.js` migration):**
+These live *inside* functions that already require direct `app` access, so the
+bridge adds no value piecemeal — comlink can only ferry structured-cloneable
+data, not live JupyterLab objects:
 
-- ✅ **Fire-and-forget saves** (lines ~1114–1132: `docmanager:save` /
-  `docmanager:save-all`) map cleanly to `await bridge.execute(...)`. This is the
-  bulk of the touch-points and the most engine-fragile, so it's the
-  highest-value, lowest-risk slice to cut over first.
-- ⚠️ **The widget-returning open/revert** (line ~1393:
-  `const widget = await app.commands.execute('docmanager:open', …)` then
-  `widget.context.revert()`) does **NOT** translate to a drop-in bridge call:
-  comlink RPC structured-clones the return value, so the live `widget` (with its
-  `context.revert()` method) does not cross the frame boundary. Options: (a) keep
-  this one path on the existing `jupyterapp` poke (hybrid); (b) register a custom
-  command in a thin Chickadee labextension that does open+revert atomically
-  inside the iframe and returns a plain boolean; (c) `bridge.execute('docmanager:open')`
-  then a separate `bridge.execute('docmanager:reload')`-style command if one
-  exists. Resolve before deleting the `jupyterapp` fallback entirely.
+- **Notebook read-back** (`readNotebookFromJupyterFrame` → `app.shell`,
+  `notebookWidgetFromShell`, `widget.context.model.toJSON()`,
+  `app.serviceManager.contents.get`). Falls back to the server snapshot
+  (`fetchNotebookSnapshot`) when the frame read fails, so it's already resilient.
+- **Server-snapshot reseed** (`syncNotebookFromServerSnapshot` → `contents.save`,
+  then `docmanager:open` returning a `widget` whose `context.revert()` is called).
+  The widget can't cross the comlink boundary.
+- **Readiness probes** (`probeIframeReadiness`, `waitForJupyterApp`) read
+  `win.jupyterapp`; already hardened with DOM-presence fallbacks.
 
-Recommended path: land this prototype (extension + vendor + probe) so the bridge
-ships and is CI-guarded, then migrate `notebook.js`'s save paths to it in a
-follow-up, keeping the open/revert path on the fallback until (b)/(c) is decided.
+**To fully retire the `jupyterapp` poke:** add a thin Chickadee labextension that
+registers serializable commands inside the iframe — e.g. `chickadee:read-notebook`
+(returns the notebook JSON) and `chickadee:reseed` (does the `contents.save` +
+open + `context.revert` atomically and returns a boolean). Then the read/reseed
+paths can move to `bridge.execute(...)` too. Larger effort (new labextension +
+build/federation wiring + tests); its own PR.
 Docs: https://jupyterlite.readthedocs.io/en/latest/howto/configure/advanced/iframe.html
 
 ## Note on the iframe itself


### PR DESCRIPTION
## What

Full migration of `notebook.js`'s **save flushes** off the fragile cross-frame `frame.contentWindow.jupyterapp.commands.execute(…)` poke and onto the `jupyter-iframe-commands` bridge landed in #1035. Follow-up to the bridge prototype.

## Why

The `jupyterapp` global is reachable in Chromium but **flaky/absent under WebKit's cross-origin-isolated process model** (a same-origin iframe can land in another process, where the JS-global poke isn't reliably reachable). The bridge talks over postMessage/comlink, so it works regardless — hardening save persistence in Safari, which matters most for the idle-logout flush that protects unsaved student work.

## Changes

New helpers in `notebook.js`:
- **`getCommandBridge()`** — lazily `import()`s the vendored host bundle (`/vendor/iframe-commands-host.js`), builds the bridge against `iframe#jl-frame`, awaits readiness (bounded to 10s, cached). Any failure (missing/old extension, import error, never-ready) resolves to `null` so callers fall back transparently.
- **`executeEditorCommand(command, args)`** — bridge-first with a `jupyterapp` poke fallback. Best-effort, never throws. A not-yet-ready bridge is raced against a 2.5s budget so a cold bridge never stalls a save; it keeps warming for the next call.

Migrated to `executeEditorCommand`:
- `window.chickadeeSaveNotebook` — the idle-logout flush (called by `idle-logout.js`).
- the pre-read flush in `readNotebookFromJupyterFrame`.

## Deliberately NOT migrated (documented)

These live *inside* functions that already require direct `app` access, so the bridge adds no value piecemeal — comlink can only ferry structured-cloneable data, not live JupyterLab objects:
- **Notebook read-back** (`readNotebookFromJupyterFrame` → `app.shell`, `widget.context.model.toJSON()`, `app.serviceManager.contents.get`). Already falls back to the server snapshot.
- **Server-snapshot reseed** (`syncNotebookFromServerSnapshot` → `contents.save`, then `docmanager:open` returning a `widget` whose `context.revert()` is called — the widget can't cross the comlink boundary).
- **Readiness probes** (`probeIframeReadiness`, `waitForJupyterApp`) — already hardened with DOM-presence fallbacks.

Fully retiring the poke needs a thin Chickadee labextension exposing **serializable** commands (e.g. `chickadee:read-notebook` returning JSON, `chickadee:reseed` doing open+revert atomically and returning a boolean). That's a larger effort tracked in `docs/jupyterlite-0.8-integration-followups.md` for its own PR.

## Verification

The bridge probe (`notebook-bridge-probe.yml`, chromium+webkit) now drives `docmanager:save` **directly through the bridge** (a regression there fails even if the fallback would have saved) AND via the **migrated `window.chickadeeSaveNotebook()`**, asserting both persist across reload. The required `editor-smoke-gate` + lifecycle probe cover the rest of the editor. (The server can't build locally — SwiftPM proxy 403s dependency clones — so CI is the e2e gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm

---
_Generated by [Claude Code](https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm)_