### PR TITLE
Rework top nav with dropdown menus

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -90,3 +90,47 @@ if (root) {
         }, 2000);
     }
 }
+
+// ── Nav dropdown menus ─────────────────────────────────────────────────────
+// Click-to-open menus for nav items that carry more than one option (the
+// Instructor course picker, the account/log-out menu).  Each is a
+// [data-nav-dropdown] wrapper holding a .nav-dropdown-toggle button and a
+// .nav-dropdown-menu panel.  Only one menu is open at a time; a click outside
+// or Escape closes it.
+(function navDropdowns() {
+    const dropdowns = Array.from(document.querySelectorAll('[data-nav-dropdown]'));
+    if (dropdowns.length === 0) return;
+
+    function closeAll(except) {
+        dropdowns.forEach((dd) => {
+            if (dd === except) return;
+            dd.classList.remove('open');
+            const t = dd.querySelector('.nav-dropdown-toggle');
+            if (t) t.setAttribute('aria-expanded', 'false');
+        });
+    }
+
+    dropdowns.forEach((dd) => {
+        const toggle = dd.querySelector('.nav-dropdown-toggle');
+        if (!toggle) return;
+        toggle.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const willOpen = !dd.classList.contains('open');
+            closeAll(dd);
+            dd.classList.toggle('open', willOpen);
+            toggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+        });
+    });
+
+    // Outside click closes any open menu.  Clicks inside a menu (e.g. the
+    // account link, or a submitting course-picker button) are left alone.
+    document.addEventListener('click', (e) => {
+        if (e.target.closest('[data-nav-dropdown]')) return;
+        closeAll(null);
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeAll(null);
+    });
+}());

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -824,12 +824,102 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
 
 /* ── Nav username + logout button ────────────────────── */
 
