### PR TITLE
feat(notebook-editor): polite non-blocking notice when an old browser can't boot the editor

### DIFF
--- a/Public/notebook-preflight.js
+++ b/Public/notebook-preflight.js
@@ -292,14 +292,64 @@
     }
 
     // ----------------------------------------------------------------
+    // Slow / unsupported-engine editor notice (non-blocking)
+    // ----------------------------------------------------------------
+    //
+    // Driven by notebook.js's WebKit slow-boot watchdog: if the editor hasn't
+    // reported a healthy kernel within the window, reveal the .ipynb-upload
+    // fallback panel with a polite, plain-English message WITHOUT hiding the
+    // editor. Some older engines (notably Safari 18.x and low-memory iPads)
+    // never finish booting the comlink + service-worker editor; rather than
+    // strand the student on a spinner, we surface the upload path and suggest a
+    // different device — while leaving the editor visible so a merely-slow-but-
+    // healthy boot still works (so this can never hide a working editor). Gated
+    // by `_failureShown` so a real failure (which DOES hide the editor) wins.
+
+    let _slowNoticeShown = false;
+    function showSlowEditorNotice() {
+        if (_slowNoticeShown || _failureShown) return;
+        _slowNoticeShown = true;
+
+        const fallback = document.getElementById('nb-fallback');
+        if (fallback) {
+            const titleEl = fallback.querySelector('.nb-fallback-title');
+            const textEl  = fallback.querySelector('.nb-fallback-text');
+            if (titleEl) titleEl.textContent = 'The editor is taking a while to load';
+            if (textEl) {
+                textEl.textContent =
+                    'In-browser Python may not work on older browsers, or on devices with limited ' +
+                    'memory such as some iPads. If the editor doesn’t finish loading, a laptop or ' +
+                    'desktop — or a more recent browser — may work better. You can still submit ' +
+                    'by uploading your notebook (.ipynb) file below.';
+            }
+            const resetLink = document.getElementById('nb-reset-editor-link');
+            if (resetLink) {
+                try {
+                    resetLink.href = '/reset-editor?next=' +
+                        encodeURIComponent(location.pathname + location.search);
+                } catch (_) { /* keep the static href */ }
+            }
+            // Reveal the upload path; do NOT hide the editor — it may still boot.
+            fallback.hidden = false;
+        }
+
+        reportEvent({
+            kind:    'editor_error',
+            source:  'slow_boot_notice',
+            message: 'ua=' + (navigator.userAgent || '').slice(0, 200)
+        });
+    }
+
+    // ----------------------------------------------------------------
     // Public surface
     // ----------------------------------------------------------------
 
     window.ChickadeeNotebookFailures = {
-        runPreflight:      runPreflight,
-        showFailure:       showFailure,
-        showDeviceWarning: showDeviceWarning,
-        reportEditorError: reportEditorError,
-        reportEvent:       reportEvent
+        runPreflight:         runPreflight,
+        showFailure:          showFailure,
+        showDeviceWarning:    showDeviceWarning,
+        showSlowEditorNotice: showSlowEditorNotice,
+        reportEditorError:    reportEditorError,
+        reportEvent:          reportEvent
     };
 })();

--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -235,6 +235,11 @@
             const d = e.data;
             if (!d || d.ck !== 'kernel-diag') return false;
             if (d.kind !== 'kernel_phase' && d.kind !== 'kernel_error') return false;
+            // The kernel reached idle — the editor is usable. Cancel the WebKit
+            // slow-boot notice if it is still pending.
+            if (d.kind === 'kernel_phase' && d.source === 'kernel_idle') {
+                markKernelEverReady();
+            }
             // Self-heal: a post-idle exec_hang means the kernel booted then wedged
             // on execute (the boot-failure watchdog doesn't cover it). Trigger the
             // one-shot work-preserving editor reload — independent of the telemetry
@@ -387,9 +392,46 @@
         return 'coi=' + coi + ';waitasync=' + wa;
     }
 
