### PR TITLE
feat: LEARN section sync backend

### DIFF
--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -71,6 +71,7 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
         }
         app.lifecycle.use(BrightSpaceGradeSyncLifecycleHandler())
         app.lifecycle.use(PeriodicSweepLifecycleHandler { $0.learnRosterReadinessMonitor })
+        app.lifecycle.use(PeriodicSweepLifecycleHandler { $0.learnSectionSyncMonitor })
     }
 
     if appConfig.auth.mode != .local {

--- a/Sources/APIServer/Migrations/AddCourseBrightSpaceSectionCategoryID.swift
+++ b/Sources/APIServer/Migrations/AddCourseBrightSpaceSectionCategoryID.swift
@@ -1,0 +1,22 @@
+// APIServer/Migrations/AddCourseBrightSpaceSectionCategoryID.swift
+//
+// Stores the D2L group category ID whose groups map to the "sections" concept
+// for this course (e.g. "Lab Sections" category → Lab 1/2/3 groups).  Nil
+// means no section category is configured yet; the section-sync sweep skips
+// the course until one is set.
+
+import Fluent
+
+struct AddCourseBrightSpaceSectionCategoryID: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("courses")
+            .field("brightspace_section_category_id", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("courses")
+            .deleteField("brightspace_section_category_id")
+            .update()
+    }
+}

--- a/Sources/APIServer/Migrations/AddEnrollmentBrightSpaceSection.swift
+++ b/Sources/APIServer/Migrations/AddEnrollmentBrightSpaceSection.swift
@@ -1,0 +1,22 @@
+// APIServer/Migrations/AddEnrollmentBrightSpaceSection.swift
+//
+// Stores the LEARN group name this student belongs to in the course's
+// configured section category (e.g. "Lab 3").  Populated by the periodic
+// section-sync sweep; nil until the sweep has run or the student isn't in any
+// group.
+
+import Fluent
+
+struct AddEnrollmentBrightSpaceSection: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("course_enrollments")
+            .field("brightspace_section", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("course_enrollments")
+            .deleteField("brightspace_section")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APICourse.swift
+++ b/Sources/APIServer/Models/APICourse.swift
@@ -56,6 +56,13 @@ final class APICourse: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_sync_user_id")
     var brightspaceSyncUserID: UUID?
 
+    /// D2L group category ID whose groups represent the "sections" for this
+    /// course (e.g. the numeric ID of the "Lab Sections" category). When set,
+    /// the section-sync sweep maps each student's group membership to
+    /// `APICourseEnrollment.brightspaceSection`. Nil = sync skipped.
+    @OptionalField(key: "brightspace_section_category_id")
+    var brightspaceSectionCategoryID: String?
+
     /// When this course was archived. Set by `toggleCourseArchive` when a
     /// course is archived (and cleared when un-archived). Archiving is
     /// Chickadee's "end of term" signal, so this is the anchor for the

--- a/Sources/APIServer/Models/APICourseEnrollment.swift
+++ b/Sources/APIServer/Models/APICourseEnrollment.swift
@@ -62,6 +62,12 @@ final class APICourseEnrollment: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_sync_detail")
     var brightspaceSyncDetail: String?
 
+    /// The LEARN group name this student belongs to in the course's configured
+    /// section category (e.g. "Lab 3"). Populated by the periodic section-sync
+    /// sweep. Nil until the sweep has run or the student isn't in any group.
+    @OptionalField(key: "brightspace_section")
+    var brightspaceSection: String?
+
     init() {}
 
     init(id: UUID? = nil, userID: UUID, courseID: UUID, role: CourseRole = .student) {

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -686,7 +686,6 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
                 orgDefinedID: $0.orgDefinedId, username: $0.username, userID: $0.identifier)
         }
     }
