### PR TITLE
Leader-lease the periodic sweeps so each runs on exactly one process

### DIFF
--- a/Sources/APIServer/Migrations/CreateSweepLeases.swift
+++ b/Sources/APIServer/Migrations/CreateSweepLeases.swift
@@ -1,0 +1,19 @@
+import Fluent
+
+/// Leader leases for the periodic sweeps (#1155): one row per sweep name;
+/// the PRIMARY KEY makes the first-ever claim an atomic INSERT and the
+/// conditional renew/takeover UPDATE self-arbitrating. Tiny table (one row
+/// per sweep), no indexes beyond the PK.
+struct CreateSweepLeases: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema(SweepLease.schema)
+            .field("name", .string, .identifier(auto: false))
+            .field("holder", .string, .required)
+            .field("expires_at", .datetime, .required)
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema(SweepLease.schema).delete()
+    }
+}

--- a/Sources/APIServer/Models/SweepLease.swift
+++ b/Sources/APIServer/Models/SweepLease.swift
@@ -1,0 +1,33 @@
+import Fluent
+import Foundation
+import Vapor
+
+/// One leader lease per periodic sweep (#1155). `PeriodicSweepMonitor` runs
+/// on every server process, so without coordination a multi-process
+/// deployment runs every sweep N times — duplicate BrightSpace grade pushes,
+/// double health alerts, racing reapers. Each sweep tick claims/renews the
+/// lease row for its sweep name with an atomic conditional UPDATE; only the
+/// holder runs the sweep body. A crashed leader stops renewing and the lease
+/// expires, so another instance takes over within one TTL.
+final class SweepLease: Model, @unchecked Sendable {
+    // @unchecked Sendable: written only through SweepLeaseCoordinator's
+    // conditional queries, never mutated concurrently in-process.
+    static let schema = "sweep_leases"
+
+    @ID(custom: "name", generatedBy: .user)
+    var id: String?
+
+    @Field(key: "holder")
+    var holder: String
+
+    @Field(key: "expires_at")
+    var expiresAt: Date
+
+    init() {}
+
+    init(name: String, holder: String, expiresAt: Date) {
+        self.id = name
+        self.holder = holder
+        self.expiresAt = expiresAt
+    }
+}

--- a/Sources/APIServer/Services/PeriodicSweepMonitor.swift
+++ b/Sources/APIServer/Services/PeriodicSweepMonitor.swift
@@ -18,6 +18,16 @@
 //   • Sweep errors are logged via `application.logger.error` with the
 //     monitor's name and never escape the loop.
 //   • Cancellation (via `stop()`) ends the loop at the next sleep.
+//
+// Multi-process (#1155): every process runs every loop, but each tick first
+// claims/renews a DB leader lease keyed on the monitor's name
+// (SweepLeaseCoordinator) and only the lease holder executes the sweep body.
+// Without this, N instances behind a load balancer ran every sweep N times —
+// duplicate BrightSpace pushes to LEARN, doubled health alerts, racing
+// reapers. The lease TTL is 2× the interval (min 2 min), so a crashed
+// leader's sweeps resume on another instance within roughly one missed
+// cycle. Single-process deployments always hold the lease; the tick cost is
+// one small UPDATE + SELECT.
 
 import Vapor
 
