### PR TITLE
fix(submission): hide "Class goals" heading when there are no class goals

### DIFF
--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -51,7 +51,7 @@ Submission #(submissionID)
     #endif
 </div>
 
-#if(!classGoals.isEmpty):
+#if(hasClassGoals):
 <section class="class-goals-block">
     <h2 class="class-goals-heading">Class goals</h2>
     #for(goal in classGoals):

--- a/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
+++ b/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
@@ -373,7 +373,8 @@ extension WebRoutes {
             deltaHeaderText: delta.headerText,
             badges: badges,
             currentUser: currentUser,
-            classGoals: decorations.classGoals
+            classGoals: decorations.classGoals,
+            hasClassGoals: !decorations.classGoals.isEmpty
         )
     }
 }

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -352,6 +352,11 @@ struct SubmissionContext: Encodable {
     /// as an "Achievements" section.  Empty when the assignment has no class
     /// goals (or the sweep hasn't produced a snapshot yet).
     let classGoals: [ClassGoalView]
+    /// True iff `classGoals` is non-empty.  The template gates the "Class goals"
+    /// heading on this explicit Swift-computed flag rather than
+    /// `!classGoals.isEmpty` in Leaf, so an empty goal list never leaks a bare
+    /// heading regardless of how the Leaf encoder represents an empty array.
+    let hasClassGoals: Bool
 }
 
 /// One class-goal achievement's display state for the submission page.

--- a/Tests/APITests/AchievementDisplayTests.swift
+++ b/Tests/APITests/AchievementDisplayTests.swift
@@ -66,4 +66,33 @@ import VaporTesting
                 })
         }
     }
+
+    /// An assignment with no class-goal achievements must not render the
+    /// "Class goals" header on the submission page — the section is gated on a
+    /// non-empty goal list. (The default manifest carries only individual /
+    /// record built-ins, never a class goal.)
+    @Test func submissionPageHidesClassGoalsHeaderWhenNone() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            try await wrEnrollUser(student, on: app)
+            try await wrInsertSetup(id: "nocg_setup", on: app)
+            _ = try await wrInsertAssignment(
+                testSetupID: "nocg_setup", title: "No Goals", isOpen: true, on: app)
+            _ = try await wrInsertSubmission(
+                id: "nocg_sub", testSetupID: "nocg_setup", userID: try student.requireID(), on: app)
+            _ = try await wrInsertResult(
+                submissionID: "nocg_sub", outcomes: [wrMakeOutcome(name: "t1", status: .pass)], on: app)
+
+            try await app.asyncTest(
+                .GET, "/submissions/nocg_sub",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(!body.contains("Class goals"))
+                    #expect(!body.contains("class-goals-block"))
+                })
+        }
+    }
 }

--- a/Tests/APITests/AchievementDisplayTests.swift
+++ b/Tests/APITests/AchievementDisplayTests.swift
@@ -90,8 +90,13 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let body = res.body.string
+                    // The "Class goals" heading text appears only inside the
+                    // rendered <h2>; the section's opening tag only when the
+                    // block renders. (The `.class-goals-block` CSS selector
+                    // lives in an always-present <style> block, so we must not
+                    // assert on the bare class name.)
                     #expect(!body.contains("Class goals"))
-                    #expect(!body.contains("class-goals-block"))
+                    #expect(!body.contains(#"<section class="class-goals-block">"#))
                 })
         }
     }

--- a/changelog.d/class-goals-header-conditional.md
+++ b/changelog.d/class-goals-header-conditional.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Submission page no longer shows an empty "Class goals" heading.** The
+  class-goals section on the student submission view is now gated on an explicit
+  Swift-computed `hasClassGoals` flag rather than `!classGoals.isEmpty` in Leaf,
+  so an assignment with no class-goal achievements never renders a bare "Class
+  goals" heading with no goals beneath it.


### PR DESCRIPTION
## What & why

On the student submission page (`/submissions/:id`, reached from the instructor submissions list by clicking a student's submission), a bare **"Class goals"** heading was rendering for assignments that have **no class-goal achievements** — e.g. `G9mx8H`, which carries only the built-in individual/record awards and no `classWide` goal.

The section was gated on `#if(!classGoals.isEmpty)` in Leaf. When the encoded `classGoals` array is empty, that guard did not reliably evaluate `false`, so the visible heading leaked with no goals beneath it. The parallel badges block (`#if(!badges.isEmpty)`) has the same shape but renders an *invisible* empty `<div>`, which is why this went unnoticed there.

## Change

- Add an explicit `hasClassGoals: Bool` to `SubmissionContext`, computed in Swift as `!decorations.classGoals.isEmpty`.
- Gate the class-goals `<section>` in `submission.leaf` on `#if(hasClassGoals)` instead of the in-Leaf `!classGoals.isEmpty` check, removing any dependence on how the Leaf encoder represents an empty array.
- Add a regression test (`submissionPageHidesClassGoalsHeaderWhenNone`) asserting the heading and `class-goals-block` are absent when an assignment has no class goals. The existing positive test (goal present → heading shown) is unchanged.

No behavior change when class goals *are* configured.

## How class goals are set (for reference)

Assignment **Edit** page → **Achievements** section → **+ Add Achievement** → scope **"The class together"** → set the *Earned when* condition (e.g. `grade ≥ 80`), **Class share ≥ (%)**, and **Bonus points** → Save. (Persists via `PUT /instructor/:id/achievements`.)

## Testing

> [!NOTE]
> Could not build/run locally in this environment — SwiftPM dependency clones are blocked by the egress proxy (403). The added regression test will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeLFVpH38D1rZAv5jCKXRt)_