### PR TITLE
Make worker nonce replay protection and login rate limits multi-process safe

### DIFF
--- a/Sources/APIServer/MCP/Transport/MCPOAuthRateLimitMiddleware.swift
+++ b/Sources/APIServer/MCP/Transport/MCPOAuthRateLimitMiddleware.swift
@@ -6,9 +6,9 @@
 // attacker could flood the oauth_clients table; the limiter plus the
 // MCPConfig.maxRegisteredClients backstop bound that.
 //
-// Reuses the app's LoginAttemptStore actor with a namespaced key ("mcp-oauth:")
-// so the bookkeeping is shared and ephemeral, matching the /login limiter.
-// POST-only; other methods pass through.
+// Reuses the login_attempts-backed LoginAttemptService with a namespaced key
+// ("mcp-oauth:") so the bookkeeping is shared — across processes too, #1154 —
+// matching the /login limiter. POST-only; other methods pass through.
 
 import Foundation
 import Vapor
@@ -20,11 +20,12 @@ struct MCPOAuthRateLimitMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
         guard request.method == .POST else { return try await next.respond(to: request) }
         let ip = clientIPAddress(from: request, trustForwardedFor: trustForwardedFor)
-        let allowed = await request.application.loginAttemptStore.recordAndCheckIP(
+        let allowed = try await LoginAttemptService.recordAndCheckIP(
             ip: "mcp-oauth:\(ip)",
             now: Date(),
             windowSeconds: 60,
-            max: perMinute
+            max: perMinute,
+            on: request.db
         )
         guard allowed else {
             request.logger.warning("MCP OAuth rate limit exceeded for IP \(ip)")

--- a/Sources/APIServer/Middleware/LoginRateLimitMiddleware.swift
+++ b/Sources/APIServer/Middleware/LoginRateLimitMiddleware.swift
@@ -15,19 +15,22 @@
 //      account in a soft lockout state.  Subsequent attempts return 423
 //      Locked until the window passes or a successful login (e.g. by an
 //      admin after manual reset) clears the failure record.  Enforced by
-//      the login handler via `LoginAttemptStore.isLocked` / `recordFailure`
+//      the login handler via `LoginAttemptService.isLocked` / `recordFailure`
 //      / `clearFailures`, because the username is only known after the
 //      request body has been decoded.
 //
-// Storage is in-memory (`LoginAttemptStore` actor) — the same pattern used
-// by `WorkerNonceStore`.  Restart clears all state, which is fine for these
-// time-bounded checks; clustered deployments would need a shared store, but
-// Chickadee's deployment model is single-process today.
+// Storage is the `login_attempts` table (#1154).  The counts must be shared
+// across server processes: with the old in-memory actor, N instances behind
+// a load balancer meant N× the configured per-IP rate and lockouts that only
+// counted the failures that happened to land on the same instance.  Login
+// traffic is low-frequency, so the two or three indexed queries per POST are
+// negligible.
 //
 // IP extraction honours `X-Forwarded-For` only when the operator has set
 // TRUST_X_FORWARDED_PROTO=true (the existing trust signal), so spoofing
 // behind an untrusted proxy can't bypass the limit.
 
+import Fluent
 import Foundation
 import Vapor
 
@@ -80,16 +83,23 @@ struct LoginRateLimitMiddleware: AsyncMiddleware {
             from: request,
             trustForwardedFor: configuration.trustForwardedFor
         )
-        let allowed = await request.application.loginAttemptStore.recordAndCheckIP(
+        let allowed = try await LoginAttemptService.recordAndCheckIP(
             ip: ip,
             now: Date(),
             windowSeconds: 60,
-            max: configuration.perMinute
+            max: configuration.perMinute,
+            on: request.db
         )
         if !allowed {
             request.logger.warning("Login rate limit exceeded for IP \(ip)")
             return try Self.tooManyRequestsResponse()
         }
+        await LoginAttemptService.purgeStaleIfDue(
+            application: request.application,
+            db: request.db,
+            lockoutWindowSeconds: configuration.lockoutWindowSeconds,
+            logger: request.logger
+        )
         return try await next.respond(to: request)
     }
 
@@ -122,90 +132,138 @@ func clientIPAddress(from request: Request, trustForwardedFor: Bool) -> String {
     return "unknown"
 }
 
-// MARK: - Attempt store
+// MARK: - Attempt service (database-backed)
 
-/// Tracks per-IP request timestamps and per-username failure timestamps for
-/// brute-force protection.  All state is in-memory and ephemeral.
-actor LoginAttemptStore {
-    private var ipTimestamps: [String: [Date]] = [:]
-    private var userFailures: [String: [Date]] = [:]
+/// Tracks per-IP request events and per-username failure events for
+/// brute-force protection, in the `login_attempts` table so the sliding
+/// windows are shared across server processes (#1154). Every query is
+/// covered by the (scope, attempt_key, occurred_at) index; per-key rows are
+/// pruned on each write so a key's row count is bounded by its own window.
+enum LoginAttemptService {
+    /// How often (at most) a request triggers the global stale-row sweep.
+    static let purgeInterval: TimeInterval = 600
 
     /// Records a request from `ip` and reports whether it should be allowed
     /// under a sliding-window cap of `max` per `windowSeconds`.  The request
     /// is counted regardless of the return value (rejected requests still
     /// count against the limit) so a misbehaving client can't game the cap
     /// by exceeding it.
-    func recordAndCheckIP(
+    static func recordAndCheckIP(
         ip: String,
         now: Date,
         windowSeconds: TimeInterval,
-        max: Int
-    ) -> Bool {
+        max: Int,
+        on db: Database
+    ) async throws -> Bool {
         let cutoff = now.addingTimeInterval(-windowSeconds)
-        var list = (ipTimestamps[ip] ?? []).filter { $0 > cutoff }
-        list.append(now)
-        ipTimestamps[ip] = list
-        return list.count <= max
+        try await LoginAttempt.query(on: db)
+            .filter(\.$scope == LoginAttempt.Scope.ip)
+            .filter(\.$attemptKey == ip)
+            .filter(\.$occurredAt <= cutoff)
+            .delete()
+        try await LoginAttempt(scope: LoginAttempt.Scope.ip, attemptKey: ip, occurredAt: now)
+            .create(on: db)
+        let count = try await LoginAttempt.query(on: db)
+            .filter(\.$scope == LoginAttempt.Scope.ip)
+            .filter(\.$attemptKey == ip)
+            .filter(\.$occurredAt > cutoff)
+            .count()
+        return count <= max
     }
 
     /// Returns true if the given username has accumulated `threshold` or
     /// more failed logins inside the trailing `windowSeconds`.
-    func isLocked(
+    static func isLocked(
         username: String,
         now: Date,
         windowSeconds: TimeInterval,
-        threshold: Int
-    ) -> Bool {
+        threshold: Int,
+        on db: Database
+    ) async throws -> Bool {
         let cutoff = now.addingTimeInterval(-windowSeconds)
-        let list = (userFailures[username] ?? []).filter { $0 > cutoff }
-        userFailures[username] = list
-        return list.count >= threshold
+        let count = try await LoginAttempt.query(on: db)
+            .filter(\.$scope == LoginAttempt.Scope.userFailure)
+            .filter(\.$attemptKey == username)
+            .filter(\.$occurredAt > cutoff)
+            .count()
+        return count >= threshold
     }
 
     /// Records a failed login attempt against `username`.  Failures older
     /// than `windowSeconds` are pruned at the same time.
-    func recordFailure(
+    static func recordFailure(
         username: String,
         now: Date,
-        windowSeconds: TimeInterval
-    ) {
+        windowSeconds: TimeInterval,
+        on db: Database
+    ) async throws {
         let cutoff = now.addingTimeInterval(-windowSeconds)
-        var list = (userFailures[username] ?? []).filter { $0 > cutoff }
-        list.append(now)
-        userFailures[username] = list
+        try await LoginAttempt.query(on: db)
+            .filter(\.$scope == LoginAttempt.Scope.userFailure)
+            .filter(\.$attemptKey == username)
+            .filter(\.$occurredAt <= cutoff)
+            .delete()
+        try await LoginAttempt(
+            scope: LoginAttempt.Scope.userFailure, attemptKey: username, occurredAt: now
+        ).create(on: db)
     }
 
     /// Clears all failure records for `username`.  Called after a successful
     /// login so the user isn't subsequently locked out by their own pre-
     /// success retries.
-    func clearFailures(username: String) {
-        userFailures[username] = nil
+    static func clearFailures(username: String, on db: Database) async throws {
+        try await LoginAttempt.query(on: db)
+            .filter(\.$scope == LoginAttempt.Scope.userFailure)
+            .filter(\.$attemptKey == username)
+            .delete()
+    }
+
+    /// Sweeps rows old enough to be outside every window (keys that never
+    /// came back and so were never pruned on-write). Throttled per process;
+    /// best-effort.
+    static func purgeStaleIfDue(
+        application: Application,
+        db: Database,
+        lockoutWindowSeconds: TimeInterval,
+        logger: Logger
+    ) async {
+        let due = await application.loginAttemptPurgeThrottle.shouldRun(
+            now: Date(), interval: purgeInterval)
+        guard due else { return }
+        let horizon = Date().addingTimeInterval(-Swift.max(lockoutWindowSeconds, 3600))
+        do {
+            try await LoginAttempt.query(on: db)
+                .filter(\.$occurredAt <= horizon)
+                .delete()
+        } catch {
+            logger.warning("login_attempt_purge_failed: \(String(describing: error))")
+        }
     }
 }
 
 // MARK: - Application storage
 
-struct LoginAttemptStoreKey: StorageKey {
-    typealias Value = LoginAttemptStore
-}
-
 struct LoginRateLimitConfigurationKey: StorageKey {
     typealias Value = LoginRateLimitConfiguration
 }
 
-extension Application {
-    var loginAttemptStore: LoginAttemptStore {
-        get {
-            if let existing = storage[LoginAttemptStoreKey.self] { return existing }
-            let created = LoginAttemptStore()
-            storage[LoginAttemptStoreKey.self] = created
-            return created
-        }
-        set { storage[LoginAttemptStoreKey.self] = newValue }
-    }
+struct LoginAttemptPurgeThrottleKey: StorageKey {
+    typealias Value = PurgeThrottle
+}
 
+extension Application {
     var loginRateLimitConfiguration: LoginRateLimitConfiguration {
         get { storage[LoginRateLimitConfigurationKey.self] ?? .default }
         set { storage[LoginRateLimitConfigurationKey.self] = newValue }
+    }
+
+    var loginAttemptPurgeThrottle: PurgeThrottle {
+        get {
+            if let existing = storage[LoginAttemptPurgeThrottleKey.self] { return existing }
+            let created = PurgeThrottle()
+            storage[LoginAttemptPurgeThrottleKey.self] = created
+            return created
+        }
+        set { storage[LoginAttemptPurgeThrottleKey.self] = newValue }
     }
 }

--- a/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
+++ b/Sources/APIServer/Middleware/WorkerHMACAuthMiddleware.swift
@@ -1,4 +1,5 @@
 import Core
+import Fluent
 import Foundation
 import Vapor
 
@@ -43,11 +44,16 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
         }
 
         let nonceKey = (workerID ?? "_anonymous") + ":" + nonce
-        let wasInserted = await request.application.workerNonceStore
-            .insertIfNew(nonceKey, now: now, ttlSeconds: nonceTTLSeconds)
+        let wasInserted = try await WorkerNonceReplayGuard.insertIfNew(
+            nonceKey: nonceKey,
+            expiresAt: Date(timeIntervalSince1970: TimeInterval(now + nonceTTLSeconds)),
+            on: request.db
+        )
         guard wasInserted else {
             throw Abort(.unauthorized, reason: "Replay detected.")
         }
+        await WorkerNonceReplayGuard.purgeExpiredIfDue(
+            application: request.application, db: request.db, logger: request.logger)
 
         let headers = WorkerHMACSigning.SignedHeaders(
             timestamp: timestampHeader,
@@ -89,40 +95,84 @@ struct WorkerHMACAuthMiddleware: AsyncMiddleware {
     }
 }
 
-// MARK: - Application storage for the nonce store
+// MARK: - Nonce replay guard (database-backed)
 
-struct WorkerNonceStoreKey: StorageKey {
-    typealias Value = WorkerNonceStore
+/// Replay protection backed by the `worker_nonces` table (#1154). The old
+/// in-memory actor was per-process: a signed request captured on one
+/// instance could be replayed against another within the TTL window. The
+/// PRIMARY KEY insert makes first-seen atomic across every process sharing
+/// the database, and — as a free improvement — replaces the actor's
+/// O(all nonces) dictionary rebuild on every worker request with a
+/// throttled bulk DELETE.
+enum WorkerNonceReplayGuard {
+    /// How often (at most) a request triggers the expired-row purge.
+    static let purgeInterval: TimeInterval = 60
+
+    /// Atomically records first use of `nonceKey`. Returns false when the
+    /// key was already consumed (replay). A unique-constraint failure is
+    /// detected by re-fetching rather than by string-matching driver errors —
+    /// the same recover-by-re-fetch idiom as `AssignmentSeedStore`. Nonces
+    /// are random per request, so colliding with an expired-but-unpurged row
+    /// only happens when a client actually reuses a nonce — which is exactly
+    /// the thing to reject.
+    static func insertIfNew(
+        nonceKey: String, expiresAt: Date, on db: Database
+    ) async throws -> Bool {
+        let row = WorkerNonce(nonceKey: nonceKey, expiresAt: expiresAt)
+        do {
+            try await row.create(on: db)
+            return true
+        } catch {
+            if try await WorkerNonce.find(nonceKey, on: db) != nil {
+                return false
+            }
+            throw error
+        }
+    }
+
+    /// Deletes expired nonce rows, at most once per `purgeInterval` per
+    /// process. Best-effort: a failed purge only delays cleanup.
+    static func purgeExpiredIfDue(application: Application, db: Database, logger: Logger) async {
+        let due = await application.workerNoncePurgeThrottle.shouldRun(
+            now: Date(), interval: purgeInterval)
+        guard due else { return }
+        do {
+            try await WorkerNonce.query(on: db)
+                .filter(\.$expiresAt <= Date())
+                .delete()
+        } catch {
+            logger.warning("worker_nonce_purge_failed: \(String(describing: error))")
+        }
+    }
+}
+
+/// Rate-limits a recurring maintenance action to once per interval per
+/// process (same shape as `DiagnosticsMaintenanceStore`).
+actor PurgeThrottle {
+    private var lastRunAt: Date?
+
+    func shouldRun(now: Date, interval: TimeInterval) -> Bool {
+        if let lastRunAt, now.timeIntervalSince(lastRunAt) < interval {
+            return false
+        }
+        lastRunAt = now
+        return true
+    }
+}
+
+struct WorkerNoncePurgeThrottleKey: StorageKey {
+    typealias Value = PurgeThrottle
 }
 
 extension Application {
-    var workerNonceStore: WorkerNonceStore {
+    var workerNoncePurgeThrottle: PurgeThrottle {
         get {
-            if let existing = storage[WorkerNonceStoreKey.self] {
-                return existing
-            }
-            let created = WorkerNonceStore()
-            storage[WorkerNonceStoreKey.self] = created
+            if let existing = storage[WorkerNoncePurgeThrottleKey.self] { return existing }
+            let created = PurgeThrottle()
+            storage[WorkerNoncePurgeThrottleKey.self] = created
             return created
         }
-        set { storage[WorkerNonceStoreKey.self] = newValue }
-    }
-}
-
-// MARK: - Nonce store (replay protection)
-
-actor WorkerNonceStore {
-    private var seen: [String: Int64] = [:]
-
-    func insertIfNew(_ nonce: String, now: Int64, ttlSeconds: Int64) -> Bool {
-        purgeExpired(now: now)
-        if seen[nonce] != nil { return false }
-        seen[nonce] = now + ttlSeconds
-        return true
-    }
-
-    private func purgeExpired(now: Int64) {
-        seen = seen.filter { $0.value > now }
+        set { storage[WorkerNoncePurgeThrottleKey.self] = newValue }
     }
 }
 

--- a/Sources/APIServer/Migrations/CreateLoginAttempts.swift
+++ b/Sources/APIServer/Migrations/CreateLoginAttempts.swift
@@ -1,0 +1,29 @@
+import Fluent
+import SQLKit
+
+/// Shared login-rate-limit events (#1154): per-IP window counts and
+/// per-username failure counts move from process-local memory to the
+/// database so brute-force protection holds across a multi-process
+/// deployment. The composite index backs every query the service issues
+/// (count/prune by (scope, key) with an `occurred_at` bound).
+struct CreateLoginAttempts: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(LoginAttempt.schema)
+            .id()
+            .field("scope", .string, .required)
+            .field("attempt_key", .string, .required)
+            .field("occurred_at", .datetime, .required)
+            .create()
+
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "CREATE INDEX IF NOT EXISTS idx_login_attempts_scope_key_time "
+                    + "ON login_attempts(scope, attempt_key, occurred_at)"
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(LoginAttempt.schema).delete()
+    }
+}

--- a/Sources/APIServer/Migrations/CreateWorkerNonces.swift
+++ b/Sources/APIServer/Migrations/CreateWorkerNonces.swift
@@ -1,0 +1,25 @@
+import Fluent
+import SQLKit
+
+/// Replay-protection nonces for worker HMAC auth (#1154). The PRIMARY KEY on
+/// `nonce_key` makes first-seen an atomic INSERT across every server process
+/// sharing the database. The `expires_at` index backs the opportunistic
+/// purge (`DELETE WHERE expires_at <= now`).
+struct CreateWorkerNonces: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(WorkerNonce.schema)
+            .field("nonce_key", .string, .identifier(auto: false))
+            .field("expires_at", .datetime, .required)
+            .create()
+
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "CREATE INDEX IF NOT EXISTS idx_worker_nonces_expires_at ON worker_nonces(expires_at)"
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(WorkerNonce.schema).delete()
+    }
+}

--- a/Sources/APIServer/Models/LoginAttempt.swift
+++ b/Sources/APIServer/Models/LoginAttempt.swift
@@ -1,0 +1,41 @@
+import Fluent
+import Foundation
+import Vapor
+
+/// One login-rate-limit event: either a POST hitting the per-IP window
+/// (`scope == "ip"`) or a failed login against a username
+/// (`scope == "user_failure"`). Stored in the database so the sliding-window
+/// counts are shared across server processes — with the old in-memory
+/// `LoginAttemptStore`, N instances behind a load balancer meant N× the
+/// configured per-IP rate and lockouts that only counted same-instance
+/// failures (2026-07 audit, #1154). Rows are pruned per-key on write and
+/// globally by a throttled sweep in the middleware.
+final class LoginAttempt: Model, @unchecked Sendable {
+    // @unchecked Sendable: written once at creation, never mutated after.
+    static let schema = "login_attempts"
+
+    enum Scope {
+        static let ip = "ip"
+        static let userFailure = "user_failure"
+    }
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "scope")
+    var scope: String
+
+    @Field(key: "attempt_key")
+    var attemptKey: String
+
+    @Field(key: "occurred_at")
+    var occurredAt: Date
+
+    init() {}
+
+    init(scope: String, attemptKey: String, occurredAt: Date) {
+        self.scope = scope
+        self.attemptKey = attemptKey
+        self.occurredAt = occurredAt
+    }
+}

--- a/Sources/APIServer/Models/WorkerNonce.swift
+++ b/Sources/APIServer/Models/WorkerNonce.swift
@@ -1,0 +1,28 @@
+import Fluent
+import Foundation
+import Vapor
+
+/// One consumed worker-HMAC nonce. The PRIMARY KEY on `nonce_key` is the
+/// replay guard: first-seen is an atomic INSERT, and a unique violation means
+/// the (workerID, nonce) pair was already consumed — by ANY server process
+/// sharing this database, which is the property the old in-memory
+/// `WorkerNonceStore` could not provide behind a load balancer (2026-07
+/// audit, #1154). Rows expire after the signing TTL and are purged
+/// opportunistically by the middleware.
+final class WorkerNonce: Model, @unchecked Sendable {
+    // @unchecked Sendable: written once at creation, never mutated after.
+    static let schema = "worker_nonces"
+
+    @ID(custom: "nonce_key", generatedBy: .user)
+    var id: String?
+
+    @Field(key: "expires_at")
+    var expiresAt: Date
+
+    init() {}
+
+    init(nonceKey: String, expiresAt: Date) {
+        self.id = nonceKey
+        self.expiresAt = expiresAt
+    }
+}

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -87,16 +87,16 @@ struct AuthRoutes: RouteCollection {
 
         let body = try req.content.decode(LoginBody.self)
         let rateConfig = req.application.loginRateLimitConfiguration
-        let attemptStore = req.application.loginAttemptStore
         let usernameKey = body.username.lowercased()
         let now = Date()
 
         if rateConfig.enabled {
-            let locked = await attemptStore.isLocked(
+            let locked = try await LoginAttemptService.isLocked(
                 username: usernameKey,
                 now: now,
                 windowSeconds: rateConfig.lockoutWindowSeconds,
-                threshold: rateConfig.lockoutThreshold
+                threshold: rateConfig.lockoutThreshold,
+                on: req.db
             )
             if locked {
                 req.logger.warning("Login locked for user '\(usernameKey)' (too many failures)")
@@ -119,10 +119,11 @@ struct AuthRoutes: RouteCollection {
             )
         else {
             if rateConfig.enabled {
-                await attemptStore.recordFailure(
+                try await LoginAttemptService.recordFailure(
                     username: usernameKey,
                     now: now,
-                    windowSeconds: rateConfig.lockoutWindowSeconds
+                    windowSeconds: rateConfig.lockoutWindowSeconds,
+                    on: req.db
                 )
             }
             await AuditLogger.record(
@@ -136,7 +137,7 @@ struct AuthRoutes: RouteCollection {
         }
 
         if rateConfig.enabled {
-            await attemptStore.clearFailures(username: usernameKey)
+            try await LoginAttemptService.clearFailures(username: usernameKey, on: req.db)
         }
         user.lastLoginAt = now
         user.lastSeenAt = now

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -378,4 +378,10 @@ func registerMigrations(on app: Application) {
     // the now-meaningless global label here loses no teaching authority.
     app.migrations.add(CollapseUserRoles())
 
+    // Multi-process security state (#1154): worker-HMAC replay nonces and
+    // login rate-limit/lockout events move from process-local memory to the
+    // database so their guarantees hold behind a load balancer. New tables,
+    // no ordering constraints.
+    app.migrations.add(CreateWorkerNonces())
+    app.migrations.add(CreateLoginAttempts())
 }

--- a/Tests/APITests/LoginRateLimitTests.swift
+++ b/Tests/APITests/LoginRateLimitTests.swift
@@ -1,94 +1,206 @@
+// Tests/APITests/LoginRateLimitTests.swift
+//
+// LoginAttemptService semantics (sliding IP window, username lockout) and —
+// the point of #1154 — that the counts are shared across Application
+// instances backed by the same database, so brute-force protection holds in
+// a multi-process deployment.
+
 import Fluent
 import Foundation
 import Testing
+import Vapor
+import VaporTesting
 
 @testable import APIServer
 
-@Suite struct LoginRateLimitTests {
+@Suite(.serialized) final class LoginRateLimitTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-loginrl")
+    }
 
     @Test func ipRateLimitTrips429AfterCap() async throws {
-        let store = LoginAttemptStore()
-        let now = Date()
-        let max = 3
-
-        let allowed1 = await store.recordAndCheckIP(ip: "1.2.3.4", now: now, windowSeconds: 60, max: max)
-        let allowed2 = await store.recordAndCheckIP(ip: "1.2.3.4", now: now, windowSeconds: 60, max: max)
-        let allowed3 = await store.recordAndCheckIP(ip: "1.2.3.4", now: now, windowSeconds: 60, max: max)
-        let allowed4 = await store.recordAndCheckIP(ip: "1.2.3.4", now: now, windowSeconds: 60, max: max)
-
-        #expect(allowed1)
-        #expect(allowed2)
-        #expect(allowed3)
-        #expect(!allowed4)
+        try await withApp(app) { _ in
+            let now = Date()
+            let max = 3
+            var results: [Bool] = []
+            for _ in 0..<4 {
+                results.append(
+                    try await LoginAttemptService.recordAndCheckIP(
+                        ip: "1.2.3.4", now: now, windowSeconds: 60, max: max, on: app.db))
+            }
+            #expect(results == [true, true, true, false])
+        }
     }
 
     @Test func ipRateLimitResetsAfterWindow() async throws {
-        let store = LoginAttemptStore()
-        let start = Date()
-        let later = start.addingTimeInterval(61)
+        try await withApp(app) { _ in
+            let start = Date()
+            let later = start.addingTimeInterval(61)
 
-        _ = await store.recordAndCheckIP(ip: "1.2.3.4", now: start, windowSeconds: 60, max: 1)
-        let blocked = await store.recordAndCheckIP(ip: "1.2.3.4", now: start, windowSeconds: 60, max: 1)
-        #expect(!blocked)
+            _ = try await LoginAttemptService.recordAndCheckIP(
+                ip: "1.2.3.4", now: start, windowSeconds: 60, max: 1, on: app.db)
+            let blocked = try await LoginAttemptService.recordAndCheckIP(
+                ip: "1.2.3.4", now: start, windowSeconds: 60, max: 1, on: app.db)
+            #expect(!blocked)
 
-        let allowedLater = await store.recordAndCheckIP(ip: "1.2.3.4", now: later, windowSeconds: 60, max: 1)
-        #expect(allowedLater)
+            let allowedLater = try await LoginAttemptService.recordAndCheckIP(
+                ip: "1.2.3.4", now: later, windowSeconds: 60, max: 1, on: app.db)
+            #expect(allowedLater)
+        }
     }
 
     @Test func usernameLockoutAfterThreshold() async throws {
-        let store = LoginAttemptStore()
-        let now = Date()
-
-        for _ in 0..<5 {
-            await store.recordFailure(username: "alice", now: now, windowSeconds: 900)
+        try await withApp(app) { _ in
+            let now = Date()
+            for _ in 0..<5 {
+                try await LoginAttemptService.recordFailure(
+                    username: "alice", now: now, windowSeconds: 900, on: app.db)
+            }
+            let locked = try await LoginAttemptService.isLocked(
+                username: "alice", now: now, windowSeconds: 900, threshold: 5, on: app.db)
+            #expect(locked)
         }
-
-        let locked = await store.isLocked(username: "alice", now: now, windowSeconds: 900, threshold: 5)
-        #expect(locked)
     }
 
     @Test func usernameLockoutNotTrippedBelowThreshold() async throws {
-        let store = LoginAttemptStore()
-        let now = Date()
-
-        for _ in 0..<3 {
-            await store.recordFailure(username: "alice", now: now, windowSeconds: 900)
+        try await withApp(app) { _ in
+            let now = Date()
+            for _ in 0..<3 {
+                try await LoginAttemptService.recordFailure(
+                    username: "alice", now: now, windowSeconds: 900, on: app.db)
+            }
+            let locked = try await LoginAttemptService.isLocked(
+                username: "alice", now: now, windowSeconds: 900, threshold: 5, on: app.db)
+            #expect(!locked)
         }
-
-        let locked = await store.isLocked(username: "alice", now: now, windowSeconds: 900, threshold: 5)
-        #expect(!locked)
     }
 
     @Test func clearFailuresResetsLockout() async throws {
-        let store = LoginAttemptStore()
-        let now = Date()
+        try await withApp(app) { _ in
+            let now = Date()
+            for _ in 0..<5 {
+                try await LoginAttemptService.recordFailure(
+                    username: "alice", now: now, windowSeconds: 900, on: app.db)
+            }
+            let lockedBefore = try await LoginAttemptService.isLocked(
+                username: "alice", now: now, windowSeconds: 900, threshold: 5, on: app.db)
+            #expect(lockedBefore)
 
-        for _ in 0..<5 {
-            await store.recordFailure(username: "alice", now: now, windowSeconds: 900)
+            try await LoginAttemptService.clearFailures(username: "alice", on: app.db)
+            let lockedAfter = try await LoginAttemptService.isLocked(
+                username: "alice", now: now, windowSeconds: 900, threshold: 5, on: app.db)
+            #expect(!lockedAfter)
         }
-        let lockedBefore = await store.isLocked(
-            username: "alice", now: now, windowSeconds: 900, threshold: 5
-        )
-        #expect(lockedBefore)
-
-        await store.clearFailures(username: "alice")
-        let lockedAfter = await store.isLocked(
-            username: "alice", now: now, windowSeconds: 900, threshold: 5
-        )
-        #expect(!lockedAfter)
     }
 
     @Test func failuresExpireAfterWindow() async throws {
-        let store = LoginAttemptStore()
-        let start = Date()
-        let later = start.addingTimeInterval(901)
-
-        for _ in 0..<5 {
-            await store.recordFailure(username: "alice", now: start, windowSeconds: 900)
+        try await withApp(app) { _ in
+            let start = Date()
+            let later = start.addingTimeInterval(901)
+            for _ in 0..<5 {
+                try await LoginAttemptService.recordFailure(
+                    username: "alice", now: start, windowSeconds: 900, on: app.db)
+            }
+            let lockedLater = try await LoginAttemptService.isLocked(
+                username: "alice", now: later, windowSeconds: 900, threshold: 5, on: app.db)
+            #expect(!lockedLater)
         }
-        let lockedLater = await store.isLocked(
-            username: "alice", now: later, windowSeconds: 900, threshold: 5
-        )
-        #expect(!lockedLater)
     }
+}
+
+// MARK: - Cross-instance sharing (#1154 acceptance)
+
+/// Two Application instances backed by ONE SQLite file — the multi-process
+/// deployment shape. Failure counts and rate windows recorded through one
+/// instance must be visible to the other.
+@Suite(.serialized) struct LoginRateLimitCrossInstanceTests {
+
+    @Test func lockoutAccumulatesAcrossInstances() async throws {
+        try await withTwoAppsOnSharedDatabase { appA, appB in
+            let now = Date()
+            // Three failures land on instance A, two on instance B.
+            for _ in 0..<3 {
+                try await LoginAttemptService.recordFailure(
+                    username: "mallory", now: now, windowSeconds: 900, on: appA.db)
+            }
+            for _ in 0..<2 {
+                try await LoginAttemptService.recordFailure(
+                    username: "mallory", now: now, windowSeconds: 900, on: appB.db)
+            }
+            // Either instance must see the combined total and lock.
+            let lockedOnA = try await LoginAttemptService.isLocked(
+                username: "mallory", now: now, windowSeconds: 900, threshold: 5, on: appA.db)
+            let lockedOnB = try await LoginAttemptService.isLocked(
+                username: "mallory", now: now, windowSeconds: 900, threshold: 5, on: appB.db)
+            #expect(lockedOnA)
+            #expect(lockedOnB)
+        }
+    }
+
+    @Test func ipWindowIsSharedAcrossInstances() async throws {
+        try await withTwoAppsOnSharedDatabase { appA, appB in
+            let now = Date()
+            // Cap of 3: two requests via A, one via B — the fourth (via B)
+            // must be rejected even though B only saw two locally.
+            _ = try await LoginAttemptService.recordAndCheckIP(
+                ip: "9.9.9.9", now: now, windowSeconds: 60, max: 3, on: appA.db)
+            _ = try await LoginAttemptService.recordAndCheckIP(
+                ip: "9.9.9.9", now: now, windowSeconds: 60, max: 3, on: appA.db)
+            let third = try await LoginAttemptService.recordAndCheckIP(
+                ip: "9.9.9.9", now: now, windowSeconds: 60, max: 3, on: appB.db)
+            let fourth = try await LoginAttemptService.recordAndCheckIP(
+                ip: "9.9.9.9", now: now, windowSeconds: 60, max: 3, on: appB.db)
+            #expect(third)
+            #expect(!fourth)
+        }
+    }
+}
+
+// MARK: - Shared-database two-app helper
+
+/// Builds two bare Applications over one SQLite file (migrations run once)
+/// and guarantees both are shut down. Used by the #1154 cross-instance
+/// tests; lives here because this file hosts the first of them.
+func withTwoAppsOnSharedDatabase(
+    _ body: (Application, Application) async throws -> Void
+) async throws {
+    let dbPath = FileManager.default.temporaryDirectory
+        .appendingPathComponent("chickadee-shared-\(UUID().uuidString).sqlite").path
+
+    func makeApp(migrate: Bool) async throws -> Application {
+        try await makeTestingApplication { app in
+            try configureDatabase(app, settings: .sqlite(path: dbPath))
+            registerMigrations(on: app)
+            if migrate {
+                let priorLogLevel = app.logger.logLevel
+                app.logger.logLevel = .warning
+                try await app.autoMigrate()
+                app.logger.logLevel = priorLogLevel
+            }
+        }
+    }
+
+    let appA = try await makeApp(migrate: true)
+    let appB: Application
+    do {
+        appB = try await makeApp(migrate: false)
+    } catch {
+        try? await appA.asyncShutdown()
+        throw error
+    }
+
+    do {
+        try await body(appA, appB)
+    } catch {
+        try? await appA.asyncShutdown()
+        try? await appB.asyncShutdown()
+        try? FileManager.default.removeItem(atPath: dbPath)
+        throw error
+    }
+    try await appA.asyncShutdown()
+    try await appB.asyncShutdown()
+    try? FileManager.default.removeItem(atPath: dbPath)
 }

--- a/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
+++ b/Tests/APITests/WorkerHMACAuthMiddlewareTests.swift
@@ -12,6 +12,17 @@ import VaporTesting
     private func makeApp() async throws -> Application {
         let app = try await Application.make(.testing)
         app.routes.defaultMaxBodySize = "10mb"
+        // Replay nonces persist to the database as of #1154, so the stub app
+        // needs one (accessing request.db with no default database configured
+        // is a process-killing fatalError on Linux, not a catchable throw).
+        do {
+            try configureDatabase(app, settings: .sqliteInMemory())
+            app.migrations.add(CreateWorkerNonces())
+            try await app.autoMigrate()
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
         app.workerSecretStore = WorkerSecretStore(initialOverride: sharedSecret)
         let middleware = WorkerHMACAuthMiddleware(maxClockSkewSeconds: 60, nonceTTLSeconds: 300)
         app.grouped(middleware).post("internal", "worker", "ping") { _ in

--- a/Tests/APITests/WorkerNonceReplayGuardTests.swift
+++ b/Tests/APITests/WorkerNonceReplayGuardTests.swift
@@ -1,0 +1,93 @@
+// Tests/APITests/WorkerNonceReplayGuardTests.swift
+//
+// #1154: worker-HMAC replay protection moved from a per-process actor to the
+// worker_nonces table. The property that matters is cross-instance: a nonce
+// consumed through one Application must be rejected by another sharing the
+// same database — the old in-memory store silently voided this behind a
+// load balancer.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class WorkerNonceReplayGuardTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-nonce")
+    }
+
+    @Test func firstUseInsertsAndReplayIsRejected() async throws {
+        try await withApp(app) { _ in
+            let expiry = Date().addingTimeInterval(300)
+            let first = try await WorkerNonceReplayGuard.insertIfNew(
+                nonceKey: "w1:nonce-a", expiresAt: expiry, on: app.db)
+            #expect(first)
+
+            let replay = try await WorkerNonceReplayGuard.insertIfNew(
+                nonceKey: "w1:nonce-a", expiresAt: expiry, on: app.db)
+            #expect(!replay)
+
+            // A different worker using the same raw nonce is a different key.
+            let otherWorker = try await WorkerNonceReplayGuard.insertIfNew(
+                nonceKey: "w2:nonce-a", expiresAt: expiry, on: app.db)
+            #expect(otherWorker)
+        }
+    }
+
+    @Test func purgeDropsExpiredRowsOnly() async throws {
+        try await withApp(app) { _ in
+            _ = try await WorkerNonceReplayGuard.insertIfNew(
+                nonceKey: "w1:expired", expiresAt: Date().addingTimeInterval(-10), on: app.db)
+            _ = try await WorkerNonceReplayGuard.insertIfNew(
+                nonceKey: "w1:live", expiresAt: Date().addingTimeInterval(300), on: app.db)
+
+            await WorkerNonceReplayGuard.purgeExpiredIfDue(
+                application: app, db: app.db, logger: app.logger)
+
+            let remaining = try await WorkerNonce.query(on: app.db).all()
+            #expect(remaining.map(\.id) == ["w1:live"])
+        }
+    }
+
+    @Test func purgeIsThrottledPerProcess() async throws {
+        try await withApp(app) { _ in
+            // First call consumes the throttle slot…
+            await WorkerNonceReplayGuard.purgeExpiredIfDue(
+                application: app, db: app.db, logger: app.logger)
+
+            // …so an expired row inserted now survives the second call.
+            _ = try await WorkerNonceReplayGuard.insertIfNew(
+                nonceKey: "w1:stale", expiresAt: Date().addingTimeInterval(-10), on: app.db)
+            await WorkerNonceReplayGuard.purgeExpiredIfDue(
+                application: app, db: app.db, logger: app.logger)
+
+            let count = try await WorkerNonce.query(on: app.db).count()
+            #expect(count == 1)
+        }
+    }
+
+    /// The #1154 acceptance property: replay across processes is rejected.
+    /// (Wrapped in withApp so the suite's own init-created app is shut down —
+    /// every test in a class suite must consume `app` or Linux SIGILLs on
+    /// the un-shutdown Application's deinit.)
+    @Test func nonceConsumedOnOneInstanceIsRejectedOnAnother() async throws {
+        try await withApp(app) { _ in
+            try await withTwoAppsOnSharedDatabase { appA, appB in
+                let expiry = Date().addingTimeInterval(300)
+                let first = try await WorkerNonceReplayGuard.insertIfNew(
+                    nonceKey: "w1:cross", expiresAt: expiry, on: appA.db)
+                #expect(first)
+
+                let replayOnOtherInstance = try await WorkerNonceReplayGuard.insertIfNew(
+                    nonceKey: "w1:cross", expiresAt: expiry, on: appB.db)
+                #expect(!replayOnOtherInstance)
+            }
+        }
+    }
+}

--- a/changelog.d/multiprocess-security-1154.md
+++ b/changelog.d/multiprocess-security-1154.md
@@ -1,0 +1,12 @@
+### Security
+
+- **Replay protection and login rate-limits now hold across server processes
+  (#1154).** Worker-HMAC nonces move from a per-process in-memory store to a
+  `worker_nonces` table where first-seen is an atomic PRIMARY KEY insert — a
+  signed request captured on one instance can no longer be replayed against
+  another within the TTL window. Login brute-force state (per-IP window,
+  per-username lockout) moves to a `login_attempts` table, so N instances
+  behind a load balancer no longer multiply the configured rate cap by N or
+  count lockout failures per-instance. Both tables self-clean (per-key prune
+  on write plus throttled sweeps). This also removes the old nonce store's
+  full-dictionary rebuild on every worker request.


### PR DESCRIPTION
Closes #1154.

Two security-relevant stores were in-memory per process, so their guarantees quietly disappeared with 2+ server processes behind a load balancer:

**1. Worker-HMAC replay protection.** `WorkerNonceStore` was a per-process actor: a signed worker request captured on instance A could be replayed against instance B within the 300 s TTL window — the anti-replay guarantee simply didn't exist in a multi-process deployment. Nonces now live in a `worker_nonces` table where first-seen is an **atomic PRIMARY KEY insert**; a unique violation means replay (detected by recover-by-re-fetch rather than string-matching driver errors — the `AssignmentSeedStore` idiom). Expired rows are purged by a throttled bulk DELETE (≤1/min per process). Bonus fix from the audit: the old actor rebuilt its entire nonce dictionary on **every** worker request (`seen.filter{…}` in `insertIfNew`) — that O(n)-per-request scan is gone.

**2. Login brute-force protection.** `LoginAttemptStore` kept the per-IP window and per-username lockout in process-local dictionaries: N instances meant N× the configured per-IP rate cap, and lockouts only counted failures that landed on the same instance. Events now live in a `login_attempts` table indexed on `(scope, attempt_key, occurred_at)`; per-key rows are pruned on each write, and a throttled sweep (≤1/10 min) clears abandoned keys. The MCP OAuth rate limiter (`mcp-oauth:`-prefixed keys) rides the same service unchanged. Login traffic is low-frequency, so the 2–3 indexed queries per POST are negligible.

**Cost trade-off, stated plainly:** replay protection is inherently shared state, so every authenticated worker request now performs one tiny PK INSERT into a self-cleaning table (~≤1/s per runner). That is the floor for cross-process replay safety; it is small next to the 3 writes + serialized transaction per poll that #1162/#1163 removed.

**Migrations:** `CreateWorkerNonces`, `CreateLoginAttempts` — new tables, no ordering constraints, registered at the end of `registerMigrations`.

**Tests:** the acceptance property is tested the way the issue specified — two `Application` instances over one shared SQLite file: a nonce consumed through instance A is rejected through instance B; username lockout accumulates 3 failures on A + 2 on B into a lock visible from both; the IP window rejects the 4th request even when instance B only saw two locally. Plus service-level semantics tests (window expiry, clear-on-success, purge throttling) replacing the old in-memory actor tests one-for-one, and the full `WorkerRoutesTests` / `AuthRoutesTests` / `SecurityAndHealthTests` / `MCPOAuthFlowTests` / `MCPSecurityHardeningTests` suites green.

Part of the 2026-07 performance/scalability audit series (#1151–#1160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_