### PR TITLE
Exec-hang probe: lost-dispatch classification + network forensics

### DIFF
--- a/.github/workflows/editor-smoke.yml
+++ b/.github/workflows/editor-smoke.yml
@@ -192,9 +192,14 @@ jobs:
   # (no editor-relevant changes), red only when the smoke actually failed — so
   # this one check can be marked required without blocking unrelated PRs. Mark
   # THIS job ("editor-smoke-gate") required in branch protection.
+  # `!cancelled()` is run-scoped: a superseded run (concurrency cancel from a
+  # newer push, or a rerun of an older head entering the shared group) skips
+  # the gate instead of reporting its cancelled smoke jobs as a failure. A
+  # smoke job killed by its own timeout-minutes still fails the gate — the
+  # run survives in that case, so the gate runs and sees result=cancelled.
   editor-smoke-gate:
     needs: [changes, smoke]
-    if: always()
+    if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Gate on editor smoke result

--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -371,6 +371,14 @@ jobs:
   # rename or matrix change can't silently detach a required check. Every
   # job above always runs (no internal skips), so anything short of
   # `success` fails the gate.
+  #
+  # `!cancelled()` is run-scoped: when this whole run is superseded
+  # (concurrency cancel — e.g. a newer push, or a rerun of an older head
+  # entering the shared group), the gate SKIPS instead of reporting a
+  # spurious failure for the cancelled jobs. A single job killed by its
+  # own timeout-minutes also reads "cancelled", but the run survives, so
+  # the gate still runs and still fails — that detection is load-bearing
+  # (2026-07-02: it caught the WorkerDaemonTests 20-minute wedge).
   swift-tests-gate:
     needs:
       - format-lint
@@ -380,7 +388,7 @@ jobs:
       - api-tests-postgres
       - browser-runner-tests
       - worker-tests
-    if: always()
+    if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,26 +448,24 @@ version — the guard against repeating #574.  jszip is fetched by
 every contributor and CI runner sees the same bytes without a build-time
 network fetch.
 
-**Extra packages + nb_mypy.** Pure-Python packages not in the upstream Pyodide
-distribution are declared in `Tools/vendor/pyodide-extra-packages.json` (pinned
-URL + sha256) and injected into the one lock by `scripts/add-pyodide-extras.py`
-(run from `setup-vendor.sh`); `check-pyodide-parity.sh` then asserts they're
-present so a re-vendor can't silently drop them.  This is how `nb_mypy` (+
-`astor`) gets into the editor.  nb_mypy type-checking is **on by default** but
-**loaded lazily, off the kernel-boot critical path**: the kernel wheel's
-`__init__.py` is patched (deterministically, `ZIP_STORED`, by
-`scripts/patch-pyodide-kernel.py` from `setup-jupyterlite.sh`) to schedule a
-background task that — once the kernel is up — `loadPackage`s nb_mypy from the
-vended Pyodide lock and runs `%load_ext nb_mypy; %nb_mypy On`.  nb_mypy is
-deliberately **not** in `loadPyodideOptions.packages`: a package named there is
-loaded by `loadPyodide()` itself, so any failure (bad PEP 503 lock key, dropped
-wheel, ABI mismatch) would reject the boot and brick the whole editor.  The
-background load is wrapped in a fail-safe try/except so a missing/incompatible
-nb_mypy degrades to "no type warnings", never a dead kernel.  Patching a bundled
-wheel means a sha cascade (wheel → `all.json` digest → `pipliteUrls` sha);
-`verify-jupyterlite.sh` asserts that chain is consistent so a mismatch (which
-would make piplite reject the kernel) is a build failure, not a browser
-surprise.
+**Extra packages + nb_mypy (currently DISABLED).** Pure-Python packages not
+in the upstream Pyodide distribution are declared in
+`Tools/vendor/pyodide-extra-packages.json` (pinned URL + sha256) and injected
+into the one lock by `scripts/add-pyodide-extras.py` (run from
+`setup-vendor.sh`); `check-pyodide-parity.sh` then asserts they're present so
+a re-vendor can't silently drop them.  This is how the `nb_mypy` (+ `astor`)
+wheels get into the editor bundle — but **nb_mypy type-checking is disabled**
+(see the `scripts/patch-pyodide-kernel.py` docstring): its IPython
+`pre_run_cell` hook ran a synchronous compiled-WASM mypy on every cell
+execute, on the kernel's single thread, and wedged the first cell in the real
+editor.  The wheels stay vended (harmless, unloaded) and the patch keeps an
+empty activation block so re-enabling is a one-line change; revisit
+type-checking only as a feature that never runs on the cell-execute path.
+The same kernel-wheel patch is what carries the v0.4.526 chdir fix; patching
+a bundled wheel means a sha cascade (wheel → `all.json` digest →
+`pipliteUrls` sha); `verify-jupyterlite.sh` asserts that chain is consistent
+so a mismatch (which would make piplite reject the kernel) is a build
+failure, not a browser surprise.
 
 ---
 

--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -289,6 +289,51 @@ import Testing
     // plus blocking Thread.sleep in mocks/teardown) that Task can be starved
     // for several seconds before it gets to run.  A tight 2–4s window made
     // these tests flaky there; 10s removes the class of failure.
