### PR TITLE
Keep the Instructor nav link visible on every page

### DIFF
--- a/Sources/APIServer/Middleware/NavCourseContextMiddleware.swift
+++ b/Sources/APIServer/Middleware/NavCourseContextMiddleware.swift
@@ -1,0 +1,27 @@
+// APIServer/Middleware/NavCourseContextMiddleware.swift
+//
+// Resolves the course-aware nav context once per authenticated web request and
+// caches it on the request, so the shared nav bar (the Instructor link and the
+// course-tab strips, rendered by base.leaf) appears on *every* page.
+//
+// Without this, pages whose handlers build only a `req.currentUserContext` —
+// the admin panel, the account page, the enrol page, and many others — render
+// a course-free user context, so the Instructor link and course tabs vanish the
+// moment you navigate to one of them. Populating the cache here lets
+// `currentUserContext` return the course-aware snapshot uniformly, with no
+// per-handler changes.
+//
+// Must sit downstream of the session authenticator so `auth.get(APIUser)` is
+// populated. Best-effort: a resolution failure is swallowed so the nav simply
+// degrades to the course-free fallback rather than failing the page.
+
+import Vapor
+
+struct NavCourseContextMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        if request.auth.has(APIUser.self) {
+            _ = try? await request.courseAwareUserContext()
+        }
+        return try await next.respond(to: request)
+    }
+}

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -218,20 +218,50 @@ struct UserSessionAuthenticator: AsyncSessionAuthenticator {
 
 // MARK: - Request helper
 
+/// Per-request cache of the course-aware nav context.  `NavCourseContextMiddleware`
+/// populates it once for every authenticated web request so the shared nav
+/// (Instructor link + course tabs) renders on *every* page — including the
+/// course-free ones (admin, account, …) whose handlers only ever build a
+/// `req.currentUserContext`.
+private struct CourseAwareUserContextStorageKey: StorageKey {
+    typealias Value = CurrentUserContext
+}
+
+/// Per-request cache of the resolved active-course state, so the several
+/// callers in one request (the nav middleware, `ActiveCourseInstructorMiddleware`,
+/// and the page handler) share a single DB resolution rather than each
+/// re-querying — and so the auto-enroll/session side effects run once.
+private struct ResolvedCourseStateStorageKey: StorageKey {
+    typealias Value = ResolvedCourseState
+}
+
 extension Request {
     /// Returns a Leaf-encodable snapshot of the current user for view contexts.
-    /// Does not include course information; use `courseAwareUserContext()` for pages with tabs.
+    ///
+    /// Prefers the course-aware context resolved once per request by
+    /// `NavCourseContextMiddleware`, so the nav's Instructor link and course
+    /// tabs appear on every rendered page — not just the course-scoped ones.
+    /// Falls back to a course-free snapshot when no middleware has populated the
+    /// cache (e.g. the MCP OAuth consent flow or any non-web request), which
+    /// keeps the historical behaviour for those callers.
     var currentUserContext: CurrentUserContext? {
+        if let cached = storage[CourseAwareUserContextStorageKey.self] { return cached }
         guard let user = auth.get(APIUser.self) else { return nil }
         return CurrentUserContext(user: user)
     }
 
     /// Builds a `CurrentUserContext` populated with course information from the DB.
     /// Call this from any route that needs course tabs or active-course filtering.
+    /// The result is cached on the request so `currentUserContext` and any later
+    /// caller reuse it without re-querying.
     func courseAwareUserContext() async throws -> CurrentUserContext? {
+        if let cached = storage[CourseAwareUserContextStorageKey.self] { return cached }
         guard let user = auth.get(APIUser.self) else { return nil }
         let state = try await resolveActiveCourse(for: user)
-        return CurrentUserContext(user: user, activeCourse: state.active, enrolledCourses: state.all)
+        let context = CurrentUserContext(
+            user: user, activeCourse: state.active, enrolledCourses: state.all)
+        storage[CourseAwareUserContextStorageKey.self] = context
+        return context
     }
 
     private static let activeCourseSessionKey = "activeCourseID"
@@ -239,7 +269,16 @@ extension Request {
     /// Resolves the active course for `user`, consulting the session and DB.
     /// Auto-enrolls the user in every course with enrollmentMode == .auto.
     /// Returns `activeCourseUUID == nil` when the user is not enrolled anywhere.
+    /// Cached per request (the underlying work, including its side effects, runs
+    /// once); see `computeActiveCourse` for the resolution itself.
     func resolveActiveCourse(for user: APIUser) async throws -> ResolvedCourseState {
+        if let cached = storage[ResolvedCourseStateStorageKey.self] { return cached }
+        let state = try await computeActiveCourse(for: user)
+        storage[ResolvedCourseStateStorageKey.self] = state
+        return state
+    }
+
+    private func computeActiveCourse(for user: APIUser) async throws -> ResolvedCourseState {
         guard let userID = user.id else {
             return ResolvedCourseState(active: nil, all: [], activeCourseUUID: nil)
         }

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -31,7 +31,11 @@ func routes(_ app: Application) throws {
 
     // MARK: - Any authenticated user
 
-    let auth = app.grouped(sessionAuth, RoleMiddleware(required: .authenticated), csrf)
+    // `NavCourseContextMiddleware` resolves the course-aware nav context once
+    // per request so the Instructor link + course tabs render on every page,
+    // including the course-free ones (admin, account, …).
+    let auth = app.grouped(
+        sessionAuth, RoleMiddleware(required: .authenticated), NavCourseContextMiddleware(), csrf)
     try auth.register(collection: SessionRoutes())
     try auth.register(collection: WebRoutes())
     try auth.register(collection: EnrollmentRoutes())
@@ -52,7 +56,8 @@ func routes(_ app: Application) throws {
 
     // Per-course instructor authority (Phase 4b): admits admins, or a user who
     // is an instructor in their active course — not the bare global role.
-    let instructor = app.grouped(sessionAuth, ActiveCourseInstructorMiddleware(), csrf)
+    let instructor = app.grouped(
+        sessionAuth, ActiveCourseInstructorMiddleware(), NavCourseContextMiddleware(), csrf)
     try instructor.register(collection: InstructorDashboardRoutes())
     try instructor.register(collection: DraftAssignmentRoutes())
     try instructor.register(collection: PublishedAssignmentRoutes())
@@ -66,7 +71,8 @@ func routes(_ app: Application) throws {
 
     // MARK: - Admin only
 
-    let admin = app.grouped(sessionAuth, RoleMiddleware(required: .admin), csrf)
+    let admin = app.grouped(
+        sessionAuth, RoleMiddleware(required: .admin), NavCourseContextMiddleware(), csrf)
     try admin.register(collection: AdminRoutes())
     try admin.register(collection: InternalMetricsRoutes())
     try admin.register(collection: CourseBundleRoutes())

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -584,6 +584,29 @@ import VaporTesting
         }
     }
 
+    /// The nav (Instructor link + course tabs) must persist on pages whose
+    /// handler only builds a course-free `req.currentUserContext` — the bug the
+    /// `NavCourseContextMiddleware` fixes.  `/account` is such a page; an
+    /// enrolled instructor must still see the Instructor link there.
+    @Test func instructorNavPersistsOnCourseFreePage() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+
+            try await app.asyncTest(
+                .GET, "/account",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(
+                        res.body.string.contains(#"value="/instructor""#),
+                        "The Instructor nav link must persist on a course-free page like /account")
+                })
+        }
+    }
+
     /// Phase 2 wiring, end-to-end: the nav's Instructor tab keys off the
     /// *per-course* role. A global `student` whose enrollment in the active
     /// course carries `.instructor` sees the Instructor tab there — the

--- a/changelog.d/nav-instructor-persist.md
+++ b/changelog.d/nav-instructor-persist.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **The Instructor nav link no longer disappears on the Admin (and other)
+  pages.** Pages whose handlers build only a course-free user context — the
+  admin panel, the account page, and many others — were dropping the nav's
+  Instructor link and course tabs. A new `NavCourseContextMiddleware` resolves
+  the course-aware nav context once per authenticated web request (cached, so it
+  shares the existing active-course resolution), so the Instructor link and
+  course tabs now render on every page.


### PR DESCRIPTION
## Why

Follow-up to #1061. After that change, the nav's **Instructor** link (and the course tabs) still disappeared the moment you navigated to the **Admin** panel — and the same happened on the account page, the enrol page, and many others.

Root cause: those pages' handlers build only a course-free `req.currentUserContext`, which carries no enrolled-course / instructor-course information. The course-aware context (with `instructorCourses` etc.) was only built on the handful of course-scoped pages (`/`, `/instructor`). So `currentUser.primaryInstructorCourse` / `showInstructorTabs` were empty everywhere else and the nav collapsed.

## What changed

- **New `NavCourseContextMiddleware`** (`Sources/APIServer/Middleware/`) resolves the course-aware nav context once per authenticated web request and caches it on the request.
- **`req.currentUserContext` now prefers that cached context**, falling back to the course-free snapshot when no middleware populated it (e.g. the MCP OAuth consent flow). This fixes every page with **no per-handler changes** — the ~35 `req.currentUserContext` call sites all benefit automatically.
- **Per-request caching** of both the resolved active-course state and the built context (`resolveActiveCourse` split into a cached wrapper + `computeActiveCourse`), so the nav middleware, `ActiveCourseInstructorMiddleware`, and the page handler share a single DB resolution — and the auto-enroll/session side effects still run exactly once.
- Registered the middleware on the **authenticated**, **instructor**, and **admin** web route groups.

## Tests

- `WebRoutesIndexTests.instructorNavPersistsOnCourseFreePage` — an enrolled instructor hitting `/account` (a course-free page) still sees the Instructor link.

## Note

> ⚠️ Could not compile or run the test suite locally — this environment's egress policy blocks GitHub clones (403), so SwiftPM can't resolve dependencies. Relying on CI for build + tests. `swift-format --strict` passes locally on all changed files.

This is a separate branch/PR because #1061's branch was already squash-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1vvrb1duTXnZFgzLXbcsC)_