### PR TITLE
feat(brightspace): grade pending students and push override-only grades

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1060,6 +1060,24 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 .ext-details[open] > .ext-summary { background: var(--gray-100); }
 .ext-details form { min-width: 14rem; }
 @media (max-width: 640px) { .ext-details form { min-width: 0; } }
+/* Inline set/clear panel shared by the grade-override control
+   (assignment-submissions.leaf) and the register-pending-student control
+   (instructor-students.leaf) — hoisted from a page block so both pages render
+   identically. */
+.form-flush { margin: 0; }
+.ext-panel {
+    margin-top: .4rem;
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+    padding: .5rem;
+    background: var(--gray-50);
+    border: 1px solid var(--gray-300);
+    border-radius: .25rem;
+}
+.ext-field-label { font-size: .78rem; color: var(--gray-700); }
+.ext-field-input { width: 100%; margin-top: .2rem; }
+.ext-panel-actions { display: flex; gap: .3rem; }
 
 /* ── Submission view (submission.leaf) ───────────────── */
 /* Migrated out of submission.leaf's embedded <style> block (v0.4.x UI audit)

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -118,31 +118,6 @@
     flex-wrap: wrap;
     align-items: center;
 }
-.form-flush {
-    margin: 0;
-}
-.ext-panel {
-    margin-top: .4rem;
-    display: flex;
-    flex-direction: column;
-    gap: .3rem;
-    padding: .5rem;
-    background: var(--gray-50);
-    border: 1px solid var(--gray-300);
-    border-radius: .25rem;
-}
-.ext-field-label {
-    font-size: .78rem;
-    color: var(--gray-700);
-}
-.ext-field-input {
-    width: 100%;
-    margin-top: .2rem;
-}
-.ext-panel-actions {
-    display: flex;
-    gap: .3rem;
-}
 #assignment-submissions-table th[data-sort-key] {
     cursor: pointer;
     user-select: none;

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -95,15 +95,46 @@ Students
             </td>
             <td>
                 #if(!courseIsArchived):
-                <form method="post" action="#(student.unenrollURL)"
-                      class="inline-form">
-                    #csrfFormField()
-                    <button class="btn action-btn action-danger students-unenroll-btn" type="submit"
-                            title="Remove from course" aria-label="Remove from course"
-                            onclick="return confirm('Remove @#(student.username) from this course?')">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
-                    </button>
-                </form>
+                <div class="students-row-actions">
+                    #if(student.isPending):
+                    <details class="ext-details form-flush">
+                        <summary class="btn action-btn action-btn-tight" title="Register this student now"
+                                 aria-label="Register pending student">Register</summary>
+                        <form method="post" action="#(student.registerURL)" class="ext-panel">
+                            #csrfFormField()
+                            <p class="students-register-hint">Materialize <code>#(student.username)</code> into a real account now (for grade-sync testing). They appear on assignment rosters immediately; their real login adopts this account.</p>
+                            <label class="ext-field-label">
+                                Display name
+                                <input type="text" name="displayName" placeholder="#(student.username)" class="ext-field-input">
+                            </label>
+                            <label class="ext-field-label">
+                                Student number (optional)
+                                <input type="text" name="studentID" class="ext-field-input">
+                            </label>
+                            <label class="ext-field-label">
+                                Email (optional)
+                                <input type="email" name="email" class="ext-field-input">
+                            </label>
+                            <label class="ext-field-label">
+                                SSO subject (optional)
+                                <input type="text" name="externalSubject" placeholder="leave blank to adopt by username" class="ext-field-input">
+                            </label>
+                            <div class="ext-panel-actions">
+                                <button class="btn action-btn" type="submit">Register</button>
+                            </div>
+                        </form>
+                    </details>
+                    #endif
+                    <form method="post" action="#(student.unenrollURL)"
+                          class="inline-form">
+                        #csrfFormField()
+                        <button class="btn action-btn action-danger students-unenroll-btn" type="submit"
+                                title="Remove from course" aria-label="Remove from course"
+                                onclick="return confirm('Remove @#(student.username) from this course?')">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                        </button>
+                    </form>
+                </div>
                 #endif
             </td>
         </tr>
@@ -133,6 +164,8 @@ Students
 .students-role-form { margin: 0; }
 .students-role-select { display: inline-block; font-size: .8rem; padding: .1rem .3rem; }
 .students-pending-role { color: var(--gray-500); }
+.students-row-actions { display: flex; align-items: center; gap: .3rem; }
+.students-register-hint { font-size: .72rem; color: var(--gray-600); margin: 0 0 .2rem; }
 #enrolled-students-table th.sortable {
     cursor: pointer;
     user-select: none;
@@ -229,12 +262,29 @@ Students
             : '<a href="' + subURL + '"><code>' + username + '</code></a>';
         var actionCell = '';
         if (!archived) {
-            actionCell = '<form method="post" action="' + unenrollURL + '" class="inline-form">'
+            var registerCell = '';
+            if (student.isPending && student.registerURL) {
+                registerCell = '<details class="ext-details form-flush">'
+                    + '<summary class="btn action-btn action-btn-tight" title="Register this student now"'
+                    + ' aria-label="Register pending student">Register</summary>'
+                    + '<form method="post" action="' + escapeHtml(student.registerURL) + '" class="ext-panel">'
+                    + csrfField
+                    + '<p class="students-register-hint">Materialize <code>' + username
+                    + '</code> into a real account now (for grade-sync testing). They appear on assignment rosters immediately; their real login adopts this account.</p>'
+                    + '<label class="ext-field-label">Display name<input type="text" name="displayName" placeholder="' + username + '" class="ext-field-input"></label>'
+                    + '<label class="ext-field-label">Student number (optional)<input type="text" name="studentID" class="ext-field-input"></label>'
+                    + '<label class="ext-field-label">Email (optional)<input type="email" name="email" class="ext-field-input"></label>'
+                    + '<label class="ext-field-label">SSO subject (optional)<input type="text" name="externalSubject" placeholder="leave blank to adopt by username" class="ext-field-input"></label>'
+                    + '<div class="ext-panel-actions"><button class="btn action-btn" type="submit">Register</button></div>'
+                    + '</form></details>';
+            }
+            actionCell = '<div class="students-row-actions">' + registerCell
+                + '<form method="post" action="' + unenrollURL + '" class="inline-form">'
                 + csrfField
                 + '<button class="btn action-btn action-danger students-unenroll-btn" type="submit" title="Remove from course"'
                 + ' aria-label="Remove from course"'
                 + ' onclick="return confirm(\'Remove @' + username + ' from this course?\')">'
-                + deleteIcon + '</button></form>';
+                + deleteIcon + '</button></form></div>';
         }
 
         return '<tr class="student-row-link' + (student.isPending ? ' student-row-pending' : '') + '"'

--- a/Sources/APIServer/Migrations/AddGradeOverrideBrightSpaceSync.swift
+++ b/Sources/APIServer/Migrations/AddGradeOverrideBrightSpaceSync.swift
@@ -1,0 +1,38 @@
+// APIServer/Migrations/AddGradeOverrideBrightSpaceSync.swift
+//
+// Adds BrightSpace grade-sync bookkeeping columns to `grade_overrides`,
+// mirroring the four columns already on `results`
+// (brightspace_sync_pending / _pending_since / _synced_at / _sync_error).
+//
+// Why the override row needs its own sync flags: the grade-sync sweep is
+// driven by pending flags, but a student with NO submissions has no `results`
+// row to flag.  An instructor override on such a student (e.g. a pre-enrolled
+// student manually registered for grade-sync testing) is the only thing to
+// push, so the override row itself carries the pending flag the sweep scans.
+//
+// Standalone Add* migration (not folded into CreateGradeOverrides) because
+// production databases have already applied CreateGradeOverrides without these
+// columns and would never pick them up from a body change.  Fresh deploys run
+// CreateGradeOverrides then this migration; existing prod runs only this one.
+
+import Fluent
+
+struct AddGradeOverrideBrightSpaceSync: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("grade_overrides")
+            .field("brightspace_sync_pending", .bool)
+            .field("brightspace_pending_since", .datetime)
+            .field("brightspace_synced_at", .datetime)
+            .field("brightspace_sync_error", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("grade_overrides")
+            .deleteField("brightspace_sync_pending")
+            .deleteField("brightspace_pending_since")
+            .deleteField("brightspace_synced_at")
+            .deleteField("brightspace_sync_error")
+            .update()
+    }
+}

--- a/Sources/APIServer/Migrations/AddGradeOverrideBrightSpaceSync.swift
+++ b/Sources/APIServer/Migrations/AddGradeOverrideBrightSpaceSync.swift
@@ -19,20 +19,25 @@ import Fluent
 
 struct AddGradeOverrideBrightSpaceSync: ChickadeeMigration {
     func prepare(on database: Database) async throws {
+        // One ADD COLUMN per statement — SQLite rejects a multi-column ALTER.
         try await database.schema("grade_overrides")
-            .field("brightspace_sync_pending", .bool)
-            .field("brightspace_pending_since", .datetime)
-            .field("brightspace_synced_at", .datetime)
-            .field("brightspace_sync_error", .string)
-            .update()
+            .field("brightspace_sync_pending", .bool).update()
+        try await database.schema("grade_overrides")
+            .field("brightspace_pending_since", .datetime).update()
+        try await database.schema("grade_overrides")
+            .field("brightspace_synced_at", .datetime).update()
+        try await database.schema("grade_overrides")
+            .field("brightspace_sync_error", .string).update()
     }
 
     func revert(on database: Database) async throws {
         try await database.schema("grade_overrides")
-            .deleteField("brightspace_sync_pending")
-            .deleteField("brightspace_pending_since")
-            .deleteField("brightspace_synced_at")
-            .deleteField("brightspace_sync_error")
-            .update()
+            .deleteField("brightspace_sync_error").update()
+        try await database.schema("grade_overrides")
+            .deleteField("brightspace_synced_at").update()
+        try await database.schema("grade_overrides")
+            .deleteField("brightspace_pending_since").update()
+        try await database.schema("grade_overrides")
+            .deleteField("brightspace_sync_pending").update()
     }
 }

--- a/Sources/APIServer/Models/APIGradeOverride.swift
+++ b/Sources/APIServer/Models/APIGradeOverride.swift
@@ -41,6 +41,22 @@ final class APIGradeOverride: Model, Content, @unchecked Sendable {
     @Timestamp(key: "updated_at", on: .update)
     var updatedAt: Date?
 
+    // BrightSpace grade-sync bookkeeping, mirroring the columns on APIResult.
+    // Only set when the override is the *only* thing to push — i.e. the student
+    // has no submissions, so there's no result row to carry the pending flag
+    // (see `applyGradeOverride` / `sweepBrightSpaceGradeSync`).
+    @OptionalField(key: "brightspace_sync_pending")
+    var brightspaceSyncPending: Bool?
+
+    @OptionalField(key: "brightspace_pending_since")
+    var brightspacePendingSince: Date?
+
+    @OptionalField(key: "brightspace_synced_at")
+    var brightspaceSyncedAt: Date?
+
+    @OptionalField(key: "brightspace_sync_error")
+    var brightspaceSyncError: String?
+
     init() {}
 
     init(

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -205,6 +205,10 @@ struct EnrolledStudentRow: Content {
     /// in yet).  Template renders these visually muted; pending students
     /// have no submissions or last-seen data.
     let isPending: Bool
+    /// For pending rows: URL to POST to to manually materialize this
+    /// pre-enrollment into a real user (the grade-sync-testing escape valve).
+    /// Empty for active enrollments.
+    let registerURL: String
 }
 
 struct AssignmentSubmissionsContext: Encodable {

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -9,6 +9,13 @@ import Core
 import Fluent
 import Vapor
 
+/// Trims whitespace and collapses an empty string to nil, so blank form
+/// fields are stored as NULL rather than "".
+private func trimmedOrNil(_ value: String?) -> String? {
+    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return (trimmed?.isEmpty == false) ? trimmed : nil
+}
+
 extension CourseAdminRoutes {
     // MARK: - GET /instructor/enroll-csv
 
@@ -182,6 +189,101 @@ extension CourseAdminRoutes {
             .delete()
 
         return req.redirect(to: "/instructor")
+    }
+
+    // MARK: - POST /courses/:courseID/pre-enroll/:preEnrollmentID/register
+    //
+    // Manually materializes a pending pre-enrollment into a real APIUser +
+    // enrollment, without waiting for the student to log in.  This is the
+    // debug / grade-sync-testing escape valve: an instructor can register a
+    // CSV-uploaded student now (supplying their SSO identity), then the
+    // student appears on the assignment roster and can be assigned a grade
+    // override that pushes to BrightSpace.
+    //
+    // SSO-safe: the user is created with authProvider "duo-oidc" and the
+    // supplied externalSubject (if any).  When the real student later logs in,
+    // the SSO upsert adopts the same row — by externalSubject when provided, or
+    // by username (empty-subject adoption) otherwise — so no duplicate account
+    // is created.
+
+    @Sendable
+    func instructorRegisterPreEnrollment(req: Request) async throws -> Response {
+        struct Body: Content {
+            var externalSubject: String?
+            var displayName: String?
+            var email: String?
+            var studentID: String?
+        }
+
+        guard
+            let courseIDString = req.parameters.get("courseID"),
+            let courseID = UUID(uuidString: courseIDString),
+            let preIDString = req.parameters.get("preEnrollmentID"),
+            let preID = UUID(uuidString: preIDString)
+        else {
+            throw WebAssignmentError.invalidParameter(
+                name: "courseID/preEnrollmentID", reason: "Invalid courseID or preEnrollmentID parameter")
+        }
+
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+
+        guard
+            let preEnrollment = try await APIPreEnrollment.query(on: req.db)
+                .filter(\.$id == preID)
+                .filter(\.$course.$id == courseID)
+                .first()
+        else {
+            throw WebAssignmentError.notFound(resource: "Pre-enrollment")
+        }
+
+        let body = try? req.content.decode(Body.self)
+        let username = preEnrollment.username
+
+        // Reuse an existing account with this username (e.g. the student
+        // already logged into another course) instead of creating a duplicate.
+        let user =
+            try await APIUser.query(on: req.db)
+            .filter(\.$username == username)
+            .first()
+            ?? APIUser(
+                username: username,
+                passwordHash: "",  // SSO users have no local password
+                role: UserRole.student.rawValue,
+                authProvider: "duo-oidc",
+                externalSubject: trimmedOrNil(body?.externalSubject),
+                email: trimmedOrNil(body?.email),
+                studentID: trimmedOrNil(body?.studentID),
+                displayName: trimmedOrNil(body?.displayName)
+            )
+        if user.id == nil {
+            try await user.save(on: req.db)
+        }
+        let userID = try user.requireID()
+
+        // Enrol (skip if already enrolled), then drop the pre-enrollment.
+        let alreadyEnrolled =
+            try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseID)
+            .filter(\.$userID == userID)
+            .first() != nil
+        if !alreadyEnrolled {
+            try await saveSeededEnrollment(for: user, courseID: courseID, on: req.db)
+        }
+        try await preEnrollment.delete(on: req.db)
+
+        await AuditLogger.record(
+            action: .userProvisioned,
+            targetType: .user,
+            targetID: userID.uuidString,
+            metadata: [
+                "username": username,
+                "course_id": courseIDString,
+                "source": "manual_register",
+            ],
+            on: req
+        )
+        return req.redirect(to: "/instructor/students")
     }
 
     // MARK: - POST /courses/:courseID/role/:userID

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
@@ -21,6 +21,11 @@ struct CourseAdminRoutes: RouteCollection {
         routes.post("courses", ":courseID", "enroll-csv", use: instructorBulkEnrollCSV)
         routes.post("courses", ":courseID", "unenroll", ":userID", use: instructorUnenrollUser)
         routes.post("courses", ":courseID", "pre-unenroll", ":preEnrollmentID", use: instructorCancelPreEnrollment)
+        // Manually materialize a pending pre-enrollment into a real user (debug
+        // / grade-sync-testing escape valve).
+        routes.post(
+            "courses", ":courseID", "pre-enroll", ":preEnrollmentID", "register",
+            use: instructorRegisterPreEnrollment)
         // Set a roster member's per-course role (Phase 4b).
         routes.post("courses", ":courseID", "role", ":userID", use: instructorSetEnrollmentRole)
 

--- a/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
+++ b/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
@@ -78,27 +78,24 @@ func applyGradeOverride(
     grantedByUserID: UUID?,
     on db: Database
 ) async throws {
-    let existing = try await APIGradeOverride.query(on: db)
+    let row =
+        try await APIGradeOverride.query(on: db)
         .filter(\.$testSetupID == testSetupID)
         .filter(\.$userID == studentUserID)
         .first()
-    if let existing {
-        existing.overridePercent = percent
-        existing.note = note
-        existing.grantedByUserID = grantedByUserID
-        try await existing.save(on: db)
-    } else {
-        let row = APIGradeOverride(
+        ?? APIGradeOverride(
             testSetupID: testSetupID,
             userID: studentUserID,
             overridePercent: percent,
             note: note,
             grantedByUserID: grantedByUserID
         )
-        try await row.save(on: db)
-    }
-    try await flagGradeResultsPendingSync(
-        testSetupID: testSetupID, studentUserID: studentUserID, on: db)
+    row.overridePercent = percent
+    row.note = note
+    row.grantedByUserID = grantedByUserID
+    try await row.save(on: db)
+    try await flagOverrideOrResultsPendingSync(
+        override: row, testSetupID: testSetupID, studentUserID: studentUserID, on: db)
 }
 
 /// Clears any (setup, user) override and re-flags the student's results for
@@ -120,28 +117,41 @@ func clearGradeOverride(
         return false
     }
     try await existing.delete(on: db)
-    try await flagGradeResultsPendingSync(
-        testSetupID: testSetupID, studentUserID: studentUserID, on: db)
+    // Clearing reverts to the runner-computed grade. For a student with
+    // submissions that re-flags their results; for a no-submission student
+    // there's nothing to push (override is nil → no-op), so the previously
+    // pushed grade is left as-is in BrightSpace.
+    try await flagOverrideOrResultsPendingSync(
+        override: nil, testSetupID: testSetupID, studentUserID: studentUserID, on: db)
     return true
 }
 
 /// Marks every result on one student's submissions for a test setup as pending
 /// BrightSpace sync, so the debounced sweep re-pushes the grade after an
-/// override is set or cleared.
-func flagGradeResultsPendingSync(
-    testSetupID: String, studentUserID: UUID, on db: Database
+/// override is set or cleared.  When the student has NO submissions there is no
+/// result row to flag, so the supplied override row carries the pending flag
+/// itself — the sweep scans both (see `sweepBrightSpaceGradeSync`).  `override`
+/// is nil on the clear path (the row was deleted), in which case a
+/// no-submission student is a no-op (nothing to push, nothing to revert).
+func flagOverrideOrResultsPendingSync(
+    override: APIGradeOverride?,
+    testSetupID: String,
+    studentUserID: UUID,
+    on db: Database
 ) async throws {
-    let submissionIDs = try await APISubmission.query(on: db)
-        .filter(\.$userID == studentUserID)
-        .filter(\.$testSetupID == testSetupID)
-        .filter(\.$kind == APISubmission.Kind.student)
-        .all()
-        .compactMap(\.id)
-    guard !submissionIDs.isEmpty else { return }
-    let results = try await APIResult.query(on: db)
-        .filter(\.$submissionID ~~ submissionIDs)
-        .all()
     let now = Date()
+    let results = try await gradeResultsForStudent(
+        testSetupID: testSetupID, studentUserID: studentUserID, on: db)
+    guard !results.isEmpty else {
+        // No submissions: the override row is the only thing to push.
+        guard let override else { return }
+        override.brightspaceSyncPending = true
+        if override.brightspacePendingSince == nil {
+            override.brightspacePendingSince = now
+        }
+        try await override.save(on: db)
+        return
+    }
     for result in results {
         result.brightspaceSyncPending = true
         if result.brightspacePendingSince == nil {
@@ -149,4 +159,20 @@ func flagGradeResultsPendingSync(
         }
         try await result.save(on: db)
     }
+}
+
+/// Every result on one student's student-submissions for a test setup.
+private func gradeResultsForStudent(
+    testSetupID: String, studentUserID: UUID, on db: Database
+) async throws -> [APIResult] {
+    let submissionIDs = try await APISubmission.query(on: db)
+        .filter(\.$userID == studentUserID)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .all()
+        .compactMap(\.id)
+    guard !submissionIDs.isEmpty else { return [] }
+    return try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ submissionIDs)
+        .all()
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -372,6 +372,21 @@ extension InstructorDashboardRoutes {
                 result.brightspaceSyncError = nil
                 try await result.save(on: req.db)
             }
+            // Errored override-only pushes (no-submission students) live on the
+            // override row, not a result row — re-queue those too.
+            let setupIDList = try await courseSetupIDs(req: req, courseUUID: courseUUID)
+            let overrides =
+                setupIDList.isEmpty
+                ? []
+                : try await APIGradeOverride.query(on: req.db)
+                    .filter(\.$testSetupID ~~ setupIDList)
+                    .all()
+            for override in overrides where (override.brightspaceSyncError ?? "").isEmpty == false {
+                override.brightspaceSyncPending = true
+                override.brightspacePendingSince = Date.distantPast
+                override.brightspaceSyncError = nil
+                try await override.save(on: req.db)
+            }
         }
         await runImmediateBrightspaceSweep(req: req)
         return req.redirect(to: "/instructor/brightspace")
@@ -401,6 +416,17 @@ extension InstructorDashboardRoutes {
             result.brightspaceSyncError = nil
             try await result.save(on: req.db)
         }
+        // Override-only grades (no-submission students) carry their pending
+        // flag on the override row; re-queue those for this assignment too.
+        let overrides = try await APIGradeOverride.query(on: req.db)
+            .filter(\.$testSetupID == assignment.testSetupID)
+            .all()
+        for override in overrides {
+            override.brightspaceSyncPending = true
+            override.brightspacePendingSince = Date.distantPast
+            override.brightspaceSyncError = nil
+            try await override.save(on: req.db)
+        }
         await runImmediateBrightspaceSweep(req: req)
         return req.redirect(to: "/instructor/brightspace")
     }
@@ -410,16 +436,23 @@ extension InstructorDashboardRoutes {
     /// Submission IDs (used as result-query keys) for all student submissions
     /// in the active course's test setups.
     private func courseStudentResultIDs(req: Request, courseUUID: UUID) async throws -> [String] {
+        let setupIDs = try await courseSetupIDs(req: req, courseUUID: courseUUID)
+        guard !setupIDs.isEmpty else { return [] }
+        return try await APISubmission.query(on: req.db)
+            .filter(\.$testSetupID ~~ setupIDs)
+            .filter(\.$kind == APISubmission.Kind.student)
+            .all()
+            .compactMap(\.id)
+    }
+
+    /// Distinct test setup IDs for the active course's assignments.  Used to
+    /// scope override-row queries (override-only grade pushes) by course.
+    private func courseSetupIDs(req: Request, courseUUID: UUID) async throws -> [String] {
         let setupIDs = try await APIAssignment.query(on: req.db)
             .filter(\.$courseID == courseUUID)
             .all()
             .map(\.testSetupID)
-        guard !setupIDs.isEmpty else { return [] }
-        return try await APISubmission.query(on: req.db)
-            .filter(\.$testSetupID ~~ Array(Set(setupIDs)))
-            .filter(\.$kind == APISubmission.Kind.student)
-            .all()
-            .compactMap(\.id)
+        return Array(Set(setupIDs))
     }
 
     /// Runs a grade-sync sweep immediately, bypassing the debounce window so

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -234,7 +234,8 @@ extension InstructorDashboardRoutes {
                     urlToken: token
                 ),
                 unenrollURL: "/courses/\(activeCourseUUID.uuidString)/unenroll/\(id.uuidString)",
-                isPending: false
+                isPending: false,
+                registerURL: ""
             )
         }
     }
@@ -254,7 +255,9 @@ extension InstructorDashboardRoutes {
                 lastSeenAtISO: nil,
                 submissionsURL: "#",
                 unenrollURL: "/courses/\(activeCourseUUID.uuidString)/pre-unenroll/\(preID.uuidString)",
-                isPending: true
+                isPending: true,
+                registerURL:
+                    "/courses/\(activeCourseUUID.uuidString)/pre-enroll/\(preID.uuidString)/register"
             )
         }
     }

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -15,6 +15,39 @@ import Foundation
 import JWT
 import Vapor
 
+/// SSO-derived user attributes for one login, resolved from the ID token claims
+/// once and applied to whichever user row the upsert lands on (existing match,
+/// adopted stub, or freshly created). Grouping them keeps the upsert helpers
+/// within SwiftLint's parameter-count limit and the field-application logic in
+/// one place.
+private struct SSOUserAttributes {
+    let username: String
+    let subject: String
+    let preferredName: String?
+    let userIdentifier: String
+    let studentID: String?
+    let email: String?
+    let displayName: String?
+    let mappedRole: String?
+
+    /// Applies the login's profile fields to a user row — non-destructive for
+    /// fields the IdP didn't send (`?? user.x`) — and stamps the login times.
+    /// Does not touch `externalSubject`; callers set that explicitly when they
+    /// claim a subject-less stub.
+    func apply(to user: APIUser) {
+        user.username = username
+        user.preferredName = preferredName ?? user.preferredName
+        user.userIdentifier = userIdentifier
+        user.studentID = studentID ?? user.studentID
+        user.email = email ?? user.email
+        user.displayName = displayName ?? user.displayName
+        if let mappedRole { user.role = mappedRole }
+        let now = Date()
+        user.lastLoginAt = now
+        user.lastSeenAt = now
+    }
+}
+
 struct SSOAuthRoutes: RouteCollection {
     /// Override callback path read from `AppConfig.oidc.callbackPath`. When
     /// non-empty and not equal to `/auth/sso/callback`, the same handler is
@@ -250,24 +283,18 @@ struct SSOAuthRoutes: RouteCollection {
             )
         )
 
+        let attrs = SSOUserAttributes(
+            username: username, subject: subject, preferredName: preferredName,
+            userIdentifier: userIdentifier, studentID: studentID, email: email,
+            displayName: displayName, mappedRole: mappedRole)
+
         if let existing = try await APIUser.query(on: req.db)
             .filter(\.$authProvider == "duo-oidc")
             .filter(\.$externalSubject == subject)
             .first()
         {
-            existing.username = username
-            existing.preferredName = preferredName ?? existing.preferredName
-            existing.userIdentifier = userIdentifier
-            existing.studentID = studentID ?? existing.studentID
-            existing.email = email ?? existing.email
-            existing.displayName = displayName ?? existing.displayName
             let previousRole = existing.role
-            if let mappedRole {
-                existing.role = mappedRole
-            }
-            let now = Date()
-            existing.lastLoginAt = now
-            existing.lastSeenAt = now
+            attrs.apply(to: existing)
             try await existing.save(on: req.db)
             // An allowlist-driven privilege change on login is security-relevant
             // — record it (only when the role actually moved).
@@ -292,11 +319,7 @@ struct SSOAuthRoutes: RouteCollection {
         // Adopt a manually-registered stub (duo-oidc, matching username, no
         // externalSubject) on first real login, claiming it rather than creating
         // a duplicate — so any grade override already attached stays bound.
-        if let stub = try await adoptManuallyRegisteredStub(
-            username: username, subject: subject, preferredName: preferredName,
-            userIdentifier: userIdentifier, studentID: studentID, email: email,
-            displayName: displayName, mappedRole: mappedRole, on: req)
-        {
+        if let stub = try await adoptManuallyRegisteredStub(attrs: attrs, on: req) {
             return stub
         }
 
@@ -340,35 +363,19 @@ struct SSOAuthRoutes: RouteCollection {
     /// carries its subject — can't be hijacked. Returns nil when no such stub
     /// exists, leaving the caller to create a fresh user.
     private func adoptManuallyRegisteredStub(
-        username: String,
-        subject: String,
-        preferredName: String?,
-        userIdentifier: String,
-        studentID: String?,
-        email: String?,
-        displayName: String?,
-        mappedRole: String?,
-        on req: Request
+        attrs: SSOUserAttributes, on req: Request
     ) async throws -> APIUser? {
         guard
             let stub = try await APIUser.query(on: req.db)
                 .filter(\.$authProvider == "duo-oidc")
                 .filter(\.$externalSubject == nil)
-                .filter(\.$username == username)
+                .filter(\.$username == attrs.username)
                 .first()
         else {
             return nil
         }
-        stub.externalSubject = subject
-        stub.preferredName = preferredName ?? stub.preferredName
-        stub.userIdentifier = userIdentifier
-        stub.studentID = studentID ?? stub.studentID
-        stub.email = email ?? stub.email
-        stub.displayName = displayName ?? stub.displayName
-        if let mappedRole { stub.role = mappedRole }
-        let now = Date()
-        stub.lastLoginAt = now
-        stub.lastSeenAt = now
+        attrs.apply(to: stub)
+        stub.externalSubject = attrs.subject
         try await stub.save(on: req.db)
         await AuditLogger.record(
             action: .userProvisioned,

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -289,6 +289,44 @@ struct SSOAuthRoutes: RouteCollection {
             return existing
         }
 
+        // Adopt a manually-registered stub: a `duo-oidc` user with this exact
+        // username but no externalSubject yet (created via the instructor
+        // "Register pending student" escape valve without an SSO subject on
+        // hand). Claiming it on first real login — instead of creating a second
+        // account — keeps any grade override already attached to the stub bound
+        // to the same user. Only ever matches a subject-less stub, so a normal
+        // SSO account (which always carries its subject) can't be hijacked.
+        if let stub = try await APIUser.query(on: req.db)
+            .filter(\.$authProvider == "duo-oidc")
+            .filter(\.$externalSubject == nil)
+            .filter(\.$username == username)
+            .first()
+        {
+            stub.externalSubject = subject
+            stub.preferredName = preferredName ?? stub.preferredName
+            stub.userIdentifier = userIdentifier
+            stub.studentID = studentID ?? stub.studentID
+            stub.email = email ?? stub.email
+            stub.displayName = displayName ?? stub.displayName
+            if let mappedRole { stub.role = mappedRole }
+            let now = Date()
+            stub.lastLoginAt = now
+            stub.lastSeenAt = now
+            try await stub.save(on: req.db)
+            await AuditLogger.record(
+                action: .userProvisioned,
+                targetType: .user,
+                targetID: stub.id?.uuidString,
+                metadata: [
+                    "username": stub.username,
+                    "source": "sso_stub_adoption",
+                ],
+                actorUsernameOverride: "sso",
+                on: req
+            )
+            return stub
+        }
+
         let now = Date()
         let newUser = APIUser(
             username: username,

--- a/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/SSOAuthRoutes.swift
@@ -289,41 +289,14 @@ struct SSOAuthRoutes: RouteCollection {
             return existing
         }
 
-        // Adopt a manually-registered stub: a `duo-oidc` user with this exact
-        // username but no externalSubject yet (created via the instructor
-        // "Register pending student" escape valve without an SSO subject on
-        // hand). Claiming it on first real login — instead of creating a second
-        // account — keeps any grade override already attached to the stub bound
-        // to the same user. Only ever matches a subject-less stub, so a normal
-        // SSO account (which always carries its subject) can't be hijacked.
-        if let stub = try await APIUser.query(on: req.db)
-            .filter(\.$authProvider == "duo-oidc")
-            .filter(\.$externalSubject == nil)
-            .filter(\.$username == username)
-            .first()
+        // Adopt a manually-registered stub (duo-oidc, matching username, no
+        // externalSubject) on first real login, claiming it rather than creating
+        // a duplicate — so any grade override already attached stays bound.
+        if let stub = try await adoptManuallyRegisteredStub(
+            username: username, subject: subject, preferredName: preferredName,
+            userIdentifier: userIdentifier, studentID: studentID, email: email,
+            displayName: displayName, mappedRole: mappedRole, on: req)
         {
-            stub.externalSubject = subject
-            stub.preferredName = preferredName ?? stub.preferredName
-            stub.userIdentifier = userIdentifier
-            stub.studentID = studentID ?? stub.studentID
-            stub.email = email ?? stub.email
-            stub.displayName = displayName ?? stub.displayName
-            if let mappedRole { stub.role = mappedRole }
-            let now = Date()
-            stub.lastLoginAt = now
-            stub.lastSeenAt = now
-            try await stub.save(on: req.db)
-            await AuditLogger.record(
-                action: .userProvisioned,
-                targetType: .user,
-                targetID: stub.id?.uuidString,
-                metadata: [
-                    "username": stub.username,
-                    "source": "sso_stub_adoption",
-                ],
-                actorUsernameOverride: "sso",
-                on: req
-            )
             return stub
         }
 
@@ -356,6 +329,59 @@ struct SSOAuthRoutes: RouteCollection {
             on: req
         )
         return newUser
+    }
+
+    /// Adopts a manually-registered stub on first real SSO login: a `duo-oidc`
+    /// user with this exact username but no externalSubject yet, created via the
+    /// instructor "Register pending student" escape valve without an SSO subject
+    /// on hand. Claiming it (instead of creating a second account) keeps any
+    /// grade override already attached to the stub bound to the same user. Only
+    /// ever matches a subject-less stub, so a normal SSO account — which always
+    /// carries its subject — can't be hijacked. Returns nil when no such stub
+    /// exists, leaving the caller to create a fresh user.
+    private func adoptManuallyRegisteredStub(
+        username: String,
+        subject: String,
+        preferredName: String?,
+        userIdentifier: String,
+        studentID: String?,
+        email: String?,
+        displayName: String?,
+        mappedRole: String?,
+        on req: Request
+    ) async throws -> APIUser? {
+        guard
+            let stub = try await APIUser.query(on: req.db)
+                .filter(\.$authProvider == "duo-oidc")
+                .filter(\.$externalSubject == nil)
+                .filter(\.$username == username)
+                .first()
+        else {
+            return nil
+        }
+        stub.externalSubject = subject
+        stub.preferredName = preferredName ?? stub.preferredName
+        stub.userIdentifier = userIdentifier
+        stub.studentID = studentID ?? stub.studentID
+        stub.email = email ?? stub.email
+        stub.displayName = displayName ?? stub.displayName
+        if let mappedRole { stub.role = mappedRole }
+        let now = Date()
+        stub.lastLoginAt = now
+        stub.lastSeenAt = now
+        try await stub.save(on: req.db)
+        await AuditLogger.record(
+            action: .userProvisioned,
+            targetType: .user,
+            targetID: stub.id?.uuidString,
+            metadata: [
+                "username": stub.username,
+                "source": "sso_stub_adoption",
+            ],
+            actorUsernameOverride: "sso",
+            on: req
+        )
+        return stub
     }
 
     /// Tries a small set of OAuth token request shapes for provider compatibility.

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -77,27 +77,127 @@ func sweepBrightSpaceGradeSync(
         groups[key, default: []].append(result)
     }
 
-    for key in groupOrder {
-        guard let results = groups[key] else { continue }
+    var targets: [GradePushTarget] = groupOrder.compactMap { key in
+        guard let results = groups[key] else { return nil }
         let assignment = context.assignmentsBySetupID[key.testSetupID]
-        let target = GradePushTarget(
+        return GradePushTarget(
             userID: key.userID,
             testSetupID: key.testSetupID,
             results: results,
+            pendingOverride: nil,
             assignment: assignment,
             course: assignment.flatMap { context.coursesByID[$0.courseID] },
             user: context.usersByID[key.userID]
         )
+    }
+
+    // Override-only targets: instructor overrides on students with no
+    // submissions, whose pending flag the override row carries directly (there
+    // is no result row).  De-duped against the result-driven groups so a
+    // student who also has submissions is pushed once via their results.
+    let coveredKeys = Set(groupOrder)
+    targets += try await pendingOverrideTargets(
+        coveredKeys: coveredKeys, cutoff: cutoff, db: db)
+
+    for target in targets {
+        let syncRows = target.syncRows
         do {
             let pushed = try await pushGrade(
                 for: target, db: db, resolveClient: resolveClient,
                 classlistCache: classlistCache, logger: logger, application: application)
-            if pushed { processed += results.count }
+            if pushed { processed += syncRows.count }
         } catch {
-            await recordSweepFailure(results, error: error, db: db, logger: logger)
+            await recordSweepFailure(syncRows, error: error, db: db, logger: logger)
         }
     }
     return processed
+}
+
+/// Builds override-only push targets from `grade_overrides` rows flagged
+/// pending past the debounce cutoff.  A row whose (student, test setup) is
+/// already covered by a result-driven group has its pending flag cleared in
+/// place (the results path will push it) and yields no target.
+private func pendingOverrideTargets(
+    coveredKeys: Set<GradePushKey>,
+    cutoff: Date,
+    db: Database
+) async throws -> [GradePushTarget] {
+    let pendingOverrides = try await APIGradeOverride.query(on: db)
+        .filter(\.$brightspaceSyncPending == true)
+        .filter(\.$brightspacePendingSince <= cutoff)
+        .all()
+    guard !pendingOverrides.isEmpty else { return [] }
+
+    var overrideOnly: [APIGradeOverride] = []
+    for override in pendingOverrides {
+        let key = GradePushKey(userID: override.userID, testSetupID: override.testSetupID)
+        if coveredKeys.contains(key) {
+            // The result-driven group will push this (student, setup); the
+            // override row's own flag is redundant — clear it.
+            override.brightspaceSyncPending = false
+            try await override.save(on: db)
+        } else {
+            overrideOnly.append(override)
+        }
+    }
+    guard !overrideOnly.isEmpty else { return [] }
+
+    let context = try await loadOverrideSyncContext(for: overrideOnly, db: db)
+    return overrideOnly.map { override in
+        let assignment = context.assignmentsBySetupID[override.testSetupID]
+        return GradePushTarget(
+            userID: override.userID,
+            testSetupID: override.testSetupID,
+            results: [],
+            pendingOverride: override,
+            assignment: assignment,
+            course: assignment.flatMap { context.coursesByID[$0.courseID] },
+            user: context.usersByID[override.userID]
+        )
+    }
+}
+
+/// Loads the assignments / courses / users an override-only push set
+/// references, keyed for `GradePushTarget` assembly.  Mirrors the result-driven
+/// `loadGradeSyncBatchContext` but starts from override rows (which already
+/// carry the test setup + user), so no submission lookup is needed.
+private func loadOverrideSyncContext(
+    for overrides: [APIGradeOverride],
+    db: Database
+) async throws -> GradeSyncBatchContext {
+    let setupIDs = Array(Set(overrides.map(\.testSetupID)))
+    var assignmentsBySetupID: [String: APIAssignment] = [:]
+    for chunk in chunkedForInFilter(setupIDs) {
+        for assignment in try await APIAssignment.query(on: db).filter(\.$testSetupID ~~ chunk).all()
+        where assignmentsBySetupID[assignment.testSetupID] == nil {
+            assignmentsBySetupID[assignment.testSetupID] = assignment
+        }
+    }
+
+    let courseIDs = Array(Set(assignmentsBySetupID.values.map(\.courseID)))
+    var coursesByID: [UUID: APICourse] = [:]
+    for chunk in chunkedForInFilter(courseIDs) {
+        for course in try await APICourse.query(on: db).filter(\.$id ~~ chunk).all() {
+            guard let id = course.id else { continue }
+            coursesByID[id] = course
+        }
+    }
+
+    let userIDs = Array(Set(overrides.map(\.userID)))
+    var usersByID: [UUID: APIUser] = [:]
+    for chunk in chunkedForInFilter(userIDs) {
+        for user in try await APIUser.query(on: db).filter(\.$id ~~ chunk).all() {
+            guard let id = user.id else { continue }
+            usersByID[id] = user
+        }
+    }
+
+    return GradeSyncBatchContext(
+        submissionsByID: [:],
+        assignmentsBySetupID: assignmentsBySetupID,
+        coursesByID: coursesByID,
+        usersByID: usersByID
+    )
 }
 
 // MARK: - Batch loading
@@ -112,13 +212,48 @@ private struct GradePushKey: Hashable {
 /// Everything `pushGrade` needs for one group, pre-resolved from the
 /// sweep-wide batch context.  `assignment` / `course` / `user` stay optional:
 /// a missing row takes the same no-op / skip path the per-result lookups did.
+///
+/// `pendingOverride` is set only for an override-only target — a student with
+/// no submissions whose grade comes entirely from an instructor override, so
+/// there is no result row and the override row itself carries the pending flag.
 private struct GradePushTarget {
     let userID: UUID
     let testSetupID: String
     let results: [APIResult]
+    let pendingOverride: APIGradeOverride?
     let assignment: APIAssignment?
     let course: APICourse?
     let user: APIUser?
+
+    /// Every row whose BrightSpace sync flags this push must update — the
+    /// flagged result rows plus, for an override-only target, the override row.
+    var syncRows: [any BrightSpaceSyncFlaggable] {
+        var rows: [any BrightSpaceSyncFlaggable] = results
+        if let pendingOverride { rows.append(pendingOverride) }
+        return rows
+    }
+}
+
+/// A row carrying the four BrightSpace grade-sync bookkeeping columns. Both
+/// `APIResult` and `APIGradeOverride` conform, so the sweep's success / clear /
+/// failure paths mark them identically regardless of which kind enqueued the
+/// push.
+protocol BrightSpaceSyncFlaggable: AnyObject {
+    var brightspaceSyncPending: Bool? { get set }
+    var brightspacePendingSince: Date? { get set }
+    var brightspaceSyncedAt: Date? { get set }
+    var brightspaceSyncError: String? { get set }
+    /// Stable identifier for log lines (a result's string id / an override's UUID).
+    var brightspaceSyncRowID: String { get }
+    func save(on database: Database) async throws
+}
+
+extension APIResult: BrightSpaceSyncFlaggable {
+    var brightspaceSyncRowID: String { id ?? "?" }
+}
+
+extension APIGradeOverride: BrightSpaceSyncFlaggable {
+    var brightspaceSyncRowID: String { id?.uuidString ?? "?" }
 }
 
 /// Sweep-wide lookup tables, loaded once per sweep.
@@ -197,30 +332,30 @@ private func chunkedForInFilter<T>(_ items: [T]) -> [[T]] {
 
 // MARK: - Per-group push
 
-/// Marks every result in a failed group the way the single-result error path
+/// Marks every row in a failed group the way the single-result error path
 /// did: flag cleared, error recorded, push retried on the next pending cycle.
 private func recordSweepFailure(
-    _ results: [APIResult],
+    _ rows: [any BrightSpaceSyncFlaggable],
     error: Error,
     db: Database,
     logger: Logger
 ) async {
-    for result in results {
-        result.brightspaceSyncPending = false
-        result.brightspaceSyncedAt = nil
-        result.brightspaceSyncError = error.localizedDescription
-        try? await result.save(on: db)
+    for row in rows {
+        row.brightspaceSyncPending = false
+        row.brightspaceSyncedAt = nil
+        row.brightspaceSyncError = error.localizedDescription
+        try? await row.save(on: db)
     }
-    let ids = results.map { $0.id ?? "?" }.joined(separator: ", ")
-    logger.warning("BrightSpace grade sync failed for result(s) \(ids): \(error)")
+    let ids = rows.map(\.brightspaceSyncRowID).joined(separator: ", ")
+    logger.warning("BrightSpace grade sync failed for row(s) \(ids): \(error)")
 }
 
-/// Clears the pending flag on every result in the group (the "nothing to
+/// Clears the pending flag on every row in the group (the "nothing to
 /// push" no-op outcome).
-private func clearPendingFlag(_ results: [APIResult], on db: Database) async throws {
-    for result in results {
-        result.brightspaceSyncPending = false
-        try await result.save(on: db)
+private func clearPendingFlag(_ rows: [any BrightSpaceSyncFlaggable], on db: Database) async throws {
+    for row in rows {
+        row.brightspaceSyncPending = false
+        try await row.save(on: db)
     }
 }
 
@@ -239,6 +374,7 @@ private func pushGrade(
 ) async throws -> Bool {
     let userID = target.userID
     let testSetupID = target.testSetupID
+    let syncRows = target.syncRows
 
     // The assignment for this test setup must have a grade item configured.
     guard let assignment = target.assignment,
@@ -246,7 +382,7 @@ private func pushGrade(
         !gradeObjectID.isEmpty
     else {
         // No BrightSpace grade item configured — no-op.
-        try await clearPendingFlag(target.results, on: db)
+        try await clearPendingFlag(syncRows, on: db)
         return true
     }
 
@@ -255,7 +391,7 @@ private func pushGrade(
         let orgUnitID = course.brightspaceOrgUnitID,
         !orgUnitID.isEmpty
     else {
-        try await clearPendingFlag(target.results, on: db)
+        try await clearPendingFlag(syncRows, on: db)
         return true
     }
 
@@ -271,7 +407,7 @@ private func pushGrade(
     // yet (nothing to push); throws if submissions exist but yield no points.
     guard let points = try await bestPointsForStudent(userID: userID, testSetupID: testSetupID, db: db)
     else {
-        try await clearPendingFlag(target.results, on: db)
+        try await clearPendingFlag(syncRows, on: db)
         return true
     }
 
@@ -317,10 +453,10 @@ private func pushGrade(
     )
     guard let bsUserID else {
         // No BrightSpace account for this student — record + skip.
-        for result in target.results {
-            result.brightspaceSyncPending = false
-            result.brightspaceSyncError = "Student has no BrightSpace account (orgDefinedId not found)"
-            try await result.save(on: db)
+        for row in syncRows {
+            row.brightspaceSyncPending = false
+            row.brightspaceSyncError = "Student has no BrightSpace account (orgDefinedId not found)"
+            try await row.save(on: db)
         }
         await appendSyncLog(.skipped, detail: "No BrightSpace account (orgDefinedId not found)")
         return true
@@ -343,12 +479,12 @@ private func pushGrade(
     }
 
     let syncedAt = Date()
-    for result in target.results {
-        result.brightspaceSyncPending = false
-        result.brightspacePendingSince = nil
-        result.brightspaceSyncedAt = syncedAt
-        result.brightspaceSyncError = nil
-        try await result.save(on: db)
+    for row in syncRows {
+        row.brightspaceSyncPending = false
+        row.brightspacePendingSince = nil
+        row.brightspaceSyncedAt = syncedAt
+        row.brightspaceSyncError = nil
+        try await row.save(on: db)
     }
 
     await appendSyncLog(.success, detail: nil)

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -36,13 +36,15 @@ func sweepBrightSpaceGradeSync(
 ) async throws -> Int {
     let cutoff = now.addingTimeInterval(-debounceSecs)
 
-    // All results that are past the debounce window.
+    // All results that are past the debounce window. May be empty — an
+    // override on a student with no submissions has no result row, so the sweep
+    // must still run the override scan below even when nothing here is pending.
+    // (With an empty `pending`, loadGradeSyncBatchContext issues no queries and
+    // the result loops don't execute, so there's no early-return short-circuit.)
     let pending = try await APIResult.query(on: db)
         .filter(\.$brightspaceSyncPending == true)
         .filter(\.$brightspacePendingSince <= cutoff)
         .all()
-
-    guard !pending.isEmpty else { return 0 }
 
     let context = try await loadGradeSyncBatchContext(for: pending, db: db)
 

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -341,4 +341,9 @@ func registerMigrations(on app: Application) {
     // CreateCourseEnrollments (the table) and CreateUsers (the backfill reads
     // users).
     app.migrations.add(AddCourseEnrollmentRole())
+
+    // BrightSpace grade-sync bookkeeping on grade_overrides, mirroring the
+    // columns on results. Lets an override on a student with no submissions
+    // (e.g. a manually-registered pre-enrolled student) enqueue a grade push.
+    app.migrations.add(AddGradeOverrideBrightSpaceSync())
 }

--- a/Tests/APITests/AssignmentEnrollmentTests.swift
+++ b/Tests/APITests/AssignmentEnrollmentTests.swift
@@ -543,6 +543,90 @@ import VaporTesting
         }
     }
 
+    @Test func registerPreEnrollment_materializesUserAndEnrolls() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "CSV_REG1")
+            let courseID = try course.requireID()
+
+            let pending = APIPreEnrollment(courseID: courseID, username: "csv_pre_register")
+            try await pending.save(on: app.db)
+            let preID = try pending.requireID().uuidString
+
+            let cookie = try await loginInstructor("csv_reg_instructor1", in: course)
+            let (token, newCookie) = try await csrfFields(for: "/enroll", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID.uuidString)/pre-enroll/\(preID)/register",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    try req.content.encode(
+                        [
+                            "_csrf": token,
+                            "displayName": "Reggie Test",
+                            "externalSubject": "duo-sub-123",
+                            "studentID": "20260001",
+                        ], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+
+            // Pre-enrollment is gone.
+            let remaining = try await APIPreEnrollment.query(on: app.db)
+                .filter(\.$id == pending.requireID())
+                .count()
+            #expect(remaining == 0)
+
+            // A real student user now exists, carrying the supplied SSO identity.
+            let user = try #require(
+                try await APIUser.query(on: app.db)
+                    .filter(\.$username == "csv_pre_register").first())
+            #expect(user.role == UserRole.student.rawValue)
+            #expect(user.authProvider == "duo-oidc")
+            #expect(user.externalSubject == "duo-sub-123")
+            #expect(user.displayName == "Reggie Test")
+            #expect(user.studentID == "20260001")
+
+            // And they're enrolled in the course.
+            let enrollment = try await APICourseEnrollment.query(on: app.db)
+                .filter(\.$course.$id == courseID)
+                .filter(\.$userID == user.requireID())
+                .count()
+            #expect(enrollment == 1)
+        }
+    }
+
+    @Test func registerPreEnrollment_studentForbidden() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "CSV_REG2")
+            let courseID = try course.requireID()
+
+            let pending = APIPreEnrollment(courseID: courseID, username: "csv_pre_regforbidden")
+            try await pending.save(on: app.db)
+            let preID = try pending.requireID().uuidString
+
+            let cookie = try await loginUser(
+                username: "csv_reg_student2", password: "pw", role: "student", on: app)
+            let (token, newCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID.uuidString)/pre-enroll/\(preID)/register",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                })
+
+            // Pending row untouched.
+            let remaining = try await APIPreEnrollment.query(on: app.db)
+                .filter(\.$id == pending.requireID())
+                .count()
+            #expect(remaining == 1)
+        }
+    }
+
     @Test func bulkEnrollCSV_studentForbidden() async throws {
         try await withApp(app) { _ in
             let course = try await makeCourse(code: "CSV_ENROLL3")

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -159,6 +159,44 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         return result
     }
 
+    /// A manifest whose suite items sum to `total` points, so
+    /// `suiteTotalPoints` (the override → points denominator) is non-zero.
+    private func pointsManifest(total: Int) -> String {
+        #"""
+        {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"t1.sh","points":\#(total)}],"timeLimitSeconds":10,"makefile":null}
+        """#
+    }
+
+    /// Builds a configured course/setup/assignment/user graph with NO
+    /// submission — the "pending student manually registered for grade-sync
+    /// testing" case. The setup's manifest sums to `suiteTotal` points so an
+    /// override percent converts to points.
+    private func makeOverrideOnlyScenario(
+        suiteTotal: Int = 10,
+        orgUnitID: String = "ou-ovr",
+        gradeObjectID: String = "go-ovr",
+        studentID: String? = "stu-ovr"
+    ) async throws -> (setupID: String, userID: UUID) {
+        let course = try await makeTestCourse(on: app, code: "BSOVR")
+        course.brightspaceOrgUnitID = orgUnitID
+        try await course.save(on: app.db)
+        let courseID = try course.requireID()
+
+        let setupID = "ts_\(UUID().uuidString.lowercased().prefix(8))"
+        _ = try await makeTestSetup(
+            on: app, id: setupID, courseID: courseID, manifest: pointsManifest(total: suiteTotal))
+
+        let assignment = try await makeTestAssignment(
+            on: app, testSetupID: setupID, courseID: courseID, title: "Override-only Lab")
+        assignment.brightspaceGradeObjectID = gradeObjectID
+        try await assignment.save(on: app.db)
+
+        let user = try await makeTestUser(on: app, username: "ovr_\(UUID().uuidString.lowercased().prefix(6))")
+        user.studentID = studentID
+        try await user.save(on: app.db)
+        return (setupID, try user.requireID())
+    }
+
     /// Drives the sweep with a constant per-course identity (the fake), so the
     /// existing tests exercise grade selection / debounce / caching unchanged.
     private func sweep(client: any BrightSpaceGrading, debounceSecs: TimeInterval = 90) async throws -> Int {
@@ -390,6 +428,90 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             let result = try #require(try await APIResult.query(on: app.db).first())
             #expect(result.brightspaceSyncPending == true)
             #expect(result.brightspaceSyncError == nil)
+        }
+    }
+
+    @Test func overrideOnStudentWithNoSubmissionsPushesGrade() async throws {
+        // A manually-registered pending student (no submissions) graded only by
+        // an instructor override must still push: the override row carries the
+        // pending flag, and the push converts percent → points against the
+        // suite total.
+        try await withApp(app) { _ in
+            let scenario = try await makeOverrideOnlyScenario(suiteTotal: 10, studentID: "stu-ovr")
+            try await applyGradeOverride(
+                testSetupID: scenario.setupID,
+                studentUserID: scenario.userID,
+                percent: 50,
+                note: "manual",
+                grantedByUserID: nil,
+                on: app.db
+            )
+            // applyGradeOverride flags the override row pending from "now";
+            // backdate past the debounce window so the sweep picks it up.
+            let override = try #require(try await APIGradeOverride.query(on: app.db).first())
+            #expect(override.brightspaceSyncPending == true)
+            override.brightspacePendingSince = Date().addingTimeInterval(-3600)
+            try await override.save(on: app.db)
+
+            let fake = FakeBrightSpaceGrading(userIDsByOrgDefinedId: ["stu-ovr": "d2l-ovr"])
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)
+            let pushes = await fake.pushes
+            #expect(pushes.count == 1)
+            #expect(pushes.first?.bsUserID == "d2l-ovr")
+            #expect(pushes.first?.earnedPoints == 5)  // 50% of 10
+            // Override row marked synced, flag cleared.
+            let reloaded = try #require(try await APIGradeOverride.query(on: app.db).first())
+            #expect(reloaded.brightspaceSyncPending == false)
+            #expect(reloaded.brightspaceSyncedAt != nil)
+            #expect(reloaded.brightspaceSyncError == nil)
+        }
+    }
+
+    @Test func clearingOverrideOnNoSubmissionStudentDoesNotPush() async throws {
+        // Clearing an override on a student with no submissions reverts to the
+        // (nonexistent) runner grade — nothing to push, and whatever was already
+        // in BrightSpace is left as-is.
+        try await withApp(app) { _ in
+            let scenario = try await makeOverrideOnlyScenario(studentID: "stu-ovr")
+            try await applyGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID,
+                percent: 75, note: nil, grantedByUserID: nil, on: app.db)
+            _ = try await clearGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID, on: app.db)
+
+            // The override row is gone, so there is nothing pending to sweep.
+            let remaining = try await APIGradeOverride.query(on: app.db).count()
+            #expect(remaining == 0)
+
+            let fake = FakeBrightSpaceGrading(userIDsByOrgDefinedId: ["stu-ovr": "d2l-ovr"])
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 0)
+            let pushes = await fake.pushes
+            #expect(pushes.isEmpty)
+        }
+    }
+
+    @Test func overrideOnlyPushDefersWhenNoIdentityConnected() async throws {
+        // With no connected sync identity the override-only push must defer, not
+        // clear — the grade pushes once an instructor connects.
+        try await withApp(app) { _ in
+            let scenario = try await makeOverrideOnlyScenario(studentID: "stu-ovr")
+            try await applyGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID,
+                percent: 40, note: nil, grantedByUserID: nil, on: app.db)
+            let override = try #require(try await APIGradeOverride.query(on: app.db).first())
+            override.brightspacePendingSince = Date().addingTimeInterval(-3600)
+            try await override.save(on: app.db)
+
+            let processed = try await sweepWithNoIdentity()
+
+            #expect(processed == 0)
+            let reloaded = try #require(try await APIGradeOverride.query(on: app.db).first())
+            #expect(reloaded.brightspaceSyncPending == true)
+            #expect(reloaded.brightspaceSyncError == nil)
         }
     }
 

--- a/Tests/APITests/SSOAuthFlowTests.swift
+++ b/Tests/APITests/SSOAuthFlowTests.swift
@@ -568,6 +568,83 @@ import VaporTesting
         }
     }
 
+    @Test func sSOCallbackAdoptsManuallyRegisteredStubByUsername() async throws {
+        // A pending student manually registered via the instructor escape valve
+        // exists as a `duo-oidc` user with the right username but NO
+        // externalSubject. Their real first login must adopt that exact row
+        // (claiming it with the subject), not create a duplicate — so any grade
+        // override already attached to the stub stays bound to the same user.
+        let idToken = try await signedToken(
+            issuer: "http://127.0.0.1/issuer",
+            audience: ["test-client-id"],
+            subject: "subject-stub-adopt",
+            username: nil,
+            name: "Stub Student",
+            email: "stub@example.com",
+            extraClaims: [
+                "winaccountname": "stubuser",
+                "student_id": "99887766",
+            ]
+        )
+        let provider = try await makeMockOIDCProvider(mode: .succeedImmediately(idToken: idToken))
+
+        let config = OIDCConfiguration(
+            clientID: "test-client-id",
+            clientSecret: "test-client-secret",
+            redirectURI: "http://localhost:8080/auth/sso/callback",
+            discovery: OIDCDiscovery(
+                issuer: "http://127.0.0.1/issuer",
+                authorizationEndpoint: "http://127.0.0.1:\(provider.port)/authorize",
+                tokenEndpoint: "http://127.0.0.1:\(provider.port)/token",
+                jwksURI: "http://127.0.0.1:\(provider.port)/keys",
+                revocationEndpoint: nil,
+                endSessionEndpoint: nil
+            ),
+            claimConfig: OIDCClaimConfig(usernameClaim: "winaccountname")
+        )
+
+        try await withApp(provider.app) { _ in
+            try await withApp(try await makeApp(oidcConfig: config)) { app in
+                await app.jwt.keys.add(hmac: "test-secret", digestAlgorithm: .sha256)
+
+                // Manually-registered stub: duo-oidc, matching username, no subject.
+                let stub = APIUser(
+                    username: "stubuser",
+                    passwordHash: "",
+                    role: "student",
+                    authProvider: "duo-oidc",
+                    externalSubject: nil
+                )
+                try await stub.save(on: app.db)
+                let stubID = try stub.requireID()
+
+                let start = try await startSSOSession(on: app)
+
+                try await app.asyncTest(
+                    .GET,
+                    "/auth/sso/callback?code=code123&state=\(start.state)",
+                    beforeRequest: { req in
+                        req.headers.add(name: .cookie, value: start.cookie)
+                    },
+                    afterResponse: { res in
+                        #expect(res.status == .seeOther)
+                    }
+                )
+
+                // Exactly one duo-oidc user for this username — the stub, adopted.
+                let users = try await APIUser.query(on: app.db)
+                    .filter(\.$username == "stubuser")
+                    .all()
+                #expect(users.count == 1)
+                let user = try #require(users.first)
+                #expect(user.id == stubID)
+                #expect(user.externalSubject == "subject-stub-adopt")
+                #expect(user.studentID == "99887766")
+                #expect(user.email == "stub@example.com")
+            }
+        }
+    }
+
     @Test func sSOCallbackPreservesExplicitUserIDClaimWhenRepairingUsername() async throws {
         let idToken = try await signedToken(
             issuer: "http://127.0.0.1/issuer",

--- a/changelog.d/brightspace-grade-pending-students.md
+++ b/changelog.d/brightspace-grade-pending-students.md
@@ -1,0 +1,19 @@
+### Added
+
+- **Grade pending students and push to BrightSpace.** Instructors can now
+  register a pending (pre-enrolled, never-logged-in) student into a real
+  account from the **Students** tab — supplying their SSO identity — so they
+  appear on assignment rosters and can be assigned a grade override. The real
+  student's first SSO login adopts that account (by `externalSubject`, or by
+  username when no subject was supplied), so no duplicate account is created.
+
+### Fixed
+
+- **BrightSpace grade sync now pushes override-only grades.** An instructor
+  grade override on a student with no submissions previously stored and
+  displayed the grade but never reached BrightSpace, because the sync sweep
+  was driven solely by submission result rows. The override row now carries its
+  own pending flag and the sweep pushes it (`override% × suite total points`).
+  The manual **Push all** / **Retry failed** buttons cover these override-only
+  grades too. Clearing an override on a no-submission student leaves the
+  already-pushed grade as-is.


### PR DESCRIPTION
## Why

To test the BrightSpace grade-sync integration end-to-end, an instructor needs to be able to assign a grade to a **pending** student — pre-enrolled (e.g. via CSV) but never logged in — and have it push to LEARN. Two gaps blocked this:

1. A pending student exists only as an `APIPreEnrollment` (a username, no `APIUser`), so they never appear on the assignment roster and there's no UUID-keyed row to attach a grade override to.
2. Even once a student exists, a grade override on a student with **no submissions** was stored and displayed but never pushed: the sync sweep is driven entirely by `APIResult.brightspaceSyncPending` flags, and a no-submission student has no result row to flag.

## What changed

### Register pending students (the escape valve)
- **New route** `POST /courses/:courseID/pre-enroll/:preEnrollmentID/register` materializes an `APIPreEnrollment` into a real `APIUser` (role `student`, `duo-oidc`) + course enrollment and deletes the pre-enrollment. The instructor supplies the SSO identity (display name, student number, email, SSO subject). Instructor-gated (`requireCourseInstructor`), audit-logged.
- **UI:** a "Register" action on each pending row of the **Instructor → Students** tab (server-rendered + JS-poll row builder). Once registered, the student appears on assignment rosters and is gradeable via the existing override control.
- **SSO-safe:** `SSOUpsert` now adopts a manually-registered stub by **username** when no `externalSubject` match is found and the stub has no subject yet. So the student's real first login claims the same account (instead of spawning a duplicate), keeping any grade override bound to the same user. If the SSO subject *was* supplied at register time, adoption happens by subject as before.

### Push override-only grades
- `grade_overrides` gains the four BrightSpace bookkeeping columns that `results` already has (`AddGradeOverrideBrightSpaceSync` migration; mirrored on `APIGradeOverride`).
- `applyGradeOverride` flags the override row pending when the student has **no submissions** (otherwise it flags the result rows as before).
- The sweep loads pending override rows and pushes override-only targets through the same `pushGrade` path (`override% × suite total points`), deduped against the result-driven groups. A shared `BrightSpaceSyncFlaggable` protocol lets the success / clear / failure bookkeeping mark either row kind.
- Manual **Push all** / **Retry failed** cover override-only grades too.
- **Clearing** an override on a no-submission student is a no-op — the already-pushed grade is left as-is in BrightSpace (deliberate, per design discussion).

## Live test path (Path B / service account)
Set the `sphs-dev` credentials → bind org unit + map grade item → **Register** a pending test student → set their override on the assignment roster → **Sync now** → confirm in the `learntest` gradebook. (Live push still depends on the `sphs-dev` key being provisioned — see `docs/brightspace-per-instructor-status.md`; this PR is independent of that.)

## Tests
- `BrightSpaceGradeSyncTests`: override on a no-submission student pushes the right points; clearing it pushes nothing; override-only push defers when no identity is connected.
- `AssignmentEnrollmentTests`: register route materializes the user + enrollment and removes the pre-enrollment; student is forbidden.
- `SSOAuthFlowTests`: real SSO login adopts a manually-registered stub by username (no duplicate account).

## Notes
- `swift-format` + `check-styles.sh` pass locally. The full `swift build`/test/SwiftLint couldn't run in this environment (dependency fetch is blocked by egress policy); CI will compile and run the suite.
- No `VERSION` / `CHANGELOG.md` edits — one `changelog.d/` fragment added per the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_