### PR TITLE
Self-serve instructor staff invites (#417 Slice F)

### DIFF
--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -9,10 +9,17 @@ Students
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
 </nav>
 
+#if(flashSuccess):
+<div class="notice-banner students-flash"><p>#(flashSuccess)</p></div>
+#endif
+#if(flashError):
+<div class="form-error students-flash">#(flashError)</div>
+#endif
+
 <div class="students-titlebar">
     <h1 class="students-title">Enrolled students (<span id="enrolled-count">#(enrolledStudentCount)</span>)</h1>
     #if(currentUser.activeCourse):
-    #if(!courseIsArchived):
+    #if(!rosterReadOnly):
     <form method="post" action="/courses/#(currentUser.activeCourse.id)/enrollment-mode" class="students-mode-form">
         #csrfFormField()
         <label class="form-label students-mode-label">
@@ -25,6 +32,27 @@ Students
         </label>
     </form>
     <a class="btn action-btn" href="/instructor/enroll-csv">Enrol from CSV</a>
+    <details class="ext-details students-add-staff">
+        <summary class="btn action-btn" title="Add a co-instructor or TA">Add staff</summary>
+        <form method="post" action="/courses/#(currentUser.activeCourse.id)/staff" class="ext-panel">
+            #csrfFormField()
+            <p class="students-register-hint">Add a co-instructor or TA by username or email. If they have no account yet, a placeholder is created and adopted on their first login.</p>
+            <label class="ext-field-label">
+                Username or email
+                <input type="text" name="identifier" required autocomplete="off" class="ext-field-input">
+            </label>
+            <label class="ext-field-label">
+                Role
+                <select name="role" class="ext-field-input">
+                    <option value="ta">TA</option>
+                    <option value="instructor">Instructor</option>
+                </select>
+            </label>
+            <div class="ext-panel-actions">
+                <button class="btn action-btn" type="submit">Add</button>
+            </div>
+        </form>
+    </details>
     #endif
     #if(brightspaceLinkAvailable):
     <button type="button" class="btn action-btn" id="learn-check-btn"
@@ -42,6 +70,7 @@ Students
 
 <table class="results-table" id="enrolled-students-table"
        data-archived="#if(courseIsArchived):true#else:false#endif"
+       data-can-manage="#if(canManageRoster):true#else:false#endif"
        data-course-id="#(currentUser.activeCourse.id)">
     <thead>
         <tr>
@@ -75,7 +104,7 @@ Students
             <td class="role-cell">
                 #if(student.isPending):
                 <span class="students-pending-role">(pending)</span>
-                #elseif(courseIsArchived):
+                #elseif(rosterReadOnly):
                 #(student.role)
                 #else:
                 <form method="post" action="/courses/#(currentUser.activeCourse.id)/role/#(student.id)"
@@ -95,7 +124,7 @@ Students
                 #(student.lastSeenAtText)
             </td>
             <td>
-                #if(!courseIsArchived):
+                #if(!rosterReadOnly):
                 <div class="students-row-actions">
                     #if(student.isPending):
                     <details class="ext-details form-flush">
@@ -152,6 +181,8 @@ Students
     flex-wrap: wrap;
     margin-bottom: .75rem;
 }
+.students-flash { margin-bottom: .75rem; }
+.students-add-staff { margin: 0; }
 .students-title { font-size: 1.05rem; font-weight: 600; margin: 0; }
 .students-mode-form { margin: 0; }
 .students-mode-label { font-size: .875rem; margin: 0; }
@@ -212,6 +243,7 @@ Students
     var emptyMsg = document.getElementById('no-students-msg');
     var countEl = document.getElementById('enrolled-count');
     var archived = table.getAttribute('data-archived') === 'true';
+    var canManage = table.getAttribute('data-can-manage') === 'true';
     var courseId = table.getAttribute('data-course-id') || '';
 
     var sortCol = 3;
@@ -243,7 +275,7 @@ Students
         var roleCell;
         if (student.isPending) {
             roleCell = '<span class="students-pending-role">(pending)</span>';
-        } else if (archived) {
+        } else if (archived || !canManage) {
             roleCell = role;
         } else {
             roleCell = '<form method="post" action="/courses/' + courseId + '/role/' + escapeHtml(student.id)
@@ -263,7 +295,7 @@ Students
             ? '<code class="students-pending-username">' + username + '</code>'
             : '<a href="' + subURL + '"><code>' + username + '</code></a>';
         var actionCell = '';
-        if (!archived) {
+        if (!archived && canManage) {
             var registerCell = '';
             if (student.isPending && student.registerURL) {
                 registerCell = '<details class="ext-details form-flush">'

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -64,6 +64,16 @@ struct InstructorStudentsContext: Encodable {
     /// True when BrightSpace is configured on the server AND the active course
     /// is linked to a LEARN org unit — gates the "Check against LEARN" button.
     let brightspaceLinkAvailable: Bool
+    /// True when the viewer may manage the roster (change roles, unenroll, invite
+    /// staff): a per-course instructor or an admin. TAs pass the `/instructor`
+    /// gate but see the roster read-only (#417 Slice F). Independent of archived.
+    let canManageRoster: Bool
+    /// `courseIsArchived || !canManageRoster` — folded so the Leaf template gates
+    /// every mutating control on one flag (LeafKit 1.14.2 mis-parses `||`).
+    let rosterReadOnly: Bool
+    /// Flash banners after a staff-invite POST redirect.
+    let flashSuccess: String?
+    let flashError: String?
 }
 
 /// BrightSpace tab (`GET /instructor/brightspace`): connection status, the

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+Enrollment.swift
@@ -294,6 +294,99 @@ extension CourseAdminRoutes {
         return req.redirect(to: "/instructor/students")
     }
 
+    // MARK: - POST /courses/:courseID/staff
+    //
+    // Self-serve staff invite (#417 Slice F). An instructor adds a co-instructor
+    // or TA to *their* course by username or email. Unlike the CSV path — which
+    // records a pre-enrollment that seeds to `.student` on first login — this
+    // materializes the account immediately (SSO-style placeholder, adopted on
+    // first login by username) and enrolls it at the chosen staff role, so the
+    // role sticks. Instructor-only: TAs are read-only on the roster, so this
+    // uses the `.instructor` write floor rather than the `.ta` content floor.
+
+    @Sendable
+    func instructorInviteStaff(req: Request) async throws -> Response {
+        struct Body: Content {
+            var identifier: String?
+            var role: String?
+        }
+
+        guard
+            let courseIDString = req.parameters.get("courseID"),
+            let courseID = UUID(uuidString: courseIDString)
+        else {
+            throw WebAssignmentError.invalidParameter(name: "courseID", reason: "Invalid courseID parameter")
+        }
+
+        let caller = try req.auth.require(APIUser.self)
+        try await requireCourseWriteAccess(
+            caller: caller, courseID: courseID, atLeast: .instructor, db: req.db)
+
+        let body = try? req.content.decode(Body.self)
+        let identifier = (body?.identifier ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Only staff roles may be added here; students enrol via CSV / self-serve.
+        guard let role = CourseRole(rawValue: body?.role ?? ""), role >= .ta else {
+            return req.redirect(to: "/instructor/students?staffError=role")
+        }
+        guard isAcceptableUsernameForEnrollment(identifier) else {
+            return req.redirect(to: "/instructor/students?staffError=identifier")
+        }
+
+        // Reuse an existing account matched by username or email; otherwise mint
+        // an SSO-style placeholder (no local password) that the real login adopts
+        // by username — mirroring `instructorRegisterPreEnrollment`.
+        let existing = try await APIUser.query(on: req.db)
+            .group(.or) { or in
+                or.filter(\.$username == identifier)
+                or.filter(\.$email == identifier)
+            }
+            .first()
+
+        let user: APIUser
+        if let existing {
+            user = existing
+        } else {
+            let looksLikeEmail = identifier.contains("@")
+            user = APIUser(
+                username: identifier,
+                passwordHash: "",  // SSO users have no local password
+                role: UserRole.student.rawValue,  // deployment role stays student; staff authority is per-course
+                authProvider: "duo-oidc",
+                email: looksLikeEmail ? identifier : nil
+            )
+            try await user.save(on: req.db)
+        }
+        let userID = try user.requireID()
+
+        // Enroll at the chosen staff role, or promote an existing enrollment to it.
+        if let enrollment = try await APICourseEnrollment.query(on: req.db)
+            .filter(\.$course.$id == courseID)
+            .filter(\.$userID == userID)
+            .first()
+        {
+            enrollment.role = role
+            try await enrollment.save(on: req.db)
+        } else {
+            try await APICourseEnrollment(userID: userID, courseID: courseID, role: role)
+                .save(on: req.db)
+        }
+
+        await AuditLogger.record(
+            action: .enrollmentRoleChanged,
+            targetType: .enrollment,
+            targetID: userID.uuidString,
+            metadata: [
+                "course_id": courseIDString,
+                "subject_user_id": userID.uuidString,
+                "role": role.rawValue,
+                "source": "staff_invite",
+            ],
+            on: req
+        )
+        return req.redirect(to: "/instructor/students?staffAdded=1")
+    }
+
     // MARK: - POST /courses/:courseID/role/:userID
     //
     // Sets a roster member's per-course role (Phase 4b). Authorized per-course:

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
@@ -28,6 +28,8 @@ struct CourseAdminRoutes: RouteCollection {
             use: instructorRegisterPreEnrollment)
         // Set a roster member's per-course role (Phase 4b).
         routes.post("courses", ":courseID", "role", ":userID", use: instructorSetEnrollmentRole)
+        // Self-serve staff invite: add a co-instructor / TA by username or email (#417 Slice F).
+        routes.post("courses", ":courseID", "staff", use: instructorInviteStaff)
 
         let r = routes.grouped("instructor")
         r.get("enroll-csv", use: enrollCSVForm)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Students.swift
@@ -67,6 +67,22 @@ extension InstructorDashboardRoutes {
             }
         }
 
+        // Roster management (roles, unenroll, staff invite) is instructor-only;
+        // a TA in the active course reaches this page but sees it read-only.
+        let canManageRoster =
+            user.isAdmin || (courseState.active?.role ?? .student) >= .instructor
+
+        let flashSuccess: String? =
+            req.query[String.self, at: "staffAdded"] != nil
+            ? "Staff member added." : nil
+        let flashError: String? = {
+            switch req.query[String.self, at: "staffError"] {
+            case "role": return "Choose a staff role (TA or Instructor)."
+            case "identifier": return "Enter a valid username or email address."
+            default: return nil
+            }
+        }()
+
         let ctx = InstructorStudentsContext(
             currentUser: userContext,
             activeInstructorTab: "students",
@@ -75,7 +91,11 @@ extension InstructorDashboardRoutes {
             enrolledStudentCount: enrolledStudentCount,
             courseEnrollmentMode: courseEnrollmentMode,
             courseIsArchived: courseIsArchived,
-            brightspaceLinkAvailable: brightspaceLinkAvailable
+            brightspaceLinkAvailable: brightspaceLinkAvailable,
+            canManageRoster: canManageRoster,
+            rosterReadOnly: courseIsArchived || !canManageRoster,
+            flashSuccess: flashSuccess,
+            flashError: flashError
         )
         return try await req.view.render("instructor-students", ctx).encodeResponse(for: req)
     }

--- a/Tests/APITests/StaffInviteRouteTests.swift
+++ b/Tests/APITests/StaffInviteRouteTests.swift
@@ -1,0 +1,158 @@
+// Tests/APITests/StaffInviteRouteTests.swift
+//
+// #417 Slice F — self-serve instructor staff invites. A per-course *instructor*
+// adds a co-instructor or TA to their course by username or email; an unknown
+// identifier mints an SSO-style placeholder account enrolled at the chosen staff
+// role (so the role sticks, unlike the CSV pre-enrollment path which seeds to
+// student). TAs are read-only on the roster and cannot invite. Authority is
+// purely per-course: the acting instructor here is a *global student*.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class StaffInviteRouteTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-staff-invite")
+    }
+
+    /// A non-archived `.closed` course with `actor` (a *global student*) enrolled
+    /// at `role` — their only, hence active, course.
+    private struct Fixture {
+        let courseID: UUID
+        let csrf: String
+        let sessionCookie: String
+    }
+
+    private func fixture(actorRole: CourseRole) async throws -> Fixture {
+        let course = try await makeTestCourse(on: app, code: "STAFF", name: "Staff", mode: .closed)
+        let courseID = try course.requireID()
+
+        let cookie = try await loginUser(
+            username: "acting_user", password: "pw", role: "student", on: app)
+        let actor = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == "acting_user").first())
+        try await APICourseEnrollment(
+            userID: try actor.requireID(), courseID: courseID, role: actorRole
+        ).save(on: app.db)
+
+        let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: cookie, on: app)
+        return Fixture(courseID: courseID, csrf: csrf, sessionCookie: sessionCookie)
+    }
+
+    private func postStaff(
+        _ fx: Fixture, identifier: String, role: String
+    ) async throws -> (status: HTTPStatus, location: String?) {
+        var out: (HTTPStatus, String?) = (.internalServerError, nil)
+        try await app.asyncTest(
+            .POST, "/courses/\(fx.courseID)/staff",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: fx.sessionCookie)
+                req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                req.headers.contentType = .urlEncodedForm
+                req.body = ByteBuffer(string: "identifier=\(identifier)&role=\(role)")
+            },
+            afterResponse: { res in
+                out = (res.status, res.headers.first(name: .location))
+            })
+        return out
+    }
+
+    private func enrollment(userID: UUID, courseID: UUID) async throws -> APICourseEnrollment? {
+        try await APICourseEnrollment.query(on: app.db)
+            .filter(\.$course.$id == courseID)
+            .filter(\.$userID == userID)
+            .first()
+    }
+
+    // MARK: - Instructor can invite (floor .instructor)
+
+    @Test func instructorInvitesUnknownUser_mintsPlaceholderStaff() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(actorRole: .instructor)
+            let res = try await postStaff(fx, identifier: "brand_new_ta", role: "ta")
+            #expect(res.status == .seeOther)
+            #expect(res.location?.contains("staffAdded=1") == true)
+
+            let created = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "brand_new_ta").first(),
+                "an unknown identifier should mint a placeholder account")
+            #expect(created.passwordHash.isEmpty, "placeholder has no local password")
+            let enr = try #require(try await enrollment(userID: created.requireID(), courseID: fx.courseID))
+            #expect(enr.role == .ta, "placeholder enrolled at the chosen staff role")
+        }
+    }
+
+    @Test func instructorInvitesExistingUser_asInstructor() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(actorRole: .instructor)
+            let existing = try await makeTestUser(on: app, username: "existing_prof", role: "student")
+            let existingID = try existing.requireID()
+
+            let res = try await postStaff(fx, identifier: "existing_prof", role: "instructor")
+            #expect(res.status == .seeOther)
+
+            let enr = try #require(try await enrollment(userID: existingID, courseID: fx.courseID))
+            #expect(enr.role == .instructor)
+            // No duplicate account was created.
+            let count = try await APIUser.query(on: app.db)
+                .filter(\.$username == "existing_prof").count()
+            #expect(count == 1)
+        }
+    }
+
+    @Test func inviteExistingStudent_promotesInPlace() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(actorRole: .instructor)
+            let student = try await makeTestUser(on: app, username: "enrolled_stu", role: "student")
+            let studentID = try student.requireID()
+            try await APICourseEnrollment(userID: studentID, courseID: fx.courseID, role: .student)
+                .save(on: app.db)
+
+            let res = try await postStaff(fx, identifier: "enrolled_stu", role: "ta")
+            #expect(res.status == .seeOther)
+
+            // Same enrollment row, promoted — not a second row.
+            let rows = try await APICourseEnrollment.query(on: app.db)
+                .filter(\.$course.$id == fx.courseID)
+                .filter(\.$userID == studentID)
+                .all()
+            #expect(rows.count == 1)
+            #expect(rows.first?.role == .ta)
+        }
+    }
+
+    // MARK: - Guards
+
+    @Test func taCannotInviteStaff() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(actorRole: .ta)
+            let res = try await postStaff(fx, identifier: "someone_new", role: "ta")
+            #expect(res.status == .forbidden, "a TA must not invite staff, got \(res.status)")
+            // Nothing was created.
+            let count = try await APIUser.query(on: app.db)
+                .filter(\.$username == "someone_new").count()
+            #expect(count == 0)
+        }
+    }
+
+    @Test func inviteRejectsStudentRole() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(actorRole: .instructor)
+            let res = try await postStaff(fx, identifier: "not_staff", role: "student")
+            #expect(res.status == .seeOther)
+            #expect(res.location?.contains("staffError=role") == true)
+            // The student-role invite is refused before any account/enrollment is made.
+            let count = try await APIUser.query(on: app.db)
+                .filter(\.$username == "not_staff").count()
+            #expect(count == 0)
+        }
+    }
+}

