### PR TITLE
fix(brightspace): scale grades to the LEARN grade item's max; surface item type

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -231,6 +231,11 @@ LEARN
             if (!Array.isArray(items)) return;
             datalist.innerHTML = items.map(function (it) {
                 var label = it.name + (it.maxPoints != null ? ' (' + it.maxPoints + ' pts)' : '');
+                // Surface the grade-item type so a non-Numeric item (which
+                // Chickadee can't sync points to) is obvious before mapping.
+                if (it.gradeType && it.gradeType !== 'Numeric') {
+                    label += ' — ' + it.gradeType + ' (not supported)';
+                }
                 var opt = document.createElement('option');
                 opt.value = String(it.id);
                 opt.textContent = label;

--- a/Sources/APIServer/Models/APIGradeOverride.swift
+++ b/Sources/APIServer/Models/APIGradeOverride.swift
@@ -3,9 +3,10 @@
 // Per-student grade override on a test setup.  An override replaces the
 // runner-assigned best grade for one student on one assignment, both in the
 // instructor's per-student submissions view and in the BrightSpace grade
-// sync (see `bestPointsForStudent` in BrightSpaceGradeSyncService).  The
+// sync (see `bestGradeForStudent` in BrightSpaceGradeSyncService).  The
 // stored value is a whole-number percent (0–100); BrightSpace works in
-// points, so the sync converts it against the suite's total possible points.
+// points, so the sync converts it against the suite's total possible points
+// and rescales onto the grade item's own max.
 //
 // One row per (test_setup, user) — enforced by the composite UNIQUE index in
 // CreateGradeOverrides.

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -120,6 +120,46 @@ struct BrightSpaceGradeObject: Content, Sendable {
     let id: String
     let name: String
     let maxPoints: Double?
+    /// D2L grade item type: "Numeric", "PassFail", "SelectBox", "Text",
+    /// "Calculated", "Formula", … nil when not captured. Chickadee only syncs
+    /// points to "Numeric" items; the dropdown surfaces the type so an
+    /// instructor doesn't map a category or a non-numeric item by mistake.
+    let gradeType: String?
+    /// Whether a numeric item accepts a value above its MaxPoints. nil = unknown.
+    let canExceed: Bool?
+
+    init(
+        id: String, name: String, maxPoints: Double?,
+        gradeType: String? = nil, canExceed: Bool? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.maxPoints = maxPoints
+        self.gradeType = gradeType
+        self.canExceed = canExceed
+    }
+}
+
+/// D2L grade-object JSON, shared by the list (`grades/`) and single-item
+/// (`grades/{id}`) endpoints, which return the same shape.
+private struct GradeObjectJSON: Decodable {
+    let id: Int
+    let name: String
+    let maxPoints: Double?
+    let gradeType: String?
+    let canExceed: Bool?
+    enum CodingKeys: String, CodingKey {
+        case id = "Id"
+        case name = "Name"
+        case maxPoints = "MaxPoints"
+        case gradeType = "GradeType"
+        case canExceed = "CanExceed"
+    }
+    var asGradeObject: BrightSpaceGradeObject {
+        BrightSpaceGradeObject(
+            id: String(id), name: name, maxPoints: maxPoints,
+            gradeType: gradeType, canExceed: canExceed)
+    }
 }
 
 /// One member of a course's LEARN classlist, reduced to the identity fields
@@ -180,6 +220,12 @@ protocol BrightSpaceGrading: Sendable {
         earnedPoints: Double,
         on application: Application
     ) async throws
+    /// Fetches a single grade item's metadata (type + max points) so the sweep
+    /// can scale the grade to the item's max and refuse non-numeric items.
+    /// Returns nil when the item doesn't exist (404).
+    func fetchGradeObject(
+        orgUnitID: String, gradeObjectID: String, on application: Application
+    ) async throws -> BrightSpaceGradeObject?
 }
 
 // MARK: - Client
@@ -500,20 +546,29 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
             throw BrightSpaceSyncError.gradeObjectsFetchFailed(
                 orgUnitID: orgUnitID, status: Int(response.status.code))
         }