+    /// Tracks daemon-task completion so `awaitCancelledDaemon` can poll it
+    /// with a deadline instead of awaiting `task.value` unbounded.
+    private actor DaemonShutdownFlag {
+        private var done = false
+        private var unexpectedError: String?
+        func markDone(unexpectedError error: String?) {
+            done = true
+            unexpectedError = error
+        }
+        func isDone() -> Bool { done }
+        func failure() -> String? { unexpectedError }
+    }
+
+    /// Cancels-and-awaits a daemon task with a deadline. `Task.value` is not
+    /// cancellation-responsive: if `daemon.run()` is wedged in a
+    /// non-cancellable wait, a bare `try await task.value` after `cancel()`
+    /// suspends forever and rides the whole job to the CI 20-minute kill —
+    /// observed 2026-07-02 in `workerDaemonContinuesToNextJobAfterProcessingFailure`
+    /// (the `.timeLimit` trait attributed it but cannot interrupt it; see
+    /// docs/ci-flakiness.md). On timeout the daemon task is left orphaned —
+    /// acceptable in a test process — and the caller should fail the test.
+    private func awaitCancelledDaemon(
+        _ task: Task<Void, Error>,
+        timeoutSeconds: TimeInterval = 30
+    ) async -> Bool {
+        task.cancel()
+        let flag = DaemonShutdownFlag()
+        Task {
+            var unexpected: String?
+            do {
+                try await task.value
+            } catch is CancellationError {
+                // Expected on cooperative shutdown.
+            } catch {
+                unexpected = String(describing: error)
+            }
+            await flag.markDone(unexpectedError: unexpected)
+        }
+        let done = await waitUntil(timeoutSeconds: timeoutSeconds) { await flag.isDone() }
+        if done, let unexpectedError = await flag.failure() {
+            Issue.record("daemon.run() threw a non-cancellation error on shutdown: \(unexpectedError)")
+        }
+        return done
+    }
+
     private func waitUntil(
         timeoutSeconds: TimeInterval = 10,
         pollIntervalNanos: UInt64 = 50_000_000,
@@ -363,12 +408,11 @@ import Testing
         }
         #expect(didPoll, "Daemon should poll for work before cancellation")
 
-        task.cancel()
-        do {
-            try await task.value
-        } catch is CancellationError {
-            // Expected: the sleeping worker loop cooperatively exits on cancellation.
-        }
+        // Bounded: the sleeping worker loop cooperatively exits on
+        // cancellation; if it ever doesn't, fail here rather than suspend
+        // on task.value until the CI job kill.
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let requestCount = await poller.observedRequestCount()
         #expect(requestCount > 0)
@@ -400,12 +444,9 @@ import Testing
         }
         #expect(didReport, "Expected fallback failure report after processing error")
 
-        task.cancel()
-        do {
-            try await task.value
-        } catch is CancellationError {
-            // Expected on cooperative shutdown.
-        }
+        // Bounded cooperative shutdown (see awaitCancelledDaemon).
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let reports = await reporter.snapshot()
         #expect(reports.count == 1)
@@ -480,11 +521,8 @@ import Testing
         }
         #expect(didPollAgain, "Expected daemon to resume polling after first job")
 
-        task.cancel()
-        do {
-            try await task.value
-        } catch is CancellationError {
-        }
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let reports = await reporter.snapshot()
         let attemptCount = await reporter.observedAttempts()
@@ -547,11 +585,8 @@ import Testing
         }
         #expect(didProcessBoth, "Expected daemon to report both failed and successful jobs")
 
-        task.cancel()
-        do {
-            try await task.value
-        } catch is CancellationError {
-        }
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let reports = await reporter.snapshot()
         let runnerInvocations = await runner.observedInvocationCount()
@@ -614,8 +649,8 @@ import Testing
 
         let task = Task { try await daemon.run() }
         _ = await waitUntil(timeoutSeconds: 10) { await reporter.snapshot().count == 1 }
-        task.cancel()
-        try? await task.value
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let reports = await reporter.snapshot()
         let report = try #require(reports.first)
@@ -699,8 +734,8 @@ import Testing
         let task = Task { try await daemon.run() }
         let didReport = await waitUntil(timeoutSeconds: 10) { await reporter.snapshot().count == 1 }
         #expect(didReport, "Expected a synthetic failure report for the failed prepare")
-        task.cancel()
-        try? await task.value
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         // The scratch dir name embeds the cache key, which embeds the (unique)
         // testSetupID — so any leftover entry matching the marker is a leak
@@ -801,8 +836,8 @@ import Testing
         let task = Task { try await daemon.run() }
         let didReport = await waitUntil(timeoutSeconds: 15) { await reporter.snapshot().count == 1 }
         #expect(didReport, "Expected a failure report once the hung make is killed")
-        task.cancel()
-        try? await task.value
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let report = try #require(await reporter.snapshot().first)
         #expect(report.buildStatus == .failed, "hung make must map to a failed build")
@@ -909,8 +944,8 @@ import Testing
             }
             #expect(didKeepPolling, "Runner should keep polling after transient HTTP 500 responses")
 
-            task.cancel()
-            _ = await task.result
+            let shutDown = await awaitCancelledDaemon(task)
+            #expect(shutDown, "daemon did not shut down within 30s of cancellation")
         }
     }
 
@@ -943,8 +978,8 @@ import Testing
             }
             #expect(didKeepPolling, "Runner should keep polling after transient HTTP 401 responses")
 
-            task.cancel()
-            _ = await task.result
+            let shutDown = await awaitCancelledDaemon(task)
+            #expect(shutDown, "daemon did not shut down within 30s of cancellation")
         }
     }
 
@@ -977,8 +1012,8 @@ import Testing
             }
             #expect(didKeepPolling, "Runner should keep polling after duplicate worker ID conflicts")
 
-            task.cancel()
-            _ = await task.result
+            let shutDown = await awaitCancelledDaemon(task)
+            #expect(shutDown, "daemon did not shut down within 30s of cancellation")
         }
     }
 
@@ -1064,8 +1099,8 @@ import Testing
 
         let task = Task { try await daemon.run() }
         _ = await waitUntil(timeoutSeconds: 10) { await reporter.snapshot().count == 5 }
-        task.cancel()
-        try? await task.value
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let (maxConcurrent, total) = await runner.snapshot()
         #expect(total == 5, "all 5 jobs should have completed")
@@ -1115,8 +1150,8 @@ import Testing
 
         let task = Task { try await daemon.run() }
         _ = await waitUntil(timeoutSeconds: 10) { await reporter.snapshot().count == 1 }
-        task.cancel()
-        try? await task.value
+        let shutDown = await awaitCancelledDaemon(task)
+        #expect(shutDown, "daemon did not shut down within 30s of cancellation")
 
         let reports = await reporter.snapshot()
         #expect(reports.count == 1, "should still produce a report for the failed job")

