### PR TITLE
fix(datasets): strip grader-only filenames from the browser manifest

### DIFF
--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -110,11 +110,16 @@ struct BrowserRunnerRoutes: RouteCollection {
             try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
         }
 
+        // Withhold the *names* of grader-only support files (option B —
+        // docs/datasets.md) from the student-facing manifest. Their contents are
+        // already withheld at every download path (#1055); this closes the
+        // residual leak where `graderOnlyFiles` still named the holdout /
+        // answer-key files in the JSON served to the student's browser.
         var headers = HTTPHeaders()
         headers.add(name: .contentType, value: "application/json; charset=utf-8")
         return Response(
             status: .ok, headers: headers,
-            body: .init(string: setup.manifest))
+            body: .init(string: manifestWithGraderOnlyFilesStripped(setup.manifest)))
     }
 
     // MARK: - GET /api/v1/browser-runner/testsetups/:id/seed
@@ -187,4 +192,32 @@ struct BrowserRunnerSeedResponse: Content {
     /// writes these to `_ck_inputs.py` so generated pattern-family scripts can
     /// load per-student args / expected. Nil when there are none (issue #461).
     let personalizedInputs: [String: String]?
+}
+
+/// Returns the manifest JSON with the `graderOnlyFiles` array blanked to `[]`,
+/// so the student-facing browser manifest endpoint doesn't leak the *names* of
+/// reserved holdout / answer-key support files (option B — `docs/datasets.md`).
+/// Their contents are already withheld at every download path (#1055); this
+/// closes the residual name leak in the manifest the browser fetches.
+///
+/// Strict no-op — the input is returned byte-for-byte — when there is nothing
+/// to strip: the key is absent, already empty, or the body isn't a JSON object.
+/// Only when grader-only names are actually present is the JSON rewritten, and
+/// then only the `graderOnlyFiles` key changes; every other field is preserved.
+func manifestWithGraderOnlyFilesStripped(_ manifest: String) -> String {
+    guard
+        let data = manifest.data(using: .utf8),
+        var object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+        let existing = object["graderOnlyFiles"] as? [Any], !existing.isEmpty
+    else {
+        return manifest
+    }
+    object["graderOnlyFiles"] = [String]()
+    guard
+        let reencoded = try? JSONSerialization.data(withJSONObject: object),
+        let stripped = String(data: reencoded, encoding: .utf8)
+    else {
+        return manifest
+    }
+    return stripped
 }

--- a/Tests/APITests/BrowserManifestGraderOnlyStripTests.swift
+++ b/Tests/APITests/BrowserManifestGraderOnlyStripTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import APIServer
+
+/// Pins the contract for `manifestWithGraderOnlyFilesStripped`: the
+/// browser-runner manifest endpoint must not leak grader-only support-file
+/// names (option B — `docs/datasets.md`) to the student's browser, while
+/// leaving every other field — and the common no-grader-only case — untouched.
+@Suite struct BrowserManifestGraderOnlyStripTests {
+
+    @Test func blanksGraderOnlyNamesAndPreservesOtherFields() throws {
+        let manifest =
+            #"{"schemaVersion":1,"graderOnlyFiles":["holdout.csv","answers.py"],"requiredFiles":["warmup.py"]}"#
+
+        let stripped = manifestWithGraderOnlyFilesStripped(manifest)
+
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(stripped.utf8)) as? [String: Any])
+        #expect(try #require(object["graderOnlyFiles"] as? [String]).isEmpty)
+        // The names must be gone from the served bytes, not just the parsed array.
+        #expect(!stripped.contains("holdout.csv"))
+        #expect(!stripped.contains("answers.py"))
+        // Every other field is preserved.
+        #expect(try #require(object["requiredFiles"] as? [String]) == ["warmup.py"])
+        #expect(try #require(object["schemaVersion"] as? Int) == 1)
+    }
+
+    @Test func noOpWhenGraderOnlyArrayIsEmpty() {
+        // The common case: the field exists but is empty — return byte-for-byte
+        // so non-grader-only assignments are unchanged (no JSON re-encode).
+        let manifest = #"{"schemaVersion":1,"graderOnlyFiles":[],"requiredFiles":["warmup.py"]}"#
+        #expect(manifestWithGraderOnlyFilesStripped(manifest) == manifest)
+    }
+
+    @Test func noOpWhenGraderOnlyKeyAbsent() {
+        // Legacy manifests authored before the field existed.
+        let manifest = #"{"schemaVersion":1,"requiredFiles":["warmup.py"]}"#
+        #expect(manifestWithGraderOnlyFilesStripped(manifest) == manifest)
+    }
+
+    @Test func noOpOnNonJSONBody() {
+        let garbage = "this is not json"
+        #expect(manifestWithGraderOnlyFilesStripped(garbage) == garbage)
+    }
+}

--- a/changelog.d/browser-manifest-grader-only-strip.md
+++ b/changelog.d/browser-manifest-grader-only-strip.md
@@ -1,0 +1,11 @@
+### Security
+
+- **Grader-only support-file names no longer leak in the browser manifest.**
+  Enforcement (#1055) withholds the *contents* of `TestProperties.graderOnlyFiles`
+  (option B — `docs/datasets.md`) from every student download path, but the
+  browser-runner manifest endpoint (`GET /api/v1/browser-runner/testsetups/:id/manifest`)
+  still served `test.properties.json` verbatim — so the `graderOnlyFiles` array
+  named the reserved holdout / answer-key files to the student's browser. The
+  endpoint now blanks that array before serving (`manifestWithGraderOnlyFilesStripped`);
+  a strict no-op for assignments with no grader-only files (the array is returned
+  byte-for-byte), and every other manifest field is preserved.


### PR DESCRIPTION
## What

Closes the one student-facing leak that **#1055** (A3 hardening) left open for grader-only support files (option B — `docs/datasets.md`).

#1055 withholds the *contents* of `TestProperties.graderOnlyFiles` (reserved holdout / answer-key files) at every student download path — support download, editor symlinks, browser-runner zip. But the browser-runner **manifest** endpoint (`GET /api/v1/browser-runner/testsetups/:id/manifest`) still served `test.properties.json` **verbatim**, so the `graderOnlyFiles` array still **named** those files to the student's browser.

`getTestSetupManifest` now blanks that array before serving, via a small testable helper `manifestWithGraderOnlyFilesStripped`.

## Behaviour

| Case | Result |
|------|--------|
| Assignment with grader-only files | `graderOnlyFiles` blanked to `[]` in the served JSON; names gone from the bytes; every other field preserved |
| No grader-only files (key empty or absent) | **strict no-op** — manifest returned byte-for-byte, no JSON re-encode |
| Body isn't a JSON object | returned unchanged |

The worker delivery path and the canonical stored manifest are untouched — only the bytes served to the student browser change, and only when there's a name to withhold.

## Tests

`BrowserManifestGraderOnlyStripTests` pins the contract: names blanked + gone from the serialized body, other fields preserved, and the three no-op cases (empty array / absent key / non-JSON) returned verbatim.

`scripts/format.sh` clean. Full build can't run here (egress policy); CI is the oracle.

## Context

This is the focused follow-up after **#1021** was closed as superseded by #1055 — the manifest name-leak was the one defensible net-new piece of that branch. The #1021 MCP `GetSupportFilesTool` change was intentionally dropped: that surface is instructor/agent-facing (`content:read`), where seeing one's own answer key is allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lx1g6pnZFeZMtKhbKcJCuS)_