### PR TITLE
TA per-course role (#417 Slice E)

### DIFF
--- a/Resources/Views/admin-course.leaf
+++ b/Resources/Views/admin-course.leaf
@@ -214,6 +214,7 @@
                         <select name="role" class="form-input course-role-select"
                                 aria-label="Per-course role" onchange="this.form.submit()">
                             <option value="student"#if(user.role == "student"): selected#endif>Student</option>
+                            <option value="ta"#if(user.role == "ta"): selected#endif>TA</option>
                             <option value="instructor"#if(user.role == "instructor"): selected#endif>Instructor</option>
                         </select>
                     </form>

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -84,6 +84,7 @@ Students
                     <select name="role" class="form-input students-role-select" aria-label="Per-course role"
                             onchange="this.form.submit()">
                         <option value="student"#if(student.role == "student"): selected#endif>Student</option>
+                        <option value="ta"#if(student.role == "ta"): selected#endif>TA</option>
                         <option value="instructor"#if(student.role == "instructor"): selected#endif>Instructor</option>
                     </select>
                 </form>
@@ -249,6 +250,7 @@ Students
                 + '" class="inline-form students-role-form">' + csrfField
                 + '<select name="role" class="form-input students-role-select" aria-label="Per-course role" onchange="this.form.submit()">'
                 + '<option value="student"' + (student.role === 'student' ? ' selected' : '') + '>Student</option>'
+                + '<option value="ta"' + (student.role === 'ta' ? ' selected' : '') + '>TA</option>'
                 + '<option value="instructor"' + (student.role === 'instructor' ? ' selected' : '') + '>Instructor</option>'
                 + '</select></form>';
         }

--- a/Sources/APIServer/Middleware/ActiveCourseInstructorMiddleware.swift
+++ b/Sources/APIServer/Middleware/ActiveCourseInstructorMiddleware.swift
@@ -29,14 +29,18 @@ struct ActiveCourseInstructorMiddleware: AsyncMiddleware {
             return try await next.respond(to: request)
         }
 
-        // Everyone else must be an instructor in their active course. Instructor
-        // authority is per-course — the global instructor role no longer grants
-        // it (multi-course-roles Phase 5).
+        // Everyone else must be staff (TA or instructor) in their active course
+        // to enter the instructor area. Authority is per-course — the global
+        // instructor role no longer grants it (multi-course-roles Phase 5). This
+        // gate only opens the *area*; each mutating handler enforces its own
+        // finer floor (content edits/grading at `.ta`, enrollment/deadline/
+        // archive/delete at `.instructor`) via requireCourseWriteAccess (#417
+        // Slice E).
         let state = try await request.resolveActiveCourse(for: user)
         if let activeCourseUUID = state.activeCourseUUID,
             let userID = user.id,
             let role = try await courseRole(of: userID, inCourse: activeCourseUUID, db: request.db),