-}
 
     // MARK: - Group categories and groups (section sync)
 

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -69,6 +69,8 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible, LocalizedError {
     case orgUnitLookupFailed(orgUnitID: String, status: Int)
     case gradeObjectsFetchFailed(orgUnitID: String, status: Int)
     case classlistFetchFailed(orgUnitID: String, status: Int)
+    case groupCategoriesFetchFailed(orgUnitID: String, status: Int)
+    case groupsFetchFailed(orgUnitID: String, categoryID: String, status: Int)
 
     var description: String {
         switch self {
@@ -90,6 +92,10 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible, LocalizedError {
             return "BrightSpace grade-objects fetch for org unit '\(id)' failed (HTTP \(s))"
         case .classlistFetchFailed(let id, let s):
             return "BrightSpace classlist fetch for org unit '\(id)' failed (HTTP \(s))"
+        case .groupCategoriesFetchFailed(let id, let s):
+            return "BrightSpace group-categories fetch for org unit '\(id)' failed (HTTP \(s))"
+        case .groupsFetchFailed(let id, let cat, let s):
+            return "BrightSpace groups fetch for org unit '\(id)' category '\(cat)' failed (HTTP \(s))"
         }
     }
 
@@ -162,6 +168,23 @@ private struct GradeObjectJSON: Decodable {
     }
 }
 
+/// A D2L group category (e.g. "Lab Sections"), which contains a set of groups
+/// (e.g. "Lab 1", "Lab 2", …). One category per course is designated as the
+/// section source via `APICourse.brightspaceSectionCategoryID`.
+struct BrightSpaceGroupCategory: Content, Sendable {
+    let categoryID: String
+    let name: String
+}
+
+/// One group within a D2L group category, together with the D2L internal user
+/// IDs of its current members.
+struct BrightSpaceGroup: Content, Sendable {
+    let groupID: String
+    let name: String
+    /// D2L internal user IDs (`Identifier`) of enrolled members.
+    let enrollments: [String]
+}
+
 /// One member of a course's LEARN classlist, reduced to the identity fields
 /// Chickadee can match a roster entry against.  `orgDefinedID` is the student
 /// number (matches `APIUser.studentID`); `username` is the D2L login name.
@@ -232,6 +255,32 @@ protocol BrightSpaceGrading: Sendable {
     func clearGrade(
         orgUnitID: String, gradeObjectID: String, bsUserID: String, on application: Application
     ) async throws
+
+    /// Lists the group categories defined for the org unit (e.g. "Lab Sections",
+    /// "Tutorial Groups"). Used to let the operator configure which category
+    /// maps to Chickadee sections via `APICourse.brightspaceSectionCategoryID`.
+    func fetchGroupCategories(
+        orgUnitID: String, on application: Application
+    ) async throws -> [BrightSpaceGroupCategory]
+
+    /// Lists the groups within a category, including each group's member
+    /// D2L user IDs. Used by the section-sync sweep to populate
+    /// `APICourseEnrollment.brightspaceSection`.
+    func fetchGroups(
+        orgUnitID: String, categoryID: String, on application: Application
+    ) async throws -> [BrightSpaceGroup]
+}
+
+// Default no-op implementations so existing conformers (test fakes) don't
+// need to implement these methods.
+extension BrightSpaceGrading {
+    func fetchGroupCategories(
+        orgUnitID: String, on application: Application
+    ) async throws -> [BrightSpaceGroupCategory] { [] }
+
+    func fetchGroups(
+        orgUnitID: String, categoryID: String, on application: Application
+    ) async throws -> [BrightSpaceGroup] { [] }
 }
 
 // MARK: - Client
@@ -635,6 +684,73 @@ actor BrightSpaceAPIClient: BrightSpaceGrading {
         return rows.map {
             BrightSpaceClasslistEntry(
                 orgDefinedID: $0.orgDefinedId, username: $0.username, userID: $0.identifier)
+        }
+    }
+}
+
+    // MARK: - Group categories and groups (section sync)
+
+    /// Lists the D2L group categories for the org unit. The instructor selects
+    /// one category to act as the "sections" source for the course.
+    func fetchGroupCategories(
+        orgUnitID: String, on application: Application
+    ) async throws -> [BrightSpaceGroupCategory] {
+        guard !orgUnitID.isEmpty else { return [] }
+        let lpVersion = await apiVersion(
+            "lp", fallback: BrightSpaceSyncConfig.lpAPIVersion, on: application)
+        let encoded = orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
+        let rawURL = "\(config.baseURL)/d2l/api/lp/\(lpVersion)/\(encoded)/groupcategories/"
+        struct CategoryResponse: Decodable {
+            let groupCategoryId: Int
+            let name: String
+            enum CodingKeys: String, CodingKey {
+                case groupCategoryId = "GroupCategoryId"
+                case name = "Name"
+            }
+        }
+        let items: [CategoryResponse] = try await fetchAllPages(
+            firstRawURL: rawURL, on: application
+        ) { status in
+            .groupCategoriesFetchFailed(orgUnitID: orgUnitID, status: status)
+        }
+        return items.map {
+            BrightSpaceGroupCategory(categoryID: String($0.groupCategoryId), name: $0.name)
+        }
+    }
+
+    /// Lists the groups within a category and the D2L user IDs of their members.
+    func fetchGroups(
+        orgUnitID: String, categoryID: String, on application: Application
+    ) async throws -> [BrightSpaceGroup] {
+        guard !orgUnitID.isEmpty, !categoryID.isEmpty else { return [] }
+        let lpVersion = await apiVersion(
+            "lp", fallback: BrightSpaceSyncConfig.lpAPIVersion, on: application)
+        let encodedOrg =
+            orgUnitID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? orgUnitID
+        let encodedCat =
+            categoryID.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? categoryID
+        let rawURL =
+            "\(config.baseURL)/d2l/api/lp/\(lpVersion)/\(encodedOrg)/groupcategories/\(encodedCat)/groups/"
+        struct GroupResponse: Decodable {
+            let groupId: Int
+            let name: String
+            let enrollments: [Int]
+            enum CodingKeys: String, CodingKey {
+                case groupId = "GroupId"
+                case name = "Name"
+                case enrollments = "Enrollments"
+            }
+        }
+        let items: [GroupResponse] = try await fetchAllPages(
+            firstRawURL: rawURL, on: application
+        ) { status in
+            .groupsFetchFailed(orgUnitID: orgUnitID, categoryID: categoryID, status: status)
+        }
+        return items.map {
+            BrightSpaceGroup(
+                groupID: String($0.groupId),
+                name: $0.name,
+                enrollments: $0.enrollments.map(String.init))
         }
     }
 }

