### PR TITLE
Blob-free grade loading + bounded result collections

### DIFF
--- a/Sources/APIServer/Helpers/BestGradePercentBySubmissionID.swift
+++ b/Sources/APIServer/Helpers/BestGradePercentBySubmissionID.swift
@@ -46,7 +46,7 @@ struct GradeResultSummary: Sendable, GradeValueCarrying {
     let totalTests: Int?
     /// Set only by the loader's legacy fallback, where the percent comes
     /// from parsing the blob rather than the (nil) grade columns.
-    var legacyGradePercent: Int? = nil
+    var legacyGradePercent: Int?
 
     var gradePercentValue: Int? {
         if let legacyGradePercent { return legacyGradePercent }

--- a/Sources/APIServer/Helpers/BestGradePercentBySubmissionID.swift
+++ b/Sources/APIServer/Helpers/BestGradePercentBySubmissionID.swift
@@ -14,12 +14,65 @@
 // per-student drilldown grade.
 
 import Fluent
+import Foundation
+
+// MARK: - Grade-carrying abstraction (#1157)
+
+/// The three grade accessors the folds below need. `APIResult` conforms via
+/// its column-first accessors; `GradeResultSummary` carries the same values
+/// without ever loading `collection_json` — the audit found one CSV export
+/// pulling hundreds of MB of blobs to read four scalar columns.
+protocol GradeValueCarrying {
+    var gradePercentValue: Int? { get }
+    var gradePointsValue: Double? { get }
+    var gradeTotalPointsValue: Double? { get }
+}
+
+extension APIResult: GradeValueCarrying {}
+
+/// Blob-free projection of an `APIResult` for grade folds: the denormalized
+/// grade columns plus identity/ordering fields, computed with the same math
+/// as `APIResult`'s column-first accessors. Rows whose grade columns are all
+/// nil (pre-backfill writes the migration couldn't parse) are hydrated by
+/// the loader's legacy fallback, so the two paths can never disagree.
+struct GradeResultSummary: Sendable, GradeValueCarrying {
+    let resultID: String?
+    let submissionID: String
+    let source: String?
+    let receivedAt: Date?
+    let earnedPoints: Double?
+    let totalPoints: Double?
+    let passCount: Int?
+    let totalTests: Int?
+    /// Set only by the loader's legacy fallback, where the percent comes
+    /// from parsing the blob rather than the (nil) grade columns.
+    var legacyGradePercent: Int? = nil
+
+    var gradePercentValue: Int? {
+        if let legacyGradePercent { return legacyGradePercent }
+        if let earned = earnedPoints, let total = totalPoints, total > 0 {
+            return Int((earned / total * 100).rounded())
+        }
+        guard let pass = passCount, let total = totalTests, total > 0 else { return nil }
+        return Int((Double(pass) / Double(total) * 100).rounded())
+    }
+
+    var gradePointsValue: Double? {
+        if let total = totalPoints, total > 0, let earned = earnedPoints { return earned }
+        return passCount.map(Double.init)
+    }
+
+    var gradeTotalPointsValue: Double? {
+        if let total = totalPoints, total > 0 { return total }
+        return nil
+    }
+}
 
 // MARK: - Policy (pure)
 
 /// The highest `gradePercentValue` (0–100) across `results`, or nil when no
 /// result carries a parseable percent.
-func bestGradePercent(of results: some Sequence<APIResult>) -> Int? {
+func bestGradePercent(of results: some Sequence<some GradeValueCarrying>) -> Int? {
     var best: Int?
     for result in results {
         guard let pct = result.gradePercentValue else { continue }
@@ -34,7 +87,7 @@ func bestGradePercent(of results: some Sequence<APIResult>) -> Int? {
 /// result carries a parseable percent. Tie-breaking matches `max(by:)`
 /// (the last of the tied rows wins), preserving the pre-#1111 behaviour of
 /// the BrightSpace inline copy.
-func bestGradeResult(of results: some Sequence<APIResult>) -> APIResult? {
+func bestGradeResult<T: GradeValueCarrying>(of results: some Sequence<T>) -> T? {
     results
         .filter { $0.gradePercentValue != nil }
         .max(by: { ($0.gradePercentValue ?? 0) < ($1.gradePercentValue ?? 0) })
@@ -74,9 +127,93 @@ func allResultsBySubmissionID(
     return grouped
 }
 
-/// Loads every `APIResult` for the given submission IDs and returns the
-/// highest `gradePercentValue` (0–100) per submission, across all result
-/// sources — the loader + `bestGradePercent` fold in one call.
+/// Blob-free loader (#1157): the grade projection of every result for the
+/// given submission IDs, grouped by submission ID. Selects only the
+/// denormalized grade columns + identity fields — never `collection_json`,
+/// which dominates the row size and is irrelevant to every grade fold.
+/// Chunked like `allResultsBySubmissionID`.
+///
+/// Legacy fallback: rows whose four grade columns are all nil (written
+/// mid-deploy before `AddResultGradeColumns` backfilled, where the backfill
+/// couldn't parse the blob) are re-fetched WITH the blob — normally zero
+/// rows — and summarized via `APIResult`'s blob-parsing accessors so the
+/// projected and full paths can never disagree.
+func gradeSummariesBySubmissionID(
+    for submissionIDs: some Collection<String>,
+    on db: Database
+) async throws -> [String: [GradeResultSummary]] {
+    guard !submissionIDs.isEmpty else { return [:] }
+    let chunkSize = 5_000
+    let ids = Array(submissionIDs)
+    var grouped: [String: [GradeResultSummary]] = [:]
+    var legacyRowIDs: [String] = []
+
+    var index = ids.startIndex
+    while index < ids.endIndex {
+        let end =
+            ids.index(index, offsetBy: chunkSize, limitedBy: ids.endIndex)
+            ?? ids.endIndex
+        let page = try await APIResult.query(on: db)
+            .filter(\.$submissionID ~~ Array(ids[index..<end]))
+            .field(\.$id)
+            .field(\.$submissionID)
+            .field(\.$source)
+            .field(\.$earnedPoints)
+            .field(\.$totalPoints)
+            .field(\.$passCount)
+            .field(\.$totalTests)
+            .field(\.$receivedAt)
+            .sort(\.$receivedAt, .descending)
+            .all()
+        for row in page {
+            let allColumnsNil =
+                row.earnedPoints == nil && row.totalPoints == nil
+                && row.passCount == nil && row.totalTests == nil
+            if allColumnsNil, let rowID = row.id {
+                legacyRowIDs.append(rowID)
+                continue
+            }
+            grouped[row.submissionID, default: []].append(
+                GradeResultSummary(
+                    resultID: row.id,
+                    submissionID: row.submissionID,
+                    source: row.source,
+                    receivedAt: row.receivedAt,
+                    earnedPoints: row.earnedPoints,
+                    totalPoints: row.totalPoints,
+                    passCount: row.passCount,
+                    totalTests: row.totalTests
+                ))
+        }
+        index = end
+    }
+
+    // Rare path: hydrate column-less rows from the blob so their grades
+    // (if any) still participate in the folds.
+    if !legacyRowIDs.isEmpty {
+        let legacyRows = try await APIResult.query(on: db)
+            .filter(\.$id ~~ legacyRowIDs)
+            .all()
+        for row in legacyRows {
+            grouped[row.submissionID, default: []].append(
+                GradeResultSummary(
+                    resultID: row.id,
+                    submissionID: row.submissionID,
+                    source: row.source,
+                    receivedAt: row.receivedAt,
+                    earnedPoints: row.gradePointsValue,
+                    totalPoints: row.gradeTotalPointsValue,
+                    passCount: row.passCount,
+                    totalTests: row.totalTests,
+                    legacyGradePercent: row.gradePercentValue
+                ))
+        }
+    }
+    return grouped
+}
+
+/// The highest `gradePercentValue` (0–100) per submission, across all result
+/// sources — the blob-free loader + `bestGradePercent` fold in one call.
 ///
 /// The map contains only submissions that have at least one parseable
 /// `gradePercentValue`; missing entries mean no gradeable result exists yet.
@@ -84,6 +221,6 @@ func bestGradePercentBySubmissionID(
     for submissionIDs: some Collection<String>,
     on db: Database
 ) async throws -> [String: Int] {
-    try await allResultsBySubmissionID(for: submissionIDs, on: db)
+    try await gradeSummariesBySubmissionID(for: submissionIDs, on: db)
         .compactMapValues { bestGradePercent(of: $0) }
 }

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -56,7 +56,17 @@ struct BrowserResultRoutes: RouteCollection {
             guard let data = body.collection.data(using: .utf8) else {
                 throw AppError.invalidParameter(name: "collection", reason: "not valid UTF-8")
             }
-            collection = try decoder.decode(TestOutcomeCollection.self, from: data)
+            let decoded = try decoder.decode(TestOutcomeCollection.self, from: data)
+            // Same serialized-size budget as the worker path (#1157) — keeps
+            // the unbounded blob out of the results table regardless of which
+            // grader produced it.
+            let (bounded, didTruncate) = decoded.truncatingOversizedOutput()
+            if didTruncate {
+                req.logger.warning(
+                    "result_collection_truncated submission=\(bounded.submissionID) source=browser"
+                )
+            }
+            collection = bounded
         } catch let e as DecodingError {
             throw AppError.unprocessable(reason: "Invalid TestOutcomeCollection: \(e)")
         }

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -14,6 +14,13 @@ struct ResultRoutes: RouteCollection {
         api.post("results", use: reportResults)
     }
 
+    /// Result-ingest body limit (#1157): well above the worker's own
+    /// serialized-collection budget so a healthy report never hits it, and
+    /// generous enough that pre-budget runners with oversized collections
+    /// land in the server-side truncation guard below instead of a rejected
+    /// report leaving the submission permanently unresolved.
+    static let resultIngestBodyLimitBytes = 32 * 1024 * 1024
+
     // POST /api/v1/worker/results
     @Sendable
     func reportResults(req: Request) async throws -> ReportResponse {
@@ -23,7 +30,7 @@ struct ResultRoutes: RouteCollection {
         let report: WorkerExecutionReport
         do {
             let collectedBuffer = try await req.body.collect(
-                upTo: req.application.routes.defaultMaxBodySize.value
+                upTo: Self.resultIngestBodyLimitBytes
             )
             var readableBuffer = collectedBuffer
             guard let data = readableBuffer.readData(length: readableBuffer.readableBytes) else {
@@ -32,8 +39,24 @@ struct ResultRoutes: RouteCollection {
             report = try decodeWorkerReport(from: data, using: decoder)
         } catch let decodingError as DecodingError {
             throw WorkerJobError.unprocessableBody(reason: "Invalid worker result payload: \(decodingError)")
+        } catch {
+            // A rejected report means a submission that never resolves —
+            // fail LOUDLY so ops sees why (#1157).
+            req.logger.error(
+                "result_report_rejected reason=\(String(describing: error)) content_length=\(req.headers.first(name: .contentLength) ?? "?")"
+            )
+            throw error
         }
-        let collection = report.collection
+
+        // Server-side half of the size budget: current runners truncate
+        // before posting; this guards against older runners and keeps the
+        // unbounded blob out of the results table either way.
+        let (collection, didTruncate) = report.collection.truncatingOversizedOutput()
+        if didTruncate {
+            req.logger.warning(
+                "result_collection_truncated submission=\(collection.submissionID) — runner sent an over-budget collection"
+            )
+        }
 
         // Persist the result and advance the submission to "complete" in one
         // transaction: a failure between the two used to leave a result row

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+GradesCSV.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+GradesCSV.swift
@@ -47,7 +47,7 @@ extension InstructorDashboardRoutes {
         // a later worker regrading at a lower percentage.  The best percentage is
         // then converted to points using the manifest total so the CSV column is
         // anchored to a stable scale regardless of which tier mix each result used.
-        let allResultsBySubmission = try await allResultsBySubmissionID(
+        let allResultsBySubmission = try await gradeSummariesBySubmissionID(
             for: submissionIDs, on: req.db)
         var bestPointsByUserAndSetup = bestGradePointsByUserAndSetup(
             submissions: submissions,
@@ -190,7 +190,7 @@ extension InstructorDashboardRoutes {
     /// overwritten by a lower-percentage worker result from a later regrading.
     private func bestGradePointsByUserAndSetup(
         submissions: [(id: String, userID: UUID, setupID: String)],
-        allResultsBySubmission: [String: [APIResult]],
+        allResultsBySubmission: [String: [GradeResultSummary]],
         setupByID: [String: APITestSetup]
     ) -> [String: Double] {
         // Step 1: highest grade percentage across ALL results for ALL

--- a/Sources/APIServer/Services/BrightSpaceGradeSelection.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSelection.swift
@@ -61,9 +61,8 @@ func bestGradeForStudent(
         if let mt = manifestTotal {
             total = mt
         } else {
-            total = try await APIResult.query(on: db)
-                .filter(\.$submissionID ~~ submissionIDs)
-                .all()
+            total = try await gradeSummariesBySubmissionID(for: submissionIDs, on: db)
+                .values.joined()
                 .compactMap { $0.gradeTotalPointsValue }.max()
         }
         guard let total, total > 0 else { throw BrightSpaceSyncError.missingPoints }
@@ -76,9 +75,9 @@ func bestGradeForStudent(
     // `bestGradeResult` fold (#1111) returns the winning ROW so the push uses
     // its EXACT points — the Int percent the display surfaces use is lossy
     // for a points push (e.g. 6/7 → 86 % → 8.6 instead of 8.57).
-    let allResults = try await APIResult.query(on: db)
-        .filter(\.$submissionID ~~ submissionIDs)
-        .all()
+    // Blob-free (#1157): the fold only reads the denormalized grade values.
+    let allResults = Array(
+        try await gradeSummariesBySubmissionID(for: submissionIDs, on: db).values.joined())
     guard
         let best = bestGradeResult(of: allResults),
         let earned = best.gradePointsValue

--- a/Sources/Core/Models/TestOutcomeCollectionTruncation.swift
+++ b/Sources/Core/Models/TestOutcomeCollectionTruncation.swift
@@ -1,0 +1,114 @@
+// Core/Models/TestOutcomeCollectionTruncation.swift
+//
+// Total-size budget for a serialized TestOutcomeCollection (#1157). The
+// worker caps each captured stream at 1 MB, but nothing capped the number
+// of outcomes × longResult sizes: a many-test suite with verbose failures
+// could exceed the server's result-ingest body limit, and the report was
+// rejected — the submission never resolved. The budget is enforced at
+// report time (worker + browser ingest) by truncating `longResult`s and
+// `compilerOutput` across the whole collection; statuses, short results,
+// and every aggregate stay intact.
+
+import Foundation
+
+extension TestOutcomeCollection {
+    /// Default serialized-size budget: comfortably under the server's result
+    /// ingest limit, leaving headroom for JSON escaping and the report
+    /// envelope (diagnostics, attempt metadata).
+    public static let defaultSerializedBudgetBytes = 6 * 1024 * 1024
+
+    /// Marker appended to every truncated output so the student/instructor
+    /// can see the cut was deliberate.
+    public static let truncationMarker = "\n…[output truncated: result exceeded the size budget]"
+
+    /// Returns a collection whose serialized size fits `budgetBytes`,
+    /// truncating per-outcome `longResult`s (and `compilerOutput`) as evenly
+    /// as needed. Returns `(self, false)` when already within budget.
+    /// Statuses, short results, scores, and aggregates are never altered;
+    /// a warning is appended when anything was cut.
+    public func truncatingOversizedOutput(
+        budgetBytes: Int = TestOutcomeCollection.defaultSerializedBudgetBytes
+    ) -> (collection: TestOutcomeCollection, didTruncate: Bool) {
+        guard serializedSize() > budgetBytes else { return (self, false) }
+
+        // Everything except the long outputs is effectively fixed overhead;
+        // the budget left for outputs is shared across the carriers. JSON
+        // escaping can inflate the encoded size past the raw UTF-8 counts,
+        // so shrink the per-carrier cap until the encoded form fits.
+        let longBytes =
+            outcomes.reduce(0) { $0 + ($1.longResult?.utf8.count ?? 0) }
+            + (compilerOutput?.utf8.count ?? 0)
+        let overhead = max(0, serializedSize() - longBytes)
+        let carrierCount = max(
+            1,
+            outcomes.filter { ($0.longResult?.isEmpty == false) }.count
+                + ((compilerOutput?.isEmpty == false) ? 1 : 0))
+
+        var perCarrierCap = max(1024, (budgetBytes - overhead) / carrierCount)
+        var truncated = self
+        for _ in 0..<8 {
+            truncated = truncatedCopy(perCarrierCap: perCarrierCap)
+            if truncated.serializedSize() <= budgetBytes { break }
+            perCarrierCap = max(256, perCarrierCap / 2)
+        }
+        return (truncated, true)
+    }
+
+    private func serializedSize() -> Int {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return (try? encoder.encode(self).count) ?? 0
+    }
+
+    private func truncatedCopy(perCarrierCap: Int) -> TestOutcomeCollection {
+        func cut(_ text: String?) -> String? {
+            guard let text, text.utf8.count > perCarrierCap else { return text }
+            // Cut on a character boundary near the byte cap; prefix(_:) on
+            // characters keeps the result valid UTF-8.
+            let kept = String(text.prefix(perCarrierCap))
+            return kept + TestOutcomeCollection.truncationMarker
+        }
+
+        let cutOutcomes = outcomes.map { outcome in
+            TestOutcome(
+                testName: outcome.testName,
+                testClass: outcome.testClass,
+                tier: outcome.tier,
+                status: outcome.status,
+                shortResult: outcome.shortResult,
+                longResult: cut(outcome.longResult),
+                score: outcome.score,
+                points: outcome.points,
+                executionTimeMs: outcome.executionTimeMs,
+                memoryUsageBytes: outcome.memoryUsageBytes,
+                attemptNumber: outcome.attemptNumber,
+                isFirstPassSuccess: outcome.isFirstPassSuccess
+            )
+        }
+
+        var cutWarnings = warnings
+        let notice = "Some test output was truncated because the result exceeded the size budget."
+        if !cutWarnings.contains(notice) { cutWarnings.append(notice) }
+
+        return TestOutcomeCollection(
+            submissionID: submissionID,
+            testSetupID: testSetupID,
+            attemptNumber: attemptNumber,
+            buildStatus: buildStatus,
+            compilerOutput: cut(compilerOutput),
+            outcomes: cutOutcomes,
+            totalTests: totalTests,
+            passCount: passCount,
+            failCount: failCount,
+            errorCount: errorCount,
+            timeoutCount: timeoutCount,
+            executionTimeMs: executionTimeMs,
+            totalPoints: totalPoints,
+            earnedPoints: earnedPoints,
+            warnings: cutWarnings,
+            jobStartedAt: jobStartedAt,
+            runnerVersion: runnerVersion,
+            timestamp: timestamp
+        )
+    }
+}

--- a/Sources/Worker/Reporter.swift
+++ b/Sources/Worker/Reporter.swift
@@ -51,6 +51,18 @@ struct Reporter: Sendable {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
+        // Total-size budget (#1157): per-stream capture is already capped at
+        // 1 MB, but a many-test suite with verbose failures could exceed the
+        // server's ingest limit and the whole report was rejected — the
+        // submission never resolved. Truncate longResults across the
+        // collection instead (statuses and aggregates untouched); the
+        // collection carries a visible warning when anything was cut.
+        var report = report
+        let (bounded, didTruncate) = report.collection.truncatingOversizedOutput()
+        if didTruncate {
+            report = WorkerExecutionReport(collection: bounded, diagnostics: report.diagnostics)
+        }
+
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         do { request.httpBody = try encoder.encode(report) } catch { throw .transportError(error) }

--- a/Tests/APITests/GradeSummaryLoaderTests.swift
+++ b/Tests/APITests/GradeSummaryLoaderTests.swift
@@ -1,0 +1,122 @@
+// Tests/APITests/GradeSummaryLoaderTests.swift
+//
+// #1157: the blob-free grade loader must agree exactly with the full-row
+// loader's folds — including for legacy rows whose denormalized grade
+// columns are all nil and whose grade only exists inside collection_json.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+@Suite(.serialized) final class GradeSummaryLoaderTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-gradesum")
+    }
+
+    private func seedSubmission(id: String) async throws {
+        let setupID = "setup_gradesum"
+        if try await APITestSetup.find(setupID, on: app.db) == nil {
+            let courseID = try await app.testCourseID()
+            let setup = APITestSetup(
+                id: setupID,
+                manifest:
+                    #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+        }
+        let sub = APISubmission(
+            id: id,
+            testSetupID: setupID,
+            zipPath: app.submissionsDirectory + "\(id).zip",
+            attemptNumber: 1,
+            status: SubmissionStatus.complete.rawValue
+        )
+        try await sub.save(on: app.db)
+    }
+
+    private func collectionJSON(pass: Int, total: Int) -> String {
+        """
+        {"submissionID":"x","testSetupID":"setup_gradesum","attemptNumber":1,\
+        "buildStatus":"passed","outcomes":[],"totalTests":\(total),"passCount":\(pass),\
+        "failCount":\(total - pass),"errorCount":0,"timeoutCount":0,"executionTimeMs":10,\
+        "runnerVersion":"shell-runner/1.0","timestamp":"2026-01-01T00:00:00Z"}
+        """
+    }
+
+    @Test func summariesMatchFullRowFolds() async throws {
+        try await withApp(app) { _ in
+            try await seedSubmission(id: "sub_gs1")
+            // Two results: browser 100 %, then a lower worker regrade.
+            try await APIResult(
+                id: "res_gs1a", submissionID: "sub_gs1",
+                collectionJSON: collectionJSON(pass: 4, total: 4), source: "browser"
+            ).save(on: app.db)
+            try await APIResult(
+                id: "res_gs1b", submissionID: "sub_gs1",
+                collectionJSON: collectionJSON(pass: 3, total: 4), source: "worker"
+            ).save(on: app.db)
+
+            let viaSummaries = try await bestGradePercentBySubmissionID(
+                for: ["sub_gs1"], on: app.db)
+            let viaFullRows = try await allResultsBySubmissionID(for: ["sub_gs1"], on: app.db)
+                .compactMapValues { bestGradePercent(of: $0) }
+
+            #expect(viaSummaries["sub_gs1"] == 100)
+            #expect(viaSummaries == viaFullRows)
+        }
+    }
+
+    /// A row whose four grade columns are all nil but whose blob carries a
+    /// grade (the pre-backfill shape) must still contribute its percent.
+    @Test func legacyColumnlessRowFallsBackToBlob() async throws {
+        try await withApp(app) { _ in
+            try await seedSubmission(id: "sub_gs2")
+            let result = APIResult(
+                id: "res_gs2", submissionID: "sub_gs2",
+                collectionJSON: collectionJSON(pass: 1, total: 2), source: "worker")
+            // Simulate the legacy shape: columns never populated.
+            result.earnedPoints = nil
+            result.totalPoints = nil
+            result.passCount = nil
+            result.totalTests = nil
+            try await result.save(on: app.db)
+
+            let viaSummaries = try await bestGradePercentBySubmissionID(
+                for: ["sub_gs2"], on: app.db)
+            #expect(viaSummaries["sub_gs2"] == 50)
+        }
+    }
+
+    @Test func summariesCarryExactPointsForTheBrightSpaceFold() async throws {
+        try await withApp(app) { _ in
+            try await seedSubmission(id: "sub_gs3")
+            let json = """
+                {"submissionID":"x","testSetupID":"setup_gradesum","attemptNumber":1,\
+                "buildStatus":"passed","outcomes":[],"totalTests":7,"passCount":6,\
+                "failCount":1,"errorCount":0,"timeoutCount":0,"executionTimeMs":10,\
+                "totalPoints":7,"earnedPoints":6.0,\
+                "runnerVersion":"shell-runner/1.0","timestamp":"2026-01-01T00:00:00Z"}
+                """
+            try await APIResult(
+                id: "res_gs3", submissionID: "sub_gs3",
+                collectionJSON: json, source: "worker"
+            ).save(on: app.db)
+
+            let summaries = try await gradeSummariesBySubmissionID(for: ["sub_gs3"], on: app.db)
+            let best = try #require(bestGradeResult(of: Array(summaries.values.joined())))
+            // Exact points, not the lossy 86 % round-trip.
+            #expect(best.gradePointsValue == 6.0)
+            #expect(best.gradeTotalPointsValue == 7.0)
+        }
+    }
+}

--- a/Tests/CoreTests/TestOutcomeCollectionTruncationTests.swift
+++ b/Tests/CoreTests/TestOutcomeCollectionTruncationTests.swift
@@ -1,0 +1,115 @@
+// Tests/CoreTests/TestOutcomeCollectionTruncationTests.swift
+//
+// #1157: the serialized-size budget for a result collection. Statuses,
+// short results, and aggregates must never change; only longResults and
+// compilerOutput shrink, with a visible marker + warning.
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct TestOutcomeCollectionTruncationTests {
+
+    private func makeCollection(
+        outcomeCount: Int,
+        longResultBytes: Int,
+        compilerOutput: String? = nil
+    ) -> TestOutcomeCollection {
+        let longResult = String(repeating: "x", count: longResultBytes)
+        let outcomes = (0..<outcomeCount).map { index in
+            TestOutcome(
+                testName: "test_\(index)",
+                testClass: nil,
+                tier: .pub,
+                status: index % 2 == 0 ? .pass : .fail,
+                shortResult: "short \(index)",
+                longResult: longResult,
+                executionTimeMs: 5,
+                memoryUsageBytes: nil,
+                attemptNumber: 1,
+                isFirstPassSuccess: false
+            )
+        }
+        return TestOutcomeCollection(
+            submissionID: "sub_trunc",
+            testSetupID: "setup_trunc",
+            attemptNumber: 1,
+            buildStatus: .passed,
+            compilerOutput: compilerOutput,
+            outcomes: outcomes,
+            totalTests: outcomeCount,
+            passCount: (outcomeCount + 1) / 2,
+            failCount: outcomeCount / 2,
+            errorCount: 0,
+            timeoutCount: 0,
+            executionTimeMs: 100,
+            runnerVersion: "shell-runner/1.0",
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private func serializedSize(_ collection: TestOutcomeCollection) throws -> Int {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(collection).count
+    }
+
+    @Test func smallCollectionIsUntouched() throws {
+        let collection = makeCollection(outcomeCount: 5, longResultBytes: 1000)
+        let (result, didTruncate) = collection.truncatingOversizedOutput()
+        #expect(!didTruncate)
+        #expect(result.outcomes.map(\.longResult) == collection.outcomes.map(\.longResult))
+        #expect(result.warnings.isEmpty)
+    }
+
+    @Test func oversizedCollectionFitsBudgetAndKeepsGrades() throws {
+        // 60 outcomes x 200 KB = ~12 MB of longResult against a 1 MB budget.
+        let collection = makeCollection(outcomeCount: 60, longResultBytes: 200_000)
+        let budget = 1024 * 1024
+        let (result, didTruncate) = collection.truncatingOversizedOutput(budgetBytes: budget)
+
+        #expect(didTruncate)
+        #expect(try serializedSize(result) <= budget)
+
+        // Grade-relevant content is untouched.
+        #expect(result.outcomes.count == collection.outcomes.count)
+        #expect(result.outcomes.map(\.status) == collection.outcomes.map(\.status))
+        #expect(result.outcomes.map(\.shortResult) == collection.outcomes.map(\.shortResult))
+        #expect(result.passCount == collection.passCount)
+        #expect(result.totalPoints == collection.totalPoints)
+        #expect(result.earnedPoints == collection.earnedPoints)
+
+        // Every truncated output carries the marker, and the collection
+        // carries a warning.
+        #expect(
+            result.outcomes.allSatisfy {
+                $0.longResult?.hasSuffix(TestOutcomeCollection.truncationMarker) == true
+            })
+        #expect(result.warnings.contains { $0.contains("truncated") })
+    }
+
+    @Test func compilerOutputParticipatesInBudget() throws {
+        let collection = makeCollection(
+            outcomeCount: 1, longResultBytes: 100,
+            compilerOutput: String(repeating: "e", count: 3_000_000))
+        let budget = 512 * 1024
+        let (result, didTruncate) = collection.truncatingOversizedOutput(budgetBytes: budget)
+        #expect(didTruncate)
+        #expect(try serializedSize(result) <= budget)
+        #expect(result.compilerOutput?.hasSuffix(TestOutcomeCollection.truncationMarker) == true)
+    }
+
+    @Test func roundTripsThroughCodableAfterTruncation() throws {
+        let collection = makeCollection(outcomeCount: 20, longResultBytes: 300_000)
+        let (result, _) = collection.truncatingOversizedOutput(budgetBytes: 512 * 1024)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            TestOutcomeCollection.self, from: encoder.encode(result))
+        #expect(decoded.outcomes.count == 20)
+        #expect(decoded.passCount == result.passCount)
+    }
+}

--- a/changelog.d/results-blob-1157.md
+++ b/changelog.d/results-blob-1157.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **Grade queries stopped dragging the results blob, and result size is now
+  bounded (#1157).** The grades CSV export, instructor roster, per-student
+  drilldowns, and BrightSpace grade sync previously loaded full result rows —
+  `collection_json` included — just to read four denormalized grade columns
+  (hundreds of MB of heap for one large-course CSV export). A blob-free
+  projected loader now feeds every grade fold, with a legacy fallback for
+  pre-backfill rows so the two paths can never disagree. Separately, a
+  serialized-size budget (6 MB) now applies to every result collection at
+  report time: the worker truncates verbose `longResult`s/`compilerOutput`
+  across the collection before posting (statuses, short results, and grades
+  untouched; a visible warning is appended), the server applies the same
+  guard against older runners, and the result-ingest body limit rose to
+  32 MB — an oversized report is truncated loudly instead of rejected with
+  the submission stuck unresolved.


### PR DESCRIPTION
Closes #1157.

**Part 1 — grade folds stop dragging `collection_json`.** `allResultsBySubmissionID` selected whole `APIResult` rows for every grade computation, so the grades CSV export, instructor roster, per-student drilldowns, and BrightSpace grade sync all pulled the schema's largest column to read four denormalized scalars — at ~18k result rows × tens of KB of blob each, one large-course CSV export could hold hundreds of MB of heap. Now:

- `gradeSummariesBySubmissionID` loads a blob-free `GradeResultSummary` projection (submission id + the four grade columns + identity/ordering fields).
- A `GradeValueCarrying` protocol lets the shared `bestGradePercent` / `bestGradeResult` folds run on summaries and full rows alike — the "highest grade wins" policy stays in exactly one place (#1085/#1111 invariant preserved; the BrightSpace exact-points behavior is pinned by a new test).
- **Legacy-row correctness:** rows whose four grade columns are all nil (written mid-deploy before `AddResultGradeColumns` backfilled) fall back to a targeted re-fetch *with* the blob — normally zero rows — so projected and full paths can never disagree. Naive column projection would have silently dropped those grades (or crashed on Fluent's unfetched-field access).
- `allResultsBySubmissionID` remains for genuinely blob-consuming surfaces (`preferredResultsBySubmissionID`, result detail).

**Part 2 — result collections get a size budget.** The worker caps each captured stream at 1 MB, but nothing capped outcomes × `longResult`: a many-test suite with verbose failures could exceed the 10 MB ingest limit, the report was rejected, and the submission stayed unresolved forever. Now:

- `TestOutcomeCollection.truncatingOversizedOutput` (Core) enforces a 6 MB serialized budget by trimming `longResult`s and `compilerOutput` evenly across carriers, with an iterative cap-halving pass to absorb JSON-escaping inflation. Statuses, short results, scores, and every aggregate are untouched; truncated outputs end with a visible marker and the collection gains a warning the student sees.
- Applied worker-side before POSTing, and server-side on both the worker and browser ingest paths (guards pre-budget runners and keeps unbounded blobs out of the `results` table either way).
- The results route's body limit is now an explicit 32 MB, and both rejection and truncation log loudly (`result_report_rejected` / `result_collection_truncated`) — the failure mode changes from "submission silently never resolves" to "grades land, verbose output trimmed, ops sees a warning".

**Tests:** truncation unit suite (fit-to-budget on a 12 MB collection, grade/aggregate preservation, compiler-output participation, Codable round-trip, small-collection no-op); grade-summary loader suite (summary folds ≡ full-row folds, legacy column-less row fallback, exact-points BrightSpace fold); all existing grade surfaces green — `BestGradePolicyTests`, `GradesCSV`, BrightSpace suites, `GradeOverridesTests`, drilldowns, `ResultRoutesTests`, `BrowserResultRoutes`, achievement sweep, and the worker reporter suites (139 tests).

Part of the 2026-07 performance audit series (#1151–#1160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_