### PR TITLE
Make instructor nav always reachable; direct per-course links

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -843,6 +843,23 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     overflow-x: auto;
 }
 
+/* Instructor course strip: a second .course-tabs row, set on the muted
+   surface and led by a label so it reads as distinct from the (white) student
+   course strip when both are shown. */
+.course-tabs-instructor {
+    background: var(--gray-50);
+}
+
+.course-tabs-label {
+    display: inline-flex;
+    align-items: center;
+    padding: .5rem .85rem .5rem 0;
+    font-size: .8125rem;
+    font-weight: 600;
+    color: var(--gray-600);
+    white-space: nowrap;
+}
+
 .course-tab {
     padding: .5rem 1.1rem;
     font-size: .875rem;

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -32,8 +32,16 @@
     </a>
 
     #if(currentUser):
-        #if(currentUser.isInstructorInActiveCourse):
-            <a class="nav-link" href="/instructor">#(currentUser.activeCourse.code)</a>
+        #if(currentUser.primaryInstructorCourse):
+            <!-- Exactly one instructor course: a single direct link, POSTed
+                 through /activate so it works even when a different course is
+                 currently active (it switches active to the taught course,
+                 then lands on the instructor view). -->
+            <form method="post" action="/courses/#(currentUser.primaryInstructorCourse.id)/activate" class="inline-form">
+                #csrfFormField()
+                <input type="hidden" name="next" value="/instructor">
+                <button class="btn-link nav-link" type="submit">Instructor</button>
+            </form>
         #endif
         #if(currentUser.isAdmin):
             <a class="nav-link" href="/admin">Admin</a>
@@ -64,6 +72,24 @@
         <button type="submit"
                 class="course-tab #if(course.isActive):course-tab-active#endif"
                 aria-current="#if(course.isActive):page#else:false#endif">
+            #(course.code)
+        </button>
+    </form>
+    #endfor
+</nav>
+#endif
+#if(currentUser && currentUser.showInstructorTabs):
+<!-- More than one taught course: a dedicated strip of direct links into each
+     course's instructor view.  Each chip POSTs to /activate with next=/instructor
+     so it both switches the active course and lands on its instructor dashboard. -->
+<nav class="course-tabs course-tabs-instructor" aria-label="Instructor courses">
+    <span class="course-tabs-label">Instructor</span>
+    #for(course in currentUser.instructorCourses):
+    <form method="post" action="/courses/#(course.id)/activate" class="contents-form">
+        #csrfFormField()
+        <input type="hidden" name="next" value="/instructor">
+        <button type="submit"
+                class="course-tab #if(course.isActive):course-tab-active#endif">
             #(course.code)
         </button>
     </form>

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -357,6 +357,24 @@ struct CurrentUserContext: Encodable {
     /// every enrollment's role mirrors the global role, so this equals the
     /// previous `isInstructor && activeCourse != nil`.
     let isInstructorInActiveCourse: Bool
+    /// Every enrolled course the user can act on as an instructor: those whose
+    /// per-course role is `.instructor`, plus *all* enrolled courses for an
+    /// admin (who instructs the whole deployment). Drives the nav's Instructor
+    /// surface so an instructor always has a direct link into each course they
+    /// teach, regardless of which course is currently active. Inherits the
+    /// code-sorted order of `enrolledCourses`.
+    let instructorCourses: [CourseContext]
+    /// True when `instructorCourses` is non-empty — the user instructs at least
+    /// one enrolled course. The nav's Instructor entry shows whenever this is
+    /// true, not only when the *active* course happens to be one they teach.
+    let isInstructorAnywhere: Bool
+    /// True when the user instructs more than one course, so the nav should
+    /// render the per-course Instructor strip (mirrors `showCourseTabs`).
+    let showInstructorTabs: Bool
+    /// The single course this user instructs, when there is exactly one — the
+    /// nav renders one direct "Instructor" link for it instead of a strip. nil
+    /// when they instruct zero or many courses.
+    let primaryInstructorCourse: CourseContext?
 
     init(user: APIUser, activeCourse: CourseContext? = nil, enrolledCourses: [CourseContext] = []) {
         let normalizedPreferredName = user.preferredName?
@@ -381,5 +399,14 @@ struct CurrentUserContext: Encodable {
         self.showCourseTabs = enrolledCourses.count > 1
         self.isInstructorInActiveCourse =
             activeCourse != nil && (activeCourse?.role == .instructor || user.isAdmin)
+        // An admin instructs the whole deployment, so every enrollment counts;
+        // everyone else, only their `.instructor` enrollments. Order follows
+        // `enrolledCourses` (code-sorted).
+        let instructorCourses =
+            user.isAdmin ? enrolledCourses : enrolledCourses.filter { $0.role == .instructor }
+        self.instructorCourses = instructorCourses
+        self.isInstructorAnywhere = !instructorCourses.isEmpty
+        self.showInstructorTabs = instructorCourses.count > 1
+        self.primaryInstructorCourse = instructorCourses.count == 1 ? instructorCourses[0] : nil
     }
 }

--- a/Sources/APIServer/Routes/Web/EnrollmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/EnrollmentRoutes.swift
@@ -112,19 +112,48 @@ struct EnrollmentRoutes: RouteCollection {
             throw Abort(.badRequest)
         }
 
-        // Verify the user is actually enrolled in this course.
-        let enrolled = try await APICourseEnrollment.query(on: req.db)
-            .filter(\.$userID == userID)
-            .filter(\.$course.$id == courseID)
-            .count()
+        struct ActivateBody: Content {
+            /// Optional post-activation destination. The instructor nav chips
+            /// set this to "/instructor" so selecting a course jumps straight
+            /// into its instructor view; the course strip omits it and lands
+            /// back where the user clicked.
+            var next: String?
+        }
+        let nextPath = (try? req.content.decode(ActivateBody.self))?.next
 
-        if enrolled > 0 {
+        // Verify the user is actually enrolled in this course.
+        let activated: Bool
+        if try await userIsEnrolled(userID: userID, inCourse: courseID, db: req.db) {
             req.session.data["activeCourseID"] = idString
+            activated = true
+        } else {
+            activated = false
         }
 
-        // Redirect back to where the user came from (tab click).
-        let referer = req.headers.first(name: .referer) ?? "/"
-        return req.redirect(to: referer)
+        // Resolve the redirect target: an explicit (safe, local) `next` wins,
+        // otherwise return to where the click came from, otherwise home.
+        var target = safeLocalPath(nextPath) ?? req.headers.first(name: .referer) ?? "/"
+
+        // Guard against an instructor dead-end: a target under /instructor 403s
+        // unless the *newly active* course is one this user instructs. If the
+        // just-activated course isn't, send them home instead of into a 403.
+        if target.hasPrefix("/instructor") {
+            let role = try await courseRole(of: userID, inCourse: courseID, db: req.db)
+            let canInstruct = activated && (user.isAdmin || (role ?? .student) >= .instructor)
+            if !canInstruct { target = "/" }
+        }
+
+        return req.redirect(to: target)
+    }
+
+    /// Returns `path` only when it is a safe in-app destination: a root-relative
+    /// path (`/…`) that is not protocol-relative (`//host`). Anything else —
+    /// absolute URLs, scheme-relative URLs, nil — returns nil so the caller
+    /// falls back to the referer/home. Keeps the post-activation redirect from
+    /// becoming an open redirect.
+    private func safeLocalPath(_ path: String?) -> String? {
+        guard let path, path.hasPrefix("/"), !path.hasPrefix("//") else { return nil }
+        return path
     }
 }
 

--- a/Tests/APITests/CurrentUserContextTests.swift
+++ b/Tests/APITests/CurrentUserContextTests.swift
@@ -1,9 +1,81 @@
+import Core
 import Fluent
 import Testing
 
 @testable import APIServer
 
 @Suite struct CurrentUserContextTests {
+
+    // MARK: - Instructor course derivation
+
+    private func course(_ code: String, role: CourseRole, isActive: Bool = false) -> CourseContext {
+        CourseContext(id: code, code: code, name: code, isActive: isActive, role: role)
+    }
+
+    private func user(role: String) -> APIUser {
+        APIUser(username: "u", passwordHash: "", role: role)
+    }
+
+    @Test func studentOnly_hasNoInstructorSurface() {
+        let ctx = CurrentUserContext(
+            user: user(role: "student"),
+            activeCourse: course("CS100", role: .student, isActive: true),
+            enrolledCourses: [course("CS100", role: .student), course("CS200", role: .student)]
+        )
+        #expect(ctx.instructorCourses.isEmpty)
+        #expect(ctx.isInstructorAnywhere == false)
+        #expect(ctx.showInstructorTabs == false)
+        #expect(ctx.primaryInstructorCourse == nil)
+    }
+
+    @Test func instructorInOneCourse_exposesSinglePrimaryLink() {
+        // Instructor in CS200, student in CS100 — the Instructor surface must
+        // appear even though the *active* course is one they only take.
+        let ctx = CurrentUserContext(
+            user: user(role: "instructor"),
+            activeCourse: course("CS100", role: .student, isActive: true),
+            enrolledCourses: [course("CS100", role: .student), course("CS200", role: .instructor)]
+        )
+        #expect(ctx.isInstructorAnywhere)
+        #expect(ctx.instructorCourses.map(\.code) == ["CS200"])
+        #expect(ctx.showInstructorTabs == false)
+        #expect(ctx.primaryInstructorCourse?.code == "CS200")
+        // The active-course Instructor link stays keyed on the active course,
+        // which here is a student course — so it must be false.
+        #expect(ctx.isInstructorInActiveCourse == false)
+    }
+
+    @Test func instructorInManyCourses_showsStripNotSingleLink() {
+        let ctx = CurrentUserContext(
+            user: user(role: "instructor"),
+            activeCourse: course("CS200", role: .instructor, isActive: true),
+            enrolledCourses: [course("CS200", role: .instructor), course("CS300", role: .instructor)]
+        )
+        #expect(ctx.showInstructorTabs)
+        #expect(ctx.primaryInstructorCourse == nil)
+        #expect(ctx.instructorCourses.map(\.code) == ["CS200", "CS300"])
+    }
+
+    @Test func admin_instructsEveryEnrolledCourse() {
+        // An admin administers the whole deployment, so every enrolled course
+        // counts as instructable regardless of the per-course role.
+        let ctx = CurrentUserContext(
+            user: user(role: "admin"),
+            activeCourse: course("CS100", role: .student, isActive: true),
+            enrolledCourses: [course("CS100", role: .student), course("CS200", role: .instructor)]
+        )
+        #expect(ctx.instructorCourses.map(\.code) == ["CS100", "CS200"])
+        #expect(ctx.showInstructorTabs)
+    }
+
+    @Test func noCourseInfo_hasNoInstructorSurface() {
+        // The course-free context (used by pages without tabs) must not claim
+        // any instructor courses.
+        let ctx = CurrentUserContext(user: user(role: "instructor"))
+        #expect(ctx.instructorCourses.isEmpty)
+        #expect(ctx.isInstructorAnywhere == false)
+        #expect(ctx.primaryInstructorCourse == nil)
+    }
 
     @Test func trimsProfileFields() {
         let user = APIUser(

--- a/Tests/APITests/EnrollmentRoutesTests.swift
+++ b/Tests/APITests/EnrollmentRoutesTests.swift
@@ -478,6 +478,92 @@ import VaporTesting
         }
     }
 
+    @Test func activateCourse_instructorWithNext_redirectsToInstructorView() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "ACT_INSTR1", mode: .open)
+            let courseID = try course.requireID()
+            let cookie = try await loginUser(
+                username: "act_instr1", password: "pw",
+                role: "instructor", on: app)
+            let instructorUser = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "act_instr1").first())
+            try await APICourseEnrollment(
+                userID: try instructorUser.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
+
+            let (token, newCookie) = try await csrfFields(for: "/enroll", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID.uuidString)/activate",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    try req.content.encode(["_csrf": token, "next": "/instructor"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor")
+                })
+        }
+    }
+
+    @Test func activateCourse_studentWithInstructorNext_fallsBackHome() async throws {
+        // A student selecting a course must never be dropped into the
+        // instructor view (which would 403); the redirect falls back to home.
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "ACT_STU_NEXT1", mode: .open)
+            let courseID = try course.requireID()
+            let cookie = try await loginUser(
+                username: "act_stu_next1", password: "pw",
+                role: "student", on: app)
+            let studentUser = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "act_stu_next1").first())
+            try await APICourseEnrollment(
+                userID: try studentUser.requireID(), courseID: courseID, role: .student
+            ).save(on: app.db)
+
+            let (token, newCookie) = try await csrfFields(for: "/enroll", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID.uuidString)/activate",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    try req.content.encode(["_csrf": token, "next": "/instructor"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/")
+                })
+        }
+    }
+
+    @Test func activateCourse_nonLocalNext_ignored() async throws {
+        // A protocol-relative `next` must not become an open redirect; it is
+        // dropped in favour of the referer (or "/").
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "ACT_OPEN_REDIR1", mode: .open)
+            let courseID = try course.requireID()
+            let cookie = try await loginUser(
+                username: "act_open_redir1", password: "pw",
+                role: "student", on: app)
+            let studentUser = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "act_open_redir1").first())
+            try await APICourseEnrollment(
+                userID: try studentUser.requireID(), courseID: courseID, role: .student
+            ).save(on: app.db)
+
+            let (token, newCookie) = try await csrfFields(for: "/enroll", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/courses/\(courseID.uuidString)/activate",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: newCookie)
+                    try req.content.encode(["_csrf": token, "next": "//evil.example"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    let location = res.headers.first(name: .location)
+                    #expect(location != "//evil.example")
+                })
+        }
+    }
+
     // MARK: - Admin enrollment-mode route
 
     @Test func adminSetEnrollmentMode_setsMode() async throws {

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -549,8 +549,8 @@ import VaporTesting
                         html.contains("not enrolled in any courses"),
                         "The dashboard should show the empty not-enrolled state")
                     #expect(
