### PR TITLE
fix(notebook): stop the stray second editor tab on notebook open

### DIFF
--- a/Public/notebook.js
+++ b/Public/notebook.js
@@ -538,6 +538,36 @@
             });
         }
 
+        // Notebook 7 opens each document in its OWN browser tab via window.open
+        // (its documented default). Embedded in our iframe that's a redundant
+        // stray tab — the iframe already shows the notebook, and on WebKit the
+        // second editor boots a third Pyodide that contends with the kernel. The
+        // iframe is same-origin, so neutralize its window.open for same-site
+        // JupyterLite document URLs; re-applied on every (re)load + tick since each
+        // navigation gets a fresh window. The server self-close page
+        // (JupyterLiteAppIndexMiddleware) is the backstop for an open() that races
+        // the patch.
+        function suppressStrayEditorTabs() {
+            let win;
+            try { win = frame.contentWindow; } catch (_) { return; }
+            if (!win || win._chickadeeOpenPatched) return;
+            let nativeOpen;
+            try { nativeOpen = win.open; } catch (_) { return; }
+            if (typeof nativeOpen !== 'function') return;
+            try {
+                win._chickadeeOpenPatched = true;
+                win.open = function (url) {
+                    try {
+                        const resolved = new win.URL(String(url == null ? '' : url), win.location.href);
+                        if (resolved.pathname.indexOf('/jupyterlite/') === 0) {
+                            return null;  // swallow Notebook 7's stray same-site document tab
+                        }
+                    } catch (_) { /* unparseable / relative-resolve failed — fall through */ }
+                    return nativeOpen.apply(win, arguments);
+                };
+            } catch (_) { /* frozen/cross-origin — rely on the server self-close backstop */ }
+        }
+
         frame.addEventListener('load', () => {
             // A document committed; any forced reset we were waiting on has
             // landed, so the locked-path enforcement may act again.
@@ -548,11 +578,13 @@
             applyLockedNotebookUI();
             enforceLockedNotebookPath();
             attachNotebookActivityBridge();
+            suppressStrayEditorTabs();
         });
         setInterval(() => {
             applyLockedNotebookUI();
             enforceLockedNotebookPath();
             attachNotebookActivityBridge();
+            suppressStrayEditorTabs();
         }, 1500);
 
         armEditorWatchdog();

--- a/Sources/APIServer/Middleware/JupyterLiteAppIndexMiddleware.swift
+++ b/Sources/APIServer/Middleware/JupyterLiteAppIndexMiddleware.swift
@@ -12,12 +12,16 @@
 // (`target="_blank"`), which lands on `/jupyterlite/notebooks?path=…` and 404s
 // while the original (iframe) editor keeps working. Reproduces on every engine.
 //
-// This middleware redirects the JupyterLite app directories to their
-// `index.html`, preserving the query string, so the app loads — matching the
-// SPA-style hosting JupyterLite documents for static hosts. Registered just
-// before `FileMiddleware` (which would otherwise 404 the bare directory).
-// `/jupyterlite/<app>/index.html` and deeper paths (`…/api/contents/…`) are
-// untouched — they already resolve.
+// That bare-directory URL is therefore ONLY ever requested by the stray tab —
+// the in-iframe editor always loads `…/index.html`. Rather than redirect it to a
+// SECOND full editor (which boots a second Pyodide and, on WebKit, contends with
+// the kernel already running in the iframe), this middleware returns a tiny
+// self-closing page: the stray tab was opened by `window.open`, so `window.close()`
+// closes it, and it never boots a kernel. (`notebook.js` also suppresses the
+// stray `window.open` at the source; this is the server-side backstop.) Registered
+// just before `FileMiddleware`; `/jupyterlite/<app>/index.html` and deeper paths
+// (`…/api/contents/…`) are untouched — they already resolve, so the iframe editor
+// is unaffected.
 
 import Vapor
 
@@ -48,10 +52,26 @@ struct JupyterLiteAppIndexMiddleware: AsyncMiddleware {
             return try await next.respond(to: request)
         }
 
