### PR TITLE
fix(deploy): refresh Compose runner after blue-green swap

### DIFF
--- a/changelog.d/blue-green-runner-refresh.md
+++ b/changelog.d/blue-green-runner-refresh.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Blue-green deploys now refresh the Compose runner.** The zero-downtime swap
+  (`bluegreen-deploy.sh`) only replaces the server color containers, so the
+  Compose `runner` was left grading on whatever image it last started with — its
+  `runnerVersion` drifted behind the server release after release. The deployer
+  daemon (`chickadee-deployer.sh`) now pulls the just-deployed image and recreates
+  the runner (`docker compose up -d --no-deps <runner>`) after a verified-healthy
+  swap, so the runner stays in lockstep with the server. The step is best-effort
+  (a runner hiccup is logged to `history.jsonl` but never rolls back the deploy)
+  and can be disabled with `CHICKADEE_REFRESH_RUNNER=0`. Manual
+  `bluegreen-deploy.sh deploy` users should run the same `docker compose pull
+  runner && docker compose up -d --no-deps runner` afterward (now documented in
+  `docs/zero-downtime-deploy.md`).

--- a/deploy/chickadee-deployer.sh
+++ b/deploy/chickadee-deployer.sh
@@ -31,6 +31,13 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEPLOY_SCRIPT="${CHICKADEE_DEPLOY_SCRIPT:-$REPO_ROOT/scripts/bluegreen-deploy.sh}"
 SNAPSHOT_SCRIPT="${CHICKADEE_SNAPSHOT_SCRIPT:-$REPO_ROOT/scripts/snapshot.sh}"
 
+# Compose stack the runner service lives in. bluegreen-deploy.sh only swaps the
+# SERVER color containers; the Compose runner is left untouched, so we refresh it
+# here after a healthy swap (see refresh_runner). Same names bluegreen-deploy.sh
+# uses, so an operator override applies to both scripts.
+COMPOSE_DIR="${CHICKADEE_COMPOSE_DIR:-$REPO_ROOT}"
+COMPOSE_FILE="${CHICKADEE_COMPOSE_FILE:-$COMPOSE_DIR/docker-compose.yml}"
+
 STATE_DIR="${CHICKADEE_STATE_DIR:-/var/lib/chickadee-deploy}"
 PUBLIC_HEALTH_URL="${CHICKADEE_PUBLIC_HEALTH_URL:-https://chickadee.uwaterloo.ca/health}"
 
@@ -39,6 +46,8 @@ DEPLOY_GATE_LEVEL="${CHICKADEE_DEPLOY_GATE_LEVEL:-major}"     # major | minor
 SNAPSHOT_BEFORE_DEPLOY="${CHICKADEE_SNAPSHOT_BEFORE_DEPLOY:-1}"
 SNAPSHOT_REQUIRED="${CHICKADEE_SNAPSHOT_REQUIRED:-0}"
 POST_DEPLOY_VERIFY_SECS="${CHICKADEE_POST_DEPLOY_VERIFY_SECS:-30}"
+REFRESH_RUNNER="${CHICKADEE_REFRESH_RUNNER:-1}"
+RUNNER_SERVICE="${CHICKADEE_RUNNER_SERVICE:-runner}"
 
 STATUS_FILE="$STATE_DIR/status.json"
 HISTORY_FILE="$STATE_DIR/history.jsonl"
