### PR TITLE
fix: use shared danger button style on LEARN Class Roster

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -177,7 +177,7 @@ LEARN
                     <form method="post" action="#(student.unenrollURL)" class="inline-form"
                           onsubmit="return confirm('Remove #(student.displayName) from this course?')">
                         #csrfFormField()
-                        <button class="btn btn-danger" type="submit" title="Remove from course">Delete</button>
+                        <button class="btn action-btn action-danger" type="submit" title="Remove from course">Delete</button>
                     </form>
                 </td>
             </tr>
@@ -219,10 +219,6 @@ LEARN
 }
 .bs-roster-actions { white-space: nowrap; }
 .bs-roster-actions .inline-form { display: inline; }
-.btn-danger {
-    background: var(--red); color: #fff; border-color: var(--red);
-}
-.btn-danger:hover { opacity: .85; }
 </style>
 <script>
 (function () {

--- a/changelog.d/learn-delete-button-style.md
+++ b/changelog.d/learn-delete-button-style.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **LEARN page Delete button matches the rest of the UI.** The Class Roster "Delete" button on `/instructor/brightspace` used a one-off solid-red `.btn-danger` style that stood out from every other action button. It now uses the shared `btn action-btn action-danger` class — the same subtle danger styling used across the instructor pages — and the page-local override (which also hardcoded a `#fff` colour) is removed.


### PR DESCRIPTION
## Summary

The Class Roster **Delete** button on `/instructor/brightspace` used a one-off `.btn-danger` style (solid red fill, hardcoded `#fff` text) that stood out from the rest of the instructor UI. Everywhere else — assignment Unpublish/Delete/Withdraw on `/instructor` — danger actions use the shared `btn action-btn action-danger` class: the same size as sibling action buttons, subtle gray that reads as "danger" without shouting.

- Switch the Delete button from `btn btn-danger` → `btn action-btn action-danger`, so it now matches the **Match** link beside it (`btn action-btn`) in size and the danger styling used across the instructor pages.
- Remove the page-local `.btn-danger` `<style>` override (it also hardcoded a `#fff` colour instead of routing through the palette).

No behavioural change — same form, same action, same confirm dialog.

## Test plan

- [x] `scripts/check-styles.sh` passes (no duplicated/overriding selectors, no disallowed inline styles)
- [x] `scripts/check-css-vars.sh` passes
- [ ] Visual: Delete button on the LEARN Class Roster now matches the action-button style used on the main instructor page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA7QgBS8sx5cANT4S2jwCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA7QgBS8sx5cANT4S2jwCr)_