-        var target = "/jupyterlite/" + parts[1] + "/index.html"
-        if let query = request.url.query, !query.isEmpty {
-            target += "?" + query
-        }
-        return request.redirect(to: target, redirectType: .temporary)
+        // Close the stray tab instead of booting a second editor in it. The tab
+        // was script-opened by Notebook 7 (`window.open`), so `window.close()` is
+        // permitted; the message is the fallback if a browser refuses it.
+        let html = """
+            <!doctype html>
+            <html lang="en">
+            <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Return to your assignment</title>
+            </head>
+            <body>
+            <script>try { window.close() } catch (e) { /* self-close may be blocked; the message below covers it */ }</script>
+            <p>This notebook opened in an extra browser tab. You can close this tab and return to your assignment.</p>
+            </body>
+            </html>
+            """
+        var headers = HTTPHeaders()
+        headers.contentType = .html
+        headers.replaceOrAdd(name: .cacheControl, value: "no-store")
+        return Response(status: .ok, headers: headers, body: .init(string: html))
     }
 }

--- a/Tests/APITests/JupyterLiteAppIndexMiddlewareTests.swift
+++ b/Tests/APITests/JupyterLiteAppIndexMiddlewareTests.swift
@@ -3,11 +3,12 @@ import VaporTesting
 
 @testable import APIServer
 
-/// JupyterLiteAppIndexMiddleware redirects a bare JupyterLite app-directory URL
+/// JupyterLiteAppIndexMiddleware intercepts a bare JupyterLite app-directory URL
 /// (`/jupyterlite/notebooks?path=…`, which Notebook 7 builds when it opens a
-/// document — e.g. in a new tab) to its `index.html`, preserving the query, so
-/// the static host serves the app instead of 404ing. Deeper paths and the
-/// `index.html` itself are left untouched.
+/// document in a stray new tab) and returns a tiny self-closing page — instead of
+/// booting a SECOND editor there — so the stray tab closes itself and never boots
+/// a kernel. Deeper paths and the `index.html` itself are left untouched, so the
+/// in-iframe editor is unaffected.
 @Suite struct JupyterLiteAppIndexMiddlewareTests {
 
     private func makeApp() async throws -> Application {
@@ -19,24 +20,25 @@ import VaporTesting
         return app
     }
 
-    @Test func bareNotebooksDirRedirectsToIndexPreservingQuery() async throws {
+    @Test func bareNotebooksDirReturnsSelfClosingPage() async throws {
         try await withApp(try await makeApp()) { app in
             try await app.testing().test(
                 .GET, "/jupyterlite/notebooks?path=users%2Fx%2Fassignment.ipynb"
             ) { res async in
-                #expect(res.status == .temporaryRedirect)
-                #expect(
-                    res.headers.first(name: "Location")
-                        == "/jupyterlite/notebooks/index.html?path=users%2Fx%2Fassignment.ipynb")
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("window.close()"))
+                // Must NOT boot a second editor — no redirect to index.html.
+                #expect(res.headers.first(name: "Location") == nil)
             }
         }
     }
 
-    @Test func trailingSlashAlsoRedirects() async throws {
+    @Test func trailingSlashAlsoSelfCloses() async throws {
         try await withApp(try await makeApp()) { app in
             try await app.testing().test(.GET, "/jupyterlite/lab/") { res async in
-                #expect(res.status == .temporaryRedirect)
-                #expect(res.headers.first(name: "Location") == "/jupyterlite/lab/index.html")
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("window.close()"))
+                #expect(res.headers.first(name: "Location") == nil)
             }
         }
     }

--- a/Tools/editor-smoke-test/notebook-page-check.mjs
+++ b/Tools/editor-smoke-test/notebook-page-check.mjs
@@ -217,6 +217,19 @@ async function main() {
   });
   const page = await context.newPage();
 
