### PR TITLE
feat(brightspace): auto-retry transient sync failures, failure alert, grade rounding

### DIFF
--- a/Sources/APIServer/Services/AlertNotifier.swift
+++ b/Sources/APIServer/Services/AlertNotifier.swift
@@ -7,6 +7,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
     case errorRateSpike
     case editorKernelUnrecoverable
     case databaseUnreachable
+    case brightspaceSyncFailing
 
     var humanReadable: String {
         switch self {
@@ -15,6 +16,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
         case .errorRateSpike: return "System-level failure rate spike"
         case .editorKernelUnrecoverable: return "Editor kernel unrecoverable"
         case .databaseUnreachable: return "Database unreachable"
+        case .brightspaceSyncFailing: return "BrightSpace grade sync failing"
         }
     }
 
@@ -25,6 +27,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
         case .queueBackedUp: return "warning"
         case .errorRateSpike: return "warning"
         case .editorKernelUnrecoverable: return "warning"
+        case .brightspaceSyncFailing: return "warning"
         }
     }
 }

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -337,22 +337,49 @@ private func chunkedForInFilter<T>(_ items: [T]) -> [[T]] {
 
 // MARK: - Per-group push
 
-/// Marks every row in a failed group the way the single-result error path
-/// did: flag cleared, error recorded, push retried on the next pending cycle.
+/// True when a push failure is worth retrying automatically — a transient D2L
+/// or transport hiccup — versus a terminal failure that will keep failing until
+/// a human intervenes (a bad request, a missing account, no parseable grade).
+///
+/// HTTP 408/425/429 and 5xx are transient; other 4xx are terminal. A
+/// `missingPoints`/lookup `BrightSpaceSyncError` is terminal (the grade or item
+/// won't fix itself on retry). Anything else — a raw transport/NIO error from
+/// the signed request — is treated as transient.
+func isRetryableSyncError(_ error: Error) -> Bool {
+    if let syncError = error as? BrightSpaceSyncError {
+        switch syncError {
+        case .gradePushFailed(let status, _):
+            return [408, 425, 429, 500, 502, 503, 504].contains(status)
+        default:
+            // missingPoints / userLookupFailed / orgUnitLookupFailed /
+            // gradeObjectsFetchFailed — none retry into success on their own.
+            return false
+        }
+    }
+    // Non-BrightSpaceSyncError: a transport/timeout error from the HTTP call.
+    return true
+}
+
+/// Records a failed group. A transient (retryable) failure keeps the pending
+/// flag set so the next sweep re-attempts it automatically; a terminal failure
+/// clears the flag and waits for a manual "Retry failed". Either way the error
+/// detail is recorded and the synced timestamp cleared.
 private func recordSweepFailure(
     _ rows: [any BrightSpaceSyncFlaggable],
     error: Error,
     db: Database,
     logger: Logger
 ) async {
+    let retryable = isRetryableSyncError(error)
     for row in rows {
-        row.brightspaceSyncPending = false
+        row.brightspaceSyncPending = retryable
         row.brightspaceSyncedAt = nil
         row.brightspaceSyncError = error.localizedDescription
         try? await row.save(on: db)
     }
     let ids = rows.map(\.brightspaceSyncRowID).joined(separator: ", ")
-    logger.warning("BrightSpace grade sync failed for row(s) \(ids): \(error)")
+    logger.warning(
+        "BrightSpace grade sync \(retryable ? "transient" : "terminal") failure for row(s) \(ids): \(error)")
 }
 
 /// Clears the pending flag on every row in the group (the "nothing to
@@ -539,11 +566,17 @@ private func scaledGradePush(
     // Scale Chickadee's grade onto the D2L item's own max when both totals are
     // known (e.g. a /14 suite into a /10 LEARN item). When the item's max is
     // unknown or already equals the suite total, this is the identity, so the
-    // pushed value is unchanged.
+    // pushed value is unchanged. The result is rounded to 2 decimals so the
+    // gradebook shows a clean value (8.57) rather than 8.571428571…
     if let total = grade.total, total > 0, let maxPoints = gradeObject?.maxPoints, maxPoints > 0 {
-        return (grade.points / total * maxPoints, gradeObject, nil)
+        return (roundedGradePoints(grade.points / total * maxPoints), gradeObject, nil)
     }
-    return (grade.points, gradeObject, nil)
+    return (roundedGradePoints(grade.points), gradeObject, nil)
+}
+
+/// Rounds a grade value to 2 decimal places for the LEARN gradebook.
+private func roundedGradePoints(_ value: Double) -> Double {
+    (value * 100).rounded() / 100
 }
 
 /// Resolves the student's D2L user ID via the course classlist (cached per

--- a/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
@@ -24,6 +24,12 @@ struct ServerHealthAlertConfiguration: Sendable {
     /// students who are actually stuck.
     let editorUnrecoverableThreshold: Int
     let editorUnrecoverableWindowMinutes: Int
+    /// BrightSpace-sync-failing rule: fire when at least
+    /// `brightspaceSyncFailureThreshold` grade-push errors land in the
+    /// `brightspace_sync_log` within the last `brightspaceSyncFailureWindowMinutes`
+    /// — grades have stopped flowing to LEARN and need a human to look.
+    let brightspaceSyncFailureThreshold: Int
+    let brightspaceSyncFailureWindowMinutes: Int
     let webhookURLFromEnvironment: String?
 
     static let `default` = ServerHealthAlertConfiguration(
@@ -38,6 +44,8 @@ struct ServerHealthAlertConfiguration: Sendable {
         errorRateMinimumSamples: 10,
         editorUnrecoverableThreshold: 2,
         editorUnrecoverableWindowMinutes: 60,
+        brightspaceSyncFailureThreshold: 3,
+        brightspaceSyncFailureWindowMinutes: 60,
         webhookURLFromEnvironment: nil
     )
 
@@ -56,6 +64,9 @@ struct ServerHealthAlertConfiguration: Sendable {
                 ?? environmentInt("ALERT_EDITOR_HANG_THRESHOLD") ?? 2,
             editorUnrecoverableWindowMinutes: environmentInt("ALERT_EDITOR_UNRECOVERABLE_WINDOW_MINUTES")
                 ?? environmentInt("ALERT_EDITOR_HANG_WINDOW_MINUTES") ?? 60,
+            brightspaceSyncFailureThreshold: environmentInt("ALERT_BRIGHTSPACE_SYNC_FAILURE_THRESHOLD") ?? 3,
+            brightspaceSyncFailureWindowMinutes: environmentInt(
+                "ALERT_BRIGHTSPACE_SYNC_FAILURE_WINDOW_MINUTES") ?? 60,
             webhookURLFromEnvironment: trimmedEnv("ALERT_WEBHOOK_URL")
         )
     }

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -51,6 +51,12 @@ func evaluateHealthRules(
             configuration: configuration,
             now: now
         )) ?? .ok
+    results[.brightspaceSyncFailing] =
+        (try? await evaluateBrightspaceSyncFailing(
+            on: application,
+            configuration: configuration,
+            now: now
+        )) ?? .ok
 
     return results
 }
