### PR TITLE
fix(admin): audit log page always showed empty state

### DIFF
--- a/Resources/Views/admin-audit.leaf
+++ b/Resources/Views/admin-audit.leaf
@@ -46,7 +46,7 @@ Audit Log
         #endif
     </form>
 
-    #if(!rows.count):
+    #if(rows.isEmpty):
     <p class="audit-muted">#if(filtered):No audit entries match this filter.#else:No audit entries recorded yet.#endif</p>
     #else:
     <p class="audit-count">

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -1016,7 +1016,10 @@ private struct PassthroughResponder: AsyncResponder {
                     let body = String(buffer: res.body)
                     #expect(body.contains("testuser"), "audit table should list the actor")
                     #expect(body.contains("auth.login_success"), "audit table should show the action code")
-                    #expect(!body.contains("No audit entries recorded yet."), "empty-state should not appear when rows exist")
+                    #expect(
+                        !body.contains("No audit entries recorded yet."),
+                        "empty-state should not appear when rows exist"
+                    )
                 })
         }
     }

--- a/Tests/APITests/AdminRoutesTests.swift
+++ b/Tests/APITests/AdminRoutesTests.swift
@@ -994,6 +994,33 @@ private struct PassthroughResponder: AsyncResponder {
         }
     }
 
+    // MARK: - Audit log tab
+
+    @Test func auditPageShowsEntriesWhenPresent() async throws {
+        try await withApp(app) { _ in
+            let entry = APIAuditLogEntry(
+                actorUsername: "testuser",
+                action: AuditAction.loginSuccess.rawValue,
+                remoteAddr: "127.0.0.1"
+            )
+            try await entry.save(on: app.db)
+
+            let cookie = try await loginAsAdmin()
+            try await app.asyncTest(
+                .GET, "/admin/audit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = String(buffer: res.body)
+                    #expect(body.contains("testuser"), "audit table should list the actor")
+                    #expect(body.contains("auth.login_success"), "audit table should show the action code")
+                    #expect(!body.contains("No audit entries recorded yet."), "empty-state should not appear when rows exist")
+                })
+        }
+    }
+
     // MARK: - Storage tab per-assignment breakdown
 
     @Test func storageTabListsPerAssignmentFootprint() async throws {


### PR DESCRIPTION
## Summary

- `admin-audit.leaf` used `#if(!rows.count):` to detect an empty result set, but LeafKit does not expose `.count` as a property accessor on arrays in `#if()` expressions — it evaluates to `nil`, making `!nil` always truthy
- The page therefore always rendered "No audit entries recorded yet." regardless of how many rows the database returned
- Fixed by changing to `#if(rows.isEmpty):`, matching the pattern used in every other template in the codebase (e.g. `assignments.leaf`, `assignment-new.leaf`, `account.leaf`)
- Added a regression test that seeds an `APIAuditLogEntry` and asserts the actor name and action code appear in the rendered page body

## Root cause

The MCP admin `query_audit_log` tool confirmed 3,308 entries existed in the past week (including 469 MCP/agent calls), so the data was never the problem — only the Leaf condition guarding the table render.

## Test plan

- [ ] New test `auditPageShowsEntriesWhenPresent` in `AdminRoutesTests` seeds one entry and checks the table renders with the actor and action visible, and that the empty-state text is absent
- [ ] Existing `allAdminTabsShowVersionBanner` test continues to pass (empty-DB path still renders correctly with `rows.isEmpty` = true)

---
_Generated by [Claude Code](https://claude.ai/code/session_019wAwgViG6d4PK29vRhgg8U)_