### PR TITLE
A3 hardening: single-source expected values + grader-only support-file enforcement

### DIFF
--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -49,6 +49,15 @@ struct AuthorScriptTool: ContentTool {
         /// assignment default); absent/null leaves an existing script's
         /// override unchanged and a new script on the assignment default.
         let timeLimitSeconds: Int?
+        /// Support files only: mark the file **grader-only** (true) or clear the
+        /// mark (false). A grader-only support file still reaches the native
+        /// worker (via the zip) but is withheld from every student-facing path —
+        /// editor symlinks, the browser-runner download, and the student
+        /// support-file download. Use it for answer keys / reserved holdout
+        /// data. Requires worker grading (a browser-graded assignment can't keep
+        /// a file from the student). Absent/null leaves the current mark
+        /// unchanged. Ignored for test tiers.
+        let graderOnly: Bool?
     }
 
     struct Output: Encodable, Sendable {
@@ -90,7 +99,10 @@ struct AuthorScriptTool: ContentTool {
         + "script names or family:<id> tokens), sectionID (an existing section), and timeLimitSeconds "
         + "(a per-test execution time-limit override in seconds, 1–600; 0 clears it so the script uses "
         + "the assignment default). Cannot edit "
-        + "pattern-family or notebook-check generated scripts — edit the family/check instead. Saving "
+        + "pattern-family or notebook-check generated scripts — edit the family/check instead. "
+        + "For a support file, set graderOnly:true to withhold it from every student-facing path "
+        + "(editor, browser-runner download, support download) while still bundling it for the worker — "
+        + "use it for answer keys / reserved holdout data on worker-graded assignments. Saving "
         + "re-runs the assignment's validation and closes the assignment if it was open (re-open with "
         + "update_assignment once validation passes)."
 
@@ -159,6 +171,15 @@ struct AuthorScriptTool: ContentTool {
                         + "(\(mcpTimeLimitRange.lowerBound)–\(mcpTimeLimitRange.upperBound)); 0 clears the "
                         + "override (revert to the assignment default set by set_time_limit). Ignored for "
                         + "support files."),
+            ]),
+            "graderOnly": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "Support files only: true marks the file grader-only (reaches the worker via the "
+                        + "zip but is withheld from every student-facing path — editor symlinks, "
+                        + "browser-runner download, student support-file download); false clears the mark. "
+                        + "Use for answer keys / reserved holdout data. Requires worker grading. "
+                        + "Absent leaves the current mark unchanged; ignored for test tiers."),
             ]),
         ]),
         // content/sourceUrl are a one-of (validated in execute), so neither is
@@ -277,8 +298,22 @@ struct AuthorScriptTool: ContentTool {
                     detail: "\"\(cleaned)\" is currently a graded test; change its tier with update_suite "
                         + "or delete it before re-authoring it as a support file.")
             }
+            // A grader-only file is only safe under worker grading — the browser
+            // path ships the workspace to the student. Refuse before writing.
+            if input.graderOnly == true,
+                (setup.decodedManifest()?.gradingMode ?? .worker) != .worker
+            {
+                throw MCPToolError.invalidArguments(
+                    tool: Self.name,
+                    detail: "graderOnly requires worker grading, but this assignment is browser-graded. "
+                        + "Switch it with set_grading_mode(\"worker\") first.")
+            }
             try authorSupportFile(
                 filename: cleaned, content: content, setup: setup, assignment: assignment, context: context)