-                        !html.contains(#"href="/instructor""#),
-                        "The course-scoped Instructor tab must not render for an unenrolled admin")
+                        !html.contains(#"value="/instructor""#),
+                        "The Instructor nav entry must not render for an unenrolled admin")
                     #expect(
                         html.contains(#"href="/admin""#),
                         "The admin keeps their deployment-wide Admin tab")
@@ -559,8 +559,8 @@ import VaporTesting
     }
 
     /// The other side of the unenrolled-admin fix: an instructor enrolled in a
-    /// course still gets the course-scoped tab, labelled with the active course
-    /// code.
+    /// single course gets a direct Instructor link (the one-course case renders
+    /// a single "Instructor" entry rather than the multi-course strip).
     @Test func enrolledInstructorSeesCourseScopedInstructorTab() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsInstructor(on: app)
@@ -575,11 +575,11 @@ import VaporTesting
                     #expect(res.status == .ok)
                     let html = res.body.string
                     #expect(
-                        html.contains(#"href="/instructor""#),
-                        "An enrolled instructor must still see the Instructor tab")
+                        html.contains(#"value="/instructor""#),
+                        "An enrolled instructor must still see the Instructor entry")
                     #expect(
-                        html.contains(">CS101</a>"),
-                        "The Instructor tab is labelled with the active course code")
+                        html.contains(">Instructor</button>"),
+                        "The single-course Instructor entry is one direct link, not a per-course strip")
                 })
         }
     }
