### PR TITLE
MCP: enforce per-course TA vs instructor floor (#417)

### DIFF
--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -121,7 +121,9 @@ struct CloneAssignmentTool: ContentTool {
         // default-to-source branches). The source stays read-authorized above —
         // reviving an archived course's content into a live course is fine; only
         // the destination is write-gated (#417 Slice D-MCP).
-        try await context.authorizeCourseWriteAccess(targetCourseID, tool: Self.name)
+        // Creating an assignment (clone) into the destination is instructor-level (#417).
+        try await context.authorizeCourseWriteAccess(
+            targetCourseID, tool: Self.name, atLeast: .instructor)
 
         let cloned: AuthoredAssignment
         do {

--- a/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseSectionTools.swift
@@ -244,8 +244,9 @@ struct SetAssignmentCourseSectionTool: ContentTool {
     static let requiredScopes: Set<ContentScope> = [.write]
 
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        // Placing an assignment into a course section is instructor-level (#417).
         let assignment = try await context.authorizedAssignmentForWrite(
-            publicID: input.assignmentPublicID, tool: Self.name)
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
 
         // Resolve + validate the target section against this assignment's course.
         // A non-empty id that doesn't resolve is rejected rather than silently
@@ -450,8 +451,9 @@ struct DeleteCourseSectionTool: ContentTool {
         guard let section = try await APICourseSection.find(uuid, on: context.db) else {
             return Output(sectionID: raw, removed: false, ungroupedAssignmentCount: 0)
         }
-        // Deleting a section is a write — block it on an archived course (#417 Slice D-MCP).
-        try await context.authorizeCourseWriteAccess(section.courseID, tool: Self.name)
+        // Deleting a course section is instructor-level structure (#417); archived blocked too.
+        try await context.authorizeCourseWriteAccess(
+            section.courseID, tool: Self.name, atLeast: .instructor)
         let ungrouped = try await APIAssignment.query(on: context.db)
             .filter(\.$sectionID == uuid)
             .count()
@@ -577,7 +579,7 @@ struct ReorderCourseSectionsTool: ContentTool {
 /// delete_course_section — both mutate the section, so the write gate is the
 /// correct floor (#417 Slice D-MCP).
 func resolveCourseSectionForEdit(
-    sectionID raw: String, tool: String, context: ToolContext
+    sectionID raw: String, tool: String, context: ToolContext, atLeast minimum: CourseRole = .instructor
 ) async throws -> APICourseSection {
     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     guard let uuid = UUID(uuidString: trimmed) else {
@@ -586,7 +588,8 @@ func resolveCourseSectionForEdit(
     guard let section = try await APICourseSection.find(uuid, on: context.db) else {
         throw MCPToolError.invalidArguments(tool: tool, detail: "No course section with id \"\(trimmed)\".")
     }
-    try await context.authorizeCourseWriteAccess(section.courseID, tool: tool)
+    // Course-section structure is instructor-level (#417), matching the web.
+    try await context.authorizeCourseWriteAccess(section.courseID, tool: tool, atLeast: minimum)
     return section
 }
 
@@ -670,7 +673,9 @@ func resolveCourseID(code: String, tool: String, context: ToolContext) async thr
 /// WRITE tools (create_course_section, reorder_course_sections, and
 /// reorder_assignments) so they can't mutate an archived course; the read
 /// `list_course_sections` stays on `resolveCourseID` (#417 Slice D-MCP).
-func resolveCourseIDForWrite(code: String, tool: String, context: ToolContext) async throws -> UUID {
+func resolveCourseIDForWrite(
+    code: String, tool: String, context: ToolContext, atLeast minimum: CourseRole = .instructor
+) async throws -> UUID {
     guard
         let course = try await APICourse.query(on: context.db)
             .filter(\.$code == code)
@@ -679,6 +684,8 @@ func resolveCourseIDForWrite(code: String, tool: String, context: ToolContext) a
         throw MCPToolError.invalidArguments(tool: tool, detail: "No course found with code \"\(code)\".")
     }
     let courseID = try course.requireID()
-    try await context.authorizeCourseWriteAccess(courseID, tool: tool)
+    // Course-level structure edits (sections, assignment ordering, new
+    // assignments) are instructor-level (#417), matching the web.
+    try await context.authorizeCourseWriteAccess(courseID, tool: tool, atLeast: minimum)
     return courseID
 }

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -97,8 +97,8 @@ struct CreateAssignmentTool: ContentTool {
                 tool: Self.name, detail: "No course found with code \"\(code)\".")
         }
         let courseID = try course.requireID()
-        // Creating an assignment writes into the course — block archived (#417 Slice D-MCP).
-        try await context.authorizeCourseWriteAccess(courseID, tool: Self.name)
+        // Creating an assignment is instructor-level (#417); archived is blocked too.
+        try await context.authorizeCourseWriteAccess(courseID, tool: Self.name, atLeast: .instructor)
 
         let data: Data
         do {

--- a/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetGradingModeTool.swift
@@ -70,8 +70,9 @@ struct SetGradingModeTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "gradingMode must be \"browser\" or \"worker\".")
         }
+        // Grading mode (worker vs browser) is a lifecycle setting — instructor-level (#417).
         let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
-            publicID: input.assignmentPublicID, tool: Self.name)
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
         let effective = try await setManifestGradingMode(setup: setup, to: mode, on: context.db)
         return Output(assignmentPublicID: assignment.publicID, gradingMode: effective)
     }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -6,6 +6,7 @@
 // bearer middleware in PR B; ungated PR-A callers receive the full content
 // scope set).
 
+import Core
 import Fluent
 import Vapor
 
@@ -137,17 +138,37 @@ struct ToolContext {
     }
 
     /// Authorizes a *write* to `courseID`: the acting subject must pass
-    /// `authorizeCourseAccess` (MCP-eligible + enrolled, admin included) AND the
-    /// course must not be archived (admins exempt). The MCP analogue of the web
-    /// `requireCourseWriteAccess` — archived courses are read-only for
-    /// instructors and TAs, so a content-mutating tool can't drive a write into
-    /// one. The single chokepoint every MCP write resolver funnels through; the
-    /// *read* resolvers stay on `authorizeCourseAccess` so archived courses
-    /// remain readable (#417 Slice D-MCP).
-    func authorizeCourseWriteAccess(_ courseID: UUID, tool: String) async throws {
+    /// `authorizeCourseAccess` (MCP-eligible + enrolled, admin included), hold a
+    /// per-course role of at least `atLeast`, AND the course must not be archived
+    /// (admins exempt from both role and archive checks). The MCP analogue of the
+    /// web `requireCourseWriteAccess(atLeast:)` — content-editing tools default to
+    /// the `.ta` floor, while course-lifecycle/structure tools pass `.instructor`,
+    /// so an agent acting for a TA can author content but not run the course,
+    /// exactly matching the web (#417). The single chokepoint every MCP write
+    /// resolver funnels through; the *read* resolvers stay on
+    /// `authorizeCourseAccess` (enrollment only) so archived courses remain
+    /// readable (#417 Slice D-MCP).
+    func authorizeCourseWriteAccess(
+        _ courseID: UUID, tool: String, atLeast minimum: CourseRole = .ta
+    ) async throws {
         try await authorizeCourseAccess(courseID, tool: tool)
         let user = try await requireEligibleSubject(tool: tool)
         guard !user.isAdmin else { return }
+        // Per-course role floor. `authorizeCourseAccess` already proved the
+        // subject is enrolled, so a missing role here is defensive only.
+        guard let userID = user.id,
+            let role = try await courseRole(of: userID, inCourse: courseID, db: db)
+        else {
+            throw MCPToolError.notAuthorized(
+                tool: tool, detail: "The MCP account is not enrolled in the target course.")
+        }
+        guard role >= minimum else {
+            throw MCPToolError.notAuthorized(
+                tool: tool,
+                detail:
+                    "This action requires the \(minimum.rawValue) role in the course; the MCP account holds \(role.rawValue)."
+            )
+        }
         guard let course = try await APICourse.find(courseID, on: db) else {
             throw MCPToolError.invalidArguments(
                 tool: tool, detail: "The target course could not be found.")
@@ -163,9 +184,11 @@ struct ToolContext {
     /// block, admin-exempt). Archived courses are already hidden from the MCP
     /// listing/resource surface, so this closes the by-public-ID write path an
     /// agent could still reach with a remembered id (#417 Slice C/D-MCP).
-    func authorizedAssignmentForWrite(publicID: String, tool: String) async throws -> APIAssignment {
+    func authorizedAssignmentForWrite(
+        publicID: String, tool: String, atLeast minimum: CourseRole = .ta
+    ) async throws -> APIAssignment {
         let assignment = try await requireAssignment(publicID: publicID, tool: tool)
-        try await authorizeCourseWriteAccess(assignment.courseID, tool: tool)
+        try await authorizeCourseWriteAccess(assignment.courseID, tool: tool, atLeast: minimum)
         return assignment
     }
 
@@ -194,11 +217,12 @@ struct ToolContext {
     /// content-mutating suite/manifest/notebook tool resolves through this so an
     /// agent can't edit an archived course's content by id (#417 Slice D-MCP).
     func authorizedAssignmentAndSetupForWrite(
-        publicID: String, tool: String
+        publicID: String, tool: String, atLeast minimum: CourseRole = .ta
     ) async throws
         -> (assignment: APIAssignment, setup: APITestSetup)
     {
-        let assignment = try await authorizedAssignmentForWrite(publicID: publicID, tool: tool)
+        let assignment = try await authorizedAssignmentForWrite(
+            publicID: publicID, tool: tool, atLeast: minimum)
         guard let setup = try await APITestSetup.find(assignment.testSetupID, on: db) else {
             throw MCPToolError.invalidArguments(
                 tool: tool, detail: "The assignment's test setup could not be found.")

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -133,8 +133,9 @@ struct UpdateAssignmentTool: ContentTool {
                 tool: Self.name, detail: "Specify at least one of: title, dueAt, startsAt, isOpen, visibility.")
         }
 
+        // Title / due date / open state are lifecycle — instructor-level (#417).
         let assignment = try await context.authorizedAssignmentForWrite(
-            publicID: input.assignmentPublicID, tool: Self.name)
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
         do {
             // Title/date metadata first. The legacy `isOpen` is applied here only
             // when `visibility` was not given (visibility is the richer form and

--- a/Tests/APITests/MCP/MCPRoleFloorTests.swift
+++ b/Tests/APITests/MCP/MCPRoleFloorTests.swift
@@ -1,0 +1,96 @@
+// Tests/APITests/MCP/MCPRoleFloorTests.swift
+//
+// #417: the MCP authoring surface enforces the per-course TA-vs-instructor line,
+// mirroring the web. Content-editing tools require the `.ta` floor; course
+// lifecycle / structure tools (create assignment, grading mode, sections)
+// require `.instructor`. The acting subject here is a *global student* whose
+// only staff standing is the per-course role under test, so these tests also
+// prove MCP authority is purely per-course.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPRoleFloorTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read, .write]
+        )
+    }
+
+    private let manifest = """
+        {"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
+        """
+
+    /// A live course + setup + assignment, with `tester` (a *global student*)
+    /// enrolled at the given per-course role.
+    private func fixture(
+        on app: Application, role: CourseRole, code: String
+    ) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: code, name: "Role Floor")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "student")
+        try await APICourseEnrollment(userID: try tester.requireID(), courseID: courseID, role: role)
+            .save(on: app.db)
+        try await makeTestSetup(on: app, id: "rf_setup_\(code)", courseID: courseID, manifest: manifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "rf_setup_\(code)", courseID: courseID, title: "Lab")
+    }
+
+    // MARK: - TA: content editing YES, course lifecycle NO
+
+    @Test func taMayEditContentButNotLifecycle() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, role: .ta, code: "TAFLOOR")
+
+            // Content edit (set_time_limit → `.ta` floor) succeeds for a TA.
+            let out = try await SetTimeLimitTool().execute(
+                .init(assignmentPublicID: assignment.publicID, seconds: 42), context(app))
+            #expect(out.timeLimitSeconds == 42)
+
+            // Lifecycle on the assignment resolver (set_grading_mode → `.instructor`)
+            // is refused for a TA.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetGradingModeTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, gradingMode: "browser"), context(app))
+            }
+
+            // Lifecycle on the course resolver (create course section → `.instructor`)
+            // is refused for a TA.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateCourseSectionTool().execute(
+                    .init(courseCode: "TAFLOOR", name: "Labs", defaultGradingMode: "browser"), context(app))
+            }
+        }
+    }
+
+    // MARK: - Instructor: both content editing AND lifecycle
+
+    @Test func instructorMayEditContentAndLifecycle() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, role: .instructor, code: "INSTFLOOR")
+
+            // Content still works.
+            let out = try await SetTimeLimitTool().execute(
+                .init(assignmentPublicID: assignment.publicID, seconds: 55), context(app))
+            #expect(out.timeLimitSeconds == 55)
+
+            // Lifecycle now allowed — grading-mode flip and a new course section.
+            let mode = try await SetGradingModeTool().execute(
+                .init(assignmentPublicID: assignment.publicID, gradingMode: "browser"), context(app))
+            #expect(mode.gradingMode == "browser")
+
+            let section = try await CreateCourseSectionTool().execute(
+                .init(courseCode: "INSTFLOOR", name: "Labs", defaultGradingMode: "browser"), context(app))
+            #expect(section.name == "Labs")
+        }
+    }
+}

