### PR TITLE
feat(brightspace): LEARN roster sync readiness (per-student confirm/unreachable + reconcile sweep)

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -35,7 +35,6 @@ LEARN
         <div class="bs-card"><div class="bs-card-label">Synced</div><div class="bs-card-value">#(summary.synced)</div></div>
         <div class="bs-card"><div class="bs-card-label">Pending</div><div class="bs-card-value">#(summary.pending)</div></div>
         <div class="bs-card"><div class="bs-card-label">Errored</div><div class="bs-card-value">#(summary.errored)</div></div>
-        <div class="bs-card"><div class="bs-card-label">Unmapped students</div><div class="bs-card-value">#(summary.unmapped)</div></div>
     </div>
     #if(!courseIsArchived):
     <div class="bs-summary-actions">
@@ -137,28 +136,51 @@ LEARN
     #endif
 </section>
 
-<!-- ── Unmapped students ──────────────────────────────────── -->
-#if(hasUnmapped):
+<!-- ── LEARN roster readiness ─────────────────────────────── -->
 <section class="bs-section">
-    <h2 class="bs-h2">Unmapped students (#(summary.unmapped))</h2>
+    <div class="bs-mapping-head">
+        <h2 class="bs-h2">LEARN roster readiness</h2>
+        #if(canReconcile):
+        <form method="post" action="/instructor/brightspace/reconcile-now" class="inline-form">
+            #csrfFormField()
+            <button class="btn action-btn" type="submit"
+                    title="Re-check the roster against the LEARN classlist now">Reconcile now</button>
+        </form>
+        #endif
+    </div>
+    #if(!courseLinked):
     <p class="card-meta bs-section-note">
-        These students' grades can't sync because Chickadee can't resolve a LEARN account
-        for them. Fix the student number on file, or confirm they're enrolled in the D2L course.
+        Link this course to its LEARN org unit (on the course page) to check whether each
+        student's grade can be delivered to the LEARN gradebook.
     </p>
+    #endif
+    #if(courseLinked):
+    <p class="card-meta bs-section-note">
+        Whether each enrolled student can receive grades in LEARN, checked automatically every
+        few minutes (last checked: #(readiness.lastCheckedText)). An <strong>unreachable</strong>
+        student still keeps their Chickadee grades — we just can't deliver them to LEARN yet.
+    </p>
+    <div class="bs-cards">
+        <div class="bs-card"><div class="bs-card-label">Confirmed</div><div class="bs-card-value">#(readiness.confirmed)</div></div>
+        <div class="bs-card"><div class="bs-card-label">Unconfirmed</div><div class="bs-card-value">#(readiness.unconfirmed)</div></div>
+        <div class="bs-card"><div class="bs-card-label">Unreachable</div><div class="bs-card-value">#(readiness.unreachable)</div></div>
+    </div>
+    #if(hasUnreachable):
     <div class="table-scroll"><table class="results-table">
-        <thead><tr><th>Name</th><th>Username</th><th>Reason</th></tr></thead>
+        <thead><tr><th>Name</th><th>Username</th><th>Why we can't deliver</th></tr></thead>
         <tbody>
-        #for(student in unmappedStudents):
+        #for(student in unreachableStudents):
             <tr>
                 <td>#(student.displayName)</td>
                 <td><code>#(student.username)</code></td>
-                <td>#(student.reason)</td>
+                <td>#(student.detail)</td>
             </tr>
         #endfor
         </tbody>
     </table></div>
+    #endif
+    #endif
 </section>
-#endif
 
 <!-- ── Sync log ───────────────────────────────────────────── -->
 <section class="bs-section">

--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -70,6 +70,7 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
                 "BrightSpace configured but not authorized — authorize at /admin/brightspace")
         }
         app.lifecycle.use(BrightSpaceGradeSyncLifecycleHandler())