+            if let graderOnly = input.graderOnly {
+                try await setManifestGraderOnly(
+                    setup: setup, filename: cleaned, graderOnly: graderOnly, on: context.db)
+            }
         case .test(let tier):
             try await authorTestScript(
                 filename: cleaned, content: content, tier: tier, input: input,

--- a/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
@@ -618,6 +618,34 @@ func setManifestGradingMode(
     return mode
 }
 
+/// Adds or removes `filename` in the manifest's `graderOnlyFiles` list, mutating
+/// only that JSON field on `setup.manifest` (so unrelated keys are untouched) and
+/// saving only when it actually changes. A grader-only file is bundled for the
+/// worker but withheld from every student-facing path — see docs/datasets.md.
+func setManifestGraderOnly(
+    setup: APITestSetup, filename: String, graderOnly: Bool, on db: any Database
+) async throws {
+    guard
+        var dict = (try? JSONSerialization.jsonObject(with: Data(setup.manifest.utf8))) as? [String: Any]
+    else { return }
+    var files = (dict["graderOnlyFiles"] as? [String]) ?? []
+    let present = files.contains(filename)
+    if graderOnly && !present {
+        files.append(filename)
+    } else if !graderOnly && present {
+        files.removeAll { $0 == filename }
+    } else {
+        return  // already in the desired state
+    }
+    dict["graderOnlyFiles"] = files
+    if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+        let json = String(data: data, encoding: .utf8)
+    {
+        setup.manifest = json
+        try await setup.save(on: db)
+    }
+}
+
 /// Resolves a course code to its id, enforcing that the acting account may act
 /// on it.  Shared by the course-section tools.
 func resolveCourseID(code: String, tool: String, context: ToolContext) async throws -> UUID {

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -59,7 +59,29 @@ struct BrowserRunnerRoutes: RouteCollection {
         if try await requireOpenStudentAssignment(for: setupID, user: caller, on: req) == nil {
             try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
         }
-        return try await req.fileio.asyncStreamFile(at: setup.zipPath)
+
+        // Grader-only files (answer keys, reserved holdout sets) must never reach
+        // a browser-graded student — the whole stored zip is streamed into the
+        // Pyodide FS, which a determined student can inspect. Stream a filtered
+        // copy with those entries removed. The common case declares none (a
+        // grader-only file forces worker grading, see docs/datasets.md), so the
+        // empty case takes the no-copy streaming fast path.
+        let graderOnly = setup.decodedManifest()?.graderOnlyFiles ?? []
+        guard !graderOnly.isEmpty else {
+            return try await req.fileio.asyncStreamFile(at: setup.zipPath)
+        }
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory.appendingPathComponent("ck-browser-zip-\(UUID().uuidString)")
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempDir) }
+        let tempZip = tempDir.appendingPathComponent("setup.zip").path
+        try fm.copyItem(atPath: setup.zipPath, toPath: tempZip)
+        // writes:[:] — pure deletion of the grader-only entries from the copy.
+        try applyScriptChangesToZip(zipPath: tempZip, writes: [:], deletions: graderOnly)
+        let filtered = try Data(contentsOf: URL(fileURLWithPath: tempZip))
+        var headers = HTTPHeaders()
+        headers.contentType = HTTPMediaType(type: "application", subType: "zip")
+        return Response(status: .ok, headers: headers, body: .init(data: filtered))
     }
 
     // MARK: - GET /api/v1/browser-runner/testsetups/:id/manifest

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -458,15 +458,17 @@ struct TestSetupRoutes: RouteCollection {
         let allEntries = listZipEntries(zipPath: setup.zipPath)
         guard allEntries.contains(filename) else { throw Abort(.notFound) }
 
-        let testScripts: Set<String> = {
-            guard let props = setup.decodedManifest()
-
-            else { return [] }
-            return Set(props.testSuites.map(\.script))
-        }()
+        let props = setup.decodedManifest()
+        let testScripts = Set(props?.testSuites.map(\.script) ?? [])
+        // Grader-only files (answer keys, reserved holdout sets) are bundled for
+        // the worker but never served to students — block them here alongside
+        // test scripts and the canonical notebooks. See docs/datasets.md.
+        let graderOnly = props?.graderOnlyFileSet ?? []
         let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
-        guard !testScripts.contains(filename), !reservedNames.contains(filename) else {
-            throw AppError.forbidden(action: "download '\(filename)' (not a support file)")
+        guard !testScripts.contains(filename), !reservedNames.contains(filename),
+            !graderOnly.contains(filename)
+        else {
+            throw AppError.forbidden(action: "download '\(filename)' (not a student-visible support file)")
         }
 
         guard let bytes = extractZipEntry(zipPath: setup.zipPath, entryName: filename) else {

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -77,6 +77,22 @@ func enqueueRunnerValidationSubmission(
         on: req.db)
 
     try await materialized.saveClaimable(on: req.db)
+
+    // Keep the server-side `shared/{setupID}/solution.py` in lockstep with the
+    // reference solution, so a Global Input expression can compute an expected
+    // value as `solution.<fn>(...)` — one source of truth — instead of a
+    // hand-maintained answer key that can silently drift from the solution.
+    // This file lives ONLY in the shared directory (never the test-setup zip),
+    // so it never reaches the worker, the browser, or a student support-file
+    // download — mirroring how `solution.ipynb` is kept out of every
+    // student-facing path. Best-effort: failure just leaves `import solution`
+    // unavailable (the prior behaviour) and never blocks the save.
+    let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+    SolutionNotebookExtractor.writeSolutionPy(
+        notebookData: solutionNotebookData,
+        sharedDirectory: sharedDir,
+        overwrite: true)
+
     return subID
 }
 

--- a/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
+++ b/Sources/APIServer/Routes/Web/TestSetupZipHelpers.swift
@@ -435,13 +435,6 @@ func extractSupportFilesToSharedDirectory(
     let sharedDir = testSetupsDirectory + "shared/\(setupID)/"
     let fm = FileManager.default
     do {
-        // Always remove the stale shared dir before re-extracting so a support
-        // file removed on edit doesn't linger (and so student symlinks to it
-        // become visibly broken rather than silently stale).
-        if fm.fileExists(atPath: sharedDir) {
-            try fm.removeItem(atPath: sharedDir)
-        }
-
         // Slice 5 of #461: also extract solution.ipynb's code cells
         // into `solution.py` so personalization expressions can `import
         // solution` and call the canonical helpers (e.g.
@@ -450,8 +443,33 @@ func extractSupportFilesToSharedDirectory(
         // checks for existence first).
         let solutionData = extractZipEntry(zipPath: zipPath, entryName: "solution.ipynb")
 
+        // Preserve a solution-save-generated `solution.py` across the wipe.
+        // It is written by the solution-save path (enqueueRunnerValidationSubmission)
+        // and lives ONLY in the shared dir — never in the zip — so removing the
+        // dir would otherwise drop it until the next solution save, breaking
+        // `import solution` in expressions on the next edit. Skip preserving when
+        // the zip itself carries the solution: `solution.ipynb` regenerates
+        // `solution.py` below, and an instructor-uploaded `solution.py` support
+        // file is in `supportNames` and re-copied — either way the zip stays
+        // authoritative.
+        let solutionPyPath = sharedDir + "solution.py"
+        let zipCarriesSolution = solutionData != nil || allEntries.contains("solution.py")
+        let preservedSolutionPy: String?
+        if !zipCarriesSolution && fm.fileExists(atPath: solutionPyPath) {
+            preservedSolutionPy = try? String(contentsOfFile: solutionPyPath, encoding: .utf8)
+        } else {
+            preservedSolutionPy = nil
+        }
+
+        // Always remove the stale shared dir before re-extracting so a support
+        // file removed on edit doesn't linger (and so student symlinks to it
+        // become visibly broken rather than silently stale).
+        if fm.fileExists(atPath: sharedDir) {
+            try fm.removeItem(atPath: sharedDir)
+        }
+
         // Skip the dir creation when nothing's going to land in it.
-        guard !supportNames.isEmpty || solutionData != nil else { return }
+        guard !supportNames.isEmpty || solutionData != nil || preservedSolutionPy != nil else { return }
         try fm.createDirectory(atPath: sharedDir, withIntermediateDirectories: true)
         for name in supportNames {
             guard let data = extractZipEntry(zipPath: zipPath, entryName: name) else { continue }
@@ -467,6 +485,9 @@ func extractSupportFilesToSharedDirectory(
                 notebookData: solutionData,
                 sharedDirectory: sharedDir
             )
+        } else if let preservedSolutionPy {
+            // Restore the server-side-only solution.py the wipe removed.
+            try preservedSolutionPy.write(toFile: solutionPyPath, atomically: true, encoding: .utf8)
         }
     } catch {
         // Non-fatal: support files are a convenience; log and continue.

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -454,13 +454,18 @@ func createSupportFileSymlinks(req: Request, setup: APITestSetup, studentDir: St
 
     let testScriptNames = Set(props.testSuites.map { $0.script })
     let reservedNames: Set<String> = ["assignment.ipynb", "solution.ipynb"]
+    // Grader-only support files (e.g. an answer-key helper or a reserved
+    // holdout) reach the worker via the zip but are withheld from every
+    // student-facing path — here, the editor must not symlink them into the
+    // student's working copy. See docs/datasets.md (option B).
+    let graderOnly = props.graderOnlyFileSet
     // Cached: this pass runs on every notebook visit (the symlinks are
     // idempotent), so listing the zip fresh each time would spawn a serialized
     // `unzip` subprocess per load. The cache busts when the zip's mtime/size
     // changes — i.e. whenever the instructor edits support files.
     let allEntries = await req.application.zipEntryListCache.entries(zipPath: setup.zipPath)
     let supportNames = allEntries.filter {
-        !testScriptNames.contains($0) && !reservedNames.contains($0)
+        !testScriptNames.contains($0) && !reservedNames.contains($0) && !graderOnly.contains($0)
     }
     guard !supportNames.isEmpty else { return }
 

--- a/Sources/APIServer/Services/SolutionNotebookExtractor.swift
+++ b/Sources/APIServer/Services/SolutionNotebookExtractor.swift
@@ -58,11 +58,33 @@ enum SolutionNotebookExtractor {
         notebookData: Data,
         sharedDirectory: String
     ) -> Bool {
+        writeSolutionPy(notebookData: notebookData, sharedDirectory: sharedDirectory, overwrite: false)
+    }
+
+    /// Like `writeSolutionPyIfNeeded`, but `overwrite: true` refreshes an
+    /// existing `solution.py`.  Used by the solution-save path so the
+    /// server-side `shared/{setupID}/solution.py` the personalization
+    /// evaluator imports stays in lockstep with the instructor's reference
+    /// solution — the keystone that lets a Global Input expression compute an
+    /// expected value as `solution.<fn>(...)` instead of a parallel answer key
+    /// that can drift.  `solution.py` lives ONLY in the shared directory; it is
+    /// never written into the test-setup zip, so it never reaches the worker,
+    /// the browser, or a student support-file download (mirroring the reserved
+    /// treatment of `solution.ipynb`).
+    ///
+    /// With `overwrite: false` an existing `solution.py` is left alone so an
+    /// instructor-uploaded support file still wins.
+    @discardableResult
+    static func writeSolutionPy(
+        notebookData: Data,
+        sharedDirectory: String,
+        overwrite: Bool
+    ) -> Bool {
         let fm = FileManager.default
         let target = (sharedDirectory as NSString).appendingPathComponent("solution.py")
 
-        // Don't overwrite an instructor-uploaded solution.py.
-        if fm.fileExists(atPath: target) { return false }
+        // Don't clobber an instructor-uploaded solution.py unless asked to.
+        if fm.fileExists(atPath: target) && !overwrite { return false }
 
         guard let py = extractCodeToPython(notebookData: notebookData) else { return false }
         // Skip when the notebook had no executable cells — writing an

--- a/Tests/APITests/AssignmentHelpersManifestTests.swift
+++ b/Tests/APITests/AssignmentHelpersManifestTests.swift
@@ -539,6 +539,45 @@ final class AssignmentHelpersManifestTests {
         #expect(extracted.contains("stale.txt") == false)
     }
 
+    @Test func extractSupportFiles_preservesServerSideSolutionPyAcrossRebuild() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preserve-solpy-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        // A zip WITHOUT solution.ipynb / solution.py — like a draft/MCP-created
+        // setup whose reference solution lives only as a validation submission.
+        let zipPath = tempRoot.appendingPathComponent("setup.zip").path
+        try ahMakeZip(
+            at: zipPath,
+            entries: [
+                ("tests.py", "print('t')"),
+                ("dbgen.py", "def gen():\n    return 1\n"),
+            ])
+
+        let testSetupsDirectory = tempRoot.appendingPathComponent("testsetups").path + "/"
+        let sharedDir = testSetupsDirectory + "shared/setup_sol/"
+        try FileManager.default.createDirectory(atPath: sharedDir, withIntermediateDirectories: true)
+        // The solution-save path wrote this server-side-only file.
+        try "def answer():\n    return 42\n".write(
+            toFile: sharedDir + "solution.py", atomically: true, encoding: .utf8)
+
+        // An edit triggers a shared-dir rebuild (wipe + re-extract). solution.py
+        // is not in the zip, so without preservation the wipe would drop it.
+        extractSupportFilesToSharedDirectory(
+            zipPath: zipPath,
+            setupID: "setup_sol",
+            testSuiteScripts: ["tests.py"],
+            testSetupsDirectory: testSetupsDirectory
+        )
+
+        let onDisk = try? String(contentsOfFile: sharedDir + "solution.py", encoding: .utf8)
+        #expect(onDisk?.contains("def answer():") == true)
+        // Ordinary support files still extract; the test script does not.
+        #expect(FileManager.default.fileExists(atPath: sharedDir + "dbgen.py"))
+        #expect(FileManager.default.fileExists(atPath: sharedDir + "tests.py") == false)
+    }
+
     @Test func removeMaterializedNotebookFilesDeletesLegacyNotebookArtifactsForSetup() async throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("materialized-files-\(UUID().uuidString)")

--- a/Tests/APITests/AssignmentHelpersManifestTests.swift
+++ b/Tests/APITests/AssignmentHelpersManifestTests.swift
@@ -578,6 +578,38 @@ final class AssignmentHelpersManifestTests {
         #expect(FileManager.default.fileExists(atPath: sharedDir + "tests.py") == false)
     }
 
+    @Test func applyScriptChanges_filtersGraderOnlyEntryFromZipCopy() throws {
+        // The browser-runner download withholds grader-only files by streaming a
+        // COPY of the stored zip with those entries deleted (via
+        // applyScriptChangesToZip(deletions:)). Pin that primitive: it removes
+        // exactly the named entries, keeps the rest, and leaves the original
+        // (which the trusted worker download streams) untouched.
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("graderonly-filter-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let zipPath = tempRoot.appendingPathComponent("setup.zip").path
+        try ahMakeZip(
+            at: zipPath,
+            entries: [
+                ("tests.py", "print('t')"),
+                ("dbgen.py", "ANSWER = 42\n"),
+                ("data.csv", "a,b\n1,2\n"),
+            ])
+
+        let copyPath = tempRoot.appendingPathComponent("filtered.zip").path
+        try FileManager.default.copyItem(atPath: zipPath, toPath: copyPath)
+        try applyScriptChangesToZip(zipPath: copyPath, writes: [:], deletions: ["dbgen.py"])
+
+        let remaining = Set(listZipEntries(zipPath: copyPath))
+        #expect(remaining.contains("dbgen.py") == false)  // grader-only entry removed
+        #expect(remaining.contains("tests.py"))  // others kept
+        #expect(remaining.contains("data.csv"))
+        // The stored zip (what the trusted worker download streams) is untouched.
+        #expect(Set(listZipEntries(zipPath: zipPath)).contains("dbgen.py"))
+    }
+
     @Test func removeMaterializedNotebookFilesDeletesLegacyNotebookArtifactsForSetup() async throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("materialized-files-\(UUID().uuidString)")

--- a/Tests/APITests/MCP/AuthorScriptToolTests.swift
+++ b/Tests/APITests/MCP/AuthorScriptToolTests.swift
@@ -77,13 +77,13 @@ import Vapor
         sourceUrl: String? = nil,
         tier: String? = nil, points: Int? = nil, displayName: String? = nil,
         dependsOn: [String]? = nil, sectionID: String? = nil,
-        timeLimitSeconds: Int? = nil
+        timeLimitSeconds: Int? = nil, graderOnly: Bool? = nil
     ) -> AuthorScriptTool.Input {
         AuthorScriptTool.Input(
             assignmentPublicID: assignment.publicID, filename: filename, content: content,
             sourceUrl: sourceUrl,
             tier: tier, points: points, displayName: displayName, dependsOn: dependsOn,
-            sectionID: sectionID, timeLimitSeconds: timeLimitSeconds)
+            sectionID: sectionID, timeLimitSeconds: timeLimitSeconds, graderOnly: graderOnly)
     }
 
     @Test func createsNewTestScriptWithMetadata() async throws {

--- a/Tests/APITests/SupportImportTests.swift
+++ b/Tests/APITests/SupportImportTests.swift
@@ -75,6 +75,60 @@ import Testing
         #expect(onDisk == instructorOwn)
     }
 
+    @Test func extractor_overwriteRefreshesExistingSolutionPy() throws {
+        // The solution-save path uses `overwrite: true` to keep
+        // `shared/solution.py` in lockstep with the reference solution, so a
+        // Global Input expression's `solution.<fn>(...)` never drifts.
+        let nb: [String: Any] = [
+            "cells": [["cell_type": "code", "source": "def f(x):\n    return x + 1\n"]],
+            "metadata": [:], "nbformat": 4, "nbformat_minor": 5,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: nb)
+        let shared = tempDir.path + "/"
+        let pyPath = shared + "solution.py"
+
+        // A stale solution.py is present.
+        try "STALE = 1\n".write(toFile: pyPath, atomically: true, encoding: .utf8)
+
+        // overwrite:false leaves it (instructor-uploaded support file wins).
+        #expect(
+            SolutionNotebookExtractor.writeSolutionPy(
+                notebookData: data, sharedDirectory: shared, overwrite: false) == false)
+        #expect(try String(contentsOfFile: pyPath, encoding: .utf8) == "STALE = 1\n")
+
+        // overwrite:true refreshes it from the current solution notebook.
+        #expect(
+            SolutionNotebookExtractor.writeSolutionPy(
+                notebookData: data, sharedDirectory: shared, overwrite: true))
+        let refreshed = try String(contentsOfFile: pyPath, encoding: .utf8)
+        #expect(refreshed.contains("def f(x):"))
+        #expect(refreshed.contains("STALE") == false)
+    }
+
+    @Test func evaluator_importsSolutionAfterOverwriteWrite() async throws {
+        // End-to-end keystone: once `shared/solution.py` exists, an expression
+        // can source an expected value straight from the reference solution.
+        let nb: [String: Any] = [
+            "cells": [
+                ["cell_type": "code", "source": "def double(x):\n    return x * 2\n"]
+            ],
+            "metadata": [:], "nbformat": 4, "nbformat_minor": 5,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: nb)
+        #expect(
+            SolutionNotebookExtractor.writeSolutionPy(
+                notebookData: data, sharedDirectory: tempDir.path + "/", overwrite: true))
+
+        let result = try await PersonalizationEvaluator.evaluate(
+            seedHex: "0005",
+            staticVariables: [],
+            expressions: [PersonalizationExpression(name: "x", expression: "solution.double(seed)")],
+            supportFilesDirectory: tempDir.path
+        )
+        // seed = 5; solution.double(5) = 10.
+        #expect(result["x"] == "10")
+    }
+
     @Test func extractor_skipsEmptyNotebook() throws {
         let nb: [String: Any] = [
             "cells": [["cell_type": "markdown", "source": "Just text"]],

--- a/changelog.d/grader-only-files-enforcement.md
+++ b/changelog.d/grader-only-files-enforcement.md
@@ -1,0 +1,19 @@
+### Security
+
+- **Grader-only support files are now withheld from students (enforcement +
+  authoring).** The `TestProperties.graderOnlyFiles` marker (option B in
+  `docs/datasets.md`) was a foundation-only field — nothing consulted it, so a
+  support file bundled for the grader (e.g. an answer-key helper like a
+  `dbgen.py`, or a reserved holdout test set) was still downloadable by any
+  enrolled student via the support-file endpoint, symlinked into the in-browser
+  editor, and streamed in full to a browser-graded student. Enforcement now
+  unions `graderOnlyFiles` into the student-facing filters at all three points:
+  the student support-file download (`TestSetupRoutes.downloadSupportFile`
+  blocks it), the editor symlink pass (`NotebookWorkingCopyStore` skips it), and
+  the browser-runner zip download (`BrowserRunnerRoutes.downloadTestSetup`
+  streams a copy with the entries removed). The trusted native-worker download
+  is unchanged (it needs the file), and the file still extracts into the
+  server-side `shared/` dir so personalization expressions can import it.
+  `author_script` gains a `graderOnly` flag for support files to set/clear the
+  mark; it requires worker grading (a browser-graded assignment can't keep a
+  file from the student).

--- a/changelog.d/shared-solution-py-sync.md
+++ b/changelog.d/shared-solution-py-sync.md
@@ -1,0 +1,17 @@
+### Added
+
+- **Reference solution is now importable in personalization expressions
+  (`shared/solution.py` kept in sync).** Saving an assignment's reference
+  solution now (re)writes a server-side `shared/{setupID}/solution.py` from the
+  solution notebook's code cells, so a Global Input expression can compute an
+  expected value as `solution.<fn>(...)` — a single source of truth — instead of
+  a hand-maintained answer key that can silently drift from the solution. The
+  file lives **only** in the shared directory: it is never written into the
+  test-setup zip, so it never reaches the worker, the browser runner, or a
+  student support-file download (the same treatment `solution.ipynb` already
+  gets). The shared-directory rebuild that runs on every suite edit now
+  preserves this file across its wipe when the zip does not itself carry the
+  solution, so `import solution` keeps working after an edit. Previously this
+  worked only for setups whose uploaded zip happened to contain `solution.ipynb`
+  (draft-/MCP-created assignments never do), leaving the feature dormant for
+  them.


### PR DESCRIPTION
Two related changes from the HLTH 230 Assignment 3 review, bundled on one branch (`claude/quirky-rubin-x2br84`). Both close risks surfaced in that review; happy to split if you'd prefer two PRs.

> **Local-build caveat:** the authoring sandbox has no network to fetch SwiftPM deps, so I could not `swift build`/test locally — changes are parse-checked and swift-format-clean, CI is the real verifier. Draft for review; the browser-download change is a student-facing security boundary and deserves a careful read.

---

## 1. Sync server-side `shared/solution.py` on solution save (the enabler)

Makes "the reference solution is the single source of truth for expected values" achievable, so a Global Input expression can write `count_adults_expected = solution.countAdults(patients)` instead of a hand-maintained answer key that can silently diverge from the solution (the false-failure class from the A3 review).

- `enqueueRunnerValidationSubmission` now (re)writes `shared/{setupID}/solution.py` from the solution notebook's code cells (`overwrite: true`).
- `extractSupportFilesToSharedDirectory` preserves that file across the shared-dir rebuild a suite edit triggers (unless the zip itself carries the solution).
- `SolutionNotebookExtractor.writeSolutionPy(…, overwrite:)`; `writeSolutionPyIfNeeded` delegates with `overwrite: false`.

`solution.py` lives **only** in the server-side `shared/` dir — never in the zip — so it never reaches the worker, the browser, or a student download (mirroring `solution.ipynb`). Previously this worked only for setups whose uploaded zip happened to contain `solution.ipynb`; draft-/MCP-created assignments never do, leaving the documented `import solution` feature dormant for them (e.g. A3).

## 2. Enforce grader-only support files (the security fix)

`TestProperties.graderOnlyFiles` (option B in `docs/datasets.md`) existed as a Core marker but **nothing consulted it** — so a support file bundled for the grader (an answer-key helper like `dbgen.py`, or a reserved holdout set) was still downloadable by any enrolled student, symlinked into the in-browser editor, and streamed in full to a browser-graded student. This was the exposure flagged in the review: A3's `dbgen.py` currently ships `ref_count_adults` / `ref_average_age` / … — effectively the answer key.

Enforcement at the three student-facing delivery points:
- `TestSetupRoutes.downloadSupportFile` — blocks grader-only files (403).
- `NotebookWorkingCopyStore.createSupportFileSymlinks` — skips them (editor).
- `BrowserRunnerRoutes.downloadTestSetup` — streams a filtered copy with the entries removed (empty case keeps the no-copy streaming fast path).

The trusted native-worker download is unchanged (it needs the file), and the file still extracts into `shared/` so server-side personalization expressions can import it. `author_script` gains a `graderOnly` flag (set/clear the mark); it requires worker grading, since the browser path can't keep a file from the student.

> Once this deploys, A3's `dbgen.py` gets marked grader-only (closing the leak), and PR 2 — the MCP refactor — slims it to generators-only and points the expressions at `solution.*` (built + verified across 400k seeds).

## Tests
- `extractor_overwriteRefreshesExistingSolutionPy`, `evaluator_importsSolutionAfterOverwriteWrite`, `extractSupportFiles_preservesServerSideSolutionPyAcrossRebuild` (enabler).
- `applyScriptChanges_filtersGraderOnlyEntryFromZipCopy` (browser-filter primitive), on top of the existing `GraderOnlyFilesTests` foundation suite.

## Related finding (not addressed here)
The browser manifest endpoint (`BrowserRunnerRoutes.getTestSetupManifest`) returns the **raw** `setup.manifest`, which includes `globalExpressions` — for a personalized assignment that ships expression *source* to an enrolled student. Returning `runnerSanitized()` there would close it, but it touches browser-grading and I couldn't test it locally, so I left it out of this PR. Flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhCtqrZZccY2XvDLeoEmW9