### PR TITLE
feat(notebook-editor): device-memory warning + fatal-crash recovery

### DIFF
--- a/Public/jl-kernel-diagnostics.js
+++ b/Public/jl-kernel-diagnostics.js
@@ -118,6 +118,38 @@
         });
     } catch (_) { /* ignore */ }
 
+    // ---- fatal WASM / OOM crash (the kernel DIED) ----------------------
+    //
+    // The fatal upstream WebKit/Safari WASM crash (WebKit #286266 — "Out of
+    // bounds memory access" in __pyproxy_apply) and genuine WASM OOM aborts kill
+    // the kernel mid-execute, which is AFTER the boot window — so the done-gated
+    // reportError() above deliberately ignores them. A dead kernel always
+    // matters, so capture the fatal-crash signature separately: NOT done-gated,
+    // one-shot, forwarded as a distinct `wasm_crash` source the parent turns into
+    // a memory-specific recovery notice (instead of a silently wedged cell).
+    var WASM_CRASH_RE = /out of bounds memory access|Pyodide has suffered a fatal error|__pyproxy_apply|RangeError: Bad value|abort\(.*[Oo]ut of memory|abort\(OOM\)|memory access out of bounds/;
+    var wasmCrashReported = false;
+    function reportWasmCrashIfMatch(message) {
+        try {
+            if (wasmCrashReported) return;
+            var msg = String(message || '');
+            if (!WASM_CRASH_RE.test(msg)) return;
+            wasmCrashReported = true;
+            post('kernel_error', 'wasm_crash', msg);
+        } catch (_) { /* never throw */ }
+    }
+    try {
+        window.addEventListener('unhandledrejection', function (e) {
+            try {
+                var reason = e && e.reason;
+                reportWasmCrashIfMatch((reason && reason.message) || String(reason || ''));
+            } catch (_) { /* ignore */ }
+        });
+        window.addEventListener('error', function (e) {
+            try { if (e && e.message) reportWasmCrashIfMatch(e.message); } catch (_) { /* ignore */ }
+        }, true);
+    } catch (_) { /* ignore */ }
+
     // ---- boot-phase detection (the WHERE) ------------------------------
     //
     // This JupyterLite build (Notebook 7) does NOT expose window.jupyterapp, so

--- a/Public/notebook-preflight.js
+++ b/Public/notebook-preflight.js
@@ -76,7 +76,15 @@
             }
         }
 
-        return { ok: failed.length === 0, failed: failed };
+        // Proactive low-memory hint (non-blocking — NOT a `failed` capability).
+        // `navigator.deviceMemory` is GB rounded to a power of two, and is exposed
+        // on Chromium only (Safari/Firefox omit it for fingerprinting privacy), so
+        // this catches low-RAM Chromebooks/Android but can't see iOS — the runtime
+        // `wasm_crash` recovery covers the WebKit case where this signal is absent.
+        var dm = (navigator && typeof navigator.deviceMemory === 'number') ? navigator.deviceMemory : null;
+        var lowMemory = (dm !== null && dm > 0 && dm <= 2);
+
+        return { ok: failed.length === 0, failed: failed, lowMemory: lowMemory, deviceMemory: dm };
     }
 
     // ----------------------------------------------------------------
@@ -105,6 +113,23 @@
         if (frame)    frame.style.display = 'none';
         if (submit)   submit.style.display = 'none';
         if (fallback) fallback.hidden = false;
+
+        // Memory-crash variant: the editor DID load, but the kernel died on a
+        // fatal WASM/OOM crash mid-session — swap in memory-specific copy on the
+        // same fallback panel (which already offers .ipynb upload + reset link),
+        // instead of the generic "Editor didn't load" message.
+        if (info.variant === 'memory' && fallback) {
+            const titleEl = fallback.querySelector('.nb-fallback-title');
+            const textEl  = fallback.querySelector('.nb-fallback-text');
+            if (titleEl) titleEl.textContent = 'Your browser ran low on memory';
+            if (textEl) {
+                textEl.textContent =
+                    'The Python kernel stopped because your browser hit a memory limit — ' +
+                    'common on Safari and on phones, tablets, or low-memory computers. ' +
+                    'Reload to try again, or open this assignment on a laptop or desktop in ' +
+                    'Chrome or Firefox. You can also submit by uploading your .ipynb file below.';
+            }
+        }
 
         // Point the "reset the notebook editor" link back at THIS assignment, so
         // after clearing site data the student lands on the same page (which now
@@ -213,12 +238,53 @@
     }
 
     // ----------------------------------------------------------------
