### PR TITLE
Fix LEARN grade push (mandatory Comments) + unmapped-panel accuracy

### DIFF
--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -684,13 +684,21 @@ extension InstructorDashboardRoutes {
                 .map(\.username))
         var unmapped: [BrightspaceUnmappedStudentRow] = []
         for student in students {
-            let sid = student.studentID ?? ""
-            if sid.isEmpty {
+            // Grade sync resolves a student by username (against the LEARN
+            // classlist) OR student number, caching the resolved D2L id on first
+            // success. A student is only truly unmapped with neither a student
+            // number nor an already-resolved id — checking studentID alone
+            // wrongly flags students who match LEARN by username.
+            let hasStudentID = !(student.studentID ?? "").isEmpty
+            let hasResolvedID = !(student.brightspaceUserID ?? "").isEmpty
+            if !hasStudentID && !hasResolvedID {
                 unmapped.append(
                     BrightspaceUnmappedStudentRow(
                         username: student.username,
                         displayName: student.displayName ?? student.username,
-                        reason: "No student/org-defined ID on file"))
+                        reason:
+                            "No LEARN match — add a student/org-defined ID, or check the username matches LEARN"
+                    ))
             } else if noAccountUsernames.contains(student.username) {
                 unmapped.append(
                     BrightspaceUnmappedStudentRow(

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -336,15 +336,33 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         let rawURL =
             "\(config.baseURL)/d2l/api/le/\(leVersion)/\(orgUnitID)/grades/\(gradeObjectID)/values/\(bsUserID)"
 
+        // D2L's IncomingGradeValueNumeric requires `Comments` and
+        // `PrivateComments` RichText blocks — omitting them 400s with
+        // "Comments and PrivateComments are mandatory". We send empty Text.
+        struct RichTextInput: Content {
+            let content: String
+            let type: String
+            enum CodingKeys: String, CodingKey {
+                case content = "Content"
+                case type = "Type"
+            }
+        }
         struct NumericGradeValue: Content {
             let gradeObjectType: Int
             let pointsNumerator: Double
+            let comments: RichTextInput
+            let privateComments: RichTextInput
             enum CodingKeys: String, CodingKey {
                 case gradeObjectType = "GradeObjectType"
                 case pointsNumerator = "PointsNumerator"
+                case comments = "Comments"
+                case privateComments = "PrivateComments"
             }
         }
-        let body = NumericGradeValue(gradeObjectType: 1, pointsNumerator: earnedPoints)
+        let emptyRichText = RichTextInput(content: "", type: "Text")
+        let body = NumericGradeValue(
+            gradeObjectType: 1, pointsNumerator: earnedPoints,
+            comments: emptyRichText, privateComments: emptyRichText)
 
         let response = try await sendSigned(method: "PUT", rawURL: rawURL, on: application) { req in
             req.headers.contentType = .json

--- a/changelog.d/brightspace-grade-comments.md
+++ b/changelog.d/brightspace-grade-comments.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **LEARN grade push now includes the mandatory comment fields.** D2L's
+  `IncomingGradeValueNumeric` requires `Comments` and `PrivateComments`
+  RichText blocks; omitting them rejected every push with HTTP 400 "Comments
+  and PrivateComments are mandatory". `BrightSpaceAPIClient.pushGrade` now
+  sends empty `Text` RichText for both, so grades actually write to LEARN.
+- **LEARN unmapped-students panel no longer misflags username matches.** The
+  instructor sync panel decided a student was unmapped purely on an empty
+  student/org-defined ID, which wrongly listed students who match LEARN by
+  username (and whose resolved D2L id is already cached). It now treats a
+  student as unmapped only when they have neither a student number nor an
+  already-resolved LEARN id.


### PR DESCRIPTION
## What this fixes

Two bugs surfaced while debugging why the registered test students (`_sgwtest3` / `_sgwtest4`) "are not being detected" in LEARN grade sync. Both are confirmed against production diagnostics.

### 1. Grade push 400 — the real blocker (`BrightSpaceAPIClient.pushGrade`)

Production logs showed 16 sync errors, all **"Comments and PrivateComments are mandatory"**. D2L's `IncomingGradeValueNumeric` body requires `Comments` and `PrivateComments` RichText blocks alongside `GradeObjectType` / `PointsNumerator`. We were omitting them, so every push was rejected with HTTP 400 — grades were reaching D2L, authenticating fine, and matching the right student, but failing validation at the last step.

`pushGrade` now sends an empty `Text` RichText for both fields. This is the change that actually lets grades write to LEARN.

### 2. Unmapped-students panel misflagged username matches (`InstructorDashboardRoutes+BrightSpace.swift`)

The instructor sync panel decided a student was "unmapped" purely on an empty student/org-defined ID. But grade sync resolves a student by **username** (against the LEARN classlist) *or* student number, and caches the resolved D2L id on first success. So a student who matches LEARN by username — and already has `brightspace_user_id` cached — was still being listed as *"No student/org-defined ID on file"*. That's exactly the misleading message that prompted *"Isn't it supposed to use their ID from here?"*

The panel now treats a student as unmapped only when they have **neither** a student number **nor** an already-resolved LEARN id, with a clearer reason string.

## Verification

- `swift build --target APIServer` — clean
- `swift test --filter BrightSpace` — 46 tests across 6 suites pass
- `scripts/format.sh` / `scripts/swiftlint.sh --strict` — 0 violations

## After merge/deploy

Re-check sync status for `_sgwtest4`; with the Comments fix the override-only pushes should land. The surest manual link remains: supply the Org-Defined ID (`_sgwtest4`) in the Register form, or rely on username matching now that the panel reflects it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK2WyLPhsMjigTKg2Pxdzi)_