### PR TITLE
Eliminate per-poll DB writes on the worker check-in path

### DIFF
--- a/Sources/APIServer/Compatibility/RunnerProfileService.swift
+++ b/Sources/APIServer/Compatibility/RunnerProfileService.swift
@@ -19,12 +19,23 @@ struct LoadedAssignmentRequirement: Sendable {
 }
 
 struct RunnerProfileService {
+    /// How stale the persisted `lastSeenAt` may get before an otherwise
+    /// unchanged check-in writes it again. Runners poll at up to 1/s; without
+    /// a debounce every poll is a row UPDATE (2026-07 audit). Must stay well
+    /// under `RUNNER_ACTIVE_WINDOW_SECONDS` (default 120 s) so
+    /// `refreshActiveFlags` never sees a live runner as stale: a live runner
+    /// checks in at least every 30 s (heartbeat), so persisted freshness lags
+    /// true freshness by at most ~`debounce` seconds. The live dashboard
+    /// reads `WorkerActivityStore` (in-memory), not this column.
+    static let lastSeenPersistInterval: TimeInterval = 60
+
     func registerOrUpdate(
         runnerID: String,
         displayName: String?,
         profile: RunnerCapabilityProfile?,
         seenAt: Date,
-        on db: Database
+        on db: Database,
+        lastSeenPersistInterval: TimeInterval = RunnerProfileService.lastSeenPersistInterval
     ) async throws -> RunnerProfileUpsertResult {
         guard !runnerID.isEmpty else {
             return RunnerProfileUpsertResult(profile: nil, event: nil)
@@ -34,12 +45,28 @@ struct RunnerProfileService {
             .filter(\.$runnerID == runnerID)
             .first()
 
+        // A check-in that changes nothing but the freshness timestamp only
+        // persists when the stored timestamp has aged past the debounce
+        // window — the poll-frequency UPDATE-per-poll is the thing being
+        // avoided here. Any real change (capabilities, display name,
+        // reactivation) still writes immediately.
+        func onlyRefreshesFreshness(_ existing: RunnerProfile, displayNameChanged: Bool) -> Bool {
+            !displayNameChanged
+                && existing.isActive
+                && seenAt.timeIntervalSince(existing.lastSeenAt) < lastSeenPersistInterval
+        }
+
         guard let profile else {
             if let existing {
+                let newName = nonEmpty(displayName)
+                let displayNameChanged = newName != nil && newName != existing.displayName
+                if onlyRefreshesFreshness(existing, displayNameChanged: displayNameChanged) {
+                    return RunnerProfileUpsertResult(profile: existing, event: nil)
+                }
                 existing.lastSeenAt = seenAt
                 existing.isActive = true
-                if let displayName, !displayName.isEmpty {
-                    existing.displayName = displayName
+                if let newName {
+                    existing.displayName = newName
                 }
                 try await existing.save(on: db)
             }
@@ -49,7 +76,12 @@ struct RunnerProfileService {
         let profileHash = self.profileHash(for: profile)
         if let existing {
             let event: RunnerProfileRegistrationEvent? = existing.profileHash == profileHash ? nil : .updated
-            existing.displayName = nonEmpty(displayName) ?? existing.displayName
+            let newName = nonEmpty(displayName)
+            let displayNameChanged = newName != nil && newName != existing.displayName
+            if event == nil, onlyRefreshesFreshness(existing, displayNameChanged: displayNameChanged) {
+                return RunnerProfileUpsertResult(profile: existing, event: nil)
+            }
+            existing.displayName = newName ?? existing.displayName
             existing.capabilityProfile = profile
             existing.profileHash = profileHash
             existing.lastRegisteredAt = seenAt

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
@@ -77,19 +77,31 @@ extension OperationalDiagnosticsService {
     ) async {
         guard configuration.enabled else { return }
         do {
-            let row = RunnerSnapshot(
+            // Sampled, not per-check-in: one snapshot row per runner per
+            // sample interval, plus an immediate row on any load-shape
+            // change (see RunnerSnapshotSampleStore). The check-in log
+            // event below still fires every time.
+            let persistSnapshot = await snapshotSampler.shouldPersist(
                 runnerID: snapshot.workerID,
                 recordedAt: snapshot.lastActive,
                 activeJobs: snapshot.activeJobs,
-                maxJobs: snapshot.maxConcurrentJobs,
-                availableCapacity: max(0, snapshot.maxConcurrentJobs - snapshot.activeJobs),
-                hostname: snapshot.hostname.isEmpty ? nil : snapshot.hostname,
-                runnerVersion: snapshot.runnerVersion.isEmpty ? nil : snapshot.runnerVersion,
-                lastPollAt: snapshot.lastPollAt,
-                lastHeartbeatAt: snapshot.lastHeartbeatAt,
-                serverAssignedJobCountSinceStart: snapshot.serverAssignedJobCountSinceStart
+                maxJobs: snapshot.maxConcurrentJobs
             )
-            try await row.save(on: db)
+            if persistSnapshot {
+                let row = RunnerSnapshot(
+                    runnerID: snapshot.workerID,
+                    recordedAt: snapshot.lastActive,
+                    activeJobs: snapshot.activeJobs,
+                    maxJobs: snapshot.maxConcurrentJobs,
+                    availableCapacity: max(0, snapshot.maxConcurrentJobs - snapshot.activeJobs),
+                    hostname: snapshot.hostname.isEmpty ? nil : snapshot.hostname,
+                    runnerVersion: snapshot.runnerVersion.isEmpty ? nil : snapshot.runnerVersion,
+                    lastPollAt: snapshot.lastPollAt,
+                    lastHeartbeatAt: snapshot.lastHeartbeatAt,
+                    serverAssignedJobCountSinceStart: snapshot.serverAssignedJobCountSinceStart
+                )
+                try await row.save(on: db)
+            }
 
             let event: ObservabilityEvent = reason == .poll ? .runnerPolled : .runnerHeartbeat
             logger.info(

--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics.swift
@@ -170,6 +170,44 @@ actor DiagnosticsMaintenanceStore {
     }
 }
 
+/// Decides whether a runner check-in persists a `RunnerSnapshot` row.
+/// Runners poll at up to 1/s, and one INSERT per poll made `runner_snapshots`
+/// the dominant idle write load (~2,880 rows/day/runner even at the 30 s
+/// backoff — 2026-07 audit). One row per runner per sample interval is
+/// plenty for the admin dashboard's sparklines; a change in load shape
+/// (activeJobs/maxJobs) persists immediately so spikes stay visible at
+/// full resolution.
+actor RunnerSnapshotSampleStore {
+    static let defaultSampleInterval: TimeInterval = 30
+
+    private struct LastPersisted {
+        let recordedAt: Date
+        let activeJobs: Int
+        let maxJobs: Int
+    }
+
+    private var lastByRunnerID: [String: LastPersisted] = [:]
+
+    func shouldPersist(
+        runnerID: String,
+        recordedAt: Date,
+        activeJobs: Int,
+        maxJobs: Int,
+        sampleInterval: TimeInterval = RunnerSnapshotSampleStore.defaultSampleInterval
+    ) -> Bool {
+        if let last = lastByRunnerID[runnerID],
+            last.activeJobs == activeJobs,
+            last.maxJobs == maxJobs,
+            recordedAt.timeIntervalSince(last.recordedAt) < sampleInterval
+        {
+            return false
+        }
+        lastByRunnerID[runnerID] = LastPersisted(
+            recordedAt: recordedAt, activeJobs: activeJobs, maxJobs: maxJobs)
+        return true
+    }
+}
+
 actor CompatibilityCounterStore {
     private var compatibleAssignmentAttempts = 0
     private var incompatibleAssignmentAttempts = 0
@@ -210,6 +248,7 @@ final class OperationalDiagnosticsService: @unchecked Sendable {
     let configuration: DiagnosticsConfiguration
     let maintenance = DiagnosticsMaintenanceStore()
     let compatibilityCounters = CompatibilityCounterStore()
+    let snapshotSampler = RunnerSnapshotSampleStore()
 
     init(configuration: DiagnosticsConfiguration) {
         self.configuration = configuration

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -109,6 +109,24 @@ struct WorkerJobRoutes: RouteCollection {
     private func claimNextEligibleJob(
         req: Request, body: WorkerActivityPayload, runnerProfile: RunnerCapabilityProfile?
     ) async throws -> ClaimedJob? {
+        // Idle-poll short-circuit (2026-07 audit): most polls find nothing to
+        // claim, yet each one previously entered the globally-serialized
+        // claim section and opened a write transaction issuing 2–3 candidate
+        // SELECTs. One cheap indexed existence probe (status prefix of
+        // idx_submissions_status_kind_submitted_at) outside the serialized
+        // section answers the empty case. Deliberately a fresh DB read, not
+        // cached state: there is nothing to invalidate, it is correct across
+        // processes, and a submission enqueued right after the probe is
+        // simply seen by the runner's next poll — the same pickup latency
+        // the poll cadence already implies. The claim transaction below
+        // re-reads candidates, so this never affects claim atomicity.
+        let hasPendingWork =
+            try await APISubmission.query(on: req.db)
+            .filter(\.$status == SubmissionStatus.pending.rawValue)
+            .field(\.$id)
+            .first() != nil
+        guard hasPendingWork else { return nil }
+
         let evaluator = ClaimEvaluator(
             assignmentRequirements: req.application.assignmentRequirements,
             compatibilityMatcher: CompatibilityMatcher()

--- a/Tests/APITests/WorkerPollWriteReductionTests.swift
+++ b/Tests/APITests/WorkerPollWriteReductionTests.swift
@@ -1,0 +1,203 @@
+// Tests/APITests/WorkerPollWriteReductionTests.swift
+//
+// 2026-07 audit: the worker poll previously wrote to the DB on every poll —
+// a RunnerProfile UPDATE and a RunnerSnapshot INSERT per check-in, at up to
+// 1/s per runner. These tests pin the two write-reduction behaviours:
+// unchanged check-ins inside the debounce/sample window persist nothing,
+// while any real change (capabilities, reactivation, load shape) or an
+// elapsed window persists immediately.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+@Suite(.serialized) final class WorkerPollWriteReductionTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-pollwrites")
+    }
+
+    private func makeProfile(capability: String = "numpy") -> RunnerCapabilityProfile {
+        RunnerCapabilityProfile(
+            platform: "linux",
+            architecture: "x86_64",
+            languageVersions: [LanguageVersion(language: "python", version: "3.11.8")],
+            capabilities: [RunnerCapability(name: capability)]
+        )
+    }
+
+    private func storedLastSeenAt(runnerID: String) async throws -> Date {
+        let row = try #require(
+            try await RunnerProfile.query(on: app.db)
+                .filter(\.$runnerID == runnerID).first())
+        return row.lastSeenAt
+    }
+
+    // MARK: - RunnerProfile lastSeenAt debounce
+
+    @Test func unchangedCheckInWithinDebounceWindowSkipsWrite() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+            let service = app.runnerProfiles
+
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db1", displayName: "host-a",
+                profile: makeProfile(), seenAt: t0, on: app.db)
+            let persisted = try await storedLastSeenAt(runnerID: "runner-db1")
+            #expect(persisted == t0)
+
+            // 5 s later, identical payload: no write.
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db1", displayName: "host-a",
+                profile: makeProfile(), seenAt: t0.addingTimeInterval(5), on: app.db)
+            let afterSecond = try await storedLastSeenAt(runnerID: "runner-db1")
+            #expect(afterSecond == t0)
+        }
+    }
+
+    @Test func unchangedCheckInAfterDebounceWindowPersists() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+            let service = app.runnerProfiles
+
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db2", displayName: "host-a",
+                profile: makeProfile(), seenAt: t0, on: app.db)
+
+            let late = t0.addingTimeInterval(RunnerProfileService.lastSeenPersistInterval + 1)
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db2", displayName: "host-a",
+                profile: makeProfile(), seenAt: late, on: app.db)
+            let persisted = try await storedLastSeenAt(runnerID: "runner-db2")
+            #expect(persisted == late)
+        }
+    }
+
+    @Test func changedProfilePersistsImmediatelyDespiteDebounce() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+            let service = app.runnerProfiles
+
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db3", displayName: "host-a",
+                profile: makeProfile(capability: "numpy"), seenAt: t0, on: app.db)
+
+            let result = try await service.registerOrUpdate(
+                runnerID: "runner-db3", displayName: "host-a",
+                profile: makeProfile(capability: "pandas"),
+                seenAt: t0.addingTimeInterval(2), on: app.db)
+            #expect(result.event == .updated)
+            let persisted = try await storedLastSeenAt(runnerID: "runner-db3")
+            #expect(persisted == t0.addingTimeInterval(2))
+
+            let row = try #require(
+                try await RunnerProfile.query(on: app.db)
+                    .filter(\.$runnerID == "runner-db3").first())
+            #expect(row.capabilityProfile.capabilities.map(\.name) == ["pandas"])
+        }
+    }
+
+    @Test func inactiveProfileReactivatesImmediately() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+            let service = app.runnerProfiles
+
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db4", displayName: "host-a",
+                profile: makeProfile(), seenAt: t0, on: app.db)
+            let row = try #require(
+                try await RunnerProfile.query(on: app.db)
+                    .filter(\.$runnerID == "runner-db4").first())
+            row.isActive = false
+            try await row.save(on: app.db)
+
+            // Within the debounce window, but the runner needs reactivating —
+            // must write.
+            _ = try await service.registerOrUpdate(
+                runnerID: "runner-db4", displayName: "host-a",
+                profile: makeProfile(), seenAt: t0.addingTimeInterval(2), on: app.db)
+            let reloaded = try #require(
+                try await RunnerProfile.query(on: app.db)
+                    .filter(\.$runnerID == "runner-db4").first())
+            #expect(reloaded.isActive == true)
+            #expect(reloaded.lastSeenAt == t0.addingTimeInterval(2))
+        }
+    }
+
+    // MARK: - RunnerSnapshot sampling
+
+    private func makeSnapshot(
+        workerID: String, at date: Date, activeJobs: Int, maxJobs: Int = 4
+    ) -> WorkerActivitySnapshot {
+        WorkerActivitySnapshot(
+            workerID: workerID,
+            lastActive: date,
+            hostname: "host-a",
+            runnerVersion: "runner/1.0",
+            maxConcurrentJobs: maxJobs,
+            activeJobs: activeJobs,
+            lastPollAt: date,
+            lastHeartbeatAt: nil,
+            serverAssignedJobCountSinceStart: 0
+        )
+    }
+
+    private func snapshotCount(runnerID: String) async throws -> Int {
+        try await RunnerSnapshot.query(on: app.db)
+            .filter(\.$runnerID == runnerID)
+            .count()
+    }
+
+    // Snapshot tests use near-now timestamps: rows dated older than the
+    // 30-day snapshot retention get deleted by the prune sweep that runs on
+    // the first check-in, which would silently swallow the inserts.
+    @Test func identicalCheckInsWithinSampleIntervalPersistOneRow() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date().addingTimeInterval(-120)
+            for offset in [0.0, 1.0, 2.0, 3.0] {
+                await app.diagnostics.recordRunnerCheckIn(
+                    snapshot: makeSnapshot(workerID: "runner-s1", at: t0.addingTimeInterval(offset), activeJobs: 0),
+                    reason: .poll, on: app.db, logger: app.logger)
+            }
+            let rows = try await snapshotCount(runnerID: "runner-s1")
+            #expect(rows == 1)
+        }
+    }
+
+    @Test func loadShapeChangePersistsImmediately() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date().addingTimeInterval(-120)
+            await app.diagnostics.recordRunnerCheckIn(
+                snapshot: makeSnapshot(workerID: "runner-s2", at: t0, activeJobs: 0),
+                reason: .poll, on: app.db, logger: app.logger)
+            // 1 s later a job is running — must persist despite the interval.
+            await app.diagnostics.recordRunnerCheckIn(
+                snapshot: makeSnapshot(workerID: "runner-s2", at: t0.addingTimeInterval(1), activeJobs: 1),
+                reason: .poll, on: app.db, logger: app.logger)
+            let rows = try await snapshotCount(runnerID: "runner-s2")
+            #expect(rows == 2)
+        }
+    }
+
+    @Test func elapsedSampleIntervalPersistsFreshRow() async throws {
+        try await withApp(app) { _ in
+            let t0 = Date().addingTimeInterval(-120)
+            await app.diagnostics.recordRunnerCheckIn(
+                snapshot: makeSnapshot(workerID: "runner-s3", at: t0, activeJobs: 0),
+                reason: .poll, on: app.db, logger: app.logger)
+            let later = t0.addingTimeInterval(RunnerSnapshotSampleStore.defaultSampleInterval + 1)
+            await app.diagnostics.recordRunnerCheckIn(
+                snapshot: makeSnapshot(workerID: "runner-s3", at: later, activeJobs: 0),
+                reason: .poll, on: app.db, logger: app.logger)
+            let rows = try await snapshotCount(runnerID: "runner-s3")
+            #expect(rows == 2)
+        }
+    }
+}

