### PR TITLE
fix(editor): no-cache on stable-name bundle assets so deploys propagate

### DIFF
--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -173,6 +173,14 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // existing Cache-Control.
     app.middleware.use(StaticAssetCacheMiddleware())
     app.middleware.use(RunnerWasmCacheMiddleware())
+    // Cache discipline for the editor bundle assets that ride the SLOW path
+    // (FileMiddleware) rather than EditorAssetFastPathMiddleware — notably
+    // /jupyterlite/jupyter-lite.json and the lab/notebooks/repl entry HTML, whose
+    // stable filenames hide mutable content. Stamps `no-cache` so a deploy
+    // propagates on the next load; immutable only for content-hashed chunks. The
+    // fast path stamps the build/extensions/pyodide trees itself (it
+    // short-circuits before this runs); this covers what falls through to it.
+    app.middleware.use(BundleAssetCacheMiddleware())
     // Cross-origin isolation for the notebook editor (unconditional). This
     // middleware runs BEFORE FileMiddleware so it can decorate the SLOW-PATH
     // /jupyterlite/* responses FileMiddleware serves (the editor HTML documents —

--- a/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
@@ -125,11 +125,10 @@ struct UpdateGlobalInputsTool: ContentTool {
                 actingUserID: actingUser.id,
                 inputs: .init(variables: input.variables, expressions: input.expressions ?? []),
                 testSetupsDirectory: context.request.application.testSetupsDirectory,
-                on: context.db,
                 // Content edits run on the (least-privilege) MCP pool; the
                 // acting-user seed bookkeeping runs on the owner pool, which is
                 // the only one granted `assignment_personalization_seeds`.
-                seedDB: context.mainDB)
+                pools: .init(content: context.db, seed: context.mainDB))
         } catch let error as WebAssignmentError {
             throw MCPToolError.from(error, tool: Self.name)
         }

--- a/Sources/APIServer/Middleware/BundleAssetCacheMiddleware.swift
+++ b/Sources/APIServer/Middleware/BundleAssetCacheMiddleware.swift
@@ -1,0 +1,76 @@
+// APIServer/Middleware/BundleAssetCacheMiddleware.swift
+//
+// Cache discipline for the vended in-browser editor bundle — JupyterLite
+// (`/jupyterlite/`) and Pyodide (`/pyodide/`). FileMiddleware serves these with
+// an ETag but NO Cache-Control, so browsers fall back to *heuristic* caching and
+// can reuse a stale copy for hours without revalidating. That is exactly how the
+// exec_hang fix (a changed kernel wheel, same filename) failed to reach
+// already-cached students after deploy — the bytes were new on the server, but
+// the browser never asked. This middleware makes propagation deterministic.
+//
+// Two policies, by filename shape:
+//   * Content-hashed chunks — `<name>.<hash>.{js,mjs,css,woff,woff2}` with a
+//     ≥7-char hex hash segment (the webpack/JupyterLite chunk shape, e.g.
+//     `1.f448c86.js`, `remoteEntry.c6732262d69c5d22.js`). The bytes behind such
+//     a URL never change — a rebuild mints a new hash → a new URL — so cache
+//     immutably for a year. Cheap repeat loads, clean busts.
+//   * Everything else — `jupyter-lite.json`, `all.json`, the `*.whl` kernel
+//     wheel, `pyodide.asm.wasm`, `pyodide-lock.json`, the entry HTML: a STABLE
+//     filename whose content changes on a deploy. `no-cache` = "revalidate
+//     before use"; with FileMiddleware's ETag that is a cheap 304 when
+//     unchanged, so a deploy propagates on the NEXT page load instead of waiting
+//     on the browser's cache heuristics.
+//
+// Immutable is gated on a cacheable *extension* (never `.json` / `.whl` /
+// `.wasm` / `.html`), so a mutable config file can never be frozen by accident —
+// the worst a misjudged filename costs is one extra 304. Registered just OUTSIDE
+// FileMiddleware (which short-circuits the chain) and skips any response that
+// already carries a Cache-Control, so it never overrides a more specific policy.
+
+import Vapor
+
+struct BundleAssetCacheMiddleware: AsyncMiddleware {
+    /// Extensions whose content-hashed builds may be cached immutably. Mutable
+    /// stable-name assets (`json`, `whl`, `wasm`, `zip`, `html`, …) are absent on
+    /// purpose: they always revalidate.
+    static let immutableExtensions: Set<String> = ["js", "mjs", "css", "woff", "woff2"]
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let response = try await next.respond(to: request)
+        let path = request.url.path
+        guard path.hasPrefix("/jupyterlite/") || path.hasPrefix("/pyodide/") else {
+            return response
+        }
+        guard
+            request.method == .GET || request.method == .HEAD,
+            response.status == .ok || response.status == .notModified,
+            response.headers.first(name: .cacheControl) == nil
+        else {
+            return response
+        }
+
+        if Self.isContentHashed(path) {
+            response.headers.replaceOrAdd(
+                name: .cacheControl, value: "public, max-age=31536000, immutable")
+        } else {
+            response.headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
+        }
+        return response
+    }
+
+    /// True when the final path component is `<name>.<hash>.<ext>` with a
+    /// cacheable extension and a ≥7-char pure-hex hash segment.
+    static func isContentHashed(_ path: String) -> Bool {
+        guard let filename = path.split(separator: "/").last else { return false }
+        let parts = filename.split(separator: ".")
+        guard
+            parts.count >= 3,
+            let ext = parts.last,
+            immutableExtensions.contains(ext.lowercased())
+        else {
+            return false
+        }
+        let hashSegment = parts[parts.count - 2]
+        return hashSegment.count >= 7 && hashSegment.allSatisfy { $0.isHexDigit }
+    }
+}