--- a/Tools/editor-smoke-test/editor-exec-check.mjs
+++ b/Tools/editor-smoke-test/editor-exec-check.mjs
@@ -389,6 +389,15 @@ async function main() {
           `(indicator=${r.status}, net4xx=${(r.badResponses || []).length}, consoleErr=${(r.errors || []).length})`
       );
     }
+    // Identify the ambient noise once per run (it is constant per engine:
+    // chromium 11x4xx/6err, webkit 4x4xx/6err on 2026-07-02): the deduped
+    // URL set turns "net4xx=11" from a count into a diagnosis.
+    if (i === 0) {
+      const uniqueBad = [...new Set(r.badResponses || [])];
+      const uniqueErr = [...new Set(r.errors || [])];
+      if (uniqueBad.length) console.log(`  ambient http (iter 1): ${uniqueBad.join(" | ")}`);
+      if (uniqueErr.length) console.log(`  ambient console (iter 1): ${uniqueErr.join(" | ")}`);
+    }
   }
 
   const avg = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0;

--- a/Tools/editor-smoke-test/editor-exec-check.mjs
+++ b/Tools/editor-smoke-test/editor-exec-check.mjs
@@ -234,7 +234,8 @@ async function probeOnce(browser, storageState, notebookURL) {
   });
 
   const result = {
-    hung: true, wasmCrash: false, lostDispatch: false, ms: 0, status: null,
+    hung: true, wasmCrash: false, lostDispatch: false, dialogStole: false,
+    dialogText: "", ms: 0, status: null,
     note: "", diag: [], errors, badResponses, cellState: "",
   };
   const readDiag = () => page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
@@ -307,11 +308,37 @@ async function probeOnce(browser, storageState, notebookURL) {
         return `prompt="${prompt}" docFocus=${document.hasFocus()} active="${active}" out="${out}"`;
       }).catch(() => "unavailable");
 
