### PR TITLE
fix(personalization): render solution.py through the shared resilient extractor

### DIFF
--- a/Sources/APIServer/Services/SolutionNotebookExtractor.swift
+++ b/Sources/APIServer/Services/SolutionNotebookExtractor.swift
@@ -2,11 +2,15 @@
 //
 // Slice 5 of #461 — walks a solution notebook's code cells and writes
 // a flat `solution.py` file that personalization expressions can
-// `import`.  Mirrors the Worker's `NotebookExtractor` in spirit but
-// scoped to the server-side authoring path (no IPython-magic stripping,
-// no `if __name__ == "__main__"` wrapping — we want the function
-// definitions and module-level constants exactly as the instructor
-// wrote them so expressions can call them).
+// `import`.  Built on the SAME `RunnerCore.extractPython` the native
+// worker and the (wasm) browser runner use to load a notebook for
+// grading, so the module expressions import and the module the grader
+// runs are one implementation and cannot drift.  That shared extractor
+// also loads each cell under its own `try/except` and quarantines
+// side-effecting statements into `if __name__ == "__main__":`, so a
+// broken demo/example cell (a JSON-ism like `null`, a failing
+// module-level `assert`) is skipped without taking the instructor's
+// helper functions down with it.
 //
 // Lives parallel to `extractSupportFilesToSharedDirectory` in
 // `TestSetupZipHelpers.swift`: called after every test-setup save so