--- a/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
+++ b/Sources/APIServer/Middleware/EditorAssetFastPathMiddleware.swift
@@ -25,11 +25,14 @@
 //     change; a rebuild produces a new hash → new URL.  Cached immutably
 //     for a year, eliminating the per-boot revalidation storm.
 //   * Everything else on the fast path (unhashed names like the MathJax
-//     fonts, all of /pyodide/, /vendor/) keeps default ETag revalidation:
-//     re-vendoring rewrites those bytes IN PLACE under stable names —
-//     including the deterministically patched pyodide-kernel wheel — so
-//     immutable caching would pin stale bytes across an upgrade (#574's
-//     failure class).
+//     fonts, all of /pyodide/, /vendor/) is stamped `no-cache` so it
+//     revalidates: re-vendoring rewrites those bytes IN PLACE under stable
+//     names — including the deterministically patched pyodide-kernel wheel —
+//     so immutable caching would pin stale bytes across an upgrade (#574's
+//     failure class). `no-cache` (an explicit "revalidate before use", a cheap
+//     304 via ETag when unchanged) is required because an ETag ALONE lets the
+//     browser cache heuristically and skip the check — which is how a deployed
+//     wheel fix failed to reach already-loaded students until they hard-refreshed.
 //
 // On any miss (file absent, traversal attempt, undecodable path) the
 // request falls through to the normal chain unchanged, so worst case is