-            role >= .instructor
+            role >= .ta
         {
             return try await next.respond(to: request)
         }

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -436,13 +436,16 @@ struct CurrentUserContext: Encodable {
         self.activeCourse = activeCourse
         self.enrolledCourses = enrolledCourses
         self.showCourseTabs = enrolledCourses.count > 1
+        // Staff (TA or instructor) in the active course see the Instructor
+        // surface; the finer per-action floor is enforced server-side (#417
+        // Slice E). The name is kept for back-compat but now means "staff".
         self.isInstructorInActiveCourse =
-            activeCourse != nil && (activeCourse?.role == .instructor || user.isAdmin)
+            activeCourse != nil && ((activeCourse?.role ?? .student) >= .ta || user.isAdmin)
         // An admin instructs the whole deployment, so every enrollment counts;
-        // everyone else, only their `.instructor` enrollments. Order follows
-        // `enrolledCourses` (code-sorted).
+        // everyone else, every course where they are staff (TA or instructor).
+        // Order follows `enrolledCourses` (code-sorted).
         let instructorCourses =
-            user.isAdmin ? enrolledCourses : enrolledCourses.filter { $0.role == .instructor }
+            user.isAdmin ? enrolledCourses : enrolledCourses.filter { $0.role >= .ta }
         self.instructorCourses = instructorCourses
         self.isInstructorAnywhere = !instructorCourses.isEmpty
         self.showInstructorTabs = instructorCourses.count > 1

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
@@ -81,7 +81,7 @@ extension InstructorDashboardRoutes {
         }
 
         let user = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignmentForWrite(req)
+        let assignment = try await loadAssignmentForWrite(req, atLeast: .ta)
         let assignmentIDRaw = assignment.publicID
         guard
             let submissionID = req.parameters.get("submissionID"),
@@ -191,7 +191,7 @@ extension InstructorDashboardRoutes {
         }
 
         let user = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignmentForWrite(req)
+        let assignment = try await loadAssignmentForWrite(req, atLeast: .ta)
         let assignmentIDRaw = assignment.publicID
         guard let studentIDRaw = req.parameters.get("studentID"),
             let studentID = UUID(uuidString: studentIDRaw)
@@ -262,7 +262,7 @@ extension InstructorDashboardRoutes {
         }
 
         let actor = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignmentForWrite(req)
+        let assignment = try await loadAssignmentForWrite(req, atLeast: .ta)
         let assignmentIDRaw = assignment.publicID
         let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
         guard let studentUUID = student.id else {
@@ -313,7 +313,7 @@ extension InstructorDashboardRoutes {
         struct DeleteBody: Content { var returnTo: String? }
 
         _ = try req.auth.require(APIUser.self)
-        let assignment = try await loadAssignmentForWrite(req)
+        let assignment = try await loadAssignmentForWrite(req, atLeast: .ta)
         let assignmentIDRaw = assignment.publicID
         let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
         guard let studentUUID = student.id else {

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -292,7 +292,9 @@ struct InstructorDashboardRoutes: RouteCollection {
         // assignment is a write to an archived course and is blocked for
         // non-admins (#417, follow-up to Slice A — "clone reads from a
         // possibly-archived source").
-        let (source, sourceSetup) = try await loadAssignmentAndSetupForWrite(req)
+        // Cloning creates a *new* assignment (course structure), so it's
+        // instructor-only — unlike the content edits this loader defaults to .ta.
+        let (source, sourceSetup) = try await loadAssignmentAndSetupForWrite(req, atLeast: .instructor)
         let cloned = try await AssignmentAuthoringService.cloneAssignment(
             source: source,
             sourceSetup: sourceSetup,

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -24,13 +24,14 @@ extension StudentCourseRoutes {
     @Sendable
     func courseStudentSubmissionsPage(req: Request) async throws -> View {
         let viewer = try req.auth.require(APIUser.self)
-        guard viewer.isInstructor else {
-            throw WebAssignmentError.forbidden(action: "view student submissions")
-        }
         let (course, student) = try await resolveCourseAndStudent(req: req)
         guard let courseID = course.id else {
             throw WebAssignmentError.notFound(resource: "Course")
         }
+        // Per-course staff (TA+) may view a student's submissions — replaces the
+        // old global `isInstructor` guard, which would reject a per-course TA
+        // whose deployment role is student (#417 Slice E).
+        try await requireCourseRole(caller: viewer, courseID: courseID, atLeast: .ta, db: req.db)
 
         // Phase 1: assignments + sections in parallel.  The sections query
         // only needs `courseID`, so it doesn't have to wait for assignments
@@ -345,7 +346,7 @@ extension StudentCourseRoutes {
     @Sendable
     func retestStudentAssignment(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "retest student submissions", requireWrite: true)
+            req: req, action: "retest student submissions", writeFloor: .ta)
         let (actor, student, assignment) = (action.actor, action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
 
@@ -386,7 +387,7 @@ extension StudentCourseRoutes {
     @Sendable
     func resetStudentAssignmentNotebook(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "reset student notebooks", requireWrite: true)
+            req: req, action: "reset student notebooks", writeFloor: .ta)
         let (actor, student, assignment) = (action.actor, action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
         guard let setup = try await APITestSetup.find(assignment.testSetupID, on: req.db) else {
@@ -428,7 +429,7 @@ extension StudentCourseRoutes {
         }
 
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "grant deadline extensions", requireWrite: true)
+            req: req, action: "grant deadline extensions", writeFloor: .instructor)
         let (actor, student) = (action.actor, action.student)
         let assignmentIDRaw = action.assignment.publicID
         let studentUUID = action.studentID
@@ -490,7 +491,7 @@ extension StudentCourseRoutes {
     @Sendable
     func deleteStudentAssignmentExtension(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "revoke deadline extensions", requireWrite: true)
+            req: req, action: "revoke deadline extensions", writeFloor: .instructor)
         let student = action.student
         let assignmentIDRaw = action.assignment.publicID
         let studentUUID = action.studentID
@@ -529,7 +530,7 @@ extension StudentCourseRoutes {
         }
 
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "override grades", requireWrite: true)
+            req: req, action: "override grades", writeFloor: .ta)
         let (actor, student, assignment) = (action.actor, action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
         let studentUUID = action.studentID
@@ -574,7 +575,7 @@ extension StudentCourseRoutes {
     @Sendable
     func deleteStudentAssignmentGradeOverride(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "clear grade overrides", requireWrite: true)
+            req: req, action: "clear grade overrides", writeFloor: .ta)
         let (student, assignment) = (action.student, action.assignment)
         let assignmentIDRaw = assignment.publicID
         let studentUUID = action.studentID
@@ -663,34 +664,37 @@ extension StudentCourseRoutes {
     /// ever changes. `action` carries each handler's original forbidden-message
     /// wording.
     ///
-    /// `requireWrite` adds a per-course write authorization on the assignment's
-    /// **own** course (`requireCourseWriteAccess`: per-course instructor, admin
-    /// bypass, archived-course block). The mutating handlers pass `true` so a
-    /// retest / reset / extension / grade-override can't be driven against an
-    /// archived course — or a course the caller only instructs *elsewhere* — by
-    /// URL, which the active-course group gate can't see (#417, follow-up to
-    /// Slice A). The read-only history page leaves it `false` so archived
-    /// courses stay auditable.
+    /// Authorization is per-course (#417 Slice E): every caller must be staff
+    /// (TA or instructor) in the assignment's **own** course — `requireCourseRole
+    /// (atLeast: .ta)`, which replaces the old global `isInstructor` guard that
+    /// would wrongly reject a per-course TA whose deployment role is student.
+    /// This covers the read-only history page.
+    ///
+    /// `writeFloor`, when non-nil, additionally authorizes a *write* on that
+    /// course via `requireCourseWriteAccess` (archived-course block + the
+    /// action's minimum role): grading actions (retest / reset / grade-override)
+    /// pass `.ta`; deadline grants (extensions) pass `.instructor`. The read-only
+    /// history page leaves it nil so archived courses stay auditable.
     ///
     /// Error semantics match the guard chain each handler previously
     /// inlined: `notFound("Assignment '<id>'")` when the assignment is
     /// missing, belongs to a different course, or (unreachable for a
     /// DB-loaded model) the student row has no id.
     fileprivate func resolveStudentAssignmentAction(
-        req: Request, action: String, requireWrite: Bool = false
+        req: Request, action: String, writeFloor: CourseRole? = nil
     ) async throws -> StudentAssignmentActionContext {
         let actor = try req.auth.require(APIUser.self)
-        guard actor.isInstructor else {
-            throw WebAssignmentError.forbidden(action: action)
-        }
         let (course, student) = try await resolveCourseAndStudent(req: req)
         let assignment = try await loadAssignment(req)
         guard assignment.courseID == course.id, let studentID = student.id else {
             throw WebAssignmentError.notFound(resource: "Assignment '\(assignment.publicID)'")
         }
-        if requireWrite {
+        // Per-course staff gate (TA+ in THIS course; admin bypass).
+        try await requireCourseRole(
+            caller: actor, courseID: assignment.courseID, atLeast: .ta, db: req.db)
+        if let writeFloor {
             try await requireCourseWriteAccess(
-                caller: actor, courseID: assignment.courseID, db: req.db)
+                caller: actor, courseID: assignment.courseID, atLeast: writeFloor, db: req.db)
         }
         return StudentAssignmentActionContext(
             actor: actor, course: course, student: student,

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -61,29 +61,43 @@ func loadAssignment(_ req: Request) async throws -> APIAssignment {
 
 /// Write-authorizing sibling of `loadAssignmentAndSetup(_:)`. After loading,
 /// authorizes the caller for a *write* to the assignment's **own** course via
-/// `requireCourseWriteAccess` (per-course instructor, admin bypass,
-/// archived-course block). Mutating editor handlers use this so a write is
-/// scoped to the resource's course rather than the caller's active course —
-/// closing both the archived-course and cross-course write paths the
-/// `/instructor` group middleware can't see (see docs/multi-course-roles.md).
-func loadAssignmentAndSetupForWrite(_ req: Request) async throws -> (APIAssignment, APITestSetup) {
+/// `requireCourseWriteAccess` (per-course role + admin bypass + archived-course
+/// block). Mutating editor handlers use this so a write is scoped to the
+/// resource's course rather than the caller's active course — closing both the
+/// archived-course and cross-course write paths the `/instructor` group
+/// middleware can't see (see docs/multi-course-roles.md).
+///
+/// `atLeast` defaults to `.ta` because this is the assignment **content**
+/// editor loader (suite/scripts/sections/families/checks/global-inputs/
+/// datasets/achievements/notebook/solution/save-edit/retest-all) — all of which
+/// a TA may do. The one structural caller, `cloneAssignment` (it creates a new
+/// assignment), passes `.instructor` (#417 Slice E).
+func loadAssignmentAndSetupForWrite(
+    _ req: Request, atLeast: CourseRole = .ta
+) async throws -> (APIAssignment, APITestSetup) {
     let (assignment, setup) = try await loadAssignmentAndSetup(req)
     let caller = try req.auth.require(APIUser.self)
-    try await requireCourseWriteAccess(caller: caller, courseID: assignment.courseID, db: req.db)
+    try await requireCourseWriteAccess(
+        caller: caller, courseID: assignment.courseID, atLeast: atLeast, db: req.db)
     return (assignment, setup)
 }
 
 /// Write-authorizing sibling of `loadAssignment(_:)`, for handlers that mutate
-/// per-course state but never touch the test setup (retest, grade override,
-/// notebook reset). Same `requireCourseWriteAccess` gate as
-/// `loadAssignmentAndSetupForWrite` — scoping the write to the assignment's
-/// **own** course closes the archived-course and cross-course write paths the
-/// `ActiveCourseInstructorMiddleware` group gate (which only inspects the
-/// caller's *active* course) can't see (#417, follow-up to Slice A).
-func loadAssignmentForWrite(_ req: Request) async throws -> APIAssignment {
+/// per-course state but never touch the test setup. Same `requireCourseWriteAccess`
+/// gate as `loadAssignmentAndSetupForWrite`, scoping the write to the
+/// assignment's **own** course (#417, follow-up to Slice A).
+///
+/// `atLeast` defaults to `.instructor` because this loader is shared by both
+/// per-student grading actions (retest/reset/grade-override — TA-allowed, which
+/// pass `atLeast: .ta`) and assignment-lifecycle actions (open/close/status/
+/// delete/BrightSpace — instructor-only, which take the default) (#417 Slice E).
+func loadAssignmentForWrite(
+    _ req: Request, atLeast: CourseRole = .instructor
+) async throws -> APIAssignment {
     let assignment = try await loadAssignment(req)
     let caller = try req.auth.require(APIUser.self)
-    try await requireCourseWriteAccess(caller: caller, courseID: assignment.courseID, db: req.db)
+    try await requireCourseWriteAccess(
+        caller: caller, courseID: assignment.courseID, atLeast: atLeast, db: req.db)
     return assignment
 }
 

--- a/Sources/Core/CourseRole.swift
+++ b/Sources/Core/CourseRole.swift
@@ -9,23 +9,28 @@
 // per-enrollment is what lets a single account be an instructor in one course
 // and a student in another. See docs/multi-course-roles.md.
 //
-// Two rungs ship initially. The type is `String`-backed and deliberately open
-// to a future `ta` rung between `student` and `instructor` without a schema
-// change — the column is a string; only the vocabulary grows.
+// Three rungs ship. The type is `String`-backed, so the vocabulary can grow
+// without a schema change — the column is a string; only the vocabulary grows.
 
 public enum CourseRole: String, Codable, Sendable, Comparable {
     /// Submits to the course's assignments and views their own results.
     case student
-    /// Authors and manages the course's assignments, suites, and content.
+    /// Teaching assistant: views all students' submissions, retests, and edits
+    /// assignments/tests/content — everything an instructor authors — but
+    /// cannot manage enrollment, deadlines, archival, or course staff.
+    case ta
+    /// Authors and manages the course's assignments, suites, and content, plus
+    /// enrollment, deadlines, archival, and staff (everything a TA can do, more).
     case instructor
 
     /// Privilege rank for `atLeast`-style comparisons (higher = more
-    /// privilege). The gap leaves room to slot a future `ta` rung between
-    /// `student` and `instructor` without renumbering, so an
-    /// `enrollment.role >= .instructor` check keeps reading naturally.
+    /// privilege). `ta` sits between `student` and `instructor`, so
+    /// `role >= .ta` admits TAs and instructors while `role >= .instructor`
+    /// admits instructors only.
     private var rank: Int {
         switch self {
         case .student: return 0
+        case .ta: return 10
         case .instructor: return 20
         }
     }

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -24,9 +24,11 @@ import Vapor
 
     @Test func courseRoleRawValuesRoundTrip() {
         #expect(CourseRole.student.rawValue == "student")
+        #expect(CourseRole.ta.rawValue == "ta")
         #expect(CourseRole.instructor.rawValue == "instructor")
         #expect(CourseRole(rawValue: "instructor") == .instructor)
-        #expect(CourseRole(rawValue: "ta") == nil)  // not a rung yet
+        #expect(CourseRole(rawValue: "ta") == .ta)  // the TA rung (#417 Slice E)
+        #expect(CourseRole(rawValue: "wizard") == nil)
     }
 
     @Test func roleAccessorDefaultsToStudentForMissingOrUnknownRaw() {
@@ -187,6 +189,13 @@ import Vapor
         #expect(CourseRole.instructor >= .instructor)
         #expect(CourseRole.student >= .student)
         #expect(!(CourseRole.instructor < CourseRole.student))
+        // TA sits strictly between student and instructor (#417 Slice E).
+        #expect(CourseRole.student < CourseRole.ta)
+        #expect(CourseRole.ta < CourseRole.instructor)
+        #expect(CourseRole.ta >= .ta)
+        #expect(CourseRole.instructor >= .ta)
+        #expect(!(CourseRole.ta >= .instructor))  // a TA is NOT an instructor
+        #expect(CourseRole.ta >= .student)  // ...but outranks a student
     }
 
     /// `requireCourseRole` authorizes by the *per-course* role: a global student

--- a/Tests/APITests/TARoleRouteTests.swift
+++ b/Tests/APITests/TARoleRouteTests.swift
@@ -23,15 +23,20 @@ import VaporTesting
         self.app = try await makeTestApp(prefix: "chickadee-ta-role")
     }
 
+    /// The handful of values each route test threads through its request.
+    private struct Fixture {
+        let courseID: UUID
+        let assignmentID: String
+        let taUserID: UUID
+        let csrf: String
+        let sessionCookie: String
+    }
+
     /// A non-archived `.closed` course + setup + published assignment, with
     /// `ta_user` (a *global student*) enrolled at the given per-course role.
     /// `.closed` so the user isn't auto-enrolled at some other role; the manual
     /// enrollment makes this their only — hence active — course.
-    private func fixture(
-        role: CourseRole
-    ) async throws -> (
-        courseID: UUID, assignmentID: String, taUserID: UUID, csrf: String, sessionCookie: String
-    ) {
+    private func fixture(role: CourseRole) async throws -> Fixture {
         let course = try await makeTestCourse(on: app, code: "TAROLE", name: "TA Role", mode: .closed)
         let courseID = try course.requireID()
         try await makeTestSetup(on: app, id: "ta_setup", courseID: courseID)
@@ -47,7 +52,9 @@ import VaporTesting
         ).save(on: app.db)
 
         let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
-        return (courseID, assignment.publicID, try taUser.requireID(), csrf, sessionCookie)
+        return Fixture(
+            courseID: courseID, assignmentID: assignment.publicID,
+            taUserID: try taUser.requireID(), csrf: csrf, sessionCookie: sessionCookie)
     }
 
     // MARK: - TA CAN edit assignment content (floor .ta)

--- a/Tests/APITests/TARoleRouteTests.swift
+++ b/Tests/APITests/TARoleRouteTests.swift
@@ -1,0 +1,135 @@
+// Tests/APITests/TARoleRouteTests.swift
+//
+// #417 Slice E — the TA per-course role. A TA may enter the instructor area and
+// do the content-editing / grading actions (floor `.ta`), but NOT the
+// instructor-only actions (enrollment management, delete, deadlines, archive —
+// floor `.instructor`). The acting user here is a *global student* with a
+// per-course `.ta` enrollment, so these tests also prove authority is purely
+// per-course (the deployment role is irrelevant).
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class TARoleRouteTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-ta-role")
+    }
+
+    /// A non-archived `.closed` course + setup + published assignment, with
+    /// `ta_user` (a *global student*) enrolled at the given per-course role.
+    /// `.closed` so the user isn't auto-enrolled at some other role; the manual
+    /// enrollment makes this their only — hence active — course.
+    private func fixture(
+        role: CourseRole
+    ) async throws -> (
+        courseID: UUID, assignmentID: String, taUserID: UUID, csrf: String, sessionCookie: String
+    ) {
+        let course = try await makeTestCourse(on: app, code: "TAROLE", name: "TA Role", mode: .closed)
+        let courseID = try course.requireID()
+        try await makeTestSetup(on: app, id: "ta_setup", courseID: courseID)
+        let assignment = try await makeTestAssignment(
+            on: app, testSetupID: "ta_setup", courseID: courseID, title: "Lab")
+
+        let cookie = try await loginUser(
+            username: "ta_user", password: "pw", role: "student", on: app)
+        let taUser = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == "ta_user").first())
+        try await APICourseEnrollment(
+            userID: try taUser.requireID(), courseID: courseID, role: role
+        ).save(on: app.db)
+
+        let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
+        return (courseID, assignment.publicID, try taUser.requireID(), csrf, sessionCookie)
+    }
+
+    // MARK: - TA CAN edit assignment content (floor .ta)
+
+    @Test func taCanEditAssignmentSuite() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(role: .ta)
+            try await app.asyncTest(
+                .PUT, "/instructor/\(fx.assignmentID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"items":[]}"#)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .ok, "a TA may edit assignment content, got \(res.status): \(res.body.string)")
+                })
+        }
+    }
+
+    // MARK: - TA CANNOT do instructor-only actions (floor .instructor)
+
+    @Test func taCannotDeleteAssignment() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(role: .ta)
+            try await app.asyncTest(
+                .POST, "/instructor/\(fx.assignmentID)/delete",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = ByteBuffer(string: "")
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "a TA must not delete an assignment, got \(res.status)")
+                })
+        }
+    }
+
+    @Test func taCannotManageEnrollment() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(role: .ta)
+            // Set-role is enrollment management (instructor floor).
+            try await app.asyncTest(
+                .POST, "/courses/\(fx.courseID)/role/\(fx.taUserID)",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = ByteBuffer(string: "role=student")
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "a TA must not manage enrollment/staff, got \(res.status)")
+                })
+        }
+    }
+
+    // MARK: - An instructor in the same fixture CAN do the instructor-only action
+
+    @Test func instructorCanDeleteAssignment() async throws {
+        try await withApp(app) { _ in
+            // Same shape, but the acting user holds the per-course .instructor
+            // role — the delete (instructor floor) now succeeds (303 redirect),
+            // attributing the TA's 403 above to the role, not the fixture.
+            let fx = try await fixture(role: .instructor)
+            try await app.asyncTest(
+                .POST, "/instructor/\(fx.assignmentID)/delete",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = ByteBuffer(string: "")
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther, "an instructor may delete, got \(res.status)")
+                })
+        }
+    }
+}

