### PR TITLE
Add student-deny regression tests (submission-list scoping + instructor area)

### DIFF
--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -175,6 +175,47 @@ import VaporTesting
         }
     }
 
+    /// A non-staff student listing submissions sees ONLY their own — never
+    /// another student's — both with no filter and with a `testSetupID` filter
+    /// for a course they don't staff (#417; the list scopes non-staff callers to
+    /// `userID == caller.id`).
+    @Test func listSubmissionsScopesStudentToOwnSubmissions() async throws {
+        try await withApp(app) { _ in
+            let cookieA = try await loginAsStudent(username: "stu_scope_a")
+            let studentA = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "stu_scope_a").first())
+            let studentB = try await makeTestUser(on: app, username: "stu_scope_b", role: "student")
+
+            try await insertSubmission(
+                id: "sub_scope_a", testSetupID: "setup_scope", userID: try studentA.requireID())
+            try await insertSubmission(
+                id: "sub_scope_b", testSetupID: "setup_scope", userID: try studentB.requireID())
+
+            // No filter: student A sees only their own submission.
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookieA) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(SubmissionListResponse.self)
+                    #expect(body.submissions.count == 1)
+                    #expect(body.submissions.first?.submissionID == "sub_scope_a")
+                    #expect(body.submissions.contains { $0.submissionID == "sub_scope_b" } == false)
+                })
+
+            // Even filtering by a setup they don't staff, a student never sees
+            // another student's submission for it.
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions?testSetupID=setup_scope",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookieA) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(SubmissionListResponse.self)
+                    #expect(body.submissions.map(\.submissionID) == ["sub_scope_a"])
+                })
+        }
+    }
+
     @Test func listSubmissionsFilterByTestSetupID() async throws {
         try await withApp(app) { _ in
             let cookie = try await loginAsAdmin()

--- a/Tests/APITests/TARoleRouteTests.swift
+++ b/Tests/APITests/TARoleRouteTests.swift
@@ -139,4 +139,46 @@ import VaporTesting
                 })
         }
     }
+
+    // MARK: - A per-course STUDENT is shut out of the instructor area entirely
+
+    @Test func studentCannotEditAssignmentSuite() async throws {
+        try await withApp(app) { _ in
+            // Same fixture, acting user enrolled as a plain `.student` — the
+            // `/instructor` gate (role >= .ta) rejects them before any handler.
+            let fx = try await fixture(role: .student)
+            try await app.asyncTest(
+                .PUT, "/instructor/\(fx.assignmentID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"items":[]}"#)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "a student must not edit assignment content, got \(res.status)")
+                })
+        }
+    }
+
+    @Test func studentCannotRetestSubmissions() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(role: .student)
+            try await app.asyncTest(
+                .POST, "/instructor/\(fx.assignmentID)/retest",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: fx.csrf)
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = ByteBuffer(string: "")
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "a student must not retest submissions, got \(res.status)")
+                })
+        }
+    }
 }

--- a/changelog.d/417-student-deny-tests.md
+++ b/changelog.d/417-student-deny-tests.md
@@ -1,0 +1,8 @@
+### Testing
+
+- Added regression tests for the student "deny" surface (#417): a non-staff
+  student listing `GET /api/v1/submissions` is scoped to their own submissions
+  and never sees another student's (with and without a `testSetupID` filter),
+  and a per-course student is refused the instructor area entirely (assignment
+  content edit and retest both 403). Closes the two coverage gaps a test audit
+  flagged; no behaviour change.


### PR DESCRIPTION
## What & why

A test-coverage audit of the per-course authorization model (#417) confirmed the student "deny" surface is well covered — hidden secret/release tiers, viewing another student's submission/results/notebook, reference-solution access, cross-course denial, the MCP student-data wall, and instructor-route blocking all have direct tests. It flagged **two thin spots** where the logic was correct in source but had no direct test. This closes both.

## Tests added

- **`SubmissionQueryRoutesTests.listSubmissionsScopesStudentToOwnSubmissions`** — two students each own a submission; student A calls `GET /api/v1/submissions` and sees only their own, never B's — both with no filter and with a `testSetupID` filter for a setup they don't staff. (The existing list tests only exercised the admin/see-all path; the non-staff `filter(userID == caller.id)` scoping had no direct coverage.)
- **`TARoleRouteTests.studentCannotEditAssignmentSuite` / `studentCannotRetestSubmissions`** — a per-course student is refused the instructor area (403) for both content editing (`PUT /instructor/:id/suite`) and retest (`POST /instructor/:id/retest`), completing the role matrix next to the existing TA-can / TA-cannot / instructor-can cases.

## Notes

Tests only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_