### PR TITLE
Block MCP content writes to archived courses (#417 Slice D-MCP)

### DIFF
--- a/Sources/APIServer/MCP/Tools/AssignmentOrderingTools.swift
+++ b/Sources/APIServer/MCP/Tools/AssignmentOrderingTools.swift
@@ -94,7 +94,7 @@ struct ReorderAssignmentsTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let courseID = try await resolveCourseID(code: input.courseCode, tool: Self.name, context: context)
+        let courseID = try await resolveCourseIDForWrite(code: input.courseCode, tool: Self.name, context: context)
 
         let ids = input.orderedAssignmentPublicIDs.map {
             $0.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorNotebookCheckTool.swift
@@ -306,7 +306,7 @@ struct AuthorNotebookCheckTool: ContentTool {
         let tier = try Self.parseTier(input.tier)
         let columnMatch = try Self.parseColumnMatch(input.columnMatch)
 
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)

--- a/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
+++ b/Sources/APIServer/MCP/Tools/AuthorScriptTool.swift
@@ -253,7 +253,7 @@ struct AuthorScriptTool: ContentTool {
         // outbound request for a call we are about to refuse.
         let source = try Self.resolveContentSource(input)
 
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         // Never clobber a pattern-family / notebook-check generated script —

--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -113,11 +113,15 @@ struct CloneAssignmentTool: ContentTool {
                     tool: Self.name, detail: "No course found with code \"\(code)\".")
             }
             targetCourseID = try target.requireID()
-            // Must be authorized for the destination course too.
-            try await context.authorizeCourseAccess(targetCourseID, tool: Self.name)
         } else {
             targetCourseID = source.courseID
         }
+        // The clone WRITES a new assignment into the target course, so block an
+        // archived destination (covers both the explicit-target and
+        // default-to-source branches). The source stays read-authorized above —
+        // reviving an archived course's content into a live course is fine; only
+        // the destination is write-gated (#417 Slice D-MCP).
+        try await context.authorizeCourseWriteAccess(targetCourseID, tool: Self.name)
 
         let cloned: AuthoredAssignment
         do {

--- a/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
@@ -168,7 +168,7 @@ struct CreateCourseSectionTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "defaultGradingMode must be \"browser\" or \"worker\".")
         }
-        let courseID = try await resolveCourseID(code: input.courseCode, tool: Self.name, context: context)
+        let courseID = try await resolveCourseIDForWrite(code: input.courseCode, tool: Self.name, context: context)
 
         let maxOrder =
             try await APICourseSection.query(on: context.db)
