### PR TITLE
fix(notebook-editor): make notebook reset take effect on JupyterLite 0.8

### DIFF
--- a/.github/workflows/notebook-reset-probe.yml
+++ b/.github/workflows/notebook-reset-probe.yml
@@ -1,0 +1,85 @@
+name: Notebook reset probe
+
+# DIAGNOSTIC harness — NOT a required gate. Confirms instructor/self "Reset
+# notebook" actually takes effect on the JupyterLite 0.8 editor — the regression
+# fixed in the same PR: 0.8 doesn't expose window.jupyterapp, so the client
+# reseed silently no-op'd and a reset left the student's stale IndexedDB copy on
+# screen. Seeds a published, open, no-suite assignment (no runner needed), has
+# the student edit+save, hits the self-reset endpoint, reloads, and asserts the
+# edit marker is GONE. Without the fix this FAILS (stale copy survives); with it,
+# the Drive entry is evicted and the editor re-fetches the reset starter.
+#
+# Runs both engines (Chromium + WebKit). Not wired into branch protection — a
+# flaky reset run must not block unrelated merges; it's a confidence signal for
+# editor / reseed changes and an on-demand check.
+
+on:
+  workflow_dispatch:
+    inputs:
+      browser:
+        description: "Engine to drive (chromium | webkit | both)"
+        default: "both"
+  pull_request:
+    paths:
+      - "Tools/editor-smoke-test/**"
+      - ".github/workflows/notebook-reset-probe.yml"
+      - "Public/notebook*.js"
+      - "Public/jupyterlite/**"
+      - "Public/pyodide/**"
+      - "scripts/patch-pyodide-kernel.py"
+
+concurrency:
+  group: notebook-reset-probe-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  reset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, webkit]
+    container:
+      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - uses: ./.github/actions/restore-git-mtimes
+
+      - name: Resolve toolchain cache key
+        id: toolchain
+        run: echo "key=$(swift --version | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore build artifacts
+        uses: actions/cache/restore@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+
+      - name: Build chickadee-server
+        run: swift build --product chickadee-server
+
+      - name: Install Node, Playwright and the ${{ matrix.browser }} engine
+        working-directory: Tools/editor-smoke-test
+        run: |
+          set -eux
+          apt-get update -qq
+          apt-get install -y --no-install-recommends nodejs npm curl ca-certificates
+          npm ci
+          npx playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Drive notebook reset probe (${{ matrix.browser }})
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.browser == 'both' || github.event.inputs.browser == matrix.browser }}
+        env:
+          SMOKE_BROWSER: ${{ matrix.browser }}
+          SMOKE_CHECK: notebook-reset-check.mjs
+        run: Tools/editor-smoke-test/run-smoke.sh

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1388,11 +1388,6 @@
             const snapshotNotebook = await snapshotRes.json();
             if (!looksLikeNotebook(snapshotNotebook)) return;
 
-            const app = await waitForJupyterApp(8000);
-            if (!app) return;
-
-            const contents = app.serviceManager && app.serviceManager.contents;
-
             // Server-side overwrite detection.  The server stamps the iframe
             // with `data-working-copy-mtime` = the Unix-epoch mtime of the
             // working-copy file on disk.  We persist the last mtime this
@@ -1403,6 +1398,12 @@
             // preserve the local IndexedDB copy: we force-overwrite it
             // with the server snapshot so the reset is visible without a
             // manual cache-clear.
+            //
+            // Computed BEFORE we look for the in-iframe app: the 0.8 Notebook
+            // build does NOT expose `window.jupyterapp`, so `waitForJupyterApp`
+            // returns null and the contents.save + docmanager:open/revert reseed
+            // can't run — but a reset still has to take effect, via the
+            // IndexedDB-Drive eviction fallback below.
             //
             // CRITICAL SAFETY: a missing localStorage entry (`seenMtime`
             // === 0) is treated as "no baseline" — NOT as "any server
@@ -1419,6 +1420,50 @@
             let seenMtime = 0;
             try { seenMtime = parseInt(localStorage.getItem(seenKey) || '0', 10) || 0; } catch (_) {}
             const serverIsNewer = shouldForceReseed({ serverMtime, seenMtime });
+
+            const app = await waitForJupyterApp(8000);
+            if (!app) {
+                // 0.8 path: window.jupyterapp isn't exposed, so the contents.save
+                // + docmanager:open/revert reseed below can't run. If the server
+                // overwrote the working copy (instructor/self "Reset notebook"),
+                // evict the stale entry from JupyterLite's IndexedDB contents
+                // Drive and reload so the editor re-seeds the fresh server
+                // snapshot. Gated on serverIsNewer so a normal revisit never
+                // discards the student's in-progress work. Safe: a key/format
+                // mismatch makes eviction a no-op — it degrades to the prior
+                // behaviour (reset not visible), never worse, and only ever
+                // touches a copy the server just changed.
+                let reseeded = false;
+                if (serverIsNewer) {
+                    reseeded = await evictNotebookFromDrive(lockedNotebookPath);
+                }
+                // Establish/refresh the seen-mtime baseline. The pre-0.8
+                // early-return here never stamped, so serverIsNewer could never
+                // flip true on this build; stamping now makes a FUTURE reset
+                // detectable. Safe — eviction above is gated on a real baseline
+                // (serverIsNewer is false until one exists), so a first visit
+                // never reseeds and never wipes in-progress work.
+                if (serverMtime > 0) {
+                    try { localStorage.setItem(seenKey, String(serverMtime)); } catch (_) {}
+                }
+                if (reseeded) {
+                    // Reload with reset=1 so JupyterLite discards the stale
+                    // workspace and — with the Drive entry now evicted —
+                    // re-fetches the freshly-reset static working copy from the
+                    // server (jupyterlite/files/…), mirroring the submission view.
+                    let reseedURL = editorURL;
+                    try {
+                        const u = new URL(editorURL, window.location.origin);
+                        u.searchParams.set('reset', '1');
+                        reseedURL = u.pathname + u.search;
+                    } catch (_) { reseedURL = editorURL; }
+                    serverSyncComplete = true;   // avoid a reload loop
+                    frame.src = reseedURL;
+                }
+                return;
+            }
+
+            const contents = app.serviceManager && app.serviceManager.contents;
 
             // Preservation logic: if the browser already has the notebook in
             // IndexedDB AND the server hasn't overwritten it since we last
@@ -1552,6 +1597,72 @@
             await delay(100);
         }
         return null;
