### PR TITLE
fix(notebook-editor): create parent dirs in the Drive so JupyterLite 0.8 saves work

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -1486,6 +1486,17 @@
 
             const contents = app.serviceManager && app.serviceManager.contents;
 
+            // 0.8 @jupyterlite/contents.save() throws "Directory does not exist"
+            // unless the notebook's parent dir is a materialized *directory* entry
+            // in the IndexedDB Drive (0.7.x auto-created it; the server-side dir our
+            // contents route serves is NOT consulted by save()'s local
+            // this.get(dirname) check). Our working copies are nested under
+            // users/<uid>/<setup>/, which nothing creates client-side — so create
+            // each ancestor first, satisfying the guard for both the seed save below
+            // and the editor's own Ctrl-S. Frontend analog of the kernel-side
+            // os.chdir/makedirs fix (scripts/patch-pyodide-kernel.py).
+            await ensureDriveParentDirectories(contents, lockedNotebookPath);
+
             // Preservation logic: if the browser already has the notebook in
             // IndexedDB AND the server hasn't overwritten it since we last
             // saw it, keep the local version — that's the student's
@@ -1607,6 +1618,35 @@
             // directly, so there's nothing to revert.
             reloadOpenDoc: !!hasLocalContent && !!serverIsNewer,
         };
+    }
+
+    // Ensure every ancestor directory of `notebookPath` exists as a directory
+    // entry in JupyterLite's IndexedDB contents Drive. Idempotent (skips dirs
+    // that already exist) and fail-safe (any error swallowed; a genuine failure
+    // surfaces on the seed save). Walks root→leaf so each newUntitled's parent is
+    // already materialized; uses newUntitled+rename because BrowserDrive has no
+    // public "create named directory" call and save(dir,{type:'directory'}) would
+    // hit the same parent-exists guard. 0.8 added that guard; harmless on 0.7.x.
+    async function ensureDriveParentDirectories(contents, notebookPath) {
+        if (!contents || typeof contents.get !== 'function' || !notebookPath) return;
+        const parts = String(notebookPath).split('/').slice(0, -1).filter(Boolean);  // strip filename
+        let prefix = '';
+        for (const name of parts) {
+            const parent = prefix;                      // '' = Drive root
+            prefix = prefix ? `${prefix}/${name}` : name;
+            try {
+                const existing = await contents.get(prefix, { content: false }).catch(() => null);
+                if (existing && existing.type === 'directory') continue;  // already present
+            } catch (_) { /* fall through to create */ }
+            try {
+                const tmp = (typeof contents.newUntitled === 'function')
+                    ? await contents.newUntitled({ path: parent, type: 'directory' })
+                    : null;
+                if (tmp && tmp.path !== prefix && typeof contents.rename === 'function') {
+                    await contents.rename(tmp.path, prefix);
+                }
+            } catch (_) { /* best-effort; the seed save reports a genuine failure */ }
+        }
     }
 
     async function waitForJupyterApp(timeoutMs) {
@@ -2229,6 +2269,7 @@
             shouldForceReseed,
             reseedPlan,
             handleKernelDiagMessage,
+            ensureDriveParentDirectories,
         };
     }
 })();

--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -188,6 +188,13 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // path above isolates the vendored asset trees it serves itself, and
     // COEPMiddleware (after FileMiddleware) covers the dynamic notebook page.
     app.middleware.use(NotebookAssetIsolationMiddleware(enabled: true))
+    // Inject the `exposeAppInBrowser` PageConfig flag into the served JupyterLite
+    // jupyter-lite.json configs (kept OUT of the verified bundle — see the
+    // middleware). Runs just before FileMiddleware so it intercepts the static
+    // config fetch; the cache + isolation middlewares above still decorate its
+    // response on the way back.
+    app.middleware.use(
+        JupyterLiteConfigFlagMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(COEPMiddleware(isolateNotebook: true))
 }