@@ -450,7 +450,8 @@ struct DeleteCourseSectionTool: ContentTool {
         guard let section = try await APICourseSection.find(uuid, on: context.db) else {
             return Output(sectionID: raw, removed: false, ungroupedAssignmentCount: 0)
         }
-        try await context.authorizeCourseAccess(section.courseID, tool: Self.name)
+        // Deleting a section is a write — block it on an archived course (#417 Slice D-MCP).
+        try await context.authorizeCourseWriteAccess(section.courseID, tool: Self.name)
         let ungrouped = try await APIAssignment.query(on: context.db)
             .filter(\.$sectionID == uuid)
             .count()
@@ -530,7 +531,7 @@ struct ReorderCourseSectionsTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let courseID = try await resolveCourseID(code: input.courseCode, tool: Self.name, context: context)
+        let courseID = try await resolveCourseIDForWrite(code: input.courseCode, tool: Self.name, context: context)
         let uuids = input.orderedSectionIDs.compactMap {
             UUID(uuidString: $0.trimmingCharacters(in: .whitespacesAndNewlines))
         }
@@ -571,8 +572,10 @@ struct ReorderCourseSectionsTool: ContentTool {
 
 // MARK: - Shared
 
-/// Resolves a course section by id and authorizes the acting account for its
-/// course.  Shared by rename_course_section / delete_course_section.
+/// Resolves a course section by id and authorizes the acting account for a
+/// *write* to its course (archived block).  Shared by rename_course_section /
+/// delete_course_section — both mutate the section, so the write gate is the
+/// correct floor (#417 Slice D-MCP).
 func resolveCourseSectionForEdit(
     sectionID raw: String, tool: String, context: ToolContext
 ) async throws -> APICourseSection {
@@ -583,7 +586,7 @@ func resolveCourseSectionForEdit(
     guard let section = try await APICourseSection.find(uuid, on: context.db) else {
         throw MCPToolError.invalidArguments(tool: tool, detail: "No course section with id \"\(trimmed)\".")
     }
-    try await context.authorizeCourseAccess(section.courseID, tool: tool)
+    try await context.authorizeCourseWriteAccess(section.courseID, tool: tool)
     return section
 }
 
@@ -647,7 +650,8 @@ func setManifestGraderOnly(
 }
 
 /// Resolves a course code to its id, enforcing that the acting account may act
-/// on it.  Shared by the course-section tools.
+/// on it (read access).  Shared by the course-section tools, including the READ
+/// `list_course_sections` — so this must NOT carry the archived-write block.
 func resolveCourseID(code: String, tool: String, context: ToolContext) async throws -> UUID {
     guard
         let course = try await APICourse.query(on: context.db)
@@ -658,5 +662,23 @@ func resolveCourseID(code: String, tool: String, context: ToolContext) async thr
     }
     let courseID = try course.requireID()
     try await context.authorizeCourseAccess(courseID, tool: tool)
+    return courseID
+}
+
+/// Write variant of `resolveCourseID`: resolves the course by code and
+/// authorizes a *write* to it (archived block).  Used by the course-section
+/// WRITE tools (create_course_section, reorder_course_sections, and
+/// reorder_assignments) so they can't mutate an archived course; the read
+/// `list_course_sections` stays on `resolveCourseID` (#417 Slice D-MCP).
+func resolveCourseIDForWrite(code: String, tool: String, context: ToolContext) async throws -> UUID {
+    guard
+        let course = try await APICourse.query(on: context.db)
+            .filter(\.$code == code)
+            .first()
+    else {
+        throw MCPToolError.invalidArguments(tool: tool, detail: "No course found with code \"\(code)\".")
+    }
+    let courseID = try course.requireID()
+    try await context.authorizeCourseWriteAccess(courseID, tool: tool)
     return courseID
 }

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -97,7 +97,8 @@ struct CreateAssignmentTool: ContentTool {
                 tool: Self.name, detail: "No course found with code \"\(code)\".")
         }
         let courseID = try course.requireID()
-        try await context.authorizeCourseAccess(courseID, tool: Self.name)
+        // Creating an assignment writes into the course — block archived (#417 Slice D-MCP).
+        try await context.authorizeCourseWriteAccess(courseID, tool: Self.name)
 
         let data: Data
         do {

--- a/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreatePatternFamilyTool.swift
@@ -334,7 +334,7 @@ struct CreatePatternFamilyTool: ContentTool {
         }
         try Self.assertUniqueCaseKeys(input.cases, tool: Self.name)
 
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)

--- a/Sources/APIServer/MCP/Tools/DeleteSuiteItemTool.swift
+++ b/Sources/APIServer/MCP/Tools/DeleteSuiteItemTool.swift
@@ -100,7 +100,7 @@ struct DeleteSuiteItemTool: ContentTool {
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         let target = try Self.resolveTarget(input)
 
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)

--- a/Sources/APIServer/MCP/Tools/MoveSuiteItemTool.swift
+++ b/Sources/APIServer/MCP/Tools/MoveSuiteItemTool.swift
@@ -108,7 +108,7 @@ struct MoveSuiteItemTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let resolved = try await context.authorizedAssignmentAndSetup(
+        let resolved = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: resolved.setup.manifest, zipPath: resolved.setup.zipPath)

--- a/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
@@ -70,7 +70,7 @@ struct SetGradingModeTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "gradingMode must be \"browser\" or \"worker\".")
         }
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         let effective = try await setManifestGradingMode(setup: setup, to: mode, on: context.db)
         return Output(assignmentPublicID: assignment.publicID, gradingMode: effective)

--- a/Sources/APIServer/MCP/Tools/SetTimeLimitTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetTimeLimitTool.swift
@@ -71,7 +71,7 @@ struct SetTimeLimitTool: ContentTool {
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         let seconds = try validateTimeLimitSeconds(input.seconds, tool: Self.name)
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         let effective = try await setManifestTimeLimitSeconds(setup: setup, to: seconds, on: context.db)
         return Output(assignmentPublicID: assignment.publicID, timeLimitSeconds: effective)

--- a/Sources/APIServer/MCP/Tools/SuiteSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/SuiteSectionTools.swift
@@ -81,7 +81,7 @@ struct CreateSuiteSectionTool: ContentTool {
         guard !name.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "Section name must not be empty.")
         }
