### PR TITLE
Make "Do not sync" an option in the LEARN grade-item dropdown (follow-up to #1091)

### DIFF
--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -68,20 +68,6 @@ LEARN
             <tr>
                 <td><strong>#(row.title)</strong></td>
                 <td>
-                    #if(row.syncExcluded):
-                    <div class="bs-excluded-cell">
-                        <span class="tier bs-donotsync-pill" title="This assignment's grades are not sent to LEARN">Do not sync</span>
-                        #if(!courseIsArchived):
-                        <form method="post" action="/instructor/#(row.assignmentID)/brightspace" class="inline-form">
-                            #csrfFormField()
-                            <input type="hidden" name="returnTo" value="brightspace">
-                            <input type="hidden" name="action" value="enable">
-                            <button class="btn action-btn" type="submit"
-                                    title="Resume sending this assignment's grades to LEARN">Enable sync</button>
-                        </form>
-                        #endif
-                    </div>
-                    #else:
                     <form method="post" action="/instructor/#(row.assignmentID)/brightspace"
                           class="bs-grade-form" data-assignment-id="#(row.assignmentID)">
                         #csrfFormField()
@@ -90,16 +76,10 @@ LEARN
                         <label class="visually-hidden" for="bs-go-#(row.assignmentID)">LEARN Assessment for #(row.title)</label>
                         <input class="form-input bs-grade-input" type="text"
                                id="bs-go-#(row.assignmentID)" list="bs-grade-objects"
-                               value="#(row.gradeObjectID)" placeholder="Search assessments…"
-                               data-raw-id="#(row.gradeObjectID)" autocomplete="off">
-                        <button class="btn action-btn" type="submit" name="action" value="save">Save</button>
-                        #if(!courseIsArchived):
-                        <button class="btn action-btn bs-donotsync-btn" type="submit"
-                                name="action" value="exclude" formnovalidate
-                                title="Exclude this assignment from LEARN grade sync">Do not sync</button>
-                        #endif
+                               value="#(row.gradeFieldValue)" placeholder="Search assessments…"
+                               data-raw-id="#(row.gradeFieldValue)" autocomplete="off">
+                        <button class="btn action-btn" type="submit">Save</button>
                     </form>
-                    #endif
                 </td>
                 <td class="bs-col-synced">
                     #if(row.hasSyncActivity):
@@ -216,9 +196,6 @@ LEARN
 .bs-section-note { margin: 0 0 .6rem; max-width: 62ch; }
 .bs-grade-form { display: flex; gap: .4rem; align-items: center; margin: 0; flex-wrap: wrap; }
 .bs-grade-input { width: 14rem; max-width: 100%; font-size: .85rem; padding: .25rem .45rem; }
-.bs-donotsync-btn { color: var(--gray-600); }
-.bs-excluded-cell { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
-.bs-donotsync-pill { color: var(--gray-600); }
 .bs-sync-detail { font-size: .72rem; }
 .bs-count {
     display: inline-block; font-size: .88rem; font-weight: 600;
@@ -245,16 +222,54 @@ LEARN
     var datalist = document.getElementById('bs-grade-objects');
     if (!datalist) return;
 
+    // "Do not sync" is an option in this same dropdown: picking it excludes the
+    // assignment from LEARN. It resolves to a reserved token (kept in sync with
+    // BrightspaceSync.doNotSyncToken on the server) the save handler maps to the
+    // do-not-sync flag — never a real grade item.
+    var DO_NOT_SYNC_ID = "#(doNotSyncToken)";
+    var DO_NOT_SYNC_LABEL = 'Do not sync (exclude from LEARN)';
+
+    function optionHTML(value, id) {
+        var opt = document.createElement('option');
+        opt.value = value;
+        opt.dataset.id = id;
+        return opt.outerHTML;
+    }
+
+    // Wire each row: resolve its stored value to a display name on load, and
+    // resolve the chosen name back to an ID (or the do-not-sync token) on submit.
+    function wireForms(byId, byName) {
+        document.querySelectorAll('.bs-grade-form').forEach(function (form) {
+            var visibleInput = form.querySelector('.bs-grade-input');
+            var hiddenInput = form.querySelector('.bs-grade-id-hidden');
+            if (!visibleInput || !hiddenInput) return;
+            var rawId = visibleInput.dataset.rawId || '';
+            if (rawId && byId[rawId]) {
+                visibleInput.value = byId[rawId];
+            }
+            // Pre-fill hidden with the raw value so save works even without a match.
+            hiddenInput.value = rawId;
+            form.addEventListener('submit', function () {
+                var val = visibleInput.value.trim();
+                // Resolve a display name to its ID / the do-not-sync token; else
+                // submit the typed value as-is.
+                hiddenInput.value = byName[val] || val;
+            });
+        });
+    }
+
     fetch('/instructor/brightspace/grade-objects', {
         headers: { 'Accept': 'application/json' }, cache: 'no-store'
     }).then(function (res) {
         return res.ok ? res.json() : [];
     }).then(function (items) {
-        if (!Array.isArray(items)) return;
+        if (!Array.isArray(items)) items = [];
 
-        // Build id→name and name→id maps.
+        // Build id→name and name→id maps, seeded with the do-not-sync option.
         var byId = {};
         var byName = {};
+        byId[DO_NOT_SYNC_ID] = DO_NOT_SYNC_LABEL;
+        byName[DO_NOT_SYNC_LABEL] = DO_NOT_SYNC_ID;
         items.forEach(function (it) {
             var label = it.name;
             if (it.gradeType && it.gradeType !== 'Numeric') {
@@ -264,56 +279,27 @@ LEARN
             byName[label] = String(it.id);
         });
 
-        // Populate datalist with names (value = display name).
-        datalist.innerHTML = items.map(function (it) {
-            var label = it.name;
-            if (it.gradeType && it.gradeType !== 'Numeric') {
-                label += ' — ' + it.gradeType + ' (not supported)';
-            }
-            var opt = document.createElement('option');
-            opt.value = label;
-            opt.dataset.id = String(it.id);
-            return opt.outerHTML;
-        }).join('');
+        // Populate datalist: do-not-sync first, then the grade items by name.
+        datalist.innerHTML = optionHTML(DO_NOT_SYNC_LABEL, DO_NOT_SYNC_ID)
+            + items.map(function (it) {
+                var label = it.name;
+                if (it.gradeType && it.gradeType !== 'Numeric') {
+                    label += ' — ' + it.gradeType + ' (not supported)';
+                }
+                return optionHTML(label, String(it.id));
+            }).join('');
 
-        // For each grade form, resolve the stored numeric ID to a display name.
-        document.querySelectorAll('.bs-grade-form').forEach(function (form) {
-            var visibleInput = form.querySelector('.bs-grade-input');
-            var hiddenInput = form.querySelector('.bs-grade-id-hidden');
-            if (!visibleInput || !hiddenInput) return;
-            var rawId = visibleInput.dataset.rawId || '';
-            if (rawId && byId[rawId]) {
-                visibleInput.value = byId[rawId];
-                hiddenInput.value = rawId;
-            } else {
-                // Pre-fill hidden with the raw ID so save works even if no match.
-                hiddenInput.value = rawId;
-            }
-        });
+        wireForms(byId, byName);
 
-        // On form submit, resolve display name → ID.
-        document.querySelectorAll('.bs-grade-form').forEach(function (form) {
-            form.addEventListener('submit', function () {
-                var visibleInput = form.querySelector('.bs-grade-input');
-                var hiddenInput = form.querySelector('.bs-grade-id-hidden');
-                if (!visibleInput || !hiddenInput) return;
-                var val = visibleInput.value.trim();
-                // If it's a name in the map, resolve to ID; else submit as-is.
-                hiddenInput.value = byName[val] || val;
-            });
-        });
-
-    }).catch(function () { /* leave free-text inputs — sync still works */
-        // Fallback: copy visible input value into hidden on submit.
-        document.querySelectorAll('.bs-grade-form').forEach(function (form) {
-            var visibleInput = form.querySelector('.bs-grade-input');
-            var hiddenInput = form.querySelector('.bs-grade-id-hidden');
-            if (!visibleInput || !hiddenInput) return;
-            hiddenInput.value = visibleInput.dataset.rawId || '';
-            form.addEventListener('submit', function () {
-                hiddenInput.value = visibleInput.value.trim();
-            });
-        });
+    }).catch(function () {
+        // D2L unreachable: only the do-not-sync option is offered; grade-item
+        // names can't be resolved, so any typed ID passes through unchanged.
+        var byId = {};
+        var byName = {};
+        byId[DO_NOT_SYNC_ID] = DO_NOT_SYNC_LABEL;
+        byName[DO_NOT_SYNC_LABEL] = DO_NOT_SYNC_ID;
+        datalist.innerHTML = optionHTML(DO_NOT_SYNC_LABEL, DO_NOT_SYNC_ID);
+        wireForms(byId, byName);
     });
 })();
 </script>

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -104,6 +104,10 @@ struct InstructorBrightspaceContext: Encodable {
     /// gates the top-bar "Sync now" button. Precomputed so the template branches
     /// on a flat bool (LeafKit 1.14.2 mis-parses `&&` / nested `#if`).
     let canSyncNow: Bool
+    /// The reserved value the grade-item dropdown submits for the "Do not sync"
+    /// option (`BrightspaceSync.doNotSyncToken`), surfaced so the page JS uses
+    /// the one server-side source of truth instead of a duplicated literal.
+    let doNotSyncToken: String
     let assignmentRows: [BrightspaceAssignmentRow]
     let hasAssignments: Bool
     let logRows: [BrightspaceLogRow]
@@ -123,15 +127,25 @@ struct InstructorBrightspaceContext: Encodable {
     let hasUnreachable: Bool
 }
 
+/// Constants shared between the BrightSpace grade-sync server code and the
+/// instructor LEARN tab's page JS.
+enum BrightspaceSync {
+    /// Reserved value the grade-item dropdown submits when the instructor picks
+    /// the "Do not sync" option. The save handler maps it to
+    /// `brightspaceSyncExcluded` and never stores it; the page JS uses it (via
+    /// `doNotSyncToken` in the context) to recognise the option. Not a valid D2L
+    /// grade-object ID, so it can't collide with a real mapping.
+    static let doNotSyncToken = "__do_not_sync__"
+}
+
 /// One assignment's BrightSpace grade-item mapping + its latest sync state.
 struct BrightspaceAssignmentRow: Encodable {
     let assignmentID: String  // publicID
     let title: String
-    let gradeObjectID: String  // "" when unmapped
-    /// True when the instructor has explicitly chosen "Do not sync" for this
-    /// assignment — the mapping cell shows a pill + "Enable sync" instead of the
-    /// grade-item combobox, and the sweep skips it.
-    let syncExcluded: Bool
+    /// The value to prefill the grade-item combobox with: a D2L grade-object ID,
+    /// the `BrightspaceSync.doNotSyncToken` (when the assignment is excluded), or
+    /// "" when unmapped. The page JS resolves an ID to its display name on load.
+    let gradeFieldValue: String
     let lastSyncText: String  // formatted time, or "—"
     let lastSyncStatus: String  // "success" | "error" | "skipped" | "none"
     let lastSyncDetail: String?

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -570,7 +570,7 @@ extension InstructorDashboardRoutes {
             syncIdentityName: nil, syncIdentityIsMe: false,
             syncIdentityConnected: false, syncIdentityNeedsReconnect: false,
             flashSuccess: flashSuccess, flashError: flashError,
-            canSyncNow: false,
+            canSyncNow: false, doNotSyncToken: BrightspaceSync.doNotSyncToken,
             assignmentRows: [], hasAssignments: false,
             logRows: [], hasLog: false,
             summary: BrightspaceSyncSummary(synced: 0, pending: 0, errored: 0),
@@ -692,6 +692,7 @@ extension InstructorDashboardRoutes {
             syncIdentityNeedsReconnect: syncIdentityName != nil && !syncIdentityConnected,
             flashSuccess: flashSuccess, flashError: flashError,
             canSyncNow: syncEnabled && !course.isArchived,
+            doNotSyncToken: BrightspaceSync.doNotSyncToken,
             assignmentRows: assignmentRows, hasAssignments: !assignmentRows.isEmpty,
             logRows: logRows, hasLog: !logRows.isEmpty,
             summary: summary, canReconcile: courseLinked && !course.isArchived,
@@ -710,11 +711,14 @@ extension InstructorDashboardRoutes {
         assignments.map { a in
             let last = latestBySetup[a.testSetupID]
             let counts = perSetupCounts[a.testSetupID] ?? SetupSyncCounts()
+            let gradeFieldValue =
+                a.brightspaceSyncExcluded == true
+                ? BrightspaceSync.doNotSyncToken
+                : (a.brightspaceGradeObjectID ?? "")
             return BrightspaceAssignmentRow(
                 assignmentID: a.publicID,
                 title: a.title,
-                gradeObjectID: a.brightspaceGradeObjectID ?? "",
-                syncExcluded: a.brightspaceSyncExcluded == true,
+                gradeFieldValue: gradeFieldValue,
                 lastSyncText: last?.attemptedAt.map { fmt.string(from: $0) } ?? "—",
                 lastSyncStatus: last?.status ?? "none",
                 lastSyncDetail: last?.detail,

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -301,25 +301,20 @@ struct InstructorDashboardRoutes: RouteCollection {
         let assignment = try await loadAssignment(req)
         struct BSBody: Content {
             var gradeObjectID: String?
-            /// "save" (default) maps the grade item; "exclude" marks the
-            /// assignment do-not-sync; "enable" clears that exclusion. Driven by
-            /// the clicked submit button on the mapping row.
-            var action: String?
             /// "brightspace" → return to the BrightSpace tab (mapping table);
             /// otherwise the assignment edit page (the legacy caller).
             var returnTo: String?
         }
         let body = try req.content.decode(BSBody.self)
-        switch body.action ?? "save" {
-        case "exclude":
-            // Keep any existing grade-item mapping so re-enabling restores it;
-            // the sweep skips the assignment while excluded regardless.
+        let raw = (body.gradeObjectID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw == BrightspaceSync.doNotSyncToken {
+            // The instructor picked the "Do not sync" option in the grade-item
+            // dropdown — exclude this assignment from LEARN. The sweep then skips
+            // it; the dropdown shows "Do not sync" until a real item is chosen.
             assignment.brightspaceSyncExcluded = true
-        case "enable":
+            assignment.brightspaceGradeObjectID = nil
+        } else {
             assignment.brightspaceSyncExcluded = false
-        default:  // "save"
-            assignment.brightspaceSyncExcluded = false
-            let raw = (body.gradeObjectID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
             assignment.brightspaceGradeObjectID = raw.isEmpty ? nil : raw
         }
         try await assignment.save(on: req.db)

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -271,7 +271,7 @@ import VaporTesting
         }
     }
 
-    @Test func doNotSyncExcludesAndEnableRestores() async throws {
+    @Test func doNotSyncDropdownTokenExcludesAndMappingRestores() async throws {
         try await withAssignmentRoutesApp { app in
             let cookie = try await arLoginAsInstructor(on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
@@ -280,33 +280,39 @@ import VaporTesting
                 testSetupID: "setup_bs_excl", title: "BS Excl", isOpen: true, on: app)
             let assignmentID = assignment.publicID
 
-            // "Do not sync" → excluded.
+            // Selecting "Do not sync" in the dropdown submits the reserved token →
+            // the assignment is excluded and any grade-item mapping is cleared.
             try await app.asyncTest(
                 .POST, "/instructor/\(assignmentID)/brightspace",
                 beforeRequest: { req in
                     req.headers.add(name: .cookie, value: sessionCookie)
                     try req.content.encode(
-                        ["action": "exclude", "returnTo": "brightspace", "_csrf": csrf],
+                        [
+                            "gradeObjectID": BrightspaceSync.doNotSyncToken,
+                            "returnTo": "brightspace", "_csrf": csrf,
+                        ],
                         as: .urlEncodedForm)
                 },
                 afterResponse: { res in #expect(res.status == .seeOther) })
             let excluded = try await APIAssignment.query(on: app.db)
                 .filter(\.$publicID == assignmentID).first()
             #expect(excluded?.brightspaceSyncExcluded == true)
+            #expect(excluded?.brightspaceGradeObjectID == nil)
 
-            // "Enable sync" → no longer excluded.
+            // Picking a real grade item again clears the exclusion.
             try await app.asyncTest(
                 .POST, "/instructor/\(assignmentID)/brightspace",
                 beforeRequest: { req in
                     req.headers.add(name: .cookie, value: sessionCookie)
                     try req.content.encode(
-                        ["action": "enable", "returnTo": "brightspace", "_csrf": csrf],
+                        ["gradeObjectID": "78901", "returnTo": "brightspace", "_csrf": csrf],
                         as: .urlEncodedForm)
                 },
                 afterResponse: { res in #expect(res.status == .seeOther) })
             let enabled = try await APIAssignment.query(on: app.db)
                 .filter(\.$publicID == assignmentID).first()
             #expect(enabled?.brightspaceSyncExcluded == false)
+            #expect(enabled?.brightspaceGradeObjectID == "78901")
         }
     }
 

--- a/changelog.d/brightspace-do-not-sync-dropdown.md
+++ b/changelog.d/brightspace-do-not-sync-dropdown.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **LEARN grade-item mapping: "Do not sync" is now an option in the assessment
+  dropdown** rather than a separate button. Selecting it from the grade-item
+  combobox excludes the assignment from LEARN grade sync (and clears any
+  mapping); picking a real grade item again re-enables it. Functionally
+  unchanged — the sweep still skips excluded assignments — just folded into the
+  one control instead of an extra button.


### PR DESCRIPTION
Follow-up correction to #1091.

"Do not sync" shipped as a **separate button** next to Save, but it was meant to be an **option inside the assessment dropdown**. This PR folds it into the single grade-item combobox.

## Change
- The grade-item `<datalist>` now offers a **"Do not sync (exclude from LEARN)"** option (listed first). Selecting it and saving excludes the assignment from LEARN; picking a real grade item again clears the exclusion. When excluded, the dropdown displays "Do not sync".
- Removed the separate **Do not sync** / **Enable sync** buttons and the excluded-cell branch — it's all one control now.
- The dropdown submits a reserved token (`BrightspaceSync.doNotSyncToken`) which the save handler maps to `brightspace_sync_excluded`. The token is surfaced to the page JS via the view context, so there's one server-side source of truth (no duplicated literal). It's never stored and can't collide with a real D2L grade-object ID.

## Unchanged
- The `brightspace_sync_excluded` column/migration and the sweep's skip-when-excluded logic shipped in #1091 and are untouched here — this is purely how the exclusion is exposed in the UI.

## Tests
- Updated the panel test to drive exclusion via the dropdown token (`doNotSyncDropdownTokenExcludesAndMappingRestores`): posting the token excludes + clears the mapping; posting a real ID clears the exclusion.

## Notes
- Changelog fragment included under `changelog.d/`.
- Couldn't run `swift build`/`swift test` here (egress policy blocks SwiftPM dependency fetches); verified with standalone `swift-format --strict` and the `check-styles.sh`/`check-css-vars.sh` guards. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ecQM7NsKLDeD4X3PiV56s

---
_Generated by [Claude Code](https://claude.ai/code/session_017ecQM7NsKLDeD4X3PiV56s)_