### PR TITLE
feat(brightspace): per-assignment grade-sync counts on the instructor LEARN tab

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -77,6 +77,7 @@ LEARN
             <tr>
                 <th>Assignment</th>
                 <th>Grade item ID</th>
+                <th>Students</th>
                 <th>Last sync</th>
                 <th>Actions</th>
             </tr>
@@ -96,6 +97,15 @@ LEARN
                                value="#(row.gradeObjectID)" placeholder="e.g. 78901">
                         <button class="btn action-btn" type="submit">Save</button>
                     </form>
+                </td>
+                <td>
+                    #if(row.hasSyncActivity):
+                    <span class="bs-count bs-count-ok" title="Synced to LEARN">#(row.syncedCount) ✓</span>
+                    #if(row.hasPending):<span class="bs-count bs-count-pending" title="Pending push">#(row.pendingCount) ⏳</span>#endif
+                    #if(row.hasErrored):<span class="bs-count bs-count-err" title="Failed to push">#(row.erroredCount) ✗</span>#endif
+                    #else:
+                    <span class="card-meta">—</span>
+                    #endif
                 </td>
                 <td>
                     #if(row.lastSyncStatus == "success"):
@@ -212,6 +222,13 @@ LEARN
 }
 .bs-sync-detail { font-size: .72rem; }
 .bs-log-when { white-space: nowrap; }
