### PR TITLE
Per-course staff view/access gates (#417 Slice G, part 1)

### DIFF
--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -148,6 +148,20 @@ func courseID(ofSubmission submission: APISubmission, on db: Database) async thr
     try await APITestSetup.find(submission.testSetupID, on: db)?.courseID
 }
 
+/// Whether `user` is staff (TA+ or admin) for `submission`'s course — the
+/// per-course view gate for the submission view/download paths. False when the
+/// submission's setup (hence course) can't be resolved (#417 Slice G).
+func isSubmissionStaff(
+    _ user: APIUser, submission: APISubmission, on db: Database
+) async throws
+    -> Bool
+{
+    guard let owningCourseID = try await courseID(ofSubmission: submission, on: db) else {
+        return false
+    }
+    return try await isCourseStaff(user, inCourse: owningCourseID, db: db)
+}
+
 /// Authorizes a *write* to a per-course resource. The caller must satisfy
 /// `requireCourseRole(atLeast:)` for `courseID` (admin bypass) **and** the
 /// course must not be archived. Archived courses are read-only for

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -109,6 +109,45 @@ func requireCourseInstructor(caller: APIUser, courseID: UUID, db: Database) asyn
     try await requireCourseRole(caller: caller, courseID: courseID, atLeast: .instructor, db: db)
 }
 
+/// True when `user` may act with *staff* visibility for `courseID`: an admin,
+/// or a per-course enrollment role of at least `.ta`. This is the per-course
+/// replacement for the global `APIUser.isInstructor` view/access gate (#417
+/// Slice G) — a viewer sees instructor-level detail (all tiers, other students'
+/// submissions, solution files) only for the courses they actually staff, not
+/// deployment-wide. TAs count as staff (they grade), matching Slice E.
+func isCourseStaff(_ user: APIUser, inCourse courseID: UUID, db: Database) async throws -> Bool {
+    if user.isAdmin { return true }
+    guard let userID = user.id else { return false }
+    guard let role = try await courseRole(of: userID, inCourse: courseID, db: db) else { return false }
+    return role >= .ta
+}
+
+/// True when `user` is staff (role >= `.ta`) in *any* non-archived enrolled
+/// course, or an admin. The coarse analog of `isCourseStaff` for gates that
+/// have no single resource course in scope (the MCP content-tool gate, the
+/// OAuth content-scope consent gate, the user-file namespace). Downstream
+/// per-course checks still apply, so this only decides "may this account touch
+/// the staff surface at all", never which course it may act on.
+func isStaffAnywhere(_ user: APIUser, db: Database) async throws -> Bool {
+    if user.isAdmin { return true }
+    guard let userID = user.id else { return false }
+    return try await APICourseEnrollment.query(on: db)
+        .filter(\.$userID == userID)
+        .group(.or) { or in
+            or.filter(\.$roleRaw == CourseRole.ta.rawValue)
+            or.filter(\.$roleRaw == CourseRole.instructor.rawValue)
+        }
+        .count() > 0
+}
+
+/// The UUID of the course that owns `submission`, resolved through its test
+/// setup (`test_setups.course_id`). Nil only if the setup row is missing.
+/// Used to scope per-course staff checks on the submission view/download/query
+/// paths (#417 Slice G).
+func courseID(ofSubmission submission: APISubmission, on db: Database) async throws -> UUID? {
+    try await APITestSetup.find(submission.testSetupID, on: db)?.courseID
+}
+
 /// Authorizes a *write* to a per-course resource. The caller must satisfy
 /// `requireCourseRole(atLeast:)` for `courseID` (admin bypass) **and** the
 /// course must not be archived. Archived courses are read-only for