--- a/changelog.d/worker-poll-writes-1152.md
+++ b/changelog.d/worker-poll-writes-1152.md
@@ -1,0 +1,13 @@
+### Changed
+
+- **Idle worker polls no longer write to the database (#1152).** Every
+  `POST /worker/request` previously cost a `RunnerProfile` UPDATE, a
+  `RunnerSnapshot` INSERT, and a globally-serialized claim transaction with
+  2–3 SELECTs — at up to one poll per second per runner, even with an empty
+  queue. The profile's `lastSeenAt` now persists at most once per 60 s when
+  nothing else changed (capability changes, display-name changes, and
+  reactivation still write immediately); runner snapshots are sampled — one
+  row per runner per 30 s, with an immediate row on any activeJobs/maxJobs
+  change so load spikes keep full resolution; and an indexed existence probe
+  short-circuits the claim path before the serialized transaction when no
+  pending submission exists.


### PR DESCRIPTION
Closes #1152.

Every `POST /worker/request` previously cost a `RunnerProfile` UPDATE, a `RunnerSnapshot` INSERT, and a globally-serialized claim transaction issuing 2–3 SELECTs — at up to one poll per second per runner, **even with an empty queue**. This was the dominant runner-side DB load and the piece that scaled worst with runner count. Three changes:

**1. `RunnerProfile.lastSeenAt` debounce (60 s).** An unchanged check-in only refreshes the freshness column, and now does so at most once per 60 s. Capability changes, display-name changes, and reactivation still write immediately (pinned by tests). Safety margin: a live runner checks in at least every 30 s, so the persisted timestamp lags true freshness by at most ~60 s — well inside the 120 s `RUNNER_ACTIVE_WINDOW_SECONDS` that `refreshActiveFlags` uses, so no active-flag flapping. The live admin dashboard reads the in-memory `WorkerActivityStore`, not this column.

**2. `RunnerSnapshot` sampling (30 s + change-triggered).** One snapshot row per runner per 30 s, plus an immediate row whenever the load shape (`activeJobs`/`maxJobs`) changes — so load spikes keep full resolution while idle runners stop appending ~2,880 rows/day each. The check-in observability log event still fires on every poll.

**3. Idle-poll short-circuit on the claim path.** `claimNextEligibleJob` now runs one indexed existence probe (`status == pending`, `LIMIT 1`, on the `idx_submissions_status_kind_submitted_at` prefix) *outside* the serialized claim section and returns 204 when the queue is empty. This is deliberately a fresh DB read rather than a cached pending flag: nothing to invalidate, correct across processes, and a submission enqueued right after the probe is picked up by the next poll — the same latency the poll cadence already implies. The claim transaction re-reads candidates, so claim atomicity is untouched.

**Tests:** new `WorkerPollWriteReductionTests` (7 tests) pin the debounce window, the immediate-write-on-change paths (profile change, reactivation), and the snapshot sampling (skip within interval, immediate on load change, fresh row after interval). Existing `WorkerRoutesTests`, `RunnerCompatibilityTests`, and `ObservabilityTests` (including the poll→claim and heartbeat→snapshot round-trips) pass unchanged.

Part of the 2026-07 performance audit series (#1151–#1160); companion to #1153 which shrinks the serialized claim section itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_