-/* Also applied alongside .nav-link on the account <a>; color intentionally
+/* Applied alongside .nav-link on the account-menu toggle; color intentionally
    overrides nav-link's white — username appears dimmed, less prominent than nav actions. */
 .nav-username {
     font-size: .875rem;
     color: rgba(255,255,255,.6);
+}
+
+/* ── Nav dropdown menus ──────────────────────────────── */
+
+/* A nav item with more than one option (the Instructor course picker, the
+   account/log-out menu) renders as a click-to-open dropdown.  Toggled by the
+   `open` class from app.js; the menu is display:none until then, so no inline
+   style is needed and check-styles stays green. */
+.nav-dropdown {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+/* The account menu sits at the far right of the nav, where the bare username
+   link used to. */
+.nav-user {
     margin-left: auto;
+}
+
+.nav-dropdown-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.nav-dropdown-caret {
+    font-size: .65em;
+    line-height: 1;
+    transition: transform .12s ease;
+}
+
+.nav-dropdown.open .nav-dropdown-caret {
+    transform: rotate(180deg);
+}
+
+.nav-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + .55rem);
+    left: 0;
+    min-width: 11rem;
+    background: var(--surface);
+    border: 1px solid var(--gray-200);
+    border-radius: 8px;
+    box-shadow: 0 6px 20px rgba(0,0,0,.22);
+    padding: .3rem;
+    z-index: 50;
+}
+
+/* The account menu is flush to the right edge of the nav, so its panel opens
+   rightward-aligned to avoid spilling off-screen. */
+.nav-user .nav-dropdown-menu {
+    left: auto;
+    right: 0;
+}
+
+.nav-dropdown.open .nav-dropdown-menu {
+    display: block;
+}
+
+.nav-dropdown-item {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: left;
+    padding: .5rem .7rem;
+    font-size: .875rem;
+    font-family: inherit;
+    color: var(--gray-700);
+    text-decoration: none;
+    background: none;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.nav-dropdown-item:hover {
+    background: var(--hover-bg);
+    color: var(--gray-900);
+}
+
+.nav-dropdown-item-active {
+    color: var(--blue);
+    font-weight: 600;
 }
 
 /* ── Course tabs ─────────────────────────────────────── */
@@ -841,23 +931,6 @@ code { font-family: ui-monospace, monospace; font-size: .9em; }
     background: var(--surface);
     border-bottom: 2px solid var(--gray-200);
     overflow-x: auto;
-}
-
-/* Instructor course strip: a second .course-tabs row, set on the muted
-   surface and led by a label so it reads as distinct from the (white) student
-   course strip when both are shown. */
-.course-tabs-instructor {
-    background: var(--gray-50);
-}
-
-.course-tabs-label {
-    display: inline-flex;
-    align-items: center;
-    padding: .5rem .85rem .5rem 0;
-    font-size: .8125rem;
-    font-weight: 600;
-    color: var(--gray-600);
-    white-space: nowrap;
 }
 
 .course-tab {
@@ -1868,7 +1941,7 @@ tr.drop-adopt  { outline: 2px solid var(--blue); outline-offset: -2px; }
        viewport; the account/username link sits inline rather than being
        pushed to the far right. */
     .nav { flex-wrap: wrap; row-gap: .35rem; column-gap: 1.1rem; }
-    .nav-username { margin-left: 0; }
+    .nav-user { margin-left: 0; }
 
     /* Allow long assignment titles to wrap inside their flex cell rather than
        forcing the table (and page) wider than the screen. */

--- a/Resources/Views/base.leaf
+++ b/Resources/Views/base.leaf
@@ -42,23 +42,55 @@
                 <input type="hidden" name="next" value="/instructor">
                 <button class="btn-link nav-link" type="submit">Instructor</button>
             </form>
+        #elseif(currentUser.showInstructorTabs):
+            <!-- More than one taught course: an Instructor menu whose items each
+                 POST to /activate with next=/instructor, so picking a course both
+                 switches the active course and lands on its instructor view. -->
+            <div class="nav-dropdown" data-nav-dropdown>
+                <button type="button" class="nav-link nav-dropdown-toggle"
+                        aria-haspopup="true" aria-expanded="false">
+                    <span>Instructor</span>
+                    <span class="nav-dropdown-caret" aria-hidden="true">▾</span>
+                </button>
+                <div class="nav-dropdown-menu" role="menu">
+                    #for(course in currentUser.instructorCourses):
+                    <form method="post" action="/courses/#(course.id)/activate" class="contents-form">
+                        #csrfFormField()
+                        <input type="hidden" name="next" value="/instructor">
+                        <button type="submit" role="menuitem"
+                                class="nav-dropdown-item #if(course.isActive):nav-dropdown-item-active#endif">
+                            #(course.code) — #(course.name)
+                        </button>
+                    </form>
+                    #endfor
+                </div>
+            </div>
         #endif
         #if(currentUser.isAdmin):
             <a class="nav-link" href="/admin">Admin</a>
         #endif
-        <a class="nav-link nav-username" href="/account" aria-label="My account">
-            #if(currentUser.preferredName):
-                #(currentUser.preferredName)
-            #elseif(currentUser.displayName):
-                #(currentUser.displayName)
-            #else:
-                #(currentUser.username)
-            #endif
-        </a>
-        <form method="post" action="/logout" class="inline-form">
-            #csrfFormField()
-            <button class="btn-link nav-link" type="submit">Log out</button>
-        </form>
+        <div class="nav-dropdown nav-user" data-nav-dropdown>
+            <button type="button" class="nav-link nav-username nav-dropdown-toggle"
+                    aria-haspopup="true" aria-expanded="false" aria-label="Account menu">
+                <span>
+                    #if(currentUser.preferredName):
+                        #(currentUser.preferredName)
+                    #elseif(currentUser.displayName):
+                        #(currentUser.displayName)
+                    #else:
+                        #(currentUser.username)
+                    #endif
+                </span>
+                <span class="nav-dropdown-caret" aria-hidden="true">▾</span>
+            </button>
+            <div class="nav-dropdown-menu" role="menu">
+                <a class="nav-dropdown-item" href="/account" role="menuitem">Account</a>
+                <form method="post" action="/logout" class="contents-form">
+                    #csrfFormField()
+                    <button class="nav-dropdown-item" type="submit" role="menuitem">Log out</button>
+                </form>
+            </div>
+        </div>
     #else:
         <a class="nav-link" href="/login">Log in</a>
     #endif
@@ -72,24 +104,6 @@
         <button type="submit"
                 class="course-tab #if(course.isActive):course-tab-active#endif"
                 aria-current="#if(course.isActive):page#else:false#endif">
-            #(course.code)
-        </button>
-    </form>
-    #endfor
-</nav>
-#endif
-#if(currentUser && currentUser.showInstructorTabs):
-<!-- More than one taught course: a dedicated strip of direct links into each
-     course's instructor view.  Each chip POSTs to /activate with next=/instructor
-     so it both switches the active course and lands on its instructor dashboard. -->
-<nav class="course-tabs course-tabs-instructor" aria-label="Instructor courses">
-    <span class="course-tabs-label">Instructor</span>
-    #for(course in currentUser.instructorCourses):
-    <form method="post" action="/courses/#(course.id)/activate" class="contents-form">
-        #csrfFormField()
-        <input type="hidden" name="next" value="/instructor">
-        <button type="submit"
-                class="course-tab #if(course.isActive):course-tab-active#endif">
             #(course.code)
         </button>
     </form>

--- a/changelog.d/top-nav-dropdowns.md
+++ b/changelog.d/top-nav-dropdowns.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **Top-nav dropdown menus.** Nav items that carry more than one option now
+  open a click-to-open dropdown instead of a separate strip. An instructor who
+  teaches more than one course gets a single **Instructor** menu that lists each
+  course (picking one switches the active course and lands on its instructor
+  view), replacing the second course-tab row. The username and **Log out** entries
+  are bundled into one account menu that shows the person's name and drops down
+  to **Account** and **Log out**. Single-course instructors keep their direct
+  Instructor link; the student course-tab strip is unchanged. Menus close on an
+  outside click or Escape and are keyboard/`aria`-annotated.


### PR DESCRIPTION
## Summary

Reworks the top nav bar so that items carrying more than one option open a click-to-open dropdown, and folds the account/log-out actions into a single named menu.

- **Instructor menu.** When the user teaches more than one course, the nav now shows a single **Instructor** dropdown listing each course (`code — name`, active one highlighted). Picking a course POSTs to `/courses/:id/activate` with `next=/instructor`, so it both switches the active course and lands on that course's instructor view — the same behaviour the old second course-tab strip had. Single-course instructors keep their existing direct **Instructor** link unchanged.
- **Account menu.** The dimmed username link and the **Log out** button are bundled into one account dropdown that shows the person's name and drops down to **Account** (link to `/account`) and **Log out** (the existing POST form).
- Removed the now-redundant `course-tabs-instructor` strip (and its dead `.course-tabs-instructor` / `.course-tabs-label` CSS). The student enrolled-course tab strip is unchanged.

## Implementation

- `Resources/Views/base.leaf` — new dropdown markup for the Instructor and account menus; strip block removed.
- `Public/styles.css` — shared `.nav-dropdown*` styles (menu on `--surface`, toggle caret, active-item highlight); `.nav-user` carries the far-right `margin-left:auto` the username link used to.
- `Public/app.js` — `navDropdowns()` toggles menus (one open at a time, close on outside click / Escape) and keeps `aria-expanded` in sync.
- Menus are `role="menu"` / `aria-haspopup` / `aria-label` annotated; toggles are `<button type="button">` so they never submit a form.

## Testing

- `swift build` passes.
- `scripts/check-styles.sh` passes (no inline styles, all CSS vars resolve, no duplicated selectors).
- `node --check Public/app.js` passes.
- The existing single-course Instructor render assertions (`>Instructor</button>`, `value="/instructor"`) are preserved. Full test suite runs in CI (test-only dependencies can't be fetched in this sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKazk9YM1HWJYXcBQtdhPX)_