### PR TITLE
Instructor LEARN tab UI tweaks: Sync now hard reset, Do-not-sync option, per-student counts

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -11,6 +11,13 @@ LEARN
 
 #if(hasActiveCourse):
 <div class="bs-tabbar">
+    #if(canSyncNow):
+    <form method="post" action="/instructor/brightspace/sync-now" class="inline-form">
+        #csrfFormField()
+        <button class="btn btn-primary" type="submit"
+                title="Re-queue any failed grades and push every pending grade to LEARN now">Sync now</button>
+    </form>
+    #endif
     <a class="btn action-btn" href="/instructor/grades.csv">Export Grades CSV</a>
 </div>
 #endif
@@ -28,22 +35,6 @@ LEARN
 #if(flashError):
 <div class="form-error">#(flashError)</div>
 #endif
-
-<!-- ── Summary (dashboard) ────────────────────────────────── -->
-<section class="bs-section">
-    #if(!courseIsArchived):
-    <div class="bs-summary-actions">
-        <form method="post" action="/instructor/brightspace/sync-now" class="inline-form">
-            #csrfFormField()
-            <button class="btn btn-primary" type="submit">Sync now</button>
-        </form>
-        <form method="post" action="/instructor/brightspace/retry-failed" class="inline-form">
-            #csrfFormField()
-            <button class="btn action-btn" type="submit">Retry failed</button>
-        </form>
-    </div>
-    #endif
-</section>
 
 <!-- ── Assignment → grade-item mapping ────────────────────── -->
 <section class="bs-section">
@@ -66,8 +57,8 @@ LEARN
             <tr>
                 <th>Assignment</th>
                 <th>LEARN Assessment</th>
-                <th class="bs-col-synced">Synced</th>
-                <th class="bs-col-failed">Failed</th>
+                <th class="bs-col-synced" title="Students whose most recent grade sync reached LEARN">Synced</th>
+                <th class="bs-col-failed" title="Students whose most recent grade sync failed — these need a fix">Failed</th>
                 <th>Last sync</th>
                 <th>Actions</th>
             </tr>
@@ -77,6 +68,20 @@ LEARN
             <tr>
                 <td><strong>#(row.title)</strong></td>
                 <td>
+                    #if(row.syncExcluded):
+                    <div class="bs-excluded-cell">
+                        <span class="tier bs-donotsync-pill" title="This assignment's grades are not sent to LEARN">Do not sync</span>
+                        #if(!courseIsArchived):
+                        <form method="post" action="/instructor/#(row.assignmentID)/brightspace" class="inline-form">
+                            #csrfFormField()
+                            <input type="hidden" name="returnTo" value="brightspace">
+                            <input type="hidden" name="action" value="enable">
+                            <button class="btn action-btn" type="submit"
+                                    title="Resume sending this assignment's grades to LEARN">Enable sync</button>
+                        </form>
+                        #endif
+                    </div>
+                    #else:
                     <form method="post" action="/instructor/#(row.assignmentID)/brightspace"
                           class="bs-grade-form" data-assignment-id="#(row.assignmentID)">
                         #csrfFormField()
@@ -87,8 +92,14 @@ LEARN
                                id="bs-go-#(row.assignmentID)" list="bs-grade-objects"
                                value="#(row.gradeObjectID)" placeholder="Search assessments…"
                                data-raw-id="#(row.gradeObjectID)" autocomplete="off">
-                        <button class="btn action-btn" type="submit">Save</button>
+                        <button class="btn action-btn" type="submit" name="action" value="save">Save</button>
+                        #if(!courseIsArchived):
+                        <button class="btn action-btn bs-donotsync-btn" type="submit"
+                                name="action" value="exclude" formnovalidate
+                                title="Exclude this assignment from LEARN grade sync">Do not sync</button>
+                        #endif
                     </form>
+                    #endif
                 </td>
                 <td class="bs-col-synced">
                     #if(row.hasSyncActivity):
@@ -170,14 +181,19 @@ LEARN
             <tr>
                 <td>#(student.displayName)</td>
                 <td><code>#(student.username)</code></td>
-                <td class="bs-issue-cell" title="#(student.detail)">#(student.detail)</td>
+                <td class="bs-issue-cell" title="#(student.detail)">Couldn't match to LEARN</td>
                 <td class="bs-roster-actions">
-                    <a class="btn action-btn" href="/instructor/students?highlight=#(student.userID)"
-                       title="Go to Students tab to fix this student's LEARN ID">Match</a>
+                    <a class="btn action-btn action-btn-icon" href="/instructor/students?highlight=#(student.userID)"
+                       title="Match this student's LEARN ID" aria-label="Match this student's LEARN ID">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                    </a>
                     <form method="post" action="#(student.unenrollURL)" class="inline-form"
                           onsubmit="return confirm('Remove #(student.displayName) from this course?')">
                         #csrfFormField()
