### PR TITLE
Cache-bust the editor kernel-diagnostics collector script

### DIFF
--- a/Public/jupyterlite/notebooks/index.html
+++ b/Public/jupyterlite/notebooks/index.html
@@ -187,7 +187,7 @@
         color: #bdbdbd;
       }
     </style>
-  <script src="/jl-kernel-diagnostics.js"></script>
+  <script src="/jl-kernel-diagnostics.js?v=9b4648cf"></script>
   </head>
   <body class="jp-ThemedContainer" data-notebook="notebooks">
     <div id="jupyterlite-loading-indicator" class="hidden">

--- a/Public/jupyterlite/repl/index.html
+++ b/Public/jupyterlite/repl/index.html
@@ -187,7 +187,7 @@
         color: #bdbdbd;
       }
     </style>
-  <script src="/jl-kernel-diagnostics.js"></script>
+  <script src="/jl-kernel-diagnostics.js?v=9b4648cf"></script>
   </head>
   <body class="jp-ThemedContainer" data-notebook="repl">
     <div id="jupyterlite-loading-indicator" class="hidden">

--- a/changelog.d/kernel-diagnostics-cache-buster.md
+++ b/changelog.d/kernel-diagnostics-cache-buster.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Editor kernel-diagnostics collector is now cache-busted, so collector changes
+  actually reach returning students.** `jl-kernel-diagnostics.js` was injected
+  into the editor documents as a bare `<script src="/jl-kernel-diagnostics.js">`
+  with no version query, so a browser that had cached an older copy kept running
+  it after a deploy — the editor page cache-busts itself, but this separately
+  referenced script did not. The result: collector changes (e.g. the v0.4.544
+  CASE 2 `bootContext` fields) silently failed to reach returning students until
+  the browser cache TTL expired. The injected tag now carries a `?v=<hash>`
+  derived from the collector's own bytes (`scripts/patch-jupyterlite-diagnostics.py`),
+  so a deploy that changes the script forces a fresh fetch while an unchanged
+  script keeps a stable, cacheable URL. `verify-jupyterlite.sh` now asserts the
+  tag's hash matches the current script, so a stale tag fails the build instead
+  of silently serving an old collector.

--- a/scripts/patch-jupyterlite-diagnostics.py
+++ b/scripts/patch-jupyterlite-diagnostics.py
@@ -16,17 +16,38 @@ carries it too. It is injected into the kernel-bearing editors only (notebooks,
 repl) — not consoles/edit/lab/tree — so non-kernel pages don't emit boot-stall
 noise.
 