--- a/changelog.d/417-slice-f-staff-invites.md
+++ b/changelog.d/417-slice-f-staff-invites.md
@@ -1,0 +1,24 @@
+### Added
+
+- **Self-serve instructor staff invites (#417 Slice F).** A per-course
+  instructor can now add a co-instructor or TA to their own course directly
+  from the Students tab — an **Add staff** disclosure takes a username or email
+  and a role (TA / Instructor). If the identifier matches an existing account
+  it is enrolled (or promoted) at that role; if no account exists yet, an
+  SSO-style placeholder is minted (no local password) and adopted by username
+  on the person's first login. Unlike the CSV bulk-enroll path — which records
+  a pre-enrollment that seeds to `student` at login — a staff invite
+  materializes the enrollment immediately so the chosen staff role sticks
+  (`POST /courses/:courseID/staff`, `instructorInviteStaff`).
+
+### Changed
+
+- **TAs are read-only on the roster (#417 Slice F).** The Students tab now gates
+  every mutating control — the per-row role dropdown, the unenroll / register
+  buttons, the enrolment-mode selector, "Enrol from CSV", and the new "Add
+  staff" form — on a `canManageRoster` flag (per-course instructor or admin), in
+  both the server-rendered page and the poll-driven JS repaint. A TA still
+  reaches the instructor area and sees the roster, but can no longer see
+  controls whose `POST` the server already refused with a 403. Staff invites use
+  the `.instructor` write floor (enrollment management stays instructor-only),
+  not the `.ta` content floor.


### PR DESCRIPTION
## What & why

Slice F of the per-course role work (#417). Lets a **per-course instructor** add a co-instructor or TA to their own course directly from the Students tab — no admin round-trip — and makes the roster **read-only for TAs**.

## Changes

**Staff invites**
- New `POST /courses/:courseID/staff` (`instructorInviteStaff`) at the `.instructor` write floor.
- An **Add staff** disclosure on the Students tab takes a username **or** email plus a role (TA / Instructor).
- An existing account (matched by username or email) is enrolled — or promoted in place — at the chosen staff role.
- An unknown identifier mints an SSO-style **placeholder** account (no local password) that the real login adopts by username, mirroring `instructorRegisterPreEnrollment`.
- Unlike the CSV pre-enrollment path (which seeds to `student` at first login), the enrollment is materialized immediately, so the staff role sticks.

**TA read-only roster**
- The Students tab now gates every mutating control — per-row role dropdown, unenroll/register, enrolment-mode selector, "Enrol from CSV", and the new "Add staff" form — on a `canManageRoster` flag (per-course instructor or admin), in both the server-rendered page and the poll-driven JS repaint. A TA still reaches the instructor area and sees the roster, but no longer sees controls whose `POST` the server already refused with 403.

## Tests

`StaffInviteRouteTests` covers: placeholder mint at a staff role, existing-user enroll as instructor (no duplicate account), in-place promotion of an already-enrolled student, TA → 403, and student-role rejection.

## Notes

- Enrollment management stays instructor-only; staff invites use the `.instructor` floor, not the `.ta` content floor introduced in Slice E.
- Email-identifier placeholders are keyed on the identifier as username (same limitation as CSV pre-enroll); SSO adoption is by username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_