-                        <button class="btn action-btn action-danger" type="submit" title="Remove from course">Delete</button>
+                        <button class="btn action-btn action-btn-icon action-danger" type="submit"
+                                title="Remove from course" aria-label="Remove from course">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>
+                        </button>
                     </form>
                 </td>
             </tr>
@@ -197,13 +213,12 @@ LEARN
 .bs-h2 { font-size: 1.05rem; font-weight: 600; margin: 0 0 .6rem; }
 .bs-mapping-head { display: flex; align-items: center; justify-content: space-between; gap: .75rem; flex-wrap: wrap; }
 .bs-mapping-head .bs-h2 { margin: 0; }
-.bs-summary-actions { display: flex; gap: .5rem; flex-wrap: wrap; }
 .bs-section-note { margin: 0 0 .6rem; max-width: 62ch; }
-.bs-grade-form { display: flex; gap: .4rem; align-items: center; margin: 0; }
+.bs-grade-form { display: flex; gap: .4rem; align-items: center; margin: 0; flex-wrap: wrap; }
 .bs-grade-input { width: 14rem; max-width: 100%; font-size: .85rem; padding: .25rem .45rem; }
-@media (max-width: 640px) {
-    .bs-grade-form { flex-wrap: wrap; }
-}
+.bs-donotsync-btn { color: var(--gray-600); }
+.bs-excluded-cell { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+.bs-donotsync-pill { color: var(--gray-600); }
 .bs-sync-detail { font-size: .72rem; }
 .bs-count {
     display: inline-block; font-size: .88rem; font-weight: 600;

--- a/Sources/APIServer/Migrations/AddAssignmentBrightSpaceSyncExcluded.swift
+++ b/Sources/APIServer/Migrations/AddAssignmentBrightSpaceSyncExcluded.swift
@@ -1,0 +1,27 @@
+// APIServer/Migrations/AddAssignmentBrightSpaceSyncExcluded.swift
+//
+// Adds the optional `brightspace_sync_excluded` column to the assignments
+// table: an explicit "do not sync this assignment's grades to LEARN" flag,
+// distinct from an unmapped grade item (which only means "not wired up yet").
+//
+// Shipped as a standalone Add* migration (not folded into CreateAssignments)
+// for the same reason as AddAssignmentStartsAt: production databases have
+// already applied CreateAssignments without this column and would never pick
+// it up from a body change. Fresh deploys run CreateAssignments then this
+// migration; existing prod runs only this one.
+
+import Fluent
+
+struct AddAssignmentBrightSpaceSyncExcluded: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignments")
+            .field("brightspace_sync_excluded", .bool)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("assignments")
+            .deleteField("brightspace_sync_excluded")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -93,6 +93,14 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_grade_object_id")
     var brightspaceGradeObjectID: String?
 
+    /// When true, this assignment is *explicitly* excluded from BrightSpace grade
+    /// sync — distinct from "not yet mapped" (`brightspaceGradeObjectID == nil`),
+    /// which only means the instructor hasn't wired a grade item yet. The sweep
+    /// skips an excluded assignment without recording an error, and the mapping
+    /// (if any) is preserved so re-enabling restores it. nil/false = not excluded.
+    @OptionalField(key: "brightspace_sync_excluded")
+    var brightspaceSyncExcluded: Bool?
+
     /// The course this assignment belongs to.
     @Field(key: "course_id")
     var courseID: UUID

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -100,6 +100,10 @@ struct InstructorBrightspaceContext: Encodable {
     let syncIdentityNeedsReconnect: Bool
     let flashSuccess: String?
     let flashError: String?
+    /// True when BrightSpace is configured and the active course isn't archived —
+    /// gates the top-bar "Sync now" button. Precomputed so the template branches
+    /// on a flat bool (LeafKit 1.14.2 mis-parses `&&` / nested `#if`).
+    let canSyncNow: Bool
     let assignmentRows: [BrightspaceAssignmentRow]
     let hasAssignments: Bool
     let logRows: [BrightspaceLogRow]
@@ -124,6 +128,10 @@ struct BrightspaceAssignmentRow: Encodable {
     let assignmentID: String  // publicID
     let title: String
     let gradeObjectID: String  // "" when unmapped
+    /// True when the instructor has explicitly chosen "Do not sync" for this
+    /// assignment — the mapping cell shows a pill + "Enable sync" instead of the
+    /// grade-item combobox, and the sweep skips it.
+    let syncExcluded: Bool
     let lastSyncText: String  // formatted time, or "—"
     let lastSyncStatus: String  // "success" | "error" | "skipped" | "none"
     let lastSyncDetail: String?

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -11,8 +11,7 @@
 //   GET  /instructor/brightspace                       → instructor-brightspace.leaf
 //   POST /instructor/brightspace/test                  → whoami connection test (JSON)
 //   GET  /instructor/brightspace/grade-objects         → [BrightSpaceGradeObject] (dropdown)
-//   POST /instructor/brightspace/sync-now              → run a grade-sync sweep immediately
-//   POST /instructor/brightspace/retry-failed          → re-queue errored pushes
+//   POST /instructor/brightspace/sync-now              → hard reset: re-queue errored pushes, then sweep immediately
 //   POST /instructor/brightspace/reconcile-now         → re-check roster readiness vs LEARN
 //   POST /instructor/:assignmentID/brightspace/push-all → re-push every grade for one assignment
 
@@ -347,10 +346,57 @@ extension InstructorDashboardRoutes {
 
     // MARK: - POST /instructor/brightspace/sync-now
 
+    /// "Sync now" is a hard reset, not just an early trigger of the 60-second
+    /// reaper: it first re-queues every push that previously failed *terminally*
+    /// (a D2L 4xx, a since-fixed grade item, a student newly added to the
+    /// classlist) — which the auto-sweep deliberately leaves alone — and then
+    /// runs an immediate sweep so both the retried failures and anything pending
+    /// push right away. (Transient failures already retry on their own, so they
+    /// need no special handling here.)
     @Sendable
     func brightspaceSyncNow(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        if let courseUUID = courseState.activeCourseUUID {
+            try await requeueErroredGradePushes(req: req, courseUUID: courseUUID)
+        }
         await runImmediateBrightspaceSweep(req: req)
         return req.redirect(to: "/instructor/brightspace")
+    }
+
+    /// Clears the recorded error and re-flags as pending every grade-sync row in
+    /// the course (result rows and override-only rows) that previously errored,
+    /// back-dating `pendingSince` so the next sweep retries it immediately. The
+    /// "hard reset" half of "Sync now".
+    private func requeueErroredGradePushes(req: Request, courseUUID: UUID) async throws {
+        let resultKeys = try await courseStudentResultIDs(req: req, courseUUID: courseUUID)
+        let results =
+            resultKeys.isEmpty
+            ? []
+            : try await APIResult.query(on: req.db)
+                .filter(\.$submissionID ~~ resultKeys)
+                .all()
+        for result in results where (result.brightspaceSyncError ?? "").isEmpty == false {
+            result.brightspaceSyncPending = true
+            result.brightspacePendingSince = Date.distantPast
+            result.brightspaceSyncError = nil
+            try await result.save(on: req.db)
+        }
+        // Errored override-only pushes (no-submission students) live on the
+        // override row, not a result row — re-queue those too.
+        let setupIDs = try await courseSetupIDs(req: req, courseUUID: courseUUID)
+        let overrides =
+            setupIDs.isEmpty
+            ? []
+            : try await APIGradeOverride.query(on: req.db)
+                .filter(\.$testSetupID ~~ setupIDs)
+                .all()
+        for override in overrides where (override.brightspaceSyncError ?? "").isEmpty == false {
+            override.brightspaceSyncPending = true
+            override.brightspacePendingSince = Date.distantPast
+            override.brightspaceSyncError = nil
+            try await override.save(on: req.db)
+        }
     }
 
     // MARK: - POST /instructor/brightspace/reconcile-now
@@ -392,46 +438,6 @@ extension InstructorDashboardRoutes {
             req.session.data["bs_flash_error"] =
                 "Couldn't reconcile against LEARN: \(error.localizedDescription)"
         }
-        return req.redirect(to: "/instructor/brightspace")
-    }
-
-    // MARK: - POST /instructor/brightspace/retry-failed
-
-    @Sendable
-    func brightspaceRetryFailed(req: Request) async throws -> Response {
-        let user = try req.auth.require(APIUser.self)
-        let courseState = try await req.resolveActiveCourse(for: user)
-        if let courseUUID = courseState.activeCourseUUID {
-            let setupIDs = try await courseStudentResultIDs(req: req, courseUUID: courseUUID)
-            let results =
-                setupIDs.isEmpty
-                ? []
-                : try await APIResult.query(on: req.db)
-                    .filter(\.$submissionID ~~ setupIDs)
-                    .all()
-            for result in results where (result.brightspaceSyncError ?? "").isEmpty == false {
-                result.brightspaceSyncPending = true
-                result.brightspacePendingSince = Date.distantPast
-                result.brightspaceSyncError = nil
-                try await result.save(on: req.db)
-            }
-            // Errored override-only pushes (no-submission students) live on the
-            // override row, not a result row — re-queue those too.
-            let setupIDList = try await courseSetupIDs(req: req, courseUUID: courseUUID)
-            let overrides =
-                setupIDList.isEmpty
-                ? []
-                : try await APIGradeOverride.query(on: req.db)
-                    .filter(\.$testSetupID ~~ setupIDList)
-                    .all()
-            for override in overrides where (override.brightspaceSyncError ?? "").isEmpty == false {
-                override.brightspaceSyncPending = true
-                override.brightspacePendingSince = Date.distantPast
-                override.brightspaceSyncError = nil
-                try await override.save(on: req.db)
-            }
-        }
-        await runImmediateBrightspaceSweep(req: req)
         return req.redirect(to: "/instructor/brightspace")
     }
 
@@ -564,6 +570,7 @@ extension InstructorDashboardRoutes {
             syncIdentityName: nil, syncIdentityIsMe: false,
             syncIdentityConnected: false, syncIdentityNeedsReconnect: false,
             flashSuccess: flashSuccess, flashError: flashError,
+            canSyncNow: false,
             assignmentRows: [], hasAssignments: false,
             logRows: [], hasLog: false,
             summary: BrightspaceSyncSummary(synced: 0, pending: 0, errored: 0),
@@ -684,6 +691,7 @@ extension InstructorDashboardRoutes {
             syncIdentityConnected: syncIdentityConnected,
             syncIdentityNeedsReconnect: syncIdentityName != nil && !syncIdentityConnected,
             flashSuccess: flashSuccess, flashError: flashError,
+            canSyncNow: syncEnabled && !course.isArchived,
             assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
             logRows: logRows, hasLog: !logRows.isEmpty,
             summary: summary, canReconcile: courseLinked && !course.isArchived,
@@ -706,6 +714,7 @@ extension InstructorDashboardRoutes {
                 assignmentID: a.publicID,
                 title: a.title,
                 gradeObjectID: a.brightspaceGradeObjectID ?? "",
+                syncExcluded: a.brightspaceSyncExcluded == true,
                 lastSyncText: last?.attemptedAt.map { fmt.string(from: $0) } ?? "—",
                 lastSyncStatus: last?.status ?? "none",
                 lastSyncDetail: last?.detail,
@@ -718,40 +727,60 @@ extension InstructorDashboardRoutes {
         }
     }
 
-    /// Per-test-setup grade-sync rollup, accumulated from both result rows and
-    /// override-only rows so the count reflects every gradeable student.
+    /// Per-test-setup grade-sync rollup, counting **distinct students** (not
+    /// rows), each bucketed once by the state of their most recent grade-sync
+    /// attempt.  The buckets are mutually exclusive so a student shows up in
+    /// exactly one — the instructor reads "Synced" as "students currently
+    /// delivered to LEARN" and "Failed" as "students who need a fix", not a
+    /// running tally of every historical push.
     private struct SetupSyncCounts {
         var synced = 0
         var pending = 0
         var errored = 0
 
-        /// Buckets one row by its sync bookkeeping columns. A recorded error
-        /// wins over a stale `syncedAt` so a row that synced and later failed
-        /// reads as errored, matching the headline cards.
-        mutating func add(pending isPending: Bool, error: String?, syncedAt: Date?) {
-            if isPending { pending += 1 }
+        /// Buckets one student by their latest attempt's state. A recorded error
+        /// means the most recent push failed (needs attention); else a synced
+        /// timestamp means it's delivered; else it's still queued.
+        mutating func add(error: String?, syncedAt: Date?, pending isPending: Bool) {
             if (error ?? "").isEmpty == false {
                 errored += 1
             } else if syncedAt != nil {
                 synced += 1
+            } else if isPending {
+                pending += 1
             }
         }
     }
 
-    /// Computes the headline summary counts (synced / pending / errored) and the
-    /// same counts bucketed per test setup (for the per-assignment rollup).
-    /// Counts span both result rows and override-only rows (no-submission
-    /// students whose grade rides on the override row), so override-only grades
-    /// show up in the totals.
+    /// One student's most-recent grade-sync attempt for a test setup, used to
+    /// dedupe the per-assignment counts down to distinct students.
+    private struct LatestSyncState {
+        var attemptedAt: Date
+        var error: String?
+        var syncedAt: Date?
+        var pending: Bool
+    }
+
+    /// Computes the per-assignment Synced/Failed rollup and the headline summary,
+    /// counting **distinct students by their most recent attempt** rather than
+    /// summing every historical result row.  For a student with submissions, the
+    /// latest result row (by `receivedAt`) reflects the outcome of their last
+    /// grade push; a no-submission student's grade rides on the override row, so
+    /// that row's state is used when no result covers them.
     private func brightspaceSyncSummary(
         req: Request,
         courseUUID: UUID,
         setupIDs: [String]
     ) async throws -> (BrightspaceSyncSummary, [String: SetupSyncCounts]) {
-        var perSetup: [String: SetupSyncCounts] = [:]
+        // (setupID, userID) → that student's most-recent sync state.
+        struct StudentKey: Hashable {
+            let setupID: String
+            let userID: UUID
+        }
+        var latestByStudent: [StudentKey: LatestSyncState] = [:]
 
-        // Result-level sync state across the course's student submissions. Keep
-        // the submission → test-setup map so each result buckets to its setup.
+        // Map each student submission to its (setup, student) so a result row
+        // resolves to the student whose grade it carries.
         let submissions =
             setupIDs.isEmpty
             ? []
@@ -759,11 +788,15 @@ extension InstructorDashboardRoutes {
                 .filter(\.$testSetupID ~~ setupIDs)
                 .filter(\.$kind == APISubmission.Kind.student)
                 .all()
-        var setupBySubmissionID: [String: String] = [:]
+        var keyBySubmissionID: [String: StudentKey] = [:]
         for submission in submissions {
-            if let id = submission.id { setupBySubmissionID[id] = submission.testSetupID }
+            if let id = submission.id, let userID = submission.userID {
+                keyBySubmissionID[id] = StudentKey(setupID: submission.testSetupID, userID: userID)
+            }
         }
-        let submissionIDs = Array(setupBySubmissionID.keys)
+
+        // Keep each student's latest result row (highest `receivedAt`).
+        let submissionIDs = Array(keyBySubmissionID.keys)
         let results =
             submissionIDs.isEmpty
             ? []
@@ -771,14 +804,19 @@ extension InstructorDashboardRoutes {
                 .filter(\.$submissionID ~~ submissionIDs)
                 .all()
         for result in results {
-            guard let setupID = setupBySubmissionID[result.submissionID] else { continue }
-            perSetup[setupID, default: SetupSyncCounts()].add(
-                pending: result.brightspaceSyncPending == true,
+            guard let key = keyBySubmissionID[result.submissionID] else { continue }
+            let received = result.receivedAt ?? Date.distantPast
+            if let existing = latestByStudent[key], existing.attemptedAt >= received { continue }
+            latestByStudent[key] = LatestSyncState(
+                attemptedAt: received,
                 error: result.brightspaceSyncError,
-                syncedAt: result.brightspaceSyncedAt)
+                syncedAt: result.brightspaceSyncedAt,
+                pending: result.brightspaceSyncPending == true)
         }
 
-        // Override-only rows (no-submission students) carry their own sync state.
+        // Override-only students (no submissions) — their grade rides on the
+        // override row. Skip any already covered by a result row: the latest
+        // result reflects the pushed grade (override included).
         let overrides =
             setupIDs.isEmpty
             ? []
@@ -786,10 +824,19 @@ extension InstructorDashboardRoutes {
                 .filter(\.$testSetupID ~~ setupIDs)
                 .all()
         for override in overrides {
-            perSetup[override.testSetupID, default: SetupSyncCounts()].add(
-                pending: override.brightspaceSyncPending == true,
+            let key = StudentKey(setupID: override.testSetupID, userID: override.userID)
+            if latestByStudent[key] != nil { continue }
+            latestByStudent[key] = LatestSyncState(
+                attemptedAt: override.brightspacePendingSince ?? Date.distantPast,
                 error: override.brightspaceSyncError,
-                syncedAt: override.brightspaceSyncedAt)
+                syncedAt: override.brightspaceSyncedAt,
+                pending: override.brightspaceSyncPending == true)
+        }
+
+        var perSetup: [String: SetupSyncCounts] = [:]
+        for (key, state) in latestByStudent {
+            perSetup[key.setupID, default: SetupSyncCounts()].add(
+                error: state.error, syncedAt: state.syncedAt, pending: state.pending)
         }
 
         var synced = 0

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -53,7 +53,6 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.get("brightspace", "grade-objects", use: brightspaceGradeObjects)
         r.post("brightspace", "auto-map", use: brightspaceAutoMap)
         r.post("brightspace", "sync-now", use: brightspaceSyncNow)
-        r.post("brightspace", "retry-failed", use: brightspaceRetryFailed)
         r.post("brightspace", "reconcile-now", use: brightspaceReconcileNow)
         r.get("grades.csv", use: exportGradesCSV)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
@@ -302,13 +301,27 @@ struct InstructorDashboardRoutes: RouteCollection {
         let assignment = try await loadAssignment(req)
         struct BSBody: Content {
             var gradeObjectID: String?
+            /// "save" (default) maps the grade item; "exclude" marks the
+            /// assignment do-not-sync; "enable" clears that exclusion. Driven by
+            /// the clicked submit button on the mapping row.
+            var action: String?
             /// "brightspace" → return to the BrightSpace tab (mapping table);
             /// otherwise the assignment edit page (the legacy caller).
             var returnTo: String?
         }
         let body = try req.content.decode(BSBody.self)
-        let raw = (body.gradeObjectID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        assignment.brightspaceGradeObjectID = raw.isEmpty ? nil : raw
+        switch body.action ?? "save" {
+        case "exclude":
+            // Keep any existing grade-item mapping so re-enabling restores it;
+            // the sweep skips the assignment while excluded regardless.
+            assignment.brightspaceSyncExcluded = true
+        case "enable":
+            assignment.brightspaceSyncExcluded = false
+        default:  // "save"
+            assignment.brightspaceSyncExcluded = false
+            let raw = (body.gradeObjectID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            assignment.brightspaceGradeObjectID = raw.isEmpty ? nil : raw
+        }
         try await assignment.save(on: req.db)
         if body.returnTo == "brightspace" {
             return req.redirect(to: "/instructor/brightspace")

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -106,6 +106,15 @@ func sweepBrightSpaceGradeSync(
     for target in targets {
         let syncRows = target.syncRows
         do {
+            // Explicitly excluded from LEARN sync (instructor chose "Do not
+            // sync") — a deliberate no-op, distinct from "no grade item
+            // configured": clear the pending flag and record nothing, so the row
+            // reads as neither synced nor errored.
+            if target.assignment?.brightspaceSyncExcluded == true {
+                try await clearPendingFlag(syncRows, on: db)
+                processed += syncRows.count
+                continue
+            }
             let pushed = try await pushGrade(
                 for: target, db: db, resolveClient: resolveClient,
                 classlistCache: classlistCache, gradeObjectCache: gradeObjectCache,
@@ -511,8 +520,9 @@ func isRetryableSyncError(_ error: Error) -> Bool {
 
 /// Records a failed group. A transient (retryable) failure keeps the pending
 /// flag set so the next sweep re-attempts it automatically; a terminal failure
-/// clears the flag and waits for a manual "Retry failed". Either way the error
-/// detail is recorded and the synced timestamp cleared.
+/// clears the flag and waits for a manual "Sync now" (which re-queues errored
+/// rows before sweeping). Either way the error detail is recorded and the synced
+/// timestamp cleared.
 private func recordSweepFailure(
     _ rows: [any BrightSpaceSyncFlaggable],
     error: Error,

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -366,4 +366,9 @@ func registerMigrations(on app: Application) {
     // test_setups + users.
     app.migrations.add(CreateBrightSpaceGradeClears())
 
+    // Explicit "do not sync this assignment to LEARN" flag on assignments,
+    // distinct from an unmapped grade item. Column-only; no migration
+    // full-queries APIAssignment, so ordering is unconstrained.
+    app.migrations.add(AddAssignmentBrightSpaceSyncExcluded())
+
 }

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -619,7 +619,7 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
 
     @Test func transientPushFailureKeepsRowPendingForAutoRetry() async throws {
         // A 503 is transient — the row stays pending so the next sweep retries
-        // automatically, without a manual "Retry failed".
+        // automatically, without a manual "Sync now".
         try await withApp(app) { _ in
             let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
             try await makePendingResult(
@@ -643,7 +643,7 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
 
     @Test func terminalPushFailureClearsPendingFlag() async throws {
         // A 400 is terminal — retrying won't help, so the flag clears and the
-        // row waits for a manual "Retry failed" after the cause is fixed.
+        // row waits for a manual "Sync now" (the hard reset) after the cause is fixed.
         try await withApp(app) { _ in
             let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
             try await makePendingResult(
@@ -661,6 +661,37 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             let result = try #require(try await APIResult.query(on: app.db).first())
             #expect(result.brightspaceSyncPending == false)  // not retried automatically
             #expect(result.brightspaceSyncError != nil)
+        }
+    }
+
+    @Test func excludedAssignmentIsSkippedBySweep() async throws {
+        // "Do not sync": an explicitly-excluded assignment is a deliberate no-op.
+        // The sweep consumes the pending row (clears its flag) but pushes nothing
+        // and records no error — it simply drops out of the queue.
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-1")
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db)
+                    .filter(\.$testSetupID == scenario.setupID).first())
+            assignment.brightspaceSyncExcluded = true
+            try await assignment.save(on: app.db)
+
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 7, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading()
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)
+            let pushes = await fake.pushes
+            #expect(pushes.isEmpty)
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncPending == false)
+            #expect((result.brightspaceSyncError ?? "").isEmpty)
+            #expect(result.brightspaceSyncedAt == nil)
         }
     }
 

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -241,23 +241,6 @@ import VaporTesting
         }
     }
 
-    @Test func retryFailedRedirectsWhenUnconfigured() async throws {
-        try await withAssignmentRoutesApp { app in
-            let cookie = try await arLoginAsInstructor(on: app)
-            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
-            try await app.asyncTest(
-                .POST, "/instructor/brightspace/retry-failed",
-                beforeRequest: { req in
-                    req.headers.add(name: .cookie, value: sessionCookie)
-                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
-                },
-                afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    #expect(res.headers.first(name: .location) == "/instructor/brightspace")
-                })
-        }
-    }
-
     // MARK: - Grade-item mapping save (returnTo routing)
 
     @Test func saveGradeItemReturnToBrightspaceRedirects() async throws {
@@ -285,6 +268,45 @@ import VaporTesting
             let updated = try await APIAssignment.query(on: app.db)
                 .filter(\.$publicID == assignmentID).first()
             #expect(updated?.brightspaceGradeObjectID == "78901")
+        }
+    }
+
+    @Test func doNotSyncExcludesAndEnableRestores() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "setup_bs_excl", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_bs_excl", title: "BS Excl", isOpen: true, on: app)
+            let assignmentID = assignment.publicID
+
+            // "Do not sync" → excluded.
+            try await app.asyncTest(
+                .POST, "/instructor/\(assignmentID)/brightspace",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["action": "exclude", "returnTo": "brightspace", "_csrf": csrf],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in #expect(res.status == .seeOther) })
+            let excluded = try await APIAssignment.query(on: app.db)
+                .filter(\.$publicID == assignmentID).first()
+            #expect(excluded?.brightspaceSyncExcluded == true)
+
+            // "Enable sync" → no longer excluded.
+            try await app.asyncTest(
+                .POST, "/instructor/\(assignmentID)/brightspace",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["action": "enable", "returnTo": "brightspace", "_csrf": csrf],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in #expect(res.status == .seeOther) })
+            let enabled = try await APIAssignment.query(on: app.db)
+                .filter(\.$publicID == assignmentID).first()
+            #expect(enabled?.brightspaceSyncExcluded == false)
         }
     }
 
@@ -328,7 +350,7 @@ import VaporTesting
 
     // MARK: - Per-assignment sync counts (instructor LEARN tab)
 
-    @Test func assignmentSyncCountsRenderOnInstructorTab() async throws {
+    @Test func assignmentSyncCountsAreDedupedPerStudent() async throws {
         try await withAssignmentRoutesApp { app in
             // Configured + active course so the dashboard (with the assignment
             // mapping table) renders.
@@ -337,26 +359,29 @@ import VaporTesting
             try await arInsertSetup(id: "setup_bs_counts", on: app)
             _ = try await arInsertAssignment(
                 testSetupID: "setup_bs_counts", title: "Counts Lab", isOpen: true, on: app)
-            let student = try await arInsertStudent(username: "bs_counts_student", on: app)
+
+            // Student A submitted twice and both results synced. The columns count
+            // distinct STUDENTS by their most recent attempt, so A is one synced
+            // student — not two — even though there are two synced result rows.
+            let studentA = try await arInsertStudent(username: "bs_counts_a", on: app)
             _ = try await arInsertSubmission(
-                id: "sub_bs_counts", testSetupID: "setup_bs_counts",
-                userID: try student.requireID(), on: app)
+                id: "sub_bs_a", testSetupID: "setup_bs_counts",
+                userID: try studentA.requireID(), on: app)
+            for id in ["res_a1", "res_a2"] {
+                let synced = APIResult(
+                    id: id, submissionID: "sub_bs_a", collectionJSON: "{}", source: "worker")
+                synced.brightspaceSyncPending = false
+                synced.brightspaceSyncedAt = Date()
+                try await synced.save(on: app.db)
+            }
 
-            // Three result rows on the assignment's setup: one synced, one
-            // pending, one errored → 1 ✓ / 1 ⏳ / 1 ✗.
-            let synced = APIResult(
-                id: "res_synced", submissionID: "sub_bs_counts", collectionJSON: "{}", source: "worker")
-            synced.brightspaceSyncPending = false
-            synced.brightspaceSyncedAt = Date()
-            try await synced.save(on: app.db)
-
-            let pending = APIResult(
-                id: "res_pending", submissionID: "sub_bs_counts", collectionJSON: "{}", source: "worker")
-            pending.brightspaceSyncPending = true
-            try await pending.save(on: app.db)
-
+            // Student B's only result errored → one failed student.
+            let studentB = try await arInsertStudent(username: "bs_counts_b", on: app)
+            _ = try await arInsertSubmission(
+                id: "sub_bs_b", testSetupID: "setup_bs_counts",
+                userID: try studentB.requireID(), on: app)
             let errored = APIResult(
-                id: "res_errored", submissionID: "sub_bs_counts", collectionJSON: "{}", source: "worker")
+                id: "res_b1", submissionID: "sub_bs_b", collectionJSON: "{}", source: "worker")
             errored.brightspaceSyncPending = false
             errored.brightspaceSyncError = "D2L rejected it"
             try await errored.save(on: app.db)
@@ -368,10 +393,11 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let html = res.body.string
-                    // Synced column shows 1 with ok style; failed column shows 1 with error style.
-                    #expect(html.contains("bs-count-ok"))
-                    #expect(html.contains("bs-count-err"))
                     #expect(html.contains("LEARN Assessment"))
+                    // Synced = 1 distinct student (A), not 2 result rows; Failed = 1 (B).
+                    #expect(html.contains("title=\"Synced to LEARN\">1<"))
+                    #expect(!html.contains("title=\"Synced to LEARN\">2<"))
+                    #expect(html.contains("bs-count-err"))
                 })
         }
     }

--- a/changelog.d/instructor-brightspace-ui-tweaks.md
+++ b/changelog.d/instructor-brightspace-ui-tweaks.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **Instructor LEARN tab: "Sync now" is now a hard reset and lives up top.**
+  The button moved next to "Export Grades CSV" and now also re-queues every
+  previously-errored grade push (the old separate "Retry failed" button, which
+  is gone) before sweeping — so terminal failures the auto-reaper leaves alone
+  get retried with one click.
+- **LEARN grade-item mapping gained a "Do not sync" option.** An instructor can
+  now explicitly exclude an assignment's grades from LEARN, distinct from simply
+  leaving it unmapped; the sweep skips excluded assignments and the row shows a
+  "Do not sync" pill with an "Enable sync" action to undo it.
+- **Per-assignment Synced/Failed counts now count distinct students by their
+  most recent attempt** instead of summing every historical result row, so the
+  numbers reflect how many students are currently delivered to LEARN and how
+  many need a fix.
+- **LEARN Class Roster polish.** The Match and Delete actions are now icon
+  buttons matching the rest of the UI, and the Issue column reads a simple
+  "Couldn't match to LEARN".


### PR DESCRIPTION
A round of UI tweaks to the instructor **LEARN** (BrightSpace) tab (`/instructor/brightspace`).

## Changes

### "Sync now" moved up top + made a hard reset
- The button now lives in the top action bar next to **Export Grades CSV** (gated on a precomputed `canSyncNow` so it only shows when BrightSpace is configured and the course isn't archived).
- It now **absorbs the old "Retry failed" behaviour**: before sweeping, it re-queues every grade push that previously failed *terminally* (D2L 4xx, a since-fixed grade item, a student newly added to the classlist) — the failures the 60-second auto-reaper deliberately leaves alone. Transient failures already retry on their own.
- The separate **"Retry failed"** button, its route (`POST /instructor/brightspace/retry-failed`), and its handler are removed.

### "Do not sync" option in the grade-item mapping
- New `brightspace_sync_excluded` flag on `assignments` (additive standalone migration, mirroring `AddAssignmentStartsAt`) lets an instructor **explicitly exclude** an assignment from LEARN — distinct from simply leaving it unmapped.
- The sweep skips excluded assignments without recording an error (a deliberate no-op that clears the pending flag).
- The mapping cell shows a **"Do not sync"** pill with an **"Enable sync"** action to undo; any existing grade-item mapping is preserved so re-enabling restores it. Saving a grade item also clears the exclusion.

### Per-assignment Synced / Failed counts are now per-student, most-recent-attempt
- Previously the columns summed *every historical result row*, so a student with several submissions was counted multiple times (and stale errors lingered).
- Now they count **distinct students by their most recent attempt** — the latest result row per student (by `received_at`), or the override row for no-submission students — with mutually-exclusive buckets. "Synced" reads as "students currently delivered to LEARN" and "Failed" as "students who need a fix".

### Class Roster polish
- **Match** and **Delete** actions are now icon buttons (link + trash) matching the rest of the UI.
- The **Issue** column reads a simple **"Couldn't match to LEARN"** (the full detail stays as a hover tooltip).

## Tests
- New: excluded-assignment sweep skip (`excludedAssignmentIsSkippedBySweep`), exclude/enable save round-trip (`doNotSyncExcludesAndEnableRestores`).
- Rewrote the per-assignment counts test to actually exercise per-student dedup (`assignmentSyncCountsAreDedupedPerStudent`).
- Removed the obsolete `retryFailedRedirectsWhenUnconfigured` test; refreshed stale "Retry failed" comments.

## Notes
- A changelog fragment is included under `changelog.d/`; `VERSION` / `CHANGELOG.md` are left for the auto-release workflow.
- Could not run `swift build` / `swift test` in this environment (egress policy blocks GitHub git fetch of SwiftPM dependencies, so they can't be resolved). Verified locally with the standalone `swift-format --strict`, the `check-styles.sh` / `check-css-vars.sh` guards, and by checking every changed function stays under the SwiftLint `function_body_length` limit. CI will run the full build + test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ecQM7NsKLDeD4X3PiV56s

---
_Generated by [Claude Code](https://claude.ai/code/session_017ecQM7NsKLDeD4X3PiV56s)_