+    }
+
+    // Evict a notebook from JupyterLite's IndexedDB contents Drive so a reload
+    // re-seeds it from the server. The jupyterapp-independent reseed path used
+    // when `window.jupyterapp` isn't exposed (the 0.8 Notebook build) and the
+    // normal contents.save reseed therefore can't run.
+    //
+    // JupyterLite (@jupyterlite/contents, via localforage) stores contents in
+    // an IndexedDB database named "JupyterLite Storage"; the notebook bytes live
+    // in the `files` store keyed by path, with parallel `checkpoints` / `counters`
+    // entries. localforage may key by the bare path or a normalized variant, so
+    // rather than guess the exact key we cursor each store and delete any key
+    // that equals, or ends with, the working-copy path (the paths are unique per
+    // user+setup, so a suffix match can't collateral-damage another notebook).
+    //
+    // Best-effort and self-contained: resolves true only if the file entry was
+    // actually removed; any error (no DB, schema drift, blocked) resolves false
+    // so the caller leaves the editor untouched (degrades to "reset not visible",
+    // never to data loss).
+    function evictNotebookFromDrive(path) {
+        return new Promise((resolve) => {
+            let settled = false;
+            const finish = (ok) => { if (!settled) { settled = true; resolve(ok); } };
+            // Don't hang the sync if IndexedDB never responds.
+            const guard = setTimeout(() => finish(false), 4000);
+            const matches = (key) => {
+                const k = typeof key === 'string' ? key : String(key);
+                return k === path || k.endsWith('/' + path) || k.endsWith(path);
+            };
+            try {
+                const open = indexedDB.open('JupyterLite Storage');
+                open.onerror = () => { clearTimeout(guard); finish(false); };
+                open.onsuccess = () => {
+                    const db = open.result;
+                    try {
+                        const stores = ['files', 'checkpoints', 'counters']
+                            .filter((s) => db.objectStoreNames.contains(s));
+                        if (!stores.length) { db.close(); clearTimeout(guard); return finish(false); }
+                        const tx = db.transaction(stores, 'readwrite');
+                        let removedFile = false;
+                        for (const storeName of stores) {
+                            const store = tx.objectStore(storeName);
+                            const cursorReq = store.openCursor();
+                            cursorReq.onsuccess = (e) => {
+                                const cursor = e.target.result;
+                                if (!cursor) return;
+                                if (matches(cursor.key)) {
+                                    try { cursor.delete(); if (storeName === 'files') removedFile = true; } catch (_) { /* skip */ }
+                                }
+                                cursor.continue();
+                            };
+                        }
+                        tx.oncomplete = () => { db.close(); clearTimeout(guard); finish(removedFile); };
+                        tx.onerror = () => { db.close(); clearTimeout(guard); finish(false); };
+                        tx.onabort = () => { db.close(); clearTimeout(guard); finish(false); };
+                    } catch (_) {
+                        try { db.close(); } catch (_) { /* ignore */ }
+                        clearTimeout(guard);
+                        finish(false);
+                    }
+                };
+            } catch (_) {
+                clearTimeout(guard);
+                finish(false);
+            }
+        });
     }
 
     function applyLockedNotebookUI() {

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1605,29 +1605,32 @@
     // normal contents.save reseed therefore can't run.
     //
     // JupyterLite (@jupyterlite/contents, via localforage) stores contents in
-    // an IndexedDB database named "JupyterLite Storage"; the notebook bytes live
-    // in the `files` store keyed by path, with parallel `checkpoints` / `counters`
-    // entries. localforage may key by the bare path or a normalized variant, so
-    // rather than guess the exact key we cursor each store and delete any key
-    // that equals, or ends with, the working-copy path (the paths are unique per
-    // user+setup, so a suffix match can't collateral-damage another notebook).
+    // an IndexedDB database whose name is "JupyterLite Storage - <baseUrl>"
+    // (e.g. "JupyterLite Storage - /jupyterlite/") — NOT a bare "JupyterLite
+    // Storage" — so we enumerate databases and prefix-match. The notebook bytes
+    // live in the `files` store keyed by path, with parallel `checkpoints` /
+    // `counters` entries. localforage may key by the bare path or a normalized
+    // variant, so rather than guess the exact key we cursor each store and
+    // delete any key that equals, or ends with, the working-copy path (paths are
+    // unique per user+setup, so a suffix match can't hit another notebook).
     //
-    // Best-effort and self-contained: resolves true only if the file entry was
+    // Best-effort and self-contained: resolves true only if a `files` entry was
     // actually removed; any error (no DB, schema drift, blocked) resolves false
     // so the caller leaves the editor untouched (degrades to "reset not visible",
     // never to data loss).
     function evictNotebookFromDrive(path) {
-        return new Promise((resolve) => {
-            let settled = false;
-            const finish = (ok) => { if (!settled) { settled = true; resolve(ok); } };
-            // Don't hang the sync if IndexedDB never responds.
+        const matches = (key) => {
+            const k = typeof key === 'string' ? key : String(key);
+            return k === path || k.endsWith('/' + path) || k.endsWith(path);
+        };
+        // Evict matching entries from one named IndexedDB database. Resolves true
+        // iff a `files` entry was removed.
+        const evictFromDb = (name) => new Promise((resolve) => {
+            let done = false;
+            const finish = (v) => { if (!done) { done = true; resolve(v); } };
             const guard = setTimeout(() => finish(false), 4000);
-            const matches = (key) => {
-                const k = typeof key === 'string' ? key : String(key);
-                return k === path || k.endsWith('/' + path) || k.endsWith(path);
-            };
             try {
-                const open = indexedDB.open('JupyterLite Storage');
+                const open = indexedDB.open(name);
                 open.onerror = () => { clearTimeout(guard); finish(false); };
                 open.onsuccess = () => {
                     const db = open.result;
@@ -1658,11 +1661,25 @@
                         finish(false);
                     }
                 };
-            } catch (_) {
-                clearTimeout(guard);
-                finish(false);
-            }
+            } catch (_) { clearTimeout(guard); finish(false); }
         });
+        return (async () => {
+            let names = [];
+            try {
+                if (typeof indexedDB.databases === 'function') {
+                    const dbs = await indexedDB.databases();
+                    names = (dbs || [])
+                        .map((x) => x && x.name)
+                        .filter((n) => typeof n === 'string' && n.indexOf('JupyterLite Storage') === 0);
+                }
+            } catch (_) { names = []; }
+            if (!names.length) names = ['JupyterLite Storage'];  // best-effort fallback
+            let any = false;
+            for (const name of names) {
+                try { if (await evictFromDb(name)) any = true; } catch (_) { /* keep going */ }
+            }
+            return any;
+        })();
     }
 
     function applyLockedNotebookUI() {

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -130,6 +130,8 @@ async function seed() {
       requiredLanguagesCSV: "",
       requiredCapabilitiesCSV: "",
       assignmentNotebookFile: { name: "assignment.ipynb", mimeType: "application/json", buffer: starterNotebookBuffer() },
+      // Publish requires a solution notebook ("Solution notebook (.ipynb) is required").
+      solutionNotebookFile: { name: "solution.ipynb", mimeType: "application/json", buffer: starterNotebookBuffer() },
     },
     headers: { "x-csrf-token": csrf },
     maxRedirects: 0,

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -133,10 +133,29 @@ async function seed() {
       maxRedirects: 0,
     }),
     [200, 302, 303]);