@@ -19,29 +23,51 @@ import Foundation
 
 enum SolutionNotebookExtractor {
 
-    /// Concatenates the `source` of every `code` cell in the supplied
-    /// notebook JSON into a single Python file.  Markdown / raw cells
-    /// are skipped.  Returns nil when the input isn't a valid notebook.
+    /// Renders the supplied solution notebook's `code` cells into a single,
+    /// importable Python module.  Markdown / raw cells are skipped.  Returns nil
+    /// when the input isn't a valid notebook or has no code cells.
+    ///
+    /// Built on the shared `RunnerCore.extractPython` — the SAME extractor the
+    /// native worker and the (wasm) browser runner use to load a notebook for
+    /// grading.  Two properties matter here:
+    ///
+    /// 1. **One implementation, no drift.**  The `solution.py` that
+    ///    personalization expressions import is produced by the very code path
+    ///    that grades the reference solution, so a generated expected value
+    ///    (`solution.<fn>(...)`) can't silently diverge from what the grader
+    ///    actually runs.
+    /// 2. **Resilient per-cell load.**  Each cell loads under its own
+    ///    `try/except`, and side-effecting / control-flow statements are
+    ///    quarantined into `if __name__ == "__main__":`.  A broken demo or
+    ///    example cell — a JSON-ism like a bare `null`, a failing module-level
+    ///    `assert`, a `Patient(...)` call referencing data that isn't there —
+    ///    is skipped WITHOUT taking the instructor's helper functions down with
+    ///    it.  The previous naive concat let any such cell abort `import
+    ///    solution` entirely; the evaluator's import guard then swallowed the
+    ///    error, surfacing as a baffling `name 'solution' is not defined` at the
+    ///    first `solution.<fn>` reference instead of a localized failure.
     static func extractCodeToPython(notebookData: Data) -> String? {
         guard let cells = NotebookCellSources.cells(from: notebookData) else { return nil }
 
-        var lines: [String] = [
-            "# Auto-generated from solution.ipynb by Chickadee.",
-            "# Used by personalization expressions to import the instructor's",
-            "# canonical helpers (e.g. `solution.caesar_encode(...)`).",
-            "# Regenerated on every test-setup save; do not edit by hand.",
-            "",
-        ]
-
-        // Concatenate cells with a blank line between them so module
-        // top-level statements don't accidentally merge into a single
-        // line.  `codeCellSources` already trims each cell's whitespace
-        // and skips empty cells.
-        for trimmed in NotebookCellSources.codeCellSources(cells) {
-            lines.append(trimmed)
-            lines.append("")
+        let inputCells = cells.map { cell in
+            NotebookCell(
+                cellType: (cell["cell_type"] as? String) ?? "",
+                source: NotebookCellSources.cellSource(cell))
         }
-        return lines.joined(separator: "\n")
+        let extracted = extractPython(cells: inputCells, filename: "solution.ipynb")
+        guard extracted.codeCellCount > 0 else { return nil }
+
+        let header = """
+            # Auto-generated from solution.ipynb by Chickadee.
+            # Imported by personalization expressions to call the instructor's
+            # canonical helpers (e.g. `solution.classify_bmi(...)`) — one source
+            # of truth, so a generated expected value can't drift from the
+            # reference solution.  Regenerated on every solution save; do not
+            # edit by hand.  Each cell loads resiliently, so one broken demo or
+            # example cell can't stop the helper functions from importing.
+
+            """
+        return header + extracted.executableModule
     }
 
     /// Writes `solution.py` into `sharedDirectory` from

--- a/Tests/APITests/SupportImportTests.swift
+++ b/Tests/APITests/SupportImportTests.swift
@@ -129,6 +129,42 @@ import Testing
         #expect(result["x"] == "10")
     }
 
+    @Test func evaluator_resilientToBrokenDemoCellInSolution() async throws {
+        // Regression (HLTH-230 A3): a solution notebook whose demo/example cell
+        // errors at import — here a JSON-ism `null` in a module-level list
+        // literal (copy-pasted JSON) — must NOT take the instructor's helper
+        // functions down with it. A naive concat aborted `import solution` for
+        // the whole module; the evaluator's import guard then swallowed it and
+        // every `solution.<fn>` surfaced as a baffling
+        // `name 'solution' is not defined`. The resilient per-cell load skips
+        // only the broken cell, so the helpers flanking it still resolve.
+        let nb: [String: Any] = [
+            "cells": [
+                ["cell_type": "code", "source": "def triple(x):\n    return x * 3\n"],
+                ["cell_type": "code", "source": "patients = [{\"unit\": null}]\n"],
+                ["cell_type": "code", "source": "def quad(x):\n    return x * 4\n"],
+            ],
+            "metadata": [:], "nbformat": 4, "nbformat_minor": 5,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: nb)
+        #expect(
+            SolutionNotebookExtractor.writeSolutionPy(
+                notebookData: data, sharedDirectory: tempDir.path + "/", overwrite: true))
+
+        let result = try await PersonalizationEvaluator.evaluate(
+            seedHex: "0004",
+            staticVariables: [],
+            expressions: [
+                PersonalizationExpression(name: "a", expression: "solution.triple(seed)"),
+                PersonalizationExpression(name: "b", expression: "solution.quad(seed)"),
+            ],
+            supportFilesDirectory: tempDir.path
+        )
+        // seed = 4 → triple 12, quad 16; the broken middle cell is skipped.
+        #expect(result["a"] == "12")
+        #expect(result["b"] == "16")
+    }
+
     @Test func extractor_skipsEmptyNotebook() throws {
         let nb: [String: Any] = [
             "cells": [["cell_type": "markdown", "source": "Just text"]],

--- a/changelog.d/resilient-solution-extraction.md
+++ b/changelog.d/resilient-solution-extraction.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **A solution notebook's broken demo cell no longer silently breaks
+  `solution.py` for personalization.** The server-side `solution.py` that
+  per-student expressions import (`solution.<fn>(...)`) was a naive
+  concatenation of the solution notebook's code cells, so a single cell that
+  errored at import — e.g. a copy-pasted JSON-ism like a bare `null` in a
+  module-level list literal, or a failing example-test `assert` — aborted
+  `import solution` for the whole module. The personalization evaluator's import
+  guard then swallowed it, and every `solution.<fn>` reference surfaced as a
+  baffling `name 'solution' is not defined`. `SolutionNotebookExtractor` now
+  renders `solution.py` through the shared `RunnerCore.extractPython` — the same
+  resilient extractor the native worker and browser runner use to grade — so
+  each cell loads under its own `try/except`, side-effecting statements are
+  quarantined into `if __name__ == "__main__":`, and a broken demo cell is
+  skipped without taking the helper functions down with it. Using one extractor
+  for both paths also means the imported solution and the graded solution can't
+  diverge.


### PR DESCRIPTION
## Problem

The server-side `shared/{setupID}/solution.py` that per-student personalization
expressions import (`solution.<fn>(...)`, the single-source-of-truth mechanism
from #1055) was built by **naively concatenating** the solution notebook's code
cells. So a single cell that errors *at import* aborted `import solution` for
the whole module. The personalization evaluator imports support modules under
`try: … except: pass`, so the failure was **swallowed** — and every
`solution.<fn>` reference then surfaced as a baffling
`name 'solution' is not defined`, with nothing pointing at the real cause.

This bit HLTH 230 Assignment 3: its solution notebook's `patients` demo list
contains a copy-pasted JSON-ism — `{"name": "Smoking Status", "value": "Former
smoker", "unit": null}` — and bare `null` is not a Python name. The worker
grading path never hit it, because the worker's `RunnerCore.extractPython`
quarantines bare module-level code and loads each cell resiliently; only the
naive server-side extractor took the whole import down.

## Fix

`SolutionNotebookExtractor.extractCodeToPython` now renders `solution.py`
through the shared **`RunnerCore.extractPython`** — the *same* extractor the
native worker and the (wasm) browser runner use to load a notebook for grading.
That gives two properties:

1. **Resilient per-cell load.** Each cell loads under its own `try/except`, and
   side-effecting / control-flow statements are quarantined into
   `if __name__ == "__main__":`. A broken demo/example cell (a stray `null`, a
   failing module-level `assert`) is skipped *without* taking the instructor's
   helper functions down with it. A localized `AttributeError` on the specific
   missing function (if a function-defining cell itself breaks) replaces the
   misleading "solution is not defined".
2. **One extractor, no drift.** The module expressions import and the module the
   grader actually runs are now produced by one implementation, so a generated
   expected value can't silently diverge from the reference solution.

Backend-only; no UI, schema, or API changes. Generated script bytes are
unchanged.

## Tests

- New regression `evaluator_resilientToBrokenDemoCellInSolution`: a solution
  notebook with a `null` demo cell flanked by two helper functions — both must
  still resolve through `PersonalizationEvaluator`.
- Existing `SupportImportTests` (concat/markdown-skip, overwrite refresh,
  empty-notebook skip, end-to-end `solution.double`) all still pass — their
  assertions check `contains("def …")`, which survives inside the
  `exec(compile(...))` wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhCtqrZZccY2XvDLeoEmW9)_