### PR TITLE
Remove deprecated global student/instructor roles (#417 cleanup)

### DIFF
--- a/Sources/APIServer/Helpers/ClassAchievements.swift
+++ b/Sources/APIServer/Helpers/ClassAchievements.swift
@@ -14,7 +14,9 @@ import Foundation
 /// enrolled students.  Admin/instructor test submissions used to lock in
 /// the immutable Trailblazer badge before any real student got to attempt
 /// the assignment (v0.4.127 fix).  This guard runs at the helper entry so
-/// every call site is protected — including future ones.
+/// every call site is protected — including future ones.  Student-ness is
+/// per-course now (#417 Slice G2): the submitter must hold a `.student`
+/// enrollment in the setup's own course, not a retired global role.
 func awardClassBadgesFor100Percent(
     testSetupID: String,
     userID: UUID,
@@ -24,14 +26,13 @@ func awardClassBadgesFor100Percent(
     disabled: Set<String> = [],
     on db: Database
 ) async throws {
-    guard let user = try await APIUser.find(userID, on: db),
-        user.roleValue == .student
+    guard let setup = try await APITestSetup.find(testSetupID, on: db),
+        try await courseRole(of: userID, inCourse: setup.courseID, db: db) == .student
     else { return }
 
     // The class records to award — the manifest's authored ones (or the registry
     // default), minus disabled.  Each is awarded by its dimension; firstToSubmit
     // (Pathfinder) is awarded at submission time, not on reaching 100%.
-    let setup = try await APITestSetup.find(testSetupID, on: db)
     for record in BuiltInAchievements.classRecordsForAward(in: setup, disabled: disabled) {
         switch record.recordDimension {
         case .firstToSolve:

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -216,25 +216,24 @@ func ensureNotLastInstructor(
 // MARK: - Enrollment creation (role seeding)
 
 /// Creates and saves a new enrollment for `user` in `courseID`, seeding the
-/// per-course role from the user's current global role: a global instructor or
-/// admin becomes a per-course instructor, everyone else a student. The single
-/// place the creation-time seeding rule lives (Phase 4a of
-/// docs/multi-course-roles.md), so moving authorization onto the per-course
-/// role later doesn't drop anyone's existing access — the roster can override
-/// afterward. Callers handle their own "already enrolled?" dedup.
+/// per-course role from the user's deployment role: an admin becomes a
+/// per-course instructor, everyone else a student (teaching authority is
+/// per-course now, so a plain `user` auto-enrolls as a student and the roster
+/// grants staff explicitly). The single place the creation-time seeding rule
+/// lives; callers handle their own "already enrolled?" dedup.
 func saveSeededEnrollment(for user: APIUser, courseID: UUID, on db: Database) async throws {
     try await APICourseEnrollment(
         userID: try user.requireID(), courseID: courseID,
-        role: user.isInstructor ? .instructor : .student
+        role: user.isAdmin ? .instructor : .student
     ).save(on: db)
 }
 
 /// `saveSeededEnrollment` for callers that hold only the user's ID; loads the
-/// user to read its global role. A missing user falls back to `.student`.
+/// user to read its deployment role. A missing user falls back to `.student`.
 func saveSeededEnrollment(userID: UUID, courseID: UUID, on db: Database) async throws {
-    let isInstructor = try await APIUser.find(userID, on: db)?.isInstructor ?? false
+    let isAdmin = try await APIUser.find(userID, on: db)?.isAdmin ?? false
     try await APICourseEnrollment(
         userID: userID, courseID: courseID,
-        role: isInstructor ? .instructor : .student
+        role: isAdmin ? .instructor : .student
     ).save(on: db)
 }

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes.swift
@@ -698,23 +698,15 @@ extension MCPOAuthRoutes {
 
         var scopeCeiling: Set<String> { Set(advertisedScopes) }
 
-        /// The role gate: content authoring needs course staff; admin
-        /// diagnostics needs admin. This only decides who may grant a scope at
-        /// all — per-course authority is re-checked per tool call by
-        /// `authorizeCourseAccess`, which is already enrollment-scoped, so this
-        /// coarse gate never widens what an agent can actually touch.
-        ///
-        /// Post-collapse (#417 Slice G2) content staff is `isStaffAnywhere`. The
-        /// `user.isInstructor` term is a transition-only shim: after the
-        /// CollapseUserRoles migration no human holds the global instructor role,
-        /// so in production this reduces to `isStaffAnywhere`; it stays only so the
-        /// OAuth-consent test corpus (which logs in `role: "instructor"` without a
-        /// per-course staff enrollment) keeps passing. Removable once migrated.
+        /// The role gate: content authoring needs course staff (TA+ in any
+        /// course, or admin); admin diagnostics needs admin. This only decides
+        /// who may grant a scope at all — per-course authority is re-checked per
+        /// tool call by `authorizeCourseAccess`, which is already
+        /// enrollment-scoped, so this coarse gate never widens what an agent can
+        /// actually touch (#417).
         func permits(_ user: APIUser, db: Database) async throws -> Bool {
             switch surface {
-            case .content:
-                if user.isInstructor { return true }
-                return try await isStaffAnywhere(user, db: db)
+            case .content: return try await isStaffAnywhere(user, db: db)
             case .admin: return user.isAdmin
             }
         }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -74,16 +74,8 @@ struct ToolContext {
         // MCP eligibility is coarse: course staff (TA+ in any course) or an
         // `mcp` service account — never a plain student. Per-course access is
         // enforced separately (and per-course) by `authorizeCourseAccess`, so
-        // this gate never widens what a caller can actually touch.
-        //
-        // Post-collapse (#417 Slice G2) staff is `isStaffAnywhere`. The
-        // `user.isInstructor` term is a transition-only shim: after the
-        // CollapseUserRoles migration no human holds the global instructor role,
-        // so in production this reduces to `isStaffAnywhere`; it stays only so the
-        // test corpus that still writes `role: "instructor"` (without a per-course
-        // staff enrollment) keeps resolving as staff. Removable once those tests
-        // are migrated.
-        var eligible = user.isMCPAgent || user.isInstructor
+        // this gate never widens what a caller can actually touch (#417).
+        var eligible = user.isMCPAgent
         if !eligible {
             eligible = try await isStaffAnywhere(user, db: db)
         }

--- a/Sources/APIServer/Middleware/RoleMiddleware.swift
+++ b/Sources/APIServer/Middleware/RoleMiddleware.swift
@@ -13,9 +13,11 @@ struct RoleMiddleware: AsyncMiddleware {
 
     enum Required {
         case authenticated  // any logged-in user
-        case instructor  // instructor or admin
         case admin  // admin only
     }
+    // Note: there is no `.instructor` tier — teaching authority is per-course
+    // (`ActiveCourseInstructorMiddleware` + the per-course `requireCourseRole`
+    // chokepoints), not a deployment-global role (#417).
 
     let required: Required
 
@@ -31,8 +33,6 @@ struct RoleMiddleware: AsyncMiddleware {
         switch required {
         case .authenticated:
             break
-        case .instructor:
-            guard user.isInstructor else { throw Abort(.forbidden) }
         case .admin:
             guard user.isAdmin else { throw Abort(.forbidden) }
         }

--- a/Sources/APIServer/Migrations/AddCourseEnrollmentRole.swift
+++ b/Sources/APIServer/Migrations/AddCourseEnrollmentRole.swift
@@ -81,16 +81,20 @@ struct AddCourseEnrollmentRole: ChickadeeMigration {
             .all(decoding: PendingEnrollment.self)
         guard !pending.isEmpty else { return }
 
-        // Instructor-ness comes from each user's *global* role. The user lookup
-        // stays a Fluent model query: it reads the `users` table, which no later
-        // migration extends, so it isn't exposed to the column-drift hazard the
-        // enrollment query above hardens against.
+        // Instructor-ness comes from each user's *global* role at backfill time.
+        // This migration runs before `CollapseUserRoles`, so on the DBs where it
+        // does real work a user could still carry the legacy `instructor` (or
+        // `admin`) role — matched here by its raw string, since those enum cases
+        // were retired. The user lookup stays a Fluent model query: it reads the
+        // `users` table, which no later migration extends, so it isn't exposed to
+        // the column-drift hazard the enrollment query above hardens against.
         let userIDs = Set(pending.map(\.userID))
         let users = try await APIUser.query(on: database).filter(\.$id ~~ userIDs).all()
+        let staffRoleStrings: Set<String> = ["instructor", UserRole.admin.rawValue]
         var isInstructorByUserID: [UUID: Bool] = [:]
         for user in users {
             guard let id = user.id else { continue }
-            isInstructorByUserID[id] = user.isInstructor
+            isInstructorByUserID[id] = staffRoleStrings.contains(user.role)
         }
 
         for row in pending {

--- a/Sources/APIServer/Migrations/CollapseUserRoles.swift
+++ b/Sources/APIServer/Migrations/CollapseUserRoles.swift
@@ -25,13 +25,16 @@ struct CollapseUserRoles: ChickadeeMigration {
             // Only the SQL drivers (SQLite / Postgres) are used in practice.
             return
         }
+        // The legacy `student` / `instructor` role strings are matched as
+        // literals: the enum cases were retired in the G2 cleanup, but old rows
+        // in production DBs still carry those exact strings and must be rewritten.
         try await sql.update("users")
             .set("role", to: UserRole.user.rawValue)
-            .where("role", .equal, UserRole.student.rawValue)
+            .where("role", .equal, "student")
             .run()
         try await sql.update("users")
             .set("role", to: UserRole.user.rawValue)
-            .where("role", .equal, UserRole.instructor.rawValue)
+            .where("role", .equal, "instructor")
             .run()
     }
 

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -15,25 +15,19 @@ import Vapor
 /// The `role` DB column stays a plain string (no migration); this enum is
 /// the authoritative vocabulary for it.
 enum UserRole: String, Sendable {
-    /// The deployment-global role of an ordinary human account (#417 Slice G2).
-    /// Teaching authority is per-course now (`CourseRole` on the enrollment), so
-    /// the deployment role only distinguishes an ordinary `user` from an `admin`
-    /// operator (and the non-human `mcp` service account).
+    /// The deployment-global role of an ordinary human account (#417). Teaching
+    /// authority is per-course now (`CourseRole` on the enrollment), so the
+    /// deployment role only distinguishes an ordinary `user` from an `admin`
+    /// operator (and the non-human `mcp` service account). The retired global
+    /// `student` / `instructor` roles were folded into `user` by the
+    /// `CollapseUserRoles` migration and are no longer part of the vocabulary; a
+    /// row that still carries one of those legacy strings simply decodes to
+    /// `nil` (`roleValue`), which reads as a non-admin, non-agent user.
     case user
     case admin
     /// MCP service accounts (admin-provisioned, non-loginable agents).
     /// `mcp` is its own role — it does NOT imply admin.
     case mcp
-
-    /// DEPRECATED, decode-only (#417 Slice G2). The global `student` / `instructor`
-    /// roles were retired when teaching authority moved per-course: the
-    /// `CollapseUserRoles` migration rewrites every such row to `user`, no login
-    /// path or admin control assigns them, and they're dropped from
-    /// `autoAssignableRoles`. The cases remain so historical rows and the large
-    /// test corpus that still writes these strings keep decoding; a follow-up
-    /// removes them once those are migrated.
-    case student
-    case instructor
 }
 
 final class APIUser: Model, Content, @unchecked Sendable {
@@ -164,13 +158,6 @@ extension APIUser {
     }
 
     var isAdmin: Bool { roleValue == .admin }
-
-    /// Whether the account holds deployment-wide teaching authority. Since the
-    /// global `instructor` role was retired (#417 Slice G2 — teaching authority
-    /// is per-course), this is true only for admins; the legacy `.instructor`
-    /// case is still honoured so historical rows and the test corpus that writes
-    /// `role: "instructor"` keep resolving as staff until they're migrated.
-    var isInstructor: Bool { roleValue == .instructor || roleValue == .admin }
 
     /// True for MCP service accounts (admin-provisioned, non-loginable agents).
     /// `mcp` is its own role — it does NOT imply admin.
@@ -398,7 +385,6 @@ struct CurrentUserContext: Encodable {
     let email: String?
     let role: String
     let isAdmin: Bool
-    let isInstructor: Bool
     /// The course the user is currently viewing (nil if no course info was resolved).
     let activeCourse: CourseContext?
     /// All courses the user is enrolled in (empty if no course info was resolved).
@@ -451,7 +437,6 @@ struct CurrentUserContext: Encodable {
         self.email = email
         self.role = user.role
         self.isAdmin = user.isAdmin
-        self.isInstructor = user.isInstructor
         self.activeCourse = activeCourse
         self.enrolledCourses = enrolledCourses
         self.showCourseTabs = enrolledCourses.count > 1

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+List.swift
@@ -115,13 +115,13 @@ extension InstructorDashboardRoutes {
             )
         )
 
-        // The "Y students enrolled" denominator still keys off the global role
-        // (instructor/admin test accounts excluded). Switching it to the
-        // per-course role is a follow-up once mixed roles are in real use.
+        // The "Y students enrolled" denominator counts per-course students only
+        // (TA/instructor/admin test accounts excluded), keyed off the enrollment
+        // role now that the global student role is retired (#417 Slice G2).
         let activeStudentIDs = Set(
             enrolledUsers
-                .filter { $0.roleValue == .student }
                 .compactMap(\.id)
+                .filter { rolesByUserID[$0] == .student }
         )
         // Pending pre-enrollments are CSV-uploaded students who haven't
         // logged in yet — count them toward the "Y students enrolled"
@@ -168,7 +168,8 @@ extension InstructorDashboardRoutes {
                 activeCourseUUID: activeCourseUUID
             )
         )
-        let activeStudentCount = enrolledUsers.filter { $0.roleValue == .student }.count
+        let activeStudentCount =
+            enrolledUsers.compactMap(\.id).filter { rolesByUserID[$0] == .student }.count
         return (rows, activeStudentCount + pendingPreEnrollments.count)
     }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
@@ -21,7 +21,9 @@ extension InstructorDashboardRoutes {
             let studentIDRaw = req.parameters.get("studentID"),
             let studentID = UUID(uuidString: studentIDRaw),
             let student = try await APIUser.find(studentID, on: req.db),
-            student.roleValue == .student
+            // Student-ness is per-course now (#417 Slice G2): the target must
+            // hold a `.student` enrollment in this assignment's course.
+            try await courseRole(of: studentID, inCourse: assignment.courseID, db: req.db) == .student
         else {
             throw WebAssignmentError.notFound(resource: "Assignment or student")
         }
@@ -352,17 +354,17 @@ extension InstructorDashboardRoutes {
     ) async throws -> APIUser {
         guard let studentIDRaw = req.parameters.get("studentID"),
             let studentID = UUID(uuidString: studentIDRaw),
-            let student = try await APIUser.find(studentID, on: req.db),
-            student.roleValue == .student
+            let student = try await APIUser.find(studentID, on: req.db)
         else {
             throw WebAssignmentError.notFound(resource: "Student")
         }
-        let isEnrolled =
-            try await APICourseEnrollment.query(on: req.db)
-            .filter(\.$course.$id == assignment.courseID)
-            .filter(\.$userID == studentID)
-            .count() > 0
-        guard isEnrolled else {
+        // Student-ness is per-course now (#417 Slice G2): require a `.student`
+        // enrollment in the assignment's course. This subsumes the old
+        // global-role check *and* the separate enrollment query — a non-enrolled
+        // user has no per-course role, so `courseRole` returns nil.
+        guard
+            try await courseRole(of: studentID, inCourse: assignment.courseID, db: req.db) == .student
+        else {
             throw WebAssignmentError.notFound(resource: "Enrolled student")
         }
         return student

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -149,7 +149,12 @@ extension WebRoutes {
         // checks the submitter's role and uses the existence of a
         // pathfinder row directly (the unique constraint on
         // (test_setup_id, achievement_id) makes this the natural query).
-        if user.roleValue == .student, let uid = user.id {
+        // Award only to a per-course STUDENT in this setup's course (#417 Slice
+        // G2 — the global student role was retired); an admin/TA/instructor
+        // testing the assignment must not lock in the immutable badge.
+        if let uid = user.id,
+            try await courseRole(of: uid, inCourse: setup.courseID, db: req.db) == .student
+        {
             // First-to-submit records (Pathfinder) — the manifest's authored
             // ones, or the registry default, minus any the instructor disabled.
             let records = BuiltInAchievements.classRecordsForAward(

--- a/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
@@ -79,6 +79,7 @@ import VaporTesting
 
         let cookie = try await loginUser(
             username: "lc_inst", password: "pw", role: "instructor", on: app)
+        try await promoteToInstructor("lc_inst", on: app)  // active .auto course: promote (#417)
         let user = try #require(
             try await APIUser.query(on: app.db).filter(\.$username == "lc_inst").first())
         try await APICourseEnrollment(

--- a/Tests/APITests/ArchivedCourseStudentActionRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseStudentActionRouteTests.swift
@@ -78,6 +78,7 @@ import VaporTesting
 
             let cookie = try await loginUser(
                 username: "asa_inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("asa_inst", on: app)  // active .auto course: promote (#417)
             let user = try #require(
                 try await APIUser.query(on: app.db).filter(\.$username == "asa_inst").first())
             try await APICourseEnrollment(

--- a/Tests/APITests/ArchivedCourseWriteRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseWriteRouteTests.swift
@@ -73,6 +73,7 @@ import VaporTesting
 
             let cookie = try await loginUser(
                 username: "awr_inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("awr_inst", on: app)  // active .auto course: promote (#417)
             let user = try #require(
                 try await APIUser.query(on: app.db).filter(\.$username == "awr_inst").first())
             try await APICourseEnrollment(

--- a/Tests/APITests/AssignmentEnrollmentTests.swift
+++ b/Tests/APITests/AssignmentEnrollmentTests.swift
@@ -34,7 +34,10 @@ import VaporTesting
     private func enroll(user: APIUser, in course: APICourse) async throws {
         // Seed the per-course role from the global role so a global-instructor
         // caller becomes a per-course instructor (Phase 5: authority is per-course).
-        let role: CourseRole = user.isInstructor ? .instructor : .student
+        // The global `instructor` UserRole case is gone (#417 Slice G2); a legacy
+        // `"instructor"` role string or an admin seeds to instructor.
+        let role: CourseRole =
+            (user.role == "instructor") || user.isAdmin ? .instructor : .student
         let enrollment = APICourseEnrollment(
             userID: try user.requireID(), courseID: try course.requireID(), role: role)
         try await enrollment.save(on: app.db)

--- a/Tests/APITests/AssignmentRoutesHelpers.swift
+++ b/Tests/APITests/AssignmentRoutesHelpers.swift
@@ -35,10 +35,19 @@ func arLoginAsInstructor(on app: Application) async throws -> String {
         .filter(\.$username == "testinstructor").first()
     {
         let userID = try user.requireID()
-        let alreadyEnrolled =
-            try await APICourseEnrollment.query(on: app.db)
-            .filter(\.$userID == userID).filter(\.$course.$id == courseID).first() != nil
-        if !alreadyEnrolled {
+        // Upsert the `.instructor` role — don't just skip when a row exists. A
+        // `.auto` course auto-enrolls the user at login (AuthRoutes) and, since
+        // the deployment role collapsed (#417 Slice G2), that seeds a non-admin
+        // as a per-course `.student`. Skipping on "already enrolled" would leave
+        // the test instructor a student and 403 every per-course staff gate.
+        if let existing = try await APICourseEnrollment.query(on: app.db)
+            .filter(\.$userID == userID).filter(\.$course.$id == courseID).first()
+        {
+            if existing.role != .instructor {
+                existing.role = .instructor
+                try await existing.save(on: app.db)
+            }
+        } else {
             try await APICourseEnrollment(userID: userID, courseID: courseID, role: .instructor)
                 .save(on: app.db)
         }
@@ -151,9 +160,16 @@ func arInsertSubmission(
 
 func arEnrollStudentInTestCourse(_ student: APIUser, on app: Application) async throws {
     let courseID = try await app.testCourseID(enrollmentMode: .auto)
+    // Seed the per-course role from the user's global role (mirroring production
+    // saveSeededEnrollment / makeTestEnrollment) so a helper-enrolled instructor
+    // or admin becomes course staff, not a per-course student. The per-course
+    // roster counts (#417 Slice G2) key off the enrollment role, so enrolling a
+    // staff account as `.student` here would wrongly inflate the student count.
+    let isStaff = (student.role == "instructor") || student.isAdmin
     let enrollment = APICourseEnrollment(
         userID: try student.requireID(),
-        courseID: courseID
+        courseID: courseID,
+        role: isStaff ? .instructor : .student
     )
     try await enrollment.save(on: app.db)
 }

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -439,6 +439,7 @@ import VaporTesting
 
             let staffCookie = try await loginUser(
                 username: "prof1", password: "pass", role: "instructor", on: app)
+            try await promoteToInstructor("prof1", on: app)
             try await app.asyncTest(
                 .GET, "/api/v1/browser-runner/testsetups/\(setupID)/manifest",
                 beforeRequest: { req in req.headers.add(name: .cookie, value: staffCookie) },
@@ -473,6 +474,7 @@ import VaporTesting
 
             let staffCookie = try await loginUser(
                 username: "prof1", password: "pass", role: "instructor", on: app)
+            try await promoteToInstructor("prof1", on: app)
             try await app.asyncTest(
                 .GET, "/api/v1/browser-runner/testsetups/\(setupID)/manifest",
                 beforeRequest: { req in req.headers.add(name: .cookie, value: staffCookie) },

--- a/Tests/APITests/BuiltInAwardTogglesTests.swift
+++ b/Tests/APITests/BuiltInAwardTogglesTests.swift
@@ -53,6 +53,10 @@ import VaporTesting
                 zipPath: app.testSetupsDirectory + "ba_award_setup.zip", courseID: courseID)
             try await setup.save(on: app.db)
             let student = try await arInsertStudent(username: "ba_student", on: app)
+            // Class badges gate on a per-course `.student` enrollment now (#417
+            // Slice G2) — enrol so the award path is actually reached (the
+            // disabled set, not the role gate, is what leaves it empty).
+            try await arEnrollStudentInTestCourse(student, on: app)
             let uid = try student.requireID()
             _ = try await arInsertSubmission(
                 id: "ba_award_sub", testSetupID: "ba_award_setup", userID: uid, on: app)

--- a/Tests/APITests/ClassRecordManifestTests.swift
+++ b/Tests/APITests/ClassRecordManifestTests.swift
@@ -31,6 +31,9 @@ import VaporTesting
                 zipPath: app.testSetupsDirectory + "cr_setup.zip", courseID: courseID)
             try await setup.save(on: app.db)
             let student = try await arInsertStudent(username: "cr_student", on: app)
+            // Class badges award only to a per-course `.student` now (#417 Slice
+            // G2) — enrol the student in the setup's course.
+            try await arEnrollStudentInTestCourse(student, on: app)
             let uid = try student.requireID()
             _ = try await arInsertSubmission(
                 id: "cr_sub", testSetupID: "cr_setup", userID: uid, on: app)

--- a/Tests/APITests/CourseEnrollmentRoleTests.swift
+++ b/Tests/APITests/CourseEnrollmentRoleTests.swift
@@ -124,7 +124,7 @@ import Vapor
     /// active course's per-course role, with a transitional fallback to the
     /// global role.
     @Test func instructorInActiveCourseReflectsPerCourseRole() {
-        func context(globalRole: UserRole, active: CourseContext?) -> CurrentUserContext {
+        func context(globalRole: LegacyGlobalRole, active: CourseContext?) -> CurrentUserContext {
             let user = APIUser(username: "u", passwordHash: "x", role: globalRole.rawValue)
             return CurrentUserContext(
                 user: user, activeCourse: active, enrolledCourses: active.map { [$0] } ?? [])
@@ -255,10 +255,12 @@ import Vapor
 
     // MARK: - Enrollment seeding (Phase 4a)
 
-    /// New enrollments seed their per-course role from the user's global role,
-    /// so moving authorization onto the per-course role doesn't drop anyone's
-    /// access. Exercises both the `for:` overload and the userID overload.
-    @Test func saveSeededEnrollmentSeedsRoleFromGlobalRole() async throws {
+    /// New enrollments seed their per-course role from the user's *deployment*
+    /// role: an admin becomes a per-course instructor, everyone else a student.
+    /// Teaching authority is per-course now (#417 Slice G2) — a plain user (or a
+    /// legacy global-`instructor` role string) auto-enrolls as a student, and
+    /// the roster grants staff explicitly. Exercises both overloads.
+    @Test func saveSeededEnrollmentSeedsRoleFromDeploymentRole() async throws {
         let app = try await Application.make(.testing)
         try await withApp(app) { app in
             try await configureTestDatabase(app)
@@ -267,17 +269,21 @@ import Vapor
             try await course.save(on: app.db)
             let courseID = try course.requireID()
 
-            let instructor = makeUser(role: .instructor)
+            // A user still carrying the retired `instructor` role string is NOT
+            // an admin, so it no longer auto-seeds staff.
+            let legacyInstructor = makeUser(role: .instructor)
             let admin = makeUser(role: .admin)
             let student = makeUser(role: .student)
-            for user in [instructor, admin, student] { try await user.save(on: app.db) }
+            for user in [legacyInstructor, admin, student] { try await user.save(on: app.db) }
 
-            try await saveSeededEnrollment(for: instructor, courseID: courseID, on: app.db)
+            try await saveSeededEnrollment(for: legacyInstructor, courseID: courseID, on: app.db)
             try await saveSeededEnrollment(userID: try admin.requireID(), courseID: courseID, on: app.db)
             try await saveSeededEnrollment(userID: try student.requireID(), courseID: courseID, on: app.db)
 
-            #expect(try await courseRole(of: instructor, on: app.db) == .instructor)
-            #expect(try await courseRole(of: admin, on: app.db) == .instructor, "admin implies instructor")
+            #expect(
+                try await courseRole(of: legacyInstructor, on: app.db) == .student,
+                "a legacy global-instructor string no longer auto-seeds staff — the roster grants it")
+            #expect(try await courseRole(of: admin, on: app.db) == .instructor, "admin seeds to instructor")
             #expect(try await courseRole(of: student, on: app.db) == .student)
         }
     }
@@ -385,7 +391,24 @@ import Vapor
 
     // MARK: - Helpers
 
-    private func makeUser(role: UserRole) -> APIUser {
+    /// Test-only stand-in for the retired global `student` / `instructor`
+    /// roles. The deployment role enum collapsed to `user` / `admin` / `mcp`
+    /// (#417 Slice G2), but these role-model tests still construct users
+    /// carrying the legacy role strings a pre-collapse production row would
+    /// have (the backfill reads them). `.rawValue` is faithful, so behaviour is
+    /// identical to the old `UserRole` cases.
+    private enum LegacyGlobalRole {
+        case student, instructor, admin
+        var rawValue: String {
+            switch self {
+            case .student: return "student"
+            case .instructor: return "instructor"
+            case .admin: return UserRole.admin.rawValue
+            }
+        }
+    }
+
+    private func makeUser(role: LegacyGlobalRole) -> APIUser {
         APIUser(
             username: "\(role.rawValue)_\(UUID().uuidString.prefix(8))",
             passwordHash: "x",

--- a/Tests/APITests/DraftSuiteSectionRoutesTests.swift
+++ b/Tests/APITests/DraftSuiteSectionRoutesTests.swift
@@ -84,6 +84,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let draftID = try await makeDraft()
             let cookie = try await loginUser(username: "dssrt_inst1", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst1", on: app)
             // CSRF token cooks against any GET — the create page itself works fine here.
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
@@ -114,6 +115,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let draftID = try await makeDraft()
             let cookie = try await loginUser(username: "dssrt_inst2", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst2", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -136,6 +138,7 @@ import VaporTesting
         try await withApp(app) { _ in
             _ = try await makeDraft()
             let cookie = try await loginUser(username: "dssrt_inst3", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst3", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -161,6 +164,7 @@ import VaporTesting
             let sid = UUID().uuidString
             let draftID = try await makeDraft(seedSections: [(sid, "Original")])
             let cookie = try await loginUser(username: "dssrt_inst4", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst4", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -189,6 +193,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let draftID = try await makeDraft(seedSections: [(UUID().uuidString, "Existing")])
             let cookie = try await loginUser(username: "dssrt_inst5", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst5", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -222,6 +227,7 @@ import VaporTesting
                 ]
             )
             let cookie = try await loginUser(username: "dssrt_inst6", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst6", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -256,6 +262,7 @@ import VaporTesting
             let sid = UUID().uuidString
             let draftID = try await makeDraft(seedSections: [(sid, "Q1")])
             let cookie = try await loginUser(username: "dssrt_inst7", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst7", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             // Persist a valid pair (use the real `FamilyVariable` shape — same
@@ -331,6 +338,7 @@ import VaporTesting
                 seedSections: [(sidA, "A"), (sidB, "B"), (sidC, "C")]
             )
             let cookie = try await loginUser(username: "dssrt_inst8", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst8", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -360,6 +368,7 @@ import VaporTesting
             let sidB = UUID().uuidString
             let draftID = try await makeDraft(seedSections: [(sidA, "A"), (sidB, "B")])
             let cookie = try await loginUser(username: "dssrt_inst9", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dssrt_inst9", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(

--- a/Tests/APITests/DraftSupportFilesTests.swift
+++ b/Tests/APITests/DraftSupportFilesTests.swift
@@ -65,6 +65,7 @@ import VaporTesting
             let payload = "name,age\nAlice,30\nBob,25\n"
             let draftID = try await makeDraft(withSupportFile: (name: "fixtures.csv", contents: payload))
             let cookie = try await loginUser(username: "dsft_inst1", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dsft_inst1", on: app)
             let (_, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -84,6 +85,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let draftID = try await makeDraft(withSupportFile: (name: "fixtures.csv", contents: "x"))
             let cookie = try await loginUser(username: "dsft_inst2", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dsft_inst2", on: app)
             let (_, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -102,6 +104,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let draftID = try await makeDraft(withSupportFile: (name: "fixtures.csv", contents: "x"))
             let cookie = try await loginUser(username: "dsft_inst3", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dsft_inst3", on: app)
             let (_, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -120,6 +123,7 @@ import VaporTesting
         try await withApp(app) { _ in
             _ = try await makeDraft(withSupportFile: (name: "fixtures.csv", contents: "x"))
             let cookie = try await loginUser(username: "dsft_inst4", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dsft_inst4", on: app)
             let (_, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -140,6 +144,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let draftID = try await makeDraft()
             let cookie = try await loginUser(username: "dsft_inst5", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("dsft_inst5", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/new", cookie: cookie, on: app)
 
             // Upload via the existing draft-scripts endpoint with tier=support.

--- a/Tests/APITests/Fixtures.swift
+++ b/Tests/APITests/Fixtures.swift
@@ -78,8 +78,12 @@ func makeTestEnrollment(
     // Seed the per-course role from the user's global role (mirroring production
     // saveSeededEnrollment) so a global instructor/admin enrolled for testing
     // becomes course staff — otherwise the per-course roster counts and staff
-    // gates (#417 Slice G) would treat them as an ordinary student.
-    let isInstructor = try await APIUser.find(userID, on: app.db)?.isInstructor ?? false
+    // gates (#417 Slice G) would treat them as an ordinary student. The global
+    // `instructor` role no longer exists as a UserRole case (#417 Slice G2), so
+    // legacy `"instructor"` role strings (still used by test logins) and admins
+    // seed to a per-course instructor, matching the migration backfill.
+    let user = try await APIUser.find(userID, on: app.db)
+    let isInstructor = (user?.role == "instructor") || (user?.isAdmin ?? false)
     let enrollment = APICourseEnrollment(
         userID: userID, courseID: courseID, role: isInstructor ? .instructor : .student)
     try await enrollment.save(on: app.db)

--- a/Tests/APITests/MCP/AdminMCPOAuthTests.swift
+++ b/Tests/APITests/MCP/AdminMCPOAuthTests.swift
@@ -194,6 +194,8 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            // Content consent requires per-course staff now (#417); enrol prof.
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let consentToken = try await mintConsentToken(
                 app, cookie: cookie, scope: "content:read content:write", resource: contentResource)
             let consentRes = try await submitConsent(app, token: consentToken)

--- a/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
+++ b/Tests/APITests/MCP/MCPDynamicRegistrationTests.swift
@@ -96,6 +96,9 @@ import VaporTesting
 
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            // MCP content consent renders the permitted screen only for per-course
+            // staff now (#417 Slice G2); enrol prof so the client name shows.
+            try await enrollAsTestInstructor(username: "prof", on: app)
             var components = URLComponents()
             components.path = "/oauth/authorize"
             components.queryItems = [

--- a/Tests/APITests/MCP/MCPModeScopeContractTests.swift
+++ b/Tests/APITests/MCP/MCPModeScopeContractTests.swift
@@ -142,6 +142,8 @@ import VaporTesting
             // 3. Authorize: the agent requests the granted scope; consent yields a code.
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            // Content consent requires per-course staff now (#417); enrol prof.
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let consentRes = try await consent(
                 app, cookie: cookie, clientID: clientID, scope: expectedScopes.joined(separator: " "))
             #expect(consentRes.status == .seeOther)
@@ -213,6 +215,8 @@ import VaporTesting
             let clientID = try #require(jsonField("client_id", in: try await register(app)))
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            // In-mode consent renders the permitted screen; enrol prof as staff.
+            try await enrollAsTestInstructor(username: "prof", on: app)
             try await app.asyncTest(
                 .GET, authorizePath(clientID: clientID, scope: "content:read"),
                 beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },

--- a/Tests/APITests/MCP/MCPOAuthFlowTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthFlowTests.swift
@@ -132,6 +132,8 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            // Content consent requires per-course staff now (#417); enrol prof.
+            try await enrollAsTestInstructor(username: "prof", on: app)
 
             // Consent → authorization code.
             let consentRes = try await consent(
@@ -188,6 +190,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
 
             let consentRes = try await consent(
                 app, cookie: cookie, scope: "content:read content:write", decision: "authorize")
@@ -219,6 +222,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let consentRes = try await consent(
                 app, cookie: cookie, scope: "content:read content:write", decision: "authorize")
             let code = try #require(queryValue("code", in: consentRes.headers.first(name: .location)))
@@ -232,10 +236,9 @@ import VaporTesting
             let refreshToken = try #require(jsonField("refresh_token", in: tokenRes))
 
             // The instructor is demoted to student (role downgrade / repurpose).
-            let prof = try #require(
-                await APIUser.query(on: app.db).filter(\.$username == "prof").first())
-            prof.role = "student"
-            try await prof.save(on: app.db)
+            // Authority is per-course now (#417 Slice G2), so strip the enrollment
+            // staff role — the global role no longer governs MCP eligibility.
+            try await demoteToStudentEverywhere(username: "prof", on: app)
 
             // Refresh now fails, and the grant is revoked so a retry also fails.
             let refreshRes = try await tokenPost(
@@ -253,6 +256,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let consentRes = try await consent(
                 app, cookie: cookie, scope: "content:read", decision: "authorize")
             let code = try #require(queryValue("code", in: consentRes.headers.first(name: .location)))
@@ -275,6 +279,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let res = try await consent(
                 app, cookie: cookie, scope: "content:read", decision: "deny")
             #expect(res.status == .seeOther)
@@ -290,6 +295,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let token = try await mintConsentToken(
                 app, cookie: cookie, scope: "content:read content:write")
             let res = try await submitConsent(app, token: token, decision: "authorize", cookie: nil)
@@ -314,6 +320,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let token = try await mintConsentToken(app, cookie: cookie, scope: "content:read")
             #expect(try await submitConsent(app, token: token, decision: "authorize").status == .seeOther)
             // Single-use: replaying the same token is rejected.
@@ -352,12 +359,11 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let token = try await mintConsentToken(app, cookie: cookie, scope: "content:read")
             // Demote the consenting user after the screen rendered but before submit.
-            let prof = try #require(
-                await APIUser.query(on: app.db).filter(\.$username == "prof").first())
-            prof.role = "student"
-            try await prof.save(on: app.db)
+            // Authority is per-course now (#417 Slice G2) — strip the enrollment.
+            try await demoteToStudentEverywhere(username: "prof", on: app)
             let res = try await submitConsent(app, token: token, decision: "authorize")
             #expect(res.status == .forbidden)
         }
@@ -401,6 +407,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let refresh = try await obtainRefreshToken(app, cookie: cookie)
 
             let revokeRes = try await app.asyncSendRequest(
@@ -421,6 +428,7 @@ import VaporTesting
             try await seedClient(app)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let firstRefresh = try await obtainRefreshToken(app, cookie: cookie)
 
             // Legitimate rotation.

--- a/Tests/APITests/MCP/MCPResourcesTests.swift
+++ b/Tests/APITests/MCP/MCPResourcesTests.swift
@@ -91,7 +91,12 @@ import Vapor
     @Test func listIncludesAuthoringGuides() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
-            _ = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            let prof = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            // MCP eligibility is per-course staff now (#417 Slice G2); enrol prof
+            // so the subject is staff-anywhere even for the global-guide listing.
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            try await makeTestEnrollment(
+                on: app, userID: prof.requireID(), courseID: course.requireID())
             let result = try await MCPResourceProvider().list(context: context(app, subject: "prof"))
             let uris = Self.resourceURIs(result)
             #expect(uris.contains("chickadee://docs/personalization-solution-notebooks"))
@@ -101,7 +106,11 @@ import Vapor
     @Test func readReturnsGuideMarkdown() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
-            _ = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            let prof = try await makeTestUser(on: app, username: "prof", role: "instructor")
+            // MCP eligibility is per-course staff now (#417 Slice G2); enrol prof.
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            try await makeTestEnrollment(
+                on: app, userID: prof.requireID(), courseID: course.requireID())
             let result = try await MCPResourceProvider().read(
                 uri: "chickadee://docs/personalization-solution-notebooks",
                 context: context(app, subject: "prof"))

--- a/Tests/APITests/MCP/MCPRoleGuardrailTests.swift
+++ b/Tests/APITests/MCP/MCPRoleGuardrailTests.swift
@@ -28,7 +28,9 @@ import Testing
     @Test func mcpRoleDoesNotImplyInstructorOrAdmin() {
         let agent = APIUser(username: "claude-agent", passwordHash: "x", role: "mcp")
         #expect(agent.isMCPAgent)
-        #expect(agent.isInstructor == false)
+        // The global instructor role is gone (#417 Slice G2) — teaching authority
+        // is per-course now — so an `mcp` account is neither admin nor `user`.
         #expect(agent.isAdmin == false)
+        #expect(agent.roleValue == .mcp)
     }
 }

--- a/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
+++ b/Tests/APITests/MCP/MCPSecurityHardeningTests.swift
@@ -192,6 +192,8 @@ import VaporTesting
             try await seedClient(app, clientID: clientID, name: clientName, redirectURI: redirectURI)
             let cookie = try await loginUser(
                 username: "prof", password: "testpassword", role: "instructor", on: app)
+            // MCP content consent needs per-course staff now (#417 Slice G2).
+            try await enrollAsTestInstructor(username: "prof", on: app)
             let consentRes = try await consent(
                 app, cookie: cookie, clientID: clientID, redirectURI: redirectURI,
                 scope: "content:read", decision: "authorize")
@@ -218,14 +220,17 @@ import VaporTesting
             try await seedClient(app, clientID: "agent-b", name: "Agent Beta", redirectURI: redirectURI)
             let profA = try await loginUser(
                 username: "profA", password: "testpassword", role: "instructor", on: app)
+            // MCP content consent needs per-course staff now (#417 Slice G2).
+            try await enrollAsTestInstructor(username: "profA", on: app)
             try await createGrant(
                 app, cookie: profA, clientID: "agent-a", redirectURI: redirectURI, scope: "content:read")
             let profB = try await loginUser(
                 username: "profB", password: "testpassword", role: "instructor", on: app)
+            // Phase 5: /agents is under the per-course-gated /instructor group;
+            // MCP content consent also needs per-course staff (#417 Slice G2).
+            try await enrollAsTestInstructor(username: "profB", on: app)
             try await createGrant(
                 app, cookie: profB, clientID: "agent-b", redirectURI: redirectURI, scope: "content:read")
-            // Phase 5: /agents is under the per-course-gated /instructor group.
-            try await enrollAsTestInstructor(username: "profB", on: app)
 
             try await app.asyncTest(
                 .GET, "/agents",
@@ -244,6 +249,8 @@ import VaporTesting
             try await seedClient(app, clientID: clientID, name: clientName, redirectURI: redirectURI)
             let profA = try await loginUser(
                 username: "profA", password: "testpassword", role: "instructor", on: app)
+            // MCP content consent needs per-course staff now (#417 Slice G2).
+            try await enrollAsTestInstructor(username: "profA", on: app)
             try await createGrant(
                 app, cookie: profA, clientID: clientID, redirectURI: redirectURI, scope: "content:read")
             let grantID = try #require(try await MCPGrant.query(on: app.db).first()).requireID()
@@ -273,6 +280,8 @@ import VaporTesting
             try await seedClient(app, clientID: clientID, name: clientName, redirectURI: redirectURI)
             let profA = try await loginUser(
                 username: "profA", password: "testpassword", role: "instructor", on: app)
+            // MCP content consent needs per-course staff now (#417 Slice G2).
+            try await enrollAsTestInstructor(username: "profA", on: app)
             try await createGrant(
                 app, cookie: profA, clientID: clientID, redirectURI: redirectURI, scope: "content:read")
             let grantID = try #require(try await MCPGrant.query(on: app.db).first()).requireID()

--- a/Tests/APITests/NotebookDownloadTests.swift
+++ b/Tests/APITests/NotebookDownloadTests.swift
@@ -35,7 +35,13 @@ import VaporTesting
     // MARK: - Auth helpers
 
     private func loginAsInstructor() async throws -> String {
-        return try await loginUser(username: "testinstructor", password: "testpassword", role: "instructor", on: app)
+        let cookie = try await loginUser(
+            username: "testinstructor", password: "testpassword", role: "instructor", on: app)
+        // Teaching authority is per-course now (#417 Slice G2): explicitly enrol
+        // the instructor as course staff in the shared TEST101 course (the
+        // setups here live in it) instead of relying on auto-enroll granting it.
+        try await enrollAsTestInstructor(username: "testinstructor", on: app)
+        return cookie
     }
 
     private func loginAsStudent() async throws -> String {

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -95,10 +95,13 @@ import VaporTesting
         // Seed the per-course role from the global role (mirroring production
         // saveSeededEnrollment) so a global instructor becomes course staff —
         // the notebook solution view is per-course staff now (#417 Slice G).
+        // The global `instructor` UserRole case is gone (#417 Slice G2); a
+        // legacy `"instructor"` role string or an admin seeds to instructor.
+        let isStaff = (user.role == "instructor") || user.isAdmin
         let enrollment = APICourseEnrollment(
             userID: try user.requireID(),
             courseID: try course.requireID(),
-            role: user.isInstructor ? .instructor : .student
+            role: isStaff ? .instructor : .student
         )
         try await enrollment.save(on: app.db)
     }

--- a/Tests/APITests/RoleMiddlewareTests.swift
+++ b/Tests/APITests/RoleMiddlewareTests.swift
@@ -23,16 +23,13 @@ import VaporTesting
         app.grouped(sessionAuth, RoleMiddleware(required: .authenticated))
             .get("__test_auth") { _ in "auth-ok" }
 
-        app.grouped(sessionAuth, RoleMiddleware(required: .instructor))
-            .get("__test_instructor") { _ in "instructor-ok" }
-
+        // There is no `.instructor` tier any more — teaching authority is
+        // per-course (#417), enforced by the per-course chokepoints, not this
+        // deployment-global middleware. Only `.authenticated` and `.admin` remain.
         app.grouped(sessionAuth, RoleMiddleware(required: .admin))
             .get("__test_admin") { _ in "admin-ok" }
 
-        // API-prefixed equivalents to exercise the 401 (non-browser) path.
-        app.grouped(sessionAuth, RoleMiddleware(required: .instructor))
-            .get("api", "__test_instructor") { _ in "api-instructor-ok" }
-
+        // API-prefixed equivalent to exercise the 401 (non-browser) path.
         app.grouped(sessionAuth, RoleMiddleware(required: .admin))
             .get("api", "__test_admin") { _ in "api-admin-ok" }
 
@@ -46,14 +43,6 @@ import VaporTesting
             try await app.asyncTest(.GET, "/__test_auth") { res in
                 #expect(res.status == .seeOther)
                 #expect(res.headers.first(name: .location) == "/login")
-            }
-        }
-    }
-
-    @Test func unauthenticated_apiRoute_returns401() async throws {
-        try await withApp(try await makeApp()) { app in
-            try await app.asyncTest(.GET, "/api/__test_instructor") { res in
-                #expect(res.status == .unauthorized)
             }
         }
     }
@@ -81,23 +70,6 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     #expect(res.body.string == "auth-ok")
-                })
-
-        }
-    }
-
-    @Test func student_instructorRoute_returns403() async throws {
-        try await withApp(try await makeApp()) { app in
-            let cookie = try await loginUser(
-                username: "role_student2", password: "pw",
-                role: "student", on: app)
-            try await app.asyncTest(
-                .GET, "/__test_instructor",
-                beforeRequest: { req in
-                    req.headers.add(name: .cookie, value: cookie)
-                },
-                afterResponse: { res in
-                    #expect(res.status == .forbidden)
                 })
 
         }
@@ -139,24 +111,6 @@ import VaporTesting
         }
     }
 
-    @Test func instructor_instructorRoute_returns200() async throws {
-        try await withApp(try await makeApp()) { app in
-            let cookie = try await loginUser(
-                username: "role_instructor2", password: "pw",
-                role: "instructor", on: app)
-            try await app.asyncTest(
-                .GET, "/__test_instructor",
-                beforeRequest: { req in
-                    req.headers.add(name: .cookie, value: cookie)
-                },
-                afterResponse: { res in
-                    #expect(res.status == .ok)
-                    #expect(res.body.string == "instructor-ok")
-                })
-
-        }
-    }
-
     @Test func instructor_adminRoute_returns403() async throws {
         try await withApp(try await makeApp()) { app in
             let cookie = try await loginUser(
@@ -188,25 +142,6 @@ import VaporTesting
                 },
                 afterResponse: { res in
                     #expect(res.status == .ok)
-                })
-
-        }
-    }
-
-    @Test func admin_instructorRoute_returns200() async throws {
-        try await withApp(try await makeApp()) { app in
-            // Admin implies instructor — should be granted access.
-            let cookie = try await loginUser(
-                username: "role_admin2", password: "pw",
-                role: "admin", on: app)
-            try await app.asyncTest(
-                .GET, "/__test_instructor",
-                beforeRequest: { req in
-                    req.headers.add(name: .cookie, value: cookie)
-                },
-                afterResponse: { res in
-                    #expect(res.status == .ok)
-                    #expect(res.body.string == "instructor-ok")
                 })
 
         }

--- a/Tests/APITests/SectionRoutesTests.swift
+++ b/Tests/APITests/SectionRoutesTests.swift
@@ -75,6 +75,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor1", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor1", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -110,6 +111,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor2", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor2", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -140,6 +142,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor3", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor3", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -164,6 +167,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor4", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor4", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -223,6 +227,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_ro", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_ro", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             // Reverse the order: C, B, A
@@ -254,6 +259,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_ri", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_ri", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             struct ReorderBody: Content { var sectionIDs: [String] }
@@ -286,6 +292,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_rn", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_rn", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -318,6 +325,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_rne", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_rne", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -342,6 +350,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_rnf", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_rnf", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             let randomID = UUID().uuidString
@@ -373,6 +382,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_del", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_del", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -408,6 +418,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_del2", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_del2", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -444,6 +455,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_mv", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_mv", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             struct MoveBody: Content { var sectionID: String }
@@ -481,6 +493,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_mv2", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_mv2", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             struct MoveBody: Content { var sectionID: String }
@@ -529,6 +542,7 @@ import VaporTesting
             let cookie = try await loginUser(
                 username: "sect_instructor_mv3", password: "pw",
                 role: "instructor", on: app)
+            try await promoteToInstructor("sect_instructor_mv3", on: app)
             let (token, newCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
 
             struct MoveBody: Content { var sectionID: String }

--- a/Tests/APITests/SuiteRouteTests.swift
+++ b/Tests/APITests/SuiteRouteTests.swift
@@ -88,6 +88,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             try await app.asyncTest(
                 .GET, "/instructor/\(id)/suite",
                 beforeRequest: { req in
@@ -108,6 +109,7 @@ import VaporTesting
                 ("publictest_second.py", "passed('2')\n"),
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             try await app.asyncTest(
                 .GET, "/instructor/\(id)/suite",
                 beforeRequest: { req in
@@ -133,6 +135,7 @@ import VaporTesting
                 ("publictest_b.py", "passed('b')\n"),
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             let body = #"""
@@ -177,6 +180,7 @@ import VaporTesting
                 ("publictest_existing.py", "passed('existing body')\n")
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             // Keep the existing script (no content → preserved) and add a
@@ -222,6 +226,7 @@ import VaporTesting
                 ("publictest_a.py", "passed('original body')\n")
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             let body = #"""
@@ -264,6 +269,7 @@ import VaporTesting
                 ("publictest_a.py", "passed('body a')\n")
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             let withHint = #"""
@@ -322,6 +328,7 @@ import VaporTesting
                 ("publictest_followup.py", "passed('ok')\n")
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             // Add a family + a raw script that depends on it.
@@ -385,6 +392,7 @@ import VaporTesting
                 ("publictest_followup.py", "passed('ok')\n")
             ])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             // Add + then remove a family, with a script that had depended on it.
@@ -440,6 +448,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
             let body = #"""
                 {"items":[
@@ -489,6 +498,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             let body = #"""
@@ -546,6 +556,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
             let body = #"""
                 {"items":[
@@ -591,6 +602,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
             let body = #"""
                 {"items":[
@@ -632,6 +644,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             // Step 1: install a notebook check through PUT /suite (the
@@ -717,6 +730,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             // Install a check through PUT /suite (PUT /checks retired v0.4.227).
@@ -773,6 +787,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let id = try await makeAssignment(withScripts: [])
             let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
             let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
 
             let installBody = #"""

--- a/Tests/APITests/SuiteSectionRoutesTests.swift
+++ b/Tests/APITests/SuiteSectionRoutesTests.swift
@@ -91,6 +91,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let (aid, setupID) = try await makeAssignment()
             let cookie = try await loginUser(username: "ssrt_inst1", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst1", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -120,6 +121,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let (aid, _) = try await makeAssignment()
             let cookie = try await loginUser(username: "ssrt_inst2", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst2", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -145,6 +147,7 @@ import VaporTesting
             let sid = UUID().uuidString
             let (aid, setupID) = try await makeAssignment(seedSections: [(sid, "Original")])
             let cookie = try await loginUser(username: "ssrt_inst3", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst3", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -173,6 +176,7 @@ import VaporTesting
         try await withApp(app) { _ in
             let (aid, _) = try await makeAssignment(seedSections: [(UUID().uuidString, "Existing")])
             let cookie = try await loginUser(username: "ssrt_inst4", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst4", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -206,6 +210,7 @@ import VaporTesting
                 ]
             )
             let cookie = try await loginUser(username: "ssrt_inst5", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst5", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -244,6 +249,7 @@ import VaporTesting
                 seedSections: [(sidA, "A"), (sidB, "B"), (sidC, "C")]
             )
             let cookie = try await loginUser(username: "ssrt_inst6", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst6", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(
@@ -273,6 +279,7 @@ import VaporTesting
             let sidB = UUID().uuidString
             let (aid, _) = try await makeAssignment(seedSections: [(sidA, "A"), (sidB, "B")])
             let cookie = try await loginUser(username: "ssrt_inst7", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("ssrt_inst7", on: app)
             let (csrf, sessionCookie) = try await csrfFields(for: "/instructor/\(aid)/edit", cookie: cookie, on: app)
 
             try await app.asyncTest(

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -183,10 +183,18 @@ func enrollAsTestInstructor(
     guard let user = try await APIUser.query(on: app.db).filter(\.$username == username).first()
     else { return }
     let userID = try user.requireID()
-    let exists =
-        try await APICourseEnrollment.query(on: app.db)
-        .filter(\.$userID == userID).filter(\.$course.$id == courseID).first() != nil
-    if !exists {
+    // Upsert to `.instructor` — a `.auto` course auto-enrolls the user at login
+    // and (post role-collapse, #417 Slice G2) seeds a non-admin as a per-course
+    // `.student`, so skipping on "already enrolled" could leave them a student
+    // and 403 the per-course staff gates.
+    if let existing = try await APICourseEnrollment.query(on: app.db)
+        .filter(\.$userID == userID).filter(\.$course.$id == courseID).first()
+    {
+        if existing.role != .instructor {
+            existing.role = .instructor
+            try await existing.save(on: app.db)
+        }
+    } else {
         try await APICourseEnrollment(userID: userID, courseID: courseID, role: .instructor)
             .save(on: app.db)
     }
@@ -575,6 +583,28 @@ func loginUser(
             // Use the new cookie if the session was rotated, otherwise keep the old one.
             if let c = res.headers.first(name: .setCookie) { authCookie = c }
         })
+
+    // Bridge (#417 Slice G2): production auto-enroll at login now seeds a
+    // non-admin — including a legacy `"instructor"` role string — as a per-course
+    // `.student` (teaching authority is per-course; the roster grants staff
+    // explicitly). Many suites create `.auto` courses and rely on an instructor
+    // login being staff in them (the pre-collapse behaviour, e.g. "Creates an
+    // .auto course (auto-enrolls the instructor on login)"). Restore that here
+    // for the legacy `"instructor"` string by upgrading the enrollments the
+    // login just auto-created, so those suites keep passing without a per-test
+    // enrollment. Only touches `.student` rows (the auto-seeded ones); anything
+    // a test enrolls explicitly afterward is untouched.
+    if role == "instructor",
+        let user = try await APIUser.query(on: app.db).filter(\.$username == username).first(),
+        let userID = user.id
+    {
+        for enrollment in try await APICourseEnrollment.query(on: app.db)
+            .filter(\.$userID == userID).all() where enrollment.role == .student
+        {
+            enrollment.role = .instructor
+            try await enrollment.save(on: app.db)
+        }
+    }
     return authCookie
 }
 

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -192,6 +192,23 @@ func enrollAsTestInstructor(
     }
 }
 
+/// Demotes every one of `username`'s course enrollments to `.student` — the
+/// per-course equivalent of the retired "downgrade the global role" move (#417
+/// Slice G2 collapsed the deployment role to user/admin/mcp, so teaching
+/// authority lives on the enrollment). After this the user is staff nowhere, so
+/// MCP content consent / refresh re-authorization (`isStaffAnywhere`) must fail.
+func demoteToStudentEverywhere(username: String, on app: Application) async throws {
+    guard let user = try await APIUser.query(on: app.db).filter(\.$username == username).first()
+    else { return }
+    let userID = try user.requireID()
+    for enrollment in try await APICourseEnrollment.query(on: app.db)
+        .filter(\.$userID == userID).all()
+    {
+        enrollment.role = .student
+        try await enrollment.save(on: app.db)
+    }
+}
+
 // MARK: - Async app lifecycle
 
 /// Runs an async test body with a Vapor application and always shuts it down.

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -583,29 +583,27 @@ func loginUser(
             // Use the new cookie if the session was rotated, otherwise keep the old one.
             if let c = res.headers.first(name: .setCookie) { authCookie = c }
         })
-
-    // Bridge (#417 Slice G2): production auto-enroll at login now seeds a
-    // non-admin — including a legacy `"instructor"` role string — as a per-course
-    // `.student` (teaching authority is per-course; the roster grants staff
-    // explicitly). Many suites create `.auto` courses and rely on an instructor
-    // login being staff in them (the pre-collapse behaviour, e.g. "Creates an
-    // .auto course (auto-enrolls the instructor on login)"). Restore that here
-    // for the legacy `"instructor"` string by upgrading the enrollments the
-    // login just auto-created, so those suites keep passing without a per-test
-    // enrollment. Only touches `.student` rows (the auto-seeded ones); anything
-    // a test enrolls explicitly afterward is untouched.
-    if role == "instructor",
-        let user = try await APIUser.query(on: app.db).filter(\.$username == username).first(),
-        let userID = user.id
-    {
-        for enrollment in try await APICourseEnrollment.query(on: app.db)
-            .filter(\.$userID == userID).all() where enrollment.role == .student
-        {
-            enrollment.role = .instructor
-            try await enrollment.save(on: app.db)
-        }
-    }
     return authCookie
+}
+
+/// Explicit-roster promotion: an admin promotes an already-enrolled user to a
+/// per-course instructor. Teaching authority is per-course now (#417 Slice G2):
+/// login auto-enrolls a non-admin as a `.student` and there is NO auto-grant, so
+/// suites whose `.auto` fixtures used to rely on "auto-enroll the instructor on
+/// login" call this after `loginUser(role: "instructor")` to simulate the admin
+/// promotion. Upgrades every `.student` enrollment the user holds to
+/// `.instructor` (a fresh test instructor's only enrollments are the ones login
+/// just auto-created); anything enrolled explicitly at another role is untouched.
+func promoteToInstructor(_ username: String, on app: Application) async throws {
+    guard let user = try await APIUser.query(on: app.db).filter(\.$username == username).first(),
+        let userID = user.id
+    else { return }
+    for enrollment in try await APICourseEnrollment.query(on: app.db)
+        .filter(\.$userID == userID).all() where enrollment.role == .student
+    {
+        enrollment.role = .instructor
+        try await enrollment.save(on: app.db)
+    }
 }
 
 /// Wraps a runtime skip-or-fail condition as a throwable error.  Use

--- a/Tests/APITests/WebRoutesBadgeTests.swift
+++ b/Tests/APITests/WebRoutesBadgeTests.swift
@@ -94,6 +94,12 @@ import VaporTesting
             )
             try await student.save(on: app.db)
 
+            // Class badges gate on the per-course enrollment role now (#417 Slice
+            // G2): enrol each in the setup's course (CS101). The global role seeds
+            // the per-course role — admin/instructor become staff (no badge), the
+            // student becomes a per-course `.student` (earns badges).
+            for user in [admin, instructor, student] { try await wrEnrollUser(user, on: app) }
+
             // Admin call — must persist no badges.
             try await awardClassBadgesFor100Percent(
                 testSetupID: "setup_100_gate",

--- a/Tests/APITests/WebRoutesHelpers.swift
+++ b/Tests/APITests/WebRoutesHelpers.swift
@@ -65,7 +65,10 @@ func wrEnrollUser(_ user: APIUser, on app: Application) async throws {
         // Seed the per-course role from the global role, mirroring production
         // (saveSeededEnrollment), so a global-instructor caller becomes a
         // per-course instructor — Phase 5 made instructor authority per-course.
-        let role: CourseRole = user.isInstructor ? .instructor : .student
+        // The global `instructor` UserRole case is gone (#417 Slice G2); a
+        // legacy `"instructor"` role string or an admin seeds to instructor.
+        let isStaff = (user.role == "instructor") || user.isAdmin
+        let role: CourseRole = isStaff ? .instructor : .student
         let enrollment = APICourseEnrollment(userID: userID, courseID: courseID, role: role)
         try await enrollment.save(on: app.db)
     }

--- a/changelog.d/417-collapse-remove-legacy-roles.md
+++ b/changelog.d/417-collapse-remove-legacy-roles.md
@@ -1,0 +1,15 @@
+### Removed
+
+- **Retired the deprecated global `student` / `instructor` user roles (#417).**
+  The deployment role enum is now `user` / `admin` / `mcp` only; teaching
+  authority lives entirely on the per-course enrollment (`CourseRole`). The
+  transitional `APIUser.isInstructor` shim and the `RoleMiddleware(.instructor)`
+  tier are gone — the `CourseAccessHelpers` per-course chokepoints
+  (`requireCourseRole`, `isCourseStaff`, `isStaffAnywhere`) are the sole
+  authority. MCP consent/eligibility (`ToolContext.requireEligibleSubject`,
+  the OAuth content surface's `permits`) now key off `isStaffAnywhere`, and
+  auto-enrollment (`saveSeededEnrollment`) seeds a per-course instructor only
+  for admins; every other account auto-enrolls as a student and the roster
+  grants staff explicitly. Production DBs that still carry the legacy role
+  strings decode them as ordinary non-admin users, and the `CollapseUserRoles`
+  migration rewrites them to `user`.


### PR DESCRIPTION
## Summary

Final #417 follow-up: removes the deprecated deployment-global `student` /
`instructor` roles now that teaching authority lives entirely on the per-course
enrollment (`CourseRole`). The deployment `UserRole` enum is now `user` /
`admin` / `mcp` only.

Removed:
- `APIUser.isInstructor` (the transitional shim) and the
  `CurrentUserContext.isInstructor` field.
- The `RoleMiddleware(required: .instructor)` tier — teaching authority is
  per-course, enforced by the `CourseAccessHelpers` chokepoints
  (`requireCourseRole`, `isCourseStaff`, `isStaffAnywhere`), not a
  deployment-global middleware.
- The two MCP compatibility shims added in G1/G2:
  `ToolContext.requireEligibleSubject` and the OAuth content surface's
  `permits` now key off `isStaffAnywhere` alone.

Behaviour changes:
- `saveSeededEnrollment` seeds a per-course instructor **only for admins**;
  every other account auto-enrolls as a student and the roster grants staff
  explicitly. (In the post-collapse model no human holds a global instructor
  role, so this is a no-op in production.)
- `AddCourseEnrollmentRole`'s backfill matches the legacy role strings
  (`"instructor"` / `"admin"`) as raw values (the enum cases are gone), and
  `CollapseUserRoles` rewrites legacy `"student"` / `"instructor"` rows to
  `"user"` via literal string matches. Production DBs still carrying those
  legacy strings decode them as ordinary non-admin users.

## Test changes

- A test-local `LegacyGlobalRole` shim keeps the role-model unit tests compiling
  without a mass corpus rewrite; its `.rawValue` is faithful to the retired
  strings.
- MCP OAuth flow tests enrol `prof` as per-course staff (the content-consent
  gate is `isStaffAnywhere` now), and the two role-downgrade tests demote the
  per-course enrollment (`demoteToStudentEverywhere`) instead of the global
  role.
- `RoleMiddlewareTests` drops the obsolete `.instructor` tier and its
  tier-specific cases; the `.authenticated` / `.admin` coverage is unchanged.
- Enrollment-seeding unit test updated to assert the new "admins seed to
  instructor, legacy-instructor strings seed to student" semantics.

## Notes

- No `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` edits — a `changelog.d/`
  fragment is included per the release process.
- Local build unavailable in this environment (org egress policy blocks
  SwiftPM dependency clones); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AipZH25f7z1cgscaLfo9vu)_