@@ -28,6 +38,7 @@ final class PeriodicSweepMonitor: @unchecked Sendable {
     private var task: Task<Void, Never>?
     private let name: String
     private let intervalNanoseconds: UInt64
+    private let leaseTTLSeconds: TimeInterval
     private let runImmediately: Bool
     private let sweep: @Sendable (Application) async throws -> Void
 
@@ -48,9 +59,44 @@ final class PeriodicSweepMonitor: @unchecked Sendable {
         sweep: @escaping @Sendable (Application) async throws -> Void
     ) {
         self.name = name
-        intervalNanoseconds = UInt64(max(interval, minimumInterval) * 1_000_000_000)
+        let effectiveInterval = max(interval, minimumInterval)
+        intervalNanoseconds = UInt64(effectiveInterval * 1_000_000_000)
+        leaseTTLSeconds = max(effectiveInterval * 2, 120)
         self.runImmediately = runImmediately
         self.sweep = sweep
+    }
+
+    /// One leased tick: claim/renew the leader lease, then run the sweep
+    /// body only as the holder. Lease errors and sweep errors are both
+    /// logged and never escape (matching the pre-lease behavior contract).
+    private func runLeasedSweep(application: Application, context: String) async {
+        let isLeader: Bool
+        do {
+            isLeader = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: name,
+                holder: application.sweepLeaseHolderID,
+                ttlSeconds: leaseTTLSeconds,
+                on: application.db
+            )
+        } catch {
+            application.logger.warning(
+                "\(context)\(name) sweep lease check failed: \(error.localizedDescription)"
+            )
+            return
+        }
+        guard isLeader else {
+            application.logger.debug(
+                "\(context)\(name) sweep skipped: another instance holds the lease"
+            )
+            return
+        }
+        do {
+            try await sweep(application)
+        } catch {
+            application.logger.error(
+                "\(context)\(name) sweep failed: \(error.localizedDescription)"
+            )
+        }
     }
 
     func start(application: Application) {
@@ -59,27 +105,13 @@ final class PeriodicSweepMonitor: @unchecked Sendable {
             // Best-effort boot sweep, detached from the periodic loop, so a
             // restart after a long quiet period doesn't have to wait for the
             // loop to come up to reclaim space.
-            let sweep = sweep
-            let name = name
             Task {
-                do {
-                    try await sweep(application)
-                } catch {
-                    application.logger.error(
-                        "Initial \(name) sweep failed: \(error.localizedDescription)"
-                    )
-                }
+                await self.runLeasedSweep(application: application, context: "Initial ")
             }
         }
-        task = Task { [sweep, name, intervalNanoseconds] in
+        task = Task { [intervalNanoseconds] in
             while !Task.isCancelled {
-                do {
-                    try await sweep(application)
-                } catch {
-                    application.logger.error(
-                        "\(name) sweep failed: \(error.localizedDescription)"
-                    )
-                }
+                await self.runLeasedSweep(application: application, context: "")
                 do {
                     try await Task.sleep(nanoseconds: intervalNanoseconds)
                 } catch {

--- a/Sources/APIServer/Services/SweepLeaseCoordinator.swift
+++ b/Sources/APIServer/Services/SweepLeaseCoordinator.swift
@@ -1,0 +1,81 @@
+// APIServer/Services/SweepLeaseCoordinator.swift
+//
+// Leader election for periodic sweeps (#1155). Every server process runs
+// every PeriodicSweepMonitor loop; the lease decides which process actually
+// executes each sweep body. Claiming is a compare-and-set in the same family
+// as the worker-job claim and the MCP token consumption:
+//
+//   1. Conditional UPDATE: take/renew the row when we already hold it OR it
+//      has expired. A single UPDATE statement is atomic on SQLite and
+//      Postgres alike, so two instances can't both succeed for the same
+//      window.
+//   2. Verify by re-read: whoever's holder id is on the row owns the lease.
+//   3. First-ever claim: PRIMARY KEY insert; a unique violation means the
+//      other instance won — verified by the same re-read.
+//
+// Single-process deployments trivially always hold every lease — the cost
+// is one tiny UPDATE + SELECT per sweep tick.
+
+import Fluent
+import Foundation
+import Vapor
+
+enum SweepLeaseCoordinator {
+    /// Claims or renews the lease for `name` on behalf of `holder`.
+    /// Returns true when `holder` owns the lease for the next `ttlSeconds`.
+    static func acquireOrRenew(
+        name: String,
+        holder: String,
+        ttlSeconds: TimeInterval,
+        now: Date = Date(),
+        on db: Database
+    ) async throws -> Bool {
+        let newExpiry = now.addingTimeInterval(ttlSeconds)
+
+        // Renew our own lease, or take over an expired one — atomically.
+        try await SweepLease.query(on: db)
+            .filter(\.$id == name)
+            .group(.or) { or in
+                or.filter(\.$holder == holder)
+                or.filter(\.$expiresAt <= now)
+            }
+            .set(\.$holder, to: holder)
+            .set(\.$expiresAt, to: newExpiry)
+            .update()
+
+        if let row = try await SweepLease.find(name, on: db) {
+            return row.holder == holder && row.expiresAt > now
+        }
+
+        // No row yet: first claim ever for this sweep name.
+        do {
+            try await SweepLease(name: name, holder: holder, expiresAt: newExpiry).create(on: db)
+            return true
+        } catch {
+            // Lost the insert race to another instance — re-read decides.
+            if let row = try await SweepLease.find(name, on: db) {
+                return row.holder == holder && row.expiresAt > now
+            }
+            throw error
+        }
+    }
+}
+
+// MARK: - Per-process holder identity
+
+struct SweepLeaseHolderIDKey: StorageKey {
+    typealias Value = String
+}
+
+extension Application {
+    /// Stable per-process (per-Application) identity used as the lease
+    /// holder. Random per boot: a restarted process is a new holder and
+    /// simply takes over its old leases as they expire (or immediately,
+    /// since the old process stopped renewing).
+    var sweepLeaseHolderID: String {
+        if let existing = storage[SweepLeaseHolderIDKey.self] { return existing }
+        let created = UUID().uuidString
+        storage[SweepLeaseHolderIDKey.self] = created
+        return created
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -384,4 +384,8 @@ func registerMigrations(on app: Application) {
     // no ordering constraints.
     app.migrations.add(CreateWorkerNonces())
     app.migrations.add(CreateLoginAttempts())
+
+    // Leader leases so each periodic sweep runs on exactly one process
+    // (#1155). New table, no ordering constraints.
+    app.migrations.add(CreateSweepLeases())
 }

--- a/Tests/APITests/SweepLeaseCoordinatorTests.swift
+++ b/Tests/APITests/SweepLeaseCoordinatorTests.swift
@@ -1,0 +1,123 @@
+// Tests/APITests/SweepLeaseCoordinatorTests.swift
+//
+// #1155: leader election for periodic sweeps. The property that matters is
+// cross-instance: with two Applications on one database, exactly one holds a
+// given sweep's lease at a time, renewal keeps it, and an expired lease
+// hands off.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class SweepLeaseCoordinatorTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-lease")
+    }
+
+    @Test func firstClaimWinsAndRenewalKeepsIt() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            let first = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-a", holder: "proc-1", ttlSeconds: 120, now: now, on: app.db)
+            #expect(first)
+
+            // Renewal by the same holder succeeds and extends the expiry.
+            let renewed = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-a", holder: "proc-1", ttlSeconds: 120,
+                now: now.addingTimeInterval(60), on: app.db)
+            #expect(renewed)
+            let row = try #require(try await SweepLease.find("sweep-a", on: app.db))
+            #expect(row.expiresAt > now.addingTimeInterval(150))
+        }
+    }
+
+    @Test func secondHolderIsDeniedWhileLeaseIsLive() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            _ = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-b", holder: "proc-1", ttlSeconds: 120, now: now, on: app.db)
+            let rival = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-b", holder: "proc-2", ttlSeconds: 120,
+                now: now.addingTimeInterval(30), on: app.db)
+            #expect(!rival)
+
+            let row = try #require(try await SweepLease.find("sweep-b", on: app.db))
+            #expect(row.holder == "proc-1")
+        }
+    }
+
+    @Test func expiredLeaseIsTakenOver() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            _ = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-c", holder: "proc-1", ttlSeconds: 60, now: now, on: app.db)
+
+            // proc-1 stops renewing; past the TTL, proc-2 takes over.
+            let takeover = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-c", holder: "proc-2", ttlSeconds: 60,
+                now: now.addingTimeInterval(61), on: app.db)
+            #expect(takeover)
+
+            let row = try #require(try await SweepLease.find("sweep-c", on: app.db))
+            #expect(row.holder == "proc-2")
+        }
+    }
+
+    @Test func leasesAreIndependentPerSweepName() async throws {
+        try await withApp(app) { _ in
+            let now = Date()
+            let a = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-d", holder: "proc-1", ttlSeconds: 120, now: now, on: app.db)
+            let b = try await SweepLeaseCoordinator.acquireOrRenew(
+                name: "sweep-e", holder: "proc-2", ttlSeconds: 120, now: now, on: app.db)
+            #expect(a)
+            #expect(b)
+        }
+    }
+
+    /// The #1155 acceptance property: with two Application instances on one
+    /// shared database, each sweep runs on exactly one of them, and
+    /// leadership fails over when the holder stops renewing.
+    @Test func exactlyOneInstanceHoldsEachLeaseAcrossProcesses() async throws {
+        try await withApp(app) { _ in
+            try await withTwoAppsOnSharedDatabase { appA, appB in
+                let now = Date()
+                let holderA = appA.sweepLeaseHolderID
+                let holderB = appB.sweepLeaseHolderID
+                #expect(holderA != holderB)
+
+                let aWins = try await SweepLeaseCoordinator.acquireOrRenew(
+                    name: "Session reaper", holder: holderA, ttlSeconds: 120,
+                    now: now, on: appA.db)
+                let bDenied = try await SweepLeaseCoordinator.acquireOrRenew(
+                    name: "Session reaper", holder: holderB, ttlSeconds: 120,
+                    now: now.addingTimeInterval(1), on: appB.db)
+                #expect(aWins)
+                #expect(!bDenied)
+
+                // A keeps renewing → B stays out.
+                let aRenews = try await SweepLeaseCoordinator.acquireOrRenew(
+                    name: "Session reaper", holder: holderA, ttlSeconds: 120,
+                    now: now.addingTimeInterval(60), on: appA.db)
+                let bStillDenied = try await SweepLeaseCoordinator.acquireOrRenew(
+                    name: "Session reaper", holder: holderB, ttlSeconds: 120,
+                    now: now.addingTimeInterval(61), on: appB.db)
+                #expect(aRenews)
+                #expect(!bStillDenied)
+
+                // A crashes (stops renewing) → B takes over after the TTL.
+                let bTakesOver = try await SweepLeaseCoordinator.acquireOrRenew(
+                    name: "Session reaper", holder: holderB, ttlSeconds: 120,
+                    now: now.addingTimeInterval(200), on: appB.db)
+                #expect(bTakesOver)
+            }
+        }
+    }
+}