@@ -83,6 +86,16 @@ struct EditorAssetFastPathMiddleware: AsyncMiddleware {
         if Self.isContentHashedBundleAsset(path: path) {
             response.headers.replaceOrAdd(
                 name: .cacheControl, value: "public, max-age=31536000, immutable")
+        } else {
+            // Stable-name vendored bytes (the patched kernel wheel, all.json, the
+            // Pyodide runtime, MathJax fonts) are rewritten IN PLACE across a
+            // re-vendor, so they must revalidate. An ETag ALONE is not enough:
+            // with no Cache-Control the browser caches heuristically and skips the
+            // conditional request, which is exactly how a deployed wheel fix
+            // failed to reach already-loaded students for hours. `no-cache` forces
+            // a conditional GET — a cheap 304 when unchanged — so a deploy
+            // propagates on the next load instead of waiting on cache heuristics.
+            response.headers.replaceOrAdd(name: .cacheControl, value: "no-cache")
         }
         // The slow-path NotebookAssetIsolationMiddleware never sees these
         // short-circuited responses, so the fast path must isolate them itself.

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+GlobalVariables.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+GlobalVariables.swift
@@ -81,10 +81,9 @@ extension PublishedAssignmentRoutes {
             actingUserID: actingUserID,
             inputs: .init(variables: body.variables, expressions: body.expressions ?? []),
             testSetupsDirectory: req.application.testSetupsDirectory,
-            on: req.db,
             // Web requests use one (owner) pool; seed bookkeeping and content
             // share it here. The split only matters on the MCP least-privilege path.
-            seedDB: req.db
+            pools: .init(content: req.db, seed: req.db)
         )
         return GlobalVariablesResponse(
             variables: result.variables,

--- a/Sources/APIServer/Services/GlobalInputsService.swift
+++ b/Sources/APIServer/Services/GlobalInputsService.swift
@@ -38,6 +38,21 @@ enum GlobalInputsService {
         let expressions: [PersonalizationExpression]
     }
 
+    /// The two database pools `apply` needs, bundled to keep the entry point
+    /// within the parameter-count budget (the same reason `Inputs` exists).
+    /// They are one pool for web callers; the MCP least-privilege path splits
+    /// them:
+    /// - `content`: the pool for content reads/writes (the manifest re-render).
+    ///   On the MCP path this is the least-privilege `.mcp` pool.
+    /// - `seed`: the pool for the acting-user seed bookkeeping
+    ///   (`assignment_personalization_seeds`). On the MCP path this MUST be the
+    ///   owner pool (`ToolContext.mainDB`), because the `chickadee_mcp` role is
+    ///   denied that table; web callers pass `req.db` for both.
+    struct Pools {
+        let content: any Database
+        let seed: any Database
+    }
+
     /// The currently-persisted global inputs for a setup (no validation).
     static func current(setup: APITestSetup) throws -> Result {
         let manifest = try decoded(setup)
@@ -55,20 +70,14 @@ enum GlobalInputsService {
     ///   still run.
     /// - `testSetupsDirectory`: the app's test-setups root, used to resolve the
     ///   per-setup `shared/<id>/` support-files directory for expression eval.
-    /// - `db`: the pool for content reads/writes (the manifest re-render). On
-    ///   the MCP path this is the least-privilege `.mcp` pool.
-    /// - `seedDB`: the pool for the acting-user seed bookkeeping
-    ///   (`assignment_personalization_seeds`). On the MCP path this MUST be the
-    ///   owner pool (`ToolContext.mainDB`), because the `chickadee_mcp` role is
-    ///   denied that table; web callers pass `req.db` (same as `db`).
+    /// - `pools`: the content + seed database pools (see `Pools`).
     static func apply(
         setup: APITestSetup,
         assignment: APIAssignment,
         actingUserID: UUID?,
         inputs: Inputs,
         testSetupsDirectory: String,
-        on db: any Database,
-        seedDB: any Database
+        pools: Pools
     ) async throws -> Result {
         let manifest = try decoded(setup)
 
@@ -80,15 +89,15 @@ enum GlobalInputsService {
         // 3. Starter-notebook `{{undeclared}}` scan.
         try validateStarterNotebookPlaceholders(seenNames: seenNames, manifest: manifest, setup: setup)
         // 4. Save-time eval check against the acting user's own seed. The seed
-        // lookup/insert runs on `seedDB` (the owner pool on the MCP path), not
-        // the content `db`, so it never needs a grant on the `.mcp` role.
+        // lookup/insert runs on `pools.seed` (the owner pool on the MCP path),
+        // not the content pool, so it never needs a grant on the `.mcp` role.
         try await evaluateForActingSeed(
             actingUserID: actingUserID,
             assignment: assignment,
             manifest: manifest,
             inputs: inputs,
             testSetupsDirectory: testSetupsDirectory,
-            seedDB: seedDB)
+            seedDB: pools.seed)
 
         // 5. Re-render through `applyPatternFamilies` so generated tests and raw
         // scripts pick up the new literal values.  Expressions flow through
@@ -101,7 +110,7 @@ enum GlobalInputsService {
             sections: manifest.sections,
             globalVariables: inputs.variables,
             globalExpressions: inputs.expressions,
-            on: db)
+            on: pools.content)
 
         // 6. Re-load the persisted manifest so the response reflects reconciled state.
         return try current(setup: setup)

--- a/Tests/APITests/BundleAssetCacheMiddlewareTests.swift
+++ b/Tests/APITests/BundleAssetCacheMiddlewareTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+/// BundleAssetCacheMiddleware stamps cache policy on the editor-bundle assets
+/// that ride the SLOW path (FileMiddleware) rather than the fast path — chiefly
+/// /jupyterlite/jupyter-lite.json and the lab/notebooks/repl entry HTML. Pins:
+///   1. stable-name bundle files (json, html) get `no-cache` so a deploy is
+///      picked up on the next load instead of waiting on cache heuristics;
+///   2. content-hashed chunks still get immutable caching;
+///   3. paths outside /jupyterlite/ and /pyodide/ are left untouched.
+@Suite final class BundleAssetCacheMiddlewareTests {
+    private let publicDir: String
+    private let tempRoot: String
+
+    init() throws {
+        tempRoot =
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-bundlecache-\(UUID().uuidString)")
+            .path
+        publicDir = tempRoot + "/Public/"
+        let fixtures: [(String, String)] = [
+            ("jupyterlite/jupyter-lite.json", "{}"),
+            ("jupyterlite/lab/index.html", "<html></html>"),
+            ("jupyterlite/build/100.5a28c9e.js", "hashed-chunk"),
+            ("styles.css", "body{}"),
+        ]
+        for (relativePath, contents) in fixtures {
+            let absolute = publicDir + relativePath
+            try FileManager.default.createDirectory(
+                atPath: (absolute as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true)
+            try contents.write(toFile: absolute, atomically: true, encoding: .utf8)
+        }
+    }
+
+    deinit { try? FileManager.default.removeItem(atPath: tempRoot) }
+
+    private func makeApp() async throws -> Application {
+        let app = try await Application.make(.testing)
+        app.middleware.use(BundleAssetCacheMiddleware())
+        app.middleware.use(FileMiddleware(publicDirectory: publicDir))
+        return app
+    }
+
+    @Test func stableNameBundleConfigRevalidates() async throws {
+        try await withApp(try await makeApp()) { app in
+            for path in ["/jupyterlite/jupyter-lite.json", "/jupyterlite/lab/index.html"] {
+                try await app.testing().test(.GET, path) { res async in
+                    #expect(res.status == .ok)
+                    #expect(res.headers.first(name: .cacheControl) == "no-cache")
+                }
+            }
+        }
+    }
+
+    @Test func contentHashedSlowPathChunkIsImmutable() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/build/100.5a28c9e.js") { res async in
+                #expect(res.status == .ok)
+                #expect(
+                    res.headers.first(name: .cacheControl)
+                        == "public, max-age=31536000, immutable")
+            }
+        }
+    }
+
+    @Test func nonBundlePathsAreUntouched() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/styles.css") { res async in
+                #expect(res.status == .ok)
+                // Not under /jupyterlite/ or /pyodide/, so this middleware adds nothing.
+                #expect(res.headers.first(name: .cacheControl) == nil)
+            }
+        }
+    }
+
+    @Test(arguments: [
+        ("/jupyterlite/build/100.5a28c9e.js", true),
+        ("/jupyterlite/extensions/x/static/remoteEntry.c6732262d69c5d22.js", true),
+        ("/jupyterlite/build/154.377fd2862adcf65a4294.js", true),
+        ("/jupyterlite/jupyter-lite.json", false),
+        ("/jupyterlite/extensions/x/static/pypi/all.json", false),
+        ("/jupyterlite/extensions/x/static/pypi/pyodide_kernel-0.7.2-py3-none-any.whl", false),
+        ("/pyodide/pyodide.asm.wasm", false),
+        ("/pyodide/pyodide.asm.js", false),
+        ("/jupyterlite/lab/index.html", false),
+    ])
+    func contentHashDetection(path: String, expected: Bool) {
+        #expect(BundleAssetCacheMiddleware.isContentHashed(path) == expected)
+    }
+}