@@ -165,6 +174,47 @@ verify_post_deploy() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# Refresh the Compose runner onto the just-deployed image.
+#
+# bluegreen-deploy.sh only swaps the SERVER color containers; by design it leaves
+# the Compose `runner` (and `db`) untouched. That is right for the stateful db,
+# but it strands the runner on whatever image it was last `compose up`'d with —
+# so it keeps grading on a stale build (a lagging runnerVersion on /admin/runners)
+# while the server advances release after release.
+#
+# The runner has no inbound traffic — it polls — so it needs a rolling restart,
+# not a blue-green cutover, and it should stay in lockstep with the server (they
+# share the Job / TestProperties / result schemas). We pull the same :latest the
+# swap just deployed and recreate only the runner (--no-deps leaves the fallback
+# server + db alone). A job interrupted by the brief restart is re-queued by the
+# server's StuckSubmissionReaperMonitor, and the fresh runner reconnects within a
+# poll interval.
+#
+# Best-effort: the server is already live and serving, so a runner-refresh hiccup
+# is logged but never fails or rolls back the deploy.
+# ---------------------------------------------------------------------------
+refresh_runner() {  # $1 = version tag (history label only)
+  local ver="$1"
+  [ "$REFRESH_RUNNER" = "1" ] || return 0
+
+  if [ ! -f "$COMPOSE_FILE" ]; then
+    log "runner refresh skipped: no compose file at $COMPOSE_FILE"
+    append_history "$ver" runner-refresh skipped "no compose file at $COMPOSE_FILE"
+    return 0
+  fi
+
+  log "refreshing Compose runner '$RUNNER_SERVICE' onto the new image..."
+  if docker compose --project-directory "$COMPOSE_DIR" -f "$COMPOSE_FILE" pull "$RUNNER_SERVICE" >/dev/null 2>&1 \
+     && docker compose --project-directory "$COMPOSE_DIR" -f "$COMPOSE_FILE" up -d --no-deps "$RUNNER_SERVICE" >/dev/null 2>&1; then
+    append_history "$ver" runner-refresh ok "runner '$RUNNER_SERVICE' recreated on new image"
+    log "runner refresh complete."
+  else
+    append_history "$ver" runner-refresh failed "compose pull/up failed; runner may be stale"
+    log "WARN: runner refresh failed; server is live but the runner may be on a stale image."
+  fi
+}
+
 do_deploy() {  # $1 = version tag
   local ver="$1"
   LATEST_SEEN="$ver"
@@ -198,6 +248,7 @@ do_deploy() {  # $1 = version tag
       DEPLOYED_VERSION="${running:-$(strip_v "$ver")}"
       printf '%s\n' "$DEPLOYED_VERSION" > "$DEPLOYED_VERSION_FILE"
       append_history "$ver" deploy success "running=$DEPLOYED_VERSION"
+      refresh_runner "$ver"
       write_status idle "deployed $DEPLOYED_VERSION (release $ver)"
       log "deploy complete; running version now $DEPLOYED_VERSION (target release $ver)"
       return 0

--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -91,14 +91,21 @@ working by hand, Phases 2–3 just call it.
 - The two "colors" run as plain `docker run` containers **alongside** the existing
   compose stack — `chickadee-server-blue` on `127.0.0.1:8081`,
   `chickadee-server-green` on `127.0.0.1:8082`. The compose `db` and `runner`
-  stay under compose, untouched.
+  stay under compose, untouched by the swap itself.
 - **Configuration source of truth stays in compose.** The script resolves the
   `server` service environment via `docker compose config` and passes it to the
   color with `--env-file` — no env duplication, no drift.
 - The colors join the existing `chickadee_chickadee` network (so they reach `db`)
-  and mount the existing `chickadee_chickadee-data` volume.
-- **The runner needs no changes**: it talks to the server over the public URL
-  (`https://chickadee.uwaterloo.ca`), so it follows the nginx flip automatically.
+  and mount the existing `chickadee_chickadee-data` volume. Each color also
+  registers the `server` **network alias**, so the compose runner's
+  `--api-base-url http://server:8080` keeps resolving to the active color across a
+  swap — runner→server *connectivity* follows the flip with no change.
+- **But the runner's image is NOT refreshed by the swap.** The swap only replaces
+  the server color; the compose `runner` keeps grading on whatever image it was
+  last `compose up`'d with, so its `runnerVersion` (visible on `/admin/runners`)
+  drifts behind the server. After a **manual** `bluegreen-deploy.sh deploy`, also
+  run `docker compose pull runner && docker compose up -d --no-deps runner` to put
+  the runner back in lockstep. The Phase 2 daemon does this automatically (below).
 - "Active" = the port the nginx upstream points at. It starts at `:8080` (the
   legacy compose `server`), moves onto a color on the first deploy, then colors
   alternate. The legacy server is left running as a fallback and is never
@@ -183,14 +190,26 @@ mechanism without moving any student traffic:
    `bluegreen-deploy.sh rollback --yes`. (A swap that never goes healthy is
    already aborted by the script *before* the nginx flip, so traffic never moved
    — this covers the rarer "healthy at cutover, degrades after" case.)
-8. Writes `status.json` / appends `history.jsonl` for the Phase 3 MCP surface.
+8. **Refreshes the Compose runner** onto the new image
+   (`docker compose pull <runner> && docker compose up -d --no-deps <runner>`) so
+   it grades in lockstep with the server instead of drifting on a stale build.
+   The runner polls and has no inbound traffic, so a rolling restart is the right
+   model — no blue-green needed — and any job interrupted by the brief restart is
+   re-queued by the server's `StuckSubmissionReaperMonitor`. Best-effort: this
+   runs only after the server swap is already verified healthy, so a runner hiccup
+   is logged to `history.jsonl` (`runner-refresh`) but never rolls back the deploy.
+   Disable with `CHICKADEE_REFRESH_RUNNER=0`.
+9. Writes `status.json` / appends `history.jsonl` for the Phase 3 MCP surface.
 
 ### Configuration (env / `/etc/chickadee-deployer.env`)
 
 `CHICKADEE_REPO`, `CHICKADEE_IMAGE_REPO`, `CHICKADEE_POLL_INTERVAL_SECS`,
 `CHICKADEE_DEPLOY_GATE_LEVEL` (major|minor), `CHICKADEE_SNAPSHOT_BEFORE_DEPLOY`,
 `CHICKADEE_SNAPSHOT_REQUIRED`, `CHICKADEE_POST_DEPLOY_VERIFY_SECS`,
-`CHICKADEE_PUBLIC_HEALTH_URL`, `CHICKADEE_STATE_DIR`.
+`CHICKADEE_PUBLIC_HEALTH_URL`, `CHICKADEE_STATE_DIR`,
+`CHICKADEE_REFRESH_RUNNER` (1|0, default 1), `CHICKADEE_RUNNER_SERVICE`
+(compose service name, default `runner`), `CHICKADEE_COMPOSE_DIR`,
+`CHICKADEE_COMPOSE_FILE`.
 
 ### Install
 


### PR DESCRIPTION
## Problem

After setting up the blue-green deployment, the Compose **runner** stopped tracking server releases — its `runnerVersion` on `/admin/runners` drifted behind the live server.

Root cause: `scripts/bluegreen-deploy.sh` only swaps the **server** color containers (`chickadee-server-blue`/`-green` via `docker run`) and, by design, leaves the Compose `runner` and `db` untouched. That is correct for the stateful `db`, but it strands the runner on whatever image it was last `docker compose up`'d with — so it keeps grading on a stale build while the server advances release after release. The deployer daemon (`deploy/chickadee-deployer.sh`) calls `bluegreen-deploy.sh deploy` and `docker compose pull/up` is never run, so nothing ever refreshes the runner.

(Connectivity was never the issue — the color containers register the `server` network alias, so the runner's `--api-base-url http://server:8080` keeps resolving to the active color across a swap. Only the runner's *image* was going stale.)

## Change

The deployer daemon now refreshes the Compose runner after a **verified-healthy** swap:

- New `refresh_runner()` in `deploy/chickadee-deployer.sh` runs `docker compose pull <runner>` then `docker compose up -d --no-deps <runner>` — same `:latest` the swap just deployed, so the runner lands in lockstep with the server. `--no-deps` leaves the fallback server + db alone.
- Wired into `do_deploy()` after `verify_post_deploy` succeeds and the `deploy success` history line is written.
- **Best-effort:** the server is already live, so a runner-refresh hiccup is logged to `history.jsonl` as a `runner-refresh` event but never fails or rolls back the deploy.
- A job interrupted by the brief runner restart is reclaimed by the server's `StuckSubmissionReaperMonitor` (10-min `assigned` sweep) and re-queued; the fresh runner reconnects within a poll interval.

### Why a rolling restart, not blue-green for the runner

The runner has no inbound traffic — it polls — so there is nothing to "cut over." Lockstep with the server is what you want anyway, since they share the `Job` / `TestProperties` / result schemas.

### Config (new env vars, documented)

- `CHICKADEE_REFRESH_RUNNER` (`1`|`0`, default `1`) — toggle the step off.
- `CHICKADEE_RUNNER_SERVICE` (default `runner`) — compose service name.
- `CHICKADEE_COMPOSE_DIR` / `CHICKADEE_COMPOSE_FILE` — mirror `bluegreen-deploy.sh`.

## Docs

`docs/zero-downtime-deploy.md`: corrected the Phase 1 "runner needs no changes" claim (connectivity follows the swap, but the image does not), added the manual `docker compose pull runner && docker compose up -d --no-deps runner` step for hand-run deploys, and documented the new daemon step + env vars.

## On the built-in (autostart) runner

The other "runner" — the server's local-runner-autostart subprocess (`LocalRunnerManager`) — is intentionally **not** touched here. It looks for `.build/debug/chickadee-runner` and falls back to `swift run`, neither of which exists in the production image, so it is a dev convenience only (per `docs/architecture.md`). Production grading is the Compose runner, which is what this PR keeps current. Hardening the autostart to explicitly no-op in production could be a follow-up if desired.

## Testing

- `bash -n deploy/chickadee-deployer.sh` passes.
- Manually verified the underlying commands on the live host: `docker compose pull runner && docker compose up -d --no-deps runner` pulled the new `:latest`, recreated `chickadee-runner-1`, and the runner reconnected to the dashboard on the current version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QYeHjR6KWsVKVyuBqFFFWv)_