### PR TITLE
Shrink the worker-claim critical section to an atomic compare-and-set

### DIFF
--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -160,9 +160,10 @@ struct WorkerJobRoutes: RouteCollection {
     /// SQLite's write lock, but the section it guards is now one UPDATE and
     /// one SELECT; on Postgres it could be retired entirely in favour of
     /// `FOR UPDATE SKIP LOCKED` (documented follow-up on #1153).
-    // Internal (not private) so the claim CAS semantics are directly
-    // testable — the lost-race path can't be triggered deterministically
-    // through the HTTP endpoint.
+    ///
+    /// Internal (not private) so the claim CAS semantics are directly
+    /// testable — the lost-race path can't be triggered deterministically
+    /// through the HTTP endpoint.
     func atomicallyClaimSubmission(
         id submissionID: String, req: Request, body: WorkerActivityPayload
     ) async throws -> APISubmission? {

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -102,10 +102,18 @@ struct WorkerJobRoutes: RouteCollection {
         return profileUpsert.profile?.capabilityProfile
     }
 
-    /// Atomically finds and claims the best pending job for this runner.
-    /// WorkerClaimQueue serializes concurrent calls at the application level;
-    /// the inner transaction provides the DB-level guarantee for multi-process
-    /// deployments where SQLite WAL serializes write transactions.
+    /// Finds and claims the best pending job for this runner.
+    ///
+    /// Structure (2026-07 audit): candidate collection, per-candidate
+    /// requirement loading, and compatibility evaluation are all reads and
+    /// run OUTSIDE the serialized claim section — holding the global
+    /// WorkerClaimQueue (and a write transaction) across those queries
+    /// multiplied the serialized section by the number of skipped candidates
+    /// exactly when the queue was deepest. Only the claim itself is
+    /// serialized, and it is an atomic compare-and-set
+    /// (`UPDATE … WHERE status = 'pending'`), so a candidate another runner
+    /// claimed between our scan and our claim matches zero rows and the walk
+    /// simply moves to the next candidate.
     private func claimNextEligibleJob(
         req: Request, body: WorkerActivityPayload, runnerProfile: RunnerCapabilityProfile?
     ) async throws -> ClaimedJob? {
@@ -132,19 +140,47 @@ struct WorkerJobRoutes: RouteCollection {
             compatibilityMatcher: CompatibilityMatcher()
         )
 
-        return try await req.application.workerClaimQueue.run {
+        let candidates = try await collectClaimCandidates(on: req.db)
+        return try await evaluateAndClaimCandidate(
+            candidates: candidates,
+            req: req,
+            body: body,
+            runnerProfile: runnerProfile,
+            evaluator: evaluator
+        )
+    }
+
+    /// Atomically claims one submission via compare-and-set: the UPDATE's
+    /// `status == pending` guard means concurrent claimers cannot both win,
+    /// on SQLite and Postgres alike (the same conditional-UPDATE idiom the
+    /// MCP single-use token consumption uses). The follow-up re-read
+    /// confirms *this* worker won — a lost race matched zero rows and left
+    /// the winner's id on the row. The WorkerClaimQueue actor still
+    /// serializes in-process claim attempts so concurrent polls don't thrash
+    /// SQLite's write lock, but the section it guards is now one UPDATE and
+    /// one SELECT; on Postgres it could be retired entirely in favour of
+    /// `FOR UPDATE SKIP LOCKED` (documented follow-up on #1153).
+    // Internal (not private) so the claim CAS semantics are directly
+    // testable — the lost-race path can't be triggered deterministically
+    // through the HTTP endpoint.
+    func atomicallyClaimSubmission(
+        id submissionID: String, req: Request, body: WorkerActivityPayload
+    ) async throws -> APISubmission? {
+        try await req.application.workerClaimQueue.run {
             try await retrySQLiteBusyClaim {
-                try await req.db.transaction { db -> ClaimedJob? in
-                    let candidates = try await collectClaimCandidates(on: db)
-                    return try await evaluateAndClaimCandidate(
-                        candidates: candidates,
-                        req: req,
-                        body: body,
-                        runnerProfile: runnerProfile,
-                        evaluator: evaluator,
-                        on: db
-                    )
-                }
+                try await APISubmission.query(on: req.db)
+                    .filter(\.$id == submissionID)
+                    .filter(\.$status == SubmissionStatus.pending.rawValue)
+                    .set(\.$status, to: SubmissionStatus.assigned.rawValue)
+                    .set(\.$workerID, to: body.workerID)
+                    .set(\.$assignedAt, to: Date())
+                    .update()
+                guard
+                    let fresh = try await APISubmission.find(submissionID, on: req.db),
+                    fresh.status == SubmissionStatus.assigned.rawValue,
+                    fresh.workerID == body.workerID
+                else { return nil }
+                return fresh
             }
         }
     }
@@ -299,7 +335,8 @@ private struct BlockedCandidate {
     let result: CompatibilityResult
 }
 
-/// Loads the ordered list of claim candidates inside the claim transaction.
+/// Loads the ordered list of claim candidates (plain reads, outside the
+/// serialized claim section — the compare-and-set claim re-checks pending).
 /// Fresh student work (retestedAt == nil) is claimed before any retest
 /// (retestedAt != nil), so a manifest-revision sweep can't starve students who
 /// are actively submitting (#427). Within each group, oldest submittedAt wins.
@@ -385,90 +422,97 @@ private func collectClaimCandidates(
 }
 
 /// Walks the ordered candidate list, checks each against the runner's
-/// capability profile, and claims the first compatible one inside the
-/// transaction.  When no candidate is claimable, emits a single
-/// "no compatible runner available" diagnostic for the first blocked candidate
-/// we saw and returns nil.
-/// Bundles the per-claim collaborators that don't change between candidates,
-/// so the per-candidate evaluation helper stays under the parameter-count cap.
+/// capability profile, and atomically claims the first compatible one that is
+/// still pending.  All evaluation (requirement queries, compatibility
+/// matching, diagnostics) happens outside the serialized claim section; only
+/// the compare-and-set claim itself is serialized.  A candidate that another
+/// runner claimed since the scan fails its CAS and the walk continues.  When
+/// no candidate is claimable, emits a single "no compatible runner available"
+/// diagnostic for the first blocked candidate we saw and returns nil.
+/// ClaimEvaluator bundles the per-claim collaborators that don't change
+/// between candidates, so the evaluation helper stays under the
+/// parameter-count cap.
 private struct ClaimEvaluator {
     let assignmentRequirements: AssignmentRequirementService
     let compatibilityMatcher: CompatibilityMatcher
 }
 
-private func evaluateAndClaimCandidate(
-    candidates: [(APISubmission, APITestSetup, TestProperties)],
-    req: Request,
-    body: WorkerActivityPayload,
-    runnerProfile: RunnerCapabilityProfile?,
-    evaluator: ClaimEvaluator,
-    on db: Database
-) async throws -> ClaimedJob? {
-    var blockedCandidate: BlockedCandidate?
+extension WorkerJobRoutes {
+    fileprivate func evaluateAndClaimCandidate(
+        candidates: [(APISubmission, APITestSetup, TestProperties)],
+        req: Request,
+        body: WorkerActivityPayload,
+        runnerProfile: RunnerCapabilityProfile?,
+        evaluator: ClaimEvaluator
+    ) async throws -> ClaimedJob? {
+        var blockedCandidate: BlockedCandidate?
 
-    for (submission, setup, manifest) in candidates {
-        let loadedRequirements = try await evaluator.assignmentRequirements.loadRequirement(
-            for: submission, on: db)
-        let requirementSpec = loadedRequirements.requirement?.requirementSpec
+        for (submission, setup, manifest) in candidates {
+            let loadedRequirements = try await evaluator.assignmentRequirements.loadRequirement(
+                for: submission, on: req.db)
+            let requirementSpec = loadedRequirements.requirement?.requirementSpec
 
-        req.application.diagnostics.recordAssignmentRequirementsLoaded(
-            submission: submission,
-            assignmentID: loadedRequirements.assignmentID,
-            requirements: requirementSpec,
-            logger: req.logger
-        )
+            req.application.diagnostics.recordAssignmentRequirementsLoaded(
+                submission: submission,
+                assignmentID: loadedRequirements.assignmentID,
+                requirements: requirementSpec,
+                logger: req.logger
+            )
 
-        let compatibilityResult = evaluator.compatibilityMatcher.evaluate(
-            runnerProfile: runnerProfile,
-            requirements: requirementSpec
-        )
-        await req.application.diagnostics.recordCompatibilityDecision(
-            submission: submission,
-            assignmentID: loadedRequirements.assignmentID,
-            runnerID: body.workerID,
-            requirements: requirementSpec,
-            result: compatibilityResult,
-            logger: req.logger
-        )
+            let compatibilityResult = evaluator.compatibilityMatcher.evaluate(
+                runnerProfile: runnerProfile,
+                requirements: requirementSpec
+            )
+            await req.application.diagnostics.recordCompatibilityDecision(
+                submission: submission,
+                assignmentID: loadedRequirements.assignmentID,
+                runnerID: body.workerID,
+                requirements: requirementSpec,
+                result: compatibilityResult,
+                logger: req.logger
+            )
 
-        guard compatibilityResult.isCompatible else {
-            if blockedCandidate == nil {
-                blockedCandidate = BlockedCandidate(
-                    submission: submission,
-                    assignmentID: loadedRequirements.assignmentID,
-                    requirements: requirementSpec,
-                    result: compatibilityResult
-                )
+            guard compatibilityResult.isCompatible else {
+                if blockedCandidate == nil {
+                    blockedCandidate = BlockedCandidate(
+                        submission: submission,
+                        assignmentID: loadedRequirements.assignmentID,
+                        requirements: requirementSpec,
+                        result: compatibilityResult
+                    )
+                }
+                continue
             }
-            continue
+
+            guard let submissionID = submission.id,
+                let claimed = try await atomicallyClaimSubmission(id: submissionID, req: req, body: body)
+            else {
+                // Lost the claim race (or a malformed row) — the next
+                // candidate may still be ours.
+                continue
+            }
+
+            return ClaimedJob(
+                submission: claimed,
+                setup: setup,
+                manifest: manifest,
+                assignmentID: loadedRequirements.assignmentID,
+                requirementSpec: requirementSpec
+            )
         }
 
-        // Claim inside the transaction — atomic with the select above.
-        submission.setStatus(.assigned)
-        submission.workerID = body.workerID
-        submission.assignedAt = Date()
-        try await submission.save(on: db)
-
-        return ClaimedJob(
-            submission: submission,
-            setup: setup,
-            manifest: manifest,
-            assignmentID: loadedRequirements.assignmentID,
-            requirementSpec: requirementSpec
-        )
+        if let blockedCandidate {
+            await req.application.diagnostics.recordNoCompatibleRunnerAvailable(
+                submission: blockedCandidate.submission,
+                assignmentID: blockedCandidate.assignmentID,
+                runnerID: body.workerID,
+                requirements: blockedCandidate.requirements,
+                result: blockedCandidate.result,
+                logger: req.logger
+            )
+        }
+        return nil
     }
-
-    if let blockedCandidate {
-        await req.application.diagnostics.recordNoCompatibleRunnerAvailable(
-            submission: blockedCandidate.submission,
-            assignmentID: blockedCandidate.assignmentID,
-            runnerID: body.workerID,
-            requirements: blockedCandidate.requirements,
-            result: blockedCandidate.result,
-            logger: req.logger
-        )
-    }
-    return nil
 }
 
 private func resolvedWorkerBaseURL(req: Request) -> String {
@@ -552,9 +596,14 @@ private func testSetupDownloadVersion(for setup: APITestSetup) async -> String {
 // MARK: - Application-level claim serializer
 
 /// Ensures at most one worker-job claim operation executes at a time.
-/// This complements the DB transaction: SQLite WAL serializes write
-/// transactions in file-based deployments; this queue does the same for
-/// in-process scenarios (single-node servers, test environments).
+/// Claim *correctness* comes from the compare-and-set UPDATE in
+/// `atomicallyClaimSubmission` (its `status == pending` guard is atomic on
+/// SQLite and Postgres alike); this queue exists so concurrent in-process
+/// polls don't thrash SQLite's write lock and burn busy-retries. The section
+/// it guards is one UPDATE + one SELECT (2026-07 audit — evaluation moved
+/// outside). On Postgres it could be retired in favour of
+/// `FOR UPDATE SKIP LOCKED` so claims run fully in parallel (#1153
+/// follow-up).
 ///
 /// Implemented as a Swift actor — actor isolation replaces the previous
 /// NSLock + @unchecked Sendable approach, giving compile-time concurrency

--- a/Tests/APITests/ClaimCompareAndSetTests.swift
+++ b/Tests/APITests/ClaimCompareAndSetTests.swift
@@ -1,0 +1,113 @@
+// Tests/APITests/ClaimCompareAndSetTests.swift
+//
+// atomicallyClaimSubmission is the compare-and-set at the heart of the job
+// claim (#1153): the UPDATE's `status == pending` guard means concurrent
+// claimers cannot both win, and a lost race leaves the winner's row
+// untouched. The endpoint-level race is covered by
+// WorkerRoutesTests.requestJob_concurrentClaims_onlyOneSucceeds; these tests
+// pin the CAS semantics directly, including the lost-race path that can't be
+// triggered deterministically over HTTP.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+@Suite(.serialized) final class ClaimCompareAndSetTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-claimcas")
+    }
+
+    private func seedPendingSubmission(id: String) async throws {
+        let setupID = "setup_cas"
+        if try await APITestSetup.find(setupID, on: app.db) == nil {
+            let courseID = try await app.testCourseID()
+            let setup = APITestSetup(
+                id: setupID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+        }
+        let sub = APISubmission(
+            id: id,
+            testSetupID: setupID,
+            zipPath: app.submissionsDirectory + "\(id).zip",
+            attemptNumber: 1,
+            status: SubmissionStatus.pending.rawValue
+        )
+        try await sub.save(on: app.db)
+    }
+
+    private func makeRequest() -> Request {
+        Request(
+            application: app,
+            method: .POST,
+            url: URI(path: "/api/v1/worker/request"),
+            on: app.eventLoopGroup.next()
+        )
+    }
+
+    private func payload(workerID: String) -> WorkerActivityPayload {
+        WorkerActivityPayload(
+            workerID: workerID,
+            hostname: "host-\(workerID)",
+            runnerVersion: "runner/1.0",
+            maxConcurrentJobs: 1,
+            activeJobs: 0,
+            profile: nil
+        )
+    }
+
+    @Test func pendingSubmissionIsClaimedAndStamped() async throws {
+        try await withApp(app) { _ in
+            try await seedPendingSubmission(id: "sub_cas_win")
+
+            let claimed = try await WorkerJobRoutes().atomicallyClaimSubmission(
+                id: "sub_cas_win", req: makeRequest(), body: payload(workerID: "w1"))
+
+            let row = try #require(claimed)
+            #expect(row.status == SubmissionStatus.assigned.rawValue)
+            #expect(row.workerID == "w1")
+            #expect(row.assignedAt != nil)
+        }
+    }
+
+    @Test func lostRaceReturnsNilAndLeavesWinnerUntouched() async throws {
+        try await withApp(app) { _ in
+            try await seedPendingSubmission(id: "sub_cas_race")
+            let routes = WorkerJobRoutes()
+
+            let first = try await routes.atomicallyClaimSubmission(
+                id: "sub_cas_race", req: makeRequest(), body: payload(workerID: "w1"))
+            #expect(first != nil)
+
+            // Second claimer arrives after the CAS flipped the row — must
+            // lose without disturbing the winner's stamp.
+            let second = try await routes.atomicallyClaimSubmission(
+                id: "sub_cas_race", req: makeRequest(), body: payload(workerID: "w2"))
+            #expect(second == nil)
+
+            let row = try #require(try await APISubmission.find("sub_cas_race", on: app.db))
+            #expect(row.status == SubmissionStatus.assigned.rawValue)
+            #expect(row.workerID == "w1")
+        }
+    }
+
+    @Test func unknownSubmissionReturnsNil() async throws {
+        try await withApp(app) { _ in
+            let claimed = try await WorkerJobRoutes().atomicallyClaimSubmission(
+                id: "sub_cas_missing", req: makeRequest(), body: payload(workerID: "w1"))
+            #expect(claimed == nil)
+        }
+    }
+}

--- a/changelog.d/claim-critical-section-1153.md
+++ b/changelog.d/claim-critical-section-1153.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Worker claim critical section shrunk to a compare-and-set (#1153).**
+  Candidate collection, per-candidate assignment-requirement queries, and
+  compatibility evaluation now run outside the globally-serialized
+  `WorkerClaimQueue` section (previously they all held it, plus an open write
+  transaction — so requirement-heavy queues multiplied the serialized section
+  exactly at deadline crunch). The claim itself is an atomic
+  `UPDATE … WHERE status = 'pending'`; a candidate another runner claimed
+  since the scan matches zero rows and the walk moves to the next candidate.
+  This also makes the claim genuinely race-safe on Postgres (single-statement
+  CAS rather than read-then-write in a read-committed transaction); retiring
+  the in-process queue on Postgres in favour of `FOR UPDATE SKIP LOCKED`
+  remains a documented follow-up.


### PR DESCRIPTION
Closes #1153.

The claim path previously held the global `WorkerClaimQueue` actor **and** an open write transaction across the entire candidate walk — including up to 2 assignment-requirement queries per skipped candidate (scan cap 50) plus diagnostics recording. With requirement-carrying assignments in the queue, the serialized section grew with the number of incompatible candidates, exactly when poll pressure peaked. Adding runners increased contention on this one actor rather than throughput.

**What changed:**

- **Evaluation moved outside the lock.** Candidate collection, requirement loading, compatibility matching, and diagnostics are plain reads and now run before entering the serialized section.
- **The claim is now a true compare-and-set.** A single `UPDATE … WHERE id = ? AND status = 'pending'` followed by a winner-verification read. Concurrent claimers cannot both win — on SQLite *and* Postgres (the same conditional-UPDATE idiom the MCP single-use token consumption uses). Note this is strictly *more* atomic than before: the old read-then-save inside a read-committed Postgres transaction was not actually race-safe cross-process; the CAS is.
- **Lost races degrade gracefully.** A candidate claimed by another runner between our scan and our claim matches zero rows and the walk continues to the next candidate — previously that window made the whole poll return empty-handed.
- **`WorkerClaimQueue` stays but now guards one UPDATE + one SELECT.** Its remaining job is keeping concurrent in-process polls from thrashing SQLite's write lock. Retiring it on Postgres in favour of `SELECT … FOR UPDATE SKIP LOCKED` (fully parallel claims) is left as the documented follow-up on #1153 — it needs Postgres-specific query plumbing and deserves its own PR.

**Semantics preserved:** fresh-before-retest priority (#427), the scan cap, the setup/manifest memoization, and the single "no compatible runner" diagnostic per empty walk are all unchanged. Requirement edits landing mid-poll can still race the claim by one poll interval — the same TOCTOU window that existed inside the old transaction, just marginally wider.

**Tests:** new `ClaimCompareAndSetTests` pin the CAS directly — win path (stamped status/worker/assignedAt), lost-race path (nil return, winner's row untouched), unknown id. The endpoint-level race regression test (`requestJob_concurrentClaims_onlyOneSucceeds`) and the full `WorkerRoutesTests` / `RunnerCompatibilityTests` / `WorkerPollWriteReductionTests` / `ObservabilityTests` suites pass unchanged.

Part of the 2026-07 performance audit series (#1151–#1160); builds on #1162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_