### PR TITLE
Move notebook-open blocking work off the cooperative pool

### DIFF
--- a/Sources/APIServer/Routes/JupyterLiteContentsRoutes.swift
+++ b/Sources/APIServer/Routes/JupyterLiteContentsRoutes.swift
@@ -99,7 +99,10 @@ struct JupyterLiteContentsRoutes: RouteCollection {
         }
 
         let attributes = attributesForItem(url: targetURL, fileManager: fm)
-        let fileData = try Data(contentsOf: targetURL)
+        // The editor's contents endpoint fires repeatedly while a student
+        // works; notebooks and materialized datasets can be large. Thread
+        // pool, not the request thread (#1156).
+        let fileData = try await runBlocking(on: req) { try Data(contentsOf: targetURL) }
         let isNotebook = targetURL.pathExtension.lowercased() == "ipynb"
         let (contentValue, format, mimetype): (Any, String, String) = {
             guard wantsContent else {

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -178,7 +178,9 @@ struct TestSetupRoutes: RouteCollection {
 
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
 
-        let raw = try notebookData(for: setup)
+        // File read or zip-subprocess extraction — thread pool (#1156).
+        let source = NotebookSourceRef(setup)
+        let raw = try await runBlocking(on: req) { try notebookData(from: source) }
         // Staff (TA+ or admin) of this setup's course see unfiltered tiers;
         // students get the hidden tiers stripped (#417 Slice G).
         let isStaff = try await isCourseStaff(caller, inCourse: setup.courseID, db: req.db)
@@ -205,7 +207,9 @@ struct TestSetupRoutes: RouteCollection {
 
         try await requireCourseEnrollment(caller: caller, courseID: setup.courseID, db: req.db)
 
-        let raw = try notebookData(for: setup)
+        // File read or zip-subprocess extraction — thread pool (#1156).
+        let source = NotebookSourceRef(setup)
+        let raw = try await runBlocking(on: req) { try notebookData(from: source) }
         let isStaff = try await isCourseStaff(caller, inCourse: setup.courseID, db: req.db)
         let filtered = isStaff ? raw : filterNotebook(raw, hiddenTiers: hiddenTiersForStudents)
 
@@ -262,8 +266,9 @@ struct TestSetupRoutes: RouteCollection {
 
         // Confirm the file is classified as a support file: must exist
         // in the zip, must not be in `testSuites`, must not be a
-        // canonical notebook name.
-        let allEntries = listZipEntries(zipPath: setup.zipPath)
+        // canonical notebook name. Cached (#1156) — this previously spawned
+        // a serialized `unzip` subprocess on the request thread per download.
+        let allEntries = await req.application.zipEntryListCache.entries(zipPath: setup.zipPath)
         guard allEntries.contains(filename) else { throw Abort(.notFound) }
 
         let props = setup.decodedManifest()
@@ -279,7 +284,11 @@ struct TestSetupRoutes: RouteCollection {
             throw AppError.forbidden(action: "download '\(filename)' (not a student-visible support file)")
         }
 
-        guard let bytes = extractZipEntry(zipPath: setup.zipPath, entryName: filename) else {
+        let zipPath = setup.zipPath
+        let extracted = try await runBlocking(on: req) {
+            extractZipEntry(zipPath: zipPath, entryName: filename)
+        }
+        guard let bytes = extracted else {
             throw Abort(.notFound)
         }
 

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -140,18 +140,28 @@ func ensureUserNotebookWorkingCopy(
         + resolvedRelativePath
     let workingCopyDir = (workingCopyPath as NSString).deletingLastPathComponent
 
+    // All synchronous filesystem work below runs on the thread pool (#1156):
+    // this function executes on every notebook page/source request, and a
+    // burst of them (a lab section opening an assignment) previously parked
+    // cooperative-pool threads on disk reads/writes.
     if let overwriteWith {
-        try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
-        try overwriteWith.write(to: URL(fileURLWithPath: workingCopyPath))
+        try await runBlocking(on: req) {
+            try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
+            try overwriteWith.write(to: URL(fileURLWithPath: workingCopyPath))
+        }
         await createSupportFileSymlinks(req: req, setup: fallbackSetup, studentDir: workingCopyDir)
         await writeDatasetFiles(req: req, setup: fallbackSetup, userID: userID, studentDir: workingCopyDir)
         return overwriteWith
     }
 
-    if let existingData = try? Data(contentsOf: URL(fileURLWithPath: workingCopyPath)),
-        !existingData.isEmpty,
-        (try? JSONSerialization.jsonObject(with: existingData)) != nil
-    {
+    let existingWorkingCopy: Data? = try await runBlocking(on: req) {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: workingCopyPath)),
+            !data.isEmpty,
+            (try? JSONSerialization.jsonObject(with: data)) != nil
+        else { return nil }
+        return data
+    }
+    if let existingData = existingWorkingCopy {
         // Symlinks are idempotent — run on every visit so existing working copies
         // also pick up support files when the feature is first deployed.
         await createSupportFileSymlinks(req: req, setup: fallbackSetup, studentDir: workingCopyDir)
@@ -186,8 +196,10 @@ func ensureUserNotebookWorkingCopy(
         logger: req.logger
     )
 
-    try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
-    try processedData.write(to: URL(fileURLWithPath: workingCopyPath))
+    try await runBlocking(on: req) {
+        try fileManager.createDirectory(atPath: workingCopyDir, withIntermediateDirectories: true)
+        try processedData.write(to: URL(fileURLWithPath: workingCopyPath))
+    }
     await createSupportFileSymlinks(req: req, setup: fallbackSetup, studentDir: workingCopyDir)
     await writeDatasetFiles(req: req, setup: fallbackSetup, userID: userID, studentDir: workingCopyDir)
 
@@ -429,11 +441,14 @@ func latestNotebookSubmissionData(
         guard pathExt == "ipynb" || nameExt.hasSuffix(".ipynb") else {
             continue
         }
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: submission.zipPath)),
-            (try? JSONSerialization.jsonObject(with: data)) != nil
-        else {
-            continue
+        let zipPath = submission.zipPath
+        let candidate: Data? = try await runBlocking(on: req) {
+            guard let data = try? Data(contentsOf: URL(fileURLWithPath: zipPath)),
+                (try? JSONSerialization.jsonObject(with: data)) != nil
+            else { return nil }
+            return data
         }
+        guard let data = candidate else { continue }
         return (data, submission.filename)
     }
 
@@ -442,7 +457,10 @@ func latestNotebookSubmissionData(
         let name = URL(fileURLWithPath: path).lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
         return name.isEmpty ? nil : name
     }()
-    let fallbackData = try notebookData(for: fallbackSetup)
+    // The fallback reads the setup's canonical notebook — a file read or a
+    // zip-subprocess extraction; thread pool either way (#1156).
+    let source = NotebookSourceRef(fallbackSetup)
+    let fallbackData = try await runBlocking(on: req) { try notebookData(from: source) }
     return (fallbackData, fallbackFilename)
 }
 
@@ -484,14 +502,19 @@ func createSupportFileSymlinks(req: Request, setup: APITestSetup, studentDir: St
     guard !supportNames.isEmpty else { return }
 
     let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
-    let fm = FileManager.default
 
-    for name in supportNames {
-        let src = sharedDir + name
-        let dest = studentDir + "/" + name
-        guard !fm.fileExists(atPath: dest) else { continue }  // idempotent
-        guard fm.fileExists(atPath: src) else { continue }  // skip if not yet extracted
-        try? fm.createSymbolicLink(atPath: dest, withDestinationPath: src)
+    // The exists/exists/symlink triple per support file is synchronous
+    // filesystem work on every notebook visit — run the whole pass on the
+    // thread pool (#1156).
+    try? await runBlocking(on: req) {
+        let fm = FileManager.default
+        for name in supportNames {
+            let src = sharedDir + name
+            let dest = studentDir + "/" + name
+            guard !fm.fileExists(atPath: dest) else { continue }  // idempotent
+            guard fm.fileExists(atPath: src) else { continue }  // skip if not yet extracted
+            try? fm.createSymbolicLink(atPath: dest, withDestinationPath: src)
+        }
     }
 }
 
@@ -525,16 +548,22 @@ func writeDatasetFiles(
     else { return }
 
     let sharedDir = req.application.testSetupsDirectory + "shared/\(setupID)/"
-    guard
-        let files = DatasetResolver.resolve(
-            manifest: props, seedHex: seedHex, sourceDirectory: sharedDir)
-    else { return }
 
-    for (filename, content) in files {
-        // Defense-in-depth (#1104): resolver keys are validated bare
-        // filenames, but never join an unvetted name onto the student dir.
-        guard FilenameSafety.bareFilename(filename) != nil else { continue }
-        let dest = studentDir + "/" + filename
-        try? content.write(toFile: dest, atomically: true, encoding: .utf8)
+    // Dataset resolution reads the source CSV and materializes a per-student
+    // slice, then writes one file per dataset — synchronous I/O + CPU on
+    // every visit to a dataset-carrying assignment. Thread pool (#1156).
+    try? await runBlocking(on: req) {
+        guard
+            let files = DatasetResolver.resolve(
+                manifest: props, seedHex: seedHex, sourceDirectory: sharedDir)
+        else { return }
+
+        for (filename, content) in files {
+            // Defense-in-depth (#1104): resolver keys are validated bare
+            // filenames, but never join an unvetted name onto the student dir.
+            guard FilenameSafety.bareFilename(filename) != nil else { continue }
+            let dest = studentDir + "/" + filename
+            try? content.write(toFile: dest, atomically: true, encoding: .utf8)
+        }
     }
 }

--- a/Sources/APIServer/Services/PersonalizationEvaluator.swift
+++ b/Sources/APIServer/Services/PersonalizationEvaluator.swift
@@ -33,12 +33,51 @@ enum PersonalizationEvaluatorError: Error {
     case missingName(name: String, stdout: String)
 }
 
+/// Minimal counting semaphore for async contexts: `acquire` suspends (no
+/// thread parked) once `width` slots are in use; `release` hands the slot to
+/// the oldest waiter. Used to bound concurrent python3 evaluations (#1156).
+actor AsyncCountingSemaphore {
+    private let width: Int
+    private var inUse = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    init(width: Int) {
+        self.width = max(1, width)
+    }
+
+    func acquire() async {
+        if inUse < width {
+            inUse += 1
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+        // Resumed by release(), which transfers the slot without
+        // decrementing `inUse`.
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            inUse -= 1
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
 enum PersonalizationEvaluator {
 
     /// Timeout (seconds) for a single evaluation subprocess.  Slice 2
     /// caps at 5 s — instructor expressions should be near-instant;
     /// anything slower is almost certainly a bug.
     static let defaultTimeoutSeconds: Int = 5
+
+    /// Caps concurrent interpreter spawns server-wide (#1156): a deadline
+    /// burst of first-opens on a personalized assignment previously forked
+    /// one python3 per request with no ceiling. Excess evaluations suspend
+    /// in the semaphore's queue; each is bounded by its own subprocess
+    /// timeout once running.
+    static let spawnGate = AsyncCountingSemaphore(
+        width: max(2, ProcessInfo.processInfo.activeProcessorCount))
 
     /// Evaluates each `expressions` entry with `seed` and all listed
     /// static variables in scope.  Returns the rendered Python literal
@@ -121,6 +160,7 @@ enum PersonalizationEvaluator {
         let stdout: String
         let stderr: String
         let exitCode: Int32
+        await Self.spawnGate.acquire()
         do {
             (stdout, stderr, exitCode) = try await spawnAndCapture(
                 executableURL: URL(fileURLWithPath: "/usr/bin/env"),
@@ -129,9 +169,12 @@ enum PersonalizationEvaluator {
                 env: env,
                 timeoutSeconds: timeoutSeconds
             )
+            await Self.spawnGate.release()
         } catch PersonalizationEvaluatorError.timedOut {
+            await Self.spawnGate.release()
             throw PersonalizationEvaluatorError.timedOut
         } catch {
+            await Self.spawnGate.release()
             throw PersonalizationEvaluatorError.spawnFailed(String(describing: error))
         }
 

--- a/Sources/APIServer/Services/ZipEntryListCache.swift
+++ b/Sources/APIServer/Services/ZipEntryListCache.swift
@@ -17,6 +17,8 @@
 // one zip-listing cache rather than two near-identical ones.)
 
 import Foundation
+import NIOCore
+import NIOPosix
 import Vapor
 
 actor ZipEntryListCache {
@@ -31,12 +33,31 @@ actor ZipEntryListCache {
     /// listed.  Reset wholesale in the unlikely event it grows past this.
     private static let maxEntries = 4096
 
+    /// Where the `unzip` subprocess actually runs (#1156). The old
+    /// implementation ran `listZipEntries` inside the synchronous actor
+    /// method, holding the actor's executor — a cooperative-pool thread —
+    /// for the whole subprocess and serializing every cache caller behind a
+    /// single miss. Nil (bare test instances) falls back to running the
+    /// listing inline.
+    private let threadPool: NIOThreadPool?
+    private let eventLoopGroup: EventLoopGroup?
+
+    /// One in-flight listing per zip path: concurrent misses on the same
+    /// zip (a class opening one assignment post-deploy) share a single
+    /// subprocess instead of queueing one each behind the global zip lock.
+    private var inFlight: [String: Task<[String], Never>] = [:]
+
     private var cache: [String: CachedEntries] = [:]
+
+    init(threadPool: NIOThreadPool? = nil, eventLoopGroup: EventLoopGroup? = nil) {
+        self.threadPool = threadPool
+        self.eventLoopGroup = eventLoopGroup
+    }
 
     /// The zip's entry-name list (exactly what `listZipEntries` would return),
     /// cached by the zip's mtime + size.  Returns an empty list when the zip is
     /// missing or unreadable, matching `listZipEntries`' behaviour.
-    func entries(zipPath: String) -> [String] {
+    func entries(zipPath: String) async -> [String] {
         guard
             let attributes = try? FileManager.default.attributesOfItem(atPath: zipPath),
             let zipModified = attributes[.modificationDate] as? Date
@@ -50,7 +71,25 @@ actor ZipEntryListCache {
             return cached.entries
         }
 
-        let entries = listZipEntries(zipPath: zipPath)
+        if let pending = inFlight[zipPath] {
+            return await pending.value
+        }
+
+        let threadPool = threadPool
+        let eventLoop = eventLoopGroup?.next()
+        let listing = Task<[String], Never> {
+            if let threadPool, let eventLoop {
+                return
+                    (try? await threadPool.runIfActive(eventLoop: eventLoop) {
+                        listZipEntries(zipPath: zipPath)
+                    }.get()) ?? []
+            }
+            return listZipEntries(zipPath: zipPath)
+        }
+        inFlight[zipPath] = listing
+        let entries = await listing.value
+        inFlight[zipPath] = nil
+
         if cache.count >= Self.maxEntries { cache.removeAll() }
         cache[zipPath] = CachedEntries(
             zipModified: zipModified,
@@ -62,8 +101,8 @@ actor ZipEntryListCache {
 
     /// True when the (cached) entry list contains at least one `.ipynb` entry.
     /// Returns false when the zip is missing or unreadable.
-    func zipContainsNotebook(zipPath: String) -> Bool {
-        entries(zipPath: zipPath).contains { $0.hasSuffix(".ipynb") }
+    func zipContainsNotebook(zipPath: String) async -> Bool {
+        await entries(zipPath: zipPath).contains { $0.hasSuffix(".ipynb") }
     }
 }
 
@@ -77,7 +116,8 @@ extension Application {
             if let existing = storage[ZipEntryListCacheKey.self] {
                 return existing
             }
-            let created = ZipEntryListCache()
+            let created = ZipEntryListCache(
+                threadPool: threadPool, eventLoopGroup: eventLoopGroup)
             storage[ZipEntryListCacheKey.self] = created
             return created
         }

--- a/Sources/APIServer/Utilities/BlockingWork.swift
+++ b/Sources/APIServer/Utilities/BlockingWork.swift
@@ -1,0 +1,28 @@
+// APIServer/Utilities/BlockingWork.swift
+//
+// Thread-pool offload for blocking work on request paths (#1156). Vapor
+// route handlers run on the cooperative pool, which has only a handful of
+// threads: synchronous file I/O or a subprocess wait on a handler parks one
+// of them, and a burst of such requests (a lab section opening a notebook)
+// starves every other request. Wrap the blocking section instead.
+
+import NIOCore
+import Vapor
+
+/// Runs `body` on the application's NIOThreadPool, keeping the request's
+/// event loop free. Use for synchronous file I/O, zip subprocess helpers,
+/// and anything else that blocks.
+func runBlocking<T: Sendable>(
+    on req: Request,
+    _ body: @escaping @Sendable () throws -> T
+) async throws -> T {
+    try await req.application.threadPool.runIfActive(eventLoop: req.eventLoop, body).get()
+}
+
+/// Application-scoped variant for call sites without a `Request`.
+func runBlocking<T: Sendable>(
+    app: Application,
+    _ body: @escaping @Sendable () throws -> T
+) async throws -> T {
+    try await app.threadPool.runIfActive(eventLoop: app.eventLoopGroup.next(), body).get()
+}

--- a/Tests/APITests/PersonalizationEvaluatorTests.swift
+++ b/Tests/APITests/PersonalizationEvaluatorTests.swift
@@ -175,3 +175,69 @@ import Testing
         #expect(decoded.globalExpressions.isEmpty)
     }
 }
+
+// MARK: - Spawn gate (#1156)
+
+/// The evaluator's interpreter-spawn semaphore: concurrent evaluations must
+/// be bounded, and the bound must not deadlock or lose slots under a burst.
+@Suite struct EvaluatorSpawnGateTests {
+
+    private actor PeakTracker {
+        private var current = 0
+        private(set) var peak = 0
+
+        func enter() {
+            current += 1
+            peak = max(peak, current)
+        }
+
+        func exit() {
+            current -= 1
+        }
+    }
+
+    @Test func semaphoreBoundsConcurrencyAndDrainsFully() async throws {
+        let gate = AsyncCountingSemaphore(width: 3)
+        let tracker = PeakTracker()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<20 {
+                group.addTask {
+                    await gate.acquire()
+                    await tracker.enter()
+                    try? await Task.sleep(nanoseconds: 5_000_000)
+                    await tracker.exit()
+                    await gate.release()
+                }
+            }
+        }
+
+        let peak = await tracker.peak
+        #expect(peak <= 3, "semaphore must cap concurrent holders at its width")
+        #expect(peak >= 1)
+    }
+
+    /// Burst of real evaluations through the shared gate: all complete, none
+    /// deadlock, results stay per-seed correct.
+    @Test(.timeLimit(.minutes(2))) func concurrentEvaluationsAllComplete() async throws {
+        let results = await withTaskGroup(of: [String: String]?.self) { group in
+            for index in 0..<6 {
+                group.addTask {
+                    try? await PersonalizationEvaluator.evaluate(
+                        seedHex: String(format: "%064x", index + 1),
+                        staticVariables: [],
+                        expressions: [
+                            PersonalizationExpression(name: "v", expression: "seed % 100")
+                        ]
+                    )
+                }
+            }
+            var collected: [[String: String]?] = []
+            for await value in group { collected.append(value) }
+            return collected
+        }
+
+        #expect(results.count == 6)
+        #expect(results.allSatisfy { $0?["v"] != nil })
+    }
+}

--- a/changelog.d/notebook-open-blocking-1156.md
+++ b/changelog.d/notebook-open-blocking-1156.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **Notebook-open path no longer blocks server threads (#1156).** Every
+  notebook page/source request previously ran synchronous file reads/writes,
+  the support-file symlink pass, dataset materialization, and (on first open
+  of a personalized assignment) an unbounded `python3` subprocess directly on
+  Vapor's small cooperative thread pool — a lab section opening an assignment
+  stalled unrelated requests. The filesystem work now runs on the blocking
+  thread pool; concurrent personalization interpreters are capped by a
+  counting semaphore (≈ CPU count, excess evaluations queue without holding
+  a thread); zip entry listings are single-flighted and computed off the
+  cooperative pool (concurrent misses on one zip share one subprocess);
+  student notebook/support-file downloads and the JupyterLite contents
+  endpoint offload their reads and extractions the same way, and the
+  support-file download reuses the entry-list cache instead of spawning a
+  fresh `unzip` per request.


### PR DESCRIPTION
Closes #1156.

The student notebook-open path was the audit's single worst concurrent-load finding: every `GET …/notebook` and `/notebook/source` ran synchronous disk reads/writes, zip subprocesses (under the server-wide zip process lock), dataset materialization, and — on first open of a personalized assignment — an **unbounded `python3` spawn**, all directly on Vapor's cooperative thread pool. A lab section of ~100 students opening an assignment parked the handful of pool threads and stalled unrelated requests (dashboard, submit, auth).

**What changed:**

- **`runBlocking` helper** (`Utilities/BlockingWork.swift`): thin wrapper over `threadPool.runIfActive` used by all the offloads below.
- **`ensureUserNotebookWorkingCopy`**: working-copy reads/writes, the per-visit support-file symlink pass, per-student dataset slice writes, and prior-submission notebook reads all run on the blocking pool now.
- **Personalization interpreter cap**: `PersonalizationEvaluator` spawns go through a new `AsyncCountingSemaphore` (width = max(2, CPU count)). A deadline burst queues evaluations as async suspensions — no threads parked, no process fan-out. Each running evaluation keeps its existing 5 s subprocess timeout.
- **`ZipEntryListCache`**: misses are single-flighted per zip path (concurrent misses on one zip — a class opening one assignment post-deploy — share a single subprocess) and the `unzip` runs on the thread pool instead of holding the actor's cooperative-pool executor.
- **`TestSetupRoutes`**: `getAssignment` / `downloadAssignment` extract the notebook on the thread pool via the `NotebookSourceRef` indirection that was built for exactly this; `downloadSupportFile` now reuses the entry-list cache (previously a fresh serialized `unzip` per download) and extracts off-thread.
- **`JupyterLiteContentsRoutes`**: the editor's contents endpoint reads file bytes on the thread pool.

**Deliberately deferred** (noted here rather than silently dropped): byte-level caching of extracted notebook content. The entry-list cache plus offloading removes the thread-starvation failure mode this issue targets; caching extraction bytes is a further optimization with cache-invalidation surface I'd rather not bundle into this diff.

**Tests:** new semaphore tests (peak-concurrency ≤ width under a 20-task burst; 6-way concurrent real-`python3` evaluate smoke test with per-seed correctness). Existing `ZipEntryListCacheTests`, `PersonalizationEvaluatorTests`, `NotebookWebRoutesTests`, `JupyterLiteContentsRoutesTests`, `SupportImportTests`, `SectionInputsTests`, `WebRoutesIndexTests`, and the submission/assignment route suites (112 tests) all pass unchanged — the offloads are behavior-preserving.

Part of the 2026-07 performance audit series (#1151–#1160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_