### PR TITLE
Admin per-course staff management + last-instructor guard (#417 Slice B)

### DIFF
--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -13,7 +13,7 @@
 <div class="form-error course-alert-gap">Course code and name are required.</div>
 #endif
 
-<!-- ── Create course ───────────────────────────────────── -->
+<!-- ── Create course ───────────────────────────────── -->
 <section class="admin-section">
     <h2>Course details</h2>
     <form method="post" action="/admin/courses"
@@ -60,7 +60,7 @@
     </div>
 </div>
 
-<!-- ── Edit course ─────────────────────────────────────── -->
+<!-- ── Edit course ─────────────────────────────────── -->
 <section class="admin-section">
     <h2>Edit course</h2>
     <form method="post" action="/admin/courses/#(course.id)/edit"
@@ -109,7 +109,7 @@
 </section>
 #endif
 
-<!-- ── Assignments ─────────────────────────────────────── -->
+<!-- ── Assignments ─────────────────────────────────── -->
 <section class="admin-section">
     <h2>Assignments (#(assignmentCount))</h2>
     #if(assignments.isEmpty):
@@ -151,7 +151,7 @@
     #endif
 </section>
 
-<!-- ── Enrolled students ───────────────────────────────── -->
+<!-- ── Enrolled students ────────────────────────────── -->
 <section class="admin-section">
     <div class="course-enroll-head">
         <h2 class="course-page-title">Enrolled students (#(course.enrollmentCount))</h2>
@@ -204,7 +204,21 @@
                     #endif
                 </td>
                 <td><code>#(user.username)</code></td>
-                <td>#(user.role)</td>
+                <td>
+                    #if(course.isArchived):
+                    #(user.role)
+                    #else:
+                    <form method="post" action="/admin/courses/#(course.id)/role/#(user.id)"
+                          class="inline-form">
+                        #csrfFormField()
+                        <select name="role" class="form-input course-role-select"
+                                aria-label="Per-course role" onchange="this.form.submit()">
+                            <option value="student"#if(user.role == "student"): selected#endif>Student</option>
+                            <option value="instructor"#if(user.role == "instructor"): selected#endif>Instructor</option>
+                        </select>
+                    </form>
+                    #endif
+                </td>
                 <td class="course-action-cell">
                     <a href="/admin/users/#(user.id)"
                        class="btn action-btn action-btn-icon" title="Manage user" aria-label="Manage user">
@@ -314,6 +328,10 @@
     gap: .4rem;
     flex-wrap: wrap;
     align-items: center;
+}
+.course-role-select {
+    display: block;
+    font-size: .875rem;
 }
 </style>
 #endexport

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -136,6 +136,30 @@ func requireCourseWriteAccess(
     }
 }
 
+/// Guards against orphaning a course (#417 Slice B). Throws `.conflict` if
+/// removing or downgrading the instructor enrollment held by `userID` would
+/// leave `courseID` with zero instructors. Admins are exempt — they can always
+/// re-grant — so an admin may still force the change; the guard only stops a
+/// non-admin instructor from self-demoting or unenrolling the course's last
+/// instructor without transferring the role first.
+func ensureNotLastInstructor(
+    caller: APIUser, courseID: UUID, removing userID: UUID, db: Database
+) async throws {
+    guard !caller.isAdmin else { return }
+    let otherInstructors = try await APICourseEnrollment.query(on: db)
+        .filter(\.$course.$id == courseID)
+        .filter(\.$roleRaw == CourseRole.instructor.rawValue)
+        .filter(\.$userID != userID)
+        .count()
+    guard otherInstructors > 0 else {
+        throw Abort(
+            .conflict,
+            reason:
+                "A course must keep at least one instructor. Assign another instructor before removing or demoting this one."
+        )
+    }
+}
+
 // MARK: - Enrollment creation (role seeding)
 
 /// Creates and saves a new enrollment for `user` in `courseID`, seeding the

--- a/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+Courses.swift
@@ -416,6 +416,54 @@ extension AdminRoutes {
         return req.redirect(to: "/admin/courses/\(courseIDString)")
     }
 
+    // MARK: - POST /admin/courses/:courseID/role/:userID
+    //
+    // Sets a roster member's per-course role from the admin course page —
+    // the admin-side counterpart of the instructor roster dropdown (#417
+    // Slice B), so an admin can assign a course's instructors/TAs without
+    // first making the course their active one. Admin-only (admin route
+    // group); admins are exempt from the last-instructor guard since they
+    // can always re-grant.
+    @Sendable
+    func adminSetEnrollmentRole(req: Request) async throws -> Response {
+        guard
+            let courseIDString = req.parameters.get("courseID"),
+            let courseID = UUID(uuidString: courseIDString),
+            let userIDString = req.parameters.get("userID"),
+            let userID = UUID(uuidString: userIDString)
+        else {
+            throw Abort(.badRequest)
+        }
+
+        struct Body: Content { var role: String? }
+        let body = try? req.content.decode(Body.self)
+        guard let newRole = CourseRole(rawValue: body?.role ?? "") else {
+            throw Abort(.badRequest, reason: "Unknown per-course role.")
+        }
+
+        guard
+            let enrollment = try await APICourseEnrollment.query(on: req.db)
+                .filter(\.$course.$id == courseID)
+                .filter(\.$userID == userID)
+                .first()
+        else {
+            throw Abort(.notFound)
+        }
+        enrollment.role = newRole
+        try await enrollment.save(on: req.db)
+
+        await AuditLogger.record(
+            action: .enrollmentRoleChanged,
+            targetType: .enrollment,
+            targetID: userIDString,
+            metadata: [
+                "course_id": courseIDString, "subject_user_id": userIDString, "role": newRole.rawValue,
+            ],
+            on: req
+        )
+        return req.redirect(to: "/admin/courses/\(courseIDString)")
+    }
+
     // MARK: - GET /admin/courses/:courseID
 
     @Sendable
@@ -455,6 +503,10 @@ extension AdminRoutes {
             .all()
 
         let enrolledUserIDs = enrollments.map { $0.userID }
+        // Per-course role (from the enrollment row), not the global user role —
+        // this is what the staff selector reads/writes (#417 Slice B).
+        let roleByUserID = Dictionary(
+            enrollments.map { ($0.userID, $0.role) }, uniquingKeysWith: { first, _ in first })
         let enrolledUsers: [AdminCourseEnrolledUserRow]
         if enrolledUserIDs.isEmpty {
             enrolledUsers = []
@@ -472,7 +524,7 @@ extension AdminRoutes {
                     id: uid.uuidString,
                     username: u.username,
                     displayName: u.displayName,
-                    role: u.role
+                    role: (roleByUserID[uid] ?? .student).rawValue
                 )
             }
         }

--- a/Sources/APIServer/Routes/Web/AdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes.swift
@@ -45,6 +45,7 @@ struct AdminRoutes: RouteCollection {
         admin.post("courses", ":courseID", "enrollment-mode", use: setEnrollmentMode)
         admin.post("courses", ":courseID", "enroll-csv", use: adminBulkEnrollCSV)
         admin.post("courses", ":courseID", "unenroll", ":userID", use: unenrollUserFromCourse)
+        admin.post("courses", ":courseID", "role", ":userID", use: adminSetEnrollmentRole)
         admin.get("users", ":userID", use: userDetail)
         admin.post("users", ":userID", "delete", use: deleteUser)
         admin.post("users", ":userID", "enroll", use: adminEnrollUser)

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -145,10 +145,18 @@ extension CourseAdminRoutes {
         let caller = try req.auth.require(APIUser.self)
         try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
 
-        try await APICourseEnrollment.query(on: req.db)
+        if let enrollment = try await APICourseEnrollment.query(on: req.db)
             .filter(\.$course.$id == courseID)
             .filter(\.$userID == userID)
-            .delete()
+            .first()
+        {
+            // Don't let a non-admin unenroll the course's last instructor (#417 Slice B).
+            if enrollment.role == .instructor {
+                try await ensureNotLastInstructor(
+                    caller: caller, courseID: courseID, removing: userID, db: req.db)
+            }
+            try await enrollment.delete(on: req.db)
+        }
 
         await AuditLogger.record(
             action: .enrollmentRemoved,
@@ -320,6 +328,11 @@ extension CourseAdminRoutes {
                 .first()
         else {
             throw WebAssignmentError.notFound(resource: "Enrollment")
+        }
+        // Don't let a non-admin demote the course's last instructor (#417 Slice B).
+        if enrollment.role == .instructor, newRole != .instructor {
+            try await ensureNotLastInstructor(
+                caller: caller, courseID: courseID, removing: userID, db: req.db)
         }
         enrollment.role = newRole
         try await enrollment.save(on: req.db)

--- a/Tests/APITests/AdminCourseRoleRouteTests.swift
+++ b/Tests/APITests/AdminCourseRoleRouteTests.swift
@@ -1,0 +1,57 @@
+// Tests/APITests/AdminCourseRoleRouteTests.swift
+//
+// Route-level coverage for the admin per-course staff selector (#417 Slice B):
+// POST /admin/courses/:courseID/role/:userID sets a roster member's per-course
+// role from the admin course page, so an admin can assign a course's
+// instructors without first making the course their active one. Kept in its
+// own file (rather than the large AdminRoutesTests) and driving the shared
+// Fixtures.swift builders.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class AdminCourseRoleRouteTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-admin-role")
+    }
+
+    @Test func adminSetEnrollmentRoleUpdatesPerCourseRole() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginUser(
+                username: "admin_role_rt", password: "testpassword", role: "admin", on: app)
+            let user = try await makeTestUser(on: app, username: "staff_member_rt", role: "student")
+            let userID = try user.requireID()
+            let course = try await makeTestCourse(on: app, code: "STAFFRT", name: "Staffed Course")
+            let courseID = try course.requireID()
+            try await makeTestEnrollment(on: app, userID: userID, courseID: courseID)  // defaults to student
+
+            let (token, sessionCookie) = try await csrfFields(
+                for: "/admin/courses/\(courseID.uuidString)", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/admin/courses/\(courseID.uuidString)/role/\(userID.uuidString)",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["role": "instructor", "_csrf": token], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(
+                        res.headers.first(name: .location) == "/admin/courses/\(courseID.uuidString)")
+                })
+
+            let enrollment = try #require(
+                try await APICourseEnrollment.query(on: app.db)
+                    .filter(\.$userID == userID).filter(\.$course.$id == courseID).first())
+            #expect(enrollment.role == .instructor)
+        }
+    }
+}

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -331,6 +331,49 @@ import Vapor
         }
     }
 