--- a/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
+++ b/Tests/APITests/EditorAssetFastPathMiddlewareTests.swift
@@ -11,8 +11,9 @@ import VaporTesting
 ///      fast path must not serve student working copies to anonymous
 ///      callers just because they live under /jupyterlite/.
 ///   2. Immutable cache headers land only on content-hashed bundle
-///      filenames; everything else keeps default revalidation so a
-///      re-vendor that rewrites bytes in place is picked up.
+///      filenames; everything else gets an explicit `no-cache` so a
+///      re-vendor that rewrites bytes in place is picked up on the next load
+///      (an ETag alone lets the browser cache heuristically and skip the check).
 @Suite final class EditorAssetFastPathMiddlewareTests {
     private let publicDir: String
     private let tempRoot: String
@@ -93,14 +94,14 @@ import VaporTesting
                 .GET, "/jupyterlite/build/MathJax_Main-Regular.woff"
             ) { res async in
                 #expect(res.status == .ok)
-                #expect(res.headers.first(name: .cacheControl) == nil)
+                #expect(res.headers.first(name: .cacheControl) == "no-cache")
                 #expect(res.headers.first(name: .eTag) != nil)
             }
             try await app.testing().test(
                 .GET, "/jupyterlite/extensions/@jupyterlite/kernel/install.json"
             ) { res async in
                 #expect(res.status == .ok)
-                #expect(res.headers.first(name: .cacheControl) == nil)
+                #expect(res.headers.first(name: .cacheControl) == "no-cache")
             }
         }
     }
