### PR TITLE
feat(brightspace): remove the LEARN grade when its Chickadee source is removed

### DIFF
--- a/Sources/APIServer/Migrations/CreateBrightSpaceGradeClears.swift
+++ b/Sources/APIServer/Migrations/CreateBrightSpaceGradeClears.swift
@@ -1,0 +1,35 @@
+// APIServer/Migrations/CreateBrightSpaceGradeClears.swift
+//
+// Queue of pending BrightSpace grade removals — one row per (test_setup, user)
+// whose Chickadee grade source was removed (an override cleared on a student
+// with no submissions) after Chickadee had pushed a grade.  The grade-sync
+// sweep DELETEs the D2L grade value and removes the row.
+
+import Fluent
+import SQLKit
+
+struct CreateBrightSpaceGradeClears: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("brightspace_grade_clears")
+            .id()
+            .field(
+                "test_setup_id", .string, .required,
+                .references("test_setups", "id", onDelete: .cascade)
+            )
+            .field(
+                "user_id", .uuid, .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field("brightspace_sync_pending", .bool)
+            .field("brightspace_pending_since", .datetime)
+            .field("brightspace_synced_at", .datetime)
+            .field("brightspace_sync_error", .string)
+            .field("created_at", .datetime)
+            .unique(on: "test_setup_id", "user_id")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("brightspace_grade_clears").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIBrightSpaceGradeClear.swift
+++ b/Sources/APIServer/Models/APIBrightSpaceGradeClear.swift
@@ -1,0 +1,53 @@
+// APIServer/Models/APIBrightSpaceGradeClear.swift
+//
+// A queued request to REMOVE a student's grade from BrightSpace for one test
+// setup.  Enqueued when a (student, assignment) loses its only gradeable source
+// — an instructor clears an override on a student with no submissions — AND
+// Chickadee has previously pushed a grade for it (a `success` row exists in
+// `brightspace_sync_log`).  That "we pushed it" gate is what keeps Chickadee
+// from ever touching a grade an instructor entered by hand in LEARN.
+//
+// One row per (test_setup, user).  The grade-sync sweep processes pending rows
+// with a D2L grade-value DELETE, then removes the row on success.  Carries the
+// same four BrightSpace bookkeeping columns as results/overrides so the sweep's
+// success / failure / retry paths treat it identically.
+
+import Fluent
+import Vapor
+
+final class APIBrightSpaceGradeClear: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request/DB context.
+    static let schema = "brightspace_grade_clears"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    @Field(key: "user_id")
+    var userID: UUID
+
+    @OptionalField(key: "brightspace_sync_pending")
+    var brightspaceSyncPending: Bool?
+
+    @OptionalField(key: "brightspace_pending_since")
+    var brightspacePendingSince: Date?
+
+    @OptionalField(key: "brightspace_synced_at")
+    var brightspaceSyncedAt: Date?
+
+    @OptionalField(key: "brightspace_sync_error")
+    var brightspaceSyncError: String?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(testSetupID: String, userID: UUID) {
+        self.testSetupID = testSetupID
+        self.userID = userID
+        self.brightspaceSyncPending = true
+    }
+}

--- a/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
+++ b/Sources/APIServer/Routes/Web/GradeOverrideHelpers.swift
@@ -94,6 +94,12 @@ func applyGradeOverride(
     row.note = note
     row.grantedByUserID = grantedByUserID
     try await row.save(on: db)
+    // Setting an override (re)establishes a grade — drop any queued removal for
+    // this (student, setup) so the sweep doesn't clear a grade we're pushing.
+    try await APIBrightSpaceGradeClear.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$userID == studentUserID)
+        .delete()
     try await flagOverrideOrResultsPendingSync(
         override: row, testSetupID: testSetupID, studentUserID: studentUserID, on: db)
 }