@@ -608,11 +608,11 @@ import VaporTesting
                     #expect(res.status == .ok)
                     let html = res.body.string
                     #expect(
-                        html.contains(#"href="/instructor""#),
-                        "A per-course instructor (global student) must see the Instructor tab")
+                        html.contains(#"value="/instructor""#),
+                        "A per-course instructor (global student) must see the Instructor entry")
                     #expect(
-                        html.contains(">CS301</a>"),
-                        "The Instructor tab is labelled with the active course code")
+                        html.contains(">Instructor</button>"),
+                        "The single-course Instructor entry is one direct link")
                 })
         }
     }

--- a/changelog.d/course-nav-expansion.md
+++ b/changelog.d/course-nav-expansion.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **Instructor nav is always reachable, and every course is one click away.**
+  The nav bar's Instructor entry now shows whenever you instruct *any* enrolled
+  course, not only when your currently active course happens to be one you teach.
+  Instruct exactly one course and you get a single direct "Instructor" link;
+  instruct several and a per-course Instructor strip appears, each chip jumping
+  straight into that course's instructor dashboard. The existing course strip
+  continues to give every enrolled student direct access to each of their
+  courses. Course selection still flows through `POST /courses/:id/activate`,
+  which now accepts an optional `next` destination (validated as a safe local
+  path) and falls back to the home dashboard rather than dropping a non-instructor
+  into a 403.


