### PR TITLE
feat(diagnostics): build-version tagging + alert only on unrecoverable kernel hangs

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -63,6 +63,12 @@
                 message: parts.join(';'),
             };
             if (setupID) body.testSetupID = setupID;
+            // Page-build version (the `app-version` meta), so submit breadcrumbs
+            // are attributable to a build like the editor diagnostics. Best-effort.
+            try {
+                const m = document.querySelector('meta[name="app-version"]');
+                if (m && m.content) body.appVersion = String(m.content).slice(0, 32);
+            } catch (_) { /* meta absent — fine */ }
             let csrf = '';
             try { csrf = (typeof getCsrfToken === 'function') ? getCsrfToken() : ''; } catch (_) { /* no token */ }
             fetch('/api/v1/client-diagnostics', {

--- a/Public/freeze-watchdog-worker.js
+++ b/Public/freeze-watchdog-worker.js
@@ -38,6 +38,9 @@ var beaconUrl = null;
 var setupID = null;
 var csrfToken = '';
 var thresholdMs = 8000;
+// Page-build ChickadeeVersion, passed in via `init` (a worker has no DOM to read
+// the meta). Stamped on the beacon so a freeze is attributable to a build.
+var appVersion = '';
 var lastBeatMs = Date.now();
 var visible = true;
 var reportedForThisStall = false;
@@ -134,6 +137,7 @@ function beacon(stalledMs) {
     try {
         var body = { kind: 'page_unresponsive', message: 'stalled_ms=' + stalledMs };
         if (setupID) body.testSetupID = setupID;
+        if (appVersion) body.appVersion = appVersion;
         fetch(beaconUrl, {
             method: 'POST',
             credentials: 'same-origin',
@@ -155,6 +159,7 @@ self.onmessage = function (e) {
             beaconUrl = msg.beaconUrl || null;
             setupID = msg.setupID || null;
             csrfToken = msg.csrfToken || '';
+            appVersion = msg.appVersion || '';
             if (typeof msg.thresholdMs === 'number') thresholdMs = msg.thresholdMs;
             lastBeatMs = Date.now();
             if (!timer) timer = setInterval(check, 1000);

--- a/Public/notebook-preflight.js
+++ b/Public/notebook-preflight.js
@@ -160,6 +160,16 @@
         });
     }
 
+    // The page build's ChickadeeVersion, from the `app-version` meta the base
+    // layout renders. Lets each diagnostic be attributed to a build — an old
+    // value flags a stale browser tab still on the pre-deploy bundle. '' absent.
+    function readAppVersion() {
+        try {
+            const meta = document.querySelector('meta[name="app-version"]');
+            return (meta && meta.content) ? String(meta.content).slice(0, 32) : '';
+        } catch (_) { return ''; }
+    }
+
     async function postDiagnostic(info) {
         const frame     = document.getElementById('jl-frame');
         const setupID   = frame && frame.dataset ? frame.dataset.setupId : null;
@@ -173,6 +183,10 @@
         if (info.message) body.message = String(info.message).slice(0, 2000);
         if (info.stack)   body.stack   = String(info.stack).slice(0, 8000);
         if (info.source)  body.source  = String(info.source).slice(0, 64);
+        // Page-build version, so a diagnostic is attributable to a build and a
+        // stale tab (old appVersion) is distinguishable. Best-effort.
+        const appVersion = readAppVersion();
+        if (appVersion) body.appVersion = appVersion;
 
         await fetch(PREFLIGHT_DIAGNOSTICS_URL, {
             method:  'POST',

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -59,11 +59,17 @@
             freezeWorker = new Worker('/freeze-watchdog-worker.js');
             let freezeCsrf = '';
             try { freezeCsrf = (typeof getCsrfToken === 'function') ? getCsrfToken() : ''; } catch (_) { /* no token */ }
+            let freezeAppVersion = '';
+            try {
+                const vm = document.querySelector('meta[name="app-version"]');
+                freezeAppVersion = (vm && vm.content) ? String(vm.content).slice(0, 32) : '';
+            } catch (_) { /* no meta — fine */ }
             freezeWorker.postMessage({
                 type: 'init',
                 beaconUrl: '/api/v1/client-diagnostics',
                 setupID: setupID,
                 csrfToken: freezeCsrf,
+                appVersion: freezeAppVersion,
                 thresholdMs: 8000,
             });
             const sendFreezeBeat = () => {

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
@@ -40,6 +40,7 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         let message: String?
         let stack: String?
         let userAgent: String?
+        let appVersion: String?
         let testSetupID: String?
         let createdAt: Date
     }
@@ -55,6 +56,12 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         /// breakdown needed to localize editor problems (e.g. "Kernel Unknown" on
         /// a specific platform). Derived from the User-Agent; no student identity.
         let byBrowser: [CountEntry]
+        /// Events grouped by the page build's ChickadeeVersion (the `app_version`
+        /// the client sent; "unknown" when absent). An `exec_hang` / `recover_failed`
+        /// concentrated on an OLD appVersion is a stale-tab / cached-bundle symptom
+        /// (that browser never re-fetched the fixed bundle/wheel), distinct from one
+        /// on the CURRENT build, which would mean the deployed fix is incomplete.
+        let byAppVersion: [CountEntry]
         /// Submit-flow funnel: `submit_phase` breadcrumb counts in phase order
         /// (grading_start → … → result_posted). The drop-off between consecutive
         /// phases shows where in-browser submissions are lost to a freeze — the
@@ -90,8 +97,11 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         + "breakdowns by kind (preflight_fail / watchdog_timeout / editor_error / page_unresponsive for "
         + "editor-load failures, editor_ready as the success denominator and sw_state for service-worker "
         + "registration, and submit_phase / submit_error for the grading/submission flow), by source, by "
-        + "failed capability check, and by browser/OS (byBrowser, e.g. Safari/iOS) so failures can be "
-        + "localized per device class, over a window, plus recent samples with the error message and stack. Also "
+        + "failed capability check, by browser/OS (byBrowser, e.g. Safari/iOS) so failures can be "
+        + "localized per device class, and by page-build version (byAppVersion: the ChickadeeVersion the "
+        + "client was running; an exec_hang/recover_failed concentrated on an OLD version is a stale-tab / "
+        + "cached-bundle symptom, vs. one on the current build meaning the deployed fix is incomplete), over "
+        + "a window, plus recent samples with the error message and stack. Also "
         + "returns submitFunnel: the submit_phase breadcrumb counts in phase order "
         + "(grading_start → runtime_loaded → setup_unpacked → suite_started → suite_done → "
         + "result_posting → result_posted) — the drop-off between consecutive phases shows where "
@@ -147,9 +157,11 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         var bySource: [String: Int] = [:]
         var byCheck: [String: Int] = [:]
         var byBrowser: [String: Int] = [:]
+        var byAppVersion: [String: Int] = [:]
         for row in rows {
             byKind[row.kind, default: 0] += 1
             byBrowser[Self.browserLabel(forUserAgent: row.userAgent), default: 0] += 1
+            byAppVersion[row.appVersion ?? "unknown", default: 0] += 1
             if let source = row.source { bySource[source, default: 0] += 1 }
             if let checks = row.failedChecks {
                 for check in checks.split(separator: ",") {
@@ -189,6 +201,7 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
                 message: row.message,
                 stack: row.stack,
                 userAgent: row.userAgent,
+                appVersion: row.appVersion,
                 testSetupID: row.testSetupID,
                 createdAt: row.createdAt ?? Date())
         }
@@ -200,6 +213,7 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
             bySource: Self.sortedCounts(bySource),
             byFailedCheck: Self.sortedCounts(byCheck),
             byBrowser: Self.sortedCounts(byBrowser),
+            byAppVersion: Self.sortedCounts(byAppVersion),
             submitFunnel: submitFunnel,
             kernelBootFunnel: kernelBootFunnel,
             recentSamples: Array(samples))

--- a/Sources/APIServer/Migrations/AddClientDiagnosticAppVersion.swift
+++ b/Sources/APIServer/Migrations/AddClientDiagnosticAppVersion.swift
@@ -1,0 +1,27 @@
+// APIServer/Migrations/AddClientDiagnosticAppVersion.swift
+//
+// Adds the `app_version` column to client_diagnostics: the ChickadeeVersion of
+// the page build that emitted each browser diagnostic (from the `app-version`
+// meta tag). It lets a report be attributed to a build — an OLD value flags a
+// stale browser tab still running pre-deploy code (and serving its cached
+// editor bundle/wheel), so a recurring failure on an old appVersion reads as a
+// stale-cache symptom rather than a live regression.
+//
+// Shipped as a standalone Add* migration (not folded into
+// CreateClientDiagnostics) because production databases have already applied
+// CreateClientDiagnostics without this column and would never pick it up from a
+// model change. Fresh deploys run CreateClientDiagnostics then this migration;
+// existing prod runs only this one. Nullable, so existing rows and older clients
+// that don't send the field stay valid.
+
+import Fluent
+
+struct AddClientDiagnosticAppVersion: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("client_diagnostics").field("app_version", .string).update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("client_diagnostics").deleteField("app_version").update()
+    }
+}

--- a/Sources/APIServer/Models/APIClientDiagnostic.swift
+++ b/Sources/APIServer/Models/APIClientDiagnostic.swift
@@ -54,6 +54,15 @@ final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
     @OptionalField(key: "source")
     var source: String?
 
+    /// ChickadeeVersion of the page build that emitted this report (from the
+    /// `app-version` meta tag the page carries). Lets a diagnostic be attributed
+    /// to a build: an OLD value means a stale browser tab still running
+    /// pre-deploy code — and serving its cached editor bundle/wheel — so a
+    /// recurring failure on an old appVersion is a stale-cache symptom, not a
+    /// live regression. nil for clients that predate this field.
+    @OptionalField(key: "app_version")
+    var appVersion: String?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
@@ -67,7 +76,8 @@ final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
         userAgent: String?,
         message: String? = nil,
         stack: String? = nil,
-        source: String? = nil
+        source: String? = nil,
+        appVersion: String? = nil
     ) {
         self.userID = userID
         self.testSetupID = testSetupID
@@ -77,5 +87,6 @@ final class APIClientDiagnostic: Model, Content, @unchecked Sendable {
         self.message = message
         self.stack = stack
         self.source = source
+        self.appVersion = appVersion
     }
 }

--- a/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
+++ b/Sources/APIServer/Routes/ClientDiagnosticsRoutes.swift
@@ -100,6 +100,7 @@ struct ClientDiagnosticsRoutes: RouteCollection {
         let trimmedSource = body.source.map { String($0.prefix(64)) }
         let trimmedMessage = body.message.map { String($0.prefix(1024)) }
         let trimmedStack = body.stack.map { String($0.prefix(4096)) }
+        let trimmedAppVersion = body.appVersion.map { String($0.prefix(32)) }
 
         // De-duplicate within an hour so reloads don't multiply rows.  The
         // source is part of the key so distinct error origins (onerror vs.
@@ -135,7 +136,8 @@ struct ClientDiagnosticsRoutes: RouteCollection {
             userAgent: trimmedAgent,
             message: trimmedMessage,
             stack: trimmedStack,
-            source: trimmedSource
+            source: trimmedSource,
+            appVersion: trimmedAppVersion
         )
         try await record.save(on: req.db)
         return .accepted
@@ -157,6 +159,10 @@ struct ClientDiagnosticBody: Content {
     var stack: String?
     /// Origin of the error: "onerror" | "unhandledrejection" | "kernel".
     var source: String?
+    /// ChickadeeVersion of the page build that emitted this report (from the
+    /// `app-version` meta tag). Lets a diagnostic be attributed to a build —
+    /// an old value flags a stale browser tab still on pre-deploy code.
+    var appVersion: String?
 }
 
 // MARK: - Rate limiter

--- a/Sources/APIServer/Services/AlertNotifier.swift
+++ b/Sources/APIServer/Services/AlertNotifier.swift
@@ -5,7 +5,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
     case runnerOffline
     case queueBackedUp
     case errorRateSpike
-    case editorKernelHang
+    case editorKernelUnrecoverable
     case databaseUnreachable
 
     var humanReadable: String {
@@ -13,7 +13,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
         case .runnerOffline: return "Runner offline"
         case .queueBackedUp: return "Submission queue backed up"
         case .errorRateSpike: return "System-level failure rate spike"
-        case .editorKernelHang: return "Editor kernel hang spike"
+        case .editorKernelUnrecoverable: return "Editor kernel unrecoverable"
         case .databaseUnreachable: return "Database unreachable"
         }
     }
@@ -24,7 +24,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
         case .runnerOffline: return "warning"
         case .queueBackedUp: return "warning"
         case .errorRateSpike: return "warning"
-        case .editorKernelHang: return "warning"
+        case .editorKernelUnrecoverable: return "warning"
         }
     }
 }

--- a/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
@@ -14,14 +14,16 @@ struct ServerHealthAlertConfiguration: Sendable {
     let errorRateThreshold: Double
     let errorRateWindowSize: Int
     let errorRateMinimumSamples: Int
-    /// Editor kernel-hang spike rule: fire when at least `editorHangThreshold`
-    /// distinct post-idle `exec_hang` reports land within the last
-    /// `editorHangWindowMinutes`. This is the recurrence tripwire for the
-    /// SAB/Atomics kernel deadlock — the boot funnel and watchdog can't see a
-    /// kernel that booted then wedged, so without this a regression is invisible
-    /// until students complain in the lab.
-    let editorHangThreshold: Int
-    let editorHangWindowMinutes: Int
+    /// Editor kernel-UNRECOVERABLE rule: fire when at least
+    /// `editorUnrecoverableThreshold` distinct `recover_failed` reports land
+    /// within the last `editorUnrecoverableWindowMinutes`. `recover_failed`
+    /// means a student's kernel hung, the editor auto-rebooted it, and it hung
+    /// AGAIN — the student genuinely cannot proceed. Plain post-idle `exec_hang`s
+    /// that auto-recover are deliberately NOT alerted on (they stay in
+    /// client-diagnostics telemetry for analysis); this rule pages only on the
+    /// students who are actually stuck.
+    let editorUnrecoverableThreshold: Int
+    let editorUnrecoverableWindowMinutes: Int
     let webhookURLFromEnvironment: String?
 
     static let `default` = ServerHealthAlertConfiguration(
@@ -34,8 +36,8 @@ struct ServerHealthAlertConfiguration: Sendable {
         errorRateThreshold: 0.30,
         errorRateWindowSize: 50,
         errorRateMinimumSamples: 10,
-        editorHangThreshold: 3,
-        editorHangWindowMinutes: 60,
+        editorUnrecoverableThreshold: 2,
+        editorUnrecoverableWindowMinutes: 60,
         webhookURLFromEnvironment: nil
     )
 
@@ -50,8 +52,10 @@ struct ServerHealthAlertConfiguration: Sendable {
             errorRateThreshold: environmentDouble("ALERT_ERROR_RATE_THRESHOLD") ?? 0.30,
             errorRateWindowSize: environmentInt("ALERT_ERROR_RATE_WINDOW") ?? 50,
             errorRateMinimumSamples: environmentInt("ALERT_ERROR_RATE_MIN_SAMPLES") ?? 10,
-            editorHangThreshold: environmentInt("ALERT_EDITOR_HANG_THRESHOLD") ?? 3,
-            editorHangWindowMinutes: environmentInt("ALERT_EDITOR_HANG_WINDOW_MINUTES") ?? 60,
+            editorUnrecoverableThreshold: environmentInt("ALERT_EDITOR_UNRECOVERABLE_THRESHOLD")
+                ?? environmentInt("ALERT_EDITOR_HANG_THRESHOLD") ?? 2,
+            editorUnrecoverableWindowMinutes: environmentInt("ALERT_EDITOR_UNRECOVERABLE_WINDOW_MINUTES")
+                ?? environmentInt("ALERT_EDITOR_HANG_WINDOW_MINUTES") ?? 60,
             webhookURLFromEnvironment: trimmedEnv("ALERT_WEBHOOK_URL")
         )
     }

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -45,8 +45,8 @@ func evaluateHealthRules(
             configuration: configuration,
             now: now
         )) ?? .ok
-    results[.editorKernelHang] =
-        (try? await evaluateEditorKernelHang(
+    results[.editorKernelUnrecoverable] =
+        (try? await evaluateEditorKernelUnrecoverable(
             on: application,
             configuration: configuration,
             now: now
@@ -214,48 +214,51 @@ private func evaluateErrorRateSpike(
     )
 }
 
-/// Decides the editor-kernel-hang rule purely from a count, so the firing
-/// threshold is table-testable without a database. Fire when at least
-/// `threshold` post-idle `exec_hang` reports landed inside the window — a
-/// recurrence of the SAB/Atomics kernel deadlock that the boot funnel and
-/// watchdog cannot see (the kernel booted to idle, then wedged on execute).
-func decideEditorKernelHang(
-    hangCount: Int,
+/// Decides the editor-kernel-UNRECOVERABLE rule purely from a count, so the
+/// firing threshold is table-testable without a database. Fire when at least
+/// `threshold` `recover_failed` reports landed inside the window — a student
+/// whose kernel hung, was auto-rebooted by the editor, and hung AGAIN, so they
+/// genuinely cannot proceed. Plain post-idle `exec_hang`s that auto-recover are
+/// NOT counted here — this rule pages only on the students who are actually stuck.
+func decideEditorKernelUnrecoverable(
+    failedCount: Int,
     threshold: Int,
     windowMinutes: Int
 ) -> RuleEvaluation {
-    guard threshold > 0, hangCount >= threshold else { return .ok }
+    guard threshold > 0, failedCount >= threshold else { return .ok }
     return RuleEvaluation(
         isFiring: true,
         summary:
-            "\(hangCount) editor kernel hang(s) reported in the last \(windowMinutes)m "
-            + "(post-idle exec_hang; threshold \(threshold))",
+            "\(failedCount) student(s) could not recover after an editor kernel reboot "
+            + "in the last \(windowMinutes)m (recover_failed; threshold \(threshold))",
         details: [
-            "exec_hang_count": String(hangCount),
+            "recover_failed_count": String(failedCount),
             "window_minutes": String(windowMinutes),
             "threshold": String(threshold),
         ]
     )
 }
 
-private func evaluateEditorKernelHang(
+private func evaluateEditorKernelUnrecoverable(
     on application: Application,
     configuration: ServerHealthAlertConfiguration,
     now: Date
 ) async throws -> RuleEvaluation {
-    let windowStart = now.addingTimeInterval(-Double(configuration.editorHangWindowMinutes) * 60)
-    // exec_hang rides the free-form `source` on the `kernel_error` kind
-    // (jl-kernel-diagnostics.js → ClientDiagnosticsRoutes). One row per distinct
-    // student-page that hit a sustained post-idle busy hang.
-    let hangCount = try await APIClientDiagnostic.query(on: application.db)
+    let windowStart = now.addingTimeInterval(-Double(configuration.editorUnrecoverableWindowMinutes) * 60)
+    // recover_failed rides the free-form `source` on the `kernel_error` kind
+    // (notebook.js recoverHungKernelOnce → ClientDiagnosticsRoutes): the editor
+    // auto-rebooted a hung kernel and it hung AGAIN. One row per distinct
+    // student-page that could not recover — the genuinely-stuck students. Plain
+    // `exec_hang`s (which usually auto-recover) are intentionally not counted.
+    let failedCount = try await APIClientDiagnostic.query(on: application.db)
         .filter(\.$kind == "kernel_error")
-        .filter(\.$source == "exec_hang")
+        .filter(\.$source == "recover_failed")
         .filter(\.$createdAt >= windowStart)
         .count()
-    return decideEditorKernelHang(
-        hangCount: hangCount,
-        threshold: configuration.editorHangThreshold,
-        windowMinutes: configuration.editorHangWindowMinutes
+    return decideEditorKernelUnrecoverable(
+        failedCount: failedCount,
+        threshold: configuration.editorUnrecoverableThreshold,
+        windowMinutes: configuration.editorUnrecoverableWindowMinutes
     )
 }
 

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -330,6 +330,11 @@ func registerMigrations(on app: Application) {
     // browser-side failures carry diagnosable signal.
     app.migrations.add(AddClientDiagnosticErrorDetail())
 
+    // app_version column on client_diagnostics: the page build that emitted each
+    // report, so a diagnostic can be attributed to a build (an old value flags a
+    // stale browser tab / cached bundle, not a live regression).
+    app.migrations.add(AddClientDiagnosticAppVersion())
+
     // Per-course role on each enrollment (Phase 1 of
     // docs/multi-course-roles.md). Behaviour-preserving: backfills role from
     // each user's current global role; nothing reads it yet. Runs after

--- a/Tests/APITests/ClientDiagnosticsRoutesTests.swift
+++ b/Tests/APITests/ClientDiagnosticsRoutesTests.swift
@@ -318,6 +318,48 @@ import VaporTesting
         }
     }
 
+    @Test func persistsAppVersionWhenProvided() async throws {
+        try await withApp(app) { _ in
+            // Every diagnostic stamps the page build's `app-version` so a report
+            // can be attributed to a build — an old value flags a stale browser
+            // tab still serving the pre-deploy bundle.
+            let auth = try await loginAsStudent()
+            try await insertSetup(id: "setup_ver")
+            let body = #"""
+                {"kind":"kernel_error","testSetupID":"setup_ver","source":"recover_failed","appVersion":"0.4.530"}
+                """#
+            let res = try await postJSON(body, auth: auth, userAgent: "TestUA/9.0")
+            #expect(res.status == .accepted)
+
+            let rec = try #require(try await APIClientDiagnostic.query(on: app.db).first())
+            #expect(rec.source == "recover_failed")
+            #expect(rec.appVersion == "0.4.530")
+        }
+    }
+
+    @Test func appVersionIsOptionalAndTrimmed() async throws {
+        try await withApp(app) { _ in
+            let auth = try await loginAsStudent()
+            try await insertSetup(id: "setup_nover")
+            // Absent → nil (older clients that don't send it). Checked while it's
+            // the only row, so `first()` is unambiguous.
+            _ = try await postJSON(
+                #"{"kind":"editor_ready","testSetupID":"setup_nover","message":"elapsed_ms=1"}"#,
+                auth: auth)
+            let none = try #require(try await APIClientDiagnostic.query(on: app.db).first())
+            #expect(none.appVersion == nil)
+
+            // Over-long → trimmed to the 32-char column bound.
+            let longVersion = String(repeating: "v", count: 40)
+            _ = try await postJSON(
+                #"{"kind":"editor_ready","testSetupID":"setup_nover","source":"x","appVersion":"\#(longVersion)"}"#,
+                auth: auth)
+            let rows = try await APIClientDiagnostic.query(on: app.db).all()
+            let trimmed = try #require(rows.first { $0.appVersion != nil })
+            #expect(trimmed.appVersion?.count == 32)
+        }
+    }
+
     @Test func submitPhasesRecordEachPhaseOnceForTheFunnel() async throws {
         try await withApp(app) { _ in
             // The funnel relies on each distinct phase (source) being recorded —

--- a/Tests/APITests/ServerHealthAlertTests.swift
+++ b/Tests/APITests/ServerHealthAlertTests.swift
@@ -247,26 +247,26 @@ import Testing
         #expect(HealthRule.runnerOffline.severity == "warning")
         #expect(HealthRule.queueBackedUp.severity == "warning")
         #expect(HealthRule.errorRateSpike.severity == "warning")
-        #expect(HealthRule.editorKernelHang.severity == "warning")
+        #expect(HealthRule.editorKernelUnrecoverable.severity == "warning")
     }
 
-    // MARK: - decideEditorKernelHang
+    // MARK: - decideEditorKernelUnrecoverable
 
-    @Test func editorKernelHang_firesAtThreshold() {
-        let evaluation = decideEditorKernelHang(hangCount: 3, threshold: 3, windowMinutes: 60)
+    @Test func editorKernelUnrecoverable_firesAtThreshold() {
+        let evaluation = decideEditorKernelUnrecoverable(failedCount: 2, threshold: 2, windowMinutes: 60)
         #expect(evaluation.isFiring)
-        #expect(evaluation.details["exec_hang_count"] == "3")
+        #expect(evaluation.details["recover_failed_count"] == "2")
         #expect(evaluation.details["window_minutes"] == "60")
     }
 
-    @Test func editorKernelHang_okBelowThreshold() {
-        let evaluation = decideEditorKernelHang(hangCount: 2, threshold: 3, windowMinutes: 60)
+    @Test func editorKernelUnrecoverable_okBelowThreshold() {
+        let evaluation = decideEditorKernelUnrecoverable(failedCount: 1, threshold: 2, windowMinutes: 60)
         #expect(evaluation.isFiring == false)
     }
 
-    @Test func editorKernelHang_okWhenThresholdDisabled() {
-        // A zero/negative threshold must never fire, even with hangs present.
-        let evaluation = decideEditorKernelHang(hangCount: 99, threshold: 0, windowMinutes: 60)
+    @Test func editorKernelUnrecoverable_okWhenThresholdDisabled() {
+        // A zero/negative threshold must never fire, even with failures present.
+        let evaluation = decideEditorKernelUnrecoverable(failedCount: 99, threshold: 0, windowMinutes: 60)
         #expect(evaluation.isFiring == false)
     }
 

--- a/changelog.d/diag-app-version-recovery-alert.md
+++ b/changelog.d/diag-app-version-recovery-alert.md
@@ -1,0 +1,23 @@
+### Changed
+
+- **Editor kernel alerting now targets the genuinely-stuck student.** The
+  `editorKernelHang` health-alert rule is replaced by `editorKernelUnrecoverable`,
+  which fires on `recover_failed` reports — a student whose kernel hung, was
+  auto-rebooted by the editor, and hung *again* — instead of on every post-idle
+  `exec_hang` (the vast majority of which auto-recover and never actually block
+  the student). `exec_hang`s are still collected in `client_diagnostics` /
+  `get_browser_diagnostics` for analysis; they just no longer page the operator.
+  Default threshold is 2 in 60 min, tunable via `ALERT_EDITOR_UNRECOVERABLE_THRESHOLD`
+  / `ALERT_EDITOR_UNRECOVERABLE_WINDOW_MINUTES` (the former `ALERT_EDITOR_HANG_*`
+  names still work).
+
+### Added
+
+- **Browser diagnostics carry the page-build version.** Every client diagnostic
+  (editor errors, kernel breadcrumbs including `exec_hang` / `recover_failed`, the
+  submit funnel, and the freeze beacon) now records the `app_version` of the page
+  build that emitted it, surfaced as a `byAppVersion` breakdown in
+  `get_browser_diagnostics`. A failure concentrated on an *old* version is a
+  stale-tab / cached-bundle symptom (that browser never re-fetched the fixed
+  bundle); one on the *current* build means a deployed fix is incomplete — turning
+  "is this hang old cached code or a live bug?" from a guess into data.

--- a/docs/notebook-editor-kernel-boot.md
+++ b/docs/notebook-editor-kernel-boot.md
@@ -288,15 +288,19 @@ editor-cell execute the required smoke never exercised (it checks boot + browser
 grading, never an editor cell). While the root cause is open a reproduced hang is
 the signal; a fix must turn it consistently green before it becomes a guard.
 
-**Observability.** The `editorKernelHang` health-alert rule fires when
-≥`ALERT_EDITOR_HANG_THRESHOLD` exec_hangs land within
-`ALERT_EDITOR_HANG_WINDOW_MINUTES`, so a recurrence pages the operator instead of
-waiting for a lab report.
+**Observability.** The `editorKernelUnrecoverable` health-alert rule fires when
+≥`ALERT_EDITOR_UNRECOVERABLE_THRESHOLD` `recover_failed` reports land within
+`ALERT_EDITOR_UNRECOVERABLE_WINDOW_MINUTES` — students whose kernel hung, was
+auto-rebooted, and hung AGAIN, so they genuinely cannot proceed. Plain
+`exec_hang`s that auto-recover stay in the `client_diagnostics` telemetry (and
+`get_browser_diagnostics`) for analysis but no longer page the operator; the
+alert is reserved for the students who are actually stuck. (The env names fall
+back to the former `ALERT_EDITOR_HANG_*` for back-compat.)
 
 **Root cause is still open.** The recovery + alert are a mitigation. The
 underlying SAB/Atomics execution deadlock is not yet reproduced or fixed; a
-falling `exec_hang` / `editorKernelHang` count is the success signal for that
-follow-up.
+falling `exec_hang` (and especially `recover_failed`) count is the success
+signal for that follow-up.
 
 ### Lessons (so the 4-week arc doesn't repeat)
 
@@ -311,7 +315,7 @@ follow-up.
    exec_hang appeared in exactly the lifecycle phase CI never exercised.
 3. **Lead with telemetry, don't trail it.** Each round of this arc added
    observability *after* the incident. The post-idle watcher and the
-   `editorKernelHang` alert now make this class of regression visible up front.
+   `editorKernelUnrecoverable` alert now make this class of regression visible up front.
 
 ## Quick reference
 


### PR DESCRIPTION
## Why

Two related editor-kernel-diagnostics changes, both driven by the live HLTH 230 lab.

**The question that motivated this:** when we saw `exec_hang`s persist on prod *after* the v0.4.526 fix shipped, we couldn't tell whether those kernels were running the **old cached wheel** (stale cache → the fix just hasn't propagated) or the **new wheel** (fix incomplete) — the diagnostic payload carried no build identity, so "stale cache" was an *inference*, not data. And separately, alerting on every `exec_hang` is noisy: the vast majority auto-recover and never actually block a student.

## What

### 1. Recovery-focused alerting (`editorKernelHang` → `editorKernelUnrecoverable`)
The health-alert rule now fires on **`recover_failed`** — a student whose kernel hung, was auto-rebooted by the editor, and hung *again*, so they genuinely cannot proceed — instead of on raw post-idle `exec_hang`.

- `exec_hang`s are **still collected** in `client_diagnostics` / `get_browser_diagnostics` for analysis; they just no longer page the operator.
- Default threshold **2 in 60 min** (`recover_failed` is rare and high-signal). Tunable via `ALERT_EDITOR_UNRECOVERABLE_THRESHOLD` / `ALERT_EDITOR_UNRECOVERABLE_WINDOW_MINUTES`; the former `ALERT_EDITOR_HANG_*` names are still honored as a fallback so an existing override isn't silently dropped.
- The client-side `exec_hang → auto-reboot → recover_failed` self-heal flow is unchanged.

### 2. Build-version tagging on every browser diagnostic
Every client diagnostic now records the **`app_version`** of the page build that emitted it (from the `app-version` meta the base layout renders), surfaced as a **`byAppVersion`** breakdown in `get_browser_diagnostics`.

- A failure concentrated on an **old** appVersion is a stale-tab / cached-bundle symptom (that browser never re-fetched the fixed bundle). A failure on the **current** build means a deployed fix is incomplete. That makes the next sweep *decisive* instead of inferential.
- Wired through the single chokepoint `postDiagnostic` (editor errors + the forwarded in-iframe kernel events, incl. `exec_hang`/`recover_failed`), the submit-funnel breadcrumbs (`browser-runner.js`), and the freeze worker (passed via its `init` message — a worker has no DOM to read the meta).
- New **nullable** `app_version` column (`AddClientDiagnosticAppVersion`, additive/back-compat; older clients send nothing → `nil`). Stored trimmed to 32 chars.

## Tests
- `ServerHealthAlertTests` — renamed `editorKernelUnrecoverable_*` decide tests (28 pass).
- `ClientDiagnosticsRoutesTests` — `persistsAppVersionWhenProvided` + `appVersionIsOptionalAndTrimmed` (23 pass).
- `swift build --build-tests` clean; swift-format + swiftlint clean on all changed files.

## ⚠️ Note on CI
`format-lint` will show **one** violation — `GlobalInputsService.swift:64` (a 7-param function), a **pre-existing breakage on `main`** from #1042's merge that is unrelated to this PR and is fixed by **#1043**. This branch goes green once #1043 lands and I rebase. Build + all tests pass; my changes add zero new lint violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016RS6QN9qoM54Lgu7vXBaPC)_