+  // Find the published assignment from the INSTRUCTOR dashboard (reliable — no
+  // student visibility gating) and OPEN it: createNewAssignmentRow publishes
+  // with visibility=.closed, so the student can't see it until it's opened. A
+  // no-suite assignment has validationStatus=nil, which setOpenState permits to
+  // open without a runner.
+  const instrDash = await instr.get("/instructor");
+  const instrHtml = await instrDash.text();
+  const publicID = (instrHtml.match(/\/instructor\/([A-Za-z0-9]+)\/edit/) || [])[1];
+  const setupID =
+    (instrHtml.match(/\/instructor\/setup\/([A-Za-z0-9_-]+)\/delete/) || [])[1]
+    || (instrHtml.match(/\/testsetups\/([A-Za-z0-9_-]+)\//) || [])[1];
+  if (!publicID || !setupID) {
+    throw new Error(`could not find the published assignment on /instructor (publicID=${publicID}, setupID=${setupID}):\n` + instrHtml.slice(0, 2500));
+  }
+  csrf = await csrfFrom(instr, "/instructor");
+  await expectOK("open assignment",
+    instr.post(`/instructor/${publicID}/open`, { form: { _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]);
   await instr.dispose();
 
   // Student registers + logs in; an auto-enroll course enrolls them on the next
-  // authenticated course-state resolution.
+  // authenticated course-state resolution. They reach the now-open assignment
+  // directly at /testsetups/:setupID/notebook (no dashboard scraping needed).
   const stud = await pwRequest.newContext({ baseURL });
   csrf = await csrfFrom(stud, "/register");
   await expectOK("register student",
@@ -146,32 +165,9 @@ async function seed() {
   await expectOK("login student",
     stud.post("/login", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
     [200, 302, 303]);
-
-  // Find the assignment's notebook URL from the student dashboard (triggers
-  // auto-enrollment as a side effect of resolving course state).
-  const dash = await stud.get("/");
-  const dashHtml = await dash.text();
-  // The dashboard row carries the reset form (action=/testsetups/:id/reset-notebook,
-  // rendered when isOpen && hasNotebook), the edit link (notebookURL), and the
-  // upload link (submitURL) — grab the setupID from any /testsetups/:id/<verb>.
-  const setupIDFrom = (html) =>
-    (html.match(/\/testsetups\/([A-Za-z0-9_-]+)\/(?:reset-notebook|notebook|submit)/) || [])[1];
-  let setupID = setupIDFrom(dashHtml);
-  if (!setupID) {
-    // Fall back: follow the vanity assignment link (case-insensitive course code),
-    // whose notebook page carries the setupID (data-setup-id / its own links).
-    const slugLink = (dashHtml.match(new RegExp(`/${COURSE.code}/[A-Za-z0-9\\-]+`, "i")) || [])[0];
-    if (slugLink) {
-      const a = await stud.get(slugLink);
-      const aHtml = await a.text();
-      setupID = setupIDFrom(aHtml)
-        || (aHtml.match(/data-setup-id=['"]([A-Za-z0-9_-]+)['"]/) || [])[1]
-        || (a.url().match(/\/testsetups\/([A-Za-z0-9_-]+)/) || [])[1];
-    }
-  }
-  if (!setupID) {
-    throw new Error("could not locate the published assignment's setupID from the student dashboard:\n" + dashHtml.slice(0, 2500));
-  }
+  // Resolve course state once so the auto-enroll commits before the student
+  // hits the assignment gate.
+  await stud.get("/");
   const storageState = await stud.storageState();
   await stud.dispose();
   return { setupID, storageState };

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -266,13 +266,14 @@ async function dumpDrive(ctx) {
       const dbs = await indexedDB.databases();
       out.dbs = dbs.map((d) => d.name).filter(Boolean);
     } catch (e) { out.err = "databases(): " + (e && e.message || e); }
-    if (out.dbs.includes("JupyterLite Storage")) {
+    const driveName = out.dbs.find((n) => typeof n === "string" && n.indexOf("JupyterLite Storage") === 0);
+    if (driveName) {
       out.filesKeys = await new Promise((resolve) => {
         let done = false;
         const finish = (v) => { if (!done) { done = true; resolve(v); } };
         setTimeout(() => finish("(timeout)"), 4000);
         try {
-          const req = indexedDB.open("JupyterLite Storage");
+          const req = indexedDB.open(driveName);
           req.onerror = () => finish("(open error)");
           req.onsuccess = () => {
             const db = req.result;

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -116,25 +116,34 @@ async function seed() {
   // skips the validation run, so no runner is needed. The instructor's single
   // enrolled course is auto-selected as active.
   csrf = await csrfFrom(instr, "/instructor/new");
-  // Require a redirect: a failed publish re-renders the form with 200, which we
-  // must NOT mistake for success.
-  await expectOK("publish assignment",
-    instr.post("/instructor/new/save", {
-      multipart: {
-        _csrf: csrf,
-        draftID: "",
-        assignmentName: ASSIGNMENT_NAME,
-        dueAt: "",
-        startsAt: "",
-        sectionID: "",
-        requiredLanguagesCSV: "",
-        requiredCapabilitiesCSV: "",
-        assignmentNotebookFile: { name: "assignment.ipynb", mimeType: "application/json", buffer: starterNotebookBuffer() },
-      },
-      headers: { "x-csrf-token": csrf },
-      maxRedirects: 0,
-    }),
-    [302, 303]);
+  // A successful publish redirects to exactly /instructor; a FAILED one
+  // redirects (also 302) back to /instructor/new?...&error=... — so inspect the
+  // redirect target, not just the status, and surface the error reason.
+  const pubRes = await instr.post("/instructor/new/save", {
+    multipart: {
+      _csrf: csrf,
+      draftID: "",
+      assignmentName: ASSIGNMENT_NAME,
+      dueAt: "",
+      startsAt: "",
+      sectionID: "",
+      requiredLanguagesCSV: "",
+      requiredCapabilitiesCSV: "",
+      assignmentNotebookFile: { name: "assignment.ipynb", mimeType: "application/json", buffer: starterNotebookBuffer() },
+    },
+    headers: { "x-csrf-token": csrf },
+    maxRedirects: 0,
+  });
+  if (![302, 303].includes(pubRes.status())) {
+    let body = ""; try { body = (await pubRes.text()).slice(0, 800); } catch { /* ignore */ }
+    throw new Error(`publish assignment: status ${pubRes.status()} (wanted a redirect)\n${body}`);
+  }
+  const pubLoc = pubRes.headers()["location"] || "";
+  if (pubLoc.startsWith("/instructor/new")) {
+    let errPage = "";
+    try { errPage = (await (await instr.get(pubLoc)).text()).slice(0, 1500); } catch { /* ignore */ }
+    throw new Error(`publish failed — redirected to ${decodeURIComponent(pubLoc)}\n${errPage}`);
+  }
   // Find the published assignment from the INSTRUCTOR dashboard (reliable — no
   // student visibility gating) and OPEN it: createNewAssignmentRow publishes
   // with visibility=.closed, so the student can't see it until it's opened. A
@@ -151,7 +160,16 @@ async function seed() {
     || (instrHtml.match(/value=['"]([^'"]+)['"]\s+name=['"]testSetupID['"]/) || [])[1]
     || (instrHtml.match(/\/testsetups\/([A-Za-z0-9_-]+)\//) || [])[1];
   if (!publicID || !setupID) {
-    throw new Error(`could not find the published assignment on /instructor (publicID=${publicID}, setupID=${setupID}):\n` + instrHtml.slice(0, 2500));
+    const markers = {
+      finalURL: instrDash.url(),
+      hasNoAssignments: instrHtml.includes("No assignments"),
+      hasEditLink: instrHtml.includes("/edit"),
+      hasTestSetupInput: instrHtml.includes("testSetupID"),
+      len: instrHtml.length,
+    };
+    throw new Error(
+      `could not find the published assignment on /instructor (publicID=${publicID}, setupID=${setupID}) ` +
+        `markers=${JSON.stringify(markers)}:\n` + instrHtml.slice(0, 3500));
   }
   csrf = await csrfFrom(instr, "/instructor");
   await expectOK("open assignment",

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -151,20 +151,26 @@ async function seed() {
   // auto-enrollment as a side effect of resolving course state).
   const dash = await stud.get("/");
   const dashHtml = await dash.text();
-  // Links look like /:courseCode/:slug or /testsetups/:id/... — grab a setupID.
-  let setupID = (dashHtml.match(/\/testsetups\/([0-9a-zA-Z]+)\/(?:notebook|submit)/) || [])[1];
+  // The dashboard row carries the reset form (action=/testsetups/:id/reset-notebook,
+  // rendered when isOpen && hasNotebook), the edit link (notebookURL), and the
+  // upload link (submitURL) — grab the setupID from any /testsetups/:id/<verb>.
+  const setupIDFrom = (html) =>
+    (html.match(/\/testsetups\/([A-Za-z0-9_-]+)\/(?:reset-notebook|notebook|submit)/) || [])[1];
+  let setupID = setupIDFrom(dashHtml);
   if (!setupID) {
-    // Fall back: follow the vanity assignment link, which redirects/links to the setup.
-    const slugLink = (dashHtml.match(new RegExp(`/${COURSE.code}/[A-Za-z0-9\\-]+`)) || [])[0];
+    // Fall back: follow the vanity assignment link (case-insensitive course code),
+    // whose notebook page carries the setupID (data-setup-id / its own links).
+    const slugLink = (dashHtml.match(new RegExp(`/${COURSE.code}/[A-Za-z0-9\\-]+`, "i")) || [])[0];
     if (slugLink) {
       const a = await stud.get(slugLink);
       const aHtml = await a.text();
-      setupID = (aHtml.match(/\/testsetups\/([0-9a-zA-Z]+)\/(?:notebook|submit)/) || [])[1]
-        || (a.url().match(/\/testsetups\/([0-9a-zA-Z]+)/) || [])[1];
+      setupID = setupIDFrom(aHtml)
+        || (aHtml.match(/data-setup-id=['"]([A-Za-z0-9_-]+)['"]/) || [])[1]
+        || (a.url().match(/\/testsetups\/([A-Za-z0-9_-]+)/) || [])[1];
     }
   }
   if (!setupID) {
-    throw new Error("could not locate the published assignment's setupID from the student dashboard:\n" + dashHtml.slice(0, 600));
+    throw new Error("could not locate the published assignment's setupID from the student dashboard:\n" + dashHtml.slice(0, 2500));
   }
   const storageState = await stud.storageState();
   await stud.dispose();

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -256,6 +256,38 @@ async function editCellAndSave(page, jlFrame, marker) {
   return "ok";
 }
 
+// Diagnostic: from a page OR frame context, list IndexedDB databases and the
+// "JupyterLite Storage" files-store keys. Reveals whether the parent can see
+// the iframe's Drive DB and the exact key format the eviction must match.
+async function dumpDrive(ctx) {
+  return await ctx.evaluate(async () => {
+    const out = { dbs: [], filesKeys: null, err: null };
+    try {
+      const dbs = await indexedDB.databases();
+      out.dbs = dbs.map((d) => d.name).filter(Boolean);
+    } catch (e) { out.err = "databases(): " + (e && e.message || e); }
+    if (out.dbs.includes("JupyterLite Storage")) {
+      out.filesKeys = await new Promise((resolve) => {
+        let done = false;
+        const finish = (v) => { if (!done) { done = true; resolve(v); } };
+        setTimeout(() => finish("(timeout)"), 4000);
+        try {
+          const req = indexedDB.open("JupyterLite Storage");
+          req.onerror = () => finish("(open error)");
+          req.onsuccess = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains("files")) { db.close(); return finish("(no files store)"); }
+            const kr = db.transaction("files", "readonly").objectStore("files").getAllKeys();
+            kr.onsuccess = () => { db.close(); finish((kr.result || []).map((k) => (typeof k === "object" ? JSON.stringify(k) : String(k)))); };
+            kr.onerror = () => { db.close(); finish("(getAllKeys error)"); };
+          };
+        } catch (e) { finish("(exception " + (e && e.message || e) + ")"); }
+      });
+    }
+    return out;
+  }).catch((e) => ({ err: "evaluate failed: " + (e && e.message || e) }));
+}
+
 async function main() {
   console.log(`Browser engine: ${browserName}`);
   console.log(`Seeding published assignment via ${baseURL} …`);
@@ -332,9 +364,15 @@ async function main() {
       .evaluate((m) => ((document.body && document.body.innerText) || "").includes(m), EDIT_MARKER)
       .catch(() => false);
     if (stillEdited) {
+      // Diagnose WHY the eviction didn't take: dump IndexedDB from both frames
+      // (does the parent see "JupyterLite Storage"? what are the files keys?).
+      const parentDrive = await dumpDrive(page);
+      const frameDrive = await dumpDrive(jlFrame);
       return fail(
         "the student's edit marker SURVIVED the reset — reset did not take effect " +
-          "(the 0.8 reseed regression: stale IndexedDB copy not replaced by the server starter)",
+          "(the 0.8 reseed regression: stale IndexedDB copy not replaced by the server starter)\n" +
+          "PARENT IndexedDB: " + JSON.stringify(parentDrive) + "\n" +
+          "IFRAME IndexedDB: " + JSON.stringify(frameDrive),
         (await bodyText(jlFrame)).slice(0, 300)
       );
     }

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -1,0 +1,317 @@
+// notebook-reset-check.mjs
+//
+// Headless END-TO-END check that instructor/self "Reset notebook" actually
+// takes effect in the JupyterLite 0.8 editor — the regression this confirms and
+// guards: the 0.8 Notebook build doesn't expose `window.jupyterapp`, so the
+// client reseed (`syncNotebookFromServerSnapshot`) that makes a reset visible
+// silently no-op'd, leaving the student's stale IndexedDB copy on screen.
+//
+// Flow (one student, one browser context so the IndexedDB Drive persists across
+// reloads):
+//   1. Boot the assignment editor; the seeded starter (CKSTART) renders, kernel idle.
+//   2. Append a unique edit marker (CKEDIT_<stamp>) to cell 0 and Ctrl+S — now the
+//      student's IndexedDB working copy differs from the server starter.
+//   3. POST the self-reset endpoint, which overwrites the server working copy back
+//      to the starter (bumping its mtime).
+//   4. Reload. The reset must be visible: the edit marker is GONE and the starter
+//      marker is present. WITHOUT the fix the stale IndexedDB copy survives and
+//      CKEDIT is still there -> FAIL; WITH the fix the Drive entry is evicted and
+//      the editor re-fetches the reset starter from the server -> the marker is gone.
+//
+// Unlike notebook-lifecycle-check.mjs (a bare test setup), reset needs a published,
+// open assignment (requireOpenStudentAssignment), so this seeds one through the
+// instructor draft/publish HTTP flow. Publishing with NO test suite skips the
+// validation run, so no worker/runner is required.
+//
+// Usage:  node notebook-reset-check.mjs <baseURL>
+// Env:    SMOKE_BROWSER (chromium|webkit|firefox), SMOKE_KERNEL_MS.
+// Exit 0 = reset works; exit 1 = a step failed (details printed).
+
+import { chromium, webkit, firefox } from "playwright";
+import { request as pwRequest } from "playwright";
+
+const BROWSERS = { chromium, webkit, firefox };
+const browserName = process.env.SMOKE_BROWSER || "chromium";
+const browserType = BROWSERS[browserName] || chromium;
+const baseURL = (process.argv[2] || process.env.BASE_URL || "http://127.0.0.1:8099").replace(/\/$/, "");
+
+const PAGE_LOAD_MS = 30_000;
+const KERNEL_BOOT_MS = parseInt(process.env.SMOKE_KERNEL_MS || "120000", 10);
+const IDLE_WAIT_MS = 90_000;
+
+const STAMP = Date.now().toString(36);
+const STARTER_MARKER = "CKSTART";
+const EDIT_MARKER = `CKEDIT_${STAMP}`;
+const STARTER_SOURCE = `# ${STARTER_MARKER}\nx = 1\n`;
+
+const INSTRUCTOR = { username: `rs_instr_${STAMP}`, password: "instructor-pw-123" };
+const STUDENT = { username: `rs_student_${STAMP}`, password: "student-pw-123" };
+const COURSE = { code: `RS${STAMP}`.slice(0, 12), name: "Reset Course" };
+const ASSIGNMENT_NAME = `Reset Lab ${STAMP}`;
+
+function fail(reason, extra) {
+  console.log(`RESET FAIL — ${reason}`);
+  if (extra) console.log(extra);
+  process.exit(1);
+}
+
+function extractCsrf(html) {
+  let m = html.match(/name=['"]_csrf['"][^>]*\svalue=['"]([^'"]+)['"]/i);
+  if (m) return m[1];
+  m = html.match(/\svalue=['"]([^'"]+)['"][^>]*name=['"]_csrf['"]/i);
+  if (m) return m[1];
+  m = html.match(/<meta\s+name=['"]csrf-token['"]\s+content=['"]([^'"]+)['"]/i);
+  if (m) return m[1];
+  return null;
+}
+
+async function csrfFrom(ctx, path) {
+  const res = await ctx.get(path);
+  const token = extractCsrf(await res.text());
+  if (!token) throw new Error(`could not find CSRF token on ${path} (status ${res.status()})`);
+  return token;
+}
+
+async function expectOK(label, resPromise, okStatuses) {
+  const res = await resPromise;
+  if (!okStatuses.includes(res.status())) {
+    let body = "";
+    try { body = (await res.text()).slice(0, 400); } catch { /* ignore */ }
+    throw new Error(`${label}: unexpected status ${res.status()} (wanted ${okStatuses.join("/")})\n${body}`);
+  }
+  return res;
+}
+
+function starterNotebookBuffer() {
+  const nb = {
+    nbformat: 4, nbformat_minor: 5,
+    metadata: { kernelspec: { name: "python", display_name: "Python" } },
+    cells: [{ cell_type: "code", source: [STARTER_SOURCE], metadata: {}, outputs: [], execution_count: null }],
+  };
+  return Buffer.from(JSON.stringify(nb), "utf8");
+}
+
+// Seed an instructor, an auto-enroll course, a PUBLISHED OPEN no-suite assignment,
+// and a student (auto-enrolled). Returns { storageState } for the student plus the
+// assignment's setupID + notebook URL discovered from the student dashboard.
+async function seed() {
+  const instr = await pwRequest.newContext({ baseURL });
+  let csrf = await csrfFrom(instr, "/register");
+  await expectOK("register instructor",
+    instr.post("/register", { form: { username: INSTRUCTOR.username, password: INSTRUCTOR.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]);
+
+  csrf = await csrfFrom(instr, "/admin/courses/new");
+  const courseRes = await expectOK("create course",
+    instr.post("/admin/courses", { form: { code: COURSE.code, name: COURSE.name, _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]);
+  const loc = courseRes.headers()["location"] || "";
+  const courseID = (loc.match(/\/admin\/courses\/([0-9a-fA-F-]{36})/) || [])[1];
+  if (!courseID) throw new Error(`could not parse courseID from redirect: "${loc}"`);
+  await expectOK("set enrollment auto",
+    instr.post(`/courses/${courseID}/enrollment-mode`, { form: { enrollmentMode: "auto", _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]);
+
+  // Publish a no-suite assignment (single starter notebook). An empty test suite
+  // skips the validation run, so no runner is needed. The instructor's single
+  // enrolled course is auto-selected as active.
+  csrf = await csrfFrom(instr, "/instructor/new");
+  await expectOK("publish assignment",
+    instr.post("/instructor/new/save", {
+      multipart: {
+        _csrf: csrf,
+        draftID: "",
+        assignmentName: ASSIGNMENT_NAME,
+        dueAt: "",
+        startsAt: "",
+        sectionID: "",
+        requiredLanguagesCSV: "",
+        requiredCapabilitiesCSV: "",
+        assignmentNotebookFile: { name: "assignment.ipynb", mimeType: "application/json", buffer: starterNotebookBuffer() },
+      },
+      headers: { "x-csrf-token": csrf },
+      maxRedirects: 0,
+    }),
+    [200, 302, 303]);
+  await instr.dispose();
+
+  // Student registers + logs in; an auto-enroll course enrolls them on the next
+  // authenticated course-state resolution.
+  const stud = await pwRequest.newContext({ baseURL });
+  csrf = await csrfFrom(stud, "/register");
+  await expectOK("register student",
+    stud.post("/register", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]);
+  csrf = await csrfFrom(stud, "/login");
+  await expectOK("login student",
+    stud.post("/login", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]);
+
+  // Find the assignment's notebook URL from the student dashboard (triggers
+  // auto-enrollment as a side effect of resolving course state).
+  const dash = await stud.get("/");
+  const dashHtml = await dash.text();
+  // Links look like /:courseCode/:slug or /testsetups/:id/... — grab a setupID.
+  let setupID = (dashHtml.match(/\/testsetups\/([0-9a-zA-Z]+)\/(?:notebook|submit)/) || [])[1];
+  if (!setupID) {
+    // Fall back: follow the vanity assignment link, which redirects/links to the setup.
+    const slugLink = (dashHtml.match(new RegExp(`/${COURSE.code}/[A-Za-z0-9\\-]+`)) || [])[0];
+    if (slugLink) {
+      const a = await stud.get(slugLink);
+      const aHtml = await a.text();
+      setupID = (aHtml.match(/\/testsetups\/([0-9a-zA-Z]+)\/(?:notebook|submit)/) || [])[1]
+        || (a.url().match(/\/testsetups\/([0-9a-zA-Z]+)/) || [])[1];
+    }
+  }
+  if (!setupID) {
+    throw new Error("could not locate the published assignment's setupID from the student dashboard:\n" + dashHtml.slice(0, 600));
+  }
+  const storageState = await stud.storageState();
+  await stud.dispose();
+  return { setupID, storageState };
+}
+
+async function findEditorFrame(page) {
+  for (let i = 0; i < 60; i++) {
+    const fr = page.frames().find((f) => /\/jupyterlite\//.test(f.url()));
+    if (fr) return fr;
+    await page.waitForTimeout(500);
+  }
+  return null;
+}
+
+async function waitForEditorWithSource(jlFrame, mustContain) {
+  return await jlFrame.waitForFunction(
+    (needle) => {
+      const jp = document.querySelectorAll("[class^='jp-'],[class*=' jp-']").length;
+      const text = (document.body && document.body.innerText) || "";
+      return jp > 20 && text.includes(needle);
+    },
+    mustContain,
+    { timeout: KERNEL_BOOT_MS }
+  ).then(() => true).catch(() => false);
+}
+
+async function waitForKernelIdle(page) {
+  const deadline = Date.now() + IDLE_WAIT_MS;
+  while (Date.now() < deadline) {
+    const diag = await page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
+    if (diag.some((d) => d.kind === "kernel_phase" && d.source === "kernel_idle")) return true;
+    await page.waitForTimeout(500);
+  }
+  return false;
+}
+
+async function bodyText(jlFrame) {
+  return await jlFrame.evaluate(() => (document.body && document.body.innerText) || "").catch(() => "");
+}
+
+async function editCellAndSave(page, jlFrame, marker) {
+  const cell = jlFrame.locator(".jp-Notebook .jp-CodeCell .cm-content").first();
+  try { await cell.click({ timeout: 15_000 }); }
+  catch (e) { return "could not focus the cell editor: " + (e && e.message ? e.message : e); }
+  await page.waitForTimeout(300);
+  await page.keyboard.press("Control+End").catch(() => {});
+  await page.keyboard.type(`\n# ${marker}\n`);
+  await page.waitForTimeout(300);
+  const registered = await jlFrame
+    .evaluate((m) => ((document.body && document.body.innerText) || "").includes(m), marker)
+    .catch(() => false);
+  if (!registered) return "edit did not register in the editor (typing into CodeMirror failed)";
+  await page.keyboard.press("Control+s");
+  await page.waitForTimeout(2000);
+  return "ok";
+}
+
+async function main() {
+  console.log(`Browser engine: ${browserName}`);
+  console.log(`Seeding published assignment via ${baseURL} …`);
+  let seeded;
+  try { seeded = await seed(); }
+  catch (e) { return fail(`seeding failed: ${(e && e.message) || e}`); }
+  const notebookURL = `${baseURL}/testsetups/${seeded.setupID}/notebook`;
+  console.log(`Seeded setup ${seeded.setupID}; driving reset check on ${notebookURL}`);
+
+  const launchOptions = browserName === "chromium"
+    ? { headless: true, args: ["--no-sandbox"], chromiumSandbox: false }
+    : { headless: true };
+  const browser = await browserType.launch(launchOptions);
+  const context = await browser.newContext({ storageState: seeded.storageState });
+  await context.addInitScript(() => {
+    try {
+      window.__ckKernelDiag = [];
+      window.addEventListener("message", (e) => {
+        const d = e && e.data;
+        if (d && d.ck === "kernel-diag") window.__ckKernelDiag.push({ kind: d.kind, source: d.source, message: d.message });
+      });
+    } catch (_) { /* ignore */ }
+  });
+  const page = await context.newPage();
+  const finish = async (code) => { await browser.close(); process.exit(code); };
+
+  try {
+    // ---- Step 1: boot, render starter, kernel idle ----------------------
+    await page.goto(notebookURL, { waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
+    if (/\/login/.test(page.url())) return fail(`redirected to login — student not authorized (url=${page.url()})`);
+    let jlFrame = await findEditorFrame(page);
+    if (!jlFrame) return fail("the JupyterLite editor iframe never attached");
+    if (!(await waitForEditorWithSource(jlFrame, STARTER_MARKER))) {
+      return fail("editor never rendered the seeded starter cell", (await bodyText(jlFrame)).slice(0, 300));
+    }
+    if (!(await waitForKernelIdle(page))) return fail("kernel never reported idle");
+    console.log("step 1 ok: editor booted, starter rendered, kernel idle");
+
+    // ---- Step 2: edit + save (diverge from the server starter) ----------
+    const editResult = await editCellAndSave(page, jlFrame, EDIT_MARKER);
+    if (editResult !== "ok") return fail(`could not edit + save the notebook: ${editResult}`);
+    console.log("step 2 ok: edited cell 0 and saved to the Drive");
+
+    // ---- Step 3: trigger the self-reset endpoint ------------------------
+    // Wait so the reset's working-copy mtime is strictly newer than the one the
+    // editor recorded on first open (1s filesystem mtime resolution).
+    await page.waitForTimeout(2500);
+    const resetCtx = await pwRequest.newContext({ baseURL, storageState: seeded.storageState });
+    let resetCsrf;
+    try { resetCsrf = await csrfFrom(resetCtx, "/"); }
+    catch (e) { return fail(`could not get CSRF for reset: ${(e && e.message) || e}`); }
+    const resetRes = await resetCtx.post(`/testsetups/${seeded.setupID}/reset-notebook`, {
+      form: { _csrf: resetCsrf }, headers: { "x-csrf-token": resetCsrf }, maxRedirects: 0,
+    });
+    if (![200, 302, 303].includes(resetRes.status())) {
+      let b = ""; try { b = (await resetRes.text()).slice(0, 300); } catch { /* ignore */ }
+      return fail(`reset endpoint returned ${resetRes.status()}`, b);
+    }
+    await resetCtx.dispose();
+    console.log("step 3 ok: server working copy reset to the starter");
+
+    // ---- Step 4: reload and assert the reset is visible -----------------
+    await page.waitForTimeout(1500);
+    console.log("step 4: reloading to confirm the reset is visible…");
+    await page.goto(notebookURL, { waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
+    jlFrame = await findEditorFrame(page);
+    if (!jlFrame) return fail("editor iframe never re-attached after reset + reload");
+    if (!(await waitForEditorWithSource(jlFrame, STARTER_MARKER))) {
+      return fail("editor did not re-render the notebook after reset + reload", (await bodyText(jlFrame)).slice(0, 300));
+    }
+    // The fix may itself reload the iframe (reset=1) — give the re-seed a moment.
+    await page.waitForTimeout(4000);
+    const stillEdited = await jlFrame
+      .evaluate((m) => ((document.body && document.body.innerText) || "").includes(m), EDIT_MARKER)
+      .catch(() => false);
+    if (stillEdited) {
+      return fail(
+        "the student's edit marker SURVIVED the reset — reset did not take effect " +
+          "(the 0.8 reseed regression: stale IndexedDB copy not replaced by the server starter)",
+        (await bodyText(jlFrame)).slice(0, 300)
+      );
+    }
+    console.log("step 4 ok: edit marker gone — reset is visible on the 0.8 editor");
+
+    console.log(`RESET PASS — instructor/self reset takes effect on the real 0.8 notebook editor (engine=${browserName})`);
+    await finish(0);
+  } catch (err) {
+    return fail(`exception: ${(err && err.stack) || err}`);
+  }
+}
+
+main();

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -359,22 +359,33 @@ async function main() {
     if (!(await waitForEditorWithSource(jlFrame, STARTER_MARKER))) {
       return fail("editor did not re-render the notebook after reset + reload", (await bodyText(jlFrame)).slice(0, 300));
     }
-    // The fix may itself reload the iframe (reset=1) — give the re-seed a moment.
-    await page.waitForTimeout(4000);
-    const stillEdited = await jlFrame
-      .evaluate((m) => ((document.body && document.body.innerText) || "").includes(m), EDIT_MARKER)
-      .catch(() => false);
-    if (stillEdited) {
-      // Diagnose WHY the eviction didn't take: dump IndexedDB from both frames
-      // (does the parent see "JupyterLite Storage"? what are the files keys?).
+    // The fix reseeds ASYNCHRONOUSLY: syncNotebookFromServerSnapshot waits up to
+    // 8s for window.jupyterapp (never present on 0.8), then evicts the Drive
+    // entry and reloads the iframe with reset=1, which re-boots the editor from
+    // the freshly-reset server file. Poll for the edit marker to clear, re-finding
+    // the frame each round (the fix detaches/reloads it), over a generous budget
+    // that covers the 8s app-wait + eviction + reload + kernel re-boot.
+    const RESEED_BUDGET_MS = 75_000;
+    const reseedDeadline = Date.now() + RESEED_BUDGET_MS;
+    let cleared = false;
+    while (Date.now() < reseedDeadline) {
+      const fr = await findEditorFrame(page);
+      if (fr) {
+        const txt = await fr.evaluate(() => (document.body && document.body.innerText) || "").catch(() => "");
+        if (txt.includes(STARTER_MARKER) && !txt.includes(EDIT_MARKER)) { cleared = true; jlFrame = fr; break; }
+      }
+      await page.waitForTimeout(2500);
+    }
+    if (!cleared) {
+      jlFrame = (await findEditorFrame(page)) || jlFrame;
       const parentDrive = await dumpDrive(page);
-      const frameDrive = await dumpDrive(jlFrame);
+      const frameDrive = jlFrame ? await dumpDrive(jlFrame) : null;
       return fail(
         "the student's edit marker SURVIVED the reset — reset did not take effect " +
           "(the 0.8 reseed regression: stale IndexedDB copy not replaced by the server starter)\n" +
           "PARENT IndexedDB: " + JSON.stringify(parentDrive) + "\n" +
           "IFRAME IndexedDB: " + JSON.stringify(frameDrive),
-        (await bodyText(jlFrame)).slice(0, 300)
+        jlFrame ? (await bodyText(jlFrame)).slice(0, 300) : "(no frame)"
       );
     }
     console.log("step 4 ok: edit marker gone — reset is visible on the 0.8 editor");

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -116,6 +116,8 @@ async function seed() {
   // skips the validation run, so no runner is needed. The instructor's single
   // enrolled course is auto-selected as active.
   csrf = await csrfFrom(instr, "/instructor/new");
+  // Require a redirect: a failed publish re-renders the form with 200, which we
+  // must NOT mistake for success.
   await expectOK("publish assignment",
     instr.post("/instructor/new/save", {
       multipart: {
@@ -132,7 +134,7 @@ async function seed() {
       headers: { "x-csrf-token": csrf },
       maxRedirects: 0,
     }),
-    [200, 302, 303]);
+    [302, 303]);
   // Find the published assignment from the INSTRUCTOR dashboard (reliable — no
   // student visibility gating) and OPEN it: createNewAssignmentRow publishes
   // with visibility=.closed, so the student can't see it until it's opened. A
@@ -141,8 +143,12 @@ async function seed() {
   const instrDash = await instr.get("/instructor");
   const instrHtml = await instrDash.text();
   const publicID = (instrHtml.match(/\/instructor\/([A-Za-z0-9]+)\/edit/) || [])[1];
+  // A published row exposes its setupID via a hidden `testSetupID` input; the
+  // /instructor/setup/:id/delete link only renders for UNPUBLISHED setups, so
+  // don't rely on it.
   const setupID =
-    (instrHtml.match(/\/instructor\/setup\/([A-Za-z0-9_-]+)\/delete/) || [])[1]
+    (instrHtml.match(/name=['"]testSetupID['"]\s+value=['"]([^'"]+)['"]/) || [])[1]
+    || (instrHtml.match(/value=['"]([^'"]+)['"]\s+name=['"]testSetupID['"]/) || [])[1]
     || (instrHtml.match(/\/testsetups\/([A-Za-z0-9_-]+)\//) || [])[1];
   if (!publicID || !setupID) {
     throw new Error(`could not find the published assignment on /instructor (publicID=${publicID}, setupID=${setupID}):\n` + instrHtml.slice(0, 2500));

--- a/Tools/editor-smoke-test/notebook-reset-check.mjs
+++ b/Tools/editor-smoke-test/notebook-reset-check.mjs
@@ -151,27 +151,24 @@ async function seed() {
   // with visibility=.closed, so the student can't see it until it's opened. A
   // no-suite assignment has validationStatus=nil, which setOpenState permits to
   // open without a runner.
+  // Grab the assignment's publicID from the INSTRUCTOR dashboard and OPEN it:
+  // createNewAssignmentRow publishes with visibility=.closed, so the student
+  // can't see it until it's opened. A no-suite assignment has
+  // validationStatus=nil, which setOpenState permits to open without a runner.
+  // (setupID is NOT reliably on /instructor for a fresh closed row — the hidden
+  // testSetupID input only renders in submission/retest forms — so we read it
+  // from the student dashboard once the assignment is open.)
   const instrDash = await instr.get("/instructor");
   const instrHtml = await instrDash.text();
   const publicID = (instrHtml.match(/\/instructor\/([A-Za-z0-9]+)\/edit/) || [])[1];
-  // A published row exposes its setupID via a hidden `testSetupID` input; the
-  // /instructor/setup/:id/delete link only renders for UNPUBLISHED setups, so
-  // don't rely on it.
-  const setupID =
-    (instrHtml.match(/name=['"]testSetupID['"]\s+value=['"]([^'"]+)['"]/) || [])[1]
-    || (instrHtml.match(/value=['"]([^'"]+)['"]\s+name=['"]testSetupID['"]/) || [])[1]
-    || (instrHtml.match(/\/testsetups\/([A-Za-z0-9_-]+)\//) || [])[1];
-  if (!publicID || !setupID) {
+  if (!publicID) {
     const markers = {
       finalURL: instrDash.url(),
       hasNoAssignments: instrHtml.includes("No assignments"),
       hasEditLink: instrHtml.includes("/edit"),
-      hasTestSetupInput: instrHtml.includes("testSetupID"),
       len: instrHtml.length,
     };
-    throw new Error(
-      `could not find the published assignment on /instructor (publicID=${publicID}, setupID=${setupID}) ` +
-        `markers=${JSON.stringify(markers)}:\n` + instrHtml.slice(0, 3500));
+    throw new Error(`could not find publicID on /instructor markers=${JSON.stringify(markers)}:\n` + instrHtml.slice(0, 3500));
   }
   csrf = await csrfFrom(instr, "/instructor");
   await expectOK("open assignment",
@@ -191,9 +188,17 @@ async function seed() {
   await expectOK("login student",
     stud.post("/login", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
     [200, 302, 303]);
-  // Resolve course state once so the auto-enroll commits before the student
-  // hits the assignment gate.
-  await stud.get("/");
+  // The assignment is now OPEN, so it appears on the student dashboard with the
+  // reset form (action=/testsetups/:id/reset-notebook, gated on isOpen &&
+  // hasNotebook) — read the setupID from there. The GET also commits the
+  // auto-enroll into the .auto course.
+  const dashHtml = await (await stud.get("/")).text();
+  const setupID = (dashHtml.match(/\/testsetups\/([A-Za-z0-9_-]+)\/(?:reset-notebook|notebook|submit)/) || [])[1];
+  if (!setupID) {
+    throw new Error(
+      "could not find setupID on the student dashboard after opening the assignment " +
+        `(hasNoAssignments=${dashHtml.includes("No assignments")}):\n` + dashHtml.slice(0, 3000));
+  }
   const storageState = await stud.storageState();
   await stud.dispose();
   return { setupID, storageState };

--- a/changelog.d/notebook-reset-0.8-fix.md
+++ b/changelog.d/notebook-reset-0.8-fix.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Notebook "reset" now takes effect on the JupyterLite 0.8 editor.** The 0.8
+  Notebook build does not expose `window.jupyterapp`, so the client reseed that
+  makes an instructor/self "Reset notebook" visible (`syncNotebookFromServerSnapshot`
+  → `waitForJupyterApp` → `contents.save` + `docmanager:open`/`revert`) silently
+  no-op'd, leaving the student's stale IndexedDB copy on screen. Added a
+  jupyterapp-independent fallback: when the server working copy is newer than the
+  baseline this browser last saw, evict the stale entry from JupyterLite's
+  IndexedDB contents Drive (`"JupyterLite Storage"` → `files`) and reload with
+  `reset=1` so the editor re-fetches the freshly-reset working copy from the
+  server. Gated on the reset signal and safe by construction — a key-format
+  mismatch makes the eviction a no-op (prior behaviour, never data loss), and it
+  only ever touches the one working copy the server just changed.

--- a/docs/jupyterlite-0.8-integration-followups.md
+++ b/docs/jupyterlite-0.8-integration-followups.md
@@ -129,19 +129,32 @@ grading work above; it's an independent durability win.
   diagnostic) drives `docmanager:save` directly through the bridge AND via the
   migrated `window.chickadeeSaveNotebook()`, asserting both persist across reload.
 
-**Still on the `jupyterapp` poke (NOT yet bridged) — needs a custom labextension:**
+**⚠️ `window.jupyterapp` is ABSENT on the 0.8 Notebook build.** Verified
+empirically (the shell renders ~46 `jp-` nodes but the global never appears) and
+already noted in `jl-kernel-diagnostics.js`. Consequence: every `notebook.js`
+path that reaches for `frame.contentWindow.jupyterapp` was *silently* taking its
+fallback on 0.8 — `readNotebookFromJupyterFrame` always falls back to the server
+snapshot (fine, kept current by #1036's reliable saves), but the **reseed that
+makes "Reset notebook" visible was a no-op → reset was broken on 0.8**. Fixed:
 
-These live *inside* functions that already require direct `app` access, so the
-bridge adds no value piecemeal — comlink can only ferry structured-cloneable
-data, not live JupyterLab objects:
+- **Server-snapshot reseed** (`syncNotebookFromServerSnapshot`) now has a
+  jupyterapp-independent fallback. When the server working copy is newer than
+  the seen baseline (a reset), it evicts the stale entry from JupyterLite's
+  IndexedDB contents Drive (`"JupyterLite Storage"` → `files`, format-robust
+  suffix match) via `evictNotebookFromDrive` and reloads with `reset=1`, so the
+  editor re-fetches the freshly-reset static working copy from the server. Safe:
+  a key mismatch makes eviction a no-op. (The old `contents.save` +
+  `docmanager:open`/`revert` app path is kept for builds that *do* expose the
+  global.) **Needs dev validation** — can't be exercised in the local static
+  harness (the notebooks interface won't boot without the server's seeded
+  per-student working copy + contents routes).
+
+**Still on the `jupyterapp` poke (low value to bridge) — would need a custom labextension:**
 
 - **Notebook read-back** (`readNotebookFromJupyterFrame` → `app.shell`,
-  `notebookWidgetFromShell`, `widget.context.model.toJSON()`,
-  `app.serviceManager.contents.get`). Falls back to the server snapshot
-  (`fetchNotebookSnapshot`) when the frame read fails, so it's already resilient.
-- **Server-snapshot reseed** (`syncNotebookFromServerSnapshot` → `contents.save`,
-  then `docmanager:open` returning a `widget` whose `context.revert()` is called).
-  The widget can't cross the comlink boundary.
+  `widget.context.model.toJSON()`, `app.serviceManager.contents.get`). Already
+  falls back to the server snapshot, which #1036 keeps current — so bridging it
+  is now low value.
 - **Readiness probes** (`probeIframeReadiness`, `waitForJupyterApp`) read
   `win.jupyterapp`; already hardened with DOM-presence fallbacks.
 


### PR DESCRIPTION
## What

Fixes instructor/self **"Reset notebook"** on the JupyterLite 0.8 editor, with a headless CI probe (chromium + webkit) that confirms and guards it.

## Root cause (the #9 investigation result)

The 0.8 Notebook build **does not expose `window.jupyterapp`**, so every `notebook.js` path that reaches for it silently took a fallback. Reads stayed fine, but the reseed that makes a reset *visible* — `syncNotebookFromServerSnapshot` → `waitForJupyterApp` → `contents.save` + revert — **no-op'd**, so after a reset the student kept seeing their stale IndexedDB copy.

## Fix (jupyterapp-independent)

In `syncNotebookFromServerSnapshot`: compute the reset signal (server `mtime` vs the localStorage baseline) **before** the app lookup and stamp the baseline on the no-app path too; when a reset is detected and the app global is absent, **`evictNotebookFromDrive`** removes the stale entry from JupyterLite's IndexedDB contents Drive, then reload with `reset=1` so the editor re-fetches the freshly-reset server working copy. The existing app path is kept for builds that expose the global.

## A real bug the probe caught

The end-to-end probe paid for itself: it reached the live reset and showed the edit **surviving**, and the IndexedDB diagnostic revealed why — JupyterLite's Drive DB is named **`"JupyterLite Storage - /jupyterlite/"`** (name = `"JupyterLite Storage - <baseUrl>"`), not a bare `"JupyterLite Storage"`. The first cut of `evictNotebookFromDrive` opened the literal wrong name and evicted nothing. Fixed to **enumerate `indexedDB.databases()` and prefix-match**, evicting matching `files`/`checkpoints`/`counters` entries (the `files` key is exactly the per-user working-copy path, so the match is collision-free). No static review would have caught the DB-name suffix.

## Safety

Gated on the reset signal **and** the absent global, so a normal revisit never touches local work. A key/DB mismatch makes eviction a **no-op** (degrades to "reset not visible", never data loss); it only ever touches the one working copy the server just changed; IndexedDB access is timeout-guarded and error-swallowed.

## Confirming CI probe — green on both engines

`notebook-reset-check.mjs` + `notebook-reset-probe.yml` (chromium + webkit, non-required diagnostic). It seeds a **published, open, no-suite** assignment over HTTP (instructor publish-with-solution → open → student auto-enroll; no runner needed), has the student edit + save a cell, hits the self-reset endpoint, reloads, and **polls** for the student's edit marker to disappear (the reseed is async: ~8s app-wait → evict → `reset=1` reload → re-boot). It now passes on both engines, so the fix is validated end-to-end; without the fix the stale copy survives.

## Still a draft — dev sign-off

The fix can't be exercised in the local static harness (the notebooks interface needs the server's seeded working copy) and the server can't build in the agent environment, so CI is the automated gate. A quick manual check on dev (reset a notebook in Safari **and** Chrome) is still worthwhile before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm