### PR TITLE
feat: per-student dataset delivery — browser, editor, and authoring route

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -257,6 +257,14 @@
         if (personalizedInputs && Object.keys(personalizedInputs).length > 0) {
             files['_ck_inputs.py'] = personalizationInputsSource(personalizedInputs);
         }
+        // Per-student dataset slices (Phase 1 datasets): overwrite the full-source
+        // support file from the zip with the student's personal slice so test
+        // scripts see only their rows. No-op when the response has no personalizedFiles.
+        if (parsed && parsed.personalizedFiles && typeof parsed.personalizedFiles === 'object') {
+            for (const [filename, content] of Object.entries(parsed.personalizedFiles)) {
+                files[filename] = content;
+            }
+        }
 
         // 4. Fetch manifest from server (test.properties.json is not in the zip;
         //    the server serves it directly from the database via the manifest endpoint).

--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -250,20 +250,20 @@
             if (parsed && parsed.personalizedInputs && typeof parsed.personalizedInputs === 'object') {
                 personalizedInputs = parsed.personalizedInputs;
             }
+            // Per-student dataset slices (Phase 1 datasets): overwrite the full-source
+            // support file from the zip with the student's personal slice so test
+            // scripts see only their rows. No-op when the response has no personalizedFiles.
+            if (parsed && parsed.personalizedFiles && typeof parsed.personalizedFiles === 'object') {
+                for (const [filename, content] of Object.entries(parsed.personalizedFiles)) {
+                    files[filename] = content;
+                }
+            }
         } catch (_) {
             assignmentSeed = null;  // grade without a seed rather than failing the run
             personalizedInputs = null;
         }
         if (personalizedInputs && Object.keys(personalizedInputs).length > 0) {
             files['_ck_inputs.py'] = personalizationInputsSource(personalizedInputs);
-        }
-        // Per-student dataset slices (Phase 1 datasets): overwrite the full-source
-        // support file from the zip with the student's personal slice so test
-        // scripts see only their rows. No-op when the response has no personalizedFiles.
-        if (parsed && parsed.personalizedFiles && typeof parsed.personalizedFiles === 'object') {
-            for (const [filename, content] of Object.entries(parsed.personalizedFiles)) {
-                files[filename] = content;
-            }
         }
 
         // 4. Fetch manifest from server (test.properties.json is not in the zip;

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -174,12 +174,20 @@ struct BrowserRunnerRoutes: RouteCollection {
         // the worker does — via the shared `gradingInputs` helper — so a
         // browser-graded submission binds the same values a worker would.
         var personalizedInputs: [String: String]?
+        var personalizedFiles: [String: String]?
         if let manifest = setup.decodedManifest() {
+            let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
             personalizedInputs = await PersonalizationSubstitution.gradingInputs(
                 manifest: manifest, seedHex: seed,
-                supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setupID)/")
+                supportFilesDirectory: sharedDir)
+            // Resolve per-student dataset slices (Phase 1 datasets) — returns nil when
+            // the manifest declares no datasets, which is the common case.
+            personalizedFiles = DatasetResolver.resolve(
+                manifest: manifest, seedHex: seed, sourceDirectory: sharedDir)
         }
-        return BrowserRunnerSeedResponse(seed: seed, personalizedInputs: personalizedInputs)
+        return BrowserRunnerSeedResponse(
+            seed: seed, personalizedInputs: personalizedInputs,
+            personalizedFiles: personalizedFiles)
     }
 
 }
@@ -192,6 +200,12 @@ struct BrowserRunnerSeedResponse: Content {
     /// writes these to `_ck_inputs.py` so generated pattern-family scripts can
     /// load per-student args / expected. Nil when there are none (issue #461).
     let personalizedInputs: [String: String]?
+    /// Per-student dataset file contents (CSV slices), keyed by filename.
+    /// The browser writes these into the Pyodide FS before tests run,
+    /// overwriting the full-source version from the test-setup zip so each
+    /// student's code sees only their own slice. Nil when no datasets are
+    /// declared (the common case — existing assignments are unaffected).
+    let personalizedFiles: [String: String]?
 }
 
 /// Returns the manifest JSON with the `graderOnlyFiles` array blanked to `[]`,

--- a/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserRunnerRoutes.swift
@@ -161,10 +161,10 @@ struct BrowserRunnerRoutes: RouteCollection {
         guard let assignment = try await requireOpenStudentAssignment(for: setupID, user: caller, on: req)
         else {
             try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
-            return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil)
+            return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil, personalizedFiles: nil)
         }
         guard let userID = caller.id, let assignmentID = assignment.id else {
-            return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil)
+            return BrowserRunnerSeedResponse(seed: nil, personalizedInputs: nil, personalizedFiles: nil)
         }
 
         let seed = try await AssignmentSeedStore.ensureSeed(

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -100,7 +100,8 @@ func updateManifestAddingScript(
         notebookChecks: props.notebookChecks,
         sections: props.sections,
         globalVariables: props.globalVariables,
-        globalExpressions: props.globalExpressions
+        globalExpressions: props.globalExpressions,
+        datasets: props.datasets
     )
 }
 
@@ -145,7 +146,8 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
         notebookChecks: props.notebookChecks,
         sections: props.sections,
         globalVariables: props.globalVariables,
-        globalExpressions: props.globalExpressions
+        globalExpressions: props.globalExpressions,
+        datasets: props.datasets
     )
 }
 
@@ -162,7 +164,8 @@ func makeWorkerManifestJSON(
     globalExpressions: [PersonalizationExpression] = [],
     achievements: [Achievement] = [],
     disabledBuiltInAwardIDs: [String] = [],
-    builtInAchievementsSeeded: Bool = false
+    builtInAchievementsSeeded: Bool = false,
+    datasets: [DatasetSpec] = []
 ) throws -> String {
     // Topologically sort so the runner can process dependencies with a single
     // linear pass (parents always appear before children in the array).
@@ -202,6 +205,9 @@ func makeWorkerManifestJSON(
     // Slice 2 — assignment-scope expressions (notebook only). Each
     // entry is `{ name, expression }`.
     try spliceEncodedArray(into: &manifest, key: "globalExpressions", values: globalExpressions)
+    // Phase 1 dataset specs (authoring-side only; `runnerSanitized()` strips them
+    // before sending to the runner so older workers aren't affected).
+    try spliceEncodedArray(into: &manifest, key: "datasets", values: datasets)
     // Display/award-only fields (server-side; `runnerSanitized()` strips them).
     // Spliced here so a suite rebuild doesn't wipe authored achievements or the
     // instructor's built-in-award toggles — `makeWorkerManifestJSON` builds a

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
@@ -1,0 +1,89 @@
+// APIServer/Routes/Web/PublishedAssignmentRoutes+Datasets.swift
+//
+// GET/PUT /instructor/:assignmentID/datasets
+//
+// Reads and writes the per-student dataset specs on an assignment's
+// TestProperties. Each spec marks one bundled support file as a per-student
+// dataset: the server materializes a deterministic slice from the assignment
+// seed and delivers the resulting bytes to grading and the editor under the
+// same filename — so the notebook's `pd.read_csv("…")` line is unchanged
+// but every student sees their own rows.
+//
+// See docs/datasets.md (Phase 1) for the full design.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension PublishedAssignmentRoutes {
+
+    struct DatasetsBody: Content {
+        var datasets: [DatasetSpec]
+    }
+
+    struct DatasetsResponse: Content {
+        var datasets: [DatasetSpec]
+    }
+
+    // MARK: - GET /instructor/:assignmentID/datasets
+
+    @Sendable
+    func getDatasets(req: Request) async throws -> DatasetsResponse {
+        let (_, setup) = try await loadAssignmentAndSetup(req)
+        guard let manifestData = setup.manifest.data(using: .utf8),
+            let props = try? ManifestCodec.decoder.decode(TestProperties.self, from: manifestData)
+        else {
+            return DatasetsResponse(datasets: [])
+        }
+        return DatasetsResponse(datasets: props.datasets)
+    }
+
+    // MARK: - PUT /instructor/:assignmentID/datasets
+
+    @Sendable
+    func putDatasets(req: Request) async throws -> DatasetsResponse {
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req)
+        let body = try req.content.decode(DatasetsBody.self)
+
+        // Validate: each spec must name a non-empty file; sampleSize if
+        // present must be positive.
+        for spec in body.datasets {
+            guard !spec.file.trimmingCharacters(in: .whitespaces).isEmpty else {
+                throw Abort(.badRequest, reason: "Dataset spec has an empty file name.")
+            }
+            if let n = spec.sampleSize, n <= 0 {
+                throw Abort(.badRequest, reason: "sampleSize for '\(spec.file)' must be positive.")
+            }
+        }
+
+        // Splice the updated datasets array into the manifest JSON, preserving
+        // every other field. Using JSONSerialization lets us avoid rebuilding the
+        // entire manifest from components (no risk of dropping unrecognised keys).
+        guard let manifestData = setup.manifest.data(using: .utf8),
+            var dict = try? JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
+        else {
+            throw Abort(.internalServerError, reason: "Could not decode assignment manifest.")
+        }
+
+        if body.datasets.isEmpty {
+            dict.removeValue(forKey: "datasets")
+        } else {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let encoded = try encoder.encode(body.datasets)
+            if let parsed = try? JSONSerialization.jsonObject(with: encoded) as? [Any] {
+                dict["datasets"] = parsed
+            }
+        }
+
+        let newData = try JSONSerialization.data(withJSONObject: dict)
+        guard let newManifest = String(data: newData, encoding: .utf8) else {
+            throw Abort(.internalServerError, reason: "Could not re-encode assignment manifest.")
+        }
+        setup.manifest = newManifest
+        try await setup.save(on: req.db)
+
+        return DatasetsResponse(datasets: body.datasets)
+    }
+}

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
@@ -68,6 +68,10 @@ struct PublishedAssignmentRoutes: RouteCollection {
         r.get(":assignmentID", "global-variables", use: getGlobalVariables)
         r.put(":assignmentID", "global-variables", use: putGlobalVariables)
 
+        // Per-student dataset specs (Phase 1 datasets).
+        r.get(":assignmentID", "datasets", use: getDatasets)
+        r.put(":assignmentID", "datasets", use: putDatasets)
+
         // Unified Achievements table — the whole typed achievement list (class
         // goals, badges, built-in awards).  Display-only; no retest/validation.
         r.get(":assignmentID", "achievements", use: getAchievements)

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -138,6 +138,7 @@ func ensureUserNotebookWorkingCopy(
         try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
         try overwriteWith.write(to: URL(fileURLWithPath: workingCopyPath))
         await createSupportFileSymlinks(req: req, setup: fallbackSetup, studentDir: workingCopyDir)
+        await writeDatasetFiles(req: req, setup: fallbackSetup, userID: userID, studentDir: workingCopyDir)
         return overwriteWith
     }
 
@@ -148,6 +149,7 @@ func ensureUserNotebookWorkingCopy(
         // Symlinks are idempotent — run on every visit so existing working copies
         // also pick up support files when the feature is first deployed.
         await createSupportFileSymlinks(req: req, setup: fallbackSetup, studentDir: workingCopyDir)
+        await writeDatasetFiles(req: req, setup: fallbackSetup, userID: userID, studentDir: workingCopyDir)
         return existingData
     }
 
@@ -181,6 +183,7 @@ func ensureUserNotebookWorkingCopy(
     try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
     try processedData.write(to: URL(fileURLWithPath: workingCopyPath))
     await createSupportFileSymlinks(req: req, setup: fallbackSetup, studentDir: workingCopyDir)
+    await writeDatasetFiles(req: req, setup: fallbackSetup, userID: userID, studentDir: workingCopyDir)
 
     return processedData
 }
@@ -459,13 +462,17 @@ func createSupportFileSymlinks(req: Request, setup: APITestSetup, studentDir: St
     // student-facing path — here, the editor must not symlink them into the
     // student's working copy. See docs/datasets.md (option B).
     let graderOnly = props.graderOnlyFileSet
+    // Dataset files are written as real per-student files by writeDatasetFiles;
+    // skip symlinking them here so the symlink doesn't shadow the real file.
+    let datasetFilenames = Set(props.datasets.map { $0.file })
     // Cached: this pass runs on every notebook visit (the symlinks are
     // idempotent), so listing the zip fresh each time would spawn a serialized
     // `unzip` subprocess per load. The cache busts when the zip's mtime/size
     // changes — i.e. whenever the instructor edits support files.
     let allEntries = await req.application.zipEntryListCache.entries(zipPath: setup.zipPath)
     let supportNames = allEntries.filter {
-        !testScriptNames.contains($0) && !reservedNames.contains($0) && !graderOnly.contains($0)
+        !testScriptNames.contains($0) && !reservedNames.contains($0)
+            && !graderOnly.contains($0) && !datasetFilenames.contains($0)
     }
     guard !supportNames.isEmpty else { return }
 
@@ -478,5 +485,46 @@ func createSupportFileSymlinks(req: Request, setup: APITestSetup, studentDir: St
         guard !fm.fileExists(atPath: dest) else { continue }  // idempotent
         guard fm.fileExists(atPath: src) else { continue }  // skip if not yet extracted
         try? fm.createSymbolicLink(atPath: dest, withDestinationPath: src)
+    }
+}
+
+/// Materializes per-student dataset slices into the student's JupyterLite working
+/// directory. Dataset files are written as real files (not symlinks) so each student
+/// sees only their own rows. Idempotent — safe to call on every visit; always
+/// overwrites with the current slice so a spec change is picked up automatically.
+/// A strict no-op when the assignment declares no datasets.
+func writeDatasetFiles(
+    req: Request,
+    setup: APITestSetup,
+    userID: UUID,
+    studentDir: String
+) async {
+    guard let manifestData = setup.manifest.data(using: .utf8),
+        let props = decodeManifest(from: manifestData),
+        !props.datasets.isEmpty,
+        let setupID = setup.id
+    else { return }
+
+    guard
+        let assignment = try? await APIAssignment.query(on: req.db)
+            .filter(\.$testSetupID == setupID)
+            .first(),
+        let assignmentID = assignment.id
+    else { return }
+
+    guard
+        let seedHex = try? await AssignmentSeedStore.ensureSeed(
+            userID: userID, assignmentID: assignmentID, on: req.db)
+    else { return }
+
+    let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
+    guard
+        let files = DatasetResolver.resolve(
+            manifest: props, seedHex: seedHex, sourceDirectory: sharedDir)
+    else { return }
+
+    for (filename, content) in files {
+        let dest = studentDir + "/" + filename
+        try? content.write(toFile: dest, atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -785,7 +785,8 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         globalExpressions: resolvedGlobalExpressions,
         achievements: props.achievements,
         disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
-        builtInAchievementsSeeded: props.builtInAchievementsSeeded
+        builtInAchievementsSeeded: props.builtInAchievementsSeeded,
+        datasets: props.datasets
     )
 
     // Belt-and-suspenders: the post-expansion manifest is the one the runner


### PR DESCRIPTION
## Summary

Completes Phase 1 dataset delivery for browser-graded assignments and the notebook editor, matching the worker path already in place. Motivated by Lab 9 (HLTH 230), which switches from a visible `cohort_seed` substitution to a fully invisible per-student CSV slice.

- **Browser runner** (`BrowserRunnerRoutes.swift`, `browser-runner.js`): the seed endpoint now resolves per-student dataset slices via `DatasetResolver` and returns them as `personalizedFiles`; the browser runner writes those files into the Pyodide FS before tests run, overwriting the full-source zip entry with the student's slice.
- **Notebook editor** (`NotebookWorkingCopyStore.swift`): `createSupportFileSymlinks` now skips dataset filenames; new `writeDatasetFiles` materializes per-student slices as real files in the JupyterLite working directory; called at all three `ensureUserNotebookWorkingCopy` sites.
- **Manifest preservation** (`ManifestFileHelpers.swift`, `PatternFamilyApplication.swift`): `makeWorkerManifestJSON` gains a `datasets` parameter and splices it into the manifest so suite/family edits no longer silently wipe the dataset spec.
- **Authoring route** (`PublishedAssignmentRoutes.swift`, new `+Datasets.swift`): `GET/PUT /instructor/:assignmentID/datasets` lets instructors read and write `DatasetSpec` entries without going through the full manifest rebuild.
- **Lab 9 notebook** (`Ze1JGH`): removes `cohort_seed = {{cohort_seed}}` and `build_cohort(cohort_seed)`; students now call `load_data()` directly with no seed variable visible.

## What's still needed after this merges

Wire the `DatasetSpec` on Lab 9 itself — call `PUT /instructor/Ze1JGH/datasets` with `{"datasets": [{"file": "nhanes_bp.csv", "kind": "rowSample", "sampleSize": 1000}]}` once the new route is deployed. A follow-up MCP tool (`set_dataset_spec` or similar) would let this be done without a raw HTTP call.

## Test plan

- [ ] Existing assignments with no `datasets` declared are byte-identical to before (strict no-op path in `DatasetResolver`)
- [ ] Suite edits on an assignment with a `DatasetSpec` preserve the spec through `makeWorkerManifestJSON`
- [ ] `GET /instructor/:assignmentID/datasets` returns `{"datasets": []}` for assignments with no spec
- [ ] `PUT /instructor/:assignmentID/datasets` saves a spec and it round-trips via GET
- [ ] Opening Lab 9's notebook in the editor writes a per-student `nhanes_bp.csv` (real file, not symlink) to the working copy directory
- [ ] Browser-grading Lab 9 receives `personalizedFiles` in the seed response and the Pyodide FS contains the student's slice before tests run

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nht4n4WXSErr9GYkjLTJMQ)_