+    // Proactive low-memory warning (non-blocking)
+    // ----------------------------------------------------------------
+    //
+    // Shown when the preflight PASSES but `navigator.deviceMemory` reports a
+    // low-RAM device. Reveals a dismissible banner WITHOUT hiding the editor —
+    // the student can still work; it just sets expectations. Dismissal persists
+    // per-device (localStorage) so it doesn't nag on every visit. The
+    // `device_warning` beacon fires regardless of dismissal, which also gives us
+    // the real low-memory-device rate to calibrate against.
+
+    let _deviceWarningShown = false;
+    function showDeviceWarning(info) {
+        if (_deviceWarningShown) return;
+        _deviceWarningShown = true;
+        const dm = (info && typeof info.deviceMemory === 'number') ? info.deviceMemory : null;
+
+        let dismissed = false;
+        try { dismissed = localStorage.getItem('ck_device_warn_dismissed') === '1'; } catch (_) { /* ignore */ }
+
+        const banner = document.getElementById('nb-device-warning');
+        if (banner && !dismissed) {
+            banner.hidden = false;
+            const closeBtn = document.getElementById('nb-device-warning-dismiss');
+            if (closeBtn) {
+                closeBtn.addEventListener('click', function () {
+                    banner.hidden = true;
+                    try { localStorage.setItem('ck_device_warn_dismissed', '1'); } catch (_) { /* ignore */ }
+                });
+            }
+        }
+
+        // Telemetry fires even if the banner was previously dismissed.
+        reportEvent({
+            kind:    'device_warning',
+            source:  'low_memory',
+            message: 'deviceMemory=' + (dm !== null ? dm : 'unknown')
+        });
+    }
+
+    // ----------------------------------------------------------------
     // Public surface
     // ----------------------------------------------------------------
 
     window.ChickadeeNotebookFailures = {
-        runPreflight:     runPreflight,
-        showFailure:      showFailure,
+        runPreflight:      runPreflight,
+        showFailure:       showFailure,
+        showDeviceWarning: showDeviceWarning,
         reportEditorError: reportEditorError,
         reportEvent:       reportEvent
     };

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -236,6 +236,15 @@
             if (d.kind === 'kernel_error' && d.source === 'exec_hang') {
                 recoverHungKernelOnce();
             }
+            // A fatal WASM/OOM crash (the kernel DIED — e.g. the upstream WebKit
+            // "Out of bounds memory access", or a genuine out-of-memory abort).
+            // The editor is now useless, so degrade gracefully: show the
+            // upload-fallback panel with a memory-specific message instead of
+            // leaving a silently-wedged cell. Independent of the telemetry cap so
+            // a breadcrumb flood can't gate it; showFailure() is idempotent.
+            if (d.kind === 'kernel_error' && d.source === 'wasm_crash' && failures.showFailure) {
+                failures.showFailure({ kind: 'wasm_crash', variant: 'memory', message: d.message });
+            }
             if (kernelDiagForwarded >= KERNEL_DIAG_MAX) return false;
             kernelDiagForwarded += 1;
             failures.reportEvent({
@@ -272,6 +281,12 @@
             }
             setStatus('error', 'In-browser editor unavailable — upload your notebook below.');
             return;
+        }
+        // Non-blocking proactive hint on low-RAM devices (Chromium-only signal).
+        // The editor still mounts — this just sets expectations before the kernel
+        // possibly runs out of memory mid-session.
+        if (result.lowMemory && failures && failures.showDeviceWarning) {
+            failures.showDeviceWarning({ deviceMemory: result.deviceMemory });
         }
         mountEditor();
     });

--- a/Resources/Views/notebook.leaf
+++ b/Resources/Views/notebook.leaf
@@ -19,6 +19,31 @@ Notebook
 .nb-fallback-diagnostic { margin-top: .6rem; }
 .nb-fallback-pre { white-space: pre-wrap; font-size: .85em; margin: .4rem 0; }
 
+/* Proactive low-memory hint (revealed by notebook-preflight.js on a low-RAM
+   device). Non-blocking and dismissible — the editor still loads beneath it. */
+.nb-device-warning {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    margin: .4rem 0;
+    padding: .5rem .75rem;
+    background: var(--warning-bg);
+    border: 1px solid var(--warning-border);
+    border-radius: .4rem;
+    color: var(--gray-700);
+    font-size: .9rem;
+}
+.nb-device-warning-text { flex: 1; }
+.nb-device-warning-dismiss {
+    border: 0;
+    background: transparent;
+    color: var(--gray-700);
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 .25rem;
+}
+
 /* The JupyterLite editor needs room and a pointer; it is unusable on a phone.
    Below 640px we hide the editor surface and show a notice instead.  Tablets
    (641px+) keep the full editor. */
@@ -27,6 +52,7 @@ Notebook
     .notebook-header,
     #jl-frame,
     #nb-fallback,