+  // Stray-tab guard. Notebook 7 opens each document in its own browser tab via
+  // window.open; embedded in our iframe that surfaces as a redundant second
+  // editor tab (a third Pyodide). With the fix — parent-side window.open
+  // suppression (notebook.js) + the server self-close page
+  // (JupyterLiteAppIndexMiddleware) — no such tab should ever open, so ANY new
+  // page in this context after the main one is a regression. Record + close it
+  // (so a stray second editor can't keep running and skew timings).
+  const strayTabs = [];
+  context.on("page", (p) => {
+    strayTabs.push(p.url());
+    p.close().catch(() => {});
+  });
+
   const blocked = [];
   page.on("requestfailed", (req) => {
     const why = req.failure()?.errorText || "";
@@ -393,6 +406,12 @@ async function main() {
     // loaded Pyodide, ran the test, and posted a correct outcome end-to-end.
     if (!/1\s*\/\s*1\s*passed/i.test(resultText)) {
       return fail(`grading did not pass cleanly (expected "1 / 1 passed"): ${resultText}`);
+    }
+
+    if (strayTabs.length) {
+      return fail(
+        `${strayTabs.length} stray editor tab(s) opened — Notebook 7's window.open was not suppressed: ${strayTabs.join(", ")}`
+      );
     }
 
     console.log(`E2E PASS — real notebook page isolated, workers spawned, kernel booted, submit graded 1/1 (engine=${browserName})`);

--- a/changelog.d/notebook-stray-editor-tab.md
+++ b/changelog.d/notebook-stray-editor-tab.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Opening a notebook no longer spawns a stray extra editor tab.** Notebook 7 opens each document in its own browser tab via `window.open`; embedded in Chickadee's iframe that surfaced as a redundant second editor — a third Pyodide, and on WebKit contention with the kernel already running in the iframe. v0.4.543 stopped that tab from 404ing but left it booting a full second editor. Now `notebook.js` suppresses the stray same-site `window.open` at the source (the iframe is same-origin), and `JupyterLiteAppIndexMiddleware` returns a tiny self-closing page — instead of a second editor — as the server-side backstop. An editor-smoke popup guard asserts no stray tab opens in Chromium + WebKit.


### PR DESCRIPTION
## Why

Opening a notebook spawns an **extra browser tab showing a bare JupyterLite editor** (no Chickadee chrome). Root cause: Notebook 7 opens each document in its own tab via `window.open` ([its documented default](https://jupyter-notebook.readthedocs.io/en/stable/notebook_7_features.html)). Embedded in our iframe that's a redundant tab — the iframe already shows the notebook — and it boots a **full second editor = a third Pyodide**, which on WebKit contends with the kernel already running in the iframe. #1048 (v0.4.543) only stopped that tab from *404ing*; it still opened a second editor.

## What

Two layers + a regression guard:

1. **Parent-side suppression (kills it at the source).** The iframe is same-origin, so `notebook.js` patches `contentWindow.open` on each (re)load + tick to swallow a `window.open` of a same-site `/jupyterlite/` document URL (resolving relative URLs against the iframe location). The stray tab never opens; other opens fall through to native `open` untouched.
2. **Server-side backstop.** `JupyterLiteAppIndexMiddleware` now returns a tiny **self-closing page** for the bare app-dir URL (the stray tab's signature — the iframe always loads `…/index.html`) instead of redirecting to a second editor. The tab was script-opened, so `window.close()` closes it; a "return to your assignment" message is the fallback. Never boots a kernel. Catches any `open()` that races the JS patch.
3. **Regression guard.** `editor-smoke` (`notebook-page-check.mjs`) asserts **no stray browser tab opens** in the context, in Chromium + WebKit.

`JupyterLiteAppIndexMiddlewareTests` updated to expect the self-close page rather than the old `index.html` redirect.

## Validation

- `swift-format` clean; JS suites green (`notebook.test.mjs`, `browser-runner.test.mjs`).
- The middleware test + the smoke popup-guard run in CI (`api-tests`, `editor-smoke`). *(Sandbox can't fetch SwiftPM deps, so the Swift compile + middleware test run in CI; I'll watch them.)*
- This is the path I **couldn't** reproduce locally (no built server to load the editor) — the editor-smoke popup guard is the real-browser verification.

## Notes

- Bonus: removing the second editor also removes a **third Pyodide boot** on the notebook page, which is pure win on WebKit (less kernel-boot contention).
- Draft — not deployed until reviewed + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018729ZWoL5ttaSsieNmT5Nc

---
_Generated by [Claude Code](https://claude.ai/code/session_018729ZWoL5ttaSsieNmT5Nc)_