### PR TITLE
Add shrink-only ratchet on inline template &lt;script&gt; lines

### DIFF
--- a/changelog.d/inline-script-ratchet.md
+++ b/changelog.d/inline-script-ratchet.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Inline `<script>` ratchet (#1135).** Total non-blank JS lines inside
+  template `<script>` blocks (2,481 today) may only shrink —
+  `check-styles.sh` fails CI if the count grows. Inline template JS is
+  invisible to ESLint/CodeQL/tests and keeps the CSP permissive; new page
+  behaviour goes in `Public/*.js`, with the template passing data via
+  `data-*` attributes or a JSON island (pattern documented in
+  `docs/ui-design.md`).

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -117,6 +117,21 @@ If two pages need the same rule, it belongs in `Public/styles.css`, not
 copied into both `<style>` blocks — the duplicate-selector guard fails CI on
 copies.
 
+## Page-local scripts
+
+Page behaviour belongs in a **`Public/*.js` file**, loaded with
+`<script src>` — there it is ESLint-checked and unit-testable
+(`Tests/BrowserRunnerJSTests`).  Inline `<script>` blocks in templates are
+invisible to every tool (ESLint can't parse Leaf-interpolated JS) and are
+why the CSP still allows inline script, so their total size is a
+**shrink-only ratchet** (`INLINE_SCRIPT_BASELINE` in
+`scripts/check-styles.sh`): new inline lines fail CI.
+
+The extraction pattern: the template carries page data — `data-*`
+attributes or a `<script type="application/json">` island — and the
+external file reads it.  When you shrink or extract a block, lower the
+baseline in the same PR.
+
 ## Page-local styles
 
 A page `<style>` block is for styling that genuinely exists on one page only.

--- a/scripts/check-styles.sh
+++ b/scripts/check-styles.sh
@@ -78,6 +78,35 @@ elif [ "$alert_count" -lt "$ALERT_BASELINE" ]; then
   echo "note: alert() count dropped to ${alert_count}; lower ALERT_BASELINE in scripts/check-styles.sh."
 fi
 
+# ── 3b. Inline <script> line-count ratchet (#1135) ───────────────────────────
+# JS inside a template <script> block is invisible to every tool — ESLint
+# can't parse Leaf-interpolated JS, CodeQL skips it, node --check can't run
+# it — and it's why the CSP still allows inline script.  New page behaviour
+# belongs in a lintable Public/*.js file (template carries data via data-*
+# attributes or a JSON island).  Baseline = total non-blank lines inside
+# <script> bodies across all templates; it may only go DOWN.  <script src=…>
+# includes and single-line <script>…</script> elements don't count.
+INLINE_SCRIPT_BASELINE=2481
+inline_script_count="$(
+  awk '
+    /<script[^>]*src=/ { next }
+    /<script>/ && /<\/script>/ { next }
+    /<script/ { inscript = 1; next }
+    /<\/script>/ { inscript = 0; next }
+    inscript && NF > 0 { n++ }
+    END { print n + 0 }
+  ' "${views[@]}"
+)"
+if [ "$inline_script_count" -gt "$INLINE_SCRIPT_BASELINE" ]; then
+  status=1
+  echo "ERROR: inline <script> grew (${inline_script_count} lines, baseline ${INLINE_SCRIPT_BASELINE})."
+  echo "       Put new page JS in a Public/*.js file (loaded with <script src>)"
+  echo "       so it is linted and testable; pass page data via data-* attributes"
+  echo "       or a JSON island.  See docs/ui-design.md."
+elif [ "$inline_script_count" -lt "$INLINE_SCRIPT_BASELINE" ]; then
+  echo "note: inline <script> lines dropped to ${inline_script_count}; lower INLINE_SCRIPT_BASELINE in scripts/check-styles.sh."
+fi
+
 # ── 4. No duplicated / shadowed selectors in page <style> blocks ─────────────
 # Page-local <style> blocks should only define page-unique classes.  Two
 # regressions the cleanup removed (and that render fine, so no test catches):


### PR DESCRIPTION
Closes #1135.

## What this does

Caps the ~2,481 non-blank lines of JavaScript living inside template `<script>` blocks with a shrink-only ratchet in `scripts/check-styles.sh` (same mechanism as the `alert()` baseline). Inline template JS is invisible to every tool the repo now runs — ESLint can't parse Leaf-interpolated JS (#1138), CodeQL skips it, `node --test` can't reach it — and it's the reason the CSP still allows inline script.

- New section 3b in `check-styles.sh`: counts non-blank lines inside `<script>` bodies across `Resources/Views/*.leaf`, excluding `<script src>` includes and single-line elements. Growth fails CI (`format-lint` job); shrinking prints the lower-the-baseline note.
- `docs/ui-design.md` gains a "Page-local scripts" section documenting the rule and the extraction pattern: page data via `data-*` attributes or a JSON island, behaviour in a lintable `Public/*.js` file.
- Actual extraction of the existing 2,481 lines happens incrementally in future PRs (biggest blocks: `assignment-new.leaf` ~615, `admin.leaf` ~430, `assignments.leaf` ~339); this PR makes the direction one-way.

## Validation

- `scripts/check-styles.sh` green on the current tree.
- Mutation-tested: an injected two-line inline `<script>` fails the guard with the pointer to the extraction pattern; a one-line shrink triggers the baseline note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWF6xB56TLy2MpiF6zxX7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWF6xB56TLy2MpiF6zxX7A)_