+    // MARK: - Last-instructor guard (Slice B of #417)
+
+    /// `ensureNotLastInstructor` stops a non-admin from removing or demoting a
+    /// course's only instructor (which would orphan it), while admins — who can
+    /// always re-grant — are exempt. Once a second instructor exists, either can
+    /// be removed.
+    @Test func ensureNotLastInstructorGuardsCourseFromOrphaning() async throws {
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            try await configureTestDatabase(app)
+
+            let course = APICourse(code: "CS101", name: "Intro", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let courseID = try course.requireID()
+
+            let inst1 = makeUser(role: .student)  // per-course instructor below
+            let inst2 = makeUser(role: .student)
+            let admin = makeUser(role: .admin)
+            for user in [inst1, inst2, admin] { try await user.save(on: app.db) }
+            try await APICourseEnrollment(
+                userID: try inst1.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
+
+            // Only one instructor: a non-admin cannot remove them…
+            await #expect(throws: Abort.self) {
+                try await ensureNotLastInstructor(
+                    caller: inst1, courseID: courseID, removing: try inst1.requireID(), db: app.db)
+            }
+            // …but an admin can (they can re-grant).
+            try await ensureNotLastInstructor(
+                caller: admin, courseID: courseID, removing: try inst1.requireID(), db: app.db)
+
+            // With a second instructor, a non-admin may remove either one.
+            try await APICourseEnrollment(
+                userID: try inst2.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
+            try await ensureNotLastInstructor(
+                caller: inst1, courseID: courseID, removing: try inst1.requireID(), db: app.db)
+            try await ensureNotLastInstructor(
+                caller: inst1, courseID: courseID, removing: try inst2.requireID(), db: app.db)
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeUser(role: UserRole) -> APIUser {

--- a/changelog.d/417-admin-staff-management.md
+++ b/changelog.d/417-admin-staff-management.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Admins can set per-course roles from the course page (#417).** The admin
+  course page (`/admin/courses/:id`) now shows each roster member's
+  *per-course* role and lets an admin switch it between student and instructor
+  inline — the admin-side counterpart of the instructor roster dropdown, so an
+  admin can assign a course's staff without first making it their active course.
+
+### Changed
+
+- **Courses can no longer be orphaned of their last instructor (#417).** A new
+  `ensureNotLastInstructor` guard blocks a non-admin from unenrolling or
+  demoting a course's only instructor; transfer the instructor role first.
+  Admins are exempt (they can always re-grant).


### PR DESCRIPTION
## Summary

Second slice of #417 (per-course roles). Brings admin-side parity to staff management and adds the guardrail that keeps a course from being orphaned of its instructors.

### Admin per-course staff selector
The admin course page (`/admin/courses/:id`) now shows each roster member's **per-course** role (read from the enrollment row, not the global user role) and lets an admin switch it between student and instructor inline — the admin-side counterpart of the instructor roster dropdown. This lets an admin assign a course's instructors without first making the course their active one.

- New `POST /admin/courses/:courseID/role/:userID` (`adminSetEnrollmentRole`), admin-group gated.
- `courseDetail` maps the per-course role into the enrolled-students table.
- `admin-course.leaf` renders a role `<select>` (read-only display when the course is archived).

### Last-instructor guard
New `ensureNotLastInstructor` helper blocks a **non-admin** from unenrolling or demoting a course's *only* instructor (which would orphan the course) — the instructor role must be transferred first. Admins are exempt (they can always re-grant). Wired into the instructor-side `instructorSetEnrollmentRole` (demotion) and `instructorUnenrollUser` (removal). The admin path is intentionally not guarded, per the issue ("requires admin … to avoid orphaning").

## Tests

- `CourseEnrollmentRoleTests.ensureNotLastInstructorGuardsCourseFromOrphaning` — unit matrix for the guard (last instructor blocked for non-admin, admin exempt, two-instructor case allowed).
- `AdminCourseRoleRouteTests.adminSetEnrollmentRoleUpdatesPerCourseRole` — route-level: admin POSTs a role change and the enrollment flips to instructor.
- (Slice A's `requireCourseWriteAccess` matrix remains in `CourseEnrollmentRoleTests`.)

## Notes

- **Pushed via the GitHub API**, not `git push`: the sandbox's git proxy write path is currently rejecting `git-receive-pack` (413/502) even for tiny packs, so commits were created through the API. Each file was verified byte-for-byte against the local working tree via `git fetch` + `diff`.
- One cosmetic artifact: four decorative box-drawing comment separators in `admin-course.leaf` are a few `─` shorter than before (functionally irrelevant; no rendering/test impact).
- No version bump / `CHANGELOG.md` edit; a `changelog.d/` fragment is included.
- `swift-format` + the CSS/style guards (`check-styles.sh`, `check-css-vars.sh`) pass locally; the full `swift build` + tests + SwiftLint run in CI (SwiftPM deps can't be fetched in the authoring sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChHpEeVkMigiihy4snkuiD)_