### PR TITLE
Block writes to archived courses: per-student actions, clone, MCP section (#417 Slice C)

### DIFF
--- a/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
@@ -244,7 +244,7 @@ struct SetAssignmentCourseSectionTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let assignment = try await context.authorizedAssignment(
+        let assignment = try await context.authorizedAssignmentForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         // Resolve + validate the target section against this assignment's course.

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -120,6 +120,29 @@ struct ToolContext {
         return assignment
     }
 
+    /// Like `authorizedAssignment`, but additionally blocks the write when the
+    /// assignment's course is archived (admin subjects exempt). Mirrors the web
+    /// side's `requireCourseWriteAccess`: archived courses are read-only for
+    /// instructors and TAs, so a content-mutating tool can't drive a write into
+    /// one. Archived courses are already hidden from the MCP listing/resource
+    /// surface (`enrolledCourses`), so this closes the by-public-ID write path
+    /// an agent could still reach with a remembered id (#417, follow-up to
+    /// Slice A — `set_assignment_course_section`).
+    func authorizedAssignmentForWrite(publicID: String, tool: String) async throws -> APIAssignment {
+        let assignment = try await authorizedAssignment(publicID: publicID, tool: tool)
+        let user = try await requireEligibleSubject(tool: tool)
+        guard !user.isAdmin else { return assignment }
+        guard let course = try await APICourse.find(assignment.courseID, on: db) else {
+            throw MCPToolError.invalidArguments(
+                tool: tool, detail: "The assignment's course could not be found.")
+        }
+        guard !course.isArchived else {
+            throw MCPToolError.notAuthorized(
+                tool: tool, detail: "This course is archived and is read-only.")
+        }
+        return assignment
+    }
+
     /// Resolves and authorizes the assignment, then loads its test setup,
     /// throwing the standard `invalidArguments` error if the setup is missing.
     func authorizedAssignmentAndSetup(

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
@@ -81,7 +81,7 @@ extension InstructorDashboardRoutes {
         }
 
         let user = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         let assignmentIDRaw = assignment.publicID
         guard
             let submissionID = req.parameters.get("submissionID"),
@@ -129,7 +129,7 @@ extension InstructorDashboardRoutes {
     @Sendable
     func retestAllSubmissions(req: Request) async throws -> Response {
         let user = try req.auth.require(APIUser.self)
-        let (assignment, setup) = try await loadAssignmentAndSetup(req)
+        let (assignment, setup) = try await loadAssignmentAndSetupForWrite(req)
         let assignmentIDRaw = assignment.publicID
 
         let count = try await retestAllSubmissionsForSetup(
@@ -191,7 +191,7 @@ extension InstructorDashboardRoutes {
         }
 
         let user = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         let assignmentIDRaw = assignment.publicID
         guard let studentIDRaw = req.parameters.get("studentID"),
             let studentID = UUID(uuidString: studentIDRaw)
@@ -262,7 +262,7 @@ extension InstructorDashboardRoutes {
         }
 
         let actor = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         let assignmentIDRaw = assignment.publicID
         let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
         guard let studentUUID = student.id else {
@@ -313,7 +313,7 @@ extension InstructorDashboardRoutes {
         struct DeleteBody: Content { var returnTo: String? }
 
         _ = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         let assignmentIDRaw = assignment.publicID
         let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
         guard let studentUUID = student.id else {

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -277,7 +277,12 @@ struct InstructorDashboardRoutes: RouteCollection {
     /// re-validate before opening.
     @Sendable
     func cloneAssignment(req: Request) async throws -> Response {
-        let (source, sourceSetup) = try await loadAssignmentAndSetup(req)
+        // Write-scoped to the source's own course: cloning creates a new
+        // assignment in that course, so a clone of an archived course's
+        // assignment is a write to an archived course and is blocked for
+        // non-admins (#417, follow-up to Slice A — "clone reads from a
+        // possibly-archived source").
+        let (source, sourceSetup) = try await loadAssignmentAndSetupForWrite(req)
         let cloned = try await AssignmentAuthoringService.cloneAssignment(
             source: source,
             sourceSetup: sourceSetup,

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -345,7 +345,7 @@ extension StudentCourseRoutes {
     @Sendable
     func retestStudentAssignment(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "retest student submissions")
+            req: req, action: "retest student submissions", requireWrite: true)
         let (actor, student, assignment) = (action.actor, action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
 
@@ -386,7 +386,7 @@ extension StudentCourseRoutes {
     @Sendable
     func resetStudentAssignmentNotebook(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "reset student notebooks")
+            req: req, action: "reset student notebooks", requireWrite: true)
         let (actor, student, assignment) = (action.actor, action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
         guard let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db) else {
@@ -428,7 +428,7 @@ extension StudentCourseRoutes {
         }
 
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "grant deadline extensions")
+            req: req, action: "grant deadline extensions", requireWrite: true)
         let (actor, student) = (action.actor, action.student)
         let assignmentIDRaw = action.assignment.publicID
         let studentUUID = action.studentID
@@ -490,7 +490,7 @@ extension StudentCourseRoutes {
     @Sendable
     func deleteStudentAssignmentExtension(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "revoke deadline extensions")
+            req: req, action: "revoke deadline extensions", requireWrite: true)
         let student = action.student
         let assignmentIDRaw = action.assignment.publicID
         let studentUUID = action.studentID
@@ -529,7 +529,7 @@ extension StudentCourseRoutes {
         }
 
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "override grades")
+            req: req, action: "override grades", requireWrite: true)
         let (actor, student, assignment) = (action.actor, action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
         let studentUUID = action.studentID
@@ -574,7 +574,7 @@ extension StudentCourseRoutes {
     @Sendable
     func deleteStudentAssignmentGradeOverride(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "clear grade overrides")
+            req: req, action: "clear grade overrides", requireWrite: true)
         let (student, assignment) = (action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
         let studentUUID = action.studentID
@@ -656,18 +656,28 @@ extension StudentCourseRoutes {
     /// (history page, retest, notebook reset, extension save/delete, grade
     /// override save/delete).
     ///
-    /// Note on the role check: these routes are registered under
-    /// `RoleMiddleware(required: .instructor)` (routes.swift), so the
-    /// `isInstructor` guard here is redundant — it is kept once, in this
-    /// helper, as defense-in-depth in case the route grouping ever changes.
-    /// `action` carries each handler's original forbidden-message wording.
+    /// Note on the role check: these routes are registered under the
+    /// `/instructor` group's `ActiveCourseInstructorMiddleware` (routes.swift),
+    /// which gates on instructor authority in the caller's *active* course. The
+    /// `isInstructor` guard here is defense-in-depth in case the route grouping
+    /// ever changes. `action` carries each handler's original forbidden-message
+    /// wording.
+    ///
+    /// `requireWrite` adds a per-course write authorization on the assignment's
+    /// **own** course (`requireCourseWriteAccess`: per-course instructor, admin
+    /// bypass, archived-course block). The mutating handlers pass `true` so a
+    /// retest / reset / extension / grade-override can't be driven against an
+    /// archived course — or a course the caller only instructs *elsewhere* — by
+    /// URL, which the active-course group gate can't see (#417, follow-up to
+    /// Slice A). The read-only history page leaves it `false` so archived
+    /// courses stay auditable.
     ///
     /// Error semantics match the guard chain each handler previously
     /// inlined: `notFound("Assignment '<id>'")` when the assignment is
     /// missing, belongs to a different course, or (unreachable for a
     /// DB-loaded model) the student row has no id.
     fileprivate func resolveStudentAssignmentAction(
-        req: Request, action: String
+        req: Request, action: String, requireWrite: Bool = false
     ) async throws -> StudentAssignmentActionContext {
         let actor = try req.auth.require(APIUser.self)
         guard actor.isInstructor else {
@@ -677,6 +687,10 @@ extension StudentCourseRoutes {
         let assignment = try await loadAssignment(req)
         guard assignment.courseID == course.id, let studentID = student.id else {
             throw WebAssignmentError.notFound(resource: "Assignment '\(assignment.publicID)'")
+        }
+        if requireWrite {
+            try await requireCourseWriteAccess(
+                caller: actor, courseID: assignment.courseID, db: req.db)
         }
         return StudentAssignmentActionContext(
             actor: actor, course: course, student: student,

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -73,6 +73,20 @@ func loadAssignmentAndSetupForWrite(_ req: Request) async throws -> (APIAssignme
     return (assignment, setup)
 }
 
+/// Write-authorizing sibling of `loadAssignment(_:)`, for handlers that mutate
+/// per-course state but never touch the test setup (retest, grade override,
+/// notebook reset). Same `requireCourseWriteAccess` gate as
+/// `loadAssignmentAndSetupForWrite` — scoping the write to the assignment's
+/// **own** course closes the archived-course and cross-course write paths the
+/// `ActiveCourseInstructorMiddleware` group gate (which only inspects the
+/// caller's *active* course) can't see (#417, follow-up to Slice A).
+func loadAssignmentForWrite(_ req: Request) async throws -> APIAssignment {
+    let assignment = try await loadAssignment(req)
+    let caller = try req.auth.require(APIUser.self)
+    try await requireCourseWriteAccess(caller: caller, courseID: assignment.courseID, db: req.db)
+    return assignment
+}
+
 /// Loads a draft test setup from the `?draftID=<id>` query parameter.
 /// The draft model is just an `APITestSetup` row that hasn't been
 /// linked to an `APIAssignment` yet — same row shape, no parent.

--- a/Tests/APITests/ArchivedCourseStudentActionRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseStudentActionRouteTests.swift
@@ -1,0 +1,121 @@
+// Tests/APITests/ArchivedCourseStudentActionRouteTests.swift
+//
+// Route-level coverage for the archived-course write block on the per-student
+// instructor actions (#417, follow-up to Slice A). Slice A wired the assignment
+// *editor* mutations through `loadAssignmentAndSetupForWrite`; the per-student
+// dashboard actions (retest, grade override, notebook reset) and the clone
+// endpoint were explicitly deferred because they resolve their course
+// differently. This slice closes that gap: those handlers now authorize against
+// the *assignment's own* course via `requireCourseWriteAccess`, so a per-course
+// instructor can neither retest into an archived course nor drive the action
+// against another course by URL — the `/instructor` group middleware only sees
+// the caller's *active* course, so it can't catch either.
+//
+// `POST /instructor/:assignmentID/retest` (retest-all) stands in for the family:
+// every patched handler shares the same `requireCourseWriteAccess` gate, so one
+// route-level proof plus the helper-level matrix in `CourseEnrollmentRoleTests`
+// covers the behaviour without re-staging student submissions per endpoint.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class ArchivedCourseStudentActionRouteTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-archived-sa")
+    }
+
+    /// Creates a course + test setup + published assignment and returns the
+    /// course UUID and the assignment's public ID.
+    private func makeCourseAssignment(
+        code: String, archived: Bool, enrollmentMode: CourseEnrollmentMode
+    ) async throws -> (courseID: UUID, assignmentID: String) {
+        let courseID = UUID()
+        let course = APICourse(id: courseID, code: code, name: code, enrollmentMode: enrollmentMode)
+        course.isArchived = archived
+        try await course.save(on: app.db)
+
+        let setupID = "asa_\(UUID().uuidString.prefix(8))"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        try arMakeZip(at: zipPath, entries: [(".placeholder", "x"), ("publictest_a.py", "passed('a')\n")])
+        let manifest = """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.py"}],"timeLimitSeconds":10,"makefile":null}
+            """
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: code,
+            dueAt: nil, isOpen: true, deadlineOverrideActive: false, courseID: courseID
+        )
+        try await assignment.save(on: app.db)
+        return (courseID, assignment.publicID)
+    }
+
+    /// A per-course instructor whose *active* course is a normal (non-archived)
+    /// course may retest that course's assignment, but a retest-all aimed by URL
+    /// at an *archived* course they also instruct is rejected with 403. The
+    /// active-course retest succeeding in the same test confirms the setup is
+    /// sound, so the archived 403 is attributable to the archived block — not a
+    /// stray middleware denial.
+    @Test func retestAll_blockedOnArchivedCourseEvenForItsInstructor() async throws {
+        try await withApp(app) { _ in
+            // Active, non-archived course (.auto → the instructor auto-enrols as
+            // a per-course instructor and it becomes their active course).
+            let active = try await makeCourseAssignment(
+                code: "ASAX", archived: false, enrollmentMode: .auto)
+            // Archived course with an assignment; the same instructor is enrolled
+            // here as a per-course instructor.
+            let archived = try await makeCourseAssignment(
+                code: "ASAY", archived: true, enrollmentMode: .closed)
+
+            let cookie = try await loginUser(
+                username: "asa_inst", password: "pw", role: "instructor", on: app)
+            let user = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "asa_inst").first())
+            try await APICourseEnrollment(
+                userID: try user.requireID(), courseID: archived.courseID, role: .instructor
+            ).save(on: app.db)
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
+
+            // Sanity: retesting the active (non-archived) course's assignment
+            // works (redirects back).
+            try await app.asyncTest(
+                .POST, "/instructor/\(active.assignmentID)/retest",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = ByteBuffer(string: "")
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .seeOther,
+                        "active-course retest should succeed: \(res.status) \(res.body.string)")
+                })
+
+            // The block: retesting the archived course's assignment by URL is 403.
+            try await app.asyncTest(
+                .POST, "/instructor/\(archived.assignmentID)/retest",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = ByteBuffer(string: "")
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "archived-course retest must be blocked, got \(res.status): \(res.body.string)")
+                })
+        }
+    }
+}

--- a/Tests/APITests/MCP/CourseSectionToolsTests.swift
+++ b/Tests/APITests/MCP/CourseSectionToolsTests.swift
@@ -146,6 +146,33 @@ import Vapor
         }
     }
 
+    /// Archived courses are read-only for instructors (#417, follow-up to Slice
+    /// A): the by-public-ID move is blocked even for the course's own instructor,
+    /// and the assignment stays ungrouped because the rejected write never ran.
+    /// Archived courses are already hidden from the MCP listing surface, so this
+    /// closes the remaining remembered-id write path.
+    @Test func setAssignmentSectionBlockedOnArchivedCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let fx = try await fixture(on: app)
+            let courseID = try fx.course.requireID()
+            let section = try await makeSection(
+                on: app, name: "Labs", mode: "worker", order: 1, courseID: courseID)
+            fx.course.isArchived = true
+            try await fx.course.save(on: app.db)
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetAssignmentCourseSectionTool().execute(
+                    .init(
+                        assignmentPublicID: fx.assignment.publicID,
+                        courseSectionID: try section.requireID().uuidString), context(app))
+            }
+            // The blocked write didn't persist: the assignment is still ungrouped.
+            let reloaded = try #require(try await APIAssignment.find(fx.assignment.id, on: app.db))
+            #expect(reloaded.sectionID == nil)
+        }
+    }
+
     @Test func setAssignmentSectionRejectsForeignSection() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/SpaceCourseCodeCSRFTests.swift
+++ b/Tests/APITests/SpaceCourseCodeCSRFTests.swift
@@ -26,6 +26,19 @@ import VaporTesting
             try await course.save(on: app.db)
             let courseID = try course.requireID()
 
+            // Granting an extension is a per-course write, so the acting
+            // instructor must hold an instructor enrollment in *this* course
+            // (#417 — authorization is scoped to the resource's own course, not
+            // the caller's active course). `arLoginAsInstructor` only enrols
+            // them in the AR test course, so enrol them here too; the test is
+            // about the spaced course code round-tripping CSRF, not about
+            // cross-course access.
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "testinstructor").first())
+            try await APICourseEnrollment(
+                userID: try instructor.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
+
             let student = try await arInsertStudent(username: "spaced_student", on: app)
             try await APICourseEnrollment(userID: try student.requireID(), courseID: courseID)
                 .save(on: app.db)

--- a/changelog.d/417-slice-c-archived-student-actions.md
+++ b/changelog.d/417-slice-c-archived-student-actions.md
@@ -1,0 +1,14 @@
+### Security
+
+- **Block writes to archived courses: per-student instructor actions, clone, and
+  `set_assignment_course_section` (#417, follow-up to Slice A).** Slice A wired
+  the assignment *editor* mutations through `requireCourseWriteAccess` but
+  explicitly deferred the per-student dashboard actions (retest, retest-all,
+  notebook reset, grade-override save/delete), their per-course-student-page
+  twins (plus deadline extensions), the assignment **clone** endpoint, and the
+  MCP `set_assignment_course_section` tool because they resolve their course
+  differently. Those handlers now authorize against the *assignment's own*
+  course, so a per-course instructor can no longer retest/override/reset/clone
+  into an **archived** course — or drive any of those against a *different*
+  course by URL — which the active-course group middleware can't see. Admins
+  remain exempt; read paths (history, audits) stay readable on archived courses.


### PR DESCRIPTION
## Summary

Third slice of #417 (per-course roles). Closes the archived-course / cross-course **write** gaps that Slice A (#1063) explicitly deferred:

> Instructor-dashboard student actions (retest, grade override, notebook reset) and `set_assignment_course_section` also mutate per-course state but resolve their course differently (and clone *reads* from a possibly-archived source); they're left for a focused follow-up rather than a blanket swap.

This is that focused follow-up. Each handler now authorizes against the **assignment's own** course via `requireCourseWriteAccess` (per-course instructor, admin bypass, archived-course block) — the same chokepoint Slice A wired into the assignment editor. The `/instructor` group middleware (`ActiveCourseInstructorMiddleware`) only inspects the caller's *active* course, so it can catch neither an archived target nor a cross-course write driven by URL; this is the layer that does.

### What changed

- **Dashboard per-student actions** (`InstructorDashboardRoutes+StudentActions`): `retestSubmission`, `retestAllSubmissions`, `resetStudentNotebook`, `saveStudentGradeOverride`, `deleteStudentGradeOverride`. New `loadAssignmentForWrite(_:)` — a write-authorizing sibling of `loadAssignmentAndSetupForWrite` for handlers that never touch the test setup.
- **Per-course-student-page twins + deadline extensions** (`StudentCourseRoutes+History`): a `requireWrite` flag on the shared `resolveStudentAssignmentAction` preamble, passed `true` by the six mutating handlers (retest, notebook reset, extension save/delete, grade-override save/delete). The read-only history page keeps the default `false`, so archived courses stay auditable.
- **Assignment clone** (`cloneAssignment`): switched to `loadAssignmentAndSetupForWrite`. Cloning creates a new assignment in the source's course, so a clone of an archived course's assignment is a write into an archived course.
- **MCP `set_assignment_course_section`**: new `ToolContext.authorizedAssignmentForWrite` adds the archived block (admin-exempt). Archived courses are already hidden from the MCP listing/resource surface, so this closes the remaining remembered-public-ID write path.

Read paths (history, audits, downloads) are untouched — archived courses stay readable. Admins remain write-exempt everywhere.

## Tests

- `ArchivedCourseStudentActionRouteTests.retestAll_blockedOnArchivedCourseEvenForItsInstructor` — route-level: a per-course instructor retests their *active* (non-archived) course's assignment (303 redirect), but a retest-all aimed by URL at an *archived* course they also instruct returns 403. The active success in the same test attributes the archived 403 to the block, not a stray middleware denial. Mirrors Slice A's `ArchivedCourseWriteRouteTests`.
- `CourseSectionToolsTests.setAssignmentSectionBlockedOnArchivedCourse` — MCP-level: the move is blocked for the course's own instructor and the assignment stays ungrouped (the rejected write never ran).

## Out of scope (noted for follow-up)

- The remaining non-per-student dashboard mutations not in Slice A's deferred list: open/close/status, delete, and the BrightSpace grade-item mapping. These have distinct semantics (e.g. unarchive/open) and weren't enumerated; a separate pass.
- Extending the archived-write block across the *other* MCP content-write tools (`update_suite`, `author_script`, …). The reusable `authorizedAssignmentForWrite` helper is in place; this slice wires only the named `set_assignment_course_section`, matching Slice A's deferred list. Lower urgency since archived courses are already absent from the MCP listing surface.

## Notes

- No `VERSION` / `CHANGELOG.md` edit; a `changelog.d/` fragment is included per the release process.
- `swift-format lint` is clean on all changed files. SwiftPM dependencies can't be fetched in the authoring sandbox, so the full `swift build` + tests + SwiftLint run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_