-      // Discriminator: lost keypress vs wedged kernel. If a second
-      // Shift+Enter runs the cell promptly, the kernel was healthy the whole
-      // time and the FIRST dispatch never happened (focus race) — a
-      // different bug class than the sustained-busy exec_hang, and a
-      // student-facing one ("I pressed run and nothing happened").
+      // A modal JupyterLab dialog (`.jp-Dialog`) intercepts keyboard focus, so
+      // Shift+Enter never reaches the cell — the cell prompt stays "[ ]" and the
+      // active element is a `jp-Dialog-button` (observed 2026-07-02 chromium:
+      // the folder-creation 403s / insertWidget error surface an error dialog).
+      // This is a distinct, student-facing bug ("I pressed run and nothing
+      // happened") from a wedged kernel; capture WHICH dialog and dismiss it so
+      // the second-press discriminator can confirm the kernel underneath is
+      // healthy.
+      result.dialogText = await jlFrame.evaluate(() => {
+        const dialog = document.querySelector(".jp-Dialog");
+        if (!dialog) return "";
+        const header = (dialog.querySelector(".jp-Dialog-header") || {}).textContent || "";
+        const body = (dialog.querySelector(".jp-Dialog-body") || {}).textContent || "";
+        return (header + " | " + body).trim().slice(0, 200);
+      }).catch(() => "");
+      if (result.dialogText) {
+        // Dismiss the dialog (Escape, then reject-button fallback) before the
+        // retry so the keypress can reach the cell.
+        await jlFrame.evaluate(() => {
+          const btn = document.querySelector(".jp-Dialog-button.jp-mod-reject")
+            || document.querySelector(".jp-Dialog-button");
+          if (btn) btn.click();
+        }).catch(() => {});
+        await page.keyboard.press("Escape").catch(() => {});
+        await page.waitForTimeout(500);
+      }
+
+      // Discriminator: lost keypress / dialog-steal vs wedged kernel. If a
+      // second Shift+Enter (after any dialog is dismissed) runs the cell
+      // promptly, the kernel was healthy the whole time and the FIRST dispatch
+      // never landed — a focus problem, not a deadlock.
       try {
         const cellAgain = jlFrame.locator(".jp-Notebook .jp-CodeCell .cm-content").first();
         await cellAgain.click({ timeout: 5_000 });
@@ -319,10 +346,14 @@ async function probeOnce(browser, storageState, notebookURL) {
         const retryStart = Date.now();
         while (Date.now() - retryStart < 15_000) {
           const body = await jlFrame.evaluate(() => (document.body && document.body.innerText) || "").catch(() => "");
-          if (body.includes(EXEC_TOKEN)) { result.lostDispatch = true; break; }
+          if (body.includes(EXEC_TOKEN)) {
+            if (result.dialogText) result.dialogStole = true;
+            else result.lostDispatch = true;
+            break;
+          }
           await page.waitForTimeout(500);
         }
-      } catch { /* second press unavailable — leave lostDispatch false */ }
+      } catch { /* second press unavailable — leave classification as deadlock */ }
     }
   } catch (e) {
     result.note = `exception: ${(e && e.message) || e}`;
@@ -349,6 +380,7 @@ async function main() {
   let wasmCrashes = 0;
   let deadlocks = 0;
   let lostDispatches = 0;
+  let dialogSteals = 0;
   const latencies = [];
   for (let i = 0; i < ITER; i++) {
     // Fresh browser per iteration. A single WebKit process accumulates WASM /
@@ -363,19 +395,23 @@ async function main() {
     if (r.hung) {
       hangs++;
       if (r.wasmCrash) wasmCrashes++;
+      else if (r.dialogStole) dialogSteals++;
       else if (r.lostDispatch) lostDispatches++;
       else deadlocks++;
       const exec = (r.diag || []).find((d) => d.source === "exec_hang");
       const tag = r.wasmCrash
         ? "WEBKIT-WASM-CRASH (upstream #286266)"
-        : r.lostDispatch
-          ? "LOST-DISPATCH (second press ran — kernel healthy, first keypress lost)"
-          : "HANG";
+        : r.dialogStole
+          ? "DIALOG-STEAL (modal dialog swallowed the keypress; cell ran after dismiss)"
+          : r.lostDispatch
+            ? "LOST-DISPATCH (second press ran — kernel healthy, first keypress lost)"
+            : "HANG";
       console.log(
         `  iter ${i + 1}/${ITER}: ${tag}${r.note ? " (" + r.note + ")" : ""} — ` +
           `indicator=${r.status} waited=${r.ms}ms exec_hang=${exec ? exec.message : "none"}`
       );
       if (r.cellState) console.log(`    cell: ${r.cellState}`);
+      if (r.dialogText) console.log(`    dialog: ${r.dialogText}`);
       if (r.errors && r.errors.length) console.log(`    console: ${r.errors.slice(0, 4).join(" | ")}`);
       if (r.badResponses && r.badResponses.length) {
         console.log(`    http: ${r.badResponses.slice(0, 6).join(" | ")}`);
@@ -403,9 +439,17 @@ async function main() {
   const avg = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0;
   console.log(
     `EXEC PROBE RESULT — engine=${browserName} hangs=${hangs}/${ITER} ` +
-      `(deadlock=${deadlocks}, lostDispatch=${lostDispatches}, webkitWasmCrash=${wasmCrashes}) ` +
-      `ok=${ITER - hangs} avgRunMs=${avg}`
+      `(deadlock=${deadlocks}, dialogSteal=${dialogSteals}, lostDispatch=${lostDispatches}, ` +
+      `webkitWasmCrash=${wasmCrashes}) ok=${ITER - hangs} avgRunMs=${avg}`
   );
+  if (dialogSteals > 0) {
+    console.log(
+      `NOTE: ${dialogSteals}/${ITER} run(s) had a modal dialog swallow the first Shift+Enter ` +
+        `(the cell ran after the dialog was dismissed — kernel healthy). Student-facing: an ` +
+        `error/confirm dialog over the editor makes the first run do nothing. See the per-iter ` +
+        `"dialog:" line for which dialog; likely tied to the folder-creation 403s / insertWidget error.`
+    );
+  }
   if (lostDispatches > 0) {
     console.log(
       `NOTE: ${lostDispatches}/${ITER} run(s) lost the first Shift+Enter (a second press ran fine — ` +

--- a/Tools/editor-smoke-test/editor-exec-check.mjs
+++ b/Tools/editor-smoke-test/editor-exec-check.mjs
@@ -18,7 +18,7 @@
 // data-status, and console errors, so a hung run is diagnostic rather than a
 // black box.
 //
-// TWO failure classes, classified and counted separately:
+// THREE failure classes, classified and counted separately:
 //   - deadlock      — our-code post-idle exec_hang (the bug this probe hunts);
 //                     FAILS the leg (exit 1).
 //   - webkitWasmCrash — the upstream WebKit/Safari WASM engine crash
@@ -26,6 +26,14 @@
 //                     bug #286266). NOT a Chickadee regression and not fixable in
 //                     our JS; reported but does NOT fail the leg, so WebKit's own
 //                     bug can't flake this diagnostic.
+//   - lostDispatch  — the first Shift+Enter never started the cell (indicator
+//                     stays idle, no busy phase, no exec_hang beacon) but a
+//                     SECOND press runs it promptly: the kernel was healthy and
+//                     the keypress was lost (focus race around the post-idle
+//                     window). A different bug class than the sustained-busy
+//                     hang — reported loudly but does NOT fail the leg, so the
+//                     deadlock signal stays clean (2026-07-02 chromium repro:
+//                     hangs=1/8 with indicator=idle exec_hang=none).
 // Each iteration uses a FRESH browser: one WebKit process accumulates WASM /
 // TextDecoder state across back-to-back kernel boots, inflating the WebKit crash
 // rate well above a real student (one kernel per session). Fresh-per-run makes the
@@ -201,10 +209,34 @@ async function probeOnce(browser, storageState, notebookURL) {
   });
   const page = await context.newPage();
   const errors = [];
-  page.on("console", (m) => { if (m.type() === "error") errors.push(m.text().slice(0, 200)); });
+  // Console "Failed to load resource" messages don't carry the URL in their
+  // text (the 2026-07-02 chromium hang printed four bare 403s — evidence
+  // wasted); attach the location URL so a failing resource is identifiable.
+  page.on("console", (m) => {
+    if (m.type() !== "error") return;
+    const loc = m.location();
+    const url = loc && loc.url ? ` [${loc.url}]` : "";
+    errors.push((m.text() + url).slice(0, 300));
+  });
   page.on("pageerror", (e) => errors.push(String(e).slice(0, 200)));
+  // Network-level forensics, independent of what the console reports: every
+  // >=400 response and every outright-failed request, for ALL iterations —
+  // printing them only on hangs made ambient 4xx noise look hang-correlated.
+  const badResponses = [];
+  page.on("response", (res) => {
+    if (res.status() >= 400) {
+      badResponses.push(`${res.status()} ${res.request().method()} ${res.url()}`.slice(0, 220));
+    }
+  });
+  page.on("requestfailed", (req) => {
+    const why = (req.failure() && req.failure().errorText) || "";
+    badResponses.push(`FAIL ${req.method()} ${req.url()} ${why}`.slice(0, 220));
+  });
 
-  const result = { hung: true, wasmCrash: false, ms: 0, status: null, note: "", diag: [], errors };
+  const result = {
+    hung: true, wasmCrash: false, lostDispatch: false, ms: 0, status: null,
+    note: "", diag: [], errors, badResponses, cellState: "",
+  };
   const readDiag = () => page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
   try {
     await page.goto(notebookURL, { waitUntil: "domcontentloaded", timeout: PAGE_LOAD_MS });
@@ -261,6 +293,37 @@ async function probeOnce(browser, storageState, notebookURL) {
       return ind ? ind.getAttribute("data-status") : null;
     }).catch(() => null);
     result.diag = await readDiag();
+
+    if (result.hung && !result.wasmCrash) {
+      // Cell + focus state at the moment the budget expired: prompt "[*]"
+      // means the execute was dispatched and is stuck (the sustained-busy
+      // class); "[ ]" with an idle indicator means it was never dispatched.
+      result.cellState = await jlFrame.evaluate(() => {
+        const cell = document.querySelector(".jp-Notebook .jp-CodeCell");
+        const prompt = cell ? ((cell.querySelector(".jp-InputPrompt") || {}).textContent || "").trim() : "no-cell";
+        const out = cell ? ((cell.querySelector(".jp-OutputArea") || {}).innerText || "").trim().slice(0, 60) : "";
+        const activeEl = document.activeElement;
+        const active = activeEl ? String(activeEl.className || activeEl.tagName).slice(0, 60) : "none";
+        return `prompt="${prompt}" docFocus=${document.hasFocus()} active="${active}" out="${out}"`;
+      }).catch(() => "unavailable");
+
+      // Discriminator: lost keypress vs wedged kernel. If a second
+      // Shift+Enter runs the cell promptly, the kernel was healthy the whole
+      // time and the FIRST dispatch never happened (focus race) — a
+      // different bug class than the sustained-busy exec_hang, and a
+      // student-facing one ("I pressed run and nothing happened").
+      try {
+        const cellAgain = jlFrame.locator(".jp-Notebook .jp-CodeCell .cm-content").first();
+        await cellAgain.click({ timeout: 5_000 });
+        await cellAgain.press("Shift+Enter");
+        const retryStart = Date.now();
+        while (Date.now() - retryStart < 15_000) {
+          const body = await jlFrame.evaluate(() => (document.body && document.body.innerText) || "").catch(() => "");
+          if (body.includes(EXEC_TOKEN)) { result.lostDispatch = true; break; }
+          await page.waitForTimeout(500);
+        }
+      } catch { /* second press unavailable — leave lostDispatch false */ }
+    }
   } catch (e) {
     result.note = `exception: ${(e && e.message) || e}`;
   } finally {
@@ -285,6 +348,7 @@ async function main() {
   let hangs = 0;
   let wasmCrashes = 0;
   let deadlocks = 0;
+  let lostDispatches = 0;
   const latencies = [];
   for (let i = 0; i < ITER; i++) {
     // Fresh browser per iteration. A single WebKit process accumulates WASM /
@@ -298,25 +362,49 @@ async function main() {
     finally { await browser.close().catch(() => {}); }
     if (r.hung) {
       hangs++;
-      if (r.wasmCrash) wasmCrashes++; else deadlocks++;
+      if (r.wasmCrash) wasmCrashes++;
+      else if (r.lostDispatch) lostDispatches++;
+      else deadlocks++;
       const exec = (r.diag || []).find((d) => d.source === "exec_hang");
-      const tag = r.wasmCrash ? "WEBKIT-WASM-CRASH (upstream #286266)" : "HANG";
+      const tag = r.wasmCrash
+        ? "WEBKIT-WASM-CRASH (upstream #286266)"
+        : r.lostDispatch
+          ? "LOST-DISPATCH (second press ran — kernel healthy, first keypress lost)"
+          : "HANG";
       console.log(
         `  iter ${i + 1}/${ITER}: ${tag}${r.note ? " (" + r.note + ")" : ""} — ` +
           `indicator=${r.status} waited=${r.ms}ms exec_hang=${exec ? exec.message : "none"}`
       );
+      if (r.cellState) console.log(`    cell: ${r.cellState}`);
       if (r.errors && r.errors.length) console.log(`    console: ${r.errors.slice(0, 4).join(" | ")}`);
+      if (r.badResponses && r.badResponses.length) {
+        console.log(`    http: ${r.badResponses.slice(0, 6).join(" | ")}`);
+      }
     } else {
       latencies.push(r.ms);
-      console.log(`  iter ${i + 1}/${ITER}: ok — ran in ${r.ms}ms (indicator=${r.status})`);
+      // Compact per-iteration noise summary even on green runs: without the
+      // base rate, ambient 4xx noise printed only on hangs looks correlated.
+      console.log(
+        `  iter ${i + 1}/${ITER}: ok — ran in ${r.ms}ms ` +
+          `(indicator=${r.status}, net4xx=${(r.badResponses || []).length}, consoleErr=${(r.errors || []).length})`
+      );
     }
   }
 
   const avg = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0;
   console.log(
     `EXEC PROBE RESULT — engine=${browserName} hangs=${hangs}/${ITER} ` +
-      `(deadlock=${deadlocks}, webkitWasmCrash=${wasmCrashes}) ok=${ITER - hangs} avgRunMs=${avg}`
+      `(deadlock=${deadlocks}, lostDispatch=${lostDispatches}, webkitWasmCrash=${wasmCrashes}) ` +
+      `ok=${ITER - hangs} avgRunMs=${avg}`
   );
+  if (lostDispatches > 0) {
+    console.log(
+      `NOTE: ${lostDispatches}/${ITER} run(s) lost the first Shift+Enter (a second press ran fine — ` +
+        `kernel healthy). This is a post-idle focus race, not the sustained-busy exec_hang; it is ` +
+        `student-facing ("I pressed run and nothing happened") and tracked separately so the ` +
+        `deadlock signal stays clean.`
+    );
+  }
   if (wasmCrashes > 0) {
     console.log(
       `NOTE: ${wasmCrashes}/${ITER} run(s) hit the upstream WebKit/Safari WASM crash ` +
@@ -325,7 +413,8 @@ async function main() {
     );
   }
   // Fail the leg ONLY for a real (our-code) post-idle deadlock; an upstream
-  // WebKit WASM crash is reported but must not flake this diagnostic.
+  // WebKit WASM crash or a lost first keypress (kernel healthy, different bug
+  // class) is reported but must not flake this diagnostic.
   process.exit(deadlocks > 0 ? 1 : 0);
 }
 

--- a/Tools/editor-smoke-test/editor-exec-check.mjs
+++ b/Tools/editor-smoke-test/editor-exec-check.mjs
@@ -235,7 +235,7 @@ async function probeOnce(browser, storageState, notebookURL) {
 
   const result = {
     hung: true, wasmCrash: false, lostDispatch: false, dialogStole: false,
-    dialogText: "", ms: 0, status: null,
+    bootStall: false, dialogText: "", ms: 0, status: null,
     note: "", diag: [], errors, badResponses, cellState: "",
   };
   const readDiag = () => page.evaluate(() => window.__ckKernelDiag || []).catch(() => []);
@@ -265,7 +265,16 @@ async function probeOnce(browser, storageState, notebookURL) {
       if (diag.some((d) => d.kind === "kernel_phase" && d.source === "kernel_idle")) { sawIdle = true; break; }
       await page.waitForTimeout(500);
     }
-    if (!sawIdle) { result.note = "kernel never reported idle"; result.diag = await readDiag(); return result; }
+    if (!sawIdle) {
+      // Kernel never reached idle within the window — a BOOT-stall, a distinct
+      // phenomenon from a post-idle exec hang (matches production's boot→idle
+      // funnel drop). Classified separately so the deadlock bucket means only
+      // "reached idle, then the execute wedged."
+      result.note = "kernel never reported idle";
+      result.bootStall = true;
+      result.diag = await readDiag();
+      return result;
+    }
 
     if (EXEC_DELAY_MS > 0) await page.waitForTimeout(EXEC_DELAY_MS);
 
@@ -381,6 +390,7 @@ async function main() {
   let deadlocks = 0;
   let lostDispatches = 0;
   let dialogSteals = 0;
+  let bootStalls = 0;
   const latencies = [];
   for (let i = 0; i < ITER; i++) {
     // Fresh browser per iteration. A single WebKit process accumulates WASM /
@@ -395,17 +405,20 @@ async function main() {
     if (r.hung) {
       hangs++;
       if (r.wasmCrash) wasmCrashes++;
+      else if (r.bootStall) bootStalls++;
       else if (r.dialogStole) dialogSteals++;
       else if (r.lostDispatch) lostDispatches++;
       else deadlocks++;
       const exec = (r.diag || []).find((d) => d.source === "exec_hang");
       const tag = r.wasmCrash
         ? "WEBKIT-WASM-CRASH (upstream #286266)"
-        : r.dialogStole
-          ? "DIALOG-STEAL (modal dialog swallowed the keypress; cell ran after dismiss)"
-          : r.lostDispatch
-            ? "LOST-DISPATCH (second press ran — kernel healthy, first keypress lost)"
-            : "HANG";
+        : r.bootStall
+          ? "BOOT-STALL (kernel never reached idle — a boot failure, not a post-idle hang)"
+          : r.dialogStole
+            ? "DIALOG-STEAL (modal dialog swallowed the keypress; cell ran after dismiss)"
+            : r.lostDispatch
+              ? "LOST-DISPATCH (second press ran — kernel healthy, first keypress lost)"
+              : "HANG";
       console.log(
         `  iter ${i + 1}/${ITER}: ${tag}${r.note ? " (" + r.note + ")" : ""} — ` +
           `indicator=${r.status} waited=${r.ms}ms exec_hang=${exec ? exec.message : "none"}`
@@ -439,9 +452,16 @@ async function main() {
   const avg = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0;
   console.log(
     `EXEC PROBE RESULT — engine=${browserName} hangs=${hangs}/${ITER} ` +
-      `(deadlock=${deadlocks}, dialogSteal=${dialogSteals}, lostDispatch=${lostDispatches}, ` +
-      `webkitWasmCrash=${wasmCrashes}) ok=${ITER - hangs} avgRunMs=${avg}`
+      `(deadlock=${deadlocks}, bootStall=${bootStalls}, dialogSteal=${dialogSteals}, ` +
+      `lostDispatch=${lostDispatches}, webkitWasmCrash=${wasmCrashes}) ok=${ITER - hangs} avgRunMs=${avg}`
   );
+  if (bootStalls > 0) {
+    console.log(
+      `NOTE: ${bootStalls}/${ITER} run(s) never reached kernel_idle (boot-stall) — a boot-funnel ` +
+        `failure distinct from the post-idle exec hang this probe hunts, matching production's ` +
+        `boot→idle drop. Reported separately so the deadlock count means only post-idle wedges.`
+    );
+  }
   if (dialogSteals > 0) {
     console.log(
       `NOTE: ${dialogSteals}/${ITER} run(s) had a modal dialog swallow the first Shift+Enter ` +

--- a/changelog.d/exec-probe-forensics.md
+++ b/changelog.d/exec-probe-forensics.md
@@ -1,3 +1,16 @@
+### Fixed
+
+- **Bounded daemon shutdown in WorkerDaemonTests (the residual worker-tests
+  wedge).** Twelve tests cancelled the daemon task then awaited
+  `task.value`/`task.result` unbounded; `Task.value` is not
+  cancellation-responsive, so a daemon wedged in a non-cancellable wait rode
+  the job to the CI 20-minute kill even though the `.timeLimit` trait had
+  already attributed the failure (observed 2026-07-02,
+  `workerDaemonContinuesToNextJobAfterProcessingFailure`). A shared
+  `awaitCancelledDaemon` helper now polls completion with a 30 s deadline
+  and fails the single test instead, still surfacing non-cancellation
+  shutdown errors.
+
 ### Changed
 
 - **Exec-hang probe forensics (`editor-exec-check.mjs`).** Hang iterations

--- a/changelog.d/exec-probe-forensics.md
+++ b/changelog.d/exec-probe-forensics.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Exec-hang probe forensics (`editor-exec-check.mjs`).** Hang iterations
+  now capture the failing-resource URLs behind console errors, every >=400
+  response and failed request, and the cell prompt/focus state; green
+  iterations report their 4xx/console-error base rate so noise can't
+  masquerade as a hang correlate. A second-press discriminator separates a
+  new `lostDispatch` class (first Shift+Enter lost to a post-idle focus
+  race, kernel healthy — student-facing) from the sustained-busy deadlock
+  the probe hunts; only the deadlock class fails the leg.

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -222,6 +222,29 @@ chromium failure is treated as real, first time.
      failing). The "ambient webkit exec-hang" decomposes into the wasm
      crash + boot-stalls + the fixed-endpoint blocker's tail, with
      nothing left over so far.
+   - **NEW class — DIALOG-STEAL (2026-07-02 chromium, forensic capture).**
+     A chromium exec-probe "hang" turned out to be a modal JupyterLab
+     dialog: `cell: prompt="[ ]:" active="jp-Dialog-button jp-mod-accept
+     jp-mod-styled"` — the cell never dispatched because a `.jp-Dialog`
+     had keyboard focus and swallowed the Shift+Enter (the second press
+     hit the dialog too, so it wasn't lost-dispatch either). This is a
+     distinct, student-facing bug: an error/confirm dialog over the
+     editor makes the first run silently do nothing. Very likely tied to
+     the every-boot folder-creation 403s + the `insertWidget` /
+     `updateRenderOption` null errors — the editor fails to set up its
+     working folder and surfaces a dialog. The probe now detects a
+     `.jp-Dialog` at hang time, captures its header/body text, dismisses
+     it, and re-presses to confirm the kernel underneath is healthy;
+     classified as `dialogSteal` (reported, non-failing). **Next step:**
+     read the captured `dialog:` text from the next probe run to identify
+     which dialog, then fix the folder-setup path that raises it.
+   - **Grading-hang probe: chromium also hangs (`1/12`, 2026-07-02).**
+     Not webkit-only. The grading path (a SECOND Pyodide in
+     grading-worker.js) intermittently never completes on chromium too;
+     the breadcrumb trail on the failing iteration is the lead. The gate
+     correctly held chromium to zero (webkit's PR tolerance does not
+     apply), so this failed the non-required probe — signal, not a
+     blocker.
 
 4. **Residual WorkerDaemonTests wedge (2026-07-02 evening).** With the
    fork bug fixed, worker-tests wedged once more via a different path:

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -185,7 +185,34 @@ chromium failure is treated as real, first time.
      maps checked in). Probably a benign JupyterLab race in the SW-free
      config, but it is exactly the kind of degraded widget state that
      could eat a keypress — worth tracing via the source map before
-     trusting it.
+     trusting it. Confirmed present on every CI boot too (both engines),
+     alongside a `updateRenderOption` null error.
+   - **First instrumented 45-iteration webkit dispatch:** the constant
+     4xx noise is identified — `POST /api/v1/client-diagnostics` 403 plus
+     403s on JupyterLite contents-API *folder-creation* attempts
+     (`Untitled Folder/all.json`, `users/all.json`,
+     `Untitled Folder1/all.json`): the editor's file browser appears to
+     try to materialize the missing `users/<uid>/<setup>` path over HTTP
+     and is refused on every boot. And webkit's exec latency is
+     **bimodal**: 13/45 iterations in a tight 16.2–18.2 s band (rest
+     ~507 ms; chromium 0/30 slow) — a timeout constant being waited out,
+     plausibly the same mechanism whose far tail is the ambient hang.
+     The one red iteration was a **boot-stall** (kernel never idle in
+     90 s), matching production's ~7 % boot→no-idle funnel drop — a
+     third distinct phenomenon, not a post-idle hang.
+
+4. **Residual WorkerDaemonTests wedge (2026-07-02 evening).** With the
+   fork bug fixed, worker-tests wedged once more via a different path:
+   `workerDaemonContinuesToNextJobAfterProcessingFailure` failed its
+   10 s wait, then the bare `try await task.value` after `task.cancel()`
+   suspended forever (`Task.value` is not cancellation-responsive) — the
+   `.timeLimit` trait *attributed* the failure but cannot interrupt a
+   non-cancellable wait, so the job still rode to the 20-minute kill.
+   All 12 cancel-then-await sites now go through a bounded
+   `awaitCancelledDaemon` helper (30 s deadline). The underlying
+   question — *what* in `daemon.run()` ignored cancellation under load —
+   is the remaining daemon-side item; suspects are the artifact-download
+   path and any wait not routed through cancellable primitives.
 2. **Watch the tolerated-webkit warning rate.** The `::warning`
    annotations from the probe and the smoke retries are the flake-rate
    telemetry now; if they show up more than occasionally, the ambient rate

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -162,6 +162,30 @@ chromium failure is treated as real, first time.
    `docs/exec-hang-investigation.md` with the probe breadcrumbs. The
    dispatch/scheduled hard-zero runs of `grading-hang-probe.yml` are the
    fix's acceptance test.
+
+   *2026-07-02 evening findings (probe forensics upgraded in the same
+   change as this note):*
+   - Production telemetry (admin `get_browser_diagnostics`, 96 h window)
+     shows the **sustained-busy `exec_hang` is still real for students on
+     current builds**: 19 hangs / 465 `kernel_idle` boots (~4 %), 19
+     self-heal attempts, 2 `recover_failed`. The v0.4.526 chdir fix killed
+     the 100 % class; this ~4 % residue is a distinct bug.
+   - The **CI probe hang is a different shape**: the 2026-07-02 chromium
+     repro (`hangs=1/8`) showed `indicator=idle` for the full budget and
+     `exec_hang=none` — the cell likely never *started*, i.e. the
+     Shift+Enter dispatch was lost (post-idle focus race), not a wedged
+     kernel. `editor-exec-check.mjs` now classifies this (`lostDispatch`)
+     via a second-press discriminator, captures console-error URLs +
+     all ≥400 responses + failed requests (the four bare 403s in that repro
+     were unidentifiable), reports per-iteration noise base rates on green
+     runs too, and dumps the cell prompt/focus state on every hang.
+   - **Open lead:** `unhandledrejection: Cannot read properties of null
+     (reading 'insertWidget')` fires on essentially every production boot
+     (499 events / ~500 boots in 96 h; vendored `jlab_core` bundle, source
+     maps checked in). Probably a benign JupyterLab race in the SW-free
+     config, but it is exactly the kind of degraded widget state that
+     could eat a keypress — worth tracing via the source map before
+     trusting it.
 2. **Watch the tolerated-webkit warning rate.** The `::warning`
    annotations from the probe and the smoke retries are the flake-rate
    telemetry now; if they show up more than occasionally, the ambient rate

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -238,6 +238,15 @@ chromium failure is treated as real, first time.
      classified as `dialogSteal` (reported, non-failing). **Next step:**
      read the captured `dialog:` text from the next probe run to identify
      which dialog, then fix the folder-setup path that raises it.
+   - **Probe classes are now fully separated (post-boot-stall-split).**
+     The probe distinguishes five outcomes so each maps to one
+     phenomenon: `deadlock` (reached idle, execute wedged — the only
+     leg-failing class), `bootStall` (never reached idle), `dialogSteal`
+     (modal dialog ate the keypress), `lostDispatch` (keypress lost, no
+     dialog), and `webkitWasmCrash` (upstream #286266). Boot-stalls and
+     dialog-steals used to be miscounted as deadlocks; a 30-iteration
+     chromium run's lone failure was a boot-stall (`iter 5/30 ... kernel
+     never reported idle, waited=0ms`), now labelled as such.
    - **Grading-hang probe: chromium also hangs (`1/12`, 2026-07-02).**
      Not webkit-only. The grading path (a SECOND Pyodide in
      grading-worker.js) intermittently never completes on chromium too;

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -193,13 +193,35 @@ chromium failure is treated as real, first time.
      (`Untitled Folder/all.json`, `users/all.json`,
      `Untitled Folder1/all.json`): the editor's file browser appears to
      try to materialize the missing `users/<uid>/<setup>` path over HTTP
-     and is refused on every boot. And webkit's exec latency is
-     **bimodal**: 13/45 iterations in a tight 16.2–18.2 s band (rest
-     ~507 ms; chromium 0/30 slow) — a timeout constant being waited out,
-     plausibly the same mechanism whose far tail is the ambient hang.
-     The one red iteration was a **boot-stall** (kernel never idle in
-     90 s), matching production's ~7 % boot→no-idle funnel drop — a
-     third distinct phenomenon, not a post-idle hang.
+     and is refused on every boot. The one red iteration was a
+     **boot-stall** (kernel never idle in 90 s), matching production's
+     ~7 % boot→no-idle funnel drop — a distinct phenomenon, not a
+     post-idle hang.
+   - **CONFIRMED (three-run delay experiment, 2026-07-02 evening): the
+     webkit slow-execute mode is a fixed-endpoint post-idle background
+     task, not load jitter.** Pressing run at `kernel_idle`+0 ms: 13/45
+     iterations wait 16.2–18.2 s; at +1,500 ms: 12/45 wait 15.7–16.7 s
+     (the band shifts DOWN by the delay — fixed endpoint, not fixed
+     cost); at +25,000 ms: **0/28 slow, every iteration ~510 ms**
+     (p ≈ 4×10⁻⁵ by chance). Something occupies the webkit kernel for
+     ~17–18 s after idle; a cell executed inside that window queues
+     behind it; its far tail is the ambient CI hang and, on slow student
+     hardware, plausibly the residual ~4 % production `exec_hang` (the
+     45 s telemetry threshold would classify a long-enough wait as a
+     hang, and the self-heal reload would "fix" it). It is NOT nb_mypy
+     (disabled — see `scripts/patch-pyodide-kernel.py`; CLAUDE.md was
+     stale on this and has been corrected). Chromium completes the same
+     work fast enough to never lose the race (0 slow in 75+ iterations).
+     **Next step:** identify the task — timestamp post-idle kernel/editor
+     activity (kernel-wheel patch instrumentation or a performance-trace
+     capture in the probe) and inspect what JupyterLite schedules after
+     `kernel_idle` in the SW-free config.
+   - **Cumulative webkit classification, 135 instrumented iterations:**
+     0 post-idle deadlocks, 0 lost dispatches, 1 boot-stall, 3 upstream
+     WebKit WASM crashes (bug #286266, classified separately, non-
+     failing). The "ambient webkit exec-hang" decomposes into the wasm
+     crash + boot-stalls + the fixed-endpoint blocker's tail, with
+     nothing left over so far.
 
 4. **Residual WorkerDaemonTests wedge (2026-07-02 evening).** With the
    fork bug fixed, worker-tests wedged once more via a different path:


### PR DESCRIPTION
Next phase of the exec-hang investigation (`docs/ci-flakiness.md` remaining attack order #1), motivated by two findings:

1. **Production telemetry says the sustained-busy `exec_hang` is still real**: 19 hangs / 465 `kernel_idle` boots (~4%) in the trailing 96 h on current-ish builds, 2 `recover_failed`. The v0.4.526 chdir fix killed the 100% class; this residue is a distinct bug.
2. **The 2026-07-02 CI chromium repro was a *different* shape and was undiagnosable**: `indicator=idle` for the full 60 s budget, `exec_hang=none` (no busy phase — the cell likely never started), and four bare `403` console errors with no URLs. The probe collected errors on every iteration but printed them only on hangs, so the noise base rate was invisible.

## What the probe now does

- **Console errors carry their source URL**; every ≥400 response and failed request is recorded network-side and printed on hangs.
- **Green iterations report `net4xx`/`consoleErr` counts** so ambient noise can't masquerade as a hang correlate.
- **On a hang**: captures the cell input prompt (`[*]` = dispatched-and-stuck vs `[ ]` = never dispatched), output text, `document.hasFocus()`, and the active element.
- **Second-press discriminator**: after the budget expires, press Shift+Enter once more. If the cell then runs, the kernel was healthy the whole time and the *first keypress was lost* — a post-idle focus race, classified as a new `lostDispatch` class: reported loudly, counted separately (`deadlock=` / `lostDispatch=` / `webkitWasmCrash=` in the result line), and **not** a leg failure, so the deadlock signal the probe exists for stays clean. It's still a real student-facing bug ("I pressed run and nothing happened") — just a different one.

## Open lead recorded in the doc

`unhandledrejection: Cannot read properties of null (reading 'insertWidget')` fires on essentially **every** production boot (499/~500 boots in 96 h; vendored `jlab_core`, source maps checked in). Probably a benign JupyterLab race in the SW-free config, but it's the kind of degraded widget state that could eat a keypress — needs a source-map trace before being trusted.

## Verification

`node --check` clean. I'll dispatch `editor-exec-probe` on this branch with a high iteration count (both engines) to exercise the new forensics and gather rate data with classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsDxKBe459swSprNvBJAoJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsDxKBe459swSprNvBJAoJ)_