### PR TITLE
fix(mcp): thread acting subject into post-edit revalidation enqueue

### DIFF
--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -95,6 +95,15 @@ func finalizeContentEdit(
     if retest {
         await retestSubmissionsAfterContentEdit(setup: setup, context: context)
     }
-    await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+    // Thread the acting subject: the MCP bearer context has no session
+    // `APIUser`, so without it `scheduleValidationAfterSuiteEdit`'s enqueue
+    // falls back to `req.auth.require(APIUser.self)`, throws 401, and the helper
+    // swallows it — silently skipping the post-edit re-validation and the
+    // `shared/solution.py` refresh. Best-effort (`try?`): the edit already
+    // persisted; a resolution failure just degrades to the prior no-revalidate
+    // behaviour rather than failing the edit.
+    let submitterUserID = try? await context.requireEligibleSubject(tool: "finalize_content_edit").id
+    await scheduleValidationAfterSuiteEdit(
+        req: context.request, assignment: assignment, submitterUserID: submitterUserID)
     return closed
 }

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -247,9 +247,18 @@ private func resolveAndCacheValidationMaterialization(
 ///
 /// Errors are swallowed: this is a nice-to-have trigger from live-edit
 /// endpoints and must not block the edit save.
+///
+/// `submitterUserID` attributes the re-validation submission to the acting
+/// account. Web callers leave it nil — `enqueueRunnerValidationSubmission`
+/// resolves the session `APIUser` from `req.auth`. MCP callers MUST pass the
+/// resolved subject: their bearer context has no session `APIUser`, so without
+/// it the enqueue throws `401 Unauthorized`, which the `catch` below swallows —
+/// silently skipping the post-edit re-validation AND the `shared/solution.py`
+/// refresh the enqueue performs.
 func scheduleValidationAfterSuiteEdit(
     req: Request,
-    assignment: APIAssignment
+    assignment: APIAssignment,
+    submitterUserID: UUID? = nil
 ) async {
     do {
         let existingPending = try await APISubmission.query(on: req.db)
@@ -280,7 +289,8 @@ func scheduleValidationAfterSuiteEdit(
             req: req,
             setupID: assignment.testSetupID,
             solutionNotebookData: solution.data,
-            filename: solution.filename
+            filename: solution.filename,
+            submitterUserID: submitterUserID
         )
         assignment.validationSubmissionID = subID
         assignment.validationStatus = "pending"

--- a/Tests/APITests/MCP/AuthorScriptToolTests.swift
+++ b/Tests/APITests/MCP/AuthorScriptToolTests.swift
@@ -222,6 +222,64 @@ import Vapor
         }
     }
 
+    /// Regression: an MCP content edit must re-run validation. The bearer
+    /// context has no session `APIUser`, so `finalizeContentEdit` must thread
+    /// the acting subject into the validation enqueue — otherwise the enqueue
+    /// falls back to `req.auth.require(APIUser.self)`, throws 401, and
+    /// `scheduleValidationAfterSuiteEdit` swallows it: the post-edit
+    /// re-validation (and the `shared/solution.py` refresh it performs) is
+    /// silently skipped. We prove the enqueue is reached by asserting a fresh
+    /// validation submission is created.
+    @Test func mcpEditEnqueuesRevalidationWithActingSubject() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let setupID = assignment.testSetupID
+            let tester = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "tester").first())
+
+            // An active runner so the availability pre-check passes (empty
+            // capabilities match a default assignment, as the publish tests rely on).
+            let runner = RunnerProfile()
+            runner.runnerID = "runner-revalidate"
+            runner.displayName = "Revalidate Runner"
+            runner.platform = "linux"
+            runner.architecture = "x86_64"
+            runner.languageVersionsJSON = "[]"
+            runner.capabilitiesJSON = "[]"
+            runner.profileHash = nil
+            runner.lastRegisteredAt = Date()
+            runner.lastSeenAt = Date().addingTimeInterval(3600)
+            runner.isActive = true
+            try await runner.save(on: app.db)
+
+            // A prior COMPLETED validation submission supplies the solution
+            // notebook `loadExistingSolution` reads; being complete (not
+            // pending) it does not debounce the new enqueue.
+            let existing = try await makeTestSubmission(
+                on: app, id: "sub_val_seed", setupID: setupID, userID: try tester.requireID(),
+                kind: APISubmission.Kind.validation, status: "complete", filename: "solution.ipynb")
+            assignment.validationSubmissionID = try existing.requireID()
+            try await assignment.save(on: app.db)
+
+            func validationCount() async throws -> Int {
+                try await APISubmission.query(on: app.db)
+                    .filter(\.$testSetupID == setupID)
+                    .filter(\.$kind == APISubmission.Kind.validation)
+                    .count()
+            }
+            #expect(try await validationCount() == 1)
+
+            _ = try await AuthorScriptTool().execute(
+                input(assignment, filename: "test_a.sh", content: "exit 0\n", tier: "public"),
+                context(app))
+
+            // The edit reached the (previously 401-blocked) revalidation path
+            // and enqueued a fresh validation submission.
+            #expect(try await validationCount() == 2)
+        }
+    }
+
     @Test func deniesWhenSubjectNotEnrolled() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/changelog.d/mcp-revalidation-subject.md