### PR DESCRIPTION
## Why

The nav bar's **Instructor** entry only appeared when your *currently active* course was one you taught (`isInstructorInActiveCourse`), and `/instructor` is gated on the active course too. So an instructor whose active course was one they only *take* lost the Instructor link entirely and couldn't reach their instructor view without first switching the active course. There was also no way to jump directly to a specific course you teach.

This reworks the nav around **all** the courses a user can act on, so an instructor always has a direct link into each course they teach, and students keep direct access to each course they're enrolled in — the nav stays simple for single-enrollment and expands only as needed.

## What changed

- **`CurrentUserContext` (`Sources/APIServer/Models/APIUser.swift`)** gains `instructorCourses`, `isInstructorAnywhere`, `showInstructorTabs`, and `primaryInstructorCourse`, derived from the per-course enrollment roles (admins instruct every enrolled course). These mirror the existing `enrolledCourses` / `showCourseTabs` convention.
- **`Resources/Views/base.leaf`**:
  - The Instructor entry now shows whenever you instruct *any* course, not only when the active course is one you teach.
  - Instruct exactly **one** course → a single direct **Instructor** link.
  - Instruct **several** → a per-course Instructor strip; each chip jumps straight into that course's instructor dashboard.
  - The existing course strip (student-facing) is unchanged.