@@ -119,11 +125,57 @@ func clearGradeOverride(
     try await existing.delete(on: db)
     // Clearing reverts to the runner-computed grade. For a student with
     // submissions that re-flags their results; for a no-submission student
-    // there's nothing to push (override is nil → no-op), so the previously
-    // pushed grade is left as-is in BrightSpace.
+    // there is no runner grade — so if Chickadee previously pushed a grade for
+    // them, queue a removal so the LEARN grade doesn't stay stale.
     try await flagOverrideOrResultsPendingSync(
         override: nil, testSetupID: testSetupID, studentUserID: studentUserID, on: db)
+    try await enqueueGradeClearIfOrphaned(
+        testSetupID: testSetupID, studentUserID: studentUserID, on: db)
     return true
+}
+
+/// Queues a BrightSpace grade removal for a (student, setup) that has lost its
+/// only Chickadee grade source — no student submissions remain — but ONLY when
+/// Chickadee has actually pushed a grade for it (a `success` row in the sync
+/// log). That gate is what keeps Chickadee from ever clearing a grade an
+/// instructor entered by hand in LEARN. A no-op when the student still has
+/// submissions (their runner grade is re-pushed instead) or nothing was synced.
+func enqueueGradeClearIfOrphaned(
+    testSetupID: String,
+    studentUserID: UUID,
+    on db: Database
+) async throws {
+    let hasSubmissions =
+        try await APISubmission.query(on: db)
+        .filter(\.$userID == studentUserID)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .first() != nil
+    guard !hasSubmissions else { return }
+
+    let chickadeePushed =
+        try await APIBrightSpaceSyncLog.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$userID == studentUserID)
+        .filter(\.$status == APIBrightSpaceSyncLog.Status.success.rawValue)
+        .first() != nil
+    guard chickadeePushed else { return }
+
+    let now = Date()
+    if let existing = try await APIBrightSpaceGradeClear.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$userID == studentUserID)
+        .first()
+    {
+        existing.brightspaceSyncPending = true
+        if existing.brightspacePendingSince == nil { existing.brightspacePendingSince = now }
+        existing.brightspaceSyncError = nil
+        try await existing.save(on: db)
+    } else {
+        let row = APIBrightSpaceGradeClear(testSetupID: testSetupID, userID: studentUserID)
+        row.brightspacePendingSince = now
+        try await row.save(on: db)
+    }
 }
 
 /// Marks every result on one student's submissions for a test setup as pending

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -226,6 +226,12 @@ protocol BrightSpaceGrading: Sendable {
     func fetchGradeObject(
         orgUnitID: String, gradeObjectID: String, on application: Application
     ) async throws -> BrightSpaceGradeObject?
+    /// Removes a student's grade value for a grade item (DELETE), used when
+    /// Chickadee's grade source for a (student, assignment) is removed. A 404
+    /// (no value present) is treated as success — the end state is the same.
+    func clearGrade(
+        orgUnitID: String, gradeObjectID: String, bsUserID: String, on application: Application
+    ) async throws
 }
 
 // MARK: - Client
@@ -420,6 +426,26 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
             let bodyLen = bodyBuf?.readableBytes ?? 0
             let bodyText = bodyBuf?.readString(length: bodyLen) ?? ""
             throw BrightSpaceSyncError.gradePushFailed(status: Int(response.status.code), body: bodyText)
+        }
+    }
+
+    /// Removes a student's grade value (DELETE). A 404 means there was no value
+    /// to clear, which is the same end state as a successful delete, so it's
+    /// treated as success.
+    func clearGrade(
+        orgUnitID: String, gradeObjectID: String, bsUserID: String, on application: Application
+    ) async throws {
+        let leVersion = await apiVersion(
+            "le", fallback: BrightSpaceSyncConfig.leAPIVersion, on: application)
+        let rawURL =
+            "\(config.baseURL)/d2l/api/le/\(leVersion)/\(orgUnitID)/grades/\(gradeObjectID)/values/\(bsUserID)"
+        let response = try await sendSigned(method: "DELETE", rawURL: rawURL, on: application)
+        let code = Int(response.status.code)
+        guard (200...299).contains(code) || code == 404 else {
+            var bodyBuf = response.body
+            let bodyLen = bodyBuf?.readableBytes ?? 0
+            let bodyText = bodyBuf?.readString(length: bodyLen) ?? ""
+            throw BrightSpaceSyncError.gradePushFailed(status: code, body: bodyText)
         }
     }
 

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -115,7 +115,150 @@ func sweepBrightSpaceGradeSync(
             await recordSweepFailure(syncRows, error: error, db: db, logger: logger)
         }
     }