@@ -110,7 +111,7 @@ import VaporTesting
             for path in ["/pyodide/pyodide-lock.json", "/vendor/jszip.min.js"] {
                 try await app.testing().test(.GET, path) { res async in
                     #expect(res.status == .ok)
-                    #expect(res.headers.first(name: .cacheControl) == nil)
+                    #expect(res.headers.first(name: .cacheControl) == "no-cache")
                     #expect(res.headers.first(name: .eTag) != nil)
                 }
             }

--- a/Tests/APITests/EmptySuitePersonalizationTests.swift
+++ b/Tests/APITests/EmptySuitePersonalizationTests.swift
@@ -77,8 +77,7 @@ import Vapor
                     ],
                     expressions: []),
                 testSetupsDirectory: app.testSetupsDirectory,
-                on: app.db,
-                seedDB: app.db)
+                pools: .init(content: app.db, seed: app.db))
 
             #expect(result.variables.contains { $0.name == "fortunes" })
 

--- a/Tests/APITests/MCP/MCPSeedMainPoolTests.swift
+++ b/Tests/APITests/MCP/MCPSeedMainPoolTests.swift
@@ -66,8 +66,7 @@ import Vapor
                             variables: [],
                             expressions: [PersonalizationExpression(name: "x", expression: "seed % 2")]),
                         testSetupsDirectory: app.testSetupsDirectory,
-                        on: app.db,
-                        seedDB: seedlessApp.db)
+                        pools: .init(content: app.db, seed: seedlessApp.db))
                 }
 
                 let leaked = try await APIAssignmentPersonalizationSeed.query(on: app.db).count()

