### PR TITLE
Align streaming and body limits with real artifact sizes

### DIFF
--- a/Sources/APIServer/Routes/SubmissionRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionRoutes.swift
@@ -155,8 +155,14 @@ struct SubmissionDownloadRoute: RouteCollection {
         let downloadName =
             submission.filename
             ?? URL(fileURLWithPath: submission.zipPath).lastPathComponent
-        let data = try Data(contentsOf: URL(fileURLWithPath: submission.zipPath))
-        return buildFileResponse(data: data, filename: downloadName)
+        // Stream from disk (#1158): the old Data(contentsOf:) buffered the
+        // whole artifact per request — the sibling test-setup download has
+        // streamed for a long time.
+        let response = try await req.fileio.asyncStreamFile(at: submission.zipPath)
+        response.headers.replaceOrAdd(
+            name: .contentDisposition,
+            value: "attachment; filename=\"\(downloadName)\"")
+        return response
     }
 }
 

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -36,7 +36,10 @@ import Vapor
 struct TestSetupRoutes: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let api = routes.grouped("api", "v1", "testsetups")
-        api.post(use: uploadTestSetup)
+        // Explicit cap sized to the zip-bomb guard (256 MB uncompressed,
+        // TestSetupZipHelpers): the 10 MB global default rejected legitimate
+        // dataset-heavy setups before validation ever ran (#1158).
+        api.on(.POST, body: .collect(maxSize: "300mb"), use: uploadTestSetup)
         api.group(":testSetupID") { group in
             group.get("download", use: downloadTestSetup)
             group.get("assignment", use: getAssignment)
@@ -94,14 +97,14 @@ struct TestSetupRoutes: RouteCollection {
         let zipPath = setupsDir + "\(setupID).zip"
 
         let zipBytes = upload.files
-        try zipBytes.write(to: URL(fileURLWithPath: zipPath))
+        try await req.fileio.writeFile(.init(data: zipBytes), at: zipPath)
 
         // Reject zip bombs before any DB row references this file.  The
         // upload sits in setupsDir until validation passes; on failure we
         // delete it so a malicious upload doesn't leave stale bytes on
-        // disk indefinitely.
+        // disk indefinitely.  (Subprocess — thread pool, #1158.)
         do {
-            try validateZipUploadSize(zipPath: zipPath)
+            try await runBlocking(on: req) { try validateZipUploadSize(zipPath: zipPath) }
         } catch let error as ZipUploadValidationError {
             try? FileManager.default.removeItem(atPath: zipPath)
             throw AppError.unprocessable(reason: String(describing: error))
@@ -123,7 +126,7 @@ struct TestSetupRoutes: RouteCollection {
         // instructor can edit it later without re-uploading the zip.
         if manifest.gradingMode == .browser {
             let notebookPath = setupsDir + "\(setupID).ipynb"
-            if let data = extractNotebookFromZip(zipPath: zipPath) {
+            if let data = try await runBlocking(on: req, { extractNotebookFromZip(zipPath: zipPath) }) {
                 let normalized = normalizeNotebookForJupyterLite(data)
                 try normalized.write(to: URL(fileURLWithPath: notebookPath))
                 setup.notebookPath = notebookPath

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
@@ -26,7 +26,7 @@ extension CourseBundleRoutes {
         let caller = try req.auth.require(APIUser.self)
         guard caller.isAdmin else { throw Abort(.forbidden) }
 
-        let fileBytes = try readUploadedBundleBytes(req: req)
+        let uploadBuffer = try readUploadedBundleBuffer(req: req)
 
         let tmpZipPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("chickadee-import-\(UUID().uuidString).zip").path
@@ -39,7 +39,7 @@ extension CourseBundleRoutes {
         }
 
         try await extractUploadedBundle(
-            fileBytes: fileBytes, tmpZipPath: tmpZipPath, extractDir: extractDir)
+            req: req, buffer: uploadBuffer, tmpZipPath: tmpZipPath, extractDir: extractDir)
 
         let manifest = try parseBundleManifest(extractDir: extractDir)
 
@@ -73,26 +73,26 @@ extension CourseBundleRoutes {
 
     // ── 1. Receive the uploaded bundle ────────────────────────────────
 
-    private func readUploadedBundleBytes(req: Request) throws -> [UInt8] {
+    private func readUploadedBundleBuffer(req: Request) throws -> ByteBuffer {
         struct BundleUpload: Content {
             let file: File
         }
         let upload = try req.content.decode(BundleUpload.self)
-        var buffer = upload.file.data
-        guard buffer.readableBytes > 0,
-            let fileBytes = buffer.readBytes(length: buffer.readableBytes)
-        else {
+        guard upload.file.data.readableBytes > 0 else {
             throw AppError.badRequest(reason: "Empty bundle upload")
         }
-        return fileBytes
+        // The ByteBuffer goes straight to fileio — the old
+        // ByteBuffer → [UInt8] → Data chain held three full copies of a
+        // potentially multi-hundred-MB bundle in heap at once (#1158).
+        return upload.file.data
     }
 
     // ── 2. Save to temp file and extract ─────────────────────────────
 
     private func extractUploadedBundle(
-        fileBytes: [UInt8], tmpZipPath: String, extractDir: URL
+        req: Request, buffer: ByteBuffer, tmpZipPath: String, extractDir: URL
     ) async throws {
-        try Data(fileBytes).write(to: URL(fileURLWithPath: tmpZipPath))
+        try await req.fileio.writeFile(buffer, at: tmpZipPath)
         try await extractZipArchive(zipPath: tmpZipPath, into: extractDir)
     }
 

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -24,7 +24,13 @@ struct CourseBundleRoutes: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         let admin = routes.grouped("admin")
         admin.get("courses", ":courseID", "export", use: exportCourse)
-        admin.post("courses", "import", use: importCourse)
+        admin.on(
+            .POST, "courses", "import",
+            // A real bundle is testsetup zips + every submission for the
+            // course; the 10 MB default made importing Chickadee's own
+            // exports impossible (#1158).
+            body: .collect(maxSize: "2gb"),
+            use: importCourse)
     }
 
     // MARK: - GET /admin/courses/:courseID/export
@@ -49,8 +55,26 @@ struct CourseBundleRoutes: RouteCollection {
         defer {
             try? FileManager.default.removeItem(at: stagingDir)
         }
-        try writeExportStaging(
-            stagingDir: stagingDir, manifest: manifest, data: data, logger: req.logger)
+        // Staging copies every setup zip + submission file — synchronous bulk
+        // file I/O, so run it on the thread pool (#1158). Primitives only in
+        // the closure: Fluent models aren't Sendable.
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let manifestData = try encoder.encode(manifest)
+        let setupCopies = data.testSetups.compactMap { setup in
+            setup.id.map { (id: $0, zipPath: setup.zipPath) }
+        }
+        let submissionPaths = data.submissions.map(\.zipPath)
+        let logger = req.logger
+        try await runBlocking(on: req) {
+            try writeExportStaging(
+                stagingDir: stagingDir,
+                manifestData: manifestData,
+                setupCopies: setupCopies,
+                submissionPaths: submissionPaths,
+                logger: logger)
+        }
 
         let dateStr = ISO8601DateFormatter().string(from: Date()).prefix(10)
         let safeCourseCode = course.code.replacingOccurrences(of: "/", with: "-")
@@ -58,10 +82,10 @@ struct CourseBundleRoutes: RouteCollection {
         let bundleZipPath = FileManager.default.temporaryDirectory
             .appendingPathComponent(bundleName).path
 
-        defer {
-            try? FileManager.default.removeItem(atPath: bundleZipPath)
-        }
-
+        // No defer here: the response body streams AFTER this handler
+        // returns, so the temp zip must outlive the handler. streamExportZip
+        // deletes it in the stream's onCompleted hook; the catch below covers
+        // the paths where no stream ever starts.
         try await createZipArchive(sourceDir: stagingDir, outputPath: bundleZipPath)
 
         await AuditLogger.record(
@@ -71,7 +95,13 @@ struct CourseBundleRoutes: RouteCollection {
             metadata: ["course_code": course.code],
             on: req
         )
-        return try streamExportZip(bundleZipPath: bundleZipPath, bundleName: bundleName)
+        do {
+            return try await streamExportZip(
+                req: req, bundleZipPath: bundleZipPath, bundleName: bundleName)
+        } catch {
+            try? FileManager.default.removeItem(atPath: bundleZipPath)
+            throw error
+        }
     }
 
     // ── 1. Load all course data ────────────────────────────────────────
@@ -289,65 +319,66 @@ struct CourseBundleRoutes: RouteCollection {
 
     // ── 4. Write staging directory ─────────────────────────────────────
 
-    private func writeExportStaging(
-        stagingDir: URL,
-        manifest: CourseBundleManifest,
-        data: ExportData,
-        logger: Logger
-    ) throws {
-        try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(
-            at: stagingDir.appendingPathComponent("testsetups"), withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(
-            at: stagingDir.appendingPathComponent("submissions"), withIntermediateDirectories: true)
+    // ── 6. Stream the ZIP to the browser ──────────────────────────────
 
-        // Write bundle.json
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let manifestData = try encoder.encode(manifest)
-        try manifestData.write(to: stagingDir.appendingPathComponent("bundle.json"))
-
-        // Copy test setup zips
-        for setup in data.testSetups {
-            guard let sid = setup.id else { continue }
-            let src = URL(fileURLWithPath: setup.zipPath)
-            let dst = stagingDir.appendingPathComponent("testsetups/\(sid).zip")
-            if FileManager.default.fileExists(atPath: src.path) {
-                try FileManager.default.copyItem(at: src, to: dst)
-            } else {
-                logger.warning("Export: test setup zip missing at \(src.path), skipping")
-            }
+    private func streamExportZip(
+        req: Request, bundleZipPath: String, bundleName: String
+    ) async throws -> Response {
+        // Stream instead of buffering: a bundle holds every submission for
+        // the course and routinely runs to hundreds of MB — the old
+        // Data(contentsOf:) held all of it in heap per download (#1158).
+        // The file is opened lazily when the body streams (after the handler
+        // has returned), so the temp zip is deleted in onCompleted, not in a
+        // handler defer — a defer fires before the first byte is read.
+        let response = try await req.fileio.asyncStreamFile(at: bundleZipPath) { _ in
+            try? FileManager.default.removeItem(atPath: bundleZipPath)
         }
+        response.headers.replaceOrAdd(name: .contentType, value: "application/zip")
+        response.headers.replaceOrAdd(
+            name: .contentDisposition,
+            value: "attachment; filename=\"\(bundleName)\"")
+        return response
+    }
+}
 
-        // Copy submission files
-        for sub in data.submissions {
-            let src = URL(fileURLWithPath: sub.zipPath)
-            let onDiskName = src.lastPathComponent
-            let dst = stagingDir.appendingPathComponent("submissions/\(onDiskName)")
-            if FileManager.default.fileExists(atPath: src.path) {
-                try FileManager.default.copyItem(at: src, to: dst)
-            } else {
-                logger.warning("Export: submission file missing at \(src.path), skipping")
-            }
+// ── 4. Write staging directory ─────────────────────────────────────
+//
+// Free function over primitives so the export handler can run it on the
+// thread pool without capturing non-Sendable Fluent models (#1158).
+private func writeExportStaging(
+    stagingDir: URL,
+    manifestData: Data,
+    setupCopies: [(id: String, zipPath: String)],
+    submissionPaths: [String],
+    logger: Logger
+) throws {
+    try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+        at: stagingDir.appendingPathComponent("testsetups"), withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+        at: stagingDir.appendingPathComponent("submissions"), withIntermediateDirectories: true)
+
+    try manifestData.write(to: stagingDir.appendingPathComponent("bundle.json"))
+
+    for setup in setupCopies {
+        let src = URL(fileURLWithPath: setup.zipPath)
+        let dst = stagingDir.appendingPathComponent("testsetups/\(setup.id).zip")
+        if FileManager.default.fileExists(atPath: src.path) {
+            try FileManager.default.copyItem(at: src, to: dst)
+        } else {
+            logger.warning("Export: test setup zip missing at \(src.path), skipping")
         }
     }
 
-    // ── 6. Stream the ZIP to the browser ──────────────────────────────
-
-    private func streamExportZip(bundleZipPath: String, bundleName: String) throws -> Response {
-        guard let zipData = try? Data(contentsOf: URL(fileURLWithPath: bundleZipPath)) else {
-            throw AppError.internalFailure(reason: "Failed to read bundle ZIP")
+    for zipPath in submissionPaths {
+        let src = URL(fileURLWithPath: zipPath)
+        let onDiskName = src.lastPathComponent
+        let dst = stagingDir.appendingPathComponent("submissions/\(onDiskName)")
+        if FileManager.default.fileExists(atPath: src.path) {
+            try FileManager.default.copyItem(at: src, to: dst)
+        } else {
+            logger.warning("Export: submission file missing at \(src.path), skipping")
         }
-
-        var headers = HTTPHeaders()
-        headers.add(name: .contentType, value: "application/zip")
-        headers.add(
-            name: .contentDisposition,
-            value: "attachment; filename=\"\(bundleName)\"")
-        headers.add(name: .contentLength, value: "\(zipData.count)")
-
-        return Response(status: .ok, headers: headers, body: .init(data: zipData))
     }
 }
 

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+FileDownloads.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+FileDownloads.swift
@@ -57,10 +57,13 @@ extension PublishedAssignmentRoutes {
         let (assignment, setup) = try await loadAssignmentAndSetupForStaffRead(req)
 
         // Look for a solution.* entry inside the test setup zip.
-        let solutionZipEntry = listZipEntries(zipPath: setup.zipPath)
+        // Cached entry list + off-thread extraction (#1158): both helpers
+        // spawn serialized unzip subprocesses.
+        let zipPath = setup.zipPath
+        let solutionZipEntry = await req.application.zipEntryListCache.entries(zipPath: zipPath)
             .first(where: { $0.hasPrefix("solution.") })
         if let entryName = solutionZipEntry,
-            let data = extractZipEntry(zipPath: setup.zipPath, entryName: entryName)
+            let data = try await runBlocking(on: req, { extractZipEntry(zipPath: zipPath, entryName: entryName) })
         {
             return buildFileResponse(data: data, filename: entryName)
         }
@@ -69,10 +72,11 @@ extension PublishedAssignmentRoutes {
         // the instructor's original filename (e.g. bmi.py, dna.py).
         if let validationID = assignment.validationSubmissionID,
             let validationSubmission = try await APISubmission.find(validationID, on: req.db),
-            let data = try? Data(contentsOf: URL(fileURLWithPath: validationSubmission.zipPath)),
-            !data.isEmpty
+            let response = try await streamedFileResponse(
+                req: req, path: validationSubmission.zipPath,
+                filename: validationSubmission.filename ?? "solution.ipynb")
         {
-            return buildFileResponse(data: data, filename: validationSubmission.filename ?? "solution.ipynb")
+            return response
         }
 
         if let fallbackSubmission = try await APISubmission.query(on: req.db)
@@ -80,12 +84,36 @@ extension PublishedAssignmentRoutes {
             .filter(\.$kind == APISubmission.Kind.validation)
             .sort(\.$submittedAt, .descending)
             .first(),
-            let data = try? Data(contentsOf: URL(fileURLWithPath: fallbackSubmission.zipPath)),
-            !data.isEmpty
+            let response = try await streamedFileResponse(
+                req: req, path: fallbackSubmission.zipPath,
+                filename: fallbackSubmission.filename ?? "solution.ipynb")
         {
-            return buildFileResponse(data: data, filename: fallbackSubmission.filename ?? "solution.ipynb")
+            return response
         }
 
         throw WebAssignmentError.notFound(resource: "Solution notebook for this assignment")
     }
+}
+
+/// Streams a file-backed download with the shared content-type/disposition
+/// shape of `buildFileResponse`, or nil when the file is missing/empty so
+/// callers can fall through to the next candidate (#1158).
+private func streamedFileResponse(
+    req: Request, path: String, filename: String
+) async throws -> Response? {
+    let exists: Bool = try await runBlocking(on: req) {
+        var isDirectory = ObjCBool(false)
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+            !isDirectory.boolValue,
+            let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+            (attrs[.size] as? UInt64 ?? 0) > 0
+        else { return false }
+        return true
+    }
+    guard exists else { return nil }
+    let response = try await req.fileio.asyncStreamFile(at: path)
+    response.headers.contentType = contentType(for: filename)
+    response.headers.replaceOrAdd(
+        name: .contentDisposition, value: "attachment; filename=\"\(filename)\"")
+    return response
 }

--- a/changelog.d/streaming-body-limits-1158.md
+++ b/changelog.d/streaming-body-limits-1158.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **Course-bundle import can now import Chickadee's own exports, and
+  test-setup uploads match the documented size envelope (#1158).** Bundle
+  import was capped by the global 10 MB body limit while exports routinely
+  run to hundreds of MB — a bundle the export page produced could not be
+  re-imported. The import route now accepts up to 2 GB and writes the upload
+  once (the old ByteBuffer → bytes → Data chain held three full copies in
+  heap). Test-setup uploads get an explicit 300 MB cap matching the 256 MB
+  uncompressed zip guard, so dataset-heavy setups no longer bounce before
+  validation runs.
+
+### Changed
+
+- **Large artifact downloads stream instead of buffering (#1158).** The
+  course-bundle export, submission downloads, and the solution-notebook
+  downloads now use `asyncStreamFile` (the export's temp zip is cleaned up
+  after the stream completes); the export's staging copies and the upload
+  path's zip subprocesses run on the blocking thread pool.


### PR DESCRIPTION
Closes #1158.

Two functional bugs plus the buffering cleanups from the audit's streaming theme:

**1. Course-bundle import can now import Chickadee's own exports.** Import was bounded by the global 10 MB body cap while the export it exists to round-trip routinely produces hundreds of MB (every setup zip + every submission in the course). The import route now collects up to 2 GB, and the upload is written to the temp zip once via `req.fileio` — the old `ByteBuffer → [UInt8] → Data` chain held three full copies of the bundle in heap simultaneously.

**2. Test-setup uploads match the documented size envelope.** The zip-bomb guard permits 256 MB uncompressed / 64 MB per entry, but the route rode the 10 MB default — legitimate dataset-heavy setups were rejected before validation ever ran. Now an explicit 300 MB per-route cap; the zip write goes through `req.fileio`, and the size-validation and notebook-extraction subprocesses run on the blocking thread pool.

**3. Bundle export streams.** `streamExportZip` used `Data(contentsOf:)` on the finished archive — the entire bundle in heap for the duration of the download. Now `asyncStreamFile`, with one subtlety the tests caught immediately: the file opens **lazily when the body streams, after the handler (and its `defer`) has returned** — a `defer`-based temp cleanup deletes the zip before the first byte is read. Cleanup moved to the stream's `onCompleted` hook, with a catch-path fallback for errors before any stream starts. The staging pass (bulk `copyItem` over every artifact in the course) runs on the thread pool.

**4. Downloads stream.** Submission download (`SubmissionRoutes.download`) and the two file-backed solution-notebook download branches use `asyncStreamFile` with content-disposition; the solution zip-entry branch reuses the entry-list cache and extracts off-thread. `AssignmentDraftHelpers.loadExistingSolution` is deliberately untouched — its data is consumed in-process (shared with the MCP `get_solution` tool), not served as a download.

**Known cost left in place, per the issue:** the base64-JSON submission intake (~2.7× transient heap) — bounded by its 10 MB cap, and the binary `/file` endpoint remains the preferred intake.

**Tests:** the existing bundle round-trip suite (export → import) now exercises the streamed export end-to-end — it's what caught the defer-vs-lazy-open bug — plus submission download, test-setup routes, and file-download suites (35 tests across 6 suites, all green).

Part of the 2026-07 performance audit series (#1151–#1160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_