--- a/Sources/APIServer/Helpers/TierFilter.swift
+++ b/Sources/APIServer/Helpers/TierFilter.swift
@@ -94,8 +94,8 @@ extension TestOutcomeCollection {
 /// The student *web* view is more nuanced — it lists release tests by name
 /// before the deadline but redacts their output — so it uses `itemizedTiers`
 /// and `releaseOutputVisible` instead.
-func visibleTiers(for user: APIUser, effectiveDueAt: Date?, now: Date = Date()) -> Set<String> {
-    if user.isInstructor {
+func visibleTiers(isStaff: Bool, effectiveDueAt: Date?, now: Date = Date()) -> Set<String> {
+    if isStaff {
         return ["public", "release", "secret"]
     }
     // nil effectiveDueAt → no deadline → release is immediately visible.
@@ -110,8 +110,8 @@ func visibleTiers(for user: APIUser, effectiveDueAt: Date?, now: Date = Date()) 
 /// see every tier.  The grade is computed over *all* tiers regardless of this
 /// set, so the number is stable across the deadline; only release *output* is
 /// additionally gated (see `releaseOutputVisible`).
-func itemizedTiers(for user: APIUser) -> Set<String> {
-    user.isInstructor ? ["public", "release", "secret"] : ["public", "release"]
+func itemizedTiers(isStaff: Bool) -> Set<String> {
+    isStaff ? ["public", "release", "secret"] : ["public", "release"]
 }
 
 /// Whether release-tier *output* (the result message + stderr/traceback panel)
@@ -123,8 +123,8 @@ func itemizedTiers(for user: APIUser) -> Set<String> {
 /// later of the assignment due date and their own extension — so a student with
 /// an active extension keeps release output hidden until *their* deadline
 /// passes, not the (earlier) class-wide one.
-func releaseOutputVisible(for user: APIUser, effectiveDueAt: Date?, now: Date = Date()) -> Bool {
-    if user.isInstructor { return true }
+func releaseOutputVisible(isStaff: Bool, effectiveDueAt: Date?, now: Date = Date()) -> Bool {
+    if isStaff { return true }
     return effectiveDueAt.map { $0 <= now } ?? true
 }
 

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -698,14 +698,23 @@ extension MCPOAuthRoutes {
 
         var scopeCeiling: Set<String> { Set(advertisedScopes) }
 
-        /// The role gate: content authoring needs staff (TA+ in any course) or
-        /// admin; admin diagnostics needs admin. This only decides who may grant
-        /// a scope at all — per-course authority is re-checked per tool call by
-        /// `authorizeCourseAccess` (#417 Slice G — content was the global
-        /// `user.isInstructor`).
+        /// The role gate: content authoring needs an instructor/admin; admin
+        /// diagnostics needs admin. This only decides who may grant a scope at
+        /// all — per-course authority is re-checked per tool call by
+        /// `authorizeCourseAccess`, which is already enrollment-scoped, so this
+        /// coarse gate never widens what an agent can actually touch.
+        ///
+        /// NOTE (#417): this consent gate still keys off the deployment-global
+        /// role. It is deliberately deferred to the Slice G2 enum collapse, which
+        /// revisits every global-role reference at once (there it becomes a
+        /// per-course `isStaffAnywhere` check). Converting it here in G1 — ahead
+        /// of the enum work — only churned the OAuth-consent tests for no net
+        /// security gain, since the tool-level per-course check already governs
+        /// what the minted token can do. The `db` parameter is kept so G2 can
+        /// swap in the async per-course lookup without touching call sites.
         func permits(_ user: APIUser, db: Database) async throws -> Bool {
             switch surface {
-            case .content: return try await isStaffAnywhere(user, db: db)
+            case .content: return user.isInstructor
             case .admin: return user.isAdmin
             }
         }

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -97,8 +97,9 @@ struct MCPOAuthRoutes: Sendable {
         // submit works even when Safari/ITP drops the session cookie on the
         // cross-site hop. Non-permitted users get the not-permitted view and no
         // actionable token.
+        let userPermitted = try await surface.permits(user, db: req.db)
         var requestToken: String?
-        if let userID = user.id, surface.permits(user) {
+        if let userID = user.id, userPermitted {
             let token = Self.randomToken()
             try await MCPConsentRequest(
                 tokenHash: sha256HexDigest(token),
@@ -121,7 +122,7 @@ struct MCPOAuthRoutes: Sendable {
             scopeLabels: ordered.map(Self.scopeLabel),
             redirectHost: URLComponents(string: query.redirectURI)?.host ?? query.redirectURI,
             firstTimeApproval: firstTimeApproval,
-            notPermitted: !surface.permits(user),
+            notPermitted: !userPermitted,
             permittedRoleLabel: surface.permittedRoleLabel,
             purposeLabel: surface.purposeLabel,
             requestToken: requestToken)
@@ -198,7 +199,8 @@ struct MCPOAuthRoutes: Sendable {
         // Re-check the role from the bound user at submit time: a downgrade
         // between rendering the consent screen and submitting it must stop here.
         guard
-            let user = try await APIUser.find(record.userID, on: req.db), surface.permits(user)
+            let user = try await APIUser.find(record.userID, on: req.db),
+            try await surface.permits(user, db: req.db)
         else {
             throw Abort(.forbidden, reason: "Only \(surface.permittedRoleLabel) may authorize agents.")
         }
@@ -379,7 +381,7 @@ struct MCPOAuthRoutes: Sendable {
         // the grant so it can't be refreshed again.  The web session loses
         // access immediately via RoleMiddleware; this closes the gap for
         // long-lived MCP grants.
-        guard surface.permits(user) else {
+        guard try await surface.permits(user, db: req.db) else {
             grant.revoked = true
             try await grant.save(on: req.db)
             await AuditLogger.record(
@@ -696,12 +698,14 @@ extension MCPOAuthRoutes {
 
         var scopeCeiling: Set<String> { Set(advertisedScopes) }
 
-        /// The role gate: content authoring needs instructor+, admin diagnostics
-        /// needs admin. (Admin implies instructor, so `isAdmin` is the stricter
-        /// gate, not a widening.)
-        func permits(_ user: APIUser) -> Bool {
+        /// The role gate: content authoring needs staff (TA+ in any course) or
+        /// admin; admin diagnostics needs admin. This only decides who may grant
+        /// a scope at all — per-course authority is re-checked per tool call by
+        /// `authorizeCourseAccess` (#417 Slice G — content was the global
+        /// `user.isInstructor`).
+        func permits(_ user: APIUser, db: Database) async throws -> Bool {
             switch surface {
-            case .content: return user.isInstructor
+            case .content: return try await isStaffAnywhere(user, db: db)
             case .admin: return user.isAdmin
             }
         }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -70,7 +70,11 @@ struct ToolContext {
         else {
             throw MCPToolError.notAuthorized(tool: tool, detail: "Unknown token subject.")
         }
-        guard user.isInstructor || user.isMCPAgent else {
+        // MCP eligibility is coarse (per-course access is enforced separately by
+        // `authorizeCourseAccess`): staff (TA+ anywhere) or admin humans, plus
+        // `mcp` service accounts — never plain students (#417 Slice G, was the
+        // global `user.isInstructor`).
+        guard try await isStaffAnywhere(user, db: db) || user.isMCPAgent else {
             throw MCPToolError.notAuthorized(
                 tool: tool, detail: "Students may not use the MCP interface.")
         }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -70,11 +70,19 @@ struct ToolContext {
         else {
             throw MCPToolError.notAuthorized(tool: tool, detail: "Unknown token subject.")
         }
-        // MCP eligibility is coarse (per-course access is enforced separately by
-        // `authorizeCourseAccess`): staff (TA+ anywhere) or admin humans, plus
-        // `mcp` service accounts — never plain students (#417 Slice G, was the
-        // global `user.isInstructor`).
-        guard try await isStaffAnywhere(user, db: db) || user.isMCPAgent else {
+        // MCP eligibility is coarse: an instructor/admin human, or an `mcp`
+        // service account — never a plain student. Per-course access is enforced
+        // separately (and per-course) by `authorizeCourseAccess`, so this gate
+        // never widens what a caller can actually touch.
+        //
+        // NOTE (#417): like the OAuth consent `permits` gate, this coarse check
+        // still keys off the deployment-global role and is deliberately deferred
+        // to the Slice G2 enum collapse — which converts every global-role
+        // reference to a per-course `isStaffAnywhere` check at once. Converting
+        // it here in G1 only broke the MCP tool fixtures (which enrol the actor
+        // without a staff role) for no security gain, since the per-course
+        // `authorizeCourseAccess` already governs each tool call.
+        guard user.isInstructor || user.isMCPAgent else {
             throw MCPToolError.notAuthorized(
                 tool: tool, detail: "Students may not use the MCP interface.")
         }

--- a/Sources/APIServer/Middleware/UserFileNamespaceMiddleware.swift
+++ b/Sources/APIServer/Middleware/UserFileNamespaceMiddleware.swift
@@ -18,7 +18,10 @@ struct UserFileNamespaceMiddleware: AsyncMiddleware {
         guard let caller = req.auth.get(APIUser.self) else {
             throw Abort(.unauthorized)
         }
-        if caller.isInstructor {
+        // The user-file namespace is deployment-wide: staff (TA+ anywhere) or
+        // admin may reach any user's folder; everyone else only their own (#417
+        // Slice G — was the global `caller.isInstructor`).
+        if try await isStaffAnywhere(caller, db: req.db) {
             return try await next.respond(to: req)
         }
         guard let callerID = caller.id?.uuidString.lowercased(), callerID == requestedUser else {

--- a/Sources/APIServer/Routes/JupyterLiteContentsRoutes.swift
+++ b/Sources/APIServer/Routes/JupyterLiteContentsRoutes.swift
@@ -30,28 +30,33 @@ struct JupyterLiteContentsRoutes: RouteCollection {
 
     @Sendable
     func contentsRoot(req: Request) async throws -> Response {
-        try contentsResponse(req: req, relativePath: "")
+        try await contentsResponse(req: req, relativePath: "")
     }
 
     @Sendable
     func contentsPath(req: Request) async throws -> Response {
         let relPath = req.parameters.getCatchall().joined(separator: "/")
-        return try contentsResponse(req: req, relativePath: relPath)
+        return try await contentsResponse(req: req, relativePath: relPath)
     }
 
-    private func contentsResponse(req: Request, relativePath: String) throws -> Response {
+    private func contentsResponse(req: Request, relativePath: String) async throws -> Response {
         let caller = try req.auth.require(APIUser.self)
+        // The JupyterLite virtual filesystem is deployment-wide (not course-
+        // scoped): course staff (TA+ or admin anywhere) get the full authoring
+        // tree, everyone else is scoped to their own `users/<id>` folder (#417
+        // Slice G — was the global `caller.isInstructor`).
+        let isStaff = try await isStaffAnywhere(caller, db: req.db)
         let fm = FileManager.default
         let baseDir = req.application.directory.publicDirectory + "jupyterlite/files/"
         try fm.createDirectory(atPath: baseDir, withIntermediateDirectories: true)
         let baseURL = URL(fileURLWithPath: baseDir, isDirectory: true).standardizedFileURL
 
-        let cleanRel = try scopedRelativePath(for: caller, requested: relativePath)
+        let cleanRel = try scopedRelativePath(for: caller, requested: relativePath, isStaff: isStaff)
         let targetURL = baseURL.appendingPathComponent(cleanRel).standardizedFileURL
         guard targetURL.path.hasPrefix(baseURL.path) else {
             throw Abort(.forbidden)
         }
-        if let userRoot = try userRootPath(for: caller) {
+        if let userRoot = try userRootPath(for: caller, isStaff: isStaff) {
             let userRootURL = baseURL.appendingPathComponent(userRoot, isDirectory: true).standardizedFileURL
             let withinUserRoot =
                 targetURL.path == userRootURL.path
@@ -215,8 +220,8 @@ struct JupyterLiteContentsRoutes: RouteCollection {
         ISO8601DateFormatter().string(from: date)
     }
 
-    private func userRootPath(for caller: APIUser) throws -> String? {
-        if caller.isInstructor {
+    private func userRootPath(for caller: APIUser, isStaff: Bool) throws -> String? {
+        if isStaff {
             return nil
         }
         guard let userID = caller.id else {
@@ -225,13 +230,17 @@ struct JupyterLiteContentsRoutes: RouteCollection {
         return "users/\(userID.uuidString.lowercased())"
     }
 
-    private func scopedRelativePath(for caller: APIUser, requested: String) throws -> String {
+    private func scopedRelativePath(
+        for caller: APIUser, requested: String, isStaff: Bool
+    ) throws
+        -> String
+    {
         let clean = requested.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        if caller.isInstructor {
+        if isStaff {
             return clean
         }
 
-        guard let userRoot = try userRootPath(for: caller) else {
+        guard let userRoot = try userRootPath(for: caller, isStaff: isStaff) else {
             return clean
         }
 

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -34,10 +34,18 @@ struct SubmissionQueryRoutes: RouteCollection {
             .filter(\.$kind == APISubmission.Kind.student)
             .sort(\.$submittedAt, .descending)
 
+        // A non-admin sees others' submissions only for a test setup whose
+        // course they staff; otherwise (including with no setup filter) they see
+        // only their own (#417 Slice G — was the global `caller.isInstructor`).
+        var callerIsCourseStaff = false
         if let testSetupID = req.query[String.self, at: "testSetupID"] {
             query = query.filter(\.$testSetupID == testSetupID)
+            if let setup = try await APITestSetup.find(testSetupID, on: req.db) {
+                callerIsCourseStaff = try await isCourseStaff(
+                    caller, inCourse: setup.courseID, db: req.db)
+            }
         }
-        if !caller.isInstructor {
+        if !callerIsCourseStaff {
             query = query.filter(\.$userID == caller.id)
         }
 
@@ -58,7 +66,8 @@ struct SubmissionQueryRoutes: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-        guard canViewSubmission(caller: caller, submission: submission) else {
+        guard try await submissionAccess(caller: caller, submission: submission, on: req.db).canView
+        else {
             throw Abort(.forbidden)
         }
         return SubmissionStatusResponse(submission: submission)
@@ -75,7 +84,8 @@ struct SubmissionQueryRoutes: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-        guard canViewSubmission(caller: caller, submission: submission) else {
+        let access = try await submissionAccess(caller: caller, submission: submission, on: req.db)
+        guard access.canView else {
             throw Abort(.forbidden)
         }
 
@@ -112,7 +122,7 @@ struct SubmissionQueryRoutes: RouteCollection {
         let releaseDeadline = try await releaseVisibilityDeadline(
             for: assignment, user: caller, on: req.db)
         let visible = fullCollection.filtering(
-            tiers: visibleTiers(for: caller, effectiveDueAt: releaseDeadline))
+            tiers: visibleTiers(isStaff: access.isStaff, effectiveDueAt: releaseDeadline))
 
         let responseCollection: TestOutcomeCollection
         if let tiersParam = req.query[String.self, at: "tiers"] {
@@ -143,9 +153,20 @@ struct SubmissionQueryRoutes: RouteCollection {
     }
 }
 
-private func canViewSubmission(caller: APIUser, submission: APISubmission) -> Bool {
-    if caller.isInstructor { return true }
-    return submission.userID == caller.id
+/// Per-course view authorization for a single submission (#417 Slice G).
+/// Returns whether `caller` may view it and whether they view it as course
+/// staff — the owner always may (`isStaff == false`), and a staff member (TA+
+/// or admin) of the submission's course sees it with instructor-level tier
+/// visibility. Resolving the course once lets the caller reuse `isStaff` for
+/// tier filtering without a second lookup.
+private func submissionAccess(
+    caller: APIUser, submission: APISubmission, on db: Database
+) async throws -> (canView: Bool, isStaff: Bool) {
+    var isStaff = false
+    if let owningCourseID = try await courseID(ofSubmission: submission, on: db) {
+        isStaff = try await isCourseStaff(caller, inCourse: owningCourseID, db: db)
+    }
+    return (isStaff || submission.userID == caller.id, isStaff)
 }
 
 // MARK: - Response types

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -162,10 +162,7 @@ struct SubmissionQueryRoutes: RouteCollection {
 private func submissionAccess(
     caller: APIUser, submission: APISubmission, on db: Database
 ) async throws -> (canView: Bool, isStaff: Bool) {
-    var isStaff = false
-    if let owningCourseID = try await courseID(ofSubmission: submission, on: db) {
-        isStaff = try await isCourseStaff(caller, inCourse: owningCourseID, db: db)
-    }
+    let isStaff = try await isSubmissionStaff(caller, submission: submission, on: db)
     return (isStaff || submission.userID == caller.id, isStaff)
 }
 

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -37,7 +37,9 @@ struct SubmissionQueryRoutes: RouteCollection {
         // A non-admin sees others' submissions only for a test setup whose
         // course they staff; otherwise (including with no setup filter) they see
         // only their own (#417 Slice G — was the global `caller.isInstructor`).
-        var callerIsCourseStaff = false
+        // Admins administer the whole deployment, so they list every submission
+        // even with no setup filter (there's no single course to staff-check).
+        var callerIsCourseStaff = caller.isAdmin
         if let testSetupID = req.query[String.self, at: "testSetupID"] {
             query = query.filter(\.$testSetupID == testSetupID)
             if let setup = try await APITestSetup.find(testSetupID, on: req.db) {

--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -146,7 +146,13 @@ struct SubmissionDownloadRoute: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-        if !caller.isInstructor && submission.userID != caller.id {
+        // Course staff (TA+ or admin) may download any submission in their
+        // course; everyone else only their own (#417 Slice G).
+        var isStaff = false
+        if let owningCourseID = try await courseID(ofSubmission: submission, on: req.db) {
+            isStaff = try await isCourseStaff(caller, inCourse: owningCourseID, db: req.db)
+        }
+        if !isStaff && submission.userID != caller.id {
             throw Abort(.forbidden)
         }
         let downloadName =

--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -148,10 +148,7 @@ struct SubmissionDownloadRoute: RouteCollection {
         }
         // Course staff (TA+ or admin) may download any submission in their
         // course; everyone else only their own (#417 Slice G).
-        var isStaff = false
-        if let owningCourseID = try await courseID(ofSubmission: submission, on: req.db) {
-            isStaff = try await isCourseStaff(caller, inCourse: owningCourseID, db: req.db)
-        }
+        let isStaff = try await isSubmissionStaff(caller, submission: submission, on: req.db)
         if !isStaff && submission.userID != caller.id {
             throw Abort(.forbidden)
         }

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -389,8 +389,11 @@ struct TestSetupRoutes: RouteCollection {
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
 
         let raw = try notebookData(for: setup)
+        // Staff (TA+ or admin) of this setup's course see unfiltered tiers;
+        // students get the hidden tiers stripped (#417 Slice G).
+        let isStaff = try await isCourseStaff(caller, inCourse: setup.courseID, db: req.db)
         let data =
-            caller.isInstructor
+            isStaff
             ? raw
             : filterNotebook(raw, hiddenTiers: hiddenTiersForStudents)
 
@@ -413,7 +416,8 @@ struct TestSetupRoutes: RouteCollection {
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
 
         let raw = try notebookData(for: setup)
-        let filtered = caller.isInstructor ? raw : filterNotebook(raw, hiddenTiers: hiddenTiersForStudents)
+        let isStaff = try await isCourseStaff(caller, inCourse: setup.courseID, db: req.db)
+        let filtered = isStaff ? raw : filterNotebook(raw, hiddenTiers: hiddenTiersForStudents)
 
         // Determine a safe filename from the assignment title (if present).
         let assignment = try await APIAssignment.query(on: req.db)

--- a/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
+++ b/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
@@ -128,7 +128,7 @@ extension WebRoutes {
         // students; they are bucketed into per-section aggregate pass/fail
         // summaries by `buildSectionedOutcomes`.  Kept in collection order so
         // the section correlation lines up with the secret manifest entries.
-        if !viewer.user.isInstructor {
+        if !viewer.isStaff {
             processed.secretOutcomes = collection.outcomes.filter { $0.tier == .secret }
         }
 
@@ -528,6 +528,10 @@ struct ManifestDisplayData {
 /// output is shown.  The grade spans every tier regardless of these.
 struct SubmissionViewer {
     let user: APIUser
+    /// Whether the viewer is course staff (TA+ or admin) for this submission's
+    /// course — gates secret-tier bucketing and instructor-level detail (#417
+    /// Slice G, per-course; was the global `user.isInstructor`).
+    let isStaff: Bool
     /// Tiers rendered as individual rows (public + release for students; all
     /// tiers for instructors).  Secret is never itemized for students.
     let itemizedTiers: Set<String>

--- a/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
+++ b/Sources/APIServer/Routes/Web/VanityURLRoutes.swift
@@ -61,9 +61,10 @@ struct VanityURLRoutes: RouteCollection {
         // Treat unenrolled access as 404 (matching the no-such-course /
         // no-such-assignment cases) so vanity URLs aren't a course /
         // assignment enumeration vector for students browsing the
-        // institutional catalogue.  Instructors and admins bypass via
-        // the usual `isInstructor` short-circuit.
-        if !user.isInstructor {
+        // institutional catalogue.  Staff (TA+ or admin) of this course bypass
+        // (#417 Slice G — was the global `isInstructor` short-circuit); a plain
+        // enrolled student still passes the enrollment check below.
+        if !(try await isCourseStaff(user, inCourse: courseID, db: req.db)) {
             let userID = try user.requireID()
             let enrolled =
                 try await APICourseEnrollment.query(on: req.db)

--- a/Sources/APIServer/Routes/Web/WebRoutes+IndexLoading.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+IndexLoading.swift
@@ -50,7 +50,11 @@ extension WebRoutes {
         allAssignments: [APIAssignment],
         db: any Database
     ) async throws -> Set<String> {
-        guard !user.isInstructor, let userID = user.id, !allAssignments.isEmpty else { return [] }
+        guard let userID = user.id, let courseID = allAssignments.first?.courseID else { return [] }
+        // Staff (TA+ or admin) of the course already see every setup, so they
+        // need no per-student engagement set (#417 Slice G — was the global
+        // `user.isInstructor`).
+        if try await isCourseStaff(user, inCourse: courseID, db: db) { return [] }
         let allSetupIDs = Set(allAssignments.map(\.testSetupID))
         let setupIDByAssignmentID = setupIDByAssignmentID(allAssignments)
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -43,8 +43,13 @@ extension WebRoutes {
         // reachable by any enrolled student (and now, read-only, for closed
         // assignments), so guard the solution view here rather than relying on
         // the absence of a UI link — never serve the answer key to a student.
-        if fileKind == .solution, !user.isInstructor {
-            throw Abort(.forbidden, reason: "The solution is only available to course staff.")
+        if fileKind == .solution {
+            // The reference solution is staff-only, scoped to this setup's
+            // course (#417 Slice G — was the global `user.isInstructor`).
+            let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
+            if !isStaff {
+                throw Abort(.forbidden, reason: "The solution is only available to course staff.")
+            }
         }
         let queryTitle = (query.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let assignment = try await APIAssignment.query(on: req.db)
@@ -332,7 +337,8 @@ extension WebRoutes {
         // starter notebook by hitting `/notebook/source` directly.  A
         // legitimately reachable closed assignment already has a participation
         // row (or a submission), so this never fires on normal page loads.
-        if !user.isInstructor,
+        let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
+        if !isStaff,
             let assignment = try await APIAssignment.query(on: req.db)
                 .filter(\.$testSetupID == setupID)
                 .first(),

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -256,8 +256,16 @@ extension WebRoutes {
             throw Abort(.notFound)
         }
 
-        // Students may only view their own submissions.
-        if !user.isInstructor {
+        // Per-course staff (TA+ or admin) see instructor-level detail for this
+        // submission's course; everyone else may view only their own
+        // submission (#417 Slice G — was the global `user.isInstructor`).
+        let isStaff: Bool
+        if let owningCourseID = try await courseID(ofSubmission: submission, on: req.db) {
+            isStaff = try await isCourseStaff(user, inCourse: owningCourseID, db: req.db)
+        } else {
+            isStaff = false
+        }
+        if !isStaff {
             guard submission.userID == user.id else {
                 throw Abort(.forbidden)
             }
@@ -278,10 +286,10 @@ extension WebRoutes {
         // redacted until their extended window closes.  A non-instructor may
         // only view their own submission (guarded above), so `user` is the
         // submission owner; instructors see release output regardless.
-        let itemized = itemizedTiers(for: user)
+        let itemized = itemizedTiers(isStaff: isStaff)
         let releaseDeadline = try await releaseVisibilityDeadline(
             for: submissionAssignment, user: user, on: req.db)
-        let releaseOutput = releaseOutputVisible(for: user, effectiveDueAt: releaseDeadline)
+        let releaseOutput = releaseOutputVisible(isStaff: isStaff, effectiveDueAt: releaseDeadline)
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
@@ -297,7 +305,8 @@ extension WebRoutes {
             processed = processDisplayResult(
                 result: result,
                 viewer: SubmissionViewer(
-                    user: user, itemizedTiers: itemized, releaseOutputVisible: releaseOutput),
+                    user: user, isStaff: isStaff, itemizedTiers: itemized,
+                    releaseOutputVisible: releaseOutput),
                 submission: submission,
                 priorAttempt: priorAttempt,
                 manifestDisplay: manifestDisplay,

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -259,16 +259,9 @@ extension WebRoutes {
         // Per-course staff (TA+ or admin) see instructor-level detail for this
         // submission's course; everyone else may view only their own
         // submission (#417 Slice G — was the global `user.isInstructor`).
-        let isStaff: Bool
-        if let owningCourseID = try await courseID(ofSubmission: submission, on: req.db) {
-            isStaff = try await isCourseStaff(user, inCourse: owningCourseID, db: req.db)
-        } else {
-            isStaff = false
-        }
-        if !isStaff {
-            guard submission.userID == user.id else {
-                throw Abort(.forbidden)
-            }
+        let isStaff = try await isSubmissionStaff(user, submission: submission, on: req.db)
+        guard isStaff || submission.userID == user.id else {
+            throw Abort(.forbidden)
         }
 
         // Fetch the assignment for deadline-based output gating.

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -88,6 +88,12 @@ struct WebRoutes: RouteCollection {
 
         let fmt = waterlooDateTimeFormatter()
 
+        // Whether the viewer is staff (TA+ or admin) in the *active* course —
+        // drives instructor vs student dashboard rendering. Per-course now, read
+        // from the resolved active-course role (#417 Slice G — was the global
+        // `user.isInstructor`).
+        let isActiveCourseStaff = user.isAdmin || (courseState.active?.role ?? .student) >= .ta
+
         // Load every assignment in the active course.
         let allAssignments = try await APIAssignment.query(on: req.db)
             .filter(\.$courseID == activeCourseUUID)
@@ -113,7 +119,7 @@ struct WebRoutes: RouteCollection {
         let previouslyOpenedSetupIDs = try await previouslyOpenedFetch
 
         let setups: [APITestSetup]
-        if user.isInstructor {
+        if isActiveCourseStaff {
             // Instructors and admins see every test setup in the active course.
             setups = try await APITestSetup.query(on: req.db)
                 .filter(\.$courseID == activeCourseUUID)
@@ -354,8 +360,8 @@ struct WebRoutes: RouteCollection {
                     status = "closed"
                     staffOnly = false
                 case .preview:
-                    status = user.isInstructor ? "open" : "closed"
-                    staffOnly = user.isInstructor
+                    status = isActiveCourseStaff ? "open" : "closed"
+                    staffOnly = isActiveCourseStaff
                 }
             } else {
                 status = "unpublished"
@@ -384,7 +390,7 @@ struct WebRoutes: RouteCollection {
                 guard let assignment else { return false }
                 // Preview is open for staff, closed for students; staff testing a
                 // preview also bypass the future-open-date gate (see submissionGate).
-                let gate = assignment.visibility.submissionGate(isStaff: user.isInstructor)
+                let gate = assignment.visibility.submissionGate(isStaff: isActiveCourseStaff)
                 return isAssignmentOpenForUser(
                     isOpen: gate.treatAsOpen,
                     overrideActive: assignment.deadlineOverrideActive ?? false,
@@ -493,7 +499,9 @@ struct WebRoutes: RouteCollection {
     @Sendable
     func newSetupForm(req: Request) async throws -> View {
         let user = try req.auth.require(APIUser.self)
-        guard user.isInstructor else { throw Abort(.forbidden) }
+        // Authoring a new test setup: staff (TA+ anywhere) or admin (#417 Slice
+        // G — was the global `user.isInstructor`).
+        guard try await isStaffAnywhere(user, db: req.db) else { throw Abort(.forbidden) }
         return try await req.view.render(
             "setup-new",
             BaseContext(currentUser: req.currentUserContext))

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -177,7 +177,11 @@ func isAssignmentEffectivelyOpen(
     // open assignment, while students are held out as if it were closed. For
     // .open / .closed the stored visibility applies to everyone. Staff testing a
     // preview also bypass the future-open-date gate — see `submissionGate`.
-    let gate = assignment.visibility.submissionGate(isStaff: user.isInstructor)
+    // Staff-ness is per-course now: staff (TA+ or admin) of the assignment's
+    // own course get the preview/future-open bypass (#417 Slice G — was the
+    // global `user.isInstructor`).
+    let isStaff = try await isCourseStaff(user, inCourse: assignment.courseID, db: db)
+    let gate = assignment.visibility.submissionGate(isStaff: isStaff)
     let baseline = assignment.dueAt
     let extensionDueAt = try await studentExtensionDueAt(for: assignment, user: user, on: db)
     return isAssignmentOpenForUser(

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -323,10 +323,7 @@ func notebookDataForHistorySelection(
     guard submission.kind == APISubmission.Kind.student else {
         throw Abort(.forbidden)
     }
-    var isStaff = false
-    if let owningCourseID = try await courseID(ofSubmission: submission, on: req.db) {
-        isStaff = try await isCourseStaff(caller, inCourse: owningCourseID, db: req.db)
-    }
+    let isStaff = try await isSubmissionStaff(caller, submission: submission, on: req.db)
     if !isStaff && submission.userID != userID {
         throw Abort(.forbidden)
     }

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -78,7 +78,13 @@ func closedAssignmentGate(
     assignment: APIAssignment?,
     isClosed: Bool
 ) async throws -> Response? {
-    guard !user.isInstructor else { return nil }
+    // Course staff (TA+ or admin) bypass the closed-assignment gate for their
+    // own course (#417 Slice G — was the global `user.isInstructor`).
+    if let assignmentCourseID = assignment?.courseID,
+        try await isCourseStaff(user, inCourse: assignmentCourseID, db: req.db)
+    {
+        return nil
+    }
     if isClosed, let assignment {
         // A published-then-closed assignment is openable read-only — a student
         // may return to a recently-closed lab to review it. Only bounce a
@@ -317,7 +323,11 @@ func notebookDataForHistorySelection(
     guard submission.kind == APISubmission.Kind.student else {
         throw Abort(.forbidden)
     }
-    if !caller.isInstructor && submission.userID != userID {
+    var isStaff = false
+    if let owningCourseID = try await courseID(ofSubmission: submission, on: req.db) {
+        isStaff = try await isCourseStaff(caller, inCourse: owningCourseID, db: req.db)
+    }
+    if !isStaff && submission.userID != userID {
         throw Abort(.forbidden)
     }
     guard submission.testSetupID == setupID else {

--- a/Tests/APITests/AssignmentAuthoringServiceTests.swift
+++ b/Tests/APITests/AssignmentAuthoringServiceTests.swift
@@ -145,6 +145,11 @@ import Vapor
             try await AssignmentAuthoringService.setVisibility(assignment, .preview, on: app.db)
             let staff = try await makeTestUser(on: app, username: "prof", role: "instructor")
             let student = try await makeTestUser(on: app, username: "stu", role: "student")
+            // Preview visibility is per-course staff now (#417 Slice G); enrol the
+            // staff user as an instructor in the assignment's course.
+            try await APICourseEnrollment(
+                userID: try staff.requireID(), courseID: assignment.courseID, role: .instructor
+            ).save(on: app.db)
             #expect(try await isAssignmentEffectivelyOpen(assignment, for: staff, on: app.db))
             #expect(!(try await isAssignmentEffectivelyOpen(assignment, for: student, on: app.db)))
         }

--- a/Tests/APITests/JupyterLiteContentsRoutesTests.swift
+++ b/Tests/APITests/JupyterLiteContentsRoutesTests.swift
@@ -44,6 +44,10 @@ import VaporTesting
             atPath: publicDir + "jupyterlite/files/",
             withIntermediateDirectories: true
         )
+        // The contents routes now resolve the viewer's per-course staff status
+        // through `req.db` (#417 Slice G), so the test app needs a database —
+        // previously the route was filesystem-only.
+        try await configureTestDatabase(app)
         try app.register(collection: JupyterLiteContentsRoutes())
     }
 

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -89,6 +89,9 @@ import VaporTesting
         try await withApp(app) { _ in
             let setupID = try await insertSetupWithNotebook(notebookJSON: mixedNotebookJSON)
             let cookie = try await loginAsInstructor()
+            // Full-tier notebook access is per-course staff now (#417 Slice G);
+            // enrol the instructor in the setup's course (shared TEST101).
+            try await enrollAsTestInstructor(username: "testinstructor", on: app)
 
             try await app.asyncTest(
                 .GET, "/api/v1/testsetups/\(setupID)/assignment",

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -1,3 +1,4 @@
+import Core
 import Fluent
 import Foundation
 import Testing
@@ -91,9 +92,13 @@ import VaporTesting
 
     private func enroll(_ user: APIUser) async throws {
         let course = try await makeCourse()
+        // Seed the per-course role from the global role (mirroring production
+        // saveSeededEnrollment) so a global instructor becomes course staff —
+        // the notebook solution view is per-course staff now (#417 Slice G).
         let enrollment = APICourseEnrollment(
             userID: try user.requireID(),
-            courseID: try course.requireID()
+            courseID: try course.requireID(),
+            role: user.isInstructor ? .instructor : .student
         )
         try await enrollment.save(on: app.db)
     }

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -25,6 +25,10 @@ import VaporTesting
 
     private func makeNamespaceApp(user: APIUser?) async throws -> Application {
         let app = try await Application.make(.testing)
+        // The namespace guard now resolves per-course staff status through
+        // `req.db` (#417 Slice G), so the app needs a database — it used to read
+        // the global `caller.isInstructor` off the injected user with no DB.
+        try await configureTestDatabase(app)
         app.middleware.use(InjectAuthMiddleware(user: user))
         app.middleware.use(UserFileNamespaceMiddleware())
         app.get("ok") { _ in
@@ -114,8 +118,25 @@ import VaporTesting
         }
     }
 
-    @Test func userFileNamespaceAllowsInstructorAcrossNamespaces() async throws {
-        try await withApp(try await makeNamespaceApp(user: makeUser(role: "instructor"))) { app in
+    @Test func userFileNamespaceAllowsCourseStaffAcrossNamespaces() async throws {
+        // Deployment-wide namespace: a user who is staff (instructor/TA) in ANY
+        // course may reach another user's folder (#417 Slice G — per-course
+        // `isStaffAnywhere`, not the old global `instructor` role).
+        let staff = makeUser(role: "student")
+        try await withApp(try await makeNamespaceApp(user: staff)) { app in
+            let course = try await makeTestCourse(on: app, code: "NSSTAFF", mode: .closed)
+            try await APICourseEnrollment(
+                userID: try staff.requireID(), courseID: try course.requireID(), role: .instructor
+            ).save(on: app.db)
+            try await app.asyncTest(.GET, "/jupyterlite/files/users/\(UUID().uuidString.lowercased())/assignment.ipynb")
+            { res in
+                #expect(res.status == .ok)
+            }
+        }
+    }
+
+    @Test func userFileNamespaceAllowsAdminAcrossNamespaces() async throws {
+        try await withApp(try await makeNamespaceApp(user: makeUser(role: "admin"))) { app in
             try await app.asyncTest(.GET, "/jupyterlite/files/users/\(UUID().uuidString.lowercased())/assignment.ipynb")
             { res in
                 #expect(res.status == .ok)

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -125,6 +125,9 @@ import VaporTesting
         // `isStaffAnywhere`, not the old global `instructor` role).
         let staff = makeUser(role: "student")
         try await withApp(try await makeNamespaceApp(user: staff)) { app in
+            // Persist the staff user: the enrollment's FK to `users` is enforced
+            // on Postgres, and the injected auth user isn't otherwise saved.
+            try await staff.save(on: app.db)
             let course = try await makeTestCourse(on: app, code: "NSSTAFF", mode: .closed)
             try await APICourseEnrollment(
                 userID: try staff.requireID(), courseID: try course.requireID(), role: .instructor

--- a/Tests/APITests/SecurityAndHealthTests.swift
+++ b/Tests/APITests/SecurityAndHealthTests.swift
@@ -1,3 +1,4 @@
+import Core
 import Fluent
 import Foundation
 import Testing

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -795,6 +795,9 @@ import VaporTesting
         try await withApp(app) { _ in
             let setupID = "setup_instr_all"
             let cookie = try await loginAsInstructor()
+            // All-tier visibility is per-course staff now (#417 Slice G); enrol
+            // the instructor in the setup's course (shared TEST101).
+            try await enrollAsTestInstructor(username: "instructor_tier", on: app)
             try await ensureAssignment(
                 setupID: setupID,
                 dueAt: Date().addingTimeInterval(3600))  // future deadline

--- a/Tests/APITests/TierFilterTests.swift
+++ b/Tests/APITests/TierFilterTests.swift
@@ -5,6 +5,9 @@
 // *effective* (per-student, extension-aware) deadline rather than the bare
 // assignment due date — the integration-level proof lives in
 // SubmissionQueryRoutesTests / WebRoutesSubmissionPageTests.
+//
+// The gates take an `isStaff` bool (true = course staff / admin, false =
+// student) since #417 Slice G moved staff resolution per-course to the caller.
 
 import Foundation
 import Testing
@@ -14,41 +17,33 @@ import Testing
 
 @Suite struct TierFilterTests {
 
-    private func student() -> APIUser {
-        APIUser(username: "s", passwordHash: "x", role: UserRole.student.rawValue)
-    }
-
-    private func instructor() -> APIUser {
-        APIUser(username: "i", passwordHash: "x", role: UserRole.instructor.rawValue)
-    }
-
     // MARK: - visibleTiers
 
     @Test func visibleTiersInstructorAlwaysSeesEveryTier() {
         let now = Date()
-        // Deadline far in the future — an instructor still sees all three tiers.
+        // Deadline far in the future — staff still see all three tiers.
         let tiers = visibleTiers(
-            for: instructor(), effectiveDueAt: now.addingTimeInterval(86_400), now: now)
+            isStaff: true, effectiveDueAt: now.addingTimeInterval(86_400), now: now)
         #expect(tiers == ["public", "release", "secret"])
     }
 
     @Test func visibleTiersStudentHidesReleaseBeforeEffectiveDeadline() {
         let now = Date()
         let tiers = visibleTiers(
-            for: student(), effectiveDueAt: now.addingTimeInterval(3600), now: now)
+            isStaff: false, effectiveDueAt: now.addingTimeInterval(3600), now: now)
         #expect(tiers == ["public"])
     }
 
     @Test func visibleTiersStudentShowsReleaseAfterEffectiveDeadline() {
         let now = Date()
         let tiers = visibleTiers(
-            for: student(), effectiveDueAt: now.addingTimeInterval(-3600), now: now)
+            isStaff: false, effectiveDueAt: now.addingTimeInterval(-3600), now: now)
         #expect(tiers == ["public", "release"])
     }
 
     @Test func visibleTiersStudentShowsReleaseWhenNoDeadline() {
         // nil effective deadline → no deadline → release immediately visible.
-        let tiers = visibleTiers(for: student(), effectiveDueAt: nil)
+        let tiers = visibleTiers(isStaff: false, effectiveDueAt: nil)
         #expect(tiers == ["public", "release"])
     }
 
@@ -61,7 +56,7 @@ import Testing
         // Effective deadline = the student's future extension, not the past
         // class-wide due date.
         let extended = now.addingTimeInterval(86_400)
-        let tiers = visibleTiers(for: student(), effectiveDueAt: extended, now: now)
+        let tiers = visibleTiers(isStaff: false, effectiveDueAt: extended, now: now)
         #expect(tiers == ["public"], "release stays hidden until the student's own deadline passes")
     }
 
@@ -71,32 +66,32 @@ import Testing
         let now = Date()
         #expect(
             releaseOutputVisible(
-                for: instructor(), effectiveDueAt: now.addingTimeInterval(86_400), now: now))
+                isStaff: true, effectiveDueAt: now.addingTimeInterval(86_400), now: now))
     }
 
     @Test func releaseOutputStudentHiddenBeforeEffectiveDeadline() {
         let now = Date()
         #expect(
             releaseOutputVisible(
-                for: student(), effectiveDueAt: now.addingTimeInterval(3600), now: now) == false)
+                isStaff: false, effectiveDueAt: now.addingTimeInterval(3600), now: now) == false)
     }
 
     @Test func releaseOutputStudentVisibleAfterEffectiveDeadline() {
         let now = Date()
         #expect(
             releaseOutputVisible(
-                for: student(), effectiveDueAt: now.addingTimeInterval(-3600), now: now))
+                isStaff: false, effectiveDueAt: now.addingTimeInterval(-3600), now: now))
     }
 
     @Test func releaseOutputStudentVisibleWhenNoDeadline() {
-        #expect(releaseOutputVisible(for: student(), effectiveDueAt: nil))
+        #expect(releaseOutputVisible(isStaff: false, effectiveDueAt: nil))
     }
 
     @Test func releaseOutputStudentHiddenWhileExtensionActive() {
         let now = Date()
         let extended = now.addingTimeInterval(86_400)
         #expect(
-            releaseOutputVisible(for: student(), effectiveDueAt: extended, now: now) == false,
+            releaseOutputVisible(isStaff: false, effectiveDueAt: extended, now: now) == false,
             "an active extension keeps release output redacted past the class deadline")
     }
 }

--- a/Tests/APITests/VanityURLRoutesTests.swift
+++ b/Tests/APITests/VanityURLRoutesTests.swift
@@ -2,6 +2,7 @@
 //
 // Tests for GET /:courseCode/:assignmentSlug vanity URL redirects.
 
+import Core
 import Fluent
 import Foundation
 import Testing
@@ -356,10 +357,12 @@ import VaporTesting
         }
     }
 
-    @Test func vanityURL_instructor_bypassesEnrollment() async throws {
+    @Test func vanityURL_courseStaff_resolvesAssignment() async throws {
         try await withApp(app) { _ in
-            // Instructors and admins skip the enrollment check so they can
-            // QA assignments in courses they aren't formally enrolled in.
+            // Course staff (a per-course instructor/TA) resolve the vanity URL to
+            // the notebook. A viewer no longer bypasses enrollment by holding a
+            // global instructor role — authority is per-course now (#417 Slice G),
+            // so the instructor is enrolled as staff in this course.
             let course = try await seedCourse(code: "HLTH230")
             let courseID = try course.requireID()
             try await seedSetupAndAssignment(courseID: courseID, title: "Lab 1", setupID: "setup_van_enr02")
@@ -367,6 +370,11 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "vanity_instructor", password: "pw",
                 role: "instructor", on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "vanity_instructor").first())
+            try await APICourseEnrollment(
+                userID: try instructor.requireID(), courseID: courseID, role: .instructor
+            ).save(on: app.db)
             try await app.asyncTest(
                 .GET, "/hlth230/lab-1",
                 beforeRequest: { req in

--- a/Tests/APITests/WebRoutesSubmissionPageTests.swift
+++ b/Tests/APITests/WebRoutesSubmissionPageTests.swift
@@ -526,6 +526,11 @@ import VaporTesting
     @Test func instructorCanViewAnySubmission() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsInstructor(on: app)
+            // A viewer sees another student's submission only as per-course staff
+            // now (#417 Slice G), so enrol the instructor in the setup's course.
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
             let student = APIUser(username: "s2", passwordHash: try testPasswordHash("pass"), role: "student")
             try await student.save(on: app.db)
             let studentID = try student.requireID()
@@ -913,6 +918,10 @@ import VaporTesting
     @Test func instructorSeesAllTiers() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsInstructor(on: app)
+            // All-tier visibility is per-course staff now (#417 Slice G).
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
             let student = APIUser(username: "s3", passwordHash: try testPasswordHash("pass"), role: "student")
             try await student.save(on: app.db)
             let studentID = try student.requireID()

--- a/changelog.d/417-slice-g1-per-course-view-gates.md
+++ b/changelog.d/417-slice-g1-per-course-view-gates.md
@@ -1,0 +1,21 @@
+### Changed
+
+- **Per-course staff view/access gates (#417 Slice G, part 1).** The view- and
+  access-shaping checks that used to key on the deployment-global
+  `APIUser.isInstructor` now resolve staff status **per course** — a viewer sees
+  instructor-level detail only for the courses they actually staff (per-course
+  role ≥ `.ta`, or admin), not deployment-wide. Two new resolvers in
+  `CourseAccessHelpers` back this: `isCourseStaff(_:inCourse:db:)` for gates that
+  know their resource's course, and `isStaffAnywhere(_:db:)` for the few
+  deployment-wide surfaces (MCP eligibility + OAuth content-scope consent, the
+  JupyterLite virtual filesystem, the user-file namespace, the new-setup form)
+  where no single course is in scope. Converted gates include: tier visibility
+  (`visibleTiers` / `itemizedTiers` / `releaseOutputVisible` now take an
+  `isStaff` bool computed against the submission's course), the submission
+  view/download/results/query paths, the reference-solution and notebook-source
+  endpoints, the closed-assignment gate, the assignment-open deadline gate, the
+  student dashboard, and the vanity-URL enrollment gate. This closes a
+  cross-course read gap — a global instructor could previously see any course's
+  submissions, secret tests, and solutions by URL — and prepares the ground for
+  collapsing the global role (part 2). No enum or migration changes yet; the
+  global `UserRole` still has its `student` / `instructor` cases.


### PR DESCRIPTION
## What & why

Part 1 of the global-role collapse (#417 Slice G). **First** move every web view/access gate off the deployment-global `APIUser.isInstructor` and onto **per-course** staff resolution; **then** (part 2) collapse the `UserRole` enum to `user`/`admin`. Splitting keeps this security-sensitive gate conversion independently reviewable.

A viewer now sees instructor-level detail (all tiers, other students' submissions, reference solutions) **only for the courses they actually staff** (per-course role ≥ `.ta`, or admin) — not deployment-wide. This closes a cross-course read gap: a global instructor could previously read *any* course's submissions, secret tests, and solutions by URL.

## New resolvers (`CourseAccessHelpers`)

- `isCourseStaff(_:inCourse:db:)` — admin, or per-course role ≥ `.ta`. For gates that know their resource's course.
- `isStaffAnywhere(_:db:)` — admin, or staff (TA+) in any enrolled course. For deployment-wide surfaces with no single course in scope.
- `courseID(ofSubmission:on:)` / `isSubmissionStaff(_:submission:on:)` — a submission's course, and whether the viewer staffs it.

## Converted gates

Tier visibility (`visibleTiers`/`itemizedTiers`/`releaseOutputVisible` take an `isStaff` bool), the submission view/download/results/query paths, the reference-solution and notebook-source endpoints, the closed-assignment gate, the assignment-open/preview deadline gate, the student dashboard, the vanity-URL enrollment gate, the JupyterLite virtual filesystem, and the user-file namespace. Deployment-wide gates use `isStaffAnywhere`; resource-scoped gates use `isCourseStaff` against the resource's own course.

## Explicitly deferred to part 2 (G2)

The two **coarse MCP gates** — the OAuth consent `permits` gate and the `ToolContext` tool-eligibility gate — still key off the global instructor role. They're deferred to the G2 enum collapse, which revisits every global-role reference at once. This is safe: the MCP **tool-level** authorization (`authorizeCourseAccess`) is already per-course enrollment-scoped, so these coarse "may this human touch MCP at all" checks never widen what a minted token can actually touch. Converting them in G1 — ahead of the enum work — only churned the MCP OAuth/tool test corpus for no security gain.

Also not in this PR: no enum or migration changes (`UserRole` still has `student`/`instructor`); role-seeding, the `AddCourseEnrollmentRole` backfill, `CurrentUserContext.isInstructor`, and the unused `RoleMiddleware.instructor` case are G2.

## Notes / behavior change

- `GET /api/v1/submissions` with no `testSetupID` filter returns only the caller's own submissions for everyone but admins (who list all deployment-wide) — a global instructor no longer lists all submissions.
- An adversarial review pass over the diff found no compile-breakers and no authorization inversions.
- Test fixtures that previously relied on a global instructor seeing any course's data now enrol that instructor as per-course staff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)