+    #nb-device-warning,
     #nb-results,
     #browser-runner-status { display: none; }
     .nb-smallscreen-notice {
@@ -56,6 +82,14 @@ Notebook
             #endif
         </div>
     </div>
+</div>
+<div id="nb-device-warning" class="nb-device-warning" role="note" hidden>
+    <span class="nb-device-warning-text">
+        This device may be low on memory for the in-browser editor. If the
+        notebook gets slow or the Python kernel stops, try a laptop or desktop
+        in Chrome or Firefox.
+    </span>
+    <button type="button" id="nb-device-warning-dismiss" class="nb-device-warning-dismiss" aria-label="Dismiss this notice">&times;</button>
 </div>
 <div class="nb-smallscreen-notice" role="note">
     <h2 class="nb-notice-title">Open on a larger screen</h2>

--- a/changelog.d/device-memory-resilience.md
+++ b/changelog.d/device-memory-resilience.md
@@ -1,0 +1,17 @@
+### Added
+
+- **Device-memory resilience for the in-browser notebook editor.** Two
+  complementary safeguards for low-memory / Safari devices, where the Pyodide
+  kernel can exhaust WebAssembly memory:
+  - **Proactive warning** — on a low-RAM device (`navigator.deviceMemory` ≤ 2 GB,
+    where the browser exposes it; Chromium does, Safari/Firefox omit it for
+    privacy), a non-blocking, dismissible banner suggests switching to a
+    laptop/desktop. The editor still loads normally.
+  - **Reactive recovery** — a fatal kernel crash (the upstream WebKit "Out of
+    bounds memory access", or a genuine WASM out-of-memory abort) is now caught
+    mid-session by the in-iframe collector and degrades gracefully to the
+    existing `.ipynb`-upload fallback with a memory-specific message, instead of
+    leaving a silently-wedged cell.
+  Both paths emit a diagnostic (`device_warning` / `wasm_crash`) so the
+  instructor dashboard surfaces the real low-memory-device and kernel-crash
+  rates. No always-on editor behaviour changes on healthy devices.


### PR DESCRIPTION
## What

Two complementary safeguards for the in-browser notebook editor on **low-memory / Safari devices**, where the Pyodide kernel can exhaust WebAssembly memory. No behaviour change on healthy devices.

### 1. Proactive warning (Chromium-visible)
`notebook-preflight.js` `runPreflight()` now also reads `navigator.deviceMemory`. On a low-RAM device (≤ 2 GB), `notebook.js` reveals a **non-blocking, dismissible** banner (`#nb-device-warning`) suggesting a laptop/desktop — the editor still mounts and works. Dismissal persists per-device (localStorage), and a `device_warning` beacon fires regardless of dismissal, so the dashboard learns the real low-memory-device rate.

> `deviceMemory` is Chromium-only (Safari/Firefox omit it for fingerprinting privacy) — so this proactively catches low-RAM Chromebooks/Android. iOS Safari (which hides the signal) is covered by the reactive path below.

### 2. Reactive recovery (covers Safari)
A **fatal kernel crash** — the upstream WebKit "Out of bounds memory access" ([#286266](https://bugs.webkit.org/show_bug.cgi?id=286266)) or a genuine WASM out-of-memory abort — kills the kernel *mid-session*, **after** the boot window. The collector's existing `reportError` is deliberately boot-window-only, so those were invisible. `jl-kernel-diagnostics.js` now has a dedicated, **not-`done`-gated**, one-shot listener that matches the fatal-crash signature and forwards a distinct **`wasm_crash`** source. `notebook.js` routes that to the existing `.ipynb`-upload fallback panel with a **memory-specific message** (via `showFailure({ variant: 'memory' })`) — instead of leaving a silently-wedged cell. A `wasm_crash` beacon gives the dashboard the real kernel-crash rate.

## Why this shape
Per the discussion: we **can't** fix the WebKit engine bug, and production telemetry shows real Safari students are mostly fine — so this is resilience + honest telemetry, not over-engineering. We deliberately skipped a static "system requirements" statement. The two beacons also double as the calibration data we were missing.

## Testing
- `node --check` on all three JS files; `scripts/check-styles.sh` + `scripts/check-css-vars.sh` pass (CSS uses the existing dark-mode-aware `--warning-bg` / `--warning-border`; the banner hides on phones alongside the editor).
- Can't be exercised in the local static harness (needs the server-seeded editor page) — relying on the render test (template still resolves) + the editor probes (boot unaffected). The proactive path only triggers where `deviceMemory ≤ 2`; the reactive path only on the crash signature, so healthy sessions are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm

---
_Generated by [Claude Code](https://claude.ai/code/session_012vFpX5Jg235pHPnGJgTsVm)_