### PR TITLE
fix: recover from today's main breakage — deploy disk-fill guard + BrightSpace grade-sync regression

### DIFF
--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -807,18 +807,44 @@ private func bestGradeForStudent(
         return StudentGrade(points: Double(override.overridePercent) / 100.0 * total, total: total)
     }
 
-    // Highest grade percentage across ALL results (browser and worker alike) —
-    // "highest grade wins": a 100 % browser result is never displaced by a later
-    // lower worker re-grade.  Convert via manifest total so the denominator is
-    // stable and consistent with the grades CSV export.
-    let bestPercentBySubmission = try await bestGradePercentBySubmissionID(
-        for: submissionIDs, on: db)
-    guard let bestPct = bestPercentBySubmission.values.max()
+    // Highest grade wins across ALL result sources (browser + worker alike): a
+    // 100 % browser result is never displaced by a later lower worker re-grade,
+    // matching the grades CSV / dashboard / roster surfaces.  Pick the result
+    // with the highest percent, then push its EXACT points so the LEARN value
+    // isn't degraded by integer-percent rounding (the shared
+    // `bestGradePercentBySubmissionID` helper returns an Int percent, which is
+    // fine for the display surfaces but lossy for a points push, e.g. 6/7 → 86 %
+    // → 8.6 instead of 8.57).
+    let allResults = try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ submissionIDs)
+        .all()
+    guard
+        let best =
+            allResults
+            .filter({ $0.gradePercentValue != nil })
+            .max(by: { ($0.gradePercentValue ?? 0) < ($1.gradePercentValue ?? 0) }),
+        let earned = best.gradePointsValue
     else {
         throw BrightSpaceSyncError.missingPoints
     }
-    guard let total = manifestTotal, total > 0 else { throw BrightSpaceSyncError.missingPoints }
-    let basePoints = Double(bestPct) / 100.0 * total
+    // Denominator: prefer the manifest's suite total (stable, matches the grades
+    // CSV); fall back to the winning result's own recorded total when the
+    // manifest carries no per-suite points (mirrors the override branch above and
+    // the pre-#1085 behaviour).
+    let resultTotal = best.gradeTotalPointsValue
+    guard let total = manifestTotal ?? resultTotal, total > 0 else {
+        throw BrightSpaceSyncError.missingPoints
+    }
+    // Express the winning result's grade on the chosen denominator.  When the
+    // result carries its own total, scale exactly (earned / resultTotal * total)
+    // so integer-percent rounding never enters the pushed value; otherwise the
+    // earned value is already in suite-point units (the pass-count fallback).
+    let basePoints: Double
+    if let resultTotal, resultTotal > 0 {
+        basePoints = earned / resultTotal * total
+    } else {
+        basePoints = earned
+    }
     // Class-goal bonus: extra credit, capped at the suite total (100%).
     let bonus = try await classGoalBonusPoints(testSetupID: testSetupID, on: db)
     let points = bonus > 0 ? min(total, basePoints + bonus) : basePoints

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -116,10 +116,6 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         #"{"earnedPoints":\#(earned),"totalPoints":\#(total)}"#
     }
 
-    private func passCountJSON(_ count: Int) -> String {
-        #"{"passCount":\#(count)}"#
-    }
-
     /// Builds a fully-wired course/setup/assignment/user/submission graph that
     /// the sweep will treat as eligible for grade sync.
     private func makeConfiguredScenario(
@@ -331,29 +327,24 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
         }
     }
 
