### PR TITLE
feat(deploy): auto-deploy daemon + admin-MCP oversight (Phase 2 + 3)

### DIFF
--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -150,6 +150,9 @@ struct TestSetupsDirectoryKey: StorageKey {
 struct SubmissionsDirectoryKey: StorageKey {
     typealias Value = String
 }
+struct DeployStateDirectoryKey: StorageKey {
+    typealias Value = String
+}
 struct WorkerSecretStoreKey: StorageKey {
     typealias Value = WorkerSecretStore
 }
@@ -208,6 +211,14 @@ extension Application {
     var submissionsDirectory: String {
         get { storage[SubmissionsDirectoryKey.self] ?? "submissions/" }
         set { storage[SubmissionsDirectoryKey.self] = newValue }
+    }
+    /// Directory holding the auto-deploy daemon's IPC files (status.json,
+    /// history.jsonl), mounted read-only into the container. Read by the
+    /// admin-MCP deploy tools. Defaults to the conventional mount point;
+    /// overridden from CHICKADEE_DEPLOY_STATE_DIR at startup.
+    var deployStateDirectory: String {
+        get { storage[DeployStateDirectoryKey.self] ?? "/deploy-state" }
+        set { storage[DeployStateDirectoryKey.self] = newValue }
     }
 
     var workerSecretStore: WorkerSecretStore {

--- a/Sources/APIServer/Bootstrap/AppDirectories.swift
+++ b/Sources/APIServer/Bootstrap/AppDirectories.swift
@@ -30,6 +30,10 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     app.storage[ResultsDirectoryKey.self] = resultsDir
     app.storage[TestSetupsDirectoryKey.self] = setupsDir
     app.storage[SubmissionsDirectoryKey.self] = submissionsDir
+    // Read-only mount of the auto-deploy daemon's IPC dir (status.json /
+    // history.jsonl); absolute host path, not under the data volume.
+    app.storage[DeployStateDirectoryKey.self] =
+        Environment.get("CHICKADEE_DEPLOY_STATE_DIR") ?? "/deploy-state"
     app.storage[WorkerSecretFilePathKey.self] = workerSecretFile
     app.storage[LocalRunnerAutoStartFilePathKey.self] = localRunnerAutoStartFile
     app.storage[ServerHealthAlertWebhookURLFilePathKey.self] = alertWebhookURLFile

--- a/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPServerInstructions.swift
@@ -45,7 +45,12 @@ enum AdminMCPServerInstructions {
         number. tools/list only shows the tools your grant's scope covers.
 
         What's available, by area:
-        - Deployment: get_deployment_info (version + capability surface).
+        - Deployment: get_deployment_info (version + capability surface); \
+        get_deploy_status (the zero-downtime auto-deploy daemon's current state — \
+        live version, latest release seen, paused flag, pending major approval) \
+        and get_deploy_history (recent deploy / rollback events). Both are \
+        read-only views of the daemon's status files; deploy control \
+        (pause/approve/rollback) is a host-side action, not exposed here.
         - Runners: list_runners (the fleet) and get_runner_detail (one runner's \
         capability profile + aggregate per-stage timing + cache-hit rate + \
         recent snapshots — never the per-job rows).

--- a/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPToolCatalog.swift
@@ -10,6 +10,8 @@ enum AdminMCPToolCatalog {
     static var live: DiagnosticToolRegistry {
         DiagnosticToolRegistry([
             GetDeploymentInfoTool().erased(),
+            GetDeployStatusTool().erased(),
+            GetDeployHistoryTool().erased(),
             GetMetricsSnapshotTool().erased(),
             GetMetricsCardSeriesTool().erased(),
             GetMetricsTimeseriesTool().erased(),

--- a/Sources/APIServer/MCP/Admin/Tools/GetDeployHistoryTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetDeployHistoryTool.swift
@@ -80,7 +80,8 @@ struct GetDeployHistoryTool: DiagnosticTool {
         let decoder = JSONDecoder()
         // One JSON object per line; newest entries are appended last, so take the
         // tail and reverse to return newest-first.
-        let parsed: [Entry] = text
+        let parsed: [Entry] =
+            text
             .split(whereSeparator: \.isNewline)
             .compactMap { line -> Entry? in
                 guard let e = try? decoder.decode(EntryFile.self, from: Data(line.utf8))

--- a/Sources/APIServer/MCP/Admin/Tools/GetDeployHistoryTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetDeployHistoryTool.swift
@@ -1,0 +1,95 @@
+// APIServer/MCP/Admin/Tools/GetDeployHistoryTool.swift
+//
+// Read tool: return the most recent entries from the auto-deploy daemon's
+// append-only history log (history.jsonl in the deploy state dir, mounted
+// read-only). Each entry records a deploy/gate/rollback event with its result —
+// the operational record of what the CD loop has done.
+//
+// Read-only and side-effect-free: it reads a small log file the daemon owns.
+
+import Core
+import Foundation
+import Vapor
+
+struct GetDeployHistoryTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {
+        /// Max entries to return, newest first. Defaults to 20, clamped to 1...100.
+        let limit: Int?
+    }
+
+    struct Entry: Encodable, Sendable {
+        let ts: String?
+        let version: String?
+        let action: String?
+        let result: String?
+        let detail: String?
+    }
+
+    struct Output: Encodable, Sendable {
+        /// false when the history file is missing/unreadable.
+        let available: Bool
+        /// Most-recent-first deploy events.
+        let entries: [Entry]
+        /// Explanation when `available` is false.
+        let note: String?
+    }
+
+    private struct EntryFile: Decodable {
+        let ts: String?
+        let version: String?
+        let action: String?
+        let result: String?
+        let detail: String?
+    }
+
+    static let name = "get_deploy_history"
+    static let description =
+        "Return the most recent entries from the auto-deploy daemon's append-only history log: "
+        + "each deploy / gate-hold / rollback event with its version, action, result, and detail, "
+        + "newest first. Accepts an optional `limit` (default 20, max 100). Returns "
+        + "available=false if the daemon is not running or its state dir is not mounted. "
+        + "Read-only; reads a small log file the daemon owns and touches no course, student, or "
+        + "database state."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "limit": .object([
+                "type": .string("integer"),
+                "description": .string("Max entries to return, newest first (default 20, max 100)."),
+                "minimum": .int(1),
+                "maximum": .int(100),
+            ])
+        ]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let limit = min(max(input.limit ?? 20, 1), 100)
+        let path = URL(fileURLWithPath: context.request.application.deployStateDirectory)
+            .appendingPathComponent("history.jsonl")
+
+        guard let text = try? String(contentsOf: path, encoding: .utf8) else {
+            return Output(
+                available: false, entries: [],
+                note: "No deploy history at \(path.path) — the auto-deploy daemon may not be "
+                    + "running, or its state directory is not mounted into this container.")
+        }
+
+        let decoder = JSONDecoder()
+        // One JSON object per line; newest entries are appended last, so take the
+        // tail and reverse to return newest-first.
+        let parsed: [Entry] = text
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line -> Entry? in
+                guard let e = try? decoder.decode(EntryFile.self, from: Data(line.utf8))
+                else { return nil }
+                return Entry(
+                    ts: e.ts, version: e.version, action: e.action, result: e.result,
+                    detail: e.detail)
+            }
+        let newestFirst = Array(parsed.suffix(limit).reversed())
+        return Output(available: true, entries: newestFirst, note: nil)
+    }
+}

--- a/Sources/APIServer/MCP/Admin/Tools/GetDeployStatusTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetDeployStatusTool.swift
@@ -1,0 +1,95 @@
+// APIServer/MCP/Admin/Tools/GetDeployStatusTool.swift
+//
+// Read tool: report the zero-downtime auto-deploy daemon's current state, from
+// the status file it writes (status.json in the deploy state dir, mounted
+// read-only into the container). Lets an operator/agent see what version is
+// live, what release the daemon last saw, whether auto-deploy is paused, and
+// whether a major bump is awaiting approval — without SSH.
+//
+// Read-only and side-effect-free: it reads a small JSON file the daemon owns.
+// Deploy CONTROL (pause / approve / rollback) is deliberately NOT here — it
+// stays a host-side action so the read-only admin surface keeps its guarantee
+// and a compromised app (the IPC dir is mounted read-only) cannot move traffic.
+
+import Core
+import Foundation
+import Vapor
+
+struct GetDeployStatusTool: DiagnosticTool {
+    struct Input: Decodable, Sendable {}
+
+    struct Output: Encodable, Sendable {
+        /// false when the status file is missing/unreadable (daemon not running,
+        /// or its state dir is not mounted into this container).
+        let available: Bool
+        /// idle | deploying | pending_approval | paused | error (nil if unavailable).
+        let state: String?
+        /// The version currently live, per the daemon.
+        let deployedVersion: String?
+        /// The latest release tag the daemon last observed.
+        let latestSeen: String?
+        /// Human-readable detail for the current state.
+        let detail: String?
+        /// Whether auto-deploy is currently paused.
+        let paused: Bool?
+        /// When the daemon last wrote this status (ISO-8601 UTC).
+        let updatedAt: String?
+        /// Explanation when `available` is false.
+        let note: String?
+    }
+
+    /// Mirrors the JSON the daemon writes (deploy/chickadee-deployer.sh).
+    private struct StatusFile: Decodable {
+        let state: String?
+        let deployedVersion: String?
+        let latestSeen: String?
+        let detail: String?
+        let paused: Bool?
+        let updatedAt: String?
+    }
+
+    static let name = "get_deploy_status"
+    static let description =
+        "Report the zero-downtime auto-deploy daemon's current state from the status file it "
+        + "writes: which version is live (deployedVersion), the latest release it has seen "
+        + "(latestSeen), whether auto-deploy is paused, whether a major bump is awaiting "
+        + "approval (state=pending_approval), and the last update time. Returns available=false "
+        + "if the daemon is not running or its state dir is not mounted. Read-only; reads a small "
+        + "JSON file the daemon owns and touches no course, student, or database state. Deploy "
+        + "control (pause/approve/rollback) is a host-side action, not exposed here."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([:]),
+        "additionalProperties": .bool(false),
+    ])
+
+    func execute(_ input: Input, _ context: AdminToolContext) async throws -> Output {
+        try await context.requireAdminSubject(tool: Self.name)
+
+        let path = URL(fileURLWithPath: context.request.application.deployStateDirectory)
+            .appendingPathComponent("status.json")
+
+        guard let data = try? Data(contentsOf: path) else {
+            return Output(
+                available: false, state: nil, deployedVersion: nil, latestSeen: nil,
+                detail: nil, paused: nil, updatedAt: nil,
+                note: "No deploy status at \(path.path) — the auto-deploy daemon may not be "
+                    + "running, or its state directory is not mounted into this container.")
+        }
+        guard let status = try? JSONDecoder().decode(StatusFile.self, from: data) else {
+            return Output(
+                available: false, state: nil, deployedVersion: nil, latestSeen: nil,
+                detail: nil, paused: nil, updatedAt: nil,
+                note: "Deploy status file at \(path.path) could not be parsed.")
+        }
+        return Output(
+            available: true,
+            state: status.state,
+            deployedVersion: status.deployedVersion,
+            latestSeen: status.latestSeen,
+            detail: status.detail,
+            paused: status.paused,
+            updatedAt: status.updatedAt,
+            note: nil)
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -4,6 +4,7 @@
 
 import Core
 import Fluent
+import Foundation
 import Logging
 import Testing
 import Vapor
@@ -43,6 +44,87 @@ import VaporTesting
             _ = try await makeTestUser(on: app, username: "ms-prof", role: "instructor")
             await #expect(throws: MCPToolError.self) {
                 _ = try await GetMetricsSnapshotTool().execute(.init(), context(subject: "ms-prof"))
+            }
+        }
+    }
+
+    @Test func getDeployStatusReturnsDaemonStateForAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "dep-admin", role: "admin")
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("deploy-state-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let status = """
+                {"state":"idle","deployedVersion":"0.4.558","latestSeen":"v0.4.558",\
+                "detail":"up to date","paused":false,"updatedAt":"2026-06-28T17:40:00Z"}
+                """
+            try status.write(
+                to: dir.appendingPathComponent("status.json"), atomically: true, encoding: .utf8)
+            app.deployStateDirectory = dir.path
+
+            let output = try await GetDeployStatusTool().execute(
+                .init(), context(subject: "dep-admin"))
+            #expect(output.available)
+            #expect(output.deployedVersion == "0.4.558")
+            #expect(output.state == "idle")
+            #expect(output.paused == false)
+        }
+    }
+
+    @Test func getDeployStatusReportsUnavailableWhenNoFile() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "dep-admin2", role: "admin")
+            app.deployStateDirectory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("missing-\(UUID().uuidString)").path
+            let output = try await GetDeployStatusTool().execute(
+                .init(), context(subject: "dep-admin2"))
+            #expect(!output.available)
+            #expect(output.note != nil)
+        }
+    }
+
+    @Test func getDeployStatusRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "dep-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetDeployStatusTool().execute(
+                    .init(), context(subject: "dep-prof"))
+            }
+        }
+    }
+
+    @Test func getDeployHistoryReturnsRecentEntriesNewestFirst() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "hist-admin", role: "admin")
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("deploy-hist-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let lines = """
+                {"ts":"2026-06-28T17:00:00Z","version":"v0.4.557","action":"deploy","result":"success","detail":""}
+                {"ts":"2026-06-28T17:30:00Z","version":"v0.4.558","action":"deploy","result":"success","detail":"running=0.4.558"}
+                """
+            try lines.write(
+                to: dir.appendingPathComponent("history.jsonl"), atomically: true, encoding: .utf8)
+            app.deployStateDirectory = dir.path
+
+            let output = try await GetDeployHistoryTool().execute(
+                .init(limit: 10), context(subject: "hist-admin"))
+            #expect(output.available)
+            #expect(output.entries.count == 2)
+            // Newest first.
+            #expect(output.entries.first?.version == "v0.4.558")
+            #expect(output.entries.last?.version == "v0.4.557")
+        }
+    }
+
+    @Test func getDeployHistoryRejectsNonAdmin() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "hist-prof", role: "instructor")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await GetDeployHistoryTool().execute(
+                    .init(limit: nil), context(subject: "hist-prof"))
             }
         }
     }

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -75,7 +75,8 @@ import VaporTesting
     @Test func getDeployStatusReportsUnavailableWhenNoFile() async throws {
         try await withApp(app) { app in
             _ = try await makeTestUser(on: app, username: "dep-admin2", role: "admin")
-            app.deployStateDirectory = FileManager.default.temporaryDirectory
+            app.deployStateDirectory =
+                FileManager.default.temporaryDirectory
                 .appendingPathComponent("missing-\(UUID().uuidString)").path
             let output = try await GetDeployStatusTool().execute(
                 .init(), context(subject: "dep-admin2"))

--- a/changelog.d/deploy-daemon-phase2.md
+++ b/changelog.d/deploy-daemon-phase2.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Auto-deploy daemon (`deploy/chickadee-deployer.sh` + systemd unit).** Phase 2
+  of zero-downtime deploys: a small host-side shell daemon polls GitHub Releases
+  and blue-green-deploys each new version automatically via
+  `scripts/bluegreen-deploy.sh`. Non-major bumps ship on their own; **major bumps
+  are held for human approval** (configurable `DEPLOY_GATE_LEVEL=major|minor`).
+  Each deploy is preceded by a `snapshot.sh` safety net and followed by a short
+  public-health verification that auto-rolls-back if the new release degrades
+  after the cutover. It never forces a swap (relies on the symlink guard, so a
+  not-yet-converted volume fails safe), and writes `status.json` / `history.jsonl`
+  to the shared state dir — and reads pause/resume/approve/rollback commands from
+  `command.json` — for the planned admin-MCP oversight surface (Phase 3). The app
+  container never touches Docker; the daemon is the sole holder of docker/nginx
+  privileges. See `docs/zero-downtime-deploy.md`.

--- a/changelog.d/deploy-mcp-phase3.md
+++ b/changelog.d/deploy-mcp-phase3.md
@@ -1,0 +1,14 @@
+### Added
+
+- **Deploy oversight on the admin MCP surface (Phase 3).** Two read-only admin
+  diagnostic tools — `get_deploy_status` (the auto-deploy daemon's current state:
+  live version, latest release seen, paused flag, pending-major-approval) and
+  `get_deploy_history` (recent deploy / gate / rollback events) — let an
+  operator or agent see deploy state remotely. They read the daemon's
+  `status.json` / `history.jsonl` from `Application.deployStateDirectory`
+  (`CHICKADEE_DEPLOY_STATE_DIR`, default `/deploy-state`), which the blue-green
+  script now mounts into the container **read-only** — so the app can see deploy
+  state but physically cannot write `command.json`, and can never move traffic.
+  Deploy *control* (pause/approve/rollback) stays a host-side action, preserving
+  the admin surface's read-only-by-construction guarantee. See
+  `docs/zero-downtime-deploy.md`.

--- a/deploy/chickadee-deployer.service
+++ b/deploy/chickadee-deployer.service
@@ -1,0 +1,35 @@
+# Chickadee zero-downtime auto-deploy daemon (Phase 2).
+#
+# Install on the production host:
+#   sudo cp /home/jrwallac/Chickadee/deploy/chickadee-deployer.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now chickadee-deployer
+#   journalctl -u chickadee-deployer -f
+#
+# Configuration (optional) lives in /etc/chickadee-deployer.env, e.g.:
+#   CHICKADEE_POLL_INTERVAL_SECS=300
+#   CHICKADEE_DEPLOY_GATE_LEVEL=major
+#   CHICKADEE_PUBLIC_HEALTH_URL=https://chickadee.uwaterloo.ca/health
+#
+# Adjust WorkingDirectory/ExecStart if the repo is checked out elsewhere.
+
+[Unit]
+Description=Chickadee zero-downtime auto-deploy daemon
+After=docker.service network-online.target
+Wants=network-online.target
+Requires=docker.service
+
+[Service]
+Type=simple
+# Runs as root: it drives docker and reloads nginx via bluegreen-deploy.sh.
+User=root
+WorkingDirectory=/home/jrwallac/Chickadee
+ExecStart=/home/jrwallac/Chickadee/deploy/chickadee-deployer.sh
+EnvironmentFile=-/etc/chickadee-deployer.env
+Restart=always
+RestartSec=30
+# Give an in-flight deploy time to finish on stop/restart.
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/chickadee-deployer.sh
+++ b/deploy/chickadee-deployer.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+#
+# chickadee-deployer.sh — zero-downtime auto-deploy daemon (Phase 2).
+#
+# Polls GitHub Releases for a new version and blue-green-deploys it via
+# scripts/bluegreen-deploy.sh, fully automatically. MAJOR version bumps are held
+# for human approval (SemVer gate); non-major bumps deploy on their own. Each
+# deploy is preceded by a snapshot and followed by a short health verification
+# that auto-rolls-back if the new release degrades after the cutover.
+#
+# State / IPC lives in $STATE_DIR (shared with bluegreen-deploy.sh):
+#   status.json       — current state, written every cycle (read by the admin MCP surface)
+#   history.jsonl     — append-only deploy log
+#   deployed_version  — the version currently live (the daemon's source of truth)
+#   command.json      — commands FROM the operator/MCP: {"command":"pause|resume|approve|rollback|deploy","version":"vX.Y.Z"}
+#
+# Runs as root via systemd (needs docker + nginx). See chickadee-deployer.service.
+#
+# NOTE: deliberately NOT `set -e` — a long-running daemon must survive transient
+# failures (a flaky GitHub poll, a momentary network blip) and keep looping.
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration — override via /etc/chickadee-deployer.env (EnvironmentFile).
+# ---------------------------------------------------------------------------
+REPO="${CHICKADEE_REPO:-JimWallace/Chickadee}"
+IMAGE_REPO="${CHICKADEE_IMAGE_REPO:-ghcr.io/jimwallace/chickadee}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_SCRIPT="${CHICKADEE_DEPLOY_SCRIPT:-$REPO_ROOT/scripts/bluegreen-deploy.sh}"
+SNAPSHOT_SCRIPT="${CHICKADEE_SNAPSHOT_SCRIPT:-$REPO_ROOT/scripts/snapshot.sh}"
+
+STATE_DIR="${CHICKADEE_STATE_DIR:-/var/lib/chickadee-deploy}"
+PUBLIC_HEALTH_URL="${CHICKADEE_PUBLIC_HEALTH_URL:-https://chickadee.uwaterloo.ca/health}"
+
+POLL_INTERVAL_SECS="${CHICKADEE_POLL_INTERVAL_SECS:-300}"
+DEPLOY_GATE_LEVEL="${CHICKADEE_DEPLOY_GATE_LEVEL:-major}"     # major | minor
+SNAPSHOT_BEFORE_DEPLOY="${CHICKADEE_SNAPSHOT_BEFORE_DEPLOY:-1}"
+SNAPSHOT_REQUIRED="${CHICKADEE_SNAPSHOT_REQUIRED:-0}"
+POST_DEPLOY_VERIFY_SECS="${CHICKADEE_POST_DEPLOY_VERIFY_SECS:-30}"
+
+STATUS_FILE="$STATE_DIR/status.json"
+HISTORY_FILE="$STATE_DIR/history.jsonl"
+COMMAND_FILE="$STATE_DIR/command.json"
+DEPLOYED_VERSION_FILE="$STATE_DIR/deployed_version"
+
+PAUSED=0
+APPROVED_VERSION=""
+DEPLOYED_VERSION="0.0.0"
+LATEST_SEEN=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ts()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { printf '%s [deployer] %s\n' "$(ts)" "$*"; }
+
+strip_v()  { printf '%s' "${1#v}"; }
+major_of() { strip_v "$1" | cut -d. -f1; }
+minor_of() { strip_v "$1" | cut -d. -f2; }
+
+# True (0) if $1 is a strictly newer semver than $2.
+is_newer() {
+  local a b top
+  a="$(strip_v "$1")"; b="$(strip_v "$2")"
+  [ "$a" = "$b" ] && return 1
+  top="$(printf '%s\n%s\n' "$a" "$b" | sort -V | tail -1)"
+  [ "$top" = "$a" ]
+}
+
+# True (0) if deploying $1 over current $2 crosses the configured gate.
+is_gated() {
+  local new="$1" cur="$2"
+  if [ "$(major_of "$new")" -gt "$(major_of "$cur")" ]; then
+    return 0
+  fi
+  if [ "$DEPLOY_GATE_LEVEL" = "minor" ] \
+     && [ "$(major_of "$new")" -eq "$(major_of "$cur")" ] \
+     && [ "$(minor_of "$new")" -gt "$(minor_of "$cur")" ]; then
+    return 0
+  fi
+  return 1
+}
+
+fetch_latest_release() {
+  curl -fsS --max-time 30 "https://api.github.com/repos/$REPO/releases/latest" 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("tag_name",""))' 2>/dev/null
+}
+
+read_running_version() {
+  curl -fsS --max-time 10 "$PUBLIC_HEALTH_URL" 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' 2>/dev/null
+}
+
+write_status() {  # $1=state $2=detail
+  mkdir -p "$STATE_DIR"
+  python3 - "$STATUS_FILE" "$1" "$DEPLOYED_VERSION" "$LATEST_SEEN" "$2" "$PAUSED" <<'PY' 2>/dev/null || true
+import json, sys, datetime
+path, state, deployed, latest, detail, paused = sys.argv[1:7]
+json.dump({
+    "state": state,
+    "deployedVersion": deployed,
+    "latestSeen": latest,
+    "detail": detail,
+    "paused": paused == "1",
+    "updatedAt": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+}, open(path, "w"), indent=2)
+PY
+}
+
+append_history() {  # $1=version $2=action $3=result $4=detail
+  mkdir -p "$STATE_DIR"
+  python3 - "$HISTORY_FILE" "$1" "$2" "$3" "$4" <<'PY' 2>/dev/null || true
+import json, sys, datetime
+path, version, action, result, detail = sys.argv[1:6]
+line = json.dumps({
+    "ts": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "version": version, "action": action, "result": result, "detail": detail,
+})
+open(path, "a").write(line + "\n")
+PY
+}
+
+json_field() {  # $1=file $2=key
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],""))' "$1" "$2" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Command handling (operator / MCP -> daemon, via command.json)
+# ---------------------------------------------------------------------------
+handle_commands() {
+  [ -f "$COMMAND_FILE" ] || return 0
+  local cmd ver
+  cmd="$(json_field "$COMMAND_FILE" command)"
+  ver="$(json_field "$COMMAND_FILE" version)"
+  rm -f "$COMMAND_FILE"
+  case "$cmd" in
+    pause)    PAUSED=1; log "paused by command"; append_history "" pause ok "" ;;
+    resume)   PAUSED=0; log "resumed by command"; append_history "" resume ok "" ;;
+    approve)  APPROVED_VERSION="$ver"; log "approved $ver for the next cycle" ;;
+    rollback) log "rollback requested"; "$DEPLOY_SCRIPT" rollback --yes && append_history "" rollback ok "" || append_history "" rollback failed "" ;;
+    deploy)   APPROVED_VERSION="$ver"; log "manual deploy requested for $ver" ;;
+    "")       ;;
+    *)        log "unknown command: $cmd" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Deploy a specific version tag, with snapshot + post-deploy verification.
+# ---------------------------------------------------------------------------
+verify_post_deploy() {
+  local deadline fails
+  deadline=$(( $(date +%s) + POST_DEPLOY_VERIFY_SECS ))
+  fails=0
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl -fsS --max-time 5 "$PUBLIC_HEALTH_URL" >/dev/null 2>&1; then
+      fails=0
+    else
+      fails=$(( fails + 1 ))
+      [ "$fails" -ge 3 ] && return 1
+    fi
+    sleep 3
+  done
+  return 0
+}
+
+do_deploy() {  # $1 = version tag
+  local ver="$1"
+  LATEST_SEEN="$ver"
+  write_status deploying "deploying $ver"
+  append_history "$ver" deploy start ""
+  log "deploying $ver"
+
+  if [ "$SNAPSHOT_BEFORE_DEPLOY" = "1" ] && [ -x "$SNAPSHOT_SCRIPT" ]; then
+    log "snapshotting before deploy..."
+    if ! "$SNAPSHOT_SCRIPT" --label "predeploy-$(strip_v "$ver")" >/dev/null 2>&1; then
+      if [ "$SNAPSHOT_REQUIRED" = "1" ]; then
+        append_history "$ver" deploy abort "snapshot failed (required)"
+        write_status error "snapshot failed; deploy of $ver aborted"
+        log "snapshot failed and SNAPSHOT_REQUIRED=1 — aborting"
+        return 1
+      fi
+      log "snapshot failed; continuing (SNAPSHOT_REQUIRED=0)"
+    fi
+  fi
+
+  if CHICKADEE_IMAGE="$IMAGE_REPO:$ver" "$DEPLOY_SCRIPT" deploy --yes; then
+    if verify_post_deploy; then
+      printf '%s\n' "$ver" > "$DEPLOYED_VERSION_FILE"
+      DEPLOYED_VERSION="$ver"
+      append_history "$ver" deploy success ""
+      write_status idle "deployed $ver"
+      log "deployed $ver successfully"
+      return 0
+    fi
+    log "post-deploy health degraded — rolling back $ver"
+    "$DEPLOY_SCRIPT" rollback --yes || log "rollback command failed"
+    append_history "$ver" deploy rolledback "post-deploy health degraded"
+    write_status error "rolled back $ver (post-deploy health degraded)"
+    return 1
+  fi
+
+  # bluegreen-deploy.sh health-gates the new color BEFORE flipping nginx, so an
+  # aborted swap means traffic never moved — the previous version is still live.
+  append_history "$ver" deploy failed "swap aborted (new color unhealthy); previous version still live"
+  write_status error "deploy of $ver aborted; previous version still live"
+  log "deploy of $ver aborted; previous version still serving"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+main() {
+  mkdir -p "$STATE_DIR"
+
+  if [ -f "$DEPLOYED_VERSION_FILE" ]; then
+    DEPLOYED_VERSION="$(cat "$DEPLOYED_VERSION_FILE")"
+  else
+    DEPLOYED_VERSION="$(read_running_version)"
+    [ -n "$DEPLOYED_VERSION" ] || DEPLOYED_VERSION="0.0.0"
+    printf '%s\n' "$DEPLOYED_VERSION" > "$DEPLOYED_VERSION_FILE"
+  fi
+  LATEST_SEEN="$DEPLOYED_VERSION"
+
+  log "started: repo=$REPO baseline=$DEPLOYED_VERSION gate=$DEPLOY_GATE_LEVEL interval=${POLL_INTERVAL_SECS}s"
+  write_status idle "started; baseline $DEPLOYED_VERSION"
+
+  while true; do
+    handle_commands
+
+    if [ "$PAUSED" = "1" ]; then
+      write_status paused "auto-deploy paused"
+      sleep "$POLL_INTERVAL_SECS"; continue
+    fi
+
+    local latest
+    latest="$(fetch_latest_release)"
+    if [ -z "$latest" ]; then
+      log "could not fetch latest release; retrying next cycle"
+      sleep "$POLL_INTERVAL_SECS"; continue
+    fi
+    LATEST_SEEN="$latest"
+
+    if ! is_newer "$latest" "$DEPLOYED_VERSION"; then
+      write_status idle "up to date ($DEPLOYED_VERSION)"
+      sleep "$POLL_INTERVAL_SECS"; continue
+    fi
+
+    if is_gated "$latest" "$DEPLOYED_VERSION" && [ "$APPROVED_VERSION" != "$latest" ]; then
+      log "release $latest crosses the $DEPLOY_GATE_LEVEL gate — holding for approval"
+      write_status pending_approval "release $latest needs approval ($DEPLOY_GATE_LEVEL bump)"
+      append_history "$latest" gate held "awaiting approval"
+      sleep "$POLL_INTERVAL_SECS"; continue
+    fi
+
+    do_deploy "$latest"
+    APPROVED_VERSION=""
+    sleep "$POLL_INTERVAL_SECS"
+  done
+}
+
+main

--- a/deploy/chickadee-deployer.sh
+++ b/deploy/chickadee-deployer.sh
@@ -185,16 +185,21 @@ do_deploy() {  # $1 = version tag
     fi
   fi
 
-  # The release git tag is vX.Y.Z, but the published image tag is X.Y.Z — the
-  # build's `type=semver,pattern={{version}}` strips the leading v. So strip it
-  # here when constructing the image reference.
-  if CHICKADEE_IMAGE="$IMAGE_REPO:$(strip_v "$ver")" "$DEPLOY_SCRIPT" deploy --yes; then
+  # We deploy :latest, not :vX.Y.Z. The build only publishes per-release image
+  # tags on a git-tag workflow run, but auto-release pushes the tag with the
+  # default GITHUB_TOKEN, which (by GitHub's design) does not trigger the build —
+  # so :X.Y.Z is never published. :latest IS rebuilt on every release and is the
+  # version we just gated on via the Releases API. After the swap we record the
+  # ACTUAL running version so the deployed-version bookkeeping stays accurate even
+  # if :latest moved between the release check and the pull.
+  if CHICKADEE_IMAGE="$IMAGE_REPO:latest" "$DEPLOY_SCRIPT" deploy --yes; then
     if verify_post_deploy; then
-      printf '%s\n' "$ver" > "$DEPLOYED_VERSION_FILE"
-      DEPLOYED_VERSION="$ver"
-      append_history "$ver" deploy success ""
-      write_status idle "deployed $ver"
-      log "deployed $ver successfully"
+      local running; running="$(read_running_version)"
+      DEPLOYED_VERSION="${running:-$(strip_v "$ver")}"
+      printf '%s\n' "$DEPLOYED_VERSION" > "$DEPLOYED_VERSION_FILE"
+      append_history "$ver" deploy success "running=$DEPLOYED_VERSION"
+      write_status idle "deployed $DEPLOYED_VERSION (release $ver)"
+      log "deploy complete; running version now $DEPLOYED_VERSION (target release $ver)"
       return 0
     fi
     log "post-deploy health degraded — rolling back $ver"

--- a/deploy/chickadee-deployer.sh
+++ b/deploy/chickadee-deployer.sh
@@ -185,7 +185,10 @@ do_deploy() {  # $1 = version tag
     fi
   fi
 
-  if CHICKADEE_IMAGE="$IMAGE_REPO:$ver" "$DEPLOY_SCRIPT" deploy --yes; then
+  # The release git tag is vX.Y.Z, but the published image tag is X.Y.Z — the
+  # build's `type=semver,pattern={{version}}` strips the leading v. So strip it
+  # here when constructing the image reference.
+  if CHICKADEE_IMAGE="$IMAGE_REPO:$(strip_v "$ver")" "$DEPLOY_SCRIPT" deploy --yes; then
     if verify_post_deploy; then
       printf '%s\n' "$ver" > "$DEPLOYED_VERSION_FILE"
       DEPLOYED_VERSION="$ver"

--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -158,29 +158,70 @@ mechanism without moving any student traffic:
 
 ---
 
-## Phase 2 — the deployer daemon (automatic CD)
+## Phase 2 — the deployer daemon (automatic CD) — IMPLEMENTED
 
-`chickadee-deployer` (shell + systemd). A loop that:
+`deploy/chickadee-deployer.sh` (shell) + `deploy/chickadee-deployer.service`
+(systemd). The loop, every `POLL_INTERVAL_SECS` (default 300):
 
-1. Polls the **GitHub Releases API** for the latest release tag `vX.Y.Z`.
-2. Compares its **major** to the currently-deployed release (tracked in the
-   deployer's state). `major` equal → proceed automatically; `major` greater →
-   write a "pending approval" status, alert, and stop (await `approve_major`).
-3. Runs `scripts/snapshot.sh` (Postgres dump + artifacts) as a safety net.
-4. Calls `bluegreen-deploy.sh deploy` with `CHICKADEE_IMAGE=...:vX.Y.Z`.
-5. If the swap aborts (new color never healthy), the script already left the old
-   color serving; the daemon records the failure and alerts.
-6. Writes status/history to the shared IPC dir for the MCP surface to read.
+1. Reads `command.json` (operator/MCP commands — see IPC below).
+2. Polls the **GitHub Releases API** (`/repos/<repo>/releases/latest`,
+   unauthenticated — the repo is public) for the latest tag `vX.Y.Z`.
+3. If it's not newer than the deployed version (`sort -V` compare), records
+   "up to date" and sleeps.
+4. Applies the **SemVer gate**: if the bump crosses `DEPLOY_GATE_LEVEL`
+   (default `major` → only major bumps held; set `minor` to also hold minor
+   bumps during the 0-series), it writes `pending_approval` and waits for an
+   `approve` command. Otherwise it proceeds automatically.
+5. Runs `scripts/snapshot.sh --label predeploy-<ver>` (Postgres dump +
+   artifacts) as a safety net. `SNAPSHOT_REQUIRED=1` makes a failed snapshot
+   abort the deploy; the default warns and continues.
+6. Calls `bluegreen-deploy.sh deploy --yes` with `CHICKADEE_IMAGE=...:vX.Y.Z`.
+   It **never** forces — if `/data/Public` isn't a symlink the guard refuses and
+   the daemon records an error (fail-safe).
+7. **Post-deploy verification:** watches the public `/health` for
+   `POST_DEPLOY_VERIFY_SECS` (default 30); 3 consecutive failures →
+   `bluegreen-deploy.sh rollback --yes`. (A swap that never goes healthy is
+   already aborted by the script *before* the nginx flip, so traffic never moved
+   — this covers the rarer "healthy at cutover, degrades after" case.)
+8. Writes `status.json` / appends `history.jsonl` for the Phase 3 MCP surface.
 
-A `DEPLOY_GATE_LEVEL=major|minor` knob can tighten the gate to also hold `0.x`
-minor bumps during the 0-series (default `major`, per the agreed policy).
+### Configuration (env / `/etc/chickadee-deployer.env`)
 
-### App ⇄ daemon IPC (shared bind-mount dir)
+`CHICKADEE_REPO`, `CHICKADEE_IMAGE_REPO`, `CHICKADEE_POLL_INTERVAL_SECS`,
+`CHICKADEE_DEPLOY_GATE_LEVEL` (major|minor), `CHICKADEE_SNAPSHOT_BEFORE_DEPLOY`,
+`CHICKADEE_SNAPSHOT_REQUIRED`, `CHICKADEE_POST_DEPLOY_VERIFY_SECS`,
+`CHICKADEE_PUBLIC_HEALTH_URL`, `CHICKADEE_STATE_DIR`.
 
-- `command.json` — written by MCP: `{pause|resume|approve <tag>|rollback|deploy <tag>}`.
-- `status.json` — written by the daemon: current release, last result, pending
-  approval, paused flag, last error.
+### Install
+
+```
+sudo cp deploy/chickadee-deployer.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now chickadee-deployer
+journalctl -u chickadee-deployer -f
+```
+
+### Safe first run (recommended before enabling the service)
+
+Run it in the foreground with a short interval. Since the deployed version equals
+the latest release, it will just log "up to date" — no swap — so you can watch it
+behave with zero risk:
+
+```
+sudo CHICKADEE_POLL_INTERVAL_SECS=30 deploy/chickadee-deployer.sh
+```
+
+Ctrl-C, then enable the service. Its first *real* auto-deploy then happens
+naturally on the next merge to `main` (the next release). Pause anytime by
+writing `{"command":"pause"}` to `command.json`, or `sudo systemctl stop
+chickadee-deployer`.
+
+### App ⇄ daemon IPC (files in `STATE_DIR`)
+
+- `command.json` — operator/MCP → daemon: `{"command":"pause|resume|approve|rollback|deploy","version":"vX.Y.Z"}` (consumed each cycle).
+- `status.json` — daemon → readers: `state`, `deployedVersion`, `latestSeen`, `detail`, `paused`, `updatedAt`.
 - `history.jsonl` — append-only deploy log.
+- `deployed_version` — the daemon's source of truth for what is live.
 
 ---
 

--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -225,17 +225,35 @@ chickadee-deployer`.
 
 ---
 
-## Phase 3 — MCP oversight surface (admin)
+## Phase 3 — MCP oversight surface (admin) — IMPLEMENTED (read-only)
 
-Admin-scoped, read-mostly tools on the diagnostics surface (never content-auth):
+Two read tools on the admin diagnostic MCP surface let an operator/agent see
+deploy state remotely, without SSH:
 
-- `get_deploy_status` / `get_deploy_history` — read `status.json` / `history.jsonl`.
-- `pause_auto_deploy` / `resume_auto_deploy` — write `command.json`.
-- `approve_major` — approve a held major release.
-- `rollback` — request a rollback to the previous release.
+- `get_deploy_status` — the daemon's current `status.json` (live version, latest
+  release seen, paused flag, pending-major-approval, last update).
+- `get_deploy_history` — the most recent `history.jsonl` entries (deploy / gate /
+  rollback events), newest first.
 
-These only read/write the IPC files; the daemon remains the sole holder of Docker
-and nginx privileges.
+**Control stays host-side, on purpose.** The admin MCP surface is read-only *by
+construction* — `DiagnosticScope` has no write case, the bearer middleware
+enforces it, and a contract test asserts every tool is read-only. So
+pause/approve/rollback are **not** MCP tools; they are host actions (write
+`command.json`, or `systemctl`). To support that division safely the deploy
+state dir is mounted into the container **read-only**
+(`-v $STATE_DIR:/deploy-state:ro` in `bluegreen-deploy.sh`), so the app can *read*
+deploy state but physically cannot write `command.json` — a compromised app can
+never move traffic. The path is `Application.deployStateDirectory`
+(`CHICKADEE_DEPLOY_STATE_DIR`, default `/deploy-state`).
+
+Host-side control reference:
+
+```
+echo '{"command":"pause"}'    | sudo tee /var/lib/chickadee-deploy/command.json
+echo '{"command":"resume"}'   | sudo tee /var/lib/chickadee-deploy/command.json
+echo '{"command":"approve","version":"vX.Y.Z"}' | sudo tee /var/lib/chickadee-deploy/command.json
+echo '{"command":"rollback"}' | sudo tee /var/lib/chickadee-deploy/command.json
+```
 
 ---
 

--- a/scripts/bluegreen-deploy.sh
+++ b/scripts/bluegreen-deploy.sh
@@ -223,11 +223,17 @@ cmd_deploy() {
   # (Re)create the idle color. If anything below fails, the active color is
   # untouched and still serving — that is the whole safety guarantee.
   run "docker rm -f '$idle_name' >/dev/null 2>&1 || true"
+  # The deploy state dir is mounted READ-ONLY so the admin-MCP deploy tools can
+  # read status.json / history.jsonl. Read-only is deliberate: the app can see
+  # deploy state but cannot write command.json, so it can never move traffic.
+  local state_mount=""
+  [[ -d "$STATE_DIR" ]] && state_mount="-v '${STATE_DIR}:/deploy-state:ro'"
   run "docker run -d --name '$idle_name' \
         --restart unless-stopped \
         --network '$DOCKER_NETWORK' --network-alias server \
         -p '127.0.0.1:${idle_port}:8080' \
         -v '${DATA_VOLUME}:/data' \
+        ${state_mount} \
         ${envfile:+--env-file '$envfile'} \
         '$IMAGE'"
 


### PR DESCRIPTION
Phases 2 and 3 of zero-downtime deploys, on top of the proven blue-green swap (Phase 1, #1066, live on prod). Closes the CD loop and adds remote visibility into it.

## Phase 2 — auto-deploy daemon (host-side)

`deploy/chickadee-deployer.sh` + `deploy/chickadee-deployer.service` (systemd). Polls GitHub Releases, applies a SemVer gate (non-major auto-deploys; **major bumps held for approval**), snapshots, runs `bluegreen-deploy.sh deploy --yes`, and post-deploy-verifies with auto-rollback. Deploys `:latest` (the published release image — the build doesn't emit per-version tags) and records the actual running version. Never forces (the symlink guard fails safe). The app container never gets the Docker socket.

**Already proven on prod:** the daemon auto-deployed `v0.4.557 → v0.4.558` with zero downtime, and is running as a systemd service.

## Phase 3 — admin-MCP oversight (read-only)

Two read tools on the admin diagnostic surface:
- `get_deploy_status` — the daemon's current state (live version, latest release seen, paused flag, pending-major-approval).
- `get_deploy_history` — recent deploy / gate / rollback events.

They read the daemon's `status.json` / `history.jsonl` from `Application.deployStateDirectory` (`CHICKADEE_DEPLOY_STATE_DIR`, default `/deploy-state`), which `bluegreen-deploy.sh` now mounts into the color container **read-only**.

**Control stays host-side by design.** The admin surface is read-only by construction (no write scope; a contract test enforces it), so pause/approve/rollback are host actions (write `command.json`), not MCP tools. The read-only IPC mount means a compromised app can see deploy state but physically cannot move traffic.

## Security posture

App never holds the Docker socket; the host daemon is the sole holder of docker/nginx privileges; the in-container view of deploy state is read-only. Version source is GitHub Releases.

## Testing

- Daemon: `bash -n`; unit-tested version-compare + SemVer gate (major/minor) + JSON IPC round-trip.
- MCP tools: added admin-MCP tests (status read, missing-file → unavailable, history newest-first, reject-non-admin). Swift compile validated by CI (the dev sandbox can't fetch Vapor deps).

## Deploying Phase 3 (dogfooding)

Once merged + released, the running daemon auto-deploys the release. The host's `bluegreen-deploy.sh` must be updated first so the new color gets the read-only IPC mount (pull it before the daemon picks up the release, or pause → pull → resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176Kx2ZA3rXaEiCQ2XHQDMB