+
+    // Pending grade REMOVALS (override cleared on a previously-synced
+    // no-submission student). A push queued for the same (student, setup) this
+    // sweep supersedes the clear, so pass the keys we're about to push.
+    let pushedKeys = Set(targets.map { GradePushKey(userID: $0.userID, testSetupID: $0.testSetupID) })
+    processed += try await processPendingGradeClears(
+        pushedKeys: pushedKeys, cutoff: cutoff, db: db,
+        resolveClient: resolveClient, classlistCache: classlistCache, application: application)
     return processed
+}
+
+/// A queued grade removal plus the rows it needs, pre-resolved from the
+/// sweep-wide batch context.
+private struct GradeClearTarget {
+    let clearRow: APIBrightSpaceGradeClear
+    let assignment: APIAssignment?
+    let course: APICourse?
+    let user: APIUser?
+}
+
+/// Processes pending `brightspace_grade_clears`: DELETEs each student's grade in
+/// D2L and removes the queue row on success. A clear whose (student, setup) is
+/// also being pushed this sweep is dropped (the push wins). Returns the number
+/// of clears completed.
+private func processPendingGradeClears(
+    pushedKeys: Set<GradePushKey>,
+    cutoff: Date,
+    db: Database,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
+    classlistCache: ClasslistUserIDCache,
+    application: Application
+) async throws -> Int {
+    let pending = try await APIBrightSpaceGradeClear.query(on: db)
+        .filter(\.$brightspaceSyncPending == true)
+        .filter(\.$brightspacePendingSince <= cutoff)
+        .all()
+    guard !pending.isEmpty else { return 0 }
+
+    let context = try await loadSyncContextForKeys(
+        setupIDs: pending.map(\.testSetupID), userIDs: pending.map(\.userID), db: db)
+    var processed = 0
+    for clearRow in pending {
+        let key = GradePushKey(userID: clearRow.userID, testSetupID: clearRow.testSetupID)
+        if pushedKeys.contains(key) {
+            // A grade is being (re)pushed for this (student, setup) — drop the clear.
+            try await clearRow.delete(on: db)
+            continue
+        }
+        let assignment = context.assignmentsBySetupID[clearRow.testSetupID]
+        let target = GradeClearTarget(
+            clearRow: clearRow,
+            assignment: assignment,
+            course: assignment.flatMap { context.coursesByID[$0.courseID] },
+            user: context.usersByID[clearRow.userID]
+        )
+        do {
+            let cleared = try await runGradeClear(
+                target: target, resolveClient: resolveClient,
+                classlistCache: classlistCache, db: db, application: application)
+            if cleared { processed += 1 }
+        } catch {
+            await recordSweepFailure([clearRow], error: error, db: db, logger: application.logger)
+        }
+    }
+    return processed
+}
+
+/// Removes one student's grade in D2L. Returns false when deferred (no identity
+/// connected yet) so the row stays pending; true on every terminal outcome
+/// (cleared, or a no-op delete because there was nothing in D2L to clear).
+private func runGradeClear(
+    target: GradeClearTarget,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
+    classlistCache: ClasslistUserIDCache,
+    db: Database,
+    application: Application
+) async throws -> Bool {
+    let clearRow = target.clearRow
+    // Without a configured grade item + org unit there is nothing in D2L to
+    // clear — drop the queue row.
+    guard let assignment = target.assignment,
+        let gradeObjectID = assignment.brightspaceGradeObjectID, !gradeObjectID.isEmpty,
+        let course = target.course,
+        let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty
+    else {
+        try await clearRow.delete(on: db)
+        return true
+    }
+    // A grade source may have reappeared since the clear was queued — the
+    // student submitted, or a new override was set. If so, drop the clear; the
+    // normal push path will (re)set their grade instead of us removing it.
+    if try await studentHasGradeSource(
+        testSetupID: clearRow.testSetupID, userID: clearRow.userID, db: db)
+    {
+        try await clearRow.delete(on: db)
+        return true
+    }
+
+    // Defer until the course has a connected sync identity.
+    guard let client = try await resolveClient(course) else { return false }
+
+    let bsUserID = try await resolveBSUserID(
+        for: target.user, orgUnitID: orgUnitID, client: client,
+        classlistCache: classlistCache, db: db, application: application)
+    guard let bsUserID else {
+        // No D2L account resolves — nothing to clear.
+        try await clearRow.delete(on: db)
+        return true
+    }
+
+    try await client.clearGrade(
+        orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, bsUserID: bsUserID, on: application)
+
+    let entry = APIBrightSpaceSyncLog(
+        courseID: course.id, testSetupID: assignment.testSetupID,
+        assignmentTitle: assignment.title, userID: clearRow.userID,
+        username: target.user?.username ?? clearRow.userID.uuidString,
+        orgUnitID: orgUnitID, gradeObjectID: gradeObjectID, points: nil,
+        status: .success, detail: "Grade cleared in BrightSpace")
+    try? await entry.save(on: db)
+    try await clearRow.delete(on: db)
+    application.logger.info(
+        "BrightSpace grade cleared: user \(clearRow.userID) assignment '\(assignment.title)'")
+    return true
+}
+
+/// True when the student still has a Chickadee grade source for the setup — a
+/// student submission or an instructor override — so a queued grade removal
+/// must NOT run.
+private func studentHasGradeSource(
+    testSetupID: String, userID: UUID, db: Database
+) async throws -> Bool {
+    let hasSubmission =
+        try await APISubmission.query(on: db)
+        .filter(\.$userID == userID)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$kind == APISubmission.Kind.student)
+        .first() != nil
+    if hasSubmission { return true }
+    return
+        try await APIGradeOverride.query(on: db)
+        .filter(\.$testSetupID == testSetupID)
+        .filter(\.$userID == userID)
+        .first() != nil
 }
 
 /// Builds override-only push targets from `grade_overrides` rows flagged
