### PR TITLE
Show window total on admin Active Users card, not the peak bucket

### DIFF
--- a/Resources/Views/admin.leaf
+++ b/Resources/Views/admin.leaf
@@ -631,7 +631,7 @@ tr.runner-row-offline {
 
     // Active Users card: sparkline + click-cycle 24h/7d/30d.
     // Reuses the GET /admin/activity endpoint (24h/1w/1m windows). The card's
-    // headline is the peak distinct active users in a single bucket; the spark
+    // headline is the total active users summed across the buckets; the spark
     // shows the per-bucket trend. The 24h view is server-rendered into the card
     // so there's no fetch-on-load flash; clicking the card cycles the window.
     var activitySpark = document.getElementById('activity-card-spark');
@@ -657,7 +657,7 @@ tr.runner-row-offline {
                     + '<span class="spark-fill' + (count > 0 ? '' : ' spark-fill-empty')
                     + '" style="--bar-h:' + pct.toFixed(1) + '%"></span></div>';
             }).join('');
-            if (activityValue) activityValue.textContent = String(max);
+            if (activityValue) activityValue.textContent = String(buckets.reduce(function (s, b) { return s + (Number(b.count) || 0); }, 0));
         }
 
         function activityBucketsFromDOM() {

--- a/changelog.d/active-users-card-total.md
+++ b/changelog.d/active-users-card-total.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **Admin "Active Users" card shows the window total, not the peak.** The card
+  headline now sums the active-user count across every bucket in the selected
+  24h/7d/30d window instead of taking the single busiest bucket. The sparkline
+  bars are unchanged (still scaled to the busiest bucket).


### PR DESCRIPTION
## What

The admin dashboard's **Active Users** card headline showed the **max** value across the sparkline buckets — the single busiest bucket — which reads as a peak-concurrency figure rather than "how many users were active over this window." This changes the headline to the **total (sum)** of the per-bucket counts for the selected 24h / 7d / 30d window.

## Why

Requested by the maintainer: the total over the window is a more meaningful headline for this card than the peak of any one bucket.

## How

- `Resources/Views/admin.leaf` — the `renderActivityCard()` headline reducer switched from `Math.max(...)` to a sum. The `max` value is retained because it still scales the sparkline bar heights (each bar relative to the busiest bucket), so **the bars are visually unchanged** — only the big number on the card changed.
- Kept net-zero on inline `<script>` lines so the shrink-only ratchet in `scripts/check-styles.sh` (#1140) stays green: the sum is folded inline into the headline assignment and the surrounding comment updated in place.
- Added a `changelog.d/` fragment (per the release process — no `VERSION` / `CHANGELOG.md` edits in-PR).

## Note

Each bucket stores *distinct active users in that bucket*, so a user active in more than one bucket is counted once per bucket — the headline is the summed per-bucket total, confirmed as the intended behaviour. It is not a deduplicated distinct-over-window count.

## Testing

- `scripts/check-styles.sh` passes (inline-script ratchet, CSS vars, design tokens).
- Verified the reducer in isolation: `[5,3,4] → 12` (was `5`), empty → `0`, and non-numeric/`null` counts coerce to `0`, matching the previous behaviour for those edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116Lmpw6BFv4kgpNUVU4JaV

---
_Generated by [Claude Code](https://claude.ai/code/session_0116Lmpw6BFv4kgpNUVU4JaV)_