-    @Test func bestGradePrefersWorkerResultsOverBrowser() async throws {
+    @Test func bestGradeWinsAcrossAllSourcesBrowserOrWorker() async throws {
+        // "Highest grade wins" across every source (v0.4.567): a higher browser
+        // result is NOT displaced by a lower worker re-grade, keeping the LEARN
+        // push consistent with the grades CSV / dashboard / roster surfaces.
         try await withApp(app) { _ in
             let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-cached")
-            // One pending worker result triggers the sweep; the best grade is
-            // computed across every result for this student's submissions.
+            // A pending worker re-grade at 70 % triggers the sweep...
             try await makePendingResult(
                 submissionID: scenario.submissionID,
-                json: passCountJSON(3),
+                json: pointsJSON(earned: 7, total: 10),
                 source: "worker",
                 pendingSince: Date().addingTimeInterval(-3600)
             )
+            // ...but an earlier browser result at 90 % is the best and must win.
             try await makeTestResult(
                 on: app,
                 submissionID: scenario.submissionID,
-                collectionJSON: passCountJSON(7),
-                source: "worker"
-            )
-            // Browser result with a higher score must be ignored when worker
-            // results exist.
-            try await makeTestResult(
-                on: app,
-                submissionID: scenario.submissionID,
-                collectionJSON: passCountJSON(100),
+                collectionJSON: pointsJSON(earned: 9, total: 10),
                 source: "browser"
             )
             let fake = FakeBrightSpaceGrading()
@@ -363,7 +354,7 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             #expect(processed == 1)
             let pushes = await fake.pushes
             #expect(pushes.count == 1)
-            #expect(pushes.first?.earnedPoints == 7)
+            #expect(pushes.first?.earnedPoints == 9)  // browser 90% beats worker 70%
             #expect(pushes.first?.bsUserID == "d2l-cached")
             // Cached D2L ID means no lookup call.
             let lookupCount = await fake.lookupCount

--- a/changelog.d/bluegreen-prune-images.md
+++ b/changelog.d/bluegreen-prune-images.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Blue-green deploys now reclaim disk from superseded images.** Every cutover
+  pulls a fresh multi-GB image, but `scripts/bluegreen-deploy.sh` never pruned
+  the ones it replaced, so the data disk eventually filled and Postgres PANICked
+  on its next write (`could not write lock file "postmaster.pid": No space left
+  on device`), taking the whole site down with a 500/502. The deploy now runs
+  `docker image prune -f` before each pull. Only dangling images are removed, so
+  the active color and the kept-for-rollback previous color are never touched.

--- a/changelog.d/brightspace-best-grade-fix.md
+++ b/changelog.d/brightspace-best-grade-fix.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **BrightSpace grade sync no longer fails every result-driven push.** The
+  v0.4.567 "highest grade wins" refactor (#1085) left `bestGradeForStudent`
+  requiring a manifest suite-total with no fallback and reconstructing points
+  from an integer percent, so every worker/browser-result push threw
+  `missingPoints` (and lost precision, e.g. 6/7 → 8.6 instead of 8.57) — turning
+  the whole `BrightSpaceGradeSyncTests` suite red. The sweep now selects the best
+  result across all sources (browser or worker — a higher browser grade is never
+  displaced by a lower worker re-grade) and pushes its exact points, falling back
+  to the result's own recorded total when the manifest carries no per-suite
+  points.

--- a/scripts/bluegreen-deploy.sh
+++ b/scripts/bluegreen-deploy.sh
@@ -213,6 +213,17 @@ cmd_deploy() {
 
   confirm "Deploy $IMAGE to $idle_name (:$idle_port) and cut traffic from :$active_port?"
 
+  # Reclaim disk BEFORE pulling the new image. Every swap pulls a fresh
+  # multi-GB image; without this, the images superseded by past swaps pile up
+  # until the data disk fills and Postgres PANICs on its next write ("No space
+  # left on device"), taking the whole site down — which is exactly what
+  # happened once. Only DANGLING images are removed (the old `:latest` digests
+  # that newer pulls left untagged); the active and previous colors' containers
+  # still reference their own images, so the rollback target is never pruned.
+  log "Reclaiming disk from images orphaned by past swaps (before pull)..."
+  run "docker image prune -f || true"
+  log "Free space on $(df -P / | awk 'NR==2{print $4\" KiB on \"$6}')"
+
   run "docker pull '$IMAGE'"
 
   if (( ! DRY_RUN )); then


### PR DESCRIPTION
Bundles the two fixes for today's `main` breakage (the branch is `claude/main-regression-0-4-567-ls53cs`).

---

## 1. Production outage — deploy disk-fill (commit 1)

Production went down with a 500 on `/login` (later 502). Root cause was **not** application code — the deploy host hit 100% disk:

- `df -h /` → `93G … 91G used … 0 avail … 100%`
- `docker system df` → Images **84 GB, 73 GB reclaimable**
- `chickadee-db-1` (Postgres) crash-looping: `FATAL: could not write lock file "postmaster.pid": No space left on device`
- servers exiting **132 (SIGILL)** — Vapor trapping in boot because `autoMigrate().wait()` couldn't reach the dead DB.

`scripts/bluegreen-deploy.sh` pulls a fresh multi-GB `:latest` on every cutover but never reclaimed the ones it replaced, so superseded images piled up until the disk filled.

**Fix:** `docker image prune -f` **before** each pull. Only dangling images are removed; the active color and the kept-for-rollback previous color both still have containers referencing their images, so rollback is unaffected.

## 2. CI red on main — BrightSpace grade-sync regression (commit 2)

Separately, `main` has been red since v0.4.567: all 22 failures are in `BrightSpaceGradeSyncTests`. PR #1085's "highest grade wins" refactor left `bestGradeForStudent`'s result-driven branch:
- requiring a manifest suite-total with **no fallback** → every result-driven push threw `.missingPoints` (default fixtures use an empty-suite manifest), and
- reconstructing points from an **integer percent** → precision loss (6/7 → 86% → 8.6 instead of 8.57).

**Fix:** select the best result across **all** sources by percent (a higher browser grade is never displaced by a lower worker re-grade — #1085's stated cross-surface consistency intent), then push that result's **exact** points, falling back to the result's own recorded total when the manifest carries no per-suite points (mirrors the override branch + pre-#1085 behaviour). The obsolete `bestGradePrefersWorkerResultsOverBrowser` test (worker-preference, pass-count-only fixtures) is rewritten as `bestGradeWinsAcrossAllSourcesBrowserOrWorker`.

## Testing

- `bash -n scripts/bluegreen-deploy.sh` passes; deploy fix already hot-patched onto the prod host.
- `swift-format lint --strict` clean on both changed Swift files.
- Fix verified by tracing every test in `BrightSpaceGradeSyncTests` through the new code path (the SPM build is egress-blocked in this environment, so CI is the compile/test gate). Expected: the 22 failures clear and the suite goes green.

## Changes

- `scripts/bluegreen-deploy.sh` — prune-before-pull.
- `Sources/APIServer/Services/BrightSpaceGradeSyncService.swift` — `bestGradeForStudent` best-across-all / exact-points.
- `Tests/APITests/BrightSpaceGradeSyncTests.swift` — rewrite obsolete test.
- `changelog.d/{bluegreen-prune-images,brightspace-best-grade-fix}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)