- **`POST /courses/:id/activate` (`Sources/APIServer/Routes/Web/EnrollmentRoutes.swift`)** accepts an optional `next` destination, validated as a safe local path (no open-redirect via `//host`), so the instructor chips switch the active course and land on `/instructor` in one click. If the just-activated course isn't one the user instructs, the redirect falls back to the home dashboard instead of dropping them into a `/instructor` 403.
- **`Public/styles.css`** adds `.course-tabs-instructor` / `.course-tabs-label` (reusing the existing `.course-tabs` / `.course-tab` styling).

## Design note

Kept the single session "active course" model (selecting any course makes it active everywhere) rather than introducing independent per-course URLs — the latter would be a large refactor across six route collections, the middleware, and dozens of redirects, for the same user-visible outcome. The "Chickadee" brand still links to your active course's home dashboard; the always-visible course strip serves as the list of all your courses, so no separate landing page was added.

## Tests

- `CurrentUserContextTests` — new coverage for the instructor-course derivation across student / single-instructor / multi-instructor / admin / no-course cases.
- `EnrollmentRoutesTests` — `activate` with `next=/instructor` redirects to the instructor view for an instructor, falls back to `/` for a student, and ignores a non-local `next`.
- `WebRoutesIndexTests` — updated for the new nav markup.

> ⚠️ Could not compile or run the test suite locally: this environment's egress policy blocks GitHub clones (403), so SwiftPM can't resolve dependencies. Relying on CI for the build + test run. Static guards (`swift-format --strict`, `check-styles.sh`, `check-css-vars.sh`) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1vvrb1duTXnZFgzLXbcsC)_