-Idempotent: the tag is only added when absent. Fails loudly if an expected
-editor index.html is missing (an upstream layout change to re-examine).
+Cache-busting: the tag carries a `?v=<hash>` derived from the collector's own
+bytes. The script is served as a same-origin static asset and was previously
+referenced bare (`/jl-kernel-diagnostics.js`), so a browser that had cached an
+older copy kept running it after a deploy — the editor page cache-busts itself
+but this separately-referenced script did not, so collector changes (e.g. the
+CASE 2 bootContext fields) silently failed to reach returning students until the
+cache TTL expired. The content hash makes the URL change exactly when the script
+changes, so a deploy forces a fresh fetch; an unchanged script keeps a stable
+URL (still cacheable).
+
+Idempotent: a tag with the current hash is left as-is; a tag with a stale hash
+(or the old bare form) is replaced in place — never duplicated. Fails loudly if
+an expected editor index.html is missing (an upstream layout change to
+re-examine).
 """
+import hashlib
 import pathlib
+import re
 import sys
 
 # Same-origin absolute path: the editor iframe is served by Chickadee from
 # /jupyterlite/..., so "/jl-kernel-diagnostics.js" resolves to Public/ at the
 # origin root, is allowed by the CSP (script-src 'self'), and — being same-origin
 # — loads cleanly under the editor's COEP require-corp isolation.
-SCRIPT_TAG = '<script src="/jl-kernel-diagnostics.js"></script>'
+SCRIPT_SRC = "/jl-kernel-diagnostics.js"
+
+# Matches the diagnostics <script> tag with or without a ?v=<hash> cache-buster,
+# so a stale-hash tag (or the old bare form) from a previous build is replaced,
+# not duplicated.
+TAG_RE = re.compile(
+    r'<script src="' + re.escape(SCRIPT_SRC) + r'(?:\?v=[0-9a-f]+)?"></script>'
+)
 
 # Anchor the injection right before </head> so the collector's error listeners
 # are installed as early as possible in the document, before the kernel boots.
@@ -40,10 +61,36 @@ EDITOR_INDEXES = [
 ]
 
 
+def diagnostics_source(root: pathlib.Path) -> pathlib.Path:
+    """Locate Public/jl-kernel-diagnostics.js — the file served at SCRIPT_SRC
+    from the origin root, i.e. the directory that contains the jupyterlite/
+    build (root.parent). Falls back to a repo-relative path so the script works
+    regardless of the cwd the build invokes it from."""
+    candidate = root.parent / "jl-kernel-diagnostics.js"
+    if candidate.is_file():
+        return candidate
+    return pathlib.Path(__file__).resolve().parent.parent / "Public" / "jl-kernel-diagnostics.js"
+
+
+def cache_busted_tag(root: pathlib.Path) -> str:
+    source = diagnostics_source(root)
+    if not source.is_file():
+        print(
+            f"patch-jupyterlite-diagnostics: FAIL — collector source missing: {source}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()[:8]
+    return f'<script src="{SCRIPT_SRC}?v={digest}"></script>'
+
+
 def main() -> int:
     root = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("Public/jupyterlite")
 
+    script_tag = cache_busted_tag(root)
+
     injected = 0
+    refreshed = 0
     already = 0
     for rel in EDITOR_INDEXES:
         path = root / rel
@@ -54,8 +101,15 @@ def main() -> int:
             )
             return 1
         text = path.read_text()
-        if SCRIPT_TAG in text:
-            already += 1
+        existing = TAG_RE.search(text)
+        if existing:
+            if existing.group(0) == script_tag:
+                already += 1
+                continue
+            # Replace a stale-hash (or old bare) tag in place, preserving the
+            # surrounding indentation/placement.
+            path.write_text(text[: existing.start()] + script_tag + text[existing.end():])
+            refreshed += 1
             continue
         if ANCHOR not in text:
             print(
@@ -68,14 +122,16 @@ def main() -> int:
         idx = text.index(ANCHOR)
         line_start = text.rfind("\n", 0, idx) + 1
         indent = text[line_start:idx]
-        patched = text[:line_start] + indent + SCRIPT_TAG + "\n" + text[line_start:]
+        patched = text[:line_start] + indent + script_tag + "\n" + text[line_start:]
         path.write_text(patched)
         injected += 1
 
     if injected:
         print(f"patch-jupyterlite-diagnostics: injected collector into {injected} editor document(s)")
+    if refreshed:
+        print(f"patch-jupyterlite-diagnostics: refreshed cache-buster in {refreshed} editor document(s)")
     if already:
-        print(f"patch-jupyterlite-diagnostics: already present in {already} editor document(s) — no-op")
+        print(f"patch-jupyterlite-diagnostics: already current in {already} editor document(s) — no-op")
     return 0
 
 

--- a/scripts/verify-jupyterlite.sh
+++ b/scripts/verify-jupyterlite.sh
@@ -132,16 +132,34 @@ if data_worker_chunks:
 # `jupyter lite build` regenerates these index.html files and would drop the
 # <script> tag; without it the collector never runs and the kernel boot is
 # invisible again. Assert it's present so a rebuild that forgets the patch fails
-# here, not silently in front of a student.
-diag_tag = '<script src="/jl-kernel-diagnostics.js"></script>'
+# here, not silently in front of a student. The tag carries a ?v=<hash> derived
+# from the collector's bytes (cache-buster); assert the hash matches the current
+# script so a stale tag — which would serve students an old cached collector
+# after the script changed — fails here, not silently in the browser.
+import hashlib
+import re
+
+diag_source = build_dir.parent / "jl-kernel-diagnostics.js"
+if not diag_source.is_file():
+    fail(f"missing kernel-diagnostics collector source: {diag_source}")
+expected_hash = hashlib.sha256(diag_source.read_bytes()).hexdigest()[:8]
+expected_tag = f'<script src="/jl-kernel-diagnostics.js?v={expected_hash}"></script>'
+diag_tag_re = re.compile(r'<script src="/jl-kernel-diagnostics\.js\?v=([0-9a-f]+)"></script>')
 for rel in ("notebooks/index.html", "repl/index.html"):
     index_path = build_dir / rel
     if not index_path.is_file():
         fail(f"missing editor document: {index_path}")
-    if diag_tag not in index_path.read_text():
+    found = diag_tag_re.search(index_path.read_text())
+    if not found:
         fail(
-            f"{rel} is missing the kernel-diagnostics collector tag — "
+            f"{rel} is missing the cache-busted kernel-diagnostics collector tag — "
             "run scripts/patch-jupyterlite-diagnostics.py (build-jupyterlite.sh does this)."
+        )
+    if found.group(1) != expected_hash:
+        fail(
+            f"{rel} has a stale kernel-diagnostics cache-buster "
+            f"(?v={found.group(1)}, expected ?v={expected_hash}) — the collector changed "
+            "but the tag was not re-patched; run scripts/patch-jupyterlite-diagnostics.py."
         )
 
 print("JupyterLite verification passed.")


### PR DESCRIPTION
## Why

`jl-kernel-diagnostics.js` was injected into the editor documents as a bare `<script src="/jl-kernel-diagnostics.js">` with **no version query**. The editor page cache-busts itself, but this separately-referenced script did not — so a browser holding a cached copy kept running the **old** collector after a deploy, until the cache TTL expired.

Observed live on **v0.4.545**: every `kernel_unknown` beacon still arrived as bare `"kernel status unknown"` with **no `bootContext` tail**, even though the prod server was serving the updated script (confirmed it contains `bootContext()` + `recovered=1`). The v0.4.544 CASE 2 instrumentation (#1050) was effectively stranded behind browser caches — so the data #1049 needs wasn't flowing.

## What

- **`scripts/patch-jupyterlite-diagnostics.py`** now appends `?v=<sha256(script)[:8]>` to the injected tag. The hash is **computed from the collector's own bytes at patch time** — not hard-coded. URL changes iff the script changes, so a deploy forces a fresh fetch while an unchanged script keeps a stable, cacheable URL. The patch **replaces** a stale-hash/bare tag in place (idempotent — re-running is a no-op), so a rebuild can't duplicate it.
- **`scripts/verify-jupyterlite.sh`** now asserts the injected tag's hash **matches the current script**, so a stale tag (collector changed but not re-patched) fails the build instead of silently serving an old collector in front of a student.
- Re-ran the patch to refresh the two checked-in editor `index.html` files (`?v=9b4648cf`, which is `sha256(jl-kernel-diagnostics.js)[:8]` today).

This mirrors how the rest of the app's static assets are cache-busted, and how JupyterLite already content-hashes its own chunks (`jlab_core.<hash>.js`).

## Effect on the CASE 2 rollout
The first deploy carrying this points the tag at a **new URL for every browser** (`?v=…` vs. the previously-cached bare URL), so returning students fetch the current collector on their next editor load — `bootContext`/`recovered=1` start flowing without waiting on cache TTLs. (#1049)

## Verification
- `bash scripts/verify-jupyterlite.sh` → passes; both editor docs carry `?v=9b4648cf` matching the script hash.
- Re-running the patch → `already current … — no-op` (idempotent).
- Diff to the generated `index.html` files is the single `<script>` tag line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCJgAXwhcAPrLrLaiovo4F)_