--- a/Sources/APIServer/Middleware/JupyterLiteConfigFlagMiddleware.swift
+++ b/Sources/APIServer/Middleware/JupyterLiteConfigFlagMiddleware.swift
@@ -1,0 +1,69 @@
+// APIServer/Middleware/JupyterLiteConfigFlagMiddleware.swift
+//
+// Injects the `exposeAppInBrowser` PageConfig flag into the served JupyterLite
+// `jupyter-lite.json` config files at request time, instead of baking it into
+// the checked-in bundle.
+//
+// Why not edit the bundle: `Public/jupyterlite` is a verified build artifact —
+// `jupyterlite.yml` rebuilds it from `Tools/jupyterlite` and `git diff
+// --exit-code`s against the commit, so any hand-edit drifts and fails CI. A
+// local rebuild is worse: it risks byte-instability vs CI and could regenerate
+// the kernel wheel without the nb_mypy/chdir patch. Injecting the one flag at
+// serve time leaves the bundle untouched.
+//
+// Why the flag matters: with `exposeAppInBrowser` set, JupyterLite assigns
+// `window.jupyterapp` in the editor iframe, which lets the notebook page reach
+// the app's contents manager from the parent frame and create the per-student
+// working-copy directory in the Drive before saving (see notebook.js
+// `ensureDriveParentDirectories`). JupyterLite 0.8's `contents.save()` throws
+// "Directory does not exist" unless that nested parent dir already exists, and
+// nothing else creates it client-side.
+//
+// Applies to every `*/jupyter-lite.json` under `/jupyterlite/`, so the flag is
+// present whichever config the app merges (root + per-app). Best-effort: any
+// read/parse/serialize failure falls through to the normal static-file response,
+// so a malformed or missing config never turns into a 500.
+
+import Foundation
+import Vapor
+
+struct JupyterLiteConfigFlagMiddleware: AsyncMiddleware {
+    private let publicDirectory: String
+
+    init(publicDirectory: String) {
+        self.publicDirectory = publicDirectory.hasSuffix("/") ? publicDirectory : publicDirectory + "/"
+    }
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let path = request.url.path
+        guard request.method == .GET,
+            path.hasPrefix("/jupyterlite/"),
+            path.hasSuffix("/jupyter-lite.json"),
+            !path.contains("..")
+        else {
+            return try await next.respond(to: request)
+        }
+
+        let absolutePath = publicDirectory + path.dropFirst()  // strip leading "/"
+        guard let data = FileManager.default.contents(atPath: absolutePath),
+            var json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            var configData = json["jupyter-config-data"] as? [String: Any]
+        else {
+            // Missing file or not a jupyter-lite config we can parse — serve as-is.
+            return try await next.respond(to: request)
+        }
+
+        guard configData["exposeAppInBrowser"] == nil else {
+            return try await next.respond(to: request)  // already set; nothing to do
+        }
+        configData["exposeAppInBrowser"] = "true"
+        json["jupyter-config-data"] = configData
+
+        guard let body = try? JSONSerialization.data(withJSONObject: json) else {
+            return try await next.respond(to: request)
+        }
+        let response = Response(status: .ok, body: .init(data: body))
+        response.headers.contentType = .json
+        return response
+    }
+}