-        let resolved = try await context.authorizedAssignmentAndSetup(
+        let resolved = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         let newID = UUID().uuidString
         do {
@@ -161,7 +161,7 @@ struct RenameSuiteSectionTool: ContentTool {
         guard !input.sectionID.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "sectionID must not be empty.")
         }
-        let resolved = try await context.authorizedAssignmentAndSetup(
+        let resolved = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         do {
             try await mutateManifest(setup: resolved.setup, on: context.db) { dict in
@@ -241,7 +241,7 @@ struct DeleteSuiteSectionTool: ContentTool {
         guard !input.sectionID.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "sectionID must not be empty.")
         }
-        let resolved = try await context.authorizedAssignmentAndSetup(
+        let resolved = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         // Captured inside the mutation closure so the response reflects what
         // actually changed.

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -120,37 +120,69 @@ struct ToolContext {
         return assignment
     }
 
-    /// Like `authorizedAssignment`, but additionally blocks the write when the
-    /// assignment's course is archived (admin subjects exempt). Mirrors the web
-    /// side's `requireCourseWriteAccess`: archived courses are read-only for
+    /// Authorizes a *write* to `courseID`: the acting subject must pass
+    /// `authorizeCourseAccess` (MCP-eligible + enrolled, admin included) AND the
+    /// course must not be archived (admins exempt). The MCP analogue of the web
+    /// `requireCourseWriteAccess` — archived courses are read-only for
     /// instructors and TAs, so a content-mutating tool can't drive a write into
-    /// one. Archived courses are already hidden from the MCP listing/resource
-    /// surface (`enrolledCourses`), so this closes the by-public-ID write path
-    /// an agent could still reach with a remembered id (#417, follow-up to
-    /// Slice A — `set_assignment_course_section`).
-    func authorizedAssignmentForWrite(publicID: String, tool: String) async throws -> APIAssignment {
-        let assignment = try await authorizedAssignment(publicID: publicID, tool: tool)
+    /// one. The single chokepoint every MCP write resolver funnels through; the
+    /// *read* resolvers stay on `authorizeCourseAccess` so archived courses
+    /// remain readable (#417 Slice D-MCP).
+    func authorizeCourseWriteAccess(_ courseID: UUID, tool: String) async throws {
+        try await authorizeCourseAccess(courseID, tool: tool)
         let user = try await requireEligibleSubject(tool: tool)
-        guard !user.isAdmin else { return assignment }
-        guard let course = try await APICourse.find(assignment.courseID, on: db) else {
+        guard !user.isAdmin else { return }
+        guard let course = try await APICourse.find(courseID, on: db) else {
             throw MCPToolError.invalidArguments(
-                tool: tool, detail: "The assignment's course could not be found.")
+                tool: tool, detail: "The target course could not be found.")
         }
         guard !course.isArchived else {
             throw MCPToolError.notAuthorized(
                 tool: tool, detail: "This course is archived and is read-only.")
         }
+    }
+
+    /// Like `authorizedAssignment`, but authorizes a *write* to the assignment's
+    /// own course (`authorizeCourseWriteAccess`: per-course access + archived
+    /// block, admin-exempt). Archived courses are already hidden from the MCP
+    /// listing/resource surface, so this closes the by-public-ID write path an
+    /// agent could still reach with a remembered id (#417 Slice C/D-MCP).
+    func authorizedAssignmentForWrite(publicID: String, tool: String) async throws -> APIAssignment {
+        let assignment = try await requireAssignment(publicID: publicID, tool: tool)
+        try await authorizeCourseWriteAccess(assignment.courseID, tool: tool)
         return assignment
     }
 
     /// Resolves and authorizes the assignment, then loads its test setup,
     /// throwing the standard `invalidArguments` error if the setup is missing.
+    /// READ entry point — the archived block is NOT applied, so the read tools
+    /// (`get_suite`, `get_notebook`, `get_achievements`, `get_global_inputs`,
+    /// `get_support_files`, `preview_personalization`) that route through it keep
+    /// working on archived courses. Mutating tools use
+    /// `authorizedAssignmentAndSetupForWrite`.
     func authorizedAssignmentAndSetup(
         publicID: String, tool: String
     ) async throws
         -> (assignment: APIAssignment, setup: APITestSetup)
     {
         let assignment = try await authorizedAssignment(publicID: publicID, tool: tool)
+        guard let setup = try await APITestSetup.find(assignment.testSetupID, on: db) else {
+            throw MCPToolError.invalidArguments(
+                tool: tool, detail: "The assignment's test setup could not be found.")
+        }
+        return (assignment, setup)
+    }
+
+    /// Write variant of `authorizedAssignmentAndSetup`: authorizes a write to the
+    /// assignment's own course (archived block) before loading the setup. Every
+    /// content-mutating suite/manifest/notebook tool resolves through this so an
+    /// agent can't edit an archived course's content by id (#417 Slice D-MCP).
+    func authorizedAssignmentAndSetupForWrite(
+        publicID: String, tool: String
+    ) async throws
+        -> (assignment: APIAssignment, setup: APITestSetup)
+    {
+        let assignment = try await authorizedAssignmentForWrite(publicID: publicID, tool: tool)
         guard let setup = try await APITestSetup.find(assignment.testSetupID, on: db) else {
             throw MCPToolError.invalidArguments(
                 tool: tool, detail: "The assignment's test setup could not be found.")

--- a/Sources/APIServer/MCP/Tools/UpdateAchievementsTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAchievementsTool.swift
@@ -78,7 +78,7 @@ struct UpdateAchievementsTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         let rows: [AchievementRow]

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -133,7 +133,7 @@ struct UpdateAssignmentTool: ContentTool {
                 tool: Self.name, detail: "Specify at least one of: title, dueAt, startsAt, isOpen, visibility.")
         }
 
-        let assignment = try await context.authorizedAssignment(
+        let assignment = try await context.authorizedAssignmentForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         do {
             // Title/date metadata first. The legacy `isOpen` is applied here only

--- a/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateGlobalInputsTool.swift
@@ -110,7 +110,7 @@ struct UpdateGlobalInputsTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         // The save-time expression eval runs against the acting account's own

--- a/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateNotebookTool.swift
@@ -79,7 +79,7 @@ struct UpdateNotebookTool: ContentTool {
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         try validateNotebookShape(input.notebook, tool: Self.name)
 
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         let data: Data

--- a/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdatePatternFamilyTool.swift
@@ -373,7 +373,7 @@ struct UpdatePatternFamilyTool: ContentTool {
         let editsByKey = try Self.indexCaseEdits(caseEdits)
         try CreatePatternFamilyTool.assertUniqueCaseKeys(addCases, tool: Self.name)
 
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         var payload = buildSuitePayload(fromManifest: setup.manifest, zipPath: setup.zipPath)

--- a/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSectionVariablesTool.swift
@@ -112,7 +112,7 @@ struct UpdateSectionVariablesTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         let actingUser = try await context.requireEligibleSubject(tool: Self.name)

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -87,7 +87,7 @@ struct UpdateSolutionTool: ContentTool {
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         try validateNotebookShape(input.notebook, tool: Self.name)
 
-        let assignment = try await context.authorizedAssignment(
+        let assignment = try await context.authorizedAssignmentForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
         // The bearer context has no `Request.auth` APIUser; resolve the subject
         // so the validation submission is attributed to the acting account.

--- a/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSuiteTool.swift
@@ -143,7 +143,7 @@ struct UpdateSuiteTool: ContentTool {
         guard !input.edits.isEmpty else {
             throw MCPToolError.invalidArguments(tool: Self.name, detail: "Provide at least one edit.")
         }
-        let (assignment, setup) = try await context.authorizedAssignmentAndSetup(
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
             publicID: input.assignmentPublicID, tool: Self.name)
 
         // Load the full authored suite with script bodies preserved from the zip.

--- a/Tests/APITests/MCP/MCPArchivedWriteBlockTests.swift
+++ b/Tests/APITests/MCP/MCPArchivedWriteBlockTests.swift
@@ -1,0 +1,113 @@
+// Tests/APITests/MCP/MCPArchivedWriteBlockTests.swift
+//
+// #417 Slice D-MCP: every MCP content-WRITE tool now routes through a
+// write-only resolver (`authorizedAssignment[AndSetup]ForWrite`,
+// `authorizeCourseWriteAccess`, `resolveCourseIDForWrite`,
+// `resolveCourseSectionForEdit`) so it can't mutate an ARCHIVED course's
+// content by id. The READ tools deliberately stay on the read resolvers
+// (`authorizedAssignmentAndSetup`, `resolveCourseID`) so archived courses
+// remain READABLE — the invariant the review flagged would break under a
+// naive shared chokepoint. These tests pin both halves: writes blocked,
+// reads still work, on the same archived fixtures.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPArchivedWriteBlockTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read, .write]
+        )
+    }
+
+    private let manifest = """
+        {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
+        """
+
+    /// Course + enrolled instructor + setup + assignment, optionally archived.
+    private func fixture(
+        on app: Application, archived: Bool, code: String = "ARCHMCP"
+    ) async throws -> (course: APICourse, assignment: APIAssignment) {
+        let course = try await makeTestCourse(on: app, code: code, name: "Archived MCP", archived: archived)
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+        try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+        try await makeTestSetup(on: app, id: "arch_setup_\(code)", courseID: courseID, manifest: manifest)
+        let assignment = try await makeTestAssignment(
+            on: app, testSetupID: "arch_setup_\(code)", courseID: courseID, title: "Lab")
+        return (course, assignment)
+    }
+
+    // MARK: - Assignment-scoped content write (authorizedAssignmentAndSetupForWrite)
+
+    @Test func contentWriteBlockedOnArchivedCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let fx = try await fixture(on: app, archived: true)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetTimeLimitTool().execute(
+                    .init(assignmentPublicID: fx.assignment.publicID, seconds: 42), context(app))
+            }
+        }
+    }
+
+    @Test func contentWriteSucceedsOnLiveCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Same tool + fixture shape, non-archived → must succeed, so the
+            // block above is attributable to the archived state, not the fixture.
+            let fx = try await fixture(on: app, archived: false, code: "LIVEMCP")
+            let out = try await SetTimeLimitTool().execute(
+                .init(assignmentPublicID: fx.assignment.publicID, seconds: 42), context(app))
+            #expect(out.timeLimitSeconds == 42)
+        }
+    }
+
+    // MARK: - Read invariant: archived courses stay READABLE (authorizedAssignmentAndSetup)
+
+    @Test func readToolStillWorksOnArchivedCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let fx = try await fixture(on: app, archived: true, code: "ARCHRD")
+            // get_suite routes through the READ resolver; it must NOT be blocked
+            // by the archived state — grade audits / lookups stay available. The
+            // call returning (rather than throwing MCPToolError) is the assertion.
+            let out = try await GetSuiteTool().execute(
+                .init(assignmentPublicID: fx.assignment.publicID), context(app))
+            #expect(out.items.isEmpty)
+        }
+    }
+
+    // MARK: - Course-code write resolver (resolveCourseIDForWrite)
+
+    @Test func createCourseSectionBlockedOnArchivedCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app, archived: true, code: "ARCHSEC")
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateCourseSectionTool().execute(
+                    .init(courseCode: "ARCHSEC", name: "Labs", defaultGradingMode: "browser"), context(app))
+            }
+        }
+    }
+
+    // MARK: - Read invariant on the course-code resolver (resolveCourseID)
+
+    @Test func listCourseSectionsStillWorksOnArchivedCourse() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await fixture(on: app, archived: true, code: "ARCHLS")
+            // list_course_sections routes through the READ resolveCourseID; an
+            // archived course must still list (here: empty), not 403.
+            let out = try await ListCourseSectionsTool().execute(.init(courseCode: "ARCHLS"), context(app))
+            #expect(out.sections.isEmpty)
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPAuthorizationCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPAuthorizationCoverageTests.swift
@@ -25,11 +25,18 @@ import Testing
     /// Any of these in a tool's source satisfies the per-resource check.
     private static let authorizationCalls = [
         "authorizeCourseAccess",
-        "authorizedAssignment",  // also matches authorizedAssignmentAndSetup
+        // Write chokepoint = authorizeCourseAccess + archived block (#417
+        // Slice D-MCP). NOT a superstring of authorizeCourseAccess, so it needs
+        // its own entry; tools that only write (e.g. create_assignment) call it.
+        "authorizeCourseWriteAccess",
+        "authorizedAssignment",  // also matches authorizedAssignment{AndSetup}{ForWrite}
         "requireEligibleSubject",
-        // Course-scoped wrapper: resolves the course code, then calls
-        // authorizeCourseAccess before returning the id (CourseSectionTools.swift).
+        // Course-scoped wrappers: resolve the course code / section, then
+        // authorize (read = authorizeCourseAccess, write =
+        // authorizeCourseWriteAccess) before returning (CourseSectionTools.swift).
+        // "resolveCourseID" also matches "resolveCourseIDForWrite".
         "resolveCourseID",
+        "resolveCourseSectionForEdit",
     ]
 
     /// Tools that legitimately need no per-resource authorization: they touch no