--- a/changelog.d/417-slice-e-ta-role.md
+++ b/changelog.d/417-slice-e-ta-role.md
@@ -1,0 +1,30 @@
+### Added
+
+- **TA per-course role (#417 Slice E).** `CourseRole` gains a `ta` rung between
+  `student` and `instructor`. A TA may enter the instructor area and do the
+  teaching work — view all students' submissions, retest, and edit assignments,
+  tests, suites, pattern families, notebook checks, global/section inputs,
+  datasets, achievements, the starter notebook and reference solution — but
+  **cannot** manage enrollment, set deadlines/extensions, archive, delete
+  assignments/setups, clone, create new assignments, or change course staff
+  (those stay `instructor`-only). Authority is purely per-course: a TA whose
+  deployment role is `student` still gets full TA access in the courses they
+  assist. Mechanically, `ActiveCourseInstructorMiddleware` now admits
+  `role >= .ta` into the `/instructor` area, the content-editor write loader
+  (`loadAssignmentAndSetupForWrite`) defaults to a `.ta` floor while the
+  assignment-lifecycle loader (`loadAssignmentForWrite`) stays `.instructor`
+  (the per-student grading actions pass `.ta`), the per-student-page handlers
+  gate on a per-course staff check instead of the old global `isInstructor`,
+  and the nav lights the Instructor surface for staff. The roster role dropdowns
+  (admin course page + instructor Students tab) offer **Student / TA /
+  Instructor**, and the last-instructor guard still blocks demoting a course's
+  only instructor (now including demotion to TA).
+
+### Notes
+
+- A handful of borderline actions were kept at the stricter `instructor` floor
+  (open/close/status, reorder, BrightSpace grade-item config, REST
+  test-setup upload + notebook-save, new-assignment drafts); these can be
+  relaxed to `.ta` later if desired. The MCP surface remains enrollment-gated
+  (it does not yet read the per-course role), so TA-vs-instructor distinctions
+  there are a separate follow-up.


### PR DESCRIPTION
## Summary

Adds the **TA** per-course role — the rung between `student` and `instructor` the issue calls for. A TA does the teaching work but not course management.

### Model
`CourseRole` gains `case ta` (rank 10, between student 0 and instructor 20). String-backed → **no migration**; existing rows are unaffected, and the role-setting handlers already accept `"ta"` through `CourseRole(rawValue:)`.

### What a TA can / can't do
- **Can** (floor `.ta`): enter the instructor area; view all students' submissions; retest; reset a student's notebook; set grade overrides; and edit assignment content — suite, hand-written scripts, suite sections, pattern families, notebook checks, global/section inputs, datasets, achievements, starter notebook, reference solution, save-edit.
- **Cannot** (floor `.instructor`): manage enrollment / course staff, set deadlines & extensions, archive, delete assignments/setups, clone, create new assignments.

Authority is **purely per-course**: the tests act as a *global student* with a per-course `.ta` enrollment and still get full TA access — proving the deployment role is irrelevant.

### Mechanics (fail-safe: default to the stricter floor, loosen explicitly)
- `ActiveCourseInstructorMiddleware` admits `role >= .ta` into `/instructor` (area gate only; each handler enforces its own finer floor).
- `loadAssignmentAndSetupForWrite` — the assignment **content** editor loader — defaults to `atLeast: .ta`; the lone structural caller `cloneAssignment` overrides to `.instructor`.
- `loadAssignmentForWrite` stays `.instructor` (shared by open/close/status/delete/BrightSpace); the 4 per-student grading actions pass `.ta`.
- `resolveStudentAssignmentAction` + `courseStudentSubmissionsPage` now gate on a per-course staff check (`requireCourseRole(atLeast: .ta)`) instead of the stale **global** `isInstructor` (which would have wrongly rejected a global-student TA); the mutating handlers carry a per-action `writeFloor` (grading `.ta`, extensions `.instructor`).
- Nav: `isInstructorInActiveCourse` / `instructorCourses` key off `role >= .ta`, so the Instructor surface shows for staff.
- Roster dropdowns (admin course page + instructor Students tab): **Student / TA / Instructor**. The last-instructor guard still blocks demoting a course's only instructor (now including demotion to TA).

## Tests
- `CourseEnrollmentRoleTests`: TA round-trips through `rawValue`; the ladder orders `student < ta < instructor` (a TA outranks a student but is **not** an instructor). (Also fixes the old `rawValue("ta") == nil` assertion.)
- `TARoleRouteTests`: a global-student-with-per-course-`.ta` may `PUT /suite` (content edit) but is 403'd from delete-assignment and set-role; an instructor in the **same** fixture may delete — attributing the 403s to role, not fixture.

## Notes / deliberate scope
- A few borderline actions were kept at the stricter `.instructor` floor (open/close/status, reorder, BrightSpace grade-item config, the REST test-setup upload + notebook-save, new-assignment drafts) — relaxable to `.ta` later. The MCP surface stays enrollment-gated (it doesn't yet read the per-course role); TA-vs-instructor there is a separate follow-up.
- `swift-format lint` + `check-styles` clean. Full build/tests/SwiftLint run in CI.
- Next: **F** (self-serve instructor staff invites) → **G** (system-role collapse, finale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_