@@ -285,6 +291,53 @@ enum JobFailureClassification {
             return false
         }
     }
+}
+
+/// Decides the BrightSpace-sync-failing rule purely from a recent error count,
+/// so the firing threshold is table-testable without a database. Fire when at
+/// least `threshold` grade-push errors landed inside the window — grades have
+/// stopped reaching LEARN. `lastDetail` (the most recent D2L error) is surfaced
+/// as context when present.
+func decideBrightspaceSyncFailing(
+    errorCount: Int,
+    threshold: Int,
+    windowMinutes: Int,
+    lastDetail: String?
+) -> RuleEvaluation {
+    guard threshold > 0, errorCount >= threshold else { return .ok }
+    var details: [String: String] = [
+        "error_count": String(errorCount),
+        "window_minutes": String(windowMinutes),
+        "threshold": String(threshold),
+    ]
+    if let lastDetail, !lastDetail.isEmpty { details["last_error"] = lastDetail }
+    let suffix = (lastDetail?.isEmpty == false) ? " (latest: \(lastDetail ?? ""))" : ""
+    return RuleEvaluation(
+        isFiring: true,
+        summary:
+            "\(errorCount) BrightSpace grade push(es) failed in the last \(windowMinutes)m "
+            + "(threshold \(threshold))\(suffix)",
+        details: details
+    )
+}
+
+private func evaluateBrightspaceSyncFailing(
+    on application: Application,
+    configuration: ServerHealthAlertConfiguration,
+    now: Date
+) async throws -> RuleEvaluation {
+    let windowStart = now.addingTimeInterval(-Double(configuration.brightspaceSyncFailureWindowMinutes) * 60)
+    let errored = try await APIBrightSpaceSyncLog.query(on: application.db)
+        .filter(\.$status == APIBrightSpaceSyncLog.Status.error.rawValue)
+        .filter(\.$attemptedAt >= windowStart)
+        .sort(\.$attemptedAt, .descending)
+        .all()
+    return decideBrightspaceSyncFailing(
+        errorCount: errored.count,
+        threshold: configuration.brightspaceSyncFailureThreshold,
+        windowMinutes: configuration.brightspaceSyncFailureWindowMinutes,
+        lastDetail: errored.first?.detail
+    )
 }
 
 private func evaluateDatabaseUnreachable(on application: Application) async -> RuleEvaluation {

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -630,16 +630,21 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
-    @Test func isRetryableSyncErrorClassification() {
-        #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 503, body: "")))
-        #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 429, body: "")))
-        #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 500, body: "")))
-        #expect(!isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 400, body: "")))
-        #expect(!isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 403, body: "")))
-        #expect(!isRetryableSyncError(BrightSpaceSyncError.missingPoints))
-        // A non-BrightSpace error (transport/timeout) is treated as transient.
-        struct TransportError: Error {}
-        #expect(isRetryableSyncError(TransportError()))
+    @Test func isRetryableSyncErrorClassification() async throws {
+        // This class suite builds an Application per instance; wrap in withApp
+        // so it shuts down deterministically (an un-shutdown app traps in
+        // ServeCommand.deinit), even though the assertions are pure.
+        try await withApp(app) { _ in
+            #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 503, body: "")))
+            #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 429, body: "")))
+            #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 500, body: "")))
+            #expect(!isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 400, body: "")))
+            #expect(!isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 403, body: "")))
+            #expect(!isRetryableSyncError(BrightSpaceSyncError.missingPoints))
+            // A non-BrightSpace error (transport/timeout) is treated as transient.
+            struct TransportError: Error {}
+            #expect(isRetryableSyncError(TransportError()))
+        }
     }
 
     @Test func scaledGradeIsRoundedToTwoDecimals() async throws {

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -583,7 +583,9 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
-    @Test func pushFailureRecordsErrorOnResult() async throws {
+    @Test func transientPushFailureKeepsRowPendingForAutoRetry() async throws {
+        // A 503 is transient — the row stays pending so the next sweep retries
+        // automatically, without a manual "Retry failed".
         try await withApp(app) { _ in
             let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
             try await makePendingResult(
@@ -599,8 +601,66 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
 
             #expect(processed == 0)
             let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncPending == true)  // stays queued for retry
             #expect(result.brightspaceSyncError != nil)
             #expect(result.brightspaceSyncedAt == nil)
+        }
+    }
+
+    @Test func terminalPushFailureClearsPendingFlag() async throws {
+        // A 400 is terminal — retrying won't help, so the flag clears and the
+        // row waits for a manual "Retry failed" after the cause is fixed.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 7, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                pushError: BrightSpaceSyncError.gradePushFailed(status: 400, body: "bad request")
+            )
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 0)
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncPending == false)  // not retried automatically
+            #expect(result.brightspaceSyncError != nil)
+        }
+    }
+
+    @Test func isRetryableSyncErrorClassification() {
+        #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 503, body: "")))
+        #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 429, body: "")))
+        #expect(isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 500, body: "")))
+        #expect(!isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 400, body: "")))
+        #expect(!isRetryableSyncError(BrightSpaceSyncError.gradePushFailed(status: 403, body: "")))
+        #expect(!isRetryableSyncError(BrightSpaceSyncError.missingPoints))
+        // A non-BrightSpace error (transport/timeout) is treated as transient.
+        struct TransportError: Error {}
+        #expect(isRetryableSyncError(TransportError()))
+    }
+
+    @Test func scaledGradeIsRoundedToTwoDecimals() async throws {
+        // 6/7 of a /7 suite onto a /10 item = 8.571428…, which must land as 8.57.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 6, total: 7),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                gradeObject: BrightSpaceGradeObject(
+                    id: "go-456", name: "Lab", maxPoints: 10, gradeType: "Numeric", canExceed: false))
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)
+            let pushes = await fake.pushes
+            let pushed = try #require(pushes.first?.earnedPoints)
+            #expect(abs(pushed - 8.57) < 0.0001)
         }
     }
 }