--- a/Tests/APITests/JupyterLiteConfigFlagMiddlewareTests.swift
+++ b/Tests/APITests/JupyterLiteConfigFlagMiddlewareTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+/// JupyterLiteConfigFlagMiddleware injects `exposeAppInBrowser: "true"` into the
+/// served JupyterLite `jupyter-lite.json` configs WITHOUT touching the checked-in
+/// bundle (a verified build artifact). The flag makes `window.jupyterapp`
+/// reachable in the editor iframe so the notebook page can create the per-student
+/// working-copy directory in the Drive before save (JupyterLite 0.8's
+/// `contents.save()` throws "Directory does not exist" otherwise). Pins:
+///   1. the flag is injected into both the root and per-app configs;
+///   2. an existing value is never overwritten;
+///   3. a config without `jupyter-config-data` (or a non-config path) falls
+///      through to the static file untouched — never a 500.
+@Suite final class JupyterLiteConfigFlagMiddlewareTests {
+    private let publicDir: String
+    private let tempRoot: String
+
+    init() throws {
+        tempRoot =
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-jlcfg-\(UUID().uuidString)").path
+        publicDir = tempRoot + "/Public/"
+        let fixtures: [(String, String)] = [
+            (
+                "jupyterlite/jupyter-lite.json",
+                #"{"jupyter-config-data":{"appName":"JupyterLite","defaultKernelName":"python"}}"#
+            ),
+            (
+                "jupyterlite/notebooks/jupyter-lite.json",
+                #"{"jupyter-lite-schema-version":0,"jupyter-config-data":{"appUrl":"/notebooks"}}"#
+            ),
+            (
+                "jupyterlite/already/jupyter-lite.json",
+                #"{"jupyter-config-data":{"exposeAppInBrowser":"false"}}"#
+            ),
+            ("jupyterlite/weird/jupyter-lite.json", #"{"no-config-here":true}"#),
+            ("jupyterlite/other.json", #"{"jupyter-config-data":{"x":1}}"#),
+        ]
+        for (relativePath, contents) in fixtures {
+            let absolute = publicDir + relativePath
+            try FileManager.default.createDirectory(
+                atPath: (absolute as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true)
+            try contents.write(toFile: absolute, atomically: true, encoding: .utf8)
+        }
+    }
+
+    deinit { try? FileManager.default.removeItem(atPath: tempRoot) }
+
+    private func makeApp() async throws -> Application {
+        let app = try await Application.make(.testing)
+        app.middleware.use(JupyterLiteConfigFlagMiddleware(publicDirectory: publicDir))
+        app.middleware.use(FileMiddleware(publicDirectory: publicDir))
+        return app
+    }
+
+    private func configData(_ res: TestingHTTPResponse) -> [String: Any] {
+        let obj = (try? JSONSerialization.jsonObject(with: Data(res.body.string.utf8))) as? [String: Any]
+        return (obj?["jupyter-config-data"] as? [String: Any]) ?? [:]
+    }
+
+    @Test func injectsFlagIntoRootConfig() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/jupyter-lite.json") { res async in
+                #expect(res.status == .ok)
+                let cfg = self.configData(res)
+                #expect(cfg["exposeAppInBrowser"] as? String == "true")
+                #expect(cfg["defaultKernelName"] as? String == "python")  // existing keys preserved
+            }
+        }
+    }
+
+    @Test func injectsFlagIntoPerAppConfig() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/notebooks/jupyter-lite.json") { res async in
+                #expect(res.status == .ok)
+                let cfg = self.configData(res)
+                #expect(cfg["exposeAppInBrowser"] as? String == "true")
+                #expect(cfg["appUrl"] as? String == "/notebooks")
+            }
+        }
+    }
+
+    @Test func doesNotOverrideExistingValue() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/already/jupyter-lite.json") { res async in
+                #expect(res.status == .ok)
+                #expect(self.configData(res)["exposeAppInBrowser"] as? String == "false")  // left as-is
+            }
+        }
+    }
+
+    @Test func fallsThroughWhenNoConfigData() async throws {
+        try await withApp(try await makeApp()) { app in
+            // No jupyter-config-data → served as-is by FileMiddleware, never a 500.
+            try await app.testing().test(.GET, "/jupyterlite/weird/jupyter-lite.json") { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("no-config-here"))
+                #expect(res.body.string.contains("exposeAppInBrowser") == false)
+            }
+        }
+    }
+
+    @Test func leavesNonJupyterLiteJsonUntouched() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/other.json") { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("exposeAppInBrowser") == false)
+            }
+        }
+    }
+}

