### PR TITLE
refactor(migrations): decouple AddCourseEnrollmentRole backfill from the model

### DIFF
--- a/Sources/APIServer/Migrations/AddCourseEnrollmentRole.swift
+++ b/Sources/APIServer/Migrations/AddCourseEnrollmentRole.swift
@@ -20,7 +20,9 @@
 // checks, and the enroll/roster UI), so applying this migration is observably
 // a no-op.
 
+import Core
 import Fluent
+import SQLKit
 import Vapor
 
 struct AddCourseEnrollmentRole: ChickadeeMigration {
@@ -38,31 +40,66 @@ struct AddCourseEnrollmentRole: ChickadeeMigration {
             .update()
     }
 
+    /// One enrollment still needing a role, read with only the columns the
+    /// backfill touches — never the full model (see `backfillRoles`).
+    private struct PendingEnrollment: Decodable {
+        let id: UUID
+        let userID: UUID
+        enum CodingKeys: String, CodingKey {
+            case id
+            case userID = "user_id"
+        }
+    }
+
     /// Seeds every still-unset enrollment role from the enrolled user's global
     /// role. Split out from `prepare` (which adds the column) so it can be
     /// exercised directly in tests without re-running the column add.
     /// Idempotent — only NULL roles are touched, so re-running is safe.
+    ///
+    /// Reads and writes `course_enrollments` with raw SQL over only
+    /// `id` / `user_id` / `role`, deliberately NOT a full-model
+    /// `APICourseEnrollment.query().all()`. A full-model query selects every
+    /// column the model *currently* declares, so any column added to
+    /// `course_enrollments` by a *later* migration makes this backfill fail on a
+    /// fresh database with "no such column" — which is exactly what the
+    /// roster-readiness columns did until they were reordered ahead of this
+    /// migration (#1077). Scoping the SQL to the three columns it needs removes
+    /// that coupling for good.
     func backfillRoles(on database: Database) async throws {
-        let enrollments = try await APICourseEnrollment.query(on: database).all()
+        guard let sql = database as? SQLDatabase else {
+            // Only the SQL drivers (SQLite / Postgres) are used. A non-SQL
+            // Fluent driver would no-op here, leaving roles to default to
+            // `.student` via the model accessor.
+            return
+        }
 
-        // Distinct users that still need a role, fetched in one IN-query
-        // rather than a lookup per enrollment row.
-        let pendingUserIDs = Set(enrollments.compactMap { $0.roleRaw == nil ? $0.userID : nil })
-        guard !pendingUserIDs.isEmpty else { return }
+        let pending = try await sql.select()
+            .column("id")
+            .column("user_id")
+            .from("course_enrollments")
+            .where("role", .is, SQLLiteral.null)
+            .all(decoding: PendingEnrollment.self)
+        guard !pending.isEmpty else { return }
 
-        let users = try await APIUser.query(on: database)
-            .filter(\.$id ~~ pendingUserIDs)
-            .all()
+        // Instructor-ness comes from each user's *global* role. The user lookup
+        // stays a Fluent model query: it reads the `users` table, which no later
+        // migration extends, so it isn't exposed to the column-drift hazard the
+        // enrollment query above hardens against.
+        let userIDs = Set(pending.map(\.userID))
+        let users = try await APIUser.query(on: database).filter(\.$id ~~ userIDs).all()
         var isInstructorByUserID: [UUID: Bool] = [:]
         for user in users {
             guard let id = user.id else { continue }
             isInstructorByUserID[id] = user.isInstructor
         }
 
-        for enrollment in enrollments where enrollment.roleRaw == nil {
-            let isInstructor = isInstructorByUserID[enrollment.userID] ?? false
-            enrollment.role = isInstructor ? .instructor : .student
-            try await enrollment.save(on: database)
+        for row in pending {
+            let isInstructor = isInstructorByUserID[row.userID] ?? false
+            let roleValue = (isInstructor ? CourseRole.instructor : CourseRole.student).rawValue
+            try await sql.update("course_enrollments")
+                .set("role", to: roleValue)
+                .where("id", .equal, row.id)
+                .run()
         }
     }
 }

--- a/changelog.d/enrollment-backfill-harden.md
+++ b/changelog.d/enrollment-backfill-harden.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **`AddCourseEnrollmentRole`'s backfill no longer queries the full enrollment
+  model.** It now reads and writes `course_enrollments` with raw SQL over only
+  the `id` / `user_id` / `role` columns it touches, instead of a full-model
+  `APICourseEnrollment.query().all()`. A full-model query selects every column
+  the model *currently* declares, so any column added to `course_enrollments`
+  by a later migration would make this backfill fail on a fresh database with
+  "no such column" (the roster-readiness columns did exactly that until they
+  were reordered ahead of this migration). Behaviour is unchanged — only
+  NULL roles are seeded, from each user's global role. No effect on existing
+  databases (this migration is already applied there).


### PR DESCRIPTION
## Why

Hardening follow-up to #1077. That PR fixed a deterministic `autoMigrate` crash where `AddCourseEnrollmentRole.backfillRoles` ran a **full-model** `APICourseEnrollment.query().all()` during migration. Because a full-model query selects *every* column the model declares, adding the roster-readiness columns to `course_enrollments` made that SELECT reference columns that didn't exist yet on a fresh DB → `no such column: course_enrollments.brightspace_sync_status` → migration failed → every test app's `makeTestApp` threw → the test process crashed (SIGILL).

#1077 fixed it by **ordering** the new migration ahead of `AddCourseEnrollmentRole`. This PR removes the underlying coupling so the trap can't be reintroduced by the *next* column someone adds to `course_enrollments`.

## What changed

`AddCourseEnrollmentRole.backfillRoles` now reads and writes `course_enrollments` with **raw SQLKit over only the three columns it touches** (`id`, `user_id`, `role`):

- `SELECT id, user_id FROM course_enrollments WHERE role IS NULL`
- per-row `UPDATE course_enrollments SET role = ? WHERE id = ?`

instead of `APICourseEnrollment.query().all()` + `model.save()`. The query is now decoupled from the Swift model, so a future column on `course_enrollments` can never break this backfill again.

The **users** lookup stays a Fluent model query (`APIUser.query().filter(...).all()`): it reads the `users` table, which no later migration extends, so it isn't exposed to the same column-drift hazard — and keeping it Fluent preserves the readable `user.isInstructor` logic.

## Behaviour

Identical to before:
- Only NULL roles are seeded (an enrollment already carrying a role is untouched → re-running is safe).
- The seeded role is `.instructor` when the user is a global instructor or admin, else `.student`.
- No effect on existing databases — this migration is already applied there, so the backfill never re-runs in production.

Covered by the existing `CourseEnrollmentRoleTests.backfillSeedsRoleFromGlobalRole` / `backfillLeavesExistingRolesUntouched`, which exercise this path against the fully-migrated schema.

## Notes

- One `changelog.d/` fragment; no `VERSION` / `CHANGELOG.md` edits.
- `swift-format` + lint pass locally; CI compiles/runs the suite (deps are egress-blocked here). Uses the same raw-SQLKit idiom already used across the codebase (`db as? SQLDatabase` + `sql.select()…all(decoding:)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtavBmHqzzVTcMp8SQwkyh)_