-        struct GradeObjectResponse: Decodable {
-            let id: Int
-            let name: String
-            let maxPoints: Double?
-            enum CodingKeys: String, CodingKey {
-                case id = "Id"
-                case name = "Name"
-                case maxPoints = "MaxPoints"
-            }
+        let decoded = try response.content.decode([GradeObjectJSON].self)
+        return decoded.map { $0.asGradeObject }
+    }
+
+    /// Fetches one grade item's metadata. Returns nil on 404 (item not found in
+    /// this org unit), throws on other non-2xx so the sweep can record it.
+    func fetchGradeObject(
+        orgUnitID: String, gradeObjectID: String, on application: Application
+    ) async throws -> BrightSpaceGradeObject? {
+        guard !orgUnitID.isEmpty, !gradeObjectID.isEmpty else { return nil }
+        let leVersion = await apiVersion(
+            "le", fallback: BrightSpaceSyncConfig.leAPIVersion, on: application)
+        let encodedOrg = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
+        let encodedObj =
+            gradeObjectID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? gradeObjectID
+        let rawURL = "\(config.baseURL)/d2l/api/le/\(leVersion)/\(encodedOrg)/grades/\(encodedObj)"
+        let response = try await sendSigned(method: "GET", rawURL: rawURL, on: application)
+        if response.status == .notFound { return nil }
+        guard response.status == .ok else {
+            throw BrightSpaceSyncError.gradeObjectsFetchFailed(
+                orgUnitID: orgUnitID, status: Int(response.status.code))
         }
-        let decoded = try response.content.decode([GradeObjectResponse].self)
-        return decoded.map {
-            BrightSpaceGradeObject(id: String($0.id), name: $0.name, maxPoints: $0.maxPoints)
-        }
+        return try response.content.decode(GradeObjectJSON.self).asGradeObject
     }
 
     // MARK: - Classlist (roster reconciliation)

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -50,8 +50,10 @@ func sweepBrightSpaceGradeSync(
 
     var processed = 0
 
-    // One classlist read per course is shared across all of this sweep's pushes.
+    // One classlist read per course, and one grade-object fetch per item, are
+    // shared across all of this sweep's pushes.
     let classlistCache = ClasslistUserIDCache()
+    let gradeObjectCache = GradeObjectInfoCache()
 
     // Group pushable results by (student, test setup).  Results whose
     // submission is missing or isn't a student submission are no-ops handled
@@ -106,7 +108,8 @@ func sweepBrightSpaceGradeSync(
         do {
             let pushed = try await pushGrade(
                 for: target, db: db, resolveClient: resolveClient,
-                classlistCache: classlistCache, logger: logger, application: application)
+                classlistCache: classlistCache, gradeObjectCache: gradeObjectCache,
+                application: application)
             if pushed { processed += syncRows.count }
         } catch {
             await recordSweepFailure(syncRows, error: error, db: db, logger: logger)
@@ -371,7 +374,7 @@ private func pushGrade(
     db: Database,
     resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
     classlistCache: ClasslistUserIDCache,
-    logger: Logger,
+    gradeObjectCache: GradeObjectInfoCache,
     application: Application
 ) async throws -> Bool {
     let userID = target.userID
@@ -407,7 +410,7 @@ private func pushGrade(
 
     // Best grade for this student across the test setup. nil → no submissions
     // yet (nothing to push); throws if submissions exist but yield no points.
-    guard let points = try await bestPointsForStudent(userID: userID, testSetupID: testSetupID, db: db)
+    guard let grade = try await bestGradeForStudent(userID: userID, testSetupID: testSetupID, db: db)
     else {
         try await clearPendingFlag(syncRows, on: db)
         return true
@@ -418,8 +421,8 @@ private func pushGrade(
 
     // Appends one row to the sync log. Best-effort: a logging failure must
     // never abort or retry a grade push, so errors are swallowed. Captures
-    // the surrounding push context so callers pass only status + detail.
-    func appendSyncLog(_ status: APIBrightSpaceSyncLog.Status, detail: String?) async {
+    // the surrounding push context so callers pass only status + points + detail.
+    func appendSyncLog(_ status: APIBrightSpaceSyncLog.Status, points: Double, detail: String?) async {
         let entry = APIBrightSpaceSyncLog(
             courseID: course.id,
             testSetupID: assignment.testSetupID,
@@ -435,32 +438,34 @@ private func pushGrade(
         try? await entry.save(on: db)
     }
 
-    // Resolve D2L user ID (cached on APIUser, looked up on first sync).
-    // The course's classlist identity map (username/student-number → D2L UserId),
-    // fetched once per org unit per sweep. A read failure degrades to the
-    // org-level OrgDefinedId fallback rather than aborting the push.
-    var identityMap: [String: String] = [:]
-    do {
-        identityMap = try await classlistCache.identityMap(
-            orgUnitID: orgUnitID, client: client, application: application)
-    } catch {
-        logger.warning("BrightSpace classlist resolve failed for org unit \(orgUnitID): \(error)")
-    }
-    let bsUserID = try await resolvedBrightSpaceUserID(
-        for: target.user,
-        identityMap: identityMap,
-        db: db,
-        client: client,
-        application: application
-    )
-    guard let bsUserID else {
-        // No BrightSpace account for this student — record + skip.
+    // Flags every sync row terminally (cleared + error recorded) and logs a
+    // skip — the shared shape for "we won't push this, and here's why".
+    func recordTerminalSkip(_ message: String, points: Double) async throws {
         for row in syncRows {
             row.brightspaceSyncPending = false
-            row.brightspaceSyncError = "Student has no BrightSpace account (orgDefinedId not found)"
+            row.brightspaceSyncError = message
             try await row.save(on: db)
         }
-        await appendSyncLog(.skipped, detail: "No BrightSpace account (orgDefinedId not found)")
+        await appendSyncLog(.skipped, points: points, detail: message)
+    }
+
+    // Fetch the grade item, refuse non-numeric items, and scale onto its max.
+    let scaled = await scaledGradePush(
+        grade: grade, orgUnitID: orgUnitID, gradeObjectID: gradeObjectID,
+        client: client, gradeObjectCache: gradeObjectCache, application: application)
+    if let refusal = scaled.refusal {
+        try await recordTerminalSkip(refusal, points: grade.points)
+        return true
+    }
+    let pushPoints = scaled.pushPoints
+    let gradeObject = scaled.gradeObject
+
+    let bsUserID = try await resolveBSUserID(
+        for: target.user, orgUnitID: orgUnitID, client: client,
+        classlistCache: classlistCache, db: db, application: application)
+    guard let bsUserID else {
+        try await recordTerminalSkip(
+            "Student has no BrightSpace account (orgDefinedId not found)", points: pushPoints)
         return true
     }
 
@@ -470,13 +475,17 @@ private func pushGrade(
             orgUnitID: orgUnitID,
             gradeObjectID: gradeObjectID,
             bsUserID: bsUserID,
-            earnedPoints: points,
+            earnedPoints: pushPoints,
             on: application
         )
     } catch {
-        // Log with full context here (the sweep's catch lacks it), then
+        // Enrich with item context here (the sweep's catch lacks it), then
         // rethrow so the existing per-group error handling still runs.
-        await appendSyncLog(.error, detail: error.localizedDescription)
+        let maxDesc = gradeObject?.maxPoints.map { "\($0)" } ?? "unset"
+        await appendSyncLog(
+            .error, points: pushPoints,
+            detail: "Pushed \(pushPoints) pts to '\(gradeObject?.name ?? gradeObjectID)' "
+                + "(max \(maxDesc)); D2L rejected it: \(error.localizedDescription)")
         throw error
     }
 
@@ -489,24 +498,98 @@ private func pushGrade(
         try await row.save(on: db)
     }
 
-    await appendSyncLog(.success, detail: nil)
+    await appendSyncLog(.success, points: pushPoints, detail: nil)
 
-    logger.info("BrightSpace grade synced: user \(userID) assignment '\(assignment.title)' → \(points) pts")
+    application.logger.info(
+        "BrightSpace grade synced: user \(userID) assignment '\(assignment.title)' → \(pushPoints) pts")
     return true
 }
 
-/// Best (max) points for this student across all results for the test setup,
+/// The points to push and the grade item they target, or a `refusal` message
+/// when the item can't be synced to (non-numeric). Fetches the grade item once
+/// (cached) and scales the grade onto its max; a fetch failure degrades to "no
+/// scaling, no type check" so a push that would otherwise work isn't blocked.
+private func scaledGradePush(
+    grade: StudentGrade,
+    orgUnitID: String,
+    gradeObjectID: String,
+    client: any BrightSpaceGrading,
+    gradeObjectCache: GradeObjectInfoCache,
+    application: Application
+) async -> (pushPoints: Double, gradeObject: BrightSpaceGradeObject?, refusal: String?) {
+    var gradeObject: BrightSpaceGradeObject?
+    do {
+        gradeObject = try await gradeObjectCache.info(
+            orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, client: client, application: application)
+    } catch {
+        application.logger.warning("BrightSpace grade-object fetch failed for \(gradeObjectID): \(error)")
+    }
+
+    // Refuse a non-numeric / category item with a clear message rather than a
+    // bare D2L 400 — Chickadee only writes point values to Numeric items.
+    if let type = gradeObject?.gradeType, !type.isEmpty,
+        type.caseInsensitiveCompare("Numeric") != .orderedSame
+    {
+        let message =
+            "Grade item '\(gradeObject?.name ?? gradeObjectID)' is type \(type); "
+            + "Chickadee can only sync to Numeric grade items."
+        return (grade.points, gradeObject, message)
+    }
+
+    // Scale Chickadee's grade onto the D2L item's own max when both totals are
+    // known (e.g. a /14 suite into a /10 LEARN item). When the item's max is
+    // unknown or already equals the suite total, this is the identity, so the
+    // pushed value is unchanged.
+    if let total = grade.total, total > 0, let maxPoints = gradeObject?.maxPoints, maxPoints > 0 {
+        return (grade.points / total * maxPoints, gradeObject, nil)
+    }
+    return (grade.points, gradeObject, nil)
+}
+
+/// Resolves the student's D2L user ID via the course classlist (cached per
+/// sweep), falling back to the org-level OrgDefinedId lookup. A classlist read
+/// failure degrades to the fallback rather than aborting the push.
+private func resolveBSUserID(
+    for user: APIUser?,
+    orgUnitID: String,
+    client: any BrightSpaceGrading,
+    classlistCache: ClasslistUserIDCache,
+    db: Database,
+    application: Application
+) async throws -> String? {
+    var identityMap: [String: String] = [:]
+    do {
+        identityMap = try await classlistCache.identityMap(
+            orgUnitID: orgUnitID, client: client, application: application)
+    } catch {
+        application.logger.warning("BrightSpace classlist resolve failed for org unit \(orgUnitID): \(error)")
+    }
+    return try await resolvedBrightSpaceUserID(
+        for: user, identityMap: identityMap, db: db, client: client, application: application)
+}
+
+/// One student's best grade for a test setup: the raw points Chickadee would
+/// push (in suite-point units) plus the denominator (suite total) used to
+/// derive them, so the caller can rescale to the BrightSpace grade item's own
+/// max. `total` is nil only when neither the manifest nor any result records a
+/// total.
+private struct StudentGrade {
+    let points: Double
+    let total: Double?
+}
+
+/// Best (max) grade for this student across all results for the test setup,
 /// preferring worker results over browser ones.  Returns nil when the student
 /// has no submissions yet (nothing to push); throws `.missingPoints` when
 /// submissions exist but none yielded a parseable grade.
-private func bestPointsForStudent(
+private func bestGradeForStudent(
     userID: UUID,
     testSetupID: String,
     db: Database
-) async throws -> Double? {
+) async throws -> StudentGrade? {
     // An instructor override replaces the runner-derived grade. It stores a
     // percent, so it needs a points denominator: the suite's total possible
-    // points (the BrightSpace grade item's max).
+    // points.
     let override = try await APIGradeOverride.query(on: db)
         .filter(\.$testSetupID == testSetupID)
         .filter(\.$userID == userID)
@@ -519,13 +602,13 @@ private func bestPointsForStudent(
         .all()
         .compactMap(\.id)
 
+    let manifestTotal = try await suiteTotalPoints(testSetupID: testSetupID, db: db)
+
     guard !submissionIDs.isEmpty else {
         // No submissions yet. Only an override gives us anything to push.
         guard let override else { return nil }
-        guard let total = try await suiteTotalPoints(testSetupID: testSetupID, db: db) else {
-            return nil
-        }
-        return Double(override.overridePercent) / 100.0 * total
+        guard let total = manifestTotal else { return nil }
+        return StudentGrade(points: Double(override.overridePercent) / 100.0 * total, total: total)
     }
 
     let allResults = try await APIResult.query(on: db)
@@ -538,32 +621,31 @@ private func bestPointsForStudent(
     if let override {
         // Prefer the suite manifest's total; fall back to the best result's
         // recorded totalPoints for setups whose manifest is unavailable.
-        let total =
-            try await suiteTotalPoints(testSetupID: testSetupID, db: db)
-            ?? resultsForGrade.compactMap { $0.gradeTotalPointsValue }.max()
+        let total = manifestTotal ?? resultsForGrade.compactMap { $0.gradeTotalPointsValue }.max()
         guard let total, total > 0 else { throw BrightSpaceSyncError.missingPoints }
-        return Double(override.overridePercent) / 100.0 * total
+        return StudentGrade(points: Double(override.overridePercent) / 100.0 * total, total: total)
     }
 
     guard
-        let points =
+        let basePoints =
             resultsForGrade
             .compactMap({ $0.gradePointsValue })
             .max()
     else {
         throw BrightSpaceSyncError.missingPoints
     }
+    let total = manifestTotal ?? resultsForGrade.compactMap { $0.gradeTotalPointsValue }.max()
     // Class-goal bonus: extra credit, capped at the suite total (100%).
     let bonus = try await classGoalBonusPoints(testSetupID: testSetupID, on: db)
-    if bonus > 0, let total = try await suiteTotalPoints(testSetupID: testSetupID, db: db) {
-        return min(total, points + bonus)
-    }
-    return points
+    var points = basePoints
+    if bonus > 0, let manifestTotal { points = min(manifestTotal, basePoints + bonus) }
+    return StudentGrade(points: points, total: total)
 }
 
 /// Total possible points for a test setup — the sum of its suite items'
-/// weights, which is the BrightSpace grade item's max.  Nil when the manifest
-/// is missing/malformed or sums to zero.
+/// weights.  Used as the denominator to rescale a grade onto the BrightSpace
+/// grade item's own max.  Nil when the manifest is missing/malformed or sums to
+/// zero.
 private func suiteTotalPoints(testSetupID: String, db: Database) async throws -> Double? {
     guard let setup = try await APITestSetup.find(testSetupID, on: db),
         let props = setup.decodedManifest()
@@ -601,6 +683,26 @@ private actor ClasslistUserIDCache {
         }
         mapsByOrgUnit[orgUnitID] = map
         return map
+    }
+}
+
+/// Per-sweep cache of grade-item metadata, keyed by (org unit, grade object).
+/// Fetched once per item per sweep so a backlog of pushes to the same
+/// assignment shares one lookup. A cached `nil` (item not found) is preserved
+/// distinctly from "not yet fetched".
+private actor GradeObjectInfoCache {
+    private var cache: [String: BrightSpaceGradeObject?] = [:]
+
+    func info(
+        orgUnitID: String, gradeObjectID: String,
+        client: any BrightSpaceGrading, application: Application
+    ) async throws -> BrightSpaceGradeObject? {
+        let key = "\(orgUnitID)\u{1f}\(gradeObjectID)"
+        if let cached = cache[key] { return cached }
+        let info = try await client.fetchGradeObject(
+            orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, on: application)
+        cache[key] = info
+        return info
     }
 }
 

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -30,6 +30,11 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
     private let classlist: [BrightSpaceClasslistEntry]
     private let lookupError: (any Error)?
     private let pushError: (any Error)?
+    /// Grade-item metadata returned by `fetchGradeObject`. Default `nil` mimics
+    /// "item not found", which the sweep treats as "no scaling, no type check"
+    /// — so the pushed value equals Chickadee's raw points unless a test opts
+    /// into a specific grade object (to exercise scaling / type refusal).
+    private let gradeObject: BrightSpaceGradeObject?
     private(set) var pushes: [RecordedPush] = []
     private(set) var lookupCount = 0
 
@@ -37,12 +42,14 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         userIDsByOrgDefinedId: [String: String] = [:],
         classlist: [BrightSpaceClasslistEntry] = [],
         lookupError: (any Error)? = nil,
-        pushError: (any Error)? = nil
+        pushError: (any Error)? = nil,
+        gradeObject: BrightSpaceGradeObject? = nil
     ) {
         self.userIDsByOrgDefinedId = userIDsByOrgDefinedId
         self.classlist = classlist
         self.lookupError = lookupError
         self.pushError = pushError
+        self.gradeObject = gradeObject
     }
 
     func lookupUserID(orgDefinedId: String, on application: Application) async throws -> String? {
@@ -55,6 +62,12 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         orgUnitID: String, on application: Application
     ) async throws -> [BrightSpaceClasslistEntry] {
         classlist
+    }
+
+    func fetchGradeObject(
+        orgUnitID: String, gradeObjectID: String, on application: Application
+    ) async throws -> BrightSpaceGradeObject? {
+        gradeObject
     }
 
     func pushGrade(
@@ -512,6 +525,61 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             let reloaded = try #require(try await APIGradeOverride.query(on: app.db).first())
             #expect(reloaded.brightspaceSyncPending == true)
             #expect(reloaded.brightspaceSyncError == nil)
+        }
+    }
+
+    @Test func gradeIsScaledToD2LGradeItemMaxPoints() async throws {
+        // Chickadee grades the lab out of 20; the LEARN item is out of 10.
+        // A 100% override must land as 10/10, not 20 (which would exceed the
+        // item's max and 400 on a "can't exceed" item).
+        try await withApp(app) { _ in
+            let scenario = try await makeOverrideOnlyScenario(suiteTotal: 20, studentID: "stu-ovr")
+            try await applyGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID,
+                percent: 100, note: nil, grantedByUserID: nil, on: app.db)
+            let override = try #require(try await APIGradeOverride.query(on: app.db).first())
+            override.brightspacePendingSince = Date().addingTimeInterval(-3600)
+            try await override.save(on: app.db)
+
+            let fake = FakeBrightSpaceGrading(
+                userIDsByOrgDefinedId: ["stu-ovr": "d2l-ovr"],
+                gradeObject: BrightSpaceGradeObject(
+                    id: "go-ovr", name: "Lab", maxPoints: 10, gradeType: "Numeric", canExceed: false))
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)
+            let pushes = await fake.pushes
+            #expect(pushes.count == 1)
+            #expect(pushes.first?.earnedPoints == 10)  // 100% of /20, scaled onto the /10 item
+        }
+    }
+
+    @Test func nonNumericGradeItemIsSkippedWithClearMessage() async throws {
+        // Mapping a non-Numeric item (e.g. a SelectBox) must be refused with an
+        // explanatory message instead of a bare D2L 400.
+        try await withApp(app) { _ in
+            let scenario = try await makeOverrideOnlyScenario(studentID: "stu-ovr")
+            try await applyGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID,
+                percent: 80, note: nil, grantedByUserID: nil, on: app.db)
+            let override = try #require(try await APIGradeOverride.query(on: app.db).first())
+            override.brightspacePendingSince = Date().addingTimeInterval(-3600)
+            try await override.save(on: app.db)
+
+            let fake = FakeBrightSpaceGrading(
+                userIDsByOrgDefinedId: ["stu-ovr": "d2l-ovr"],
+                gradeObject: BrightSpaceGradeObject(
+                    id: "go-ovr", name: "Participation", maxPoints: nil, gradeType: "SelectBox"))
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)  // a terminal skip is "processed", not a failure
+            let pushes = await fake.pushes
+            #expect(pushes.isEmpty)
+            let reloaded = try #require(try await APIGradeOverride.query(on: app.db).first())
+            #expect(reloaded.brightspaceSyncPending == false)
+            #expect(reloaded.brightspaceSyncError?.contains("Numeric") == true)
         }
     }
 

--- a/changelog.d/brightspace-grade-scaling.md
+++ b/changelog.d/brightspace-grade-scaling.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **BrightSpace grade sync scales to the grade item's own max.** Chickadee
+  previously pushed raw suite points and assumed the LEARN grade item's Max
+  Points equaled the assignment's suite total — so an assignment graded out of
+  more points than its grade item (with "Can Exceed" off) was rejected by D2L
+  with an opaque empty-body `400`. The sweep now fetches the grade item's max
+  at push time and pushes `percentage × maxPoints`, so a 100% always lands as
+  full marks regardless of how the two totals compare. When the item's max is
+  unknown or already matches, the pushed value is unchanged.
+
+### Added
+
+- **Grade-item type is surfaced and enforced in BrightSpace sync.** The
+  instructor grade-item dropdown now shows each item's D2L type and flags
+  non-Numeric items as unsupported, and the sync refuses to push points to a
+  non-Numeric item with a clear message instead of a bare D2L `400`. Grade-push
+  failures now record the item's name, max points, and the attempted value in
+  the sync-activity log so a rejected push is self-explanatory.


### PR DESCRIPTION
## Why

Live grade-sync testing surfaced a real bug: **Lab 0 pushed fine but Lab 1 failed with an opaque empty-body D2L `400`.** Diagnosis (via the admin sync-status surface + the instructor's LEARN config): Lab 1's grade item is a `/10` Numeric item with "Can Exceed" off, but Chickadee was pushing **raw suite points** against an assumed-equal max — Lab 1 is graded out of more than 10 in Chickadee, so the value exceeded the item's max and D2L rejected it.

The root cause is an assumption baked into the sync: *the LEARN grade item's Max Points equals the assignment's suite total.* When they differ, grades are either rejected (can't-exceed) or silently mis-scaled (e.g. 14/10 = 140%).

## What changed

**1. Scale to the grade item's own max (the fix).**
The sweep now fetches the grade item's metadata once per sweep (cached) and pushes `fraction(0..1) × maxPoints` instead of raw suite points. A 100% always lands as full marks regardless of how the suite total and the LEARN max compare. When the max is unknown or already equals the suite total (e.g. Lab 0), this is the identity — **matched setups are unchanged**. `bestPointsForStudent` → `bestGradeForStudent` now returns the denominator alongside the points so the caller can rescale.

**2. Surface + enforce the grade-item type.**
`listGradeObjects` now captures `GradeType`, and the instructor mapping dropdown shows it (flagging non-Numeric items as "not supported"). The sweep refuses to push points to a non-Numeric/category item with a clear message instead of a bare `400` — Chickadee only writes point values to Numeric items.

**3. Enrich push-failure detail.**
A rejected push now records the item's name, max points, and the attempted value in the sync-activity log, so an empty-body `400` is self-explanatory instead of just "Bad Request."

## Graceful degradation
If the grade-item fetch fails (network), the push degrades to "no scaling, no type check" and sends raw points — exactly the previous behaviour — so a metadata-fetch hiccup never blocks a push that would otherwise work.

## Tests
- `gradeIsScaledToD2LGradeItemMaxPoints` — a 100% on a `/20` suite lands as `10` on a `/10` item.
- `nonNumericGradeItemIsSkippedWithClearMessage` — a SelectBox item is refused with an explanatory message, no push.
- The `FakeBrightSpaceGrading` mock gains `fetchGradeObject` (default `nil` → no scaling/type-check), so all existing sync tests are unchanged.

## Notes
- The `Comments`/`PrivateComments` mandatory-field fix (the *other* symptom) already shipped in #1064 (live in v0.4.558); this PR addresses the remaining Lab 1 failure.
- `swift-format` + `check-styles.sh` pass locally. Full build/test/SwiftLint can't run in this environment (egress-blocked deps); CI compiles and runs the suite.
- One `changelog.d/` fragment; no `VERSION`/`CHANGELOG.md` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_