### PR TITLE
Accessibility ratchet: axe-core scan on key pages in CI

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -4,7 +4,9 @@ name: Visual regression
 # results, instructor list, admin) in BOTH colour schemes against committed
 # baselines (Tools/visual-regression/baselines/), failing on visual drift the
 # static token guards can't see — the "looks right" gap in docs/ui-design.md.
-# Issue #1136.
+# Issue #1136.  The same job then runs the axe-core accessibility scan over
+# the same pages (#1137): critical/serious violations are zero-tolerance,
+# moderate/minor ratchet down against a11y-baseline.json.
 #
 # NOT a required check (unlike editor-smoke-gate), so it is path-filtered at
 # the trigger: a skipped run can't block merges.  Chromium only — one
@@ -81,6 +83,10 @@ jobs:
       - name: Capture and compare
         working-directory: Tools/visual-regression
         run: ./run-visual.sh
+
+      - name: Accessibility scan (axe-core)
+        working-directory: Tools/visual-regression
+        run: ./run-a11y.sh
 
       - name: Upload visual diffs
         if: failure()

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1541,7 +1541,10 @@ code { font-family: var(--font-mono); font-size: .9em; }
 }
 .diagnostic-window-chip {
     font-weight: 600;
-    color: var(--health-teal-dark);
+    /* --blue, not raw --health-teal-dark: identical in light mode, but the
+       raw palette entry has no dark value — 1.9:1 on dark cards (axe
+       serious).  --blue carries the readable dark-mode teal (8.3:1). */
+    color: var(--blue);
 }
 .diagnostic-spark {
     display: flex;

--- a/Tools/visual-regression/README.md
+++ b/Tools/visual-regression/README.md
@@ -41,6 +41,15 @@ baseline image diff becomes part of code review. If no baselines are
 committed at all, the harness runs in bootstrap mode: captures are saved
 (uploaded in CI as `visual-baselines-bootstrap`) and the run passes.
 
+## Accessibility scan (#1137)
+
+`./run-a11y.sh` runs axe-core over the same seeded pages in both schemes
+(`a11y.mjs`; the CI job runs it after the visual compare).  Critical and
+serious violations always fail; moderate/minor are a shrink-only count
+ratchet against `a11y-baseline.json` (growth fails, shrinkage prints the
+lower-the-baseline note).  With no baseline committed it bootstraps the
+same way the visual harness does.
+
 ## Determinism
 
 Fixed 1280×900 viewport, `deviceScaleFactor: 1`, `en-CA` /

--- a/Tools/visual-regression/README.md
+++ b/Tools/visual-regression/README.md
@@ -57,7 +57,16 @@ Fixed 1280×900 viewport, `deviceScaleFactor: 1`, `en-CA` /
 disabled, and dynamic regions masked (`.js-relative-time`,
 `.admin-version-banner`, `canvas`). Comparison is anti-aliasing-aware
 (`pixelmatch`, threshold .15) with a 0.1 % differing-pixel budget — sub-pixel
-font drift passes, palette/layout changes fail. Baselines are
+font drift passes, palette/layout changes fail.
+
+**Sensitivity floor:** the 0.1 % budget (~1,150 px at 1280×900) is sized to
+absorb cross-runner anti-aliasing drift (~500 px observed on the busiest
+page). Component-scale changes (banners, cards, backgrounds) far exceed it;
+a recolour confined to a few words of small text can fit under it — the
+dark-mode chip-contrast fix on the dashboards moved only ~356 px and
+passed. That class is exactly what the axe-core scan catches (contrast is
+checked computationally, not by pixels), which is why the two checks run
+together. Baselines are
 **CI-canonical**: regenerate them in the CI image (or trust the bootstrap
 artifact) rather than committing captures from a host with different font
 rendering.

--- a/Tools/visual-regression/a11y-baseline.json
+++ b/Tools/visual-regression/a11y-baseline.json
@@ -1,0 +1,3 @@
+{
+  "moderateMinor": 6
+}

--- a/Tools/visual-regression/a11y.mjs
+++ b/Tools/visual-regression/a11y.mjs
@@ -1,0 +1,120 @@
+// a11y.mjs — axe-core accessibility scan of the key pages (#1137).
+//
+//   node a11y.mjs <baseURL>
+//
+// Scans the same seeded pages as the visual harness, in BOTH colour schemes
+// (contrast violations are usually scheme-specific — the dark-mode banner
+// bugs fixed in #1133 were exactly this class).  Policy:
+//
+//   * critical / serious violations — zero tolerance, always fail;
+//   * moderate / minor violations — shrink-only ratchet against the count in
+//     a11y-baseline.json.  Growth fails; shrinkage prints the
+//     lower-the-baseline note (mirrors the alert() / inline-script ratchets).
+//
+// With no a11y-baseline.json committed the scan runs in bootstrap mode: it
+// reports everything, writes a suggested baseline into visual-bootstrap/ for
+// the CI artifact, and exits 0 — committing the file flips it to enforcing.
+import { chromium } from "playwright";
+import { AxeBuilder } from "@axe-core/playwright";
+import fs from "node:fs";
+import path from "node:path";
+import { seed } from "./seed.mjs";
+
+const baseURL = process.argv[2];
+if (!baseURL) {
+  console.error("usage: node a11y.mjs <baseURL>");
+  process.exit(2);
+}
+const toolDir = path.dirname(new URL(import.meta.url).pathname);
+const baselinePath = path.join(toolDir, "a11y-baseline.json");
+const repoRoot = path.resolve(toolDir, "..", "..");
+
+async function main() {
+  console.log(`Seeding fixture data via ${baseURL} …`);
+  const { setupID, instructorState, studentState, resultsPath } = await seed(baseURL);
+
+  const PAGES = [
+    { name: "login", path: "/login", state: null },
+    { name: "student-dashboard", path: "/", state: studentState },
+    { name: "student-submit", path: `/testsetups/${setupID}/submit`, state: studentState },
+    { name: "instructor-assignments", path: "/instructor", state: instructorState },
+    { name: "admin-dashboard", path: "/admin", state: instructorState },
+    { name: "submission-pending", path: resultsPath, state: studentState },
+  ];
+
+  const browser = await chromium.launch();
+  const hard = [];   // critical + serious
+  const soft = [];   // moderate + minor
+  for (const scheme of ["light", "dark"]) {
+    for (const p of PAGES) {
+      const context = await browser.newContext({
+        baseURL,
+        colorScheme: scheme,
+        viewport: { width: 1280, height: 900 },
+        storageState: p.state || undefined,
+      });
+      const page = await context.newPage();
+      await page.goto(p.path, { waitUntil: "networkidle", timeout: 30_000 });
+      const results = await new AxeBuilder({ page }).analyze();
+      for (const v of results.violations) {
+        const entry = {
+          page: `${p.name}--${scheme}`,
+          rule: v.id,
+          impact: v.impact || "unknown",
+          help: v.help,
+          nodes: v.nodes.slice(0, 5).map((n) => n.target.join(" ")),
+          nodeCount: v.nodes.length,
+        };
+        if (v.impact === "critical" || v.impact === "serious") hard.push(entry);
+        else soft.push(entry);
+      }
+      await context.close();
+      console.log(`scanned ${p.name}--${scheme}`);
+    }
+  }
+  await browser.close();
+
+  const describe = (e) =>
+    `  [${e.impact}] ${e.page}: ${e.rule} — ${e.help} (${e.nodeCount} node(s): ${e.nodes.join(", ")})`;
+
+  if (hard.length > 0) {
+    console.error(`\n${hard.length} critical/serious accessibility violation(s):`);
+    console.error(hard.map(describe).join("\n"));
+  }
+  if (soft.length > 0) {
+    console.log(`\n${soft.length} moderate/minor violation(s):`);
+    console.log(soft.map(describe).join("\n"));
+  }
+
+  if (!fs.existsSync(baselinePath)) {
+    // Bootstrap: surface everything, suggest a baseline, pass.
+    const suggested = { moderateMinor: soft.length };
+    const outDir = path.join(repoRoot, "visual-bootstrap");
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(path.join(outDir, "a11y-baseline.json"), JSON.stringify(suggested, null, 2) + "\n");
+    console.log(`\na11y: NO BASELINE COMMITTED — suggested a11y-baseline.json written to visual-bootstrap/.`);
+    console.log(`      critical/serious found: ${hard.length} (these must be FIXED, not baselined).`);
+    process.exit(0);
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+  let failed = false;
+  if (hard.length > 0) {
+    console.error("\ncritical/serious violations are zero-tolerance — fix them (see above).");
+    failed = true;
+  }
+  if (soft.length > baseline.moderateMinor) {
+    console.error(`\nmoderate/minor count grew: ${soft.length} > baseline ${baseline.moderateMinor}.`);
+    console.error("Fix the new violation or, if pre-existing count shifted, justify in the PR.");
+    failed = true;
+  } else if (soft.length < baseline.moderateMinor) {
+    console.log(`\nnote: moderate/minor count dropped to ${soft.length}; lower a11y-baseline.json.`);
+  }
+  if (failed) process.exit(1);
+  console.log("\na11y: OK (no critical/serious; moderate/minor within baseline)");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/Tools/visual-regression/capture.mjs
+++ b/Tools/visual-regression/capture.mjs
@@ -16,10 +16,10 @@
 //   * animations, transitions, and carets disabled;
 //   * dynamic regions (relative timestamps, version banner, canvas charts)
 //     masked with a solid box via Playwright's screenshot mask.
-import { chromium, request as pwRequest } from "playwright";
-import JSZip from "jszip";
+import { chromium } from "playwright";
 import fs from "node:fs";
 import path from "node:path";
+import { seed } from "./seed.mjs";
 
 const baseURL = process.argv[2];
 const outDir = process.argv[3];
@@ -28,10 +28,6 @@ if (!baseURL || !outDir) {
   process.exit(2);
 }
 fs.mkdirSync(outDir, { recursive: true });
-
-const INSTRUCTOR = { username: "vis_instructor", password: "vis-instructor-pass-1" };
-const STUDENT = { username: "vis_student", password: "vis-student-pass-1" };
-const COURSE = { code: "VIS101", name: "Visual Regression 101" };
 
 // Selectors hidden from every screenshot: content that legitimately differs
 // run-to-run.  Keep this list SHORT — every mask is a blind spot.
@@ -42,154 +38,11 @@ const MASKS = [
   "canvas",                // sparkline charts draw async
 ];
 
-// ---------------------------------------------------------------------------
-// Seeding over the real HTTP API (register / course / setup / student).
-function extractCsrf(html) {
-  let m = html.match(/name=['"]_csrf['"][^>]*\svalue=['"]([^'"]+)['"]/i);
-  if (m) return m[1];
-  m = html.match(/\svalue=['"]([^'"]+)['"][^>]*name=['"]_csrf['"]/i);
-  if (m) return m[1];
-  m = html.match(/<meta\s+name=['"]csrf-token['"]\s+content=['"]([^'"]+)['"]/i);
-  if (m) return m[1];
-  return null;
-}
-
-async function csrfFrom(ctx, p) {
-  const res = await ctx.get(p);
-  const token = extractCsrf(await res.text());
-  if (!token) throw new Error(`could not find CSRF token on ${p} (status ${res.status()})`);
-  return token;
-}
-
-async function expectOK(label, resPromise, okStatuses) {
-  const res = await resPromise;
-  if (!okStatuses.includes(res.status())) {
-    let body = "";
-    try { body = (await res.text()).slice(0, 400); } catch { /* ignore */ }
-    throw new Error(`${label}: unexpected status ${res.status()} (wanted ${okStatuses.join("/")})\n${body}`);
-  }
-  return res;
-}
-
-async function buildSetupZip() {
-  const zip = new JSZip();
-  zip.file(
-    "assignment.ipynb",
-    JSON.stringify({
-      nbformat: 4,
-      nbformat_minor: 5,
-      metadata: { kernelspec: { name: "python", display_name: "Python" } },
-      cells: [
-        { cell_type: "code", source: ["x = 1\n"], metadata: {}, outputs: [], execution_count: null },
-      ],
-    })
-  );
-  zip.file("test_public.py", 'print("public test ok")\n');
-  return zip.generateAsync({ type: "nodebuffer" });
-}
-
-// Worker-graded on purpose: no runner is attached, so a submission stays
-// "pending" forever — a deterministic results page.
-const MANIFEST = JSON.stringify({
-  schemaVersion: 1,
-  requiredFiles: [],
-  testSuites: [{ tier: "public", script: "test_public.py" }],
-  timeLimitSeconds: 10,
-  makefile: null,
-});
-
-async function seed() {
-  const instr = await pwRequest.newContext({ baseURL });
-  let csrf = await csrfFrom(instr, "/register");
-  await expectOK(
-    "register instructor",
-    instr.post("/register", { form: { username: INSTRUCTOR.username, password: INSTRUCTOR.password, _csrf: csrf }, maxRedirects: 0 }),
-    [200, 302, 303]
-  );
-
-  csrf = await csrfFrom(instr, "/admin/courses/new");
-  const courseRes = await expectOK(
-    "create course",
-    instr.post("/admin/courses", { form: { code: COURSE.code, name: COURSE.name, _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
-    [302, 303]
-  );
-  const loc = courseRes.headers()["location"] || "";
-  const courseID = (loc.match(/\/admin\/courses\/([0-9a-fA-F-]{36})/) || [])[1];
-  if (!courseID) throw new Error(`could not parse courseID from redirect: "${loc}"`);
-  await expectOK(
-    "set enrollment auto",
-    instr.post(`/courses/${courseID}/enrollment-mode`, { form: { enrollmentMode: "auto", _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
-    [302, 303]
-  );
-
-  const zipBuf = await buildSetupZip();
-  csrf = await csrfFrom(instr, "/");
-  const setupRes = await expectOK(
-    "upload test setup",
-    instr.post("/api/v1/testsetups", {
-      multipart: {
-        manifest: MANIFEST,
-        courseID,
-        files: { name: "setup.zip", mimeType: "application/zip", buffer: zipBuf },
-      },
-      headers: { "x-csrf-token": csrf },
-    }),
-    [200, 201]
-  );
-  const setupID = JSON.parse(await setupRes.text()).testSetupID;
-  if (!setupID) throw new Error("no testSetupID in upload response");
-  const instructorState = await instr.storageState();
-  await instr.dispose();
-
-  const stud = await pwRequest.newContext({ baseURL });
-  csrf = await csrfFrom(stud, "/register");
-  await expectOK(
-    "register student",
-    stud.post("/register", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
-    [200, 302, 303]
-  );
-  csrf = await csrfFrom(stud, "/login");
-  await expectOK(
-    "login student",
-    stud.post("/login", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
-    [200, 302, 303]
-  );
-
-  // One submission so the results page has something to show (stays pending —
-  // no runner is attached).
-  csrf = await csrfFrom(stud, `/testsetups/${setupID}/submit`);
-  const subRes = await expectOK(
-    "student submission",
-    stud.post(`/testsetups/${setupID}/submit`, {
-      multipart: {
-        _csrf: csrf,
-        files: {
-          name: "solution.py",
-          mimeType: "text/x-python",
-          buffer: Buffer.from("x = 1\n"),
-        },
-      },
-      headers: { "x-csrf-token": csrf },
-      maxRedirects: 0,
-    }),
-    [200, 302, 303]
-  );
-  // The submit flow redirects to the submission page (/submissions/<id>).
-  let resultsPath = null;
-  const subLoc = subRes.headers()["location"] || "";
-  const m = subLoc.match(/\/(submissions|results)\/[A-Za-z0-9_-]+/);
-  if (m) resultsPath = m[0];
-  if (!resultsPath) throw new Error(`submit did not redirect to a submission page (location: "${subLoc}")`);
-  const studentState = await stud.storageState();
-  await stud.dispose();
-
-  return { setupID, courseID, instructorState, studentState, resultsPath };
-}
 
 // ---------------------------------------------------------------------------
 async function main() {
   console.log(`Seeding fixture data via ${baseURL} …`);
-  const { setupID, instructorState, studentState, resultsPath } = await seed();
+  const { setupID, instructorState, studentState, resultsPath } = await seed(baseURL);
   console.log(`Seeded setup ${setupID}; results page: ${resultsPath || "(none)"}`);
 
   // page name → { path, session }.  Keep names stable: they are the baseline

--- a/Tools/visual-regression/package-lock.json
+++ b/Tools/visual-regression/package-lock.json
@@ -8,10 +8,32 @@
       "name": "chickadee-visual-regression",
       "version": "0.0.0",
       "dependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "jszip": "^3.10.1",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.49.1",
         "pngjs": "^7.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/core-util-is": {

--- a/Tools/visual-regression/package.json
+++ b/Tools/visual-regression/package.json
@@ -5,6 +5,7 @@
   "description": "Visual regression harness: boots chickadee-server, screenshots key pages in light + dark colour schemes, and diffs them against committed baselines.",
   "type": "module",
   "dependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "jszip": "^3.10.1",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.49.1",

--- a/Tools/visual-regression/run-a11y.sh
+++ b/Tools/visual-regression/run-a11y.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# run-a11y.sh — boot a chickadee-server and run the axe-core accessibility
+# scan (a11y.mjs, #1137) against it.  Server-boot logic mirrors run-visual.sh.
+#
+#   run-a11y.sh          scan (exit 1 on critical/serious or ratchet growth)
+#
+# Env knobs:
+#   CHICKADEE_SERVER_BIN   path to the built server (default: debug build)
+#   PORT                   port to bind (default: 8124)
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+REPO_ROOT="$(cd ../.. && pwd)"
+PORT="${PORT:-8124}"
+BIN="${CHICKADEE_SERVER_BIN:-$REPO_ROOT/.build/debug/chickadee-server}"
+WORKDIR="$(mktemp -d)"
+LOG="$WORKDIR/server.log"
+
+if [ ! -x "$BIN" ]; then
+  alt="$(ls "$REPO_ROOT"/.build/*/debug/chickadee-server 2>/dev/null | head -1 || true)"
+  if [ -n "$alt" ]; then BIN="$alt"; else
+    echo "run-a11y: server binary not found (set CHICKADEE_SERVER_BIN or run 'swift build')" >&2
+    exit 2
+  fi
+fi
+
+cleanup() {
+  if [ -n "${SRV_PID:-}" ] && kill -0 "$SRV_PID" 2>/dev/null; then
+    kill "$SRV_PID" 2>/dev/null || true
+    wait "$SRV_PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "run-a11y: booting $BIN on 127.0.0.1:$PORT"
+(
+  cd "$REPO_ROOT"
+  ENABLE_NON_SSO_AUTH_MODES=true \
+  AUTH_MODE=local \
+  DATABASE_BACKEND=sqlite \
+  SQLITE_PATH="$WORKDIR/a11y.sqlite" \
+  MCP_MODE=off \
+  LOG_LEVEL=info \
+    exec "$BIN" serve --hostname 127.0.0.1 --port "$PORT"
+) >"$LOG" 2>&1 &
+SRV_PID=$!
+
+ready=0
+for _ in $(seq 1 40); do
+  if curl -fsS --max-time 2 -o /dev/null "http://127.0.0.1:$PORT/login" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$SRV_PID" 2>/dev/null; then
+    echo "run-a11y: server exited during boot — log follows:" >&2
+    tail -20 "$LOG" >&2
+    exit 2
+  fi
+  sleep 1
+done
+if [ "$ready" -ne 1 ]; then
+  echo "run-a11y: server did not become ready — log follows:" >&2
+  tail -20 "$LOG" >&2
+  exit 2
+fi
+
+set +e
+node a11y.mjs "http://127.0.0.1:$PORT"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  echo "run-a11y: scan failed (rc=$rc) — server log tail:" >&2
+  tail -40 "$LOG" >&2 || true
+fi
+exit "$rc"

--- a/Tools/visual-regression/seed.mjs
+++ b/Tools/visual-regression/seed.mjs
@@ -1,0 +1,153 @@
+// seed.mjs — fixture seeding over the real HTTP API, shared by capture.mjs
+// (visual regression, #1136) and a11y.mjs (accessibility scan, #1137).
+// Registers an instructor (first user becomes admin), creates an auto-enroll
+// course, uploads a worker-graded test setup, registers + logs in a student,
+// and submits once (stays pending — no runner attached).
+import { request as pwRequest } from "playwright";
+import JSZip from "jszip";
+
+export const INSTRUCTOR = { username: "vis_instructor", password: "vis-instructor-pass-1" };
+export const STUDENT = { username: "vis_student", password: "vis-student-pass-1" };
+export const COURSE = { code: "VIS101", name: "Visual Regression 101" };
+
+function extractCsrf(html) {
+  let m = html.match(/name=['"]_csrf['"][^>]*\svalue=['"]([^'"]+)['"]/i);
+  if (m) return m[1];
+  m = html.match(/\svalue=['"]([^'"]+)['"][^>]*name=['"]_csrf['"]/i);
+  if (m) return m[1];
+  m = html.match(/<meta\s+name=['"]csrf-token['"]\s+content=['"]([^'"]+)['"]/i);
+  if (m) return m[1];
+  return null;
+}
+
+async function csrfFrom(ctx, p) {
+  const res = await ctx.get(p);
+  const token = extractCsrf(await res.text());
+  if (!token) throw new Error(`could not find CSRF token on ${p} (status ${res.status()})`);
+  return token;
+}
+
+async function expectOK(label, resPromise, okStatuses) {
+  const res = await resPromise;
+  if (!okStatuses.includes(res.status())) {
+    let body = "";
+    try { body = (await res.text()).slice(0, 400); } catch { /* ignore */ }
+    throw new Error(`${label}: unexpected status ${res.status()} (wanted ${okStatuses.join("/")})\n${body}`);
+  }
+  return res;
+}
+
+async function buildSetupZip() {
+  const zip = new JSZip();
+  zip.file(
+    "assignment.ipynb",
+    JSON.stringify({
+      nbformat: 4,
+      nbformat_minor: 5,
+      metadata: { kernelspec: { name: "python", display_name: "Python" } },
+      cells: [
+        { cell_type: "code", source: ["x = 1\n"], metadata: {}, outputs: [], execution_count: null },
+      ],
+    })
+  );
+  zip.file("test_public.py", 'print("public test ok")\n');
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+// Worker-graded on purpose: no runner is attached, so a submission stays
+// "pending" forever — a deterministic results page.
+const MANIFEST = JSON.stringify({
+  schemaVersion: 1,
+  requiredFiles: [],
+  testSuites: [{ tier: "public", script: "test_public.py" }],
+  timeLimitSeconds: 10,
+  makefile: null,
+});
+
+export async function seed(baseURL) {
+  const instr = await pwRequest.newContext({ baseURL });
+  let csrf = await csrfFrom(instr, "/register");
+  await expectOK(
+    "register instructor",
+    instr.post("/register", { form: { username: INSTRUCTOR.username, password: INSTRUCTOR.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]
+  );
+
+  csrf = await csrfFrom(instr, "/admin/courses/new");
+  const courseRes = await expectOK(
+    "create course",
+    instr.post("/admin/courses", { form: { code: COURSE.code, name: COURSE.name, _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]
+  );
+  const loc = courseRes.headers()["location"] || "";
+  const courseID = (loc.match(/\/admin\/courses\/([0-9a-fA-F-]{36})/) || [])[1];
+  if (!courseID) throw new Error(`could not parse courseID from redirect: "${loc}"`);
+  await expectOK(
+    "set enrollment auto",
+    instr.post(`/courses/${courseID}/enrollment-mode`, { form: { enrollmentMode: "auto", _csrf: csrf }, headers: { "x-csrf-token": csrf }, maxRedirects: 0 }),
+    [302, 303]
+  );
+
+  const zipBuf = await buildSetupZip();
+  csrf = await csrfFrom(instr, "/");
+  const setupRes = await expectOK(
+    "upload test setup",
+    instr.post("/api/v1/testsetups", {
+      multipart: {
+        manifest: MANIFEST,
+        courseID,
+        files: { name: "setup.zip", mimeType: "application/zip", buffer: zipBuf },
+      },
+      headers: { "x-csrf-token": csrf },
+    }),
+    [200, 201]
+  );
+  const setupID = JSON.parse(await setupRes.text()).testSetupID;
+  if (!setupID) throw new Error("no testSetupID in upload response");
+  const instructorState = await instr.storageState();
+  await instr.dispose();
+
+  const stud = await pwRequest.newContext({ baseURL });
+  csrf = await csrfFrom(stud, "/register");
+  await expectOK(
+    "register student",
+    stud.post("/register", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]
+  );
+  csrf = await csrfFrom(stud, "/login");
+  await expectOK(
+    "login student",
+    stud.post("/login", { form: { username: STUDENT.username, password: STUDENT.password, _csrf: csrf }, maxRedirects: 0 }),
+    [200, 302, 303]
+  );
+
+  // One submission so the results page has something to show (stays pending —
+  // no runner is attached).
+  csrf = await csrfFrom(stud, `/testsetups/${setupID}/submit`);
+  const subRes = await expectOK(
+    "student submission",
+    stud.post(`/testsetups/${setupID}/submit`, {
+      multipart: {
+        _csrf: csrf,
+        files: {
+          name: "solution.py",
+          mimeType: "text/x-python",
+          buffer: Buffer.from("x = 1\n"),
+        },
+      },
+      headers: { "x-csrf-token": csrf },
+      maxRedirects: 0,
+    }),
+    [200, 302, 303]
+  );
+  // The submit flow redirects to the submission page (/submissions/<id>).
+  let resultsPath = null;
+  const subLoc = subRes.headers()["location"] || "";
+  const m = subLoc.match(/\/(submissions|results)\/[A-Za-z0-9_-]+/);
+  if (m) resultsPath = m[0];
+  if (!resultsPath) throw new Error(`submit did not redirect to a submission page (location: "${subLoc}")`);
+  const studentState = await stud.storageState();
+  await stud.dispose();
+
+  return { setupID, courseID, instructorState, studentState, resultsPath };
+}

--- a/changelog.d/a11y-ratchet.md
+++ b/changelog.d/a11y-ratchet.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Accessibility ratchet (#1137).** The visual-regression CI job now also
+  runs an axe-core scan (`Tools/visual-regression/a11y.mjs`) over the six
+  key pages in both colour schemes. Critical/serious violations fail CI
+  outright; moderate/minor are a shrink-only count ratchet against
+  `a11y-baseline.json`. Guards the post-phase-8 AODA work against
+  regression — a new template with a missing label or scheme-specific
+  contrast bug now fails on its introducing PR.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -188,7 +188,10 @@ The visual-regression harness (`Tools/visual-regression/`, CI
 `visual-regression.yml`) automates that last check for the key pages: it
 screenshots them in both schemes and diffs against committed baselines.  An
 intentional look change means regenerating baselines
-(`Tools/visual-regression/run-visual.sh --update`) in the same PR.
+(`Tools/visual-regression/run-visual.sh --update`) in the same PR.  The same
+CI job also runs the axe-core accessibility scan (`run-a11y.sh`) over those
+pages in both schemes: critical/serious violations are zero-tolerance,
+moderate/minor ratchet down via `a11y-baseline.json`.
 
 ## Extending the system
 


### PR DESCRIPTION
Closes #1137.

## What this does

Adds an axe-core accessibility scan to the visual-regression CI job (#1141), covering the same six seeded pages in **both** colour schemes — contrast violations are usually scheme-specific, and the dark-mode banner bugs fixed in #1133 were exactly this class.

**Policy** (mirrors the repo's ratchet conventions):
- **critical / serious** violations → zero-tolerance, always fail;
- **moderate / minor** → shrink-only count ratchet against `a11y-baseline.json` (growth fails, shrinkage prints the lower-the-baseline note);
- no baseline committed → bootstrap mode: report everything, write a suggested baseline into the CI artifact, pass.

**Mechanics:**
- Fixture seeding extracted to a shared `seed.mjs` (used by `capture.mjs` and the new `a11y.mjs`) — no duplication between the two scanners.
- `run-a11y.sh` boots the server exactly like `run-visual.sh`; the CI job runs it as a step after the visual compare (no extra workflow/build cost).
- `@axe-core/playwright` added to the tool's pinned deps.

## Validation

- Offline smoke test against a static page with planted violations: axe classifies `image-alt`/`label` as critical, `color-contrast`/`html-has-lang` as serious, landmark rules as moderate — mapping cleanly onto the hard-fail / ratchet split.
- `node --check` on all scripts; `scripts/check-styles.sh` green.
- First CI run on this PR executes in bootstrap mode and reports the real violation counts; any critical/serious findings get fixed on this branch (in scope per the issue) before the baseline is committed and the scan flips to enforcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWF6xB56TLy2MpiF6zxX7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWF6xB56TLy2MpiF6zxX7A)_