### PR TITLE
Block writes to archived courses server-side (#417 Slice A)

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -109,6 +109,33 @@ func requireCourseInstructor(caller: APIUser, courseID: UUID, db: Database) asyn
     try await requireCourseRole(caller: caller, courseID: courseID, atLeast: .instructor, db: db)
 }
 
+/// Authorizes a *write* to a per-course resource. The caller must satisfy
+/// `requireCourseRole(atLeast:)` for `courseID` (admin bypass) **and** the
+/// course must not be archived. Archived courses are read-only for
+/// instructors and TAs — editing assignments/tests, mutating enrollment, and
+/// retesting are blocked once a course is archived, while grade audits and
+/// lookups stay readable (the read helpers carry no archived block). Admins
+/// remain write-exempt: they administer the whole deployment, and unarchiving
+/// is an admin-only action.
+///
+/// Mutating per-course handlers call this in place of `requireCourseInstructor`,
+/// scoping the check to the *resource's own* course so an instructor of one
+/// course can't drive a write against another by URL — the per-course
+/// authorization the `/instructor` group middleware (which only sees the
+/// caller's active course) can't enforce. See docs/multi-course-roles.md.
+func requireCourseWriteAccess(
+    caller: APIUser, courseID: UUID, atLeast minimum: CourseRole = .instructor, db: Database
+) async throws {
+    try await requireCourseRole(caller: caller, courseID: courseID, atLeast: minimum, db: db)
+    guard !caller.isAdmin else { return }
+    guard let course = try await APICourse.find(courseID, on: db) else {
+        throw Abort(.notFound, reason: "Course not found.")
+    }
+    guard !course.isArchived else {
+        throw Abort(.forbidden, reason: "This course is archived and is read-only.")
+    }
+}
+
 // MARK: - Enrollment creation (role seeding)
 
 /// Creates and saves a new enrollment for `user` in `courseID`, seeding the

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -55,7 +55,7 @@ extension CourseAdminRoutes {
             throw WebAssignmentError.notFound(resource: "Course")
         }
         let caller = try req.auth.require(APIUser.self)
-        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+        try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
         let body = try? req.content.decode(Body.self)
         course.enrollmentMode = CourseEnrollmentMode(rawValue: body?.enrollmentMode ?? "") ?? .open
         try await course.save(on: req.db)
@@ -84,7 +84,7 @@ extension CourseAdminRoutes {
         }
 
         let caller = try req.auth.require(APIUser.self)
-        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+        try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
 
         let form = try req.content.decode(BulkEnrollForm.self)
 
@@ -143,7 +143,7 @@ extension CourseAdminRoutes {
         }
 
         let caller = try req.auth.require(APIUser.self)
-        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+        try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
 
         try await APICourseEnrollment.query(on: req.db)
             .filter(\.$course.$id == courseID)
@@ -181,7 +181,7 @@ extension CourseAdminRoutes {
         }
 
         let caller = try req.auth.require(APIUser.self)
-        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+        try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
 
         try await APIPreEnrollment.query(on: req.db)
             .filter(\.$id == preID)
@@ -226,7 +226,7 @@ extension CourseAdminRoutes {
         }
 
         let caller = try req.auth.require(APIUser.self)
-        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+        try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
 
         guard
             let preEnrollment = try await APIPreEnrollment.query(on: req.db)
@@ -305,7 +305,7 @@ extension CourseAdminRoutes {
             throw WebAssignmentError.invalidParameter(
                 name: "courseID/userID", reason: "Invalid courseID or userID parameter")
         }
-        try await requireCourseInstructor(caller: caller, courseID: courseID, db: req.db)
+        try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
 
         struct Body: Content { var role: String? }
         let body = try? req.content.decode(Body.self)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Achievements.swift