--- a/Tests/BrowserRunnerJSTests/ensure-parent-dirs.test.mjs
+++ b/Tests/BrowserRunnerJSTests/ensure-parent-dirs.test.mjs
@@ -1,0 +1,139 @@
+// Tests/BrowserRunnerJSTests/ensure-parent-dirs.test.mjs
+//
+// Regression guard for the JupyterLite 0.8 file-save fix in
+// `Public/notebook.js`'s `ensureDriveParentDirectories`.
+//
+// 0.8's `@jupyterlite/contents` `save()` added a parent-must-exist guard: it
+// throws `Directory does not exist: <dir>` unless the notebook's parent
+// directory is a materialized `directory` entry in the IndexedDB Drive (0.7.x
+// auto-created intermediate dirs). Chickadee working copies are nested under
+// `users/<uid>/<setup>/`, which nothing created client-side — so the very first
+// save (and the editor's own Ctrl-S) threw and students could lose work.
+// `ensureDriveParentDirectories` walks the ancestors root→leaf and creates each
+// missing one via newUntitled+rename, satisfying the guard.
+//
+// These tests pin: ordered ancestor creation (the chicken-and-egg the bug is
+// about — never newUntitled into a not-yet-created parent), idempotency,
+// partial pre-existence, fail-safety, and the bad-input no-op.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import vm from 'node:vm';
+
+const notebookSource = await fs.readFile(path.resolve('Public/notebook.js'), 'utf8');
+
+async function loadHarness() {
+  const hooks = {};
+  const elements = new Map();
+  const frame = {
+    dataset: {
+      setupId: 'setup_123',
+      gradingMode: 'browser',
+      notebookUrl: '/api/v1/testsetups/setup_123/assignment',
+      editorUrl: '/jupyterlite/notebooks/index.html?path=assignment.ipynb',
+    },
+    addEventListener() {},
+    getAttribute(name) { return name === 'src' ? this.dataset.editorUrl : null; },
+    contentWindow: null,
+    contentDocument: null,
+    src: '',
+  };
+  elements.set('jl-frame', frame);
+  elements.set('nb-status', { textContent: '', className: '' });
+  elements.set('nb-results', { hidden: true, innerHTML: '', appendChild() {}, scrollIntoView() {} });
+
+  const document = {
+    getElementById(id) { return elements.get(id) ?? null; },
+    createElement() { return { className: '', textContent: '', innerHTML: '', appendChild() {} }; },
+    head: { appendChild() {} },
+  };
+
+  const context = {
+    console,
+    document,
+    fetch: async () => ({ ok: true, async json() { return { cells: [] }; } }),
+    setTimeout,
+    clearTimeout,
+    setInterval: () => 1,
+    clearInterval: () => {},
+    URL, JSON, Error, Promise,
+    window: { location: { origin: 'https://example.test' } },
+    __CHICKADEE_NOTEBOOK_TEST_HOOKS__: hooks,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(notebookSource, context, { filename: 'notebook.js' });
+  return hooks.exports;
+}
+
+// A fake JupyterLite contents manager backed by a Map that replicates 0.8's
+// guard: newUntitled into a non-existent parent throws, exactly as
+// @jupyterlite/contents 0.8 does. `created` logs the final dir paths in order.
+function fakeContents() {
+  const store = new Map();   // path -> { type }
+  let untitledN = 0;
+  return {
+    store,
+    created: [],
+    async get(p) {
+      if (store.has(p)) return { type: store.get(p).type, path: p };
+      throw new Error('404');                       // missing -> reject (helper .catch -> null)
+    },
+    async newUntitled({ path: parent, type }) {
+      if (parent && !store.has(parent)) {
+        throw new Error(`Directory does not exist: ${parent}`);   // the 0.8 parent guard
+      }
+      const name = `Untitled Folder${untitledN++ || ''}`;
+      const full = parent ? `${parent}/${name}` : name;
+      store.set(full, { type });
+      return { path: full, type };
+    },
+    async rename(from, to) {
+      store.set(to, store.get(from));
+      store.delete(from);
+      this.created.push(to);
+    },
+  };
+}
+
+test('ensureDriveParentDirectories: creates every missing ancestor root→leaf, exact names', async () => {
+  const { ensureDriveParentDirectories } = await loadHarness();
+  const fc = fakeContents();
+  await ensureDriveParentDirectories(fc, 'users/abc/setup_9/assignment.ipynb');
+  // Proves it never calls newUntitled into a not-yet-created parent (the bug),
+  // and stops before the filename.
+  assert.deepEqual(fc.created, ['users', 'users/abc', 'users/abc/setup_9']);
+});
+
+test('ensureDriveParentDirectories: idempotent when every ancestor already exists', async () => {
+  const { ensureDriveParentDirectories } = await loadHarness();
+  const fc = fakeContents();
+  for (const d of ['users', 'users/abc', 'users/abc/setup_9']) fc.store.set(d, { type: 'directory' });
+  await ensureDriveParentDirectories(fc, 'users/abc/setup_9/assignment.ipynb');
+  assert.deepEqual(fc.created, []);   // nothing re-created
+});
+
+test('ensureDriveParentDirectories: only creates the missing tail when some exist', async () => {
+  const { ensureDriveParentDirectories } = await loadHarness();
+  const fc = fakeContents();
+  fc.store.set('users', { type: 'directory' });
+  await ensureDriveParentDirectories(fc, 'users/abc/setup_9/assignment.ipynb');
+  assert.deepEqual(fc.created, ['users/abc', 'users/abc/setup_9']);
+});
+
+test('ensureDriveParentDirectories: fail-safe — never rejects when the Drive errors', async () => {
+  const { ensureDriveParentDirectories } = await loadHarness();
+  const fc = fakeContents();
+  fc.newUntitled = async () => { throw new Error('Drive exploded'); };
+  await assert.doesNotReject(
+    ensureDriveParentDirectories(fc, 'users/abc/setup_9/assignment.ipynb'));
+});
+
+test('ensureDriveParentDirectories: no-op on bad input', async () => {
+  const { ensureDriveParentDirectories } = await loadHarness();
+  const fc = fakeContents();
+  await assert.doesNotReject(ensureDriveParentDirectories(null, 'a/b.ipynb'));
+  await ensureDriveParentDirectories(fc, '');
+  assert.deepEqual(fc.created, []);
+});

--- a/changelog.d/fix-08-filesave-dir.md
+++ b/changelog.d/fix-08-filesave-dir.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **In-browser notebook save on JupyterLite 0.8 ("Directory does not exist").**
+  0.8's `@jupyterlite/contents` `save()` requires the notebook's parent directory
+  to already be a materialized directory entry in the browser Drive (0.7.x
+  auto-created intermediate dirs). Chickadee working copies are nested under
+  `users/<uid>/<setup>/`, which nothing created client-side, so the first save —
+  and the editor's own Ctrl-S — threw `Directory does not exist` and students
+  could lose work. The notebook page now creates the ancestor directories in the
+  Drive before seeding (`ensureDriveParentDirectories`), and a new
+  `JupyterLiteConfigFlagMiddleware` injects the `exposeAppInBrowser` PageConfig
+  flag into the served `jupyter-lite.json` configs so the in-iframe app/contents
+  manager is reachable to do it (the flag is injected at serve time rather than
+  baked into the verified, rebuilt-and-diffed bundle). No bundle rebuild required.


### PR DESCRIPTION
## The bug (0.8 validation finding)

Saving `assignment.ipynb` in the 0.8 editor throws **`Directory does not exist: users/<uid>/setup_<id>`**, and students could lose work. Root-caused via a deep trace of the vendored 0.8 bundle:

- The save goes to the **client-side IndexedDB Drive** (`@jupyterlite/contents`), not the server.
- 0.8 **hardened `save()`** with a `_ensureParentDirectoryExists` guard that throws unless the parent is a materialized `directory` entry **in the local Drive**. 0.7.6 auto-created intermediate dirs and had no such check.
- Our working copies are nested under `users/<uid>/<setup>/` (a deliberate per-student namespace). The server *does* create + serve that directory — but the client save's parent-check **only looks at local IndexedDB**, where nothing ever created it.
- It surfaced *now* because #1035's command bridge made `docmanager:save` actually fire on the 0.8 Notebook build (it previously no-op'd).

So this is the frontend-storage analog of the kernel `os.chdir`/`makedirs` fix.

## The fix — no bundle rebuild, no bundle bytes changed

1. **`JupyterLiteConfigFlagMiddleware`** injects `exposeAppInBrowser: "true"` into the served `jupyter-lite.json` configs **at request time** — *not* baked into the checked-in bundle. `Public/jupyterlite` is a verified build artifact (`jupyterlite.yml` rebuilds it and `git diff --exit-code`s), so a hand-edit fails `build-and-verify`, and a local rebuild risks byte-instability + re-patching the kernel wheel without the nb_mypy/chdir patch. Injecting the one flag at serve time sidesteps all of that. The flag is what makes JupyterLite assign `window.jupyterapp` in the editor iframe, restoring `app.serviceManager.contents` access from the parent frame (and re-enabling the 0.7.x-era seed/reseed paths that had silently fallen back to the degraded path on 0.8).
2. **`ensureDriveParentDirectories(contents, path)`** in `notebook.js`: walk ancestors **root→leaf**, creating each missing one via `newUntitled`+`rename` (BrowserDrive has no public create-named-directory call). Idempotent + fail-safe. Called before the seed save — and once the dir entries exist, the editor's own **Ctrl-S succeeds too**.

Because the flag is injected server-side instead of baked into the bundle, a future `jupyter lite build` re-vendor can't silently drop it — there is nothing in the bundle to drop. `build-and-verify` is green, confirming **zero bundle bytes change**.

## Tests
- `Tests/BrowserRunnerJSTests/ensure-parent-dirs.test.mjs` pins ordered root→leaf creation (the chicken-and-egg the bug is about — never `newUntitled` into a not-yet-created parent), idempotency, partial pre-existence, fail-safety, and the bad-input no-op, against a fake contents manager that replicates the 0.8 guard.
- `Tests/APITests/JupyterLiteConfigFlagMiddlewareTests.swift` pins the flag injection (root + per-app config), never overriding an existing value, and falling through to the static file untouched (never a 500) for a no-config-data or non-`jupyter-lite.json` path.

## How to validate on dev
Pull this branch, restart, hard-refresh the editor, and save `assignment.ipynb` — the error should be gone (first save *and* Ctrl-S). The `exposeAppInBrowser` flip also changes which seed/sync path runs, so worth a quick check that open / reseed / instructor-reset still behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)