--- a/changelog.d/bundle-cache-no-cache.md
+++ b/changelog.d/bundle-cache-no-cache.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **Editor bundle updates now reach students on the next page load instead of
+  waiting on browser cache heuristics.** The vendored JupyterLite/Pyodide bundle
+  assets with stable filenames (the patched kernel wheel, `all.json`,
+  `jupyter-lite.json`, the Pyodide runtime, fonts) were served with an ETag but
+  no `Cache-Control`, so browsers cached them *heuristically* and could reuse a
+  stale copy for hours without revalidating — which is why the `exec_hang` wheel
+  fix (#1029) took hours to reach already-loaded students and needed a hard
+  refresh. These now carry explicit `Cache-Control: no-cache` (revalidate to a
+  cheap bodyless 304 when unchanged), so a deploy propagates deterministically.
+  Content-hashed chunks (the bulk of the bundle) keep immutable caching, so this
+  adds a revalidation round-trip only for the handful of stable-name assets — all
+  on the session-lookup-free fast path. `EditorAssetFastPathMiddleware` stamps the
+  `build/`/`extensions/`/`pyodide/` trees it serves; the new
+  `BundleAssetCacheMiddleware` covers the slow-path `jupyter-lite.json` and the
+  lab/notebooks/repl entry HTML.


### PR DESCRIPTION
## Why

The `exec_hang` wheel fix (#1029) was correct and deployed, but took **hours** to reach already-loaded students and needed a hard refresh. Root cause: the vendored JupyterLite/Pyodide bundle assets with **stable filenames** (the patched kernel wheel, `all.json`, `jupyter-lite.json`, the Pyodide runtime, fonts) were served with an ETag but **no `Cache-Control`**, so browsers cached them *heuristically* and reused stale copies without revalidating.

## What

Stamp explicit **`Cache-Control: no-cache`** on those stable-name assets — "revalidate before use," a cheap **bodyless 304** via the existing ETag when unchanged. A deploy now propagates deterministically on the next page load.

- **`EditorAssetFastPathMiddleware`** — non-content-hashed fast-path assets (the wheel, `all.json`, `/pyodide`, `/vendor`, MathJax fonts) now get `no-cache` instead of being left to heuristic caching. This was the latent bug: the comment claimed "default ETag revalidation," but an ETag *alone* lets the browser skip the check.
- **`BundleAssetCacheMiddleware`** (new) — covers the slow-path `/jupyterlite` assets FileMiddleware serves (`jupyter-lite.json`, the lab/notebooks/repl entry HTML): `no-cache`, with immutable for any content-hashed chunk.

**Content-hashed chunks (the bulk of the bundle) keep immutable caching**, so this adds a revalidation round-trip only for the handful of stable-name assets — all on the session-lookup-free fast path, so server cost is a file `stat`.

## Verified

Empirically confirmed both serving paths return **304** on a matching `If-None-Match`, so `no-cache` revalidates without re-sending the body (the 9 MB wasm is never re-downloaded on a revalidation):

```
/pyodide/pyodide-lock.json   → no-cache → 304
/jupyterlite/jupyter-lite.json → no-cache → 304
hashed chunk                  → public, max-age=31536000, immutable
```

23 tests across the 4 cache-middleware suites pass.

## Tradeoff (discussed)

Cost is ~10–30 extra conditional GETs (304s, no body) per editor boot for the stable-name assets, HTTP/2-multiplexed, on the no-DB fast path — negligible vs. boot time, and the immutable chunk bulk is unchanged. Benefit is deterministic propagation: no more multi-hour stale window. Considered `max-age=short` / `stale-while-revalidate` / URL-versioning; `no-cache` is the simplest deterministic option and the 304s are verified-cheap. If `/pyodide` runtime revalidation latency is ever measured as a problem on poor connections, those large rarely-changing assets can move to a short `max-age` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_