+++ b/changelog.d/mcp-revalidation-subject.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **MCP content edits now actually re-run validation (and refresh
+  `solution.py`).** Every MCP authoring write (`author_script`,
+  `create_pattern_family`, `author_notebook_check`, suite/section edits, …)
+  funnels through `finalizeContentEdit`, which calls
+  `scheduleValidationAfterSuiteEdit` to re-kick validation — but that helper
+  enqueued the validation submission without an acting user, so on the MCP
+  bearer path (no session `APIUser`) the enqueue threw `401 Unauthorized`. The
+  helper swallows enqueue errors, so the failure was invisible: agent edits
+  silently skipped re-validation, and the server-side `shared/{setupID}/solution.py`
+  the personalization evaluator imports was never refreshed after an edit (only
+  `update_solution`, which already threads the subject, regenerated it).
+  `finalizeContentEdit` now resolves the acting subject and threads it through
+  `scheduleValidationAfterSuiteEdit` → `enqueueRunnerValidationSubmission`, so an
+  agent edit re-validates exactly like the web Save button. Web callers are
+  unchanged (they pass nil and resolve the session user from `req.auth`).


### PR DESCRIPTION
## Problem

Every MCP content-authoring write (`author_script`, `create_pattern_family`,
`author_notebook_check`, suite/section edits, …) funnels through
`finalizeContentEdit`, which calls `scheduleValidationAfterSuiteEdit` to re-kick
validation after the edit — matching the web Save button. But that helper called
`enqueueRunnerValidationSubmission` **without a submitter**, so it fell back to
`req.auth.require(APIUser.self)` — which **401s on the MCP bearer path** (a
bearer token has no session `APIUser`). `scheduleValidationAfterSuiteEdit`
swallows enqueue errors, so the failure was invisible:

- agent edits **silently skipped re-validation**, and
- the server-side `shared/{setupID}/solution.py` that the personalization
  evaluator imports was **never refreshed after an MCP edit** — only
  `update_solution` (which already threads the subject) regenerated it.

Confirmed on the deployed server — the warning ring buffer showed
`scheduleValidationAfterSuiteEdit: Abort.401: Unauthorized` on every MCP
`author_script` edit. This is what made an `author_script` re-save fail to
regenerate `solution.py` after #1065 deployed.

## Fix

`finalizeContentEdit` resolves the acting subject and threads it through
`scheduleValidationAfterSuiteEdit` → `enqueueRunnerValidationSubmission`, so an
agent edit re-validates exactly like the web Save. Web callers are unchanged
(nil submitter → session user from `req.auth`); resolution is best-effort
(`try?`) so it can never fail an already-persisted edit.

Backend-only; no UI, schema, or API changes.

## Tests

- New `mcpEditEnqueuesRevalidationWithActingSubject`: with an active runner and
  a prior completed validation supplying the solution notebook, an MCP
  `author_script` edit enqueues a **fresh** validation submission (count 1 → 2).
  Without the subject the enqueue 401s and is swallowed, so no new submission is
  created — the test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhCtqrZZccY2XvDLeoEmW9)_