@@ -147,7 +290,8 @@ private func pendingOverrideTargets(
     }
     guard !overrideOnly.isEmpty else { return [] }
 
-    let context = try await loadOverrideSyncContext(for: overrideOnly, db: db)
+    let context = try await loadSyncContextForKeys(
+        setupIDs: overrideOnly.map(\.testSetupID), userIDs: overrideOnly.map(\.userID), db: db)
     return overrideOnly.map { override in
         let assignment = context.assignmentsBySetupID[override.testSetupID]
         return GradePushTarget(
@@ -166,11 +310,12 @@ private func pendingOverrideTargets(
 /// references, keyed for `GradePushTarget` assembly.  Mirrors the result-driven
 /// `loadGradeSyncBatchContext` but starts from override rows (which already
 /// carry the test setup + user), so no submission lookup is needed.
-private func loadOverrideSyncContext(
-    for overrides: [APIGradeOverride],
+private func loadSyncContextForKeys(
+    setupIDs rawSetupIDs: [String],
+    userIDs rawUserIDs: [UUID],
     db: Database
 ) async throws -> GradeSyncBatchContext {
-    let setupIDs = Array(Set(overrides.map(\.testSetupID)))
+    let setupIDs = Array(Set(rawSetupIDs))
     var assignmentsBySetupID: [String: APIAssignment] = [:]
     for chunk in chunkedForInFilter(setupIDs) {
         for assignment in try await APIAssignment.query(on: db).filter(\.$testSetupID ~~ chunk).all()
@@ -188,7 +333,7 @@ private func loadOverrideSyncContext(
         }
     }
 
-    let userIDs = Array(Set(overrides.map(\.userID)))
+    let userIDs = Array(Set(rawUserIDs))
     var usersByID: [UUID: APIUser] = [:]
     for chunk in chunkedForInFilter(userIDs) {
         for user in try await APIUser.query(on: db).filter(\.$id ~~ chunk).all() {
@@ -258,6 +403,10 @@ extension APIResult: BrightSpaceSyncFlaggable {
 }
 
 extension APIGradeOverride: BrightSpaceSyncFlaggable {
+    var brightspaceSyncRowID: String { id?.uuidString ?? "?" }
+}
+
+extension APIBrightSpaceGradeClear: BrightSpaceSyncFlaggable {
     var brightspaceSyncRowID: String { id?.uuidString ?? "?" }
 }
 

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -346,4 +346,9 @@ func registerMigrations(on app: Application) {
     // columns on results. Lets an override on a student with no submissions
     // (e.g. a manually-registered pre-enrolled student) enqueue a grade push.
     app.migrations.add(AddGradeOverrideBrightSpaceSync())
+
+    // Queue of pending BrightSpace grade removals (override cleared on a
+    // no-submission student Chickadee had pushed a grade for). FK to
+    // test_setups + users.
+    app.migrations.add(CreateBrightSpaceGradeClears())
 }

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -35,7 +35,9 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
     /// — so the pushed value equals Chickadee's raw points unless a test opts
     /// into a specific grade object (to exercise scaling / type refusal).
     private let gradeObject: BrightSpaceGradeObject?
+    private let clearError: (any Error)?
     private(set) var pushes: [RecordedPush] = []
+    private(set) var clears: [String] = []  // bsUserIDs whose grade was cleared
     private(set) var lookupCount = 0
 
     init(
@@ -43,13 +45,15 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         classlist: [BrightSpaceClasslistEntry] = [],
         lookupError: (any Error)? = nil,
         pushError: (any Error)? = nil,
-        gradeObject: BrightSpaceGradeObject? = nil
+        gradeObject: BrightSpaceGradeObject? = nil,
+        clearError: (any Error)? = nil
     ) {
         self.userIDsByOrgDefinedId = userIDsByOrgDefinedId
         self.classlist = classlist
         self.lookupError = lookupError
         self.pushError = pushError
         self.gradeObject = gradeObject
+        self.clearError = clearError
     }
 
     func lookupUserID(orgDefinedId: String, on application: Application) async throws -> String? {
@@ -68,6 +72,13 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         orgUnitID: String, gradeObjectID: String, on application: Application
     ) async throws -> BrightSpaceGradeObject? {
         gradeObject
+    }
+
+    func clearGrade(
+        orgUnitID: String, gradeObjectID: String, bsUserID: String, on application: Application
+    ) async throws {
+        if let clearError { throw clearError }
+        clears.append(bsUserID)
     }
 
     func pushGrade(
@@ -482,10 +493,10 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
-    @Test func clearingOverrideOnNoSubmissionStudentDoesNotPush() async throws {
-        // Clearing an override on a student with no submissions reverts to the
-        // (nonexistent) runner grade — nothing to push, and whatever was already
-        // in BrightSpace is left as-is.
+    @Test func clearingOverrideNeverSyncedQueuesNoRemoval() async throws {
+        // Clearing an override on a no-submission student that Chickadee never
+        // pushed (no success in the sync log) queues no removal — Chickadee only
+        // ever touches grades it pushed.
         try await withApp(app) { _ in
             let scenario = try await makeOverrideOnlyScenario(studentID: "stu-ovr")
             try await applyGradeOverride(
@@ -494,16 +505,48 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             _ = try await clearGradeOverride(
                 testSetupID: scenario.setupID, studentUserID: scenario.userID, on: app.db)
 
-            // The override row is gone, so there is nothing pending to sweep.
-            let remaining = try await APIGradeOverride.query(on: app.db).count()
-            #expect(remaining == 0)
+            #expect(try await APIGradeOverride.query(on: app.db).count() == 0)
+            #expect(try await APIBrightSpaceGradeClear.query(on: app.db).count() == 0)
 
             let fake = FakeBrightSpaceGrading(userIDsByOrgDefinedId: ["stu-ovr": "d2l-ovr"])
             let processed = try await sweep(client: fake)
 
             #expect(processed == 0)
-            let pushes = await fake.pushes
-            #expect(pushes.isEmpty)
+            #expect(await fake.pushes.isEmpty)
+            #expect(await fake.clears.isEmpty)
+        }
+    }
+
+    @Test func clearingOverrideAfterSyncRemovesGradeInLearn() async throws {
+        // Full bidirectional path: push a grade for a no-submission student, then
+        // clear the override — the next sweep removes the grade in LEARN.
+        try await withApp(app) { _ in
+            let scenario = try await makeOverrideOnlyScenario(studentID: "stu-ovr")
+            try await applyGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID,
+                percent: 80, note: nil, grantedByUserID: nil, on: app.db)
+            let override = try #require(try await APIGradeOverride.query(on: app.db).first())
+            override.brightspacePendingSince = Date().addingTimeInterval(-3600)
+            try await override.save(on: app.db)
+
+            let fake = FakeBrightSpaceGrading(userIDsByOrgDefinedId: ["stu-ovr": "d2l-ovr"])
+            _ = try await sweep(client: fake)  // pushes the grade + writes a success log
+            #expect(await fake.pushes.count == 1)
+
+            // Instructor clears the override → a removal is queued.
+            _ = try await clearGradeOverride(
+                testSetupID: scenario.setupID, studentUserID: scenario.userID, on: app.db)
+            let clearRow = try #require(try await APIBrightSpaceGradeClear.query(on: app.db).first())
+            #expect(clearRow.brightspaceSyncPending == true)
+            clearRow.brightspacePendingSince = Date().addingTimeInterval(-3600)
+            try await clearRow.save(on: app.db)
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)
+            #expect(await fake.clears == ["d2l-ovr"])
+            // Queue row consumed.
+            #expect(try await APIBrightSpaceGradeClear.query(on: app.db).count() == 0)
         }
     }
 

--- a/changelog.d/brightspace-grade-clearing.md
+++ b/changelog.d/brightspace-grade-clearing.md
@@ -1,0 +1,12 @@
+### Added
+
+- **BrightSpace grade sync now removes a grade when its Chickadee source is
+  removed.** When an instructor clears a grade override on a student with no
+  submissions, the grade is now removed from the LEARN gradebook on the next
+  sync — but **only if Chickadee actually pushed that grade** (there's a
+  `success` row in the sync log), so a grade an instructor entered by hand in
+  LEARN is never touched. Removals run through a small
+  `brightspace_grade_clears` queue and a D2L grade-value `DELETE`; a push queued
+  for the same student/assignment always wins over a removal, and a removal is
+  skipped if the student's grade source has reappeared (they submitted, or a new
+  override was set) before it runs.


### PR DESCRIPTION
## Why

Bidirectional grade lifecycle (PR 2 of 3 in the prod-readiness series). Today a grade push is one-way: clearing an override on a no-submission student leaves a stale grade in LEARN. You asked for this to clear — **but only grades Chickadee actually pushed** (never a hand-entered LEARN grade).

> **Stacked on #1074** (reliability batch). Base will retarget to `main` once that merges; review this PR's diff for the grade-clearing changes only.

## What changed

- **`brightspace_grade_clears` queue** (new model + migration) — isolated from `grade_overrides`, so the roster/CSV display is untouched.
- **`clearGrade` on the D2L client** — a grade-value `DELETE` (a 404 = already absent = success).
- **Enqueue gate** — `clearGradeOverride` queues a removal only when the student has **no submissions** AND a **`success` row exists in `brightspace_sync_log`** for that (student, setup). That sync-log gate is the "Chickadee pushed it" guarantee — a manually-entered LEARN grade has no such row and is never touched.
- **Push always wins** — `applyGradeOverride` drops any queued removal, and the sweep drops a removal whose (student, setup) is being pushed the same sweep.
- **Run-time re-check** — before removing, the sweep re-verifies the grade source hasn't reappeared (the student submitted, or a new override was set); if it has, the removal is dropped, not executed.

Unmapping an assignment from its grade item does **not** clear (non-destructive, per your call).

## Tests
- `clearingOverrideAfterSyncRemovesGradeInLearn` — push, clear override, next sweep removes the grade in LEARN and consumes the queue row.
- `clearingOverrideNeverSyncedQueuesNoRemoval` — clearing a never-pushed grade queues nothing.
- `FakeBrightSpaceGrading` gains `clearGrade` (records cleared user IDs).

## Notes
- One `changelog.d/` fragment; no `VERSION`/`CHANGELOG.md` edits.
- `swift-format` + lint pass locally; CI compiles/runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_