--- a/changelog.d/417-mcp-ta-instructor-floor.md
+++ b/changelog.d/417-mcp-ta-instructor-floor.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **MCP authoring enforces the per-course TA vs instructor line (#417).** The MCP
+  write tools now mirror the web floors: content-editing tools (scripts, suites,
+  pattern families, notebook checks, solution, notebook, inputs, achievements,
+  time limit, suite sections, delete/move suite items) require the per-course
+  `.ta` role, while course lifecycle/structure tools (create/clone assignment,
+  `update_assignment` title/due/open state, `set_grading_mode`, assignment
+  ordering, and course-section create/rename/delete/reorder/assign) require
+  `.instructor`. Previously every MCP write funneled through a single
+  enrollment+archived gate with no per-course role check, so an agent acting for
+  a TA had the same authority as one acting for an instructor. `authorizeCourseWriteAccess`
+  gains an `atLeast:` floor (default `.ta`); admins still bypass.


### PR DESCRIPTION
## What & why

The #417 follow-up flagged in the issue's completion note: the MCP authoring surface gated all writes at a single floor (MCP-eligible + enrolled + archived-block) with **no per-course role check**, so an agent acting for a TA had the same authority as one acting for an instructor. This makes MCP mirror the web's TA-vs-instructor split.

## Change

- **`authorizeCourseWriteAccess(_:tool:atLeast:)`** gains a per-course `CourseRole` floor (default `.ta`; admins still bypass), the MCP analogue of the web `requireCourseWriteAccess(atLeast:)`. The assignment write resolvers (`authorizedAssignment[AndSetup]ForWrite`) thread it through; the course/section write resolvers (`resolveCourseIDForWrite`, `resolveCourseSectionForEdit`) default to `.instructor` since course structure is instructor-level by nature.
- **Content-editing tools keep `.ta`**: `author_script`, `update_suite`, create/update/delete pattern family, `author_notebook_check`, `update_solution`, `update_notebook`, `update_global_inputs`, `update_section_variables`, `update_achievements`, `set_time_limit`, `delete_suite_item`, `move_suite_item`, suite-section create/rename/delete.
- **Lifecycle/structure tools pass `.instructor`**: `create_assignment`, `clone_assignment`, `update_assignment` (title/due/open state), `set_grading_mode`, `set_assignment_course_section`, `reorder_assignments`, and course-section create/rename/delete/reorder.
- **Read tools unchanged** — enrollment-only, archived courses stay readable.

## Tests

`MCPRoleFloorTests` (subject is a *global student*, so authority comes purely from the per-course role):
- A per-course **TA** may `set_time_limit` (content) but is refused `set_grading_mode` and `create_course_section` (lifecycle).
- A per-course **instructor** may do all three.

This covers both resolver paths (assignment-scoped and course-scoped) for the deny case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_