--- a/Sources/APIServer/Services/LearnSectionSyncService.swift
+++ b/Sources/APIServer/Services/LearnSectionSyncService.swift
@@ -165,9 +165,8 @@ func sweepLearnSections(
             totalUpdated += outcome.updated
             if outcome.updated > 0 {
                 logger.info(
-                    "Section sync for \(course.code): "
-                        + "\(outcome.assigned) assigned, \(outcome.cleared) cleared "
-                        + "(\(outcome.updated) changed)")
+                    "Section sync for \(course.code): \(outcome.assigned) assigned, \(outcome.cleared) cleared (\(outcome.updated) changed)"
+                )
             }
         } catch {
             logger.warning("Section sync failed for course \(course.code): \(error)")

--- a/Sources/APIServer/Services/LearnSectionSyncService.swift
+++ b/Sources/APIServer/Services/LearnSectionSyncService.swift
@@ -17,6 +17,26 @@ import Fluent
 import Foundation
 import Vapor
 
+// MARK: - Helpers
+
+/// Builds two lookup maps from a classlist: orgDefinedID→D2LUserID and username→D2LUserID.
+private func classlistIdentityMaps(
+    _ classlist: [BrightSpaceClasslistEntry]
+) -> (byOrgDefinedId: [String: String], byUsername: [String: String]) {
+    var byOrgDefinedId: [String: String] = [:]
+    var byUsername: [String: String] = [:]
+    for entry in classlist {
+        guard let uid = entry.userID, !uid.isEmpty else { continue }
+        if let oid = entry.orgDefinedID, !oid.isEmpty {
+            byOrgDefinedId[oid.lowercased()] = uid
+        }
+        if let uname = entry.username, !uname.isEmpty {
+            byUsername[uname.lowercased()] = uid
+        }
+    }
+    return (byOrgDefinedId, byUsername)
+}
+
 // MARK: - Core reconciler
 
 /// Outcome counts for one course's section-sync pass.
@@ -79,17 +99,7 @@ func syncCourseSections(
 
     // Build identity lookup: (orgDefinedId or username) → D2L user ID,
     // using the classlist as the bridge.
-    var d2lUserIDByOrgDefinedId: [String: String] = [:]
-    var d2lUserIDByUsername: [String: String] = [:]
-    for entry in classlist {
-        guard let uid = entry.userID, !uid.isEmpty else { continue }
-        if let oid = entry.orgDefinedID, !oid.isEmpty {
-            d2lUserIDByOrgDefinedId[oid.lowercased()] = uid
-        }
-        if let uname = entry.username, !uname.isEmpty {
-            d2lUserIDByUsername[uname.lowercased()] = uid
-        }
-    }
+    let (d2lUserIDByOrgDefinedId, d2lUserIDByUsername) = classlistIdentityMaps(classlist)
 
     var userByID: [UUID: APIUser] = [:]
     for user in users {
@@ -103,7 +113,7 @@ func syncCourseSections(
 
         // Resolve D2L user ID for this student via classlist identity match.
         let d2lUserID =
-            (student.studentID.map { d2lUserIDByOrgDefinedId[$0.lowercased()] } ?? nil)
+            student.studentID.flatMap { d2lUserIDByOrgDefinedId[$0.lowercased()] }
             ?? d2lUserIDByUsername[student.username.lowercased()]
 
         let section = d2lUserID.flatMap { sectionByD2LUserID[$0] }

--- a/Sources/APIServer/Services/LearnSectionSyncService.swift
+++ b/Sources/APIServer/Services/LearnSectionSyncService.swift
@@ -1,0 +1,204 @@
+// APIServer/Services/LearnSectionSyncService.swift
+//
+// Periodic sweep that maps each enrolled student to their LEARN group name
+// (e.g. "Lab 3") by fetching the course's configured D2L group category and
+// walking its groups' member lists.
+//
+// The sweep only runs for courses that have:
+//   1. A `brightspaceOrgUnitID` (bound to a LEARN org unit)
+//   2. A `brightspaceSectionCategoryID` (the D2L group category ID for sections)
+//
+// The per-student result is stored on `APICourseEnrollment.brightspaceSection`
+// (nil if the student is not in any group in that category).  Nothing here
+// touches grades or roster readiness — it is an independent signal layer.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+// MARK: - Core reconciler
+
+/// Outcome counts for one course's section-sync pass.
+struct SectionSyncOutcome: Sendable {
+    var checked = 0
+    var assigned = 0
+    var cleared = 0
+    var updated = 0
+}
+
+/// Syncs section membership for one course: fetches the configured group
+/// category's groups, maps each member's D2L user ID to an enrolled student
+/// via the classlist, and persists `brightspaceSection` on their enrollment.
+///
+/// Students not found in any group have their `brightspaceSection` cleared.
+@discardableResult
+func syncCourseSections(
+    course: APICourse,
+    orgUnitID: String,
+    categoryID: String,
+    client: any BrightSpaceGrading,
+    on db: Database,
+    application: Application
+) async throws -> SectionSyncOutcome {
+    guard let courseID = course.id else { return SectionSyncOutcome() }
+
+    // Fetch classlist and groups in parallel — independent D2L calls.
+    async let classlistTask = client.fetchClasslist(orgUnitID: orgUnitID, on: application)
+    async let groupsTask = client.fetchGroups(
+        orgUnitID: orgUnitID, categoryID: categoryID, on: application)
+    let (classlist, groups) = try await (classlistTask, groupsTask)
+
+    // Build D2L user ID → classlist identity mapping.
+    var classlistByD2LUserID: [String: BrightSpaceClasslistEntry] = [:]
+    for entry in classlist {
+        if let uid = entry.userID, !uid.isEmpty {
+            classlistByD2LUserID[uid] = entry
+        }
+    }
+
+    // Build D2L user ID → section name mapping from groups.
+    var sectionByD2LUserID: [String: String] = [:]
+    for group in groups {
+        for d2lUserID in group.enrollments {
+            sectionByD2LUserID[d2lUserID] = group.name
+        }
+    }
+
+    // Load enrolled students and their users.
+    let enrollments = try await APICourseEnrollment.query(on: db)
+        .filter(\.$course.$id == courseID)
+        .all()
+    let studentEnrollments = enrollments.filter { $0.role == .student }
+    guard !studentEnrollments.isEmpty else { return SectionSyncOutcome() }
+
+    let userIDs = studentEnrollments.map(\.userID)
+    let users = try await APIUser.query(on: db)
+        .filter(\.$id ~~ userIDs)
+        .all()
+
+    // Build identity lookup: (orgDefinedId or username) → D2L user ID,
+    // using the classlist as the bridge.
+    var d2lUserIDByOrgDefinedId: [String: String] = [:]
+    var d2lUserIDByUsername: [String: String] = [:]
+    for entry in classlist {
+        guard let uid = entry.userID, !uid.isEmpty else { continue }
+        if let oid = entry.orgDefinedID, !oid.isEmpty {
+            d2lUserIDByOrgDefinedId[oid.lowercased()] = uid
+        }
+        if let uname = entry.username, !uname.isEmpty {
+            d2lUserIDByUsername[uname.lowercased()] = uid
+        }
+    }
+
+    var userByID: [UUID: APIUser] = [:]
+    for user in users {
+        if let id = user.id { userByID[id] = user }
+    }
+
+    var outcome = SectionSyncOutcome()
+    for enrollment in studentEnrollments {
+        guard let student = userByID[enrollment.userID] else { continue }
+        outcome.checked += 1
+
+        // Resolve D2L user ID for this student via classlist identity match.
+        let d2lUserID =
+            (student.studentID.map { d2lUserIDByOrgDefinedId[$0.lowercased()] } ?? nil)
+            ?? d2lUserIDByUsername[student.username.lowercased()]
+
+        let section = d2lUserID.flatMap { sectionByD2LUserID[$0] }
+
+        let changed = enrollment.brightspaceSection != section
+        if changed {
+            enrollment.brightspaceSection = section
+            try await enrollment.save(on: db)
+            outcome.updated += 1
+        }
+        if section != nil { outcome.assigned += 1 } else { outcome.cleared += 1 }
+    }
+    return outcome
+}
+
+// MARK: - Sweep (all courses)
+
+/// Sweeps every BrightSpace-bound course that has a section category configured.
+/// Returns the total number of enrollment rows updated across all courses.
+@discardableResult
+func sweepLearnSections(
+    on db: Database,
+    resolveClient: (APICourse) async throws -> (any BrightSpaceGrading)?,
+    logger: Logger,
+    application: Application
+) async throws -> Int {
+    let courses = try await APICourse.query(on: db).all()
+    var totalUpdated = 0
+    for course in courses {
+        guard
+            let orgUnitID = course.brightspaceOrgUnitID, !orgUnitID.isEmpty,
+            let categoryID = course.brightspaceSectionCategoryID, !categoryID.isEmpty
+        else { continue }
+
+        let client: (any BrightSpaceGrading)?
+        do {
+            client = try await resolveClient(course)
+        } catch {
+            logger.warning(
+                "Section sync: client resolve failed for course \(course.code): \(error)")
+            continue
+        }
+        guard let client else { continue }
+
+        do {
+            let outcome = try await syncCourseSections(
+                course: course, orgUnitID: orgUnitID, categoryID: categoryID,
+                client: client, on: db, application: application)
+            totalUpdated += outcome.updated
+            if outcome.updated > 0 {
+                logger.info(
+                    "Section sync for \(course.code): "
+                        + "\(outcome.assigned) assigned, \(outcome.cleared) cleared "
+                        + "(\(outcome.updated) changed)")
+            }
+        } catch {
+            logger.warning("Section sync failed for course \(course.code): \(error)")
+        }
+    }
+    return totalUpdated
+}
+
+// MARK: - Monitor
+
+/// Section sync cadence: 10 minutes, matching the roster-readiness sweep.
+/// Group membership changes infrequently; a 10-minute window is fast enough
+/// to catch manual reassignments without hammering D2L.
+private let learnSectionSyncInterval: TimeInterval = 10 * 60
+
+struct LearnSectionSyncMonitorKey: StorageKey {
+    typealias Value = PeriodicSweepMonitor
+}
+
+extension Application {
+    var learnSectionSyncMonitor: PeriodicSweepMonitor {
+        get {
+            if let existing = storage[LearnSectionSyncMonitorKey.self] { return existing }
+            let created = PeriodicSweepMonitor(
+                name: "LEARN section sync",
+                interval: learnSectionSyncInterval,
+                runImmediately: false
+            ) { application in
+                guard application.brightSpaceAppCredentials != nil else { return }
+                _ = try await sweepLearnSections(
+                    on: application.db,
+                    resolveClient: { course in
+                        try await application.brightSpaceClient(forCourse: course)
+                    },
+                    logger: application.logger,
+                    application: application
+                )
+            }
+            storage[LearnSectionSyncMonitorKey.self] = created
+            return created
+        }
+        set { storage[LearnSectionSyncMonitorKey.self] = newValue }
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -260,6 +260,9 @@ func registerMigrations(on app: Application) {
     // Same ordering constraint as AddBrightSpaceOrgUnitName: a courses column
     // that must exist before AddCourseArchivedAt queries the APICourse model.
     app.migrations.add(AddCourseBrightSpaceSyncUserID())
+    // Same ordering constraint: brightspace_section_category_id must exist
+    // before AddCourseArchivedAt (or any migration) queries the APICourse model.
+    app.migrations.add(AddCourseBrightSpaceSectionCategoryID())
     app.migrations.add(CreateCourseEnrollments())
     app.migrations.add(CreateTestSetups())
     app.migrations.add(CreateSubmissions())
@@ -342,6 +345,9 @@ func registerMigrations(on app: Application) {
     // which on a fresh DB selects every column the model declares — including
     // these — so the columns have to exist by the time it runs.
     app.migrations.add(AddEnrollmentBrightSpaceSyncStatus())
+    // Same ordering constraint: brightspace_section must exist before
+    // AddCourseEnrollmentRole queries the full APICourseEnrollment model.
+    app.migrations.add(AddEnrollmentBrightSpaceSection())
 
     // Per-course role on each enrollment (Phase 1 of
     // docs/multi-course-roles.md). Behaviour-preserving: backfills role from
@@ -360,8 +366,4 @@ func registerMigrations(on app: Application) {
     // test_setups + users.
     app.migrations.add(CreateBrightSpaceGradeClears())
 
-    // LEARN section sync: which D2L group category maps to "sections" for a
-    // course, and the resulting per-student section name on each enrollment.
-    app.migrations.add(AddCourseBrightSpaceSectionCategoryID())
-    app.migrations.add(AddEnrollmentBrightSpaceSection())
 }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -359,4 +359,9 @@ func registerMigrations(on app: Application) {
     // no-submission student Chickadee had pushed a grade for). FK to
     // test_setups + users.
     app.migrations.add(CreateBrightSpaceGradeClears())
+
+    // LEARN section sync: which D2L group category maps to "sections" for a
+    // course, and the resulting per-student section name on each enrollment.
+    app.migrations.add(AddCourseBrightSpaceSectionCategoryID())
+    app.migrations.add(AddEnrollmentBrightSpaceSection())
 }

--- a/changelog.d/learn-sections-backend.md
+++ b/changelog.d/learn-sections-backend.md
@@ -1,0 +1,3 @@
+### Features
+
+- **LEARN section sync (backend).** Chickadee can now import D2L group memberships and store which lab section each student belongs to. `APICourse.brightspaceSectionCategoryID` designates which D2L group category acts as the sections source; a new periodic sweep (`LearnSectionSyncService`) fetches group memberships every 10 minutes and writes `APICourseEnrollment.brightspaceSection` (e.g. "Lab 3") for each matched student. Two new `BrightSpaceAPIClient` methods — `fetchGroupCategories` and `fetchGroups` — implement the D2L Valence `lp/groupcategories/` endpoints with full bookmark-paged enumeration and clock-skew retry. UI wiring is deferred to a follow-up.


### PR DESCRIPTION
## Summary

- Adds `brightspace_section_category_id` to `courses` — which D2L group category maps to "sections" for this course (e.g. the numeric ID of the "Lab Sections" category). Nil = sync skipped.
- Adds `brightspace_section` to `course_enrollments` — the group name the student belongs to (e.g. "Lab 3"), populated by the periodic sweep. Nil until swept or student isn't in any group.
- `BrightSpaceAPIClient` gains `fetchGroupCategories` and `fetchGroups` over the Valence `lp/{orgUnit}/groupcategories/` endpoints, using existing `fetchAllPages` / clock-skew-retry infrastructure. New `BrightSpaceGroupCategory` and `BrightSpaceGroup` types; two new `BrightSpaceSyncError` cases. Both methods added to the `BrightSpaceGrading` protocol with default no-op implementations so existing test fakes require no changes.
- `LearnSectionSyncService.swift`: `syncCourseSections` reconciles one course's group members against enrolled students via a classlist bridge (orgDefinedId/username → D2L user ID → group name), `sweepLearnSections` walks all BS-bound courses, and a `PeriodicSweepMonitor` runs every 10 minutes alongside the existing roster-readiness sweep.

No UI changes — the `brightspaceSection` field on enrollments is ready to be wired to the Students tab and any section-based features in a follow-up.

## Test plan

- [ ] Build passes in CI
- [ ] Migrations apply cleanly on a fresh DB and on an existing DB
- [ ] `BrightSpaceGrading` test fakes compile without changes (default no-ops cover the new protocol methods)
- [ ] Manual: set `brightspace_section_category_id` on a course via psql, confirm the sweep populates `brightspace_section` on enrollments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA7QgBS8sx5cANT4S2jwCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA7QgBS8sx5cANT4S2jwCr)_