--- a/Tests/APITests/ServerHealthAlertTests.swift
+++ b/Tests/APITests/ServerHealthAlertTests.swift
@@ -270,6 +270,29 @@ import Testing
         #expect(evaluation.isFiring == false)
     }
 
+    // MARK: - decideBrightspaceSyncFailing
+
+    @Test func brightspaceSyncFailing_firesAtThreshold() {
+        let evaluation = decideBrightspaceSyncFailing(
+            errorCount: 3, threshold: 3, windowMinutes: 60, lastDetail: "HTTP 503")
+        #expect(evaluation.isFiring)
+        #expect(evaluation.details["error_count"] == "3")
+        #expect(evaluation.details["last_error"] == "HTTP 503")
+        #expect(evaluation.summary.contains("503"))
+    }
+
+    @Test func brightspaceSyncFailing_okBelowThreshold() {
+        let evaluation = decideBrightspaceSyncFailing(
+            errorCount: 2, threshold: 3, windowMinutes: 60, lastDetail: nil)
+        #expect(evaluation.isFiring == false)
+    }
+
+    @Test func brightspaceSyncFailing_okWhenThresholdDisabled() {
+        let evaluation = decideBrightspaceSyncFailing(
+            errorCount: 99, threshold: 0, windowMinutes: 60, lastDetail: nil)
+        #expect(evaluation.isFiring == false)
+    }
+
     // MARK: - JobFailureClassification
 
     @Test func jobFailureClassification_studentTestErrorIsNotSystemFailure() {

--- a/changelog.d/brightspace-sync-reliability.md
+++ b/changelog.d/brightspace-sync-reliability.md
@@ -1,0 +1,18 @@
+### Added
+
+- **BrightSpace grade sync auto-retries transient failures.** A push that fails
+  on a transient D2L/transport hiccup (HTTP 408/425/429/5xx or a network error)
+  now stays queued and is re-attempted on the next sweep automatically; only
+  terminal failures (a 4xx, a missing student account, no parseable grade) clear
+  the flag and wait for a manual "Retry failed". Previously every failure waited
+  for a manual retry.
+- **Health alert when grade sync starts failing.** A new `brightspaceSyncFailing`
+  alert fires when at least `ALERT_BRIGHTSPACE_SYNC_FAILURE_THRESHOLD` (default 3)
+  grade pushes fail within `ALERT_BRIGHTSPACE_SYNC_FAILURE_WINDOW_MINUTES`
+  (default 60), surfacing the latest D2L error — so an operator knows grades
+  stopped flowing without watching the dashboard.
+
+### Fixed
+
+- **Pushed grades are rounded to 2 decimals** so a scaled value lands as `8.57`
+  in the LEARN gradebook instead of `8.571428571…`.


### PR DESCRIPTION
## Why

First of the BrightSpace prod-hardening PRs (pilot scope: one real course this term). Reliability + correctness before trusting real grades.

## What changed

**1. Auto-retry transient failures (the key reliability fix).** Previously *any* failed push cleared its pending flag and sat until someone clicked "Retry failed" — so a transient D2L blip (timeout, 5xx, 429, clock-skew) silently stalled grades. Now `recordSweepFailure` classifies the error (`isRetryableSyncError`): transient failures (HTTP 408/425/429/5xx or a raw transport/timeout error) **stay pending** and re-attempt on the next 60s sweep; terminal failures (4xx, missing account, no parseable grade) clear the flag and wait for a manual retry, as before.

**2. Health alert on sync failures.** New `brightspaceSyncFailing` `HealthRule` fires when ≥ `ALERT_BRIGHTSPACE_SYNC_FAILURE_THRESHOLD` (default 3) grade pushes fail within `ALERT_BRIGHTSPACE_SYNC_FAILURE_WINDOW_MINUTES` (default 60), surfacing the latest D2L error. Wired into the existing `evaluateHealthRules`/`AlertNotifier` pipeline; pure `decideBrightspaceSyncFailing` is table-tested.

**3. Round pushed grades to 2 decimals** so a scaled value lands as `8.57` in the LEARN gradebook, not `8.571428571…`.

## Tests
- `transientPushFailureKeepsRowPendingForAutoRetry` / `terminalPushFailureClearsPendingFlag` — the retry distinction end-to-end.
- `isRetryableSyncErrorClassification` — the classifier.
- `scaledGradeIsRoundedToTwoDecimals` — 6/7 onto a /10 item → 8.57.
- `brightspaceSyncFailing_firesAtThreshold` / below / disabled — the alert decision.

## Notes
- Alerting only fires when `ALERT_ENABLED=true` and a webhook is configured; defaults are conservative.
- `swift-format` + lint pass locally; CI compiles/runs the suite (deps are egress-blocked here).
- One `changelog.d/` fragment; no `VERSION`/`CHANGELOG.md` edits.

Part of the BrightSpace prod-readiness series (PR 1 of 3: reliability batch). Next: bidirectional grade clearing, then instructor observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_