+        app.lifecycle.use(PeriodicSweepLifecycleHandler { $0.learnRosterReadinessMonitor })
     }
 
     if appConfig.auth.mode != .local {

--- a/Sources/APIServer/Migrations/AddEnrollmentBrightSpaceSyncStatus.swift
+++ b/Sources/APIServer/Migrations/AddEnrollmentBrightSpaceSyncStatus.swift
@@ -1,0 +1,45 @@
+// APIServer/Migrations/AddEnrollmentBrightSpaceSyncStatus.swift
+//
+// Per-(student, course) LEARN grade-sync readiness on `course_enrollments`.
+// A student starts `unconfirmed` (we have not yet verified we can deliver
+// their grade to LEARN); the periodic roster-readiness sweep resolves them
+// against the course's LEARN classlist and flips them to `confirmed` (matched
+// — we can push) or `unreachable` (not on the classlist / no key to match on,
+// with a reason in `detail`).
+//
+// Three nullable columns added one at a time — SQLite can't add multiple
+// columns (or a NOT NULL column) to an existing table in one ALTER, the same
+// constraint that keeps `role` / `url_token` nullable. The model reads the
+// status through a typed accessor that treats a NULL (pre-existing row, never
+// swept) as `.unconfirmed`.
+
+import Fluent
+import SQLKit
+
+struct AddEnrollmentBrightSpaceSyncStatus: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("course_enrollments")
+            .field("brightspace_sync_status", .string)
+            .update()
+        try await database.schema("course_enrollments")
+            .field("brightspace_checked_at", .datetime)
+            .update()
+        try await database.schema("course_enrollments")
+            .field("brightspace_sync_detail", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        // One DROP COLUMN per ALTER — SQLite rejects multi-column ALTERs, the
+        // same constraint that splits the adds above.
+        try await database.schema("course_enrollments")
+            .deleteField("brightspace_sync_status")
+            .update()
+        try await database.schema("course_enrollments")
+            .deleteField("brightspace_checked_at")
+            .update()
+        try await database.schema("course_enrollments")
+            .deleteField("brightspace_sync_detail")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APICourseEnrollment.swift
+++ b/Sources/APIServer/Models/APICourseEnrollment.swift
@@ -45,6 +45,23 @@ final class APICourseEnrollment: Model, Content, @unchecked Sendable {
     @OptionalField(key: "role")
     var roleRaw: String?
 
+    /// LEARN grade-sync readiness for this (student, course): whether the
+    /// roster-readiness sweep has confirmed we can deliver this student's grade
+    /// to the course's LEARN classlist. Stored as `LearnSyncReadiness.rawValue`;
+    /// NULL (a pre-existing row never swept) reads as `.unconfirmed`. Read it
+    /// through the typed `learnSyncReadiness` accessor, never this raw column.
+    @OptionalField(key: "brightspace_sync_status")
+    var brightspaceSyncStatusRaw: String?
+
+    /// When the readiness sweep last classified this enrollment. Nil = never.
+    @OptionalField(key: "brightspace_checked_at")
+    var brightspaceCheckedAt: Date?
+
+    /// Human-readable reason for a non-`confirmed` status (e.g. "not on the
+    /// LEARN classlist" / "no student ID to match on"). Nil when confirmed.
+    @OptionalField(key: "brightspace_sync_detail")
+    var brightspaceSyncDetail: String?
+
     init() {}
 
     init(id: UUID? = nil, userID: UUID, courseID: UUID, role: CourseRole = .student) {
@@ -52,6 +69,30 @@ final class APICourseEnrollment: Model, Content, @unchecked Sendable {
         self.userID = userID
         self.$course.id = courseID
         self.roleRaw = role.rawValue
+    }
+}
+
+// MARK: - LEARN grade-sync readiness
+
+/// Whether Chickadee has verified it can deliver this student's grade to the
+/// course's LEARN gradebook. A *signal* layer, independent of the grade-push
+/// path — an `unreachable` student's grade still queues and is never lost; the
+/// status just tells the instructor we can't deliver it yet.
+enum LearnSyncReadiness: String, Codable, Sendable {
+    /// Default on enroll — not yet checked against the LEARN classlist.
+    case unconfirmed
+    /// Matched to a LEARN classlist identity — we can push this student's grade.
+    case confirmed
+    /// Checked, but we can't deliver: not on the classlist, or no key to match.
+    case unreachable
+}
+
+extension APICourseEnrollment {
+    /// The enrollment's typed LEARN sync readiness. A missing / unrecognised
+    /// stored value reads as `.unconfirmed` (a row the sweep hasn't reached).
+    var learnSyncReadiness: LearnSyncReadiness {
+        get { brightspaceSyncStatusRaw.flatMap(LearnSyncReadiness.init(rawValue:)) ?? .unconfirmed }
+        set { brightspaceSyncStatusRaw = newValue.rawValue }
     }
 }
 

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -105,8 +105,18 @@ struct InstructorBrightspaceContext: Encodable {
     let logRows: [BrightspaceLogRow]
     let hasLog: Bool
     let summary: BrightspaceSyncSummary
-    let unmappedStudents: [BrightspaceUnmappedStudentRow]
-    let hasUnmapped: Bool
+    /// True when the course is linked to a LEARN org unit and not archived —
+    /// gates the "Reconcile now" button. Precomputed so the template branches on
+    /// a flat bool (LeafKit 1.14.2 mis-parses `&&` / nested `#if`).
+    let canReconcile: Bool
+    /// LEARN roster-readiness rollup (confirmed / unconfirmed / unreachable),
+    /// maintained by the periodic reconcile sweep.
+    let readiness: BrightspaceReadinessSummary
+    /// Students we can't currently deliver a grade to (not on the LEARN
+    /// classlist, or no key to match) — the authoritative replacement for the
+    /// old log-heuristic "unmapped students" list.
+    let unreachableStudents: [BrightspaceReadinessRow]
+    let hasUnreachable: Bool
 }
 
 /// One assignment's BrightSpace grade-item mapping + its latest sync state.
@@ -146,14 +156,24 @@ struct BrightspaceSyncSummary: Encodable {
     let synced: Int
     let pending: Int
     let errored: Int
-    let unmapped: Int
 }
 
-/// A student whose grade can't sync because they have no resolvable D2L account.
-struct BrightspaceUnmappedStudentRow: Encodable {
+/// LEARN roster-readiness rollup for the active course, from the persisted
+/// per-enrollment status the reconcile sweep maintains.
+struct BrightspaceReadinessSummary: Encodable {
+    let confirmed: Int
+    let unconfirmed: Int
+    let unreachable: Int
+    let lastCheckedText: String  // formatted time, or "Never"
+    let hasBeenChecked: Bool
+}
+
+/// One student Chickadee can't currently deliver a grade to in LEARN, with the
+/// reason (not on the classlist, or no key to match).
+struct BrightspaceReadinessRow: Encodable {
     let username: String
     let displayName: String
-    let reason: String
+    let detail: String
 }
 
 /// One bar of a server-rendered sparkline.  `heightPercent` is already

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -1,8 +1,8 @@
 // APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
 //
 // The instructor BrightSpace tab: connection status, the assignment→grade-
-// item mapping, the sync-activity log, manual sync actions, and unmapped-
-// student diagnostics.  Everything here is scoped to the active course.
+// item mapping, the sync-activity log, manual sync actions, and the LEARN
+// roster-readiness panel.  Everything here is scoped to the active course.
 //
 // Connection credentials are server-level (env, ops-managed) and never
 // exposed here; the course→org-unit binding is admin-set on the course page.
@@ -11,8 +11,9 @@
 //   GET  /instructor/brightspace                       → instructor-brightspace.leaf
 //   POST /instructor/brightspace/test                  → whoami connection test (JSON)
 //   GET  /instructor/brightspace/grade-objects         → [BrightSpaceGradeObject] (dropdown)
-//   POST /instructor/brightspace/sync-now              → run a sweep immediately
+//   POST /instructor/brightspace/sync-now              → run a grade-sync sweep immediately
 //   POST /instructor/brightspace/retry-failed          → re-queue errored pushes
+//   POST /instructor/brightspace/reconcile-now         → re-check roster readiness vs LEARN
 //   POST /instructor/:assignmentID/brightspace/push-all → re-push every grade for one assignment
 
 import Core
@@ -352,6 +353,48 @@ extension InstructorDashboardRoutes {
         return req.redirect(to: "/instructor/brightspace")
     }
 
+    // MARK: - POST /instructor/brightspace/reconcile-now
+
+    /// Runs the roster-readiness reconcile for the active course immediately
+    /// (the manual counterpart to the 10-minute sweep): fetches the LEARN
+    /// classlist and re-classifies every enrolled student, persisting their
+    /// readiness. Flashes a one-line summary. A no-op when BrightSpace isn't
+    /// connected or the course isn't linked to an org unit.
+    @Sendable
+    func brightspaceReconcileNow(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else {
+            req.session.data["bs_flash_error"] = "No active course."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        guard let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty else {
+            req.session.data["bs_flash_error"] =
+                "Link this course to its LEARN org unit first."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        guard let client = try await req.application.brightSpaceClient(forCourse: course) else {
+            req.session.data["bs_flash_error"] =
+                "BrightSpace isn't connected for this course yet."
+            return req.redirect(to: "/instructor/brightspace")
+        }
+        do {
+            let outcome = try await reconcileCourseReadiness(
+                course: course, orgUnitID: orgUnitID, client: client,
+                on: req.db, application: req.application)
+            req.session.data["bs_flash_success"] =
+                "Reconciled \(outcome.checked) student\(outcome.checked == 1 ? "" : "s") against LEARN: "
+                + "\(outcome.confirmed) confirmed, \(outcome.unreachable) unreachable."
+        } catch {
+            req.logger.warning("Roster reconcile-now failed: \(error)")
+            req.session.data["bs_flash_error"] =
+                "Couldn't reconcile against LEARN: \(error.localizedDescription)"
+        }
+        return req.redirect(to: "/instructor/brightspace")
+    }
+
     // MARK: - POST /instructor/brightspace/retry-failed
 
     @Sendable
@@ -498,6 +541,39 @@ extension InstructorDashboardRoutes {
     }
 
     /// Assembles the full BrightSpace-tab context for the active course.
+    /// The BrightSpace-tab context for the "no active course selected" state —
+    /// the per-instructor account + flashes still render, but everything
+    /// course-scoped is empty. Extracted so `buildBrightspaceContext` stays
+    /// under the body-length limit. `account` groups the requesting
+    /// instructor's connection (connected, identity, "since" suffix).
+    private func noCourseBrightspaceContext(
+        userContext: CurrentUserContext,
+        hasActiveCourse: Bool,
+        syncEnabled: Bool,
+        account: (connected: Bool, identity: String?, since: String?),
+        flashSuccess: String?,
+        flashError: String?
+    ) -> InstructorBrightspaceContext {
+        InstructorBrightspaceContext(
+            currentUser: userContext, activeInstructorTab: "brightspace",
+            hasActiveCourse: hasActiveCourse, courseIsArchived: false,
+            brightspaceSyncEnabled: syncEnabled, courseLinked: false,
+            orgUnitID: nil, orgUnitName: nil,
+            accountConnected: account.connected, accountIdentity: account.identity,
+            accountConnectedSince: account.since,
+            syncIdentityName: nil, syncIdentityIsMe: false,
+            syncIdentityConnected: false, syncIdentityNeedsReconnect: false,
+            flashSuccess: flashSuccess, flashError: flashError,
+            assignmentRows: [], hasAssignments: false,
+            logRows: [], hasLog: false,
+            summary: BrightspaceSyncSummary(synced: 0, pending: 0, errored: 0),
+            canReconcile: false,
+            readiness: BrightspaceReadinessSummary(
+                confirmed: 0, unconfirmed: 0, unreachable: 0,
+                lastCheckedText: "Never", hasBeenChecked: false),
+            unreachableStudents: [], hasUnreachable: false)
+    }
+
     private func buildBrightspaceContext(
         req: Request, user: APIUser
     ) async throws
@@ -535,20 +611,11 @@ extension InstructorDashboardRoutes {
         guard let courseUUID = courseState.activeCourseUUID,
             let course = try await APICourse.find(courseUUID, on: req.db)
         else {
-            return InstructorBrightspaceContext(
-                currentUser: userContext, activeInstructorTab: "brightspace",
-                hasActiveCourse: courseState.active != nil, courseIsArchived: false,
-                brightspaceSyncEnabled: syncEnabled, courseLinked: false,
-                orgUnitID: nil, orgUnitName: nil,
-                accountConnected: accountConnected, accountIdentity: accountIdentity,
-                accountConnectedSince: accountConnectedSince,
-                syncIdentityName: nil, syncIdentityIsMe: false,
-                syncIdentityConnected: false, syncIdentityNeedsReconnect: false,
-                flashSuccess: flashSuccess, flashError: flashError,
-                assignmentRows: [], hasAssignments: false,
-                logRows: [], hasLog: false,
-                summary: BrightspaceSyncSummary(synced: 0, pending: 0, errored: 0, unmapped: 0),
-                unmappedStudents: [], hasUnmapped: false)
+            return noCourseBrightspaceContext(
+                userContext: userContext, hasActiveCourse: courseState.active != nil,
+                syncEnabled: syncEnabled,
+                account: (accountConnected, accountIdentity, accountConnectedSince),
+                flashSuccess: flashSuccess, flashError: flashError)
         }
 
         let orgUnitID = course.brightspaceOrgUnitID
@@ -587,8 +654,10 @@ extension InstructorDashboardRoutes {
             latestBySetup[log.testSetupID] = log
         }
 
-        let (summary, unmapped, perSetupCounts) = try await brightspaceSummaryAndUnmapped(
-            req: req, courseUUID: courseUUID, setupIDs: setupIDs, logModels: logModels)
+        let (summary, perSetupCounts) = try await brightspaceSyncSummary(
+            req: req, courseUUID: courseUUID, setupIDs: setupIDs)
+        let (readiness, unreachableStudents) = try await brightspaceReadiness(
+            req: req, courseUUID: courseUUID, fmt: fmt)
 
         let assignmentRows = brightspaceAssignmentRows(
             assignments: assignments, latestBySetup: latestBySetup,
@@ -617,7 +686,9 @@ extension InstructorDashboardRoutes {
             flashSuccess: flashSuccess, flashError: flashError,
             assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
             logRows: logRows, hasLog: !logRows.isEmpty,
-            summary: summary, unmappedStudents: unmapped, hasUnmapped: !unmapped.isEmpty)
+            summary: summary, canReconcile: courseLinked && !course.isArchived,
+            readiness: readiness,
+            unreachableStudents: unreachableStudents, hasUnreachable: !unreachableStudents.isEmpty)
     }
 
     /// Builds the per-assignment mapping rows: grade-item ID, latest-sync badge,
@@ -667,17 +738,16 @@ extension InstructorDashboardRoutes {
         }
     }
 
-    /// Computes the summary counts (synced / pending / errored), the same counts
-    /// bucketed per test setup (for the per-assignment rollup), and the
-    /// unmapped-student list (no D2L account resolvable). Counts span both
-    /// result rows and override-only rows (no-submission students whose grade
-    /// rides on the override row), so override-only grades show up in the totals.
-    private func brightspaceSummaryAndUnmapped(
+    /// Computes the headline summary counts (synced / pending / errored) and the
+    /// same counts bucketed per test setup (for the per-assignment rollup).
+    /// Counts span both result rows and override-only rows (no-submission
+    /// students whose grade rides on the override row), so override-only grades
+    /// show up in the totals.
+    private func brightspaceSyncSummary(
         req: Request,
         courseUUID: UUID,
-        setupIDs: [String],
-        logModels: [APIBrightSpaceSyncLog]
-    ) async throws -> (BrightspaceSyncSummary, [BrightspaceUnmappedStudentRow], [String: SetupSyncCounts]) {
+        setupIDs: [String]
+    ) async throws -> (BrightspaceSyncSummary, [String: SetupSyncCounts]) {
         var perSetup: [String: SetupSyncCounts] = [:]
 
         // Result-level sync state across the course's student submissions. Keep
@@ -731,55 +801,68 @@ extension InstructorDashboardRoutes {
             errored += counts.errored
         }
 
-        // Unmapped students: enrolled students with no usable D2L identity.
-        let enrolledUserIDs = try await APICourseEnrollment.query(on: req.db)
+        let summary = BrightspaceSyncSummary(synced: synced, pending: pending, errored: errored)
+        return (summary, perSetup)
+    }
+
+    /// Builds the LEARN roster-readiness panel for the active course from the
+    /// persisted per-enrollment status (maintained by the readiness sweep):
+    /// confirmed / unconfirmed / unreachable counts, the last-checked time, and
+    /// the list of unreachable students with the reason. Replaces the old
+    /// log-heuristic "unmapped students" view with the authoritative classlist
+    /// reconcile.
+    private func brightspaceReadiness(
+        req: Request, courseUUID: UUID, fmt: DateFormatter
+    ) async throws -> (BrightspaceReadinessSummary, [BrightspaceReadinessRow]) {
+        let enrollments = try await APICourseEnrollment.query(on: req.db)
             .filter(\.$course.$id == courseUUID)
             .all()
-            .map(\.userID)
-        let students =
-            enrolledUserIDs.isEmpty
-            ? []
-            : try await APIUser.query(on: req.db)
-                .filter(\.$id ~~ enrolledUserIDs)
-                .filter(\.$role == UserRole.student.rawValue)
-                .sort(\.$username)
-                .all()
-        let noAccountUsernames = Set(
-            logModels
-                .filter {
-                    $0.status == APIBrightSpaceSyncLog.Status.skipped.rawValue
-                        && ($0.detail?.contains("No BrightSpace account") ?? false)
-                }
-                .map(\.username))
-        var unmapped: [BrightspaceUnmappedStudentRow] = []
-        for student in students {
-            // Grade sync resolves a student by username (against the LEARN
-            // classlist) OR student number, caching the resolved D2L id on first
-            // success. A student is only truly unmapped with neither a student
-            // number nor an already-resolved id — checking studentID alone
-            // wrongly flags students who match LEARN by username.
-            let hasStudentID = !(student.studentID ?? "").isEmpty
-            let hasResolvedID = !(student.brightspaceUserID ?? "").isEmpty
-            if !hasStudentID && !hasResolvedID {
-                unmapped.append(
-                    BrightspaceUnmappedStudentRow(
-                        username: student.username,
-                        displayName: student.displayName ?? student.username,
-                        reason:
-                            "No LEARN match — add a student/org-defined ID, or check the username matches LEARN"
-                    ))
-            } else if noAccountUsernames.contains(student.username) {
-                unmapped.append(
-                    BrightspaceUnmappedStudentRow(
-                        username: student.username,
-                        displayName: student.displayName ?? student.username,
-                        reason: "Not found in BrightSpace"))
-            }
+            .filter { $0.role == .student }
+        guard !enrollments.isEmpty else {
+            return (
+                BrightspaceReadinessSummary(
+                    confirmed: 0, unconfirmed: 0, unreachable: 0,
+                    lastCheckedText: "Never", hasBeenChecked: false), []
+            )
         }
 
-        let summary = BrightspaceSyncSummary(
-            synced: synced, pending: pending, errored: errored, unmapped: unmapped.count)
-        return (summary, unmapped, perSetup)
+        let userIDs = enrollments.map(\.userID)
+        let users = try await APIUser.query(on: req.db)
+            .filter(\.$id ~~ userIDs)
+            .filter(\.$role == UserRole.student.rawValue)
+            .all()
+        var userByID: [UUID: APIUser] = [:]
+        for user in users {
+            if let id = user.id { userByID[id] = user }
+        }
+
+        var confirmed = 0
+        var unconfirmed = 0
+        var unreachable: [BrightspaceReadinessRow] = []
+        var lastChecked: Date?
+        for enrollment in enrollments {
+            guard let student = userByID[enrollment.userID] else { continue }
+            if let checked = enrollment.brightspaceCheckedAt {
+                lastChecked = max(lastChecked ?? checked, checked)
+            }
+            switch enrollment.learnSyncReadiness {
+            case .confirmed: confirmed += 1
+            case .unconfirmed: unconfirmed += 1
+            case .unreachable:
+                unreachable.append(
+                    BrightspaceReadinessRow(
+                        username: student.username,
+                        displayName: student.displayName ?? student.username,
+                        detail: enrollment.brightspaceSyncDetail ?? "Not on the LEARN classlist."))
+            }
+        }
+        unreachable.sort { $0.username.localizedCaseInsensitiveCompare($1.username) == .orderedAscending }
+
+        let summary = BrightspaceReadinessSummary(
+            confirmed: confirmed, unconfirmed: unconfirmed, unreachable: unreachable.count,
+            lastCheckedText: lastChecked.map { fmt.string(from: $0) } ?? "Never",
+            hasBeenChecked: lastChecked != nil)
+        return (summary, unreachable)
     }
 }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -54,6 +54,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post("brightspace", "auto-map", use: brightspaceAutoMap)
         r.post("brightspace", "sync-now", use: brightspaceSyncNow)
         r.post("brightspace", "retry-failed", use: brightspaceRetryFailed)
+        r.post("brightspace", "reconcile-now", use: brightspaceReconcileNow)
         r.get("grades.csv", use: exportGradesCSV)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
         r.get(":assignmentID", "students", ":studentID", "history", use: studentSubmissionHistoryPage)

--- a/Sources/APIServer/Services/LearnRosterReadinessSweep.swift
+++ b/Sources/APIServer/Services/LearnRosterReadinessSweep.swift
@@ -145,9 +145,10 @@ func sweepLearnRosterReadiness(
                 on: db, application: application)
             totalUpdated += outcome.updated
             if outcome.updated > 0 {
-                logger.info(
+                let line =
                     "Roster readiness for \(course.code): \(outcome.confirmed) confirmed, "
-                        + "\(outcome.unreachable) unreachable (\(outcome.updated) changed)")
+                    + "\(outcome.unreachable) unreachable (\(outcome.updated) changed)"
+                logger.info("\(line)")
             }
         } catch {
             logger.warning("Roster readiness sweep failed for course \(course.code): \(error)")

--- a/Sources/APIServer/Services/LearnRosterReadinessSweep.swift
+++ b/Sources/APIServer/Services/LearnRosterReadinessSweep.swift
@@ -1,0 +1,199 @@
+// APIServer/Services/LearnRosterReadinessSweep.swift
+//
+// Periodic roster-readiness sweep. For every course bound to a LEARN org unit,
+// fetches the classlist once and classifies each enrolled student against it
+// (reusing the pure `LearnRosterReconciler`), persisting the result on the
+// `course_enrollments` row as `LearnSyncReadiness` — confirmed (matched, we can
+// push their grade), unreachable (not on the classlist / no key to match), or
+// left unconfirmed when the course has no connected identity to read the
+// classlist with.
+//
+// This is a *signal* layer only: it never touches a grade. An unreachable
+// student's grade still queues and is never lost; the status tells the
+// instructor we can't deliver it yet (surfaced on the LEARN tab). It mirrors
+// the on-demand Students-tab "Check against LEARN" but runs proactively and
+// persists, so the instructor sees drift before term-end.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// Outcome counts for one course's reconcile pass.
+struct RosterReadinessOutcome: Sendable {
+    var checked = 0
+    var confirmed = 0
+    var unreachable = 0
+    /// Enrollment rows whose stored status actually changed this pass.
+    var updated = 0
+}
+
+/// Reconciles one course's enrolled students against its LEARN classlist and
+/// persists each enrollment's `LearnSyncReadiness`. The caller supplies the
+/// already-resolved client (so the sweep and the manual "Reconcile now" route
+/// share this core). Only `student`-role enrollments are classified — an
+/// instructor/admin test account isn't a roster member and is never flagged.
+@discardableResult
+func reconcileCourseReadiness(
+    course: APICourse,
+    orgUnitID: String,
+    client: any BrightSpaceGrading,
+    on db: Database,
+    application: Application
+) async throws -> RosterReadinessOutcome {
+    guard let courseID = course.id else { return RosterReadinessOutcome() }
+
+    let classlist = try await client.fetchClasslist(orgUnitID: orgUnitID, on: application)
+    let learnIdentities = LearnRosterReconciler.identitySet(from: classlist)
+
+    let enrollments = try await APICourseEnrollment.query(on: db)
+        .filter(\.$course.$id == courseID)
+        .all()
+    let studentEnrollments = enrollments.filter { $0.role == .student }
+    guard !studentEnrollments.isEmpty else { return RosterReadinessOutcome() }
+
+    let userIDs = studentEnrollments.map(\.userID)
+    let users = try await APIUser.query(on: db)
+        .filter(\.$id ~~ userIDs)
+        .filter(\.$role == UserRole.student.rawValue)
+        .all()
+    var userByID: [UUID: APIUser] = [:]
+    for user in users {
+        if let id = user.id { userByID[id] = user }
+    }
+
+    let now = Date()
+    var outcome = RosterReadinessOutcome()
+    for enrollment in studentEnrollments {
+        // A globally non-student account enrolled as a course student is skipped
+        // — it isn't a graded roster member.
+        guard let student = userByID[enrollment.userID] else { continue }
+        outcome.checked += 1
+
+        let studentID = student.studentID ?? ""
+        let (readiness, detail) = readinessFor(
+            studentID: studentID, username: student.username, learnIdentities: learnIdentities)
+        switch readiness {
+        case .confirmed: outcome.confirmed += 1
+        case .unreachable: outcome.unreachable += 1
+        case .unconfirmed: break
+        }
+
+        let changed =
+            enrollment.learnSyncReadiness != readiness
+            || enrollment.brightspaceSyncDetail != detail
+        enrollment.learnSyncReadiness = readiness
+        enrollment.brightspaceSyncDetail = detail
+        enrollment.brightspaceCheckedAt = now
+        try await enrollment.save(on: db)
+        if changed { outcome.updated += 1 }
+    }
+    return outcome
+}
+
+/// Maps the pure reconciler's classification onto the persisted readiness +
+/// a human-readable reason for the instructor.
+private func readinessFor(
+    studentID: String, username: String, learnIdentities: Set<String>
+) -> (LearnSyncReadiness, String?) {
+    switch LearnRosterReconciler.classify(
+        candidateKeys: [studentID, username],
+        hasIdentityKey: !studentID.isEmpty,
+        learnIdentities: learnIdentities
+    ) {
+    case .onLearn:
+        return (.confirmed, nil)
+    case .notOnLearn:
+        return (.unreachable, "Not on the LEARN classlist (dropped, or not enrolled in the D2L course).")
+    case .unverifiable:
+        return (
+            .unreachable,
+            "Couldn't match to LEARN — add a student/org-defined ID, or check the username matches LEARN."
+        )
+    }
+}
+
+/// Sweeps every BrightSpace-bound course's roster readiness. Returns the total
+/// number of enrollment rows whose status changed across all courses. A course
+/// with no connected sync identity (no key to read the classlist) is skipped,
+/// leaving its students' statuses as-is — never wrongly flagged unreachable.
+@discardableResult
+func sweepLearnRosterReadiness(
+    on db: Database,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
+    logger: Logger,
+    application: Application
+) async throws -> Int {
+    // Only courses bound to a LEARN org unit can be reconciled.
+    let courses = try await APICourse.query(on: db).all()
+    var totalUpdated = 0
+    for course in courses {
+        guard let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty else { continue }
+        let client: (any BrightSpaceGrading)?
+        do {
+            client = try await resolveClient(course)
+        } catch {
+            logger.warning(
+                "Roster readiness: client resolve failed for course \(course.id?.uuidString ?? "?"): \(error)")
+            continue
+        }
+        guard let client else { continue }  // no identity connected yet — defer
+
+        do {
+            let outcome = try await reconcileCourseReadiness(
+                course: course, orgUnitID: orgUnitID, client: client,
+                on: db, application: application)
+            totalUpdated += outcome.updated
+            if outcome.updated > 0 {
+                logger.info(
+                    "Roster readiness for \(course.code): \(outcome.confirmed) confirmed, "
+                        + "\(outcome.unreachable) unreachable (\(outcome.updated) changed)")
+            }
+        } catch {
+            logger.warning("Roster readiness sweep failed for course \(course.code): \(error)")
+        }
+    }
+    return totalUpdated
+}
+
+// MARK: - Monitor (reuses the shared PeriodicSweepMonitor scaffolding)
+
+/// Roster-readiness sweep cadence: 10 minutes. Classlists change rarely, so a
+/// slow cadence keeps D2L traffic low while still catching drift (a drop / late
+/// add) within the term. The identity is resolved per course each cycle, so a
+/// fresh connect takes effect without a restart.
+private let learnRosterReadinessInterval: TimeInterval = 10 * 60
+
+struct LearnRosterReadinessMonitorKey: StorageKey {
+    typealias Value = PeriodicSweepMonitor
+}
+
+extension Application {
+    /// The roster-readiness periodic sweep, built on the shared
+    /// `PeriodicSweepMonitor` (same scaffolding as the reapers). Registered via
+    /// `PeriodicSweepLifecycleHandler` in `AppServices`, only when BrightSpace
+    /// is configured. The sweep itself no-ops when credentials are absent.
+    var learnRosterReadinessMonitor: PeriodicSweepMonitor {
+        get {
+            if let existing = storage[LearnRosterReadinessMonitorKey.self] { return existing }
+            let created = PeriodicSweepMonitor(
+                name: "LEARN roster readiness",
+                interval: learnRosterReadinessInterval,
+                runImmediately: false
+            ) { application in
+                guard application.brightSpaceAppCredentials != nil else { return }
+                _ = try await sweepLearnRosterReadiness(
+                    on: application.db,
+                    resolveClient: { course in
+                        try await application.brightSpaceClient(forCourse: course)
+                    },
+                    logger: application.logger,
+                    application: application
+                )
+            }
+            storage[LearnRosterReadinessMonitorKey.self] = created
+            return created
+        }
+        set { storage[LearnRosterReadinessMonitorKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -335,6 +335,14 @@ func registerMigrations(on app: Application) {
     // stale browser tab / cached bundle, not a live regression).
     app.migrations.add(AddClientDiagnosticAppVersion())
 
+    // Per-(student, course) LEARN sync readiness on course_enrollments:
+    // unconfirmed (default) → confirmed / unreachable, maintained by the
+    // roster-readiness sweep. MUST run before AddCourseEnrollmentRole: that
+    // migration's backfill does a full-model `APICourseEnrollment.query().all()`,
+    // which on a fresh DB selects every column the model declares — including
+    // these — so the columns have to exist by the time it runs.
+    app.migrations.add(AddEnrollmentBrightSpaceSyncStatus())
+
     // Per-course role on each enrollment (Phase 1 of
     // docs/multi-course-roles.md). Behaviour-preserving: backfills role from
     // each user's current global role; nothing reads it yet. Runs after
@@ -351,9 +359,4 @@ func registerMigrations(on app: Application) {
     // no-submission student Chickadee had pushed a grade for). FK to
     // test_setups + users.
     app.migrations.add(CreateBrightSpaceGradeClears())
-
-    // Per-(student, course) LEARN sync readiness on course_enrollments:
-    // unconfirmed (default) → confirmed / unreachable, maintained by the
-    // roster-readiness sweep. Runs after CreateCourseEnrollments (the table).
-    app.migrations.add(AddEnrollmentBrightSpaceSyncStatus())
 }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -351,4 +351,9 @@ func registerMigrations(on app: Application) {
     // no-submission student Chickadee had pushed a grade for). FK to
     // test_setups + users.
     app.migrations.add(CreateBrightSpaceGradeClears())
+
+    // Per-(student, course) LEARN sync readiness on course_enrollments:
+    // unconfirmed (default) → confirmed / unreachable, maintained by the
+    // roster-readiness sweep. Runs after CreateCourseEnrollments (the table).
+    app.migrations.add(AddEnrollmentBrightSpaceSyncStatus())
 }

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -71,6 +71,45 @@ import VaporTesting
         }
     }
 
+    @Test func readinessPanelRendersUnreachableStudents() async throws {
+        try await withAssignmentRoutesApp { app in
+            // Configured + linked course with one student persisted as unreachable
+            // → the LEARN roster-readiness panel lists them with the reason.
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.test", appID: "a", appKey: "k", debounceSecs: 90)
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let course = try #require(try await APICourse.find(courseID, on: app.db))
+            course.brightspaceOrgUnitID = "999"
+            try await course.save(on: app.db)
+
+            let student = try await arInsertStudent(
+                username: "unreach_user", displayName: "Una Reachable", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            let enroll = try #require(
+                try await APICourseEnrollment.query(on: app.db)
+                    .filter(\.$userID == student.requireID()).first())
+            enroll.learnSyncReadiness = .unreachable
+            enroll.brightspaceSyncDetail = "Not on the LEARN classlist."
+            enroll.brightspaceCheckedAt = Date()
+            try await enroll.save(on: app.db)
+
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/brightspace",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("LEARN roster readiness"))
+                    #expect(html.contains("Unreachable"))
+                    #expect(html.contains("Una Reachable"))
+                    #expect(html.contains("Reconcile now"))
+                    // The old log-heuristic section is gone.
+                    #expect(!html.contains("Unmapped students"))
+                })
+        }
+    }
+
     @Test func autoMapRedirectsWhenNotConfigured() async throws {
         try await withAssignmentRoutesApp { app in
             // No live D2L in tests → brightSpaceClient is nil, so auto-map can't

--- a/Tests/APITests/LearnRosterReadinessTests.swift
+++ b/Tests/APITests/LearnRosterReadinessTests.swift
@@ -1,0 +1,119 @@
+// Tests/APITests/LearnRosterReadinessTests.swift
+//
+// Covers the persistent LEARN roster-readiness layer: the per-course reconcile
+// (classifies each enrolled student against the LEARN classlist and persists
+// the status on the enrollment), and the manual "Reconcile now" route. The
+// reconcile core takes the `BrightSpaceGrading` client as a seam, so it runs
+// against an in-memory fake — no live D2L.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+/// Minimal `BrightSpaceGrading` fake — only `fetchClasslist` is meaningful for
+/// readiness; the grade-push surface is unused here.
+private struct FakeReadinessClient: BrightSpaceGrading {
+    let classlist: [BrightSpaceClasslistEntry]
+
+    func lookupUserID(orgDefinedId: String, on application: Application) async throws -> String? { nil }
+    func fetchClasslist(
+        orgUnitID: String, on application: Application
+    ) async throws -> [BrightSpaceClasslistEntry] {
+        classlist
+    }
+    func pushGrade(
+        orgUnitID: String, gradeObjectID: String, bsUserID: String, earnedPoints: Double,
+        on application: Application
+    ) async throws {}
+    func fetchGradeObject(
+        orgUnitID: String, gradeObjectID: String, on application: Application
+    ) async throws -> BrightSpaceGradeObject? { nil }
+    func clearGrade(
+        orgUnitID: String, gradeObjectID: String, bsUserID: String, on application: Application
+    ) async throws {}
+}
+
+@Suite struct LearnRosterReadinessTests {
+
+    // MARK: - Per-course reconcile
+
+    @Test func reconcileClassifiesEnrolledStudentsAndPersists() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let course = try #require(try await APICourse.find(courseID, on: app.db))
+            course.brightspaceOrgUnitID = "12345"
+            try await course.save(on: app.db)
+
+            // One student matches the LEARN classlist by username; the other
+            // (no student ID, username not on the list) can't be delivered to.
+            let matched = try await arInsertStudent(username: "match_user", on: app)
+            try await arEnrollStudentInTestCourse(matched, on: app)
+            let missed = try await arInsertStudent(username: "miss_user", on: app)
+            try await arEnrollStudentInTestCourse(missed, on: app)
+
+            let client = FakeReadinessClient(classlist: [
+                BrightSpaceClasslistEntry(orgDefinedID: nil, username: "match_user", userID: "d2l-1")
+            ])
+            let outcome = try await reconcileCourseReadiness(
+                course: course, orgUnitID: "12345", client: client,
+                on: app.db, application: app)
+
+            #expect(outcome.checked == 2)
+            #expect(outcome.confirmed == 1)
+            #expect(outcome.unreachable == 1)
+            #expect(outcome.updated == 2)
+
+            let matchEnroll = try #require(
+                try await APICourseEnrollment.query(on: app.db)
+                    .filter(\.$userID == matched.requireID()).first())
+            #expect(matchEnroll.learnSyncReadiness == .confirmed)
+            #expect(matchEnroll.brightspaceSyncDetail == nil)
+            #expect(matchEnroll.brightspaceCheckedAt != nil)
+
+            let missEnroll = try #require(
+                try await APICourseEnrollment.query(on: app.db)
+                    .filter(\.$userID == missed.requireID()).first())
+            #expect(missEnroll.learnSyncReadiness == .unreachable)
+            #expect((missEnroll.brightspaceSyncDetail ?? "").isEmpty == false)
+        }
+    }
+
+    @Test func enrollmentReadinessDefaultsToUnconfirmed() async throws {
+        try await withAssignmentRoutesApp { app in
+            let student = try await arInsertStudent(username: "fresh_user", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            let enroll = try #require(
+                try await APICourseEnrollment.query(on: app.db)
+                    .filter(\.$userID == student.requireID()).first())
+            // Never swept → NULL stored status reads as unconfirmed.
+            #expect(enroll.learnSyncReadiness == .unconfirmed)
+            #expect(enroll.brightspaceCheckedAt == nil)
+        }
+    }
+
+    // MARK: - Reconcile-now route
+
+    @Test func reconcileNowRedirectsWhenCourseUnlinked() async throws {
+        try await withAssignmentRoutesApp { app in
+            // Active course but no org unit bound → the route flashes + redirects
+            // rather than attempting a classlist fetch.
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/reconcile-now",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
+                })
+        }
+    }
+}

--- a/changelog.d/brightspace-roster-readiness.md
+++ b/changelog.d/brightspace-roster-readiness.md
@@ -1,0 +1,17 @@
+### Added
+
+- **LEARN roster sync readiness.** Chickadee now proactively tracks, per
+  student per course, whether it can deliver that student's grade to the LEARN
+  gradebook. A background sweep (every 10 minutes, built on the shared
+  `PeriodicSweepMonitor`) reconciles each BrightSpace-linked course's roster
+  against its LEARN classlist and persists a status on the enrollment —
+  **confirmed** (matched, we can push), **unconfirmed** (not yet checked), or
+  **unreachable** (not on the classlist, or no identity to match on, with the
+  reason). The instructor LEARN tab gains a **roster-readiness panel** with the
+  confirmed/unconfirmed/unreachable counts, the last-checked time, the list of
+  unreachable students, and a **Reconcile now** button for an on-demand
+  re-check. This is a signal layer only — an unreachable student's grade still
+  queues and is never lost; the panel just surfaces that we can't deliver it
+  yet, before term-end. It reuses the existing `LearnRosterReconciler`
+  classification and replaces the LEARN tab's old log-heuristic "unmapped
+  students" section.


### PR DESCRIPTION
## Why

PR 4 of the BrightSpace prod-readiness series — proactive roster reconciliation. Grade sync resolves a student against the LEARN classlist lazily, *at push time*, and a miss is a buried log line. For a real pilot the instructor wants to know **before term-end** which students Chickadee can't deliver a grade to. This adds a persistent, proactively-maintained per-student readiness state.

## The model

Per **(student, course)** LEARN sync readiness, stored on `course_enrollments`:
- **`unconfirmed`** — default; not yet checked against the classlist.
- **`confirmed`** — matched to a LEARN classlist identity → we can push their grade.
- **`unreachable`** — checked, but can't deliver (not on the classlist, or no key to match), with the reason.

A **background sweep every 10 minutes** reconciles each BrightSpace-linked course's roster against its LEARN classlist and persists each enrollment's status. A **"Reconcile now"** button runs it on demand for the active course.

**Signal layer only — never loses data.** It never touches a grade. An `unreachable` student's grade still queues and is pushed once they appear on the classlist; the readiness panel just surfaces that we can't deliver it *yet*.

## Reuse (per review feedback)

- **Classification:** reuses the existing pure `LearnRosterReconciler` (`onLearn`/`notOnLearn`/`unverifiable`) that already backs the on-demand Students-tab check — no reinvented matching.
- **Scheduling:** built on the shared **`PeriodicSweepMonitor`** + `PeriodicSweepLifecycleHandler` (same scaffolding as the reapers), not a hand-rolled monitor.

## What changed

- **Schema:** `AddEnrollmentBrightSpaceSyncStatus` adds three nullable columns to `course_enrollments` (status / checked-at / detail), one ALTER each (SQLite-safe). NULL reads as `.unconfirmed`.
- **Model:** `LearnSyncReadiness` enum + typed `learnSyncReadiness` accessor on `APICourseEnrollment`.
- **Sweep:** `reconcileCourseReadiness` (per-course core, shared by the sweep and the route) + `sweepLearnRosterReadiness` (all bound courses) + the monitor wiring.
- **UI (instructor LEARN tab only):** new roster-readiness panel (confirmed/unconfirmed/unreachable counts, last-checked, unreachable list, Reconcile-now button), replacing the old log-heuristic "unmapped students" section. Reuses existing card/table styling — no new CSS.

UI scope is confined to the instructor LEARN tab (course-scoped); the admin LEARN tab is deployment-wide auth status with no roster context and is untouched.

## Tests

- `reconcileClassifiesEnrolledStudentsAndPersists` — a matched + an unmatched student → confirmed / unreachable persisted, with checked-at + reason.
- `enrollmentReadinessDefaultsToUnconfirmed` — NULL status reads as unconfirmed.
- `reconcileNowRedirectsWhenCourseUnlinked` — the route's no-org-unit guard.
- `readinessPanelRendersUnreachableStudents` — the panel renders the unreachable student + Reconcile-now, and the old "Unmapped students" section is gone.

## Notes

- One `changelog.d/` fragment; no `VERSION` / `CHANGELOG.md` edits.
- `swift-format` + `check-styles` + `check-css-vars` pass locally; CI compiles/runs the suite (deps are egress-blocked here).
- Dormant until BrightSpace is configured + a course is org-unit-linked (pending UWaterloo IST creds) — the sweep no-ops otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_