--- a/changelog.d/417-slice-d-mcp-archived-block.md
+++ b/changelog.d/417-slice-d-mcp-archived-block.md
@@ -1,0 +1,19 @@
+### Security
+
+- **Block MCP content writes to archived courses (#417 Slice D-MCP).** Slice C
+  added the archived-course write block to a single MCP tool
+  (`set_assignment_course_section`); this extends it across **every** MCP
+  content-write tool. A new `ToolContext.authorizeCourseWriteAccess` chokepoint
+  (per-course access + archived block, admin-exempt) backs write-only resolvers
+  — `authorizedAssignment[AndSetup]ForWrite`, `resolveCourseIDForWrite`, and the
+  now-write-gated `resolveCourseSectionForEdit` — so suite/script/family/check
+  edits, notebook + solution updates, grading-mode/time-limit/achievements/
+  global-input/section-variable changes, assignment create/clone/update,
+  reorders, and course-section CRUD all reject a write driven by id into an
+  archived (read-only) course. Critically, the **read** tools (`get_suite`,
+  `get_notebook`, `get_achievements`, `get_global_inputs`, `get_support_files`,
+  `preview_personalization`, `list_course_sections`) keep using the read
+  resolvers, so archived courses stay readable for audits/lookups — the naive
+  "add the block to the shared resolver" approach would have 403'd those reads.
+  Clone blocks on the **destination** course only, so reviving an archived
+  course's content into a live course still works. Admins remain exempt.


### PR DESCRIPTION
## Summary

Extends the archived-course write block across the **entire** MCP content-write surface. Slice C added it to one tool (`set_assignment_course_section`); the mapping workflow for Slice D found the other 25 write tools still had no archived block — an agent with a remembered assignment/course id could mutate an archived (read-only) course's content by id, even though archived courses are hidden from the MCP listing.

The Slice D review explicitly flagged the trap here: the naive "add the block to the shared resolver" approach would have broken the **read** tools, because 6 read tools route through `authorizedAssignmentAndSetup` and `list_course_sections` routes through `resolveCourseID`. So this adds **write-only** resolvers and leaves the read resolvers alone — archived courses stay readable for audits/lookups.

### The chokepoint
New `ToolContext.authorizeCourseWriteAccess(courseID:tool:)` = `authorizeCourseAccess` (MCP-eligible + enrolled, admin included) **+** archived block (admin-exempt) — the MCP analogue of the web `requireCourseWriteAccess`. Write resolvers funnel through it:

- `authorizedAssignmentForWrite` (refactored onto the helper) → `update_assignment`, `update_solution`, `set_assignment_course_section`.
- new `authorizedAssignmentAndSetupForWrite` → the 14 suite/manifest/notebook write tools (`author_script`, `update_suite`, `create`/`update_pattern_family`, `delete_suite_item`, `author_notebook_check`, `move_suite_item`, the suite-section CRUD, `set_grading_mode`, `set_time_limit`, `update_achievements`, `update_global_inputs`, `update_section_variables`, `update_notebook`).
- new `resolveCourseIDForWrite` → `create_course_section`, `reorder_course_sections`, `reorder_assignments`.
- `resolveCourseSectionForEdit` now write-gates → `rename`/`delete_course_section`.
- `create_assignment` + `clone_assignment` (destination) call the helper directly.

### Read invariant preserved
The read tools keep the **read** resolvers, so archived courses remain readable: `get_suite`, `get_notebook`, `get_achievements`, `get_global_inputs`, `get_support_files`, `preview_personalization`, `list_course_sections`.

### Clone nuance
`clone_assignment` blocks on the **destination** course only (the source stays read-authorized), so reviving an archived course's content into a live course still works. I also fixed a latent gap: the target authorization previously only ran in the explicit-`targetCourseCode` branch, skipping the default-to-source case — the write check now covers both. Admins remain exempt everywhere.

## Tests

`MCPArchivedWriteBlockTests` (new) pins both halves on archived fixtures:
- a content write (`set_time_limit`) and a course-section write (`create_course_section`) are **blocked** on an archived course (with a live-course sanity success attributing the block to the archived state);
- the read tools (`get_suite`, `list_course_sections`) **still succeed** on an archived course.

## Notes

- No `VERSION` / `CHANGELOG.md` edit; a `changelog.d/` fragment is included.
- `swift-format lint` is clean on all 22 changed files. SwiftPM deps can't be fetched in the authoring sandbox, so the full `swift build` + tests + SwiftLint run in CI.
- Next in the sequence: **E** (TA role) → **F** (instructor staff invites) → **G** (system-role collapse, finale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_