+.bs-count {
+    display: inline-block; font-size: .78rem; font-weight: 600;
+    white-space: nowrap; margin-right: .35rem;
+}
+.bs-count-ok { color: var(--green); }
+.bs-count-pending { color: var(--amber); }
+.bs-count-err { color: var(--red); }
 </style>
 <script>
 (function () {

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -117,6 +117,18 @@ struct BrightspaceAssignmentRow: Encodable {
     let lastSyncText: String  // formatted time, or "—"
     let lastSyncStatus: String  // "success" | "error" | "skipped" | "none"
     let lastSyncDetail: String?
+    /// Per-assignment student grade-sync rollup across the assignment's result
+    /// and override-only rows: how many are synced, still pending a push, or
+    /// errored.  Lets the instructor see "Lab 1: 28 synced / 2 pending / 1
+    /// errored" at a glance instead of only the single latest log line.
+    let syncedCount: Int
+    let pendingCount: Int
+    let erroredCount: Int
+    /// Precomputed visibility flags — Leaf can't reliably coerce an Int to a
+    /// bool for `#if`, so the rollup chips gate on these instead of `> 0`.
+    let hasSyncActivity: Bool
+    let hasPending: Bool
+    let hasErrored: Bool
 }
 
 /// One row of the sync-activity log.

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -587,15 +587,25 @@ extension InstructorDashboardRoutes {
             latestBySetup[log.testSetupID] = log
         }
 
+        let (summary, unmapped, perSetupCounts) = try await brightspaceSummaryAndUnmapped(
+            req: req, courseUUID: courseUUID, setupIDs: setupIDs, logModels: logModels)
+
         let assignmentRows = assignments.map { a -> BrightspaceAssignmentRow in
             let last = latestBySetup[a.testSetupID]
+            let counts = perSetupCounts[a.testSetupID]
             return BrightspaceAssignmentRow(
                 assignmentID: a.publicID,
                 title: a.title,
                 gradeObjectID: a.brightspaceGradeObjectID ?? "",
                 lastSyncText: last?.attemptedAt.map { fmt.string(from: $0) } ?? "—",
                 lastSyncStatus: last?.status ?? "none",
-                lastSyncDetail: last?.detail)
+                lastSyncDetail: last?.detail,
+                syncedCount: counts?.synced ?? 0,
+                pendingCount: counts?.pending ?? 0,
+                erroredCount: counts?.errored ?? 0,
+                hasSyncActivity: (counts?.synced ?? 0) + (counts?.pending ?? 0) + (counts?.errored ?? 0) > 0,
+                hasPending: (counts?.pending ?? 0) > 0,
+                hasErrored: (counts?.errored ?? 0) > 0)
         }
 
         let logRows = logModels.map { log -> BrightspaceLogRow in
@@ -607,9 +617,6 @@ extension InstructorDashboardRoutes {
                 status: log.status,
                 detail: log.detail)
         }
-
-        let (summary, unmapped) = try await brightspaceSummaryAndUnmapped(
-            req: req, courseUUID: courseUUID, setupIDs: setupIDs, logModels: logModels)
 
         return InstructorBrightspaceContext(
             currentUser: userContext, activeInstructorTab: "brightspace",
@@ -627,39 +634,88 @@ extension InstructorDashboardRoutes {
             summary: summary, unmappedStudents: unmapped, hasUnmapped: !unmapped.isEmpty)
     }
 
-    /// Computes the summary counts (synced / pending / errored) from result
-    /// rows and the unmapped-student list (no D2L account resolvable).
+    /// Per-test-setup grade-sync rollup, accumulated from both result rows and
+    /// override-only rows so the count reflects every gradeable student.
+    private struct SetupSyncCounts {
+        var synced = 0
+        var pending = 0
+        var errored = 0
+
+        /// Buckets one row by its sync bookkeeping columns. A recorded error
+        /// wins over a stale `syncedAt` so a row that synced and later failed
+        /// reads as errored, matching the headline cards.
+        mutating func add(pending isPending: Bool, error: String?, syncedAt: Date?) {
+            if isPending { pending += 1 }
+            if (error ?? "").isEmpty == false {
+                errored += 1
+            } else if syncedAt != nil {
+                synced += 1
+            }
+        }
+    }
+
+    /// Computes the summary counts (synced / pending / errored), the same counts
+    /// bucketed per test setup (for the per-assignment rollup), and the
+    /// unmapped-student list (no D2L account resolvable). Counts span both
+    /// result rows and override-only rows (no-submission students whose grade
+    /// rides on the override row), so override-only grades show up in the totals.
     private func brightspaceSummaryAndUnmapped(
         req: Request,
         courseUUID: UUID,
         setupIDs: [String],
         logModels: [APIBrightSpaceSyncLog]
-    ) async throws -> (BrightspaceSyncSummary, [BrightspaceUnmappedStudentRow]) {
-        // Result-level sync state across the course's student submissions.
-        let submissionIDs =
+    ) async throws -> (BrightspaceSyncSummary, [BrightspaceUnmappedStudentRow], [String: SetupSyncCounts]) {
+        var perSetup: [String: SetupSyncCounts] = [:]
+
+        // Result-level sync state across the course's student submissions. Keep
+        // the submission → test-setup map so each result buckets to its setup.
+        let submissions =
             setupIDs.isEmpty
             ? []
             : try await APISubmission.query(on: req.db)
                 .filter(\.$testSetupID ~~ setupIDs)
                 .filter(\.$kind == APISubmission.Kind.student)
                 .all()
-                .compactMap(\.id)
+        var setupBySubmissionID: [String: String] = [:]
+        for submission in submissions {
+            if let id = submission.id { setupBySubmissionID[id] = submission.testSetupID }
+        }
+        let submissionIDs = Array(setupBySubmissionID.keys)
         let results =
             submissionIDs.isEmpty
             ? []
             : try await APIResult.query(on: req.db)
                 .filter(\.$submissionID ~~ submissionIDs)
                 .all()
+        for result in results {
+            guard let setupID = setupBySubmissionID[result.submissionID] else { continue }
+            perSetup[setupID, default: SetupSyncCounts()].add(
+                pending: result.brightspaceSyncPending == true,
+                error: result.brightspaceSyncError,
+                syncedAt: result.brightspaceSyncedAt)
+        }
+
+        // Override-only rows (no-submission students) carry their own sync state.
+        let overrides =
+            setupIDs.isEmpty
+            ? []
+            : try await APIGradeOverride.query(on: req.db)
+                .filter(\.$testSetupID ~~ setupIDs)
+                .all()
+        for override in overrides {
+            perSetup[override.testSetupID, default: SetupSyncCounts()].add(
+                pending: override.brightspaceSyncPending == true,
+                error: override.brightspaceSyncError,
+                syncedAt: override.brightspaceSyncedAt)
+        }
+
         var synced = 0
         var pending = 0
         var errored = 0
-        for result in results {
-            if result.brightspaceSyncPending == true { pending += 1 }
-            if (result.brightspaceSyncError ?? "").isEmpty == false {
-                errored += 1
-            } else if result.brightspaceSyncedAt != nil {
-                synced += 1
-            }
+        for counts in perSetup.values {
+            synced += counts.synced
+            pending += counts.pending
+            errored += counts.errored
         }
 
         // Unmapped students: enrolled students with no usable D2L identity.
@@ -710,7 +766,7 @@ extension InstructorDashboardRoutes {
 
         let summary = BrightspaceSyncSummary(
             synced: synced, pending: pending, errored: errored, unmapped: unmapped.count)
-        return (summary, unmapped)
+        return (summary, unmapped, perSetup)
     }
 }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -590,23 +590,9 @@ extension InstructorDashboardRoutes {
         let (summary, unmapped, perSetupCounts) = try await brightspaceSummaryAndUnmapped(
             req: req, courseUUID: courseUUID, setupIDs: setupIDs, logModels: logModels)
 
-        let assignmentRows = assignments.map { a -> BrightspaceAssignmentRow in
-            let last = latestBySetup[a.testSetupID]
-            let counts = perSetupCounts[a.testSetupID]
-            return BrightspaceAssignmentRow(
-                assignmentID: a.publicID,
-                title: a.title,
-                gradeObjectID: a.brightspaceGradeObjectID ?? "",
-                lastSyncText: last?.attemptedAt.map { fmt.string(from: $0) } ?? "—",
-                lastSyncStatus: last?.status ?? "none",
-                lastSyncDetail: last?.detail,
-                syncedCount: counts?.synced ?? 0,
-                pendingCount: counts?.pending ?? 0,
-                erroredCount: counts?.errored ?? 0,
-                hasSyncActivity: (counts?.synced ?? 0) + (counts?.pending ?? 0) + (counts?.errored ?? 0) > 0,
-                hasPending: (counts?.pending ?? 0) > 0,
-                hasErrored: (counts?.errored ?? 0) > 0)
-        }
+        let assignmentRows = brightspaceAssignmentRows(
+            assignments: assignments, latestBySetup: latestBySetup,
+            perSetupCounts: perSetupCounts, fmt: fmt)
 
         let logRows = logModels.map { log -> BrightspaceLogRow in
             BrightspaceLogRow(
@@ -632,6 +618,33 @@ extension InstructorDashboardRoutes {
             assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
             logRows: logRows, hasLog: !logRows.isEmpty,
             summary: summary, unmappedStudents: unmapped, hasUnmapped: !unmapped.isEmpty)
+    }
+
+    /// Builds the per-assignment mapping rows: grade-item ID, latest-sync badge,
+    /// and the per-assignment synced/pending/errored rollup (from `perSetupCounts`).
+    private func brightspaceAssignmentRows(
+        assignments: [APIAssignment],
+        latestBySetup: [String: APIBrightSpaceSyncLog],
+        perSetupCounts: [String: SetupSyncCounts],
+        fmt: DateFormatter
+    ) -> [BrightspaceAssignmentRow] {
+        assignments.map { a in
+            let last = latestBySetup[a.testSetupID]
+            let counts = perSetupCounts[a.testSetupID] ?? SetupSyncCounts()
+            return BrightspaceAssignmentRow(
+                assignmentID: a.publicID,
+                title: a.title,
+                gradeObjectID: a.brightspaceGradeObjectID ?? "",
+                lastSyncText: last?.attemptedAt.map { fmt.string(from: $0) } ?? "—",
+                lastSyncStatus: last?.status ?? "none",
+                lastSyncDetail: last?.detail,
+                syncedCount: counts.synced,
+                pendingCount: counts.pending,
+                erroredCount: counts.errored,
+                hasSyncActivity: counts.synced + counts.pending + counts.errored > 0,
+                hasPending: counts.pending > 0,
+                hasErrored: counts.errored > 0)
+        }
     }
 
     /// Per-test-setup grade-sync rollup, accumulated from both result rows and

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -288,6 +288,83 @@ import VaporTesting
         }
     }
 
+    // MARK: - Per-assignment sync counts (instructor LEARN tab)
+
+    @Test func assignmentSyncCountsRenderOnInstructorTab() async throws {
+        try await withAssignmentRoutesApp { app in
+            // Configured + active course so the dashboard (with the assignment
+            // mapping table) renders.
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.test", appID: "a", appKey: "k", debounceSecs: 90)
+            try await arInsertSetup(id: "setup_bs_counts", on: app)
+            _ = try await arInsertAssignment(
+                testSetupID: "setup_bs_counts", title: "Counts Lab", isOpen: true, on: app)
+            let student = try await arInsertStudent(username: "bs_counts_student", on: app)
+            _ = try await arInsertSubmission(
+                id: "sub_bs_counts", testSetupID: "setup_bs_counts",
+                userID: try student.requireID(), on: app)
+
+            // Three result rows on the assignment's setup: one synced, one
+            // pending, one errored → 1 ✓ / 1 ⏳ / 1 ✗.
+            let synced = APIResult(
+                id: "res_synced", submissionID: "sub_bs_counts", collectionJSON: "{}", source: "worker")
+            synced.brightspaceSyncPending = false
+            synced.brightspaceSyncedAt = Date()
+            try await synced.save(on: app.db)
+
+            let pending = APIResult(
+                id: "res_pending", submissionID: "sub_bs_counts", collectionJSON: "{}", source: "worker")
+            pending.brightspaceSyncPending = true
+            try await pending.save(on: app.db)
+
+            let errored = APIResult(
+                id: "res_errored", submissionID: "sub_bs_counts", collectionJSON: "{}", source: "worker")
+            errored.brightspaceSyncPending = false
+            errored.brightspaceSyncError = "D2L rejected it"
+            try await errored.save(on: app.db)
+
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("1 ✓"))
+                    #expect(html.contains("1 ⏳"))
+                    #expect(html.contains("1 ✗"))
+                })
+        }
+    }
+
+    @Test func overrideOnlyRowCountsTowardAssignmentRollup() async throws {
+        try await withAssignmentRoutesApp { app in
+            // A no-submission student's grade rides on an override row; its
+            // pending state must count toward the per-assignment rollup even
+            // though there is no result row.
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.test", appID: "a", appKey: "k", debounceSecs: 90)
+            try await arInsertSetup(id: "setup_bs_ovr", on: app)
+            _ = try await arInsertAssignment(
+                testSetupID: "setup_bs_ovr", title: "Override Lab", isOpen: true, on: app)
+            let student = try await arInsertStudent(username: "bs_ovr_student", on: app)
+
+            let override = APIGradeOverride(
+                testSetupID: "setup_bs_ovr", userID: try student.requireID(), overridePercent: 80)
+            override.brightspaceSyncPending = true
+            try await override.save(on: app.db)
+
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("1 ⏳"))
+                })
+        }
+    }
+
     // MARK: - Sync-log model + migration round-trip
 
     @Test func syncLogModelRoundTrips() async throws {

--- a/changelog.d/brightspace-assignment-sync-counts.md
+++ b/changelog.d/brightspace-assignment-sync-counts.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Per-assignment grade-sync counts on the instructor LEARN tab.** Each
+  assignment in the grade-item mapping table now shows a student rollup —
+  how many grades are synced (✓), pending a push (⏳), or errored (✗) — so an
+  instructor can see "Lab 1: 28 synced / 2 pending / 1 errored" at a glance
+  instead of only the single most recent log line. The counts span both result
+  rows and override-only rows (no-submission students whose grade rides on the
+  override), so override-only grades are reflected too.


### PR DESCRIPTION
## Why

PR 3 of the BrightSpace prod-readiness series — instructor observability. Today the LEARN tab's assignment-mapping table shows only the **single most recent** sync-log line per assignment. An instructor can't tell, at a glance, how many students actually made it into LEARN versus how many are still pending or errored.

## What changed

- **New "Students" column** in the grade-item mapping table. Each assignment shows a sync rollup — synced (✓), pending (⏳), errored (✗) — e.g. `28 ✓  2 ⏳  1 ✗`. The chips only appear for the states that have a non-zero count.
- **Counts span result rows *and* override-only rows.** No-submission students whose grade rides on an `APIGradeOverride` row are now reflected, so the override-only grades this series added show up in the totals (previously the headline summary counted result rows only).
- **One pass, one source of truth.** `brightspaceSummaryAndUnmapped` now buckets per test setup and returns those counts; the per-assignment rollup and the headline summary cards are derived from the same accumulation, so they can't drift.

Scope is confined to the **instructor LEARN tab** (course-scoped). The admin LEARN tab is deployment-wide auth status with no course context, so per-assignment counts don't belong there and it's untouched.

## Tests

- `assignmentSyncCountsRenderOnInstructorTab` — three result rows (synced / pending / errored) render as `1 ✓` / `1 ⏳` / `1 ✗`.
- `overrideOnlyRowCountsTowardAssignmentRollup` — a no-submission student's pending override row counts toward the rollup with no result row present.

## Notes

- One `changelog.d/` fragment; no `VERSION` / `CHANGELOG.md` edits.
- `swift-format` + `check-styles` + `check-css-vars` pass locally; CI compiles/runs the suite (deps are egress-blocked here). New `.bs-count*` chip classes route through the `--green`/`--amber`/`--red` palette vars (dark-mode aware).

Next in the series: PR4 — roster sync readiness (per-student `unconfirmed`/`confirmed`/`unreachable` state + a background reconcile sweep + the instructor readiness panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_