### PR TITLE
fix(jupyterlite): redirect bare app-dir URLs to index.html (fixes notebook-open 404)

### DIFF
--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -195,6 +195,14 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
     // response on the way back.
     app.middleware.use(
         JupyterLiteConfigFlagMiddleware(publicDirectory: app.directory.publicDirectory))
+    // JupyterLite (Notebook 7) opens documents at canonical URLs like
+    // `/jupyterlite/notebooks?path=…` with no `/index.html` — it assumes the host
+    // rewrites an app directory to its index (a real Jupyter server / nginx
+    // try_files). Our static FileMiddleware doesn't, so those URLs 404 (e.g. a
+    // notebook opened in a new tab). Redirect the app dirs to their index.html,
+    // preserving the query, so the app loads. Runs just before FileMiddleware,
+    // which would otherwise 404 the bare directory.
+    app.middleware.use(JupyterLiteAppIndexMiddleware())
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(COEPMiddleware(isolateNotebook: true))
 }

--- a/Sources/APIServer/Middleware/JupyterLiteAppIndexMiddleware.swift
+++ b/Sources/APIServer/Middleware/JupyterLiteAppIndexMiddleware.swift
@@ -1,0 +1,57 @@
+// APIServer/Middleware/JupyterLiteAppIndexMiddleware.swift
+//
+// Resolves JupyterLite's app entry points when Notebook 7 builds a canonical
+// document URL WITHOUT the trailing `/index.html`.
+//
+// JupyterLite (Notebook 7) opens documents at URLs like
+// `/jupyterlite/notebooks?path=…` or `/jupyterlite/lab?path=…` — it is a
+// "single-document" app that assumes the host routes an app DIRECTORY to its
+// `index.html` (a real Jupyter server, or an nginx `try_files` / SPA rewrite).
+// Our static `FileMiddleware` serves files literally, so the bare directory URL
+// 404s — most visibly when JupyterLite opens a notebook in a NEW BROWSER TAB
+// (`target="_blank"`), which lands on `/jupyterlite/notebooks?path=…` and 404s
+// while the original (iframe) editor keeps working. Reproduces on every engine.
+//
+// This middleware redirects the JupyterLite app directories to their
+// `index.html`, preserving the query string, so the app loads — matching the
+// SPA-style hosting JupyterLite documents for static hosts. Registered just
+// before `FileMiddleware` (which would otherwise 404 the bare directory).
+// `/jupyterlite/<app>/index.html` and deeper paths (`…/api/contents/…`) are
+// untouched — they already resolve.
+
+import Vapor
+
+struct JupyterLiteAppIndexMiddleware: AsyncMiddleware {
+    /// The JupyterLite app entry directories, each of which has an `index.html`.
+    static let appDirectories: Set<String> = [
+        "lab", "notebooks", "tree", "edit", "consoles", "repl",
+    ]
+
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        guard request.method == .GET || request.method == .HEAD,
+            let path = request.url.path.removingPercentEncoding,
+            path.hasPrefix("/jupyterlite/"),
+            !path.contains("..")
+        else {
+            return try await next.respond(to: request)
+        }
+
+        // Match exactly `/jupyterlite/<app>` (optionally a trailing slash) — the
+        // bare directory URL Notebook 7 builds. A deeper path
+        // (`/jupyterlite/notebooks/index.html`, `…/api/contents/…`) has more than
+        // two components and falls through to FileMiddleware unchanged.
+        let trimmed = path.hasSuffix("/") ? String(path.dropLast()) : path
+        let parts = trimmed.split(separator: "/").map(String.init)
+        guard parts.count == 2, parts[0] == "jupyterlite",
+            Self.appDirectories.contains(parts[1])
+        else {
+            return try await next.respond(to: request)
+        }
+
+        var target = "/jupyterlite/" + parts[1] + "/index.html"
+        if let query = request.url.query, !query.isEmpty {
+            target += "?" + query
+        }
+        return request.redirect(to: target, redirectType: .temporary)
+    }
+}

