### PR TITLE
Perf quick wins from the 2026-07 server audit

### DIFF
--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -19,6 +19,11 @@
 //                               lookup.  Whitelist-only: the auth-guarded
 //                               /jupyterlite/…/files/users/ paths are not
 //                               listed and still ride the full chain below.
+//   RequestTimingMiddleware — records request_metrics rows (admin dashboard
+//                               + get_request_metrics MCP tool). Below the
+//                               asset fast path, above sessions so timings
+//                               include the session/auth cost. Idle runner
+//                               check-ins are excluded from persistence.
 //   sessions.middleware
 //   UserSessionAuthenticator
 //   SessionIdleTimeoutMiddleware — runs before UserActivityMiddleware
@@ -103,6 +108,16 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
         EditorAssetFastPathMiddleware(
             publicDirectory: app.directory.publicDirectory,
             crossOriginIsolation: true))
+    // Request timing feeds the request_metrics table behind the admin
+    // dashboard and the get_request_metrics diagnostic tool.  It sits below
+    // the editor-asset fast path (a JupyterLite boot's asset storm never
+    // reaches it) and above the session chain so measured durations include
+    // the real per-request session/auth cost.  recordRequestMetric gates
+    // persistence to /api/*, /submissions/*, /testsetups/* (everything under
+    // VERBOSE_REQUEST_TIMING) and skips idle runner check-ins, so hot-path
+    // worker polls don't turn into per-poll INSERTs.  (Shipped in v0.4.573
+    // but never registered — the metrics pipeline had been silently empty.)
+    app.middleware.use(RequestTimingMiddleware())
     app.middleware.use(app.sessions.middleware)
     app.middleware.use(UserSessionAuthenticator())
     if securityConfiguration.sessionIdleTimeoutSeconds > 0 {

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Metrics.swift
@@ -174,7 +174,7 @@ extension OperationalDiagnosticsService {
         logger: Logger
     ) async {
         guard configuration.enabled else { return }
-        guard shouldCaptureRequest(path: metric.path) else { return }
+        guard shouldCaptureRequest(path: metric.path, statusCode: metric.statusCode) else { return }
 
         do {
             try await metric.save(on: db)
@@ -201,8 +201,21 @@ extension OperationalDiagnosticsService {
             ])
     }
 
-    private func shouldCaptureRequest(path: String) -> Bool {
-        configuration.verboseRequestTiming || shouldAlwaysLogRequest(path: path)
+    private func shouldCaptureRequest(path: String, statusCode: Int) -> Bool {
+        if configuration.verboseRequestTiming { return true }
+        // Runner check-in noise: an idle poll (204, no job) and a healthy
+        // heartbeat arrive at up-to-1/s per runner. Persisting a metric row
+        // for each would be a DB INSERT per poll — the write amplification
+        // the 2026-07 audit flagged on this exact path. Real dispatches
+        // (200), result writebacks, and any error status still record.
+        if isIdleWorkerCheckIn(path: path, statusCode: statusCode) { return false }
+        return shouldAlwaysLogRequest(path: path)
+    }
+
+    private func isIdleWorkerCheckIn(path: String, statusCode: Int) -> Bool {
+        if path == "/api/v1/worker/request" { return statusCode == 204 }
+        if path == "/api/v1/worker/heartbeat" { return statusCode < 400 }
+        return false
     }
 
     private func shouldAlwaysLogRequest(path: String) -> Bool {

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -68,9 +68,14 @@ struct SubmissionQueryRoutes: RouteCollection {
         else {
             throw Abort(.notFound)
         }
-        guard try await submissionAccess(caller: caller, submission: submission, on: req.db).canView
-        else {
-            throw Abort(.forbidden)
+        // Owner-first: this endpoint is polled every 2 s by every student
+        // waiting on a grade, and only needs a view decision (no tier
+        // filtering, unlike getResults). The owner check is free; the staff
+        // check costs a setup lookup + an enrollment-role query per poll.
+        if submission.userID != caller.id {
+            guard try await isSubmissionStaff(caller, submission: submission, on: req.db) else {
+                throw Abort(.forbidden)
+            }
         }
         return SubmissionStatusResponse(submission: submission)
     }
@@ -100,6 +105,43 @@ struct SubmissionQueryRoutes: RouteCollection {
             throw AppError.notFound(resource: "Results for submission '\(subID)' (none available yet)")
         }
 
+        // Visibility inputs are resolved before touching the stored blob so
+        // the ETag can short-circuit the decode/filter/encode below.  Release
+        // is gated on the *effective* deadline — the later of the assignment
+        // due date and the caller's own per-student extension — so an
+        // accommodated student does not get release output revealed while
+        // their extended window is still open.  A non-instructor caller can
+        // only reach their own submission (`canViewSubmission`), so the caller
+        // is the submission owner; for instructors the deadline is unused
+        // (they see every tier).
+        let assignment = try await APIAssignment.query(on: req.db)
+            .filter(\.$testSetupID == submission.testSetupID)
+            .first()
+        let releaseDeadline = try await releaseVisibilityDeadline(
+            for: assignment, user: caller, on: req.db)
+        let callerVisibleTiers = visibleTiers(
+            isStaff: access.isStaff, effectiveDueAt: releaseDeadline)
+
+        // A stored result is immutable, so the response bytes are fully
+        // determined by (result row, visible tier set, ?tiers= slice).  The
+        // tier set is part of the key because it changes when the release
+        // deadline passes — the same result id must then produce a fresh
+        // response.  Repeat views (the common case: a student re-opening
+        // their grade) get a 304 without decoding the collection blob.
+        let requestedTiersParam = req.query[String.self, at: "tiers"]
+        let etagKey = [
+            result.id ?? "",
+            callerVisibleTiers.sorted().joined(separator: ","),
+            requestedTiersParam ?? "*",
+        ].joined(separator: "|")
+        let etag = "\"\(sha256HexDigest(Data(etagKey.utf8)).prefix(32))\""
+        if req.headers[.ifNoneMatch].contains(where: { header in
+            header.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                .contains(etag)
+        }) {
+            return Response(status: .notModified, headers: ["ETag": etag])
+        }
+
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard
@@ -109,25 +151,13 @@ struct SubmissionQueryRoutes: RouteCollection {
             throw AppError.internalFailure(reason: "Stored result is corrupt")
         }
 
-        // `fullCollection` carries the real grade across every tier.  The caller
-        // may only *inspect* certain outcomes: secret never, release after the
-        // deadline (instructors see all tiers).  Release is gated on the
-        // *effective* deadline — the later of the assignment due date and the
-        // caller's own per-student extension — so an accommodated student does
-        // not get release output revealed while their extended window is still
-        // open.  A non-instructor caller can only reach their own submission
-        // (`canViewSubmission`), so the caller is the submission owner; for
-        // instructors the deadline is unused (they see every tier).
-        let assignment = try await APIAssignment.query(on: req.db)
-            .filter(\.$testSetupID == submission.testSetupID)
-            .first()
-        let releaseDeadline = try await releaseVisibilityDeadline(
-            for: assignment, user: caller, on: req.db)
-        let visible = fullCollection.filtering(
-            tiers: visibleTiers(isStaff: access.isStaff, effectiveDueAt: releaseDeadline))
+        // `fullCollection` carries the real grade across every tier.  The
+        // caller may only *inspect* certain outcomes: secret never, release
+        // after the deadline (instructors see all tiers).
+        let visible = fullCollection.filtering(tiers: callerVisibleTiers)
 
         let responseCollection: TestOutcomeCollection
-        if let tiersParam = req.query[String.self, at: "tiers"] {
+        if let tiersParam = requestedTiersParam {
             // Explicit tier slice (?tiers=public,release): return a
             // self-consistent sub-collection — aggregates recomputed over the
             // requested ∩ visible tiers.
@@ -149,7 +179,7 @@ struct SubmissionQueryRoutes: RouteCollection {
 
         return Response(
             status: .ok,
-            headers: ["Content-Type": "application/json"],
+            headers: ["Content-Type": "application/json", "ETag": etag],
             body: .init(data: responseData)
         )
     }

--- a/Sources/APIServer/Services/StuckSubmissionReaperService.swift
+++ b/Sources/APIServer/Services/StuckSubmissionReaperService.swift
@@ -21,19 +21,36 @@ func reapStuckAssignedSubmissions(
     now: Date = Date()
 ) async throws -> Int {
     let cutoff = now.addingTimeInterval(-maxAge)
-    let stuck = try await APISubmission.query(on: db)
-        .filter(\.$status == SubmissionStatus.assigned.rawValue)
-        .filter(\.$assignedAt <= cutoff)
+
+    func scoped() -> QueryBuilder<APISubmission> {
+        APISubmission.query(on: db)
+            .filter(\.$status == SubmissionStatus.assigned.rawValue)
+            .filter(\.$assignedAt <= cutoff)
+    }
+
+    // Read (id, worker) pairs first so the per-submission warning keeps naming
+    // the runner that dropped the job, then flip the whole set back to pending
+    // in ONE bulk UPDATE (same pattern as bulkFlipStudentSubmissionsToPending)
+    // instead of a save per row.  After a fleet-wide runner crash near a
+    // deadline every in-flight job ages out in the same sweep; the old
+    // per-row loop turned that into N sequential round-trips every 60 s.
+    // A row newly aging past the cutoff between the read and the UPDATE is
+    // flipped without its log line and gets logged by the next sweep — benign.
+    let stuck = try await scoped()
+        .field(\.$id)
+        .field(\.$workerID)
         .all()
+    guard !stuck.isEmpty else { return 0 }
+
+    try await scoped()
+        .set(\.$status, to: SubmissionStatus.pending.rawValue)
+        .set(\.$workerID, to: nil)
+        .set(\.$assignedAt, to: nil)
+        .update()
 
     for submission in stuck {
-        let previousWorker = submission.workerID ?? "unknown"
-        submission.setStatus(.pending)
-        submission.workerID = nil
-        submission.assignedAt = nil
-        try await submission.save(on: db)
         logger.warning(
-            "Reaped stuck submission \(submission.id ?? "<nil>") (was assigned to \(previousWorker)); returned to pending queue"
+            "Reaped stuck submission \(submission.id ?? "<nil>") (was assigned to \(submission.workerID ?? "unknown")); returned to pending queue"
         )
     }
     return stuck.count

--- a/Sources/APIServer/Services/SubmissionRetentionService.swift
+++ b/Sources/APIServer/Services/SubmissionRetentionService.swift
@@ -21,6 +21,7 @@
 import Core
 import Fluent
 import Foundation
+import SQLKit
 
 enum SubmissionRetentionService {
 
@@ -53,11 +54,40 @@ enum SubmissionRetentionService {
         let setupIDs = Array(courseBySetup.keys)
         guard !setupIDs.isEmpty else { return [:] }
 
+        // Grouped COUNT(*) instead of materializing one row per submission —
+        // this backs /admin/retention across ALL archived courses at once,
+        // and submissions is the largest unbounded-growth table (2026-07
+        // audit; same pattern as loadUniqueSubmittersBySetup).
+        var counts: [UUID: Int] = [:]
+        if let sql = db as? SQLDatabase {
+            struct SetupCountRow: Decodable {
+                let testSetupID: String
+                let total: Int
+                enum CodingKeys: String, CodingKey {
+                    case testSetupID = "test_setup_id"
+                    case total
+                }
+            }
+            let rows = try await sql.select()
+                .column("test_setup_id")
+                .column(SQLFunction("COUNT", args: SQLLiteral.all), as: "total")
+                .from("submissions")
+                .where("test_setup_id", .in, setupIDs)
+                .groupBy("test_setup_id")
+                .all(decoding: SetupCountRow.self)
+            for row in rows {
+                if let courseID = courseBySetup[row.testSetupID] {
+                    counts[courseID, default: 0] += row.total
+                }
+            }
+            return counts
+        }
+
+        // Non-SQL fallback (not hit by the sqlite/postgres drivers in use).
         let submissions = try await APISubmission.query(on: db)
             .filter(\.$testSetupID ~~ setupIDs)
             .field(\.$testSetupID)
             .all()
-        var counts: [UUID: Int] = [:]
         for submission in submissions {
             if let courseID = courseBySetup[submission.testSetupID] {
                 counts[courseID, default: 0] += 1

--- a/Tests/APITests/RequestTimingMiddlewareTests.swift
+++ b/Tests/APITests/RequestTimingMiddlewareTests.swift
@@ -1,0 +1,97 @@
+// Tests/APITests/RequestTimingMiddlewareTests.swift
+//
+// RequestTimingMiddleware feeds the request_metrics table behind the admin
+// dashboard and the get_request_metrics diagnostic tool. Shipped in v0.4.573
+// but only registered in the chain as of the 2026-07 audit pass — these tests
+// pin (a) that captured routes actually produce rows now, and (b) that idle
+// runner check-ins are excluded so hot-path worker polls don't become
+// per-poll INSERTs.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class RequestTimingMiddlewareTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-reqtiming")
+        // makeTestApp builds a minimal middleware chain (it doesn't run
+        // bootstrapAppMiddleware), so attach the middleware under test the
+        // way the production chain does.
+        app.middleware.use(RequestTimingMiddleware())
+    }
+
+    private func metricCount(path: String) async throws -> Int {
+        try await APIRequestMetric.query(on: app.db)
+            .filter(\.$path == path)
+            .count()
+    }
+
+    private func recordMetric(path: String, statusCode: Int) async {
+        await app.diagnostics.recordRequestMetric(
+            APIRequestMetric(
+                method: "POST",
+                path: path,
+                requestKind: "job_dispatch",
+                statusCode: statusCode,
+                startedAt: Date(),
+                finishedAt: Date(),
+                durationMs: 5,
+                submissionID: nil,
+                workerID: "w1"
+            ),
+            on: app.db,
+            logger: app.logger
+        )
+    }
+
+    /// End-to-end through the responder chain: an /api/* request leaves a
+    /// request_metrics row (this exact pipeline was silently empty while the
+    /// middleware was unregistered in the production chain).
+    @Test func capturedAPIRequestPersistsMetricRow() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginUser(
+                username: "timing_admin", password: "testpassword", role: "admin", on: app)
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            let apiRows = try await metricCount(path: "/api/v1/submissions")
+            #expect(apiRows >= 1)
+        }
+    }
+
+    /// An idle worker poll (204, no job) must NOT persist a metric row —
+    /// that would be one INSERT per runner per second.
+    @Test func idleWorkerPollIsNotPersisted() async throws {
+        try await withApp(app) { _ in
+            await recordMetric(path: "/api/v1/worker/request", statusCode: 204)
+            let idlePollRows = try await metricCount(path: "/api/v1/worker/request")
+            #expect(idlePollRows == 0)
+        }
+    }
+
+    /// A real job dispatch (200) and a failing check-in (>=400) still record.
+    @Test func realDispatchAndErrorsArePersisted() async throws {
+        try await withApp(app) { _ in
+            await recordMetric(path: "/api/v1/worker/request", statusCode: 200)
+            let dispatchRows = try await metricCount(path: "/api/v1/worker/request")
+            #expect(dispatchRows == 1)
+
+            await recordMetric(path: "/api/v1/worker/heartbeat", statusCode: 200)
+            let healthyHeartbeatRows = try await metricCount(path: "/api/v1/worker/heartbeat")
+            #expect(healthyHeartbeatRows == 0)
+
+            await recordMetric(path: "/api/v1/worker/heartbeat", statusCode: 500)
+            let failedHeartbeatRows = try await metricCount(path: "/api/v1/worker/heartbeat")
+            #expect(failedHeartbeatRows == 1)
+        }
+    }
+}

--- a/Tests/APITests/StuckSubmissionReaperTests.swift
+++ b/Tests/APITests/StuckSubmissionReaperTests.swift
@@ -1,0 +1,101 @@
+// Tests/APITests/StuckSubmissionReaperTests.swift
+//
+// reapStuckAssignedSubmissions: `assigned` rows older than the cutoff return
+// to `pending` (worker cleared) in one bulk UPDATE; fresh rows are untouched.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+@Suite(.serialized) final class StuckSubmissionReaperTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-reaper")
+    }
+
+    @discardableResult
+    private func insertAssignedSubmission(
+        id: String,
+        workerID: String,
+        assignedAt: Date
+    ) async throws -> APISubmission {
+        let setupID = "setup_reaper"
+        if try await APITestSetup.find(setupID, on: app.db) == nil {
+            let courseID = try await app.testCourseID()
+            let setup = APITestSetup(
+                id: setupID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+        }
+        let sub = APISubmission(
+            id: id,
+            testSetupID: setupID,
+            zipPath: app.submissionsDirectory + "\(id).zip",
+            attemptNumber: 1,
+            status: SubmissionStatus.assigned.rawValue
+        )
+        sub.workerID = workerID
+        sub.assignedAt = assignedAt
+        try await sub.save(on: app.db)
+        return sub
+    }
+
+    @Test func reapsOnlySubmissionsOlderThanCutoff() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            try await insertAssignedSubmission(
+                id: "sub_stuck_old1", workerID: "w_dead",
+                assignedAt: now.addingTimeInterval(-20 * 60))
+            try await insertAssignedSubmission(
+                id: "sub_stuck_old2", workerID: "w_dead",
+                assignedAt: now.addingTimeInterval(-15 * 60))
+            try await insertAssignedSubmission(
+                id: "sub_stuck_fresh", workerID: "w_alive",
+                assignedAt: now.addingTimeInterval(-60))
+
+            let reaped = try await reapStuckAssignedSubmissions(
+                on: app.db, logger: app.logger, now: now)
+            #expect(reaped == 2)
+
+            let old1 = try #require(try await APISubmission.find("sub_stuck_old1", on: app.db))
+            #expect(old1.status == SubmissionStatus.pending.rawValue)
+            #expect(old1.workerID == nil)
+            #expect(old1.assignedAt == nil)
+
+            let old2 = try #require(try await APISubmission.find("sub_stuck_old2", on: app.db))
+            #expect(old2.status == SubmissionStatus.pending.rawValue)
+
+            let fresh = try #require(try await APISubmission.find("sub_stuck_fresh", on: app.db))
+            #expect(fresh.status == SubmissionStatus.assigned.rawValue)
+            #expect(fresh.workerID == "w_alive")
+            #expect(fresh.assignedAt != nil)
+        }
+    }
+
+    @Test func reapWithNothingStuckIsANoOp() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            try await insertAssignedSubmission(
+                id: "sub_noop_fresh", workerID: "w_alive",
+                assignedAt: now.addingTimeInterval(-30))
+
+            let reaped = try await reapStuckAssignedSubmissions(
+                on: app.db, logger: app.logger, now: now)
+            #expect(reaped == 0)
+
+            let fresh = try #require(try await APISubmission.find("sub_noop_fresh", on: app.db))
+            #expect(fresh.status == SubmissionStatus.assigned.rawValue)
+        }
+    }
+}

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -948,4 +948,153 @@ import VaporTesting
 
         }
     }
