### PR TITLE
Close the remaining per-course write gaps: lifecycle, setup, drafts, submissions (#417 Slice D)

### DIFF
--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -20,11 +20,16 @@ struct SubmissionRoutes: RouteCollection {
 
     @Sendable
     func createSubmission(req: Request) async throws -> SubmissionCreatedResponse {
+        let caller = try req.auth.require(APIUser.self)
         let body = try req.content.decode(CreateSubmissionBody.self)
 
-        guard try await APITestSetup.find(body.testSetupID, on: req.db) != nil else {
+        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
             throw AppError.invalidParameter(name: "testSetupID", reason: "no test setup with that ID")
         }
+        // Scope intake to the setup's own course: the caller must be enrolled in
+        // the course that owns the setup, so a submission can't be enqueued
+        // against another course's setup by ID (#417 Slice D).
+        try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
 
         let submissionsDir = req.application.submissionsDirectory
         let subID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
@@ -63,15 +68,18 @@ struct SubmissionRoutes: RouteCollection {
 
     @Sendable
     func createSubmissionFile(req: Request) async throws -> SubmissionCreatedResponse {
+        let caller = try req.auth.require(APIUser.self)
         let body = try req.content.decode(SubmitFileBody.self)
         let submittedFilename = submissionFilenameForStorage(
             uploadedName: body.filename,
             fallback: "submission.bin"
         )
 
-        guard try await APITestSetup.find(body.testSetupID, on: req.db) != nil else {
+        guard let setup = try await APITestSetup.find(body.testSetupID, on: req.db) else {
             throw AppError.invalidParameter(name: "testSetupID", reason: "no test setup with that ID")
         }
+        // Scope intake to the setup's own course (see createSubmission) (#417 Slice D).
+        try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
 
         let submissionsDir = req.application.submissionsDirectory
         let subID = "sub_\(UUID().uuidString.lowercased().prefix(8))"
@@ -83,14 +91,12 @@ struct SubmissionRoutes: RouteCollection {
         // For .ipynb submissions, merge the instructor's hidden test cells back in
         // before saving, so the worker grades with the full authoritative test suite.
         let fileData: Data
-        if submittedFilename.hasSuffix(".ipynb"),
-            let setup2 = try await APITestSetup.find(body.testSetupID, on: req.db)
-        {
+        if submittedFilename.hasSuffix(".ipynb") {
             // The instructor-notebook disk read and the JSON merge are both
             // blocking work; run them on the NIO thread pool so a deadline-spike
             // of concurrent .ipynb submissions doesn't serialize on the
             // cooperative executor.
-            let source = NotebookSourceRef(setup2)
+            let source = NotebookSourceRef(setup)
             let studentBytes = body.file
             fileData = try await req.application.threadPool.runIfActive(eventLoop: req.eventLoop) {
                 guard let instructorData = try? notebookData(from: source) else {

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -262,9 +262,14 @@ struct TestSetupRoutes: RouteCollection {
     @Sendable
     func uploadTestSetup(req: Request) async throws -> Response {
         let caller = try req.auth.require(APIUser.self)
-        guard caller.isInstructor else { throw Abort(.forbidden) }
-
         let upload = try req.content.decode(TestSetupUpload.self)
+
+        // Scope the create to the target course: only an instructor of that
+        // course (and not an archived one) may upload a setup into it. Replaces
+        // the old global `isInstructor` check, which trusted the client-supplied
+        // `courseID` and let any global instructor create a setup — carrying
+        // secret tests + solutions — in ANY course (#417 Slice D).
+        try await requireCourseWriteAccess(caller: caller, courseID: upload.courseID, db: req.db)
 
         // Validate manifest JSON and schema version.
         let manifestData = Data(upload.manifest.utf8)
@@ -353,13 +358,22 @@ struct TestSetupRoutes: RouteCollection {
     @Sendable
     func downloadTestSetup(req: Request) async throws -> Response {
         let caller = try req.auth.require(APIUser.self)
-        guard caller.isInstructor else { throw Abort(.forbidden) }
 
         guard let setupID = req.parameters.get("testSetupID"),
             let setup = try await APITestSetup.find(setupID, on: req.db)
         else {
             throw Abort(.notFound)
         }
+
+        // This streams the FULL setup zip — secret-tier test scripts and the
+        // reference solution — so scope it to the setup's own course rather than
+        // the old global `isInstructor` check, which let any instructor pull
+        // another course's secret tests + solution by id. Instructor-level read
+        // (admin bypass); the enrollment-gated student path is the separate
+        // /browser-runner download (#417 Slice D). Sibling reads getAssignment /
+        // downloadAssignment already scope via requireCourseEnrollment.
+        try await requireCourseInstructor(caller: caller, courseID: setup.courseID, db: req.db)
+
         return try await req.fileio.asyncStreamFile(at: setup.zipPath)
     }
 
@@ -491,13 +505,18 @@ struct TestSetupRoutes: RouteCollection {
     @Sendable
     func saveAssignment(req: Request) async throws -> HTTPStatus {
         let caller = try req.auth.require(APIUser.self)
-        guard caller.isInstructor else { throw Abort(.forbidden) }
 
         guard let setupID = req.parameters.get("testSetupID"),
             let setup = try await APITestSetup.find(setupID, on: req.db)
         else {
             throw Abort(.notFound)
         }
+
+        // Overwriting the setup's notebook on disk is a per-course write: scope
+        // it to the setup's own course (and block archived). Replaces the old
+        // global `isInstructor` check, which let any global instructor overwrite
+        // any course's notebook by :testSetupID (#417 Slice D).
+        try await requireCourseWriteAccess(caller: caller, courseID: setup.courseID, db: req.db)
 
         // Collect the raw request body as Data.
         guard let bodyBuffer = req.body.data,

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -654,6 +654,16 @@ extension DraftAssignmentRoutes {
             !draftID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
             let existing = try await APITestSetup.find(draftID, on: req.db)
         {
+            // Authorize against the draft's OWN course before handing it to the
+            // mutating service: a supplied `draftID` may point at another
+            // course's draft (or an archived course's), which the active-course
+            // group gate can't see. This closes the same cross-course/archived
+            // draft-write hole the narrower draft suite/script/section handlers
+            // gate via `loadDraftSetup(requireWrite:)` (#417 Slice D). The
+            // create-new branch below stays in the caller's active course, which
+            // `resolveActiveCourse` already proves non-archived + instructor-held.
+            let caller = try req.auth.require(APIUser.self)
+            try await requireCourseWriteAccess(caller: caller, courseID: existing.courseID, db: req.db)
             return existing
         }
 

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+Sections.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+Sections.swift
@@ -35,7 +35,7 @@ extension DraftAssignmentRoutes {
     func createDraftSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         let body = try req.content.decode(Body.self)
         try await createSuiteSectionCore(setup: setup, name: body.name, on: req.db)
         return redirectToDraft(req: req, setup: setup)
@@ -47,7 +47,7 @@ extension DraftAssignmentRoutes {
     func renameDraftSuiteSection(req: Request) async throws -> Response {
         struct Body: Content { var name: String }
 
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
@@ -60,7 +60,7 @@ extension DraftAssignmentRoutes {
 
     @Sendable
     func deleteDraftSuiteSection(req: Request) async throws -> Response {
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
@@ -89,7 +89,7 @@ extension DraftAssignmentRoutes {
             var expressions: [PersonalizationExpression]?
         }
 
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         guard let sectionID = req.parameters.get("sectionID"), !sectionID.isEmpty else {
             throw WebAssignmentError.notFound(resource: "Section")
         }
@@ -120,7 +120,7 @@ extension DraftAssignmentRoutes {
     func reorderDraftSuiteSections(req: Request) async throws -> HTTPStatus {
         struct Body: Content { var sectionIDs: [String] }
 
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         let body = try req.content.decode(Body.self)
         try await reorderSuiteSectionsCore(setup: setup, sectionIDs: body.sectionIDs, on: req.db)
         return .ok

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+SuiteEditing.swift
@@ -46,7 +46,7 @@ extension DraftAssignmentRoutes {
 
     @Sendable
     func putDraftSuite(req: Request) async throws -> Response {
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
 
         let body: SuitePayload
         do { body = try req.content.decode(SuitePayload.self) } catch {
@@ -70,7 +70,7 @@ extension DraftAssignmentRoutes {
 
     @Sendable
     func createDraftScript(req: Request) async throws -> Response {
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         let body = try req.content.decode(CreateScriptBody.self)
         let result = try await createScriptInSetup(setup: setup, body: body, on: req.db)
 
@@ -97,7 +97,7 @@ extension DraftAssignmentRoutes {
 
     @Sendable
     func deleteDraftScript(req: Request) async throws -> HTTPStatus {
-        let setup = try await loadDraftSetup(req)
+        let setup = try await loadDraftSetup(req, requireWrite: true)
         let filename = try safeScriptFilename(from: req)
         try await deleteScriptFromSetup(setup: setup, filename: filename, on: req.db)
         return .noContent

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -447,7 +447,11 @@ extension InstructorDashboardRoutes {
     /// end-of-term / first-time backfill button.
     @Sendable
     func brightspacePushAllForAssignment(req: Request) async throws -> Response {
-        let assignment = try await loadAssignment(req)
+        // Unlike its active-course-scoped BrightSpace siblings, this takes
+        // :assignmentID, so it's drivable cross-course / against an archived
+        // course by URL — scope the grade-push backfill to the assignment's own
+        // course (#417 Slice D).
+        let assignment = try await loadAssignmentForWrite(req)
         let submissionIDs = try await APISubmission.query(on: req.db)
             .filter(\.$testSetupID == assignment.testSetupID)
             .filter(\.$kind == APISubmission.Kind.student)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -184,7 +184,7 @@ struct InstructorDashboardRoutes: RouteCollection {
 
     @Sendable
     func openAssignment(req: Request) async throws -> Response {
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         do {
             try await AssignmentAuthoringService.setOpenState(assignment, open: true, on: req.db)
         } catch AssignmentAuthoringError.validationNotPassed {
@@ -202,6 +202,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         struct ReorderBody: Content {
             var assignmentIDs: [String]
         }
+        let caller = try req.auth.require(APIUser.self)
         let body = try req.content.decode(ReorderBody.self)
         let orderedIDs = Array(NSOrderedSet(array: body.assignmentIDs).compactMap { $0 as? String })
         guard !orderedIDs.isEmpty else { return .ok }
@@ -223,6 +224,15 @@ struct InstructorDashboardRoutes: RouteCollection {
             )
         }
 
+        // Reordering writes sortOrder, so it's a per-course write: authorize the
+        // caller for every distinct course the payload touches. Without this an
+        // instructor could reorder another course's (or an archived course's)
+        // assignments by submitting their IDs — the active-course group gate
+        // never sees the target courses here (#417 Slice D).
+        for courseID in Set(assignments.map(\.courseID)) {
+            try await requireCourseWriteAccess(caller: caller, courseID: courseID, db: req.db)
+        }
+
         for (index, rawID) in orderedIDs.enumerated() {
             guard let assignment = byID[rawID] else { continue }
             assignment.sortOrder = index + 1
@@ -239,7 +249,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             var status: String
         }
 
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
 
         let body = try req.content.decode(StatusBody.self)
         guard let visibility = AssignmentVisibility(rawValue: body.status) else {
@@ -262,7 +272,7 @@ struct InstructorDashboardRoutes: RouteCollection {
 
     @Sendable
     func closeAssignment(req: Request) async throws -> Response {
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         try await AssignmentAuthoringService.setOpenState(assignment, open: false, on: req.db)
         return req.redirect(to: "/instructor")
     }
@@ -298,7 +308,7 @@ struct InstructorDashboardRoutes: RouteCollection {
 
     @Sendable
     func saveBrightSpaceGradeObjectID(req: Request) async throws -> Response {
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         struct BSBody: Content {
             var gradeObjectID: String?
             /// "save" (default) maps the grade item; "exclude" marks the
@@ -333,7 +343,7 @@ struct InstructorDashboardRoutes: RouteCollection {
 
     @Sendable
     func deleteAssignment(req: Request) async throws -> Response {
-        let assignment = try await loadAssignment(req)
+        let assignment = try await loadAssignmentForWrite(req)
         let setupID = assignment.testSetupID
 
         // Delete related submissions and their result rows for this setup.
@@ -368,10 +378,15 @@ struct InstructorDashboardRoutes: RouteCollection {
 
     @Sendable
     func deleteUnpublishedSetup(req: Request) async throws -> Response {
+        let caller = try req.auth.require(APIUser.self)
         let setupID = req.parameters.get("setupID") ?? ""
         guard let setup = try await APITestSetup.find(setupID, on: req.db) else {
             throw WebAssignmentError.notFound(resource: "Test setup '\(setupID)'")
         }
+        // Scope the delete to the setup's own course (the :setupID param-taking
+        // route is otherwise drivable cross-course / against an archived course;
+        // the active-course group gate can't see the setup's course) (#417 Slice D).
+        try await requireCourseWriteAccess(caller: caller, courseID: setup.courseID, db: req.db)
         // Only allow deleting setups that have no associated assignment.
         let hasAssignment =
             try await APIAssignment.query(on: req.db)

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -92,7 +92,14 @@ func loadAssignmentForWrite(_ req: Request) async throws -> APIAssignment {
 /// linked to an `APIAssignment` yet — same row shape, no parent.
 /// Throws `.badRequest` if the parameter is missing/empty,
 /// `.notFound` if no row matches.
-func loadDraftSetup(_ req: Request) async throws -> APITestSetup {
+///
+/// `requireWrite` authorizes the caller for a per-course write on the draft's
+/// own course (`requireCourseWriteAccess`). The draft suite/script/section edit
+/// handlers pass `true` so an instructor can't mutate another course's draft —
+/// or one in an archived course — by guessing its `draftID`; the draft-read
+/// handlers (`getDraftSuite`, `downloadDraftSetupItem`) leave it `false`
+/// (#417 Slice D).
+func loadDraftSetup(_ req: Request, requireWrite: Bool = false) async throws -> APITestSetup {
     guard let draftID = try? req.query.get(String.self, at: "draftID"),
         !draftID.isEmpty
     else {
@@ -100,6 +107,10 @@ func loadDraftSetup(_ req: Request) async throws -> APITestSetup {
     }
     guard let setup = try await APITestSetup.find(draftID, on: req.db) else {
         throw WebAssignmentError.notFound(resource: "Draft '\(draftID)'")
+    }
+    if requireWrite {
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseWriteAccess(caller: caller, courseID: setup.courseID, db: req.db)
     }
     return setup
 }

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -504,7 +504,6 @@ struct WebRoutes: RouteCollection {
     @Sendable
     func createSetup(req: Request) async throws -> Response {
         let setupUser = try req.auth.require(APIUser.self)
-        guard setupUser.isInstructor else { throw Abort(.forbidden) }
         let upload = try req.content.decode(TestSetupUpload.self)
 
         let manifestData = Data(upload.manifest.utf8)
@@ -518,6 +517,17 @@ struct WebRoutes: RouteCollection {
             throw AppError.unprocessable(reason: "Unsupported schemaVersion; expected 1")
         }
 
+        // Associate the setup with the instructor's active course, and require
+        // per-course instructor authority there before touching disk. Replaces
+        // the old global `isInstructor` check, which let a global instructor who
+        // is only a student in their active course create a setup (#417 Slice D).
+        let courseState = try await req.resolveActiveCourse(for: setupUser)
+        guard let courseID = courseState.activeCourseUUID else {
+            throw Abort(
+                .badRequest, reason: "No active course selected. Please select a course before uploading a test setup.")
+        }
+        try await requireCourseWriteAccess(caller: setupUser, courseID: courseID, db: req.db)
+
         let setupsDir = req.application.testSetupsDirectory
         let setupID = "setup_\(UUID().uuidString.lowercased().prefix(8))"
         let zipPath = setupsDir + "\(setupID).zip"
@@ -525,12 +535,6 @@ struct WebRoutes: RouteCollection {
 
         let stored = String(data: try ManifestCodec.encoder.encode(manifest), encoding: .utf8) ?? upload.manifest
 
-        // Associate the setup with the instructor's active course.
-        let courseState = try await req.resolveActiveCourse(for: setupUser)
-        guard let courseID = courseState.activeCourseUUID else {
-            throw Abort(
-                .badRequest, reason: "No active course selected. Please select a course before uploading a test setup.")
-        }
         let setup = APITestSetup(
             id: setupID, manifest: stored, zipPath: zipPath,
             courseID: courseID)

--- a/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
@@ -1,0 +1,301 @@
+// Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
+//
+// Route-level coverage for the remaining per-course write gaps closed in #417
+// Slice D: the assignment-lifecycle mutations (open/close/status/delete),
+// drag-reorder, unpublished-setup delete, and the high-value TestSetupRoutes
+// endpoints (upload + notebook save). Each now authorizes against the
+// *resource's own* course via requireCourseWriteAccess, so a per-course
+// instructor can neither mutate an archived course's content nor drive a write
+// against another course by URL / by client-supplied courseID. The active-course
+// group middleware only inspects the caller's active course, so this is the
+// layer that catches it. Mirrors ArchivedCourseWriteRouteTests (Slice A) and
+// ArchivedCourseStudentActionRouteTests (Slice C).
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class ArchivedCourseLifecycleRouteTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-archived-lc")
+    }
+
+    /// Creates a course + worker-mode test setup + published assignment and
+    /// returns the course UUID, setup ID, and the assignment's public ID.
+    private func makeCourseAssignment(
+        code: String, archived: Bool, enrollmentMode: CourseEnrollmentMode
+    ) async throws -> (courseID: UUID, setupID: String, assignmentID: String) {
+        let courseID = UUID()
+        let course = APICourse(id: courseID, code: code, name: code, enrollmentMode: enrollmentMode)
+        course.isArchived = archived
+        try await course.save(on: app.db)
+
+        let setupID = "lc_\(UUID().uuidString.prefix(8))"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        try arMakeZip(at: zipPath, entries: [(".placeholder", "x"), ("publictest_a.py", "passed('a')\n")])
+        let manifest = """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_a.py"}],"timeLimitSeconds":10,"makefile":null}
+            """
+        let setup = APITestSetup(id: setupID, manifest: manifest, zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: code,
+            dueAt: nil, isOpen: true, deadlineOverrideActive: false, courseID: courseID
+        )
+        try await assignment.save(on: app.db)
+        return (courseID, setupID, assignment.publicID)
+    }
+
+    /// Logs in `lc_inst` as an instructor in an active (.auto, non-archived)
+    /// course and additionally enrols them as a per-course instructor in the
+    /// given archived course, returning the session cookie + CSRF token and both
+    /// fixtures. The active edit succeeding attributes any archived 403 to the
+    /// archived block, not a stray middleware denial.
+    private func setupInstructorWithBothCourses(
+        activeCode: String, archivedCode: String
+    ) async throws -> (
+        active: (courseID: UUID, setupID: String, assignmentID: String),
+        archived: (courseID: UUID, setupID: String, assignmentID: String),
+        csrf: String, sessionCookie: String
+    ) {
+        let active = try await makeCourseAssignment(
+            code: activeCode, archived: false, enrollmentMode: .auto)
+        let archived = try await makeCourseAssignment(
+            code: archivedCode, archived: true, enrollmentMode: .closed)
+
+        let cookie = try await loginUser(
+            username: "lc_inst", password: "pw", role: "instructor", on: app)
+        let user = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == "lc_inst").first())
+        try await APICourseEnrollment(
+            userID: try user.requireID(), courseID: archived.courseID, role: .instructor
+        ).save(on: app.db)
+
+        let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
+        return (active, archived, csrf, sessionCookie)
+    }
+
+    private func postForm(_ path: String, csrf: String, sessionCookie: String) async throws -> HTTPStatus {
+        var status: HTTPStatus = .imATeapot
+        try await app.asyncTest(
+            .POST, path,
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                req.headers.add(name: "x-csrf-token", value: csrf)
+                req.headers.contentType = .urlEncodedForm
+                req.body = ByteBuffer(string: "")
+            },
+            afterResponse: { res in status = res.status })
+        return status
+    }
+
+    // MARK: - Assignment lifecycle (open / close / delete)
+
+    @Test func closeBlockedOnArchivedCourseEvenForItsInstructor() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCAX", archivedCode: "LCAY")
+            // Sanity: closing the active (non-archived) course's assignment works.
+            let activeStatus = try await postForm(
+                "/instructor/\(fx.active.assignmentID)/close", csrf: fx.csrf, sessionCookie: fx.sessionCookie)
+            #expect(activeStatus == .seeOther, "active-course close should succeed, got \(activeStatus)")
+            // The block: closing the archived course's assignment by URL is 403.
+            let archivedStatus = try await postForm(
+                "/instructor/\(fx.archived.assignmentID)/close", csrf: fx.csrf, sessionCookie: fx.sessionCookie)
+            #expect(archivedStatus == .forbidden, "archived-course close must be blocked, got \(archivedStatus)")
+        }
+    }
+
+    @Test func deleteBlockedOnArchivedCourseEvenForItsInstructor() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCBX", archivedCode: "LCBY")
+            // The block: deleting the archived course's assignment by URL is 403.
+            let archivedStatus = try await postForm(
+                "/instructor/\(fx.archived.assignmentID)/delete", csrf: fx.csrf, sessionCookie: fx.sessionCookie)
+            #expect(archivedStatus == .forbidden, "archived-course delete must be blocked, got \(archivedStatus)")
+            // Sanity: deleting the active (non-archived) course's assignment works.
+            let activeStatus = try await postForm(
+                "/instructor/\(fx.active.assignmentID)/delete", csrf: fx.csrf, sessionCookie: fx.sessionCookie)
+            #expect(activeStatus == .seeOther, "active-course delete should succeed, got \(activeStatus)")
+        }
+    }
+
+    // MARK: - reorderAssignments — a foreign/archived course's assignment by ID
+
+    @Test func reorderRejectsArchivedCourseAssignment() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCCX", archivedCode: "LCCY")
+            // A reorder payload that includes the archived course's assignment ID
+            // must be rejected — reordering writes sortOrder, a per-course write.
+            try await app.asyncTest(
+                .POST, "/instructor/reorder",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(
+                        string: #"{"assignmentIDs":["\#(fx.archived.assignmentID)","\#(fx.active.assignmentID)"]}"#)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "reorder touching an archived course must be blocked, got \(res.status)")
+                })
+        }
+    }
+
+    // MARK: - deleteUnpublishedSetup — a foreign/archived course's setup by ID
+
+    @Test func deleteUnpublishedSetupBlockedOnArchivedCourse() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCDX", archivedCode: "LCDY")
+            // Create an unpublished (assignment-less) setup in the archived course.
+            let setupID = "lc_unpub_\(UUID().uuidString.prefix(8))"
+            let zipPath = app.testSetupsDirectory + setupID + ".zip"
+            try arMakeZip(at: zipPath, entries: [(".placeholder", "x")])
+            let setup = APITestSetup(
+                id: setupID,
+                manifest:
+                    #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#,
+                zipPath: zipPath, courseID: fx.archived.courseID)
+            try await setup.save(on: app.db)
+
+            let status = try await postForm(
+                "/instructor/setup/\(setupID)/delete", csrf: fx.csrf, sessionCookie: fx.sessionCookie)
+            #expect(status == .forbidden, "deleting an archived course's setup must be blocked, got \(status)")
+        }
+    }
+
+    // MARK: - TestSetupRoutes.saveAssignment (notebook overwrite) on archived course
+
+    @Test func saveAssignmentNotebookBlockedOnArchivedCourse() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCEX", archivedCode: "LCEY")
+            let notebook = #"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#
+
+            func putNotebook(setupID: String) async throws -> HTTPStatus {
+                var status: HTTPStatus = .imATeapot
+                try await app.asyncTest(
+                    .PUT, "/api/v1/testsetups/\(setupID)/assignment",
+                    beforeRequest: { req in
+                        req.headers.add(name: .cookie, value: fx.sessionCookie)
+                        req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                        req.headers.contentType = .json
+                        req.body = ByteBuffer(string: notebook)
+                    },
+                    afterResponse: { res in status = res.status })
+                return status
+            }
+
+            // Sanity: saving to the active course's setup works.
+            let activeStatus = try await putNotebook(setupID: fx.active.setupID)
+            #expect(activeStatus == .noContent, "active-course notebook save should succeed, got \(activeStatus)")
+            // The block: saving to the archived course's setup is 403.
+            let archivedStatus = try await putNotebook(setupID: fx.archived.setupID)
+            #expect(
+                archivedStatus == .forbidden, "archived-course notebook save must be blocked, got \(archivedStatus)")
+        }
+    }
+
+    // MARK: - TestSetupRoutes.uploadTestSetup — client-supplied foreign courseID
+
+    @Test func uploadRejectsArchivedTargetCourse() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCFX", archivedCode: "LCFY")
+
+            // A decodable upload whose courseID points at the archived course the
+            // caller instructs must be rejected — the old global isInstructor check
+            // trusted the client-supplied courseID. The manifest/files content is
+            // irrelevant: the 403 fires before manifest/zip validation.
+            let boundary = "LCUpload"
+            let manifest =
+                #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"t.sh"}],"timeLimitSeconds":10,"makefile":null}"#
+            var body = ByteBufferAllocator().buffer(capacity: 512)
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"_csrf\"\r\n\r\n")
+            body.writeString(fx.csrf)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"manifest\"\r\n\r\n")
+            body.writeString(manifest)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"courseID\"\r\n\r\n")
+            body.writeString(fx.archived.courseID.uuidString)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString(
+                "Content-Disposition: form-data; name=\"files\"; filename=\"setup.zip\"\r\n"
+                    + "Content-Type: application/zip\r\n\r\n")
+            body.writeString("PK")
+            body.writeString("\r\n--\(boundary)--\r\n")
+
+            try await app.asyncTest(
+                .POST, "/api/v1/testsetups",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+                    req.body = .init(buffer: body)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "upload targeting an archived course must be blocked, got \(res.status)")
+                })
+        }
+    }
+
+    // MARK: - updateNewAssignmentDraft — a foreign/archived course's draft by draftID
+
+    @Test func updateNewAssignmentDraftBlockedForArchivedCourseDraft() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCGX", archivedCode: "LCGY")
+
+            // An (assignment-less) draft setup owned by the archived course.
+            let draftID = "lc_draft_\(UUID().uuidString.prefix(8))"
+            let zipPath = app.testSetupsDirectory + draftID + ".zip"
+            try arMakeZip(at: zipPath, entries: [(".placeholder", "x")])
+            let draft = APITestSetup(
+                id: draftID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#,
+                zipPath: zipPath, courseID: fx.archived.courseID)
+            try await draft.save(on: app.db)
+
+            // Driving the primary draft-editor endpoint at the archived course's
+            // draft by id must be rejected before the mutating service runs — the
+            // resolver now authorizes the draft's own course.
+            let boundary = "LCDraft"
+            var body = ByteBufferAllocator().buffer(capacity: 512)
+            for (name, value) in [
+                ("_csrf", fx.csrf), ("assignmentName", "X"),
+                ("draftAction", "create-assignment-notebook"), ("draftID", draftID),
+            ] {
+                body.writeString("--\(boundary)\r\n")
+                body.writeString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+                body.writeString(value)
+                body.writeString("\r\n")
+            }
+            body.writeString("--\(boundary)--\r\n")
+
+            try await app.asyncTest(
+                .POST, "/instructor/new/draft",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+                    req.body = .init(buffer: body)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "editing an archived course's draft by draftID must be blocked, got \(res.status)")
+                })
+        }
+    }
+}

--- a/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
@@ -54,6 +54,16 @@ import VaporTesting
         return (courseID, setupID, assignment.publicID)
     }
 
+    /// The active + archived course fixtures plus the authenticated session for
+    /// `lc_inst`. A struct rather than a tuple to stay within SwiftLint's
+    /// `large_tuple` limit.
+    private struct BothCoursesFixture {
+        let active: (courseID: UUID, setupID: String, assignmentID: String)
+        let archived: (courseID: UUID, setupID: String, assignmentID: String)
+        let csrf: String
+        let sessionCookie: String
+    }
+
     /// Logs in `lc_inst` as an instructor in an active (.auto, non-archived)
     /// course and additionally enrols them as a per-course instructor in the
     /// given archived course, returning the session cookie + CSRF token and both
@@ -61,11 +71,7 @@ import VaporTesting
     /// archived block, not a stray middleware denial.
     private func setupInstructorWithBothCourses(
         activeCode: String, archivedCode: String
-    ) async throws -> (
-        active: (courseID: UUID, setupID: String, assignmentID: String),
-        archived: (courseID: UUID, setupID: String, assignmentID: String),
-        csrf: String, sessionCookie: String
-    ) {
+    ) async throws -> BothCoursesFixture {
         let active = try await makeCourseAssignment(
             code: activeCode, archived: false, enrollmentMode: .auto)
         let archived = try await makeCourseAssignment(
@@ -80,7 +86,8 @@ import VaporTesting
         ).save(on: app.db)
 
         let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
-        return (active, archived, csrf, sessionCookie)
+        return BothCoursesFixture(
+            active: active, archived: archived, csrf: csrf, sessionCookie: sessionCookie)
     }
 
     private func postForm(_ path: String, csrf: String, sessionCookie: String) async throws -> HTTPStatus {

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -220,12 +220,29 @@ import VaporTesting
             // Obtain a valid CSRF token so the middleware passes and the role check fires.
             let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
 
-            // POST to /api/v1/testsetups as a student should return 403 (instructor-only).
+            // POST to /api/v1/testsetups as a student should return 403. Per-course
+            // authorization (#417 Slice D) checks the *target* course, so the body
+            // must now carry a decodable `courseID` (the student holds no instructor
+            // enrolment there, so `requireCourseWriteAccess` rejects it). The
+            // manifest/files content is irrelevant — the 403 fires before validation.
             let boundary = "RoleCheck"
-            var body = ByteBufferAllocator().buffer(capacity: 256)
+            let manifest =
+                #"{"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}"#
+            var body = ByteBufferAllocator().buffer(capacity: 512)
             body.writeString("--\(boundary)\r\n")
             body.writeString("Content-Disposition: form-data; name=\"_csrf\"\r\n\r\n")
             body.writeString(csrf)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"manifest\"\r\n\r\n")
+            body.writeString(manifest)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"courseID\"\r\n\r\n")
+            body.writeString(UUID().uuidString)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString(
+                "Content-Disposition: form-data; name=\"files\"; filename=\"setup.zip\"\r\n"
+                    + "Content-Type: application/zip\r\n\r\n")
+            body.writeString("PK")
             body.writeString("\r\n--\(boundary)--\r\n")
 
             try await app.asyncTest(

--- a/changelog.d/417-slice-d-write-gap-sweep.md
+++ b/changelog.d/417-slice-d-write-gap-sweep.md
@@ -1,0 +1,26 @@
+### Security
+
+- **Close the remaining per-course write gaps: assignment lifecycle, setup
+  upload/notebook, submissions, drafts (#417 Slice D).** Slices A & C scoped the
+  assignment-editor and per-student mutations to the resource's own course;
+  this slice finishes the web sweep. The assignment lifecycle mutations
+  (`open`/`close`/`status`/`delete`), drag-`reorder`, unpublished-setup delete,
+  and the `:assignmentID` BrightSpace grade-push backfill now authorize via
+  `requireCourseWriteAccess`, so a per-course instructor can't drive them
+  cross-course or against an archived course by URL. The high-value
+  `POST /api/v1/testsetups` (upload) and `PUT /api/v1/testsetups/:id/assignment`
+  (notebook save) drop their global `isInstructor` check for the per-course
+  gate — closing a hole where any global instructor could create a setup
+  (carrying secret tests + solutions) in **any** course via a client-supplied
+  `courseID`, or overwrite any course's notebook by id. Submission intake
+  (`POST /api/v1/submissions[/file]`) is scoped to the setup's course via
+  `requireCourseEnrollment`, and the new-assignment draft editor — the primary
+  `POST /instructor/new/draft` endpoint **and** the suite/script/section
+  sub-edits — authorizes the draft's own course (so a draft can't be rewritten
+  cross-course by `draftID`). Also closes one adjacent cross-course **read**
+  leak on the most sensitive artifact: `GET /api/v1/testsetups/:id/download`
+  streamed the full setup zip (secret-tier tests + reference solution) on a bare
+  global-`isInstructor` check, letting any instructor pull another course's
+  secrets by id — now `requireCourseInstructor` on the setup's own course (the
+  enrollment-gated student fetch is the separate `/browser-runner` route).
+  Admins remain exempt; the student/browser read paths are untouched.


### PR DESCRIPTION
## Summary

Fourth slice of #417 (per-course roles), continuing the A → C archived/cross-course **write**-scoping work. Slices A & C scoped the assignment editor and per-student mutations to the resource's own course; this finishes the web sweep so the `/instructor` group middleware (which only sees the caller's *active* course) is no longer the sole thing between an instructor and a cross-course or archived-course write.

The map of every remaining gap, the shared-chokepoint analysis, and the test-breakage audit were produced by a read-only mapping workflow (4 parallel mappers + a completeness critic); the diff was then run through an adversarial review workflow (compile / test-breakage / completeness dimensions, each finding verified). The critic and reviewer caught two gaps the mechanical sweep missed — both fixed below.

### Newly authorized against the resource's own course
- **Assignment lifecycle** — `open`/`close`/`status`/`delete`, drag-`reorder`, unpublished-setup delete, and the `:assignmentID` BrightSpace grade-push backfill — via `requireCourseWriteAccess` / `loadAssignmentForWrite`. `reorder` authorizes every distinct course its payload touches.
- **`POST /api/v1/testsetups` (upload)** and **`PUT /api/v1/testsetups/:id/assignment` (notebook save)** — drop the global `isInstructor` check for the per-course gate. Upload previously trusted a **client-supplied `courseID`**, so any global instructor could create a setup — carrying secret tests + solutions — in *any* course; notebook-save could overwrite any course's notebook by id.
- **`POST /testsetups/new`** (createSetup) — per-course instructor in the active course.
- **Submission intake `POST /api/v1/submissions[/file]`** — scoped to the setup's course via `requireCourseEnrollment` (student-level floor; intake isn't an authoring write).
- **New-assignment draft editor** — the primary `POST /instructor/new/draft` endpoint (`resolveOrCreateNewAssignmentDraft` now authorizes an existing draft's own course) **and** the suite/script/section sub-edits (`loadDraftSetup(requireWrite:)`).

### Adjacent cross-course READ leak closed
`GET /api/v1/testsetups/:id/download` streamed the **full setup zip** (secret-tier tests + reference solution) on a bare global `isInstructor` check, letting any instructor pull another course's secrets by id. Now `requireCourseInstructor` on the setup's own course. The enrollment-gated student fetch is the separate `/browser-runner` download route; that and other read paths are untouched.

### Deliberately left as-is
The active-course-scoped BrightSpace handlers (`connect`/`use-my-identity`/`bind-org-unit`/`auto-map`/`sync-now`/`reconcile-now`) resolve their course via `resolveActiveCourse`, which already excludes archived courses, so they can't be driven cross-course or against an archived course. Admins remain write-exempt everywhere.

## Tests

- **`ArchivedCourseLifecycleRouteTests`** (new) — close/delete blocked on an archived course (with an active-course sanity success that attributes the 403 to the block, not a stray denial), reorder rejects an archived course's assignment id, unpublished-setup delete blocked, notebook-save blocked, upload rejects a client-supplied archived `courseID`, and the primary draft editor rejects an archived course's draft by `draftID`.
- **`NotebookDownloadTests.studentCannotUploadTestSetup`** — updated to send a decodable upload body, since the rejection legitimately moved from the pre-decode global guard to the post-decode per-course check (still 403). The review confirmed no other existing test breaks (the `.auto`-course auto-enroll seeds the per-course instructor role before each gated handler runs).

## Notes

- No `VERSION` / `CHANGELOG.md` edit; a `changelog.d/` fragment is included.
- `swift-format lint` is clean on all changed files. SwiftPM deps can't be fetched in the authoring sandbox, so the full `swift build` + tests + SwiftLint run in CI.
- Part of a planned sequence: **D-MCP** (extend the archived block across the MCP content-write tools via a write-only resolver — the naive shared chokepoint would have broken 6 read tools), then **E** (TA role), **F** (instructor staff invites), **G** (system-role collapse, the finale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_