--- a/Tests/APITests/JupyterLiteAppIndexMiddlewareTests.swift
+++ b/Tests/APITests/JupyterLiteAppIndexMiddlewareTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+/// JupyterLiteAppIndexMiddleware redirects a bare JupyterLite app-directory URL
+/// (`/jupyterlite/notebooks?path=…`, which Notebook 7 builds when it opens a
+/// document — e.g. in a new tab) to its `index.html`, preserving the query, so
+/// the static host serves the app instead of 404ing. Deeper paths and the
+/// `index.html` itself are left untouched.
+@Suite struct JupyterLiteAppIndexMiddlewareTests {
+
+    private func makeApp() async throws -> Application {
+        let app = try await Application.make(.testing)
+        app.middleware.use(JupyterLiteAppIndexMiddleware())
+        // Stand in for FileMiddleware: only the real index.html resolves.
+        app.get("jupyterlite", "notebooks", "index.html") { _ in "NOTEBOOKS_INDEX" }
+        app.get("jupyterlite", "lab", "index.html") { _ in "LAB_INDEX" }
+        return app
+    }
+
+    @Test func bareNotebooksDirRedirectsToIndexPreservingQuery() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(
+                .GET, "/jupyterlite/notebooks?path=users%2Fx%2Fassignment.ipynb"
+            ) { res async in
+                #expect(res.status == .temporaryRedirect)
+                #expect(
+                    res.headers.first(name: "Location")
+                        == "/jupyterlite/notebooks/index.html?path=users%2Fx%2Fassignment.ipynb")
+            }
+        }
+    }
+
+    @Test func trailingSlashAlsoRedirects() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/lab/") { res async in
+                #expect(res.status == .temporaryRedirect)
+                #expect(res.headers.first(name: "Location") == "/jupyterlite/lab/index.html")
+            }
+        }
+    }
+
+    @Test func indexHtmlPassesThrough() async throws {
+        try await withApp(try await makeApp()) { app in
+            try await app.testing().test(.GET, "/jupyterlite/notebooks/index.html") { res async in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "NOTEBOOKS_INDEX")
+            }
+        }
+    }
+
+    @Test func deeperPathPassesThrough() async throws {
+        try await withApp(try await makeApp()) { app in
+            // e.g. /jupyterlite/notebooks/api/contents/… — more than two
+            // components, so it is NOT a bare app dir and must fall through.
+            try await app.testing().test(.GET, "/jupyterlite/notebooks/api/contents/x") { res async in
+                #expect(res.status == .notFound)  // no route → 404, NOT a redirect
+            }
+        }
+    }
+
+    @Test func nonAppDirPassesThrough() async throws {
+        try await withApp(try await makeApp()) { app in
+            // /jupyterlite/build/… is a vendored asset tree, not an app dir.
+            try await app.testing().test(.GET, "/jupyterlite/build/100.abc.js") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}

--- a/changelog.d/jupyterlite-app-dir-404.md
+++ b/changelog.d/jupyterlite-app-dir-404.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Opening a notebook no longer 404s in a stray new tab.** JupyterLite
+  (Notebook 7) opens documents at canonical URLs like
+  `/jupyterlite/notebooks?path=…` with no `/index.html`, assuming the host
+  rewrites an app directory to its index (a real Jupyter server, or an nginx
+  `try_files`). Chickadee's static file serving didn't, so those URLs 404'd —
+  most visibly when the editor opened a notebook in a new browser tab (all
+  engines). A new `JupyterLiteAppIndexMiddleware` redirects the JupyterLite app
+  directories (`lab`, `notebooks`, `tree`, `edit`, `consoles`, `repl`) to their
+  `index.html`, preserving the query string. The in-iframe editor was unaffected
+  either way (it already loads `…/index.html`).


### PR DESCRIPTION
Notebook 7 opens documents at `/jupyterlite/notebooks?path=…` (no `/index.html`), assuming the host rewrites the app dir to its index (real Jupyter / nginx try_files). Our static FileMiddleware 404s it — visible as a stray new tab 404 when opening a notebook (all engines); the iframe editor was unaffected. New `JupyterLiteAppIndexMiddleware` redirects the app dirs (lab/notebooks/tree/edit/consoles/repl) → index.html, preserving the query. Unit-tested; `…/index.html` and deeper paths untouched.

Follow-up to consider (NOT this PR): the new tab opens a *non-locked* full JupyterLite — whether to suppress the new-tab open entirely is a separate UX call.