+
+    // MARK: - GET /api/v1/submissions/:id — owner fast path (2026-07 audit)
+
+    /// The status endpoint is the 2 s student poll; the owner check must
+    /// grant access without requiring course-staff authority.
+    @Test func getSubmissionOwnerCanPollOwnSubmission() async throws {
+        try await withApp(app) { _ in
+            let username = "student_owner_poll"
+            let cookie = try await loginAsStudent(username: username)
+            let owner = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == username).first())
+            try await insertSubmission(
+                id: "sub_owner_poll", testSetupID: "setup_owner_poll", userID: owner.id)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_owner_poll",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = try res.content.decode(SubmissionStatusResponse.self)
+                    #expect(body.submissionID == "sub_owner_poll")
+                })
+        }
+    }
+
+    /// A non-owner without course-staff authority still falls through to the
+    /// staff check and is rejected — the owner fast path must not widen access.
+    @Test func getSubmissionForbiddenForNonOwnerNonStaff() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsStudent(username: "student_poll_intruder")
+            let other = try await makeTestUser(
+                on: app, username: "student_poll_victim", role: "student")
+            try await insertSubmission(
+                id: "sub_poll_other", testSetupID: "setup_poll_other",
+                userID: try other.requireID())
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_poll_other",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden)
+                })
+        }
+    }
+
+    // MARK: - GET /api/v1/submissions/:id/results — ETag (2026-07 audit)
+
+    /// Results are immutable, so a repeat view with the returned ETag gets a
+    /// 304 without the server re-decoding the stored collection.
+    @Test func getResultsEmitsETagAndReturns304OnMatch() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+            try await insertSubmission(id: "sub_etag1", testSetupID: "setup_etag1")
+            let collection = makeCollection(
+                submissionID: "sub_etag1",
+                outcomes: [makeOutcome(name: "test_a")]
+            )
+            try await insertResult(submissionID: "sub_etag1", collection: collection)
+
+            var etag = ""
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_etag1/results",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    etag = try #require(res.headers.first(name: .eTag))
+                    #expect(etag.hasPrefix("\"") && etag.hasSuffix("\""))
+                })
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_etag1/results",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                    req.headers.add(name: .ifNoneMatch, value: etag)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .notModified)
+                    #expect(res.body.readableBytes == 0)
+                    #expect(res.headers.first(name: .eTag) == etag)
+                })
+
+            // A non-matching validator still gets the full representation.
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_etag1/results",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                    req.headers.add(name: .ifNoneMatch, value: "\"deadbeef\"")
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                })
+        }
+    }
+
+    /// The ETag embeds the caller's visible tier set, so a validator cached
+    /// before the release deadline must NOT produce a 304 after the deadline
+    /// passes — a stale 304 would hide the newly-released outcomes.
+    @Test func getResultsStaleETagRefreshesWhenReleaseBecomesVisible() async throws {
+        try await withApp(app) { _ in
+            let setupID = "setup_etag_deadline"
+            let username = "student_etag_dl"
+            let cookie = try await loginAsStudent(username: username)
+            let student = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == username).first())
+            let assignment = try await ensureAssignment(
+                setupID: setupID,
+                dueAt: Date().addingTimeInterval(3600))
+            try await insertSubmission(
+                id: "sub_etag_dl", testSetupID: setupID, userID: student.id)
+            let collection = makeCollection(
+                submissionID: "sub_etag_dl",
+                outcomes: [
+                    makeOutcome(name: "test_pub", tier: .pub, status: .pass),
+                    makeOutcome(name: "test_release", tier: .release, status: .fail),
+                ]
+            )
+            try await insertResult(submissionID: "sub_etag_dl", collection: collection)
+
+            var preDeadlineETag = ""
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_etag_dl/results",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    preDeadlineETag = try #require(res.headers.first(name: .eTag))
+                    let body = try self.decodeCollection(from: res.body)
+                    #expect(body.outcomes.contains { $0.tier == .release } == false)
+                })
+
+            // Deadline passes: the pre-deadline validator must miss, and the
+            // fresh response must include the release outcome.
+            assignment.dueAt = Date().addingTimeInterval(-3600)
+            try await assignment.save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_etag_dl/results",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                    req.headers.add(name: .ifNoneMatch, value: preDeadlineETag)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let freshETag = try #require(res.headers.first(name: .eTag))
+                    #expect(freshETag != preDeadlineETag)
+                    let body = try self.decodeCollection(from: res.body)
+                    #expect(body.outcomes.contains { $0.tier == .release })
+                })
+        }
+    }
 }