+    // --- WebKit slow-boot notice -------------------------------------
+    //
+    // On WebKit (the comlink + service-worker path) some old engines — notably
+    // Safari 18.x and low-memory iPads — never finish booting the editor: the
+    // service worker won't take control and/or the JupyterLite 0.8 frontend
+    // can't initialise. After SLOW_BOOT_NOTICE_MS with no positive kernel-ready
+    // signal, reveal a polite, NON-blocking upload notice (showSlowEditorNotice)
+    // — the editor stays visible, so a merely-slow-but-healthy boot still works
+    // and this can never false-hide a working editor (the reason armEditorWatchdog
+    // is deliberately conservative). WebKit-only: never touches the
+    // Chrome/Edge/Firefox SharedArrayBuffer path.
+    var SLOW_BOOT_NOTICE_MS = 25000;
+    var kernelEverReady = false;
+    var slowBootNoticeTimer = null;
+    var slowBootNoticeArmed = false;
+
+    function markKernelEverReady() {
+        kernelEverReady = true;
+        if (slowBootNoticeTimer) {
+            clearTimeout(slowBootNoticeTimer);
+            slowBootNoticeTimer = null;
+        }
+    }
+
+    function armSlowBootNotice() {
+        if (slowBootNoticeArmed || !isWebKitEngine()) return;
+        slowBootNoticeArmed = true;
+        slowBootNoticeTimer = setTimeout(function () {
+            slowBootNoticeTimer = null;
+            if (kernelEverReady) return;   // booted in time — nothing to do
+            if (failures && failures.showSlowEditorNotice) {
+                failures.showSlowEditorNotice();
+            }
+        }, SLOW_BOOT_NOTICE_MS);
+    }
+
     // The kernel reached idle/busy — the success NUMERATOR (paired with
     // editor_ready, the shell denominator).
     function reportKernelReady(elapsedMs) {
+        markKernelEverReady();
         if (failures && failures.reportEvent) {
             failures.reportEvent({
                 kind: 'kernel_ready',
@@ -415,6 +457,11 @@
         if (!isWebKitEngine()) {
             cleanupRedundantServiceWorker();
         }
+
+        // WebKit-only: if the comlink + service-worker editor never reaches a
+        // healthy kernel (old Safari / low-RAM iPad), surface the upload path
+        // after SLOW_BOOT_NOTICE_MS without hiding the still-loading editor.
+        armSlowBootNotice();
 
         // The template renders the same URL into the iframe's src, so the
         // editor is already loading by the time the preflight resolves.

--- a/changelog.d/notebook-editor-slow-boot-notice.md
+++ b/changelog.d/notebook-editor-slow-boot-notice.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Older browsers that can't run the in-browser editor now get a clear path
+  instead of an endless spinner.** Some old engines — notably Safari 18.x and
+  low-memory iPads — never finish booting the WebKit comlink + service-worker
+  editor (the service worker won't take control and/or the JupyterLite 0.8
+  frontend can't initialise). On WebKit, if the kernel hasn't come up within
+  25 s, the notebook page now reveals a polite, **non-blocking** notice plus the
+  `.ipynb`-upload fallback — *without* hiding the editor, so a merely-slow-but-
+  healthy boot still works (it can never hide a working editor). It suggests a
+  laptop/desktop or a more recent browser, and beacons `slow_boot_notice` for
+  calibration. Chrome/Edge/Firefox (the SharedArrayBuffer path) are unaffected.


### PR DESCRIPTION
Follow-up to #1046. On WebKit, old engines (Safari 18.x, low-memory iPads) never finish booting the comlink+SW editor — confirmed on Safari 18.2 (swController stays null even after reload; Lumino insertWidget/updateRenderOption null errors). Safari 26.5 boots fine, so it's an old-engine tail.

After 25s with no kernel-ready, WebKit reveals a polite **non-blocking** notice + the .ipynb-upload fallback **without hiding the editor** (so a slow-but-healthy boot still works — it can never hide a working editor). Suggests a laptop/desktop or newer browser; beacons `slow_boot_notice`. Chrome/Edge/Firefox untouched.

Safe by construction: WebKit-gated, additive, non-blocking. No smoke check asserts `#nb-fallback` hidden, so a slow CI WebKit boot revealing it can't fail the gate.