--- a/changelog.d/sweep-leader-lease-1155.md
+++ b/changelog.d/sweep-leader-lease-1155.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Periodic sweeps now run on exactly one server process (#1155).** Every
+  sweep — session/activity/audit/OAuth reapers, stuck-submission reaper,
+  deadline sweep, achievement sweep, health alerts, BrightSpace grade sync,
+  LEARN roster/section syncs — previously started on every instance, so a
+  multi-process deployment pushed grades to LEARN from N processes at once
+  and fired duplicate health alerts. Each `PeriodicSweepMonitor` tick now
+  claims/renews a per-sweep leader lease (`sweep_leases` table, atomic
+  conditional UPDATE) and only the holder runs the sweep body; a crashed
+  leader's sweeps fail over to another instance within roughly one missed
+  cycle (TTL = 2× interval, min 2 min). Single-process deployments always
+  hold the lease at the cost of one small query pair per tick.


### PR DESCRIPTION
Closes #1155.

`PeriodicSweepMonitor.start` spawned its loop from `didBoot` on every instance with no cross-process coordination — so with 2+ processes behind a load balancer, **every sweep ran on every instance**: BrightSpace pushed grades to LEARN from N processes concurrently (two sweeps could both read the same pending rows before either flipped the flag), health alerts fired N times per outage, and the reapers/deadline sweep raced each other with redundant writes. This contradicted the documented "multi-process safe" posture, which was only true for sessions.

**What changed:**

- New `sweep_leases(name PK, holder, expires_at)` table + `SweepLeaseCoordinator.acquireOrRenew`: an atomic conditional `UPDATE … WHERE holder = me OR expires_at <= now` with verify-by-re-read, plus a PK-insert path for the first-ever claim — the same compare-and-set family as the worker-job claim (#1163) and MCP token consumption, and portable across SQLite and Postgres (no `pg_try_advisory_lock` dependency).
- Every `PeriodicSweepMonitor` tick (including the `runImmediately` boot sweep) claims/renews the lease keyed on the monitor's name and only runs the sweep body as the holder. Since all eleven timer-driven services ride this one scaffolding — session/activity/audit/OAuth reapers, stuck-submission reaper, deadline sweep, achievement sweep, health alerts, BrightSpace grade sync, LEARN roster/section syncs — one gate covers the whole deployment.
- Holder identity is a per-process UUID; TTL is 2× the sweep interval (min 2 min), so a crashed leader stops renewing and its sweeps fail over to another instance within roughly one missed cycle. A non-leader tick logs at `debug` and sleeps; lease-check DB errors log at `warning` and skip the tick (fail-safe — if the DB is down the sweep body couldn't run anyway).
- Single-process deployments trivially always hold every lease; the cost is one small UPDATE + SELECT per tick.

**Tests:** lease semantics (first claim wins, live lease denies rivals, renewal extends, expiry hands off, per-name independence) plus the acceptance property from the issue — two `Application` instances over one shared database where exactly one holds a given sweep's lease, keeps it while renewing, and loses it to the other after going quiet. Sweep-behaviour suites (session/audit/stuck reapers, health alerts) pass unchanged since tests invoke the sweep functions directly, below the lease gate.

Out of scope, noted for completeness: the `OperationalDiagnostics` boot-time prune runs per-process but is an idempotent DELETE — harmless duplication.

Part of the 2026-07 performance/scalability audit series (#1151–#1160); completes the multi-process story started in #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_