--- a/changelog.d/perf-quick-wins-1151.md
+++ b/changelog.d/perf-quick-wins-1151.md
@@ -1,0 +1,20 @@
+### Changed
+
+- **Perf quick wins from the 2026-07 server audit (#1151).** The submission
+  status endpoint (the 2 s student poll) grants owners access without the
+  course-staff lookup, saving two DB queries per poll; the stuck-submission
+  reaper flips aged-out jobs back to pending in one bulk `UPDATE` instead of a
+  save per row; the retention report counts submissions with a grouped
+  `COUNT(*)` instead of materializing every row; and
+  `GET /api/v1/submissions/:id/results` now emits an `ETag` (keyed on result +
+  visible tiers) and answers matching `If-None-Match` with 304 so repeat views
+  skip the collection decode.
+
+### Fixed
+
+- **`RequestTimingMiddleware` is now actually registered.** It shipped in
+  v0.4.573 but was never added to the middleware chain, so the
+  `request_metrics` table behind the admin dashboard and the
+  `get_request_metrics` diagnostic tool had been silently empty. Idle runner
+  check-ins (204 polls, healthy heartbeats) are excluded from persistence so
+  the hot worker-poll path doesn't gain a per-poll INSERT.


### PR DESCRIPTION
Closes #1151.

Five small, independent fixes from the 2026-07 server performance audit:

1. **Owner-first access on the submission status poll.** `GET /api/v1/submissions/:id` is polled every 2 s by each student waiting on a grade; it previously ran `isSubmissionStaff` (setup lookup + enrollment-role query) before the trivial owner check. The owner case now short-circuits; non-owners still fall through to the staff check. `getResults` is untouched — it consumes `isStaff` for tier visibility, so its semantics can't take the shortcut.

2. **Stuck-submission reaper does one bulk `UPDATE`.** Previously fetched all stuck rows and saved them one by one every 60 s; after a fleet-wide runner crash near a deadline that's N sequential round-trips. Now reads `(id, workerID)` for the warning log, then flips the set in a single bulk UPDATE (the `bulkFlipStudentSubmissionsToPending` pattern).

3. **Retention report counts via grouped `COUNT(*)`.** `/admin/retention` was materializing every submission row across all archived courses just to increment counters. Same fold, two queries, no row materialization (pattern of `loadUniqueSubmittersBySetup`).

4. **ETag + `If-None-Match` on `GET /api/v1/submissions/:id/results`.** Stored results are immutable; the ETag is keyed on (result id, caller-visible tier set, `?tiers=` slice) so repeat views 304 without decoding the collection blob, while a release-deadline crossing changes the visible tier set and correctly invalidates the validator. Includes a test pinning that a pre-deadline ETag does not 304 after release becomes visible.

5. **`RequestTimingMiddleware` is now actually registered.** It shipped in v0.4.573 together with the `request_metrics` table, the accumulators, and the admin `get_request_metrics` MCP tool — but was never added to the chain in any commit, so that whole pipeline has been silently empty. Registered below the editor-asset fast path (asset storms never reach it) and above sessions (timings include real session/auth cost). To avoid trading one audit finding for another, idle runner check-ins (204 polls, healthy heartbeats) are excluded from persistence — real dispatches, result writebacks, and error statuses record.

**Tests:** new `StuckSubmissionReaperTests` (bulk flip + cutoff boundary + no-op), new `RequestTimingMiddlewareTests` (row persisted through the responder chain; idle-poll/heartbeat exclusion; dispatch + error capture), and four new `SubmissionQueryRoutesTests` (owner fast path, non-owner 403, ETag/304 round-trip, stale-ETag refresh across a deadline crossing). Existing retention and tier-visibility suites cover the rewritten query paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_