@@ -44,7 +44,7 @@ extension PublishedAssignmentRoutes {
 
     @Sendable
     func putAchievements(req: Request) async throws -> AchievementsResponse {
-        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
         let body = try req.content.decode(AchievementsBody.self)
         let rows = try await AchievementsEditing.apply(
             rows: body.achievements, setup: setup, on: req.db)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+GlobalVariables.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+GlobalVariables.swift
@@ -67,7 +67,7 @@ extension PublishedAssignmentRoutes {
 
     @Sendable
     func putGlobalVariables(req: Request) async throws -> GlobalVariablesResponse {
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
         let body = try req.content.decode(GlobalVariablesBody.self)
 
         // The save-time expression check evaluates against the acting

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+NotebookTools.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+NotebookTools.swift
@@ -111,7 +111,7 @@ extension PublishedAssignmentRoutes {
             throw WebAssignmentError.internalFailure(reason: "Authenticated user has no ID")
         }
 
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
 
         let sourceData =
             (try? notebookData(for: setup))

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -16,7 +16,7 @@ extension PublishedAssignmentRoutes {
     func saveEditedAssignment(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
 
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
         let idStr = assignment.publicID
 
         let form = try parseSaveEditedAssignmentForm(req: req)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+ScriptCRUD.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+ScriptCRUD.swift
@@ -42,7 +42,7 @@ extension PublishedAssignmentRoutes {
 
     @Sendable
     func updateScript(req: Request) async throws -> HTTPStatus {
-        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
         let filename = try safeScriptFilename(from: req)
 
         struct UpdateBody: Content { var content: String }
@@ -91,7 +91,7 @@ extension PublishedAssignmentRoutes {
 
     @Sendable
     func createScript(req: Request) async throws -> Response {
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
         let idStr = assignment.publicID
         let body = try req.content.decode(CreateScriptBody.self)
 
@@ -140,7 +140,7 @@ extension PublishedAssignmentRoutes {
 
     @Sendable
     func deleteScript(req: Request) async throws -> HTTPStatus {
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
         let filename = try safeScriptFilename(from: req)
 
         try await deleteScriptFromSetup(setup: setup, filename: filename, on: req.db)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Suite.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Suite.swift
@@ -41,7 +41,7 @@ extension PublishedAssignmentRoutes {
     /// view without a second round-trip.
     @Sendable
     func putSuite(req: Request) async throws -> Response {
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
 
         let body: SuitePayload
         do { body = try req.content.decode(SuitePayload.self) } catch {

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SuiteSections.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SuiteSections.swift
@@ -34,7 +34,7 @@ extension PublishedAssignmentRoutes {
     func createSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
         let body = try req.content.decode(Body.self)
         try await createSuiteSectionCore(setup: setup, name: body.name, on: req.db)
         return redirectToEdit(req: req)
@@ -46,7 +46,7 @@ extension PublishedAssignmentRoutes {
     func renameSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
@@ -59,7 +59,7 @@ extension PublishedAssignmentRoutes {
 
     @Sendable
     func deleteSuiteSection(req: Request) async throws -> Response {
-        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
@@ -86,7 +86,7 @@ extension PublishedAssignmentRoutes {
             var expressions: [PersonalizationExpression]?
         }
 
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
@@ -119,7 +119,7 @@ extension PublishedAssignmentRoutes {
     func reorderSuiteSections(req: Request) async throws -> HTTPStatus {
         struct Body: Content { var sectionIDs: [String] }
 
-        let (_, setup) = try await loadAssignmentAndSetup(req)
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
         let body = try req.content.decode(Body.self)
         try await reorderSuiteSectionsCore(setup: setup, sectionIDs: body.sectionIDs, on: req.db)
         return .ok

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -59,6 +59,20 @@ func loadAssignment(_ req: Request) async throws -> APIAssignment {
     return assignment
 }
 
+/// Write-authorizing sibling of `loadAssignmentAndSetup(_:)`. After loading,
+/// authorizes the caller for a *write* to the assignment's **own** course via
+/// `requireCourseWriteAccess` (per-course instructor, admin bypass,
+/// archived-course block). Mutating editor handlers use this so a write is
+/// scoped to the resource's course rather than the caller's active course —
+/// closing both the archived-course and cross-course write paths the
+/// `/instructor` group middleware can't see (see docs/multi-course-roles.md).
+func loadAssignmentAndSetupForWrite(_ req: Request) async throws -> (APIAssignment, APITestSetup) {
+    let (assignment, setup) = try await loadAssignmentAndSetup(req)
+    let caller = try req.auth.require(APIUser.self)
+    try await requireCourseWriteAccess(caller: caller, courseID: assignment.courseID, db: req.db)
+    return (assignment, setup)
+}
+
 /// Loads a draft test setup from the `?draftID=<id>` query parameter.
 /// The draft model is just an `APITestSetup` row that hasn't been
 /// linked to an `APIAssignment` yet — same row shape, no parent.

--- a/Tests/APITests/ArchivedCourseWriteRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseWriteRouteTests.swift
@@ -1,0 +1,113 @@
+// Tests/APITests/ArchivedCourseWriteRouteTests.swift
+//
+// Route-level coverage for the archived-course write block (Slice A of #417,
+// docs/multi-course-roles.md). The assignment editor's mutating endpoints
+// authorize against the *assignment's own* course via
+// `loadAssignmentAndSetupForWrite` → `requireCourseWriteAccess`, so a
+// per-course instructor can neither edit an archived course's content nor
+// drive an edit against another course by URL. The `/instructor` group
+// middleware only sees the caller's *active* course, so this is the layer
+// that catches a write whose target course differs from (or is archived
+// relative to) the active one.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class ArchivedCourseWriteRouteTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-archived-wr")
+    }
+
+    /// Creates a course + test setup + published assignment and returns the
+    /// course UUID and the assignment's public ID.
+    private func makeCourseAssignment(
+        code: String, archived: Bool, enrollmentMode: CourseEnrollmentMode
+    ) async throws -> (courseID: UUID, assignmentID: String) {
+        let courseID = UUID()
+        let course = APICourse(id: courseID, code: code, name: code, enrollmentMode: enrollmentMode)
+        course.isArchived = archived
+        try await course.save(on: app.db)
+
+        let setupID = "awr_\(UUID().uuidString.prefix(8))"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        try arMakeZip(at: zipPath, entries: [(".placeholder", "x"), ("publictest_a.py", "passed('a')\n")])
+        let manifest = """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.py"}],"timeLimitSeconds":10,"makefile":null}
+            """
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: code,
+            dueAt: nil, isOpen: true, deadlineOverrideActive: false, courseID: courseID
+        )
+        try await assignment.save(on: app.db)
+        return (courseID, assignment.publicID)
+    }
+
+    /// A per-course instructor whose *active* course is a normal (non-archived)
+    /// course may edit that course's assignment, but a `PUT /suite` aimed by URL
+    /// at an *archived* course they also instruct is rejected with 403. The
+    /// active-course edit succeeding in the same test confirms the setup is
+    /// sound, so the archived 403 is attributable to the archived block — not a
+    /// stray middleware denial.
+    @Test func putSuite_blockedOnArchivedCourseEvenForItsInstructor() async throws {
+        try await withApp(app) { _ in
+            // Active, non-archived course (.auto → the instructor auto-enrols as
+            // a per-course instructor and it becomes their active course, the
+            // same pattern SuiteRouteTests relies on).
+            let active = try await makeCourseAssignment(
+                code: "AWRX", archived: false, enrollmentMode: .auto)
+            // Archived course with an assignment; the same instructor is enrolled
+            // here as a per-course instructor.
+            let archived = try await makeCourseAssignment(
+                code: "AWRY", archived: true, enrollmentMode: .closed)
+
+            let cookie = try await loginUser(
+                username: "awr_inst", password: "pw", role: "instructor", on: app)
+            let user = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "awr_inst").first())
+            try await APICourseEnrollment(
+                userID: try user.requireID(), courseID: archived.courseID, role: .instructor
+            ).save(on: app.db)
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
+
+            // Sanity: editing the active (non-archived) course's assignment works.
+            try await app.asyncTest(
+                .PUT, "/instructor/\(active.assignmentID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"items":[]}"#)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "active-course edit should succeed: \(res.body.string)")
+                })
+
+            // The block: editing the archived course's assignment by URL is 403.
+            try await app.asyncTest(
+                .PUT, "/instructor/\(archived.assignmentID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"items":[]}"#)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "archived-course edit must be blocked, got \(res.status): \(res.body.string)")
+                })
+        }
+    }
+}

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -273,6 +273,64 @@ import Vapor
         }
     }
 
+    // MARK: - Write access / archived-course block (Slice A of #417)
+
+    /// `requireCourseWriteAccess` layers the archived-course read-only rule on
+    /// top of `requireCourseRole`: a per-course instructor may write to an
+    /// active course but not an archived one; a per-course student is forbidden
+    /// regardless; and an admin bypasses both the role check and the archived
+    /// block (admins administer the deployment and own unarchiving). The
+    /// instructor and student are enrolled with the same role in *both* courses,
+    /// so archival is the only variable across the two.
+    @Test func requireCourseWriteAccessBlocksArchivedAndEnforcesRole() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let active = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            let archived = APICourse(code: "CS999", name: "Retired", enrollmentMode: .closed)
+            archived.isArchived = true
+            for course in [active, archived] { try await course.save(on: app.db) }
+            let activeID = try active.requireID()
+            let archivedID = try archived.requireID()
+
+            // All non-admins are global students — authority is per-course.
+            let instructor = makeUser(role: .student)
+            let student = makeUser(role: .student)
+            let admin = makeUser(role: .admin)  // not enrolled anywhere
+            for user in [instructor, student, admin] { try await user.save(on: app.db) }
+
+            for courseID in [activeID, archivedID] {
+                try await APICourseEnrollment(
+                    userID: try instructor.requireID(), courseID: courseID, role: .instructor
+                ).save(on: app.db)
+                try await APICourseEnrollment(
+                    userID: try student.requireID(), courseID: courseID, role: .student
+                ).save(on: app.db)
+            }
+
+            // Per-course instructor: may write to the active course…
+            try await requireCourseWriteAccess(caller: instructor, courseID: activeID, db: app.db)
+            // …but not the archived one (read-only for instructors/TAs).
+            await #expect(throws: Abort.self) {
+                try await requireCourseWriteAccess(caller: instructor, courseID: archivedID, db: app.db)
+            }
+
+            // Per-course student: forbidden on the active course (role too low),
+            // and on the archived one.
+            await #expect(throws: Abort.self) {
+                try await requireCourseWriteAccess(caller: student, courseID: activeID, db: app.db)
+            }
+            await #expect(throws: Abort.self) {
+                try await requireCourseWriteAccess(caller: student, courseID: archivedID, db: app.db)
+            }
+
+            // Admin bypasses both the role check and the archived block.
+            try await requireCourseWriteAccess(caller: admin, courseID: activeID, db: app.db)
+            try await requireCourseWriteAccess(caller: admin, courseID: archivedID, db: app.db)
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeUser(role: UserRole) -> APIUser {

--- a/changelog.d/417-archived-course-write-block.md
+++ b/changelog.d/417-archived-course-write-block.md
@@ -1,0 +1,12 @@
+### Security
+
+- **Archived courses are now read-only on the server, not just in the UI
+  (#417).** A new `requireCourseWriteAccess` helper blocks non-admin writes to
+  an archived course, and the assignment-editor mutations
+  (`saveEditedAssignment`, `PUT /suite`, script/section/global-variable/
+  achievement edits, `create-solution`) plus the per-course enrollment
+  mutations now authorize against the **resource's own course** instead of
+  trusting only the active-course group middleware. This closes a gap where a
+  per-course instructor could edit (or mutate enrollment on) an *archived* —
+  or a different — course's content by URL. Admins remain exempt (they own
+  unarchiving); read access to archived courses is unchanged for grade audits.


### PR DESCRIPTION
## Summary

First slice of #417 (per-course roles). The foundational per-course-role work (the `CourseRole` enum, `course_enrollments.role`, `requireCourseRole`, `ActiveCourseInstructorMiddleware`, SSO simplification, MCP enrollment-scoping) already landed under the `multi-course-roles` effort. This slice closes a remaining gap the issue calls out: **archived courses were only read-only in the UI, not on the server.**

### The gap

`requireCourseRole` had no `isArchived` check, and the assignment-editor mutations relied solely on `ActiveCourseInstructorMiddleware`, which only inspects the caller's **active** course — never the course the URL-named resource actually belongs to. So a per-course instructor could `POST`/`PUT` edits (or mutate enrollment) against an **archived** course — or a *different* course — by URL, even though the dashboard never showed it and the templates disabled the controls.

### The fix

- **New `requireCourseWriteAccess(caller:courseID:atLeast:db:)`** in `CourseAccessHelpers` — layers an archived-course block on top of `requireCourseRole`. Non-admin writes to an archived course are rejected; admins remain exempt (they administer the deployment and own unarchiving). Read access to archived courses is unchanged (grade audits, lookups).
- **New `loadAssignmentAndSetupForWrite(_:)`** loader — authorizes against the **assignment's own course**, so the editor write handlers are scoped to the resource's course rather than the caller's active course. This also closes the latent cross-course write path the group middleware can't see.
- Swapped the write call sites:
  - Assignment-editor mutations (`saveEditedAssignment`, `PUT /suite`, script CRUD, suite-section CRUD, global variables, achievements, `create-solution`) → `loadAssignmentAndSetupForWrite`.
  - Per-course enrollment mutations (`requireCourseInstructor` → `requireCourseWriteAccess`): set-enrollment-mode, bulk-enroll, unenroll, cancel/register pre-enrollment, set-role.

Read endpoints (GET downloads, `GET /suite`, etc.) are deliberately untouched — archived courses stay readable.

### Out of scope (noted for follow-up)

Instructor-dashboard student actions (retest, grade override, notebook reset) and `set_assignment_course_section` also mutate per-course state but resolve their course differently (and clone *reads* from a possibly-archived source); they're left for a focused follow-up rather than a blanket swap. The TA role and the global-role collapse (Phase 6) are separate planned slices.

## Tests

- `CourseEnrollmentRoleTests.requireCourseWriteAccessBlocksArchivedAndEnforcesRole` — unit matrix: per-course instructor/student/admin × active/archived course. Same enrollment in both courses so archival is the only variable.
- `ArchivedCourseWriteRouteTests.putSuite_blockedOnArchivedCourseEvenForItsInstructor` — route-level: an instructor edits their active (non-archived) course's assignment successfully (sanity), but a `PUT /suite` aimed by URL at an archived course they also instruct returns 403.

## Notes

- No version bump / `CHANGELOG.md` edit; a `changelog.d/` fragment is included per the release process.
- `swift-format lint` is clean on all changed files. The package's SwiftPM dependencies can't be fetched in the authoring sandbox, so the full `swift build` / test run + SwiftLint happen in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChHpEeVkMigiihy4snkuiD)_