### PR TITLE
Make the Fluent connection pool size explicit and configurable

### DIFF
--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -68,7 +68,10 @@ struct AppConfig: Sendable {
     /// replaced with `[redacted]`. Use the grep guardrail in CI to keep this
     /// honest.
     func logSummary(to logger: Logger) {
-        logger.info("AppConfig loaded — auth=\(auth.mode.rawValue), database=\(database.backend.rawValue)")
+        let poolDescription = database.maxConnectionsPerEventLoop.map(String.init) ?? "default"
+        logger.info(
+            "AppConfig loaded — auth=\(auth.mode.rawValue), database=\(database.backend.rawValue), dbPoolPerLoop=\(poolDescription)"
+        )
         if security.publicBaseURL != nil || security.enforceHTTPS {
             logger.info(
                 "security: publicBaseURL=\(security.publicBaseURL?.absoluteString ?? "(unset)"), enforceHTTPS=\(security.enforceHTTPS), trustForwardedProto=\(security.trustForwardedProto), sessionCookieSecure=\(security.sessionCookieSecure)"

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -28,8 +28,15 @@ struct DatabaseSettings: Sendable {
     /// in-process boundary. nil → the MCP path shares the main pool.
     let postgresMCPUsername: String?
     let postgresMCPPassword: String?
+    /// Fluent connection-pool size per event loop (#1159 — the pool was
+    /// never configured, riding the driver default of 1/loop; the
+    /// MetricsCardCache header documents the ConnectionPoolTimeoutError
+    /// incident that caused). nil → per-backend default at configure time
+    /// (1 for SQLite, whose writes serialize anyway; 4 for Postgres).
+    let maxConnectionsPerEventLoop: Int?
 
     static func fromEnvironment(defaultSQLitePath: String) throws -> Self {
+        let poolSize = try parsedPoolSize()
         let backend: DatabaseBackend
         if let configuredBackend = trimmedEnv("DATABASE_BACKEND")?.lowercased() {
             guard let parsed = DatabaseBackend(rawValue: configuredBackend) else {
@@ -44,7 +51,9 @@ struct DatabaseSettings: Sendable {
 
         switch backend {
         case .sqlite:
-            return .sqlite(path: trimmedEnv("SQLITE_PATH") ?? defaultSQLitePath)
+            return .sqlite(
+                path: trimmedEnv("SQLITE_PATH") ?? defaultSQLitePath,
+                maxConnectionsPerEventLoop: poolSize)
         case .postgres:
             let host = trimmedEnv("DATABASE_HOST")
             let database = trimmedEnv("DATABASE_NAME")
@@ -72,12 +81,23 @@ struct DatabaseSettings: Sendable {
                 username: username,
                 password: password,
                 mcpUsername: trimmedEnv("MCP_DATABASE_USER"),
-                mcpPassword: trimmedEnv("MCP_DATABASE_PASSWORD")
+                mcpPassword: trimmedEnv("MCP_DATABASE_PASSWORD"),
+                maxConnectionsPerEventLoop: poolSize
             )
         }
     }
 
-    static func sqlite(path: String) -> Self {
+    private static func parsedPoolSize() throws -> Int? {
+        guard let raw = trimmedEnv("DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP") else { return nil }
+        guard let value = Int(raw), value > 0 else {
+            throw DatabaseConfigurationError.invalidSettings(
+                "DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP must be a positive integer"
+            )
+        }
+        return value
+    }
+
+    static func sqlite(path: String, maxConnectionsPerEventLoop: Int? = nil) -> Self {
         .init(
             backend: .sqlite,
             sqlitePath: path,
@@ -89,7 +109,8 @@ struct DatabaseSettings: Sendable {
             postgresPassword: nil,
             postgresSearchPath: nil,
             postgresMCPUsername: nil,
-            postgresMCPPassword: nil
+            postgresMCPPassword: nil,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop
         )
     }
 
@@ -105,7 +126,8 @@ struct DatabaseSettings: Sendable {
             postgresPassword: nil,
             postgresSearchPath: nil,
             postgresMCPUsername: nil,
-            postgresMCPPassword: nil
+            postgresMCPPassword: nil,
+            maxConnectionsPerEventLoop: nil
         )
     }
 
@@ -117,7 +139,8 @@ struct DatabaseSettings: Sendable {
         password: String,
         searchPath: [String]? = nil,
         mcpUsername: String? = nil,
-        mcpPassword: String? = nil
+        mcpPassword: String? = nil,
+        maxConnectionsPerEventLoop: Int? = nil
     ) -> Self {
         .init(
             backend: .postgres,
@@ -130,7 +153,8 @@ struct DatabaseSettings: Sendable {
             postgresPassword: password,
             postgresSearchPath: searchPath,
             postgresMCPUsername: mcpUsername,
-            postgresMCPPassword: mcpPassword
+            postgresMCPPassword: mcpPassword,
+            maxConnectionsPerEventLoop: maxConnectionsPerEventLoop
         )
     }
 }
@@ -175,7 +199,12 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
             storage: settings.sqliteStorage,
             enableForeignKeys: true
         )
-        app.databases.use(.sqlite(sqliteConfig), as: .chickadee, isDefault: true)
+        // Default 1/loop: SQLite serializes writes anyway, and the in-memory
+        // test storage must stay on the driver default. Raising it only helps
+        // concurrent WAL reads and only when explicitly configured (#1159).
+        app.databases.use(
+            .sqlite(sqliteConfig, maxConnectionsPerEventLoop: settings.maxConnectionsPerEventLoop ?? 1),
+            as: .chickadee, isDefault: true)
 
         if case .file = settings.sqliteStorage, let sql = app.db as? SQLDatabase {
             _ = try sql.raw("PRAGMA journal_mode = WAL").all().wait()
@@ -209,11 +238,17 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
         if let searchPath = settings.postgresSearchPath, !searchPath.isEmpty {
             configuration.searchPath = searchPath
         }
+        // Default 4/loop on Postgres (#1159): the driver default of 1/loop is
+        // the documented ConnectionPoolTimeoutError incident class — one
+        // long-held connection per event loop starves every other query on
+        // that loop. Override via DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP.
+        let poolSize = settings.maxConnectionsPerEventLoop ?? 4
         app.databases.use(
-            .postgres(configuration: configuration),
+            .postgres(configuration: configuration, maxConnectionsPerEventLoop: poolSize),
             as: .chickadee,
             isDefault: true
         )
+        app.logger.info("Postgres pool: \(poolSize) connections per event loop")
 
         // Optional: a second pool for the MCP path backed by a least-privilege
         // role (no access to student tables). Same host/database/search_path,
@@ -232,7 +267,9 @@ func configureDatabase(_ app: Application, settings: DatabaseSettings) throws {
             if let searchPath = settings.postgresSearchPath, !searchPath.isEmpty {
                 mcpConfiguration.searchPath = searchPath
             }
-            app.databases.use(.postgres(configuration: mcpConfiguration), as: .mcp)
+            app.databases.use(
+                .postgres(configuration: mcpConfiguration, maxConnectionsPerEventLoop: poolSize),
+                as: .mcp)
             app.usesDedicatedMCPDatabase = true
             app.logger.info("MCP database: dedicated least-privilege role \(mcpUsername) in use")
         }

--- a/Tests/APITests/DatabaseConfigurationTests.swift
+++ b/Tests/APITests/DatabaseConfigurationTests.swift
@@ -184,3 +184,70 @@ struct DatabaseConfigurationTests {
         }
     }
 }
+
+// MARK: - Pool sizing (#1159)
+
+@Suite(.serialized)
+struct DatabasePoolSizingTests {
+
+    @Test func poolSizeDefaultsToNilWhenUnset() async throws {
+        try await withTestEnvironment([
+            "DATABASE_BACKEND": nil,
+            "DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP": nil,
+        ]) {
+            let settings = try DatabaseSettings.fromEnvironment(
+                defaultSQLitePath: "/tmp/chickadee.sqlite")
+            #expect(settings.maxConnectionsPerEventLoop == nil)
+        }
+    }
+
+    @Test func poolSizeParsesForBothBackends() async throws {
+        try await withTestEnvironment([
+            "DATABASE_BACKEND": "sqlite",
+            "DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP": "8",
+        ]) {
+            let settings = try DatabaseSettings.fromEnvironment(
+                defaultSQLitePath: "/tmp/chickadee.sqlite")
+            #expect(settings.maxConnectionsPerEventLoop == 8)
+        }
+        try await withTestEnvironment([
+            "DATABASE_BACKEND": "postgres",
+            "DATABASE_HOST": "db",
+            "DATABASE_PORT": "5432",
+            "DATABASE_NAME": "chickadee",
+            "DATABASE_USER": "chickadee",
+            "DATABASE_PASSWORD": "secret",
+            "DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP": "6",
+        ]) {
+            let settings = try DatabaseSettings.fromEnvironment(
+                defaultSQLitePath: "/tmp/chickadee.sqlite")
+            #expect(settings.maxConnectionsPerEventLoop == 6)
+        }
+    }
+
+    @Test func poolSizeRejectsNonPositiveOrGarbageValues() async throws {
+        for bad in ["0", "-2", "many"] {
+            try await withTestEnvironment([
+                "DATABASE_BACKEND": "sqlite",
+                "DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP": bad,
+            ]) {
+                #expect(throws: DatabaseConfigurationError.self) {
+                    _ = try DatabaseSettings.fromEnvironment(
+                        defaultSQLitePath: "/tmp/chickadee.sqlite")
+                }
+            }
+        }
+    }
+
+    @Test func configureDatabaseAcceptsExplicitPoolSize() async throws {
+        let app = try await makeTestingApplication { app in
+            try configureDatabase(
+                app,
+                settings: .sqlite(
+                    path: FileManager.default.temporaryDirectory
+                        .appendingPathComponent("chickadee-pool-\(UUID().uuidString).sqlite").path,
+                    maxConnectionsPerEventLoop: 4))
+        }
+        try await app.asyncShutdown()
+    }
+}

--- a/changelog.d/db-pool-sizing-1159.md
+++ b/changelog.d/db-pool-sizing-1159.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **Fluent connection-pool size is now explicit and configurable (#1159).**
+  The pool was never configured, riding the driver default of one connection
+  per event loop — the documented `ConnectionPoolTimeoutError` incident
+  class, where one long-held admin query starved every other query on its
+  loop. Postgres now defaults to 4 connections per event loop (SQLite stays
+  at 1 — its writes serialize anyway), overridable via
+  `DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP`, logged in the startup summary,
+  and documented in the deploy README alongside the `max_connections`
+  budgeting guidance.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,6 +44,7 @@ Edit `.env`:
 | `DATABASE_BACKEND` | Optional. Leave unset or set to `sqlite` to keep the current default backend. Set to `postgres` to use PostgreSQL. |
 | `SQLITE_PATH` | Optional. Path to the SQLite file. Defaults to `/data/chickadee.sqlite` in the containerized deployment. |
 | `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_NAME` / `DATABASE_USER` / `DATABASE_PASSWORD` | Required only when `DATABASE_BACKEND=postgres`. |
+| `DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP` | Optional Fluent pool size per event loop. Defaults: 4 on Postgres, 1 on SQLite. Total Postgres connections is roughly this value times CPU cores; raise it if long admin reports overlap enough to produce `ConnectionPoolTimeoutError`, and keep the product under the Postgres `max_connections` budget shared with the runner and any second server process. |
 | `AUTH_MODE` | `local` for username/password; `sso` for OIDC |
 | `PUBLIC_BASE_URL` | Your public URL, e.g. `https://chickadee.example.com` |
 


### PR DESCRIPTION
Closes #1159.

Neither database backend ever set `maxConnectionsPerEventLoop`, so every deployment rode the Fluent driver default of **one connection per event loop**. That's the documented `ConnectionPoolTimeoutError` incident class (the `MetricsCardCache` header preserves the postmortem): one long-held admin scan starved every other query scheduled on its loop and 500'd unrelated pages. The specific query got a single-flight cache back then, but the underlying pool stayed at 1 — any new long query (report export, retention scan) could reproduce it.

**What changed:**
- **Postgres defaults to 4 connections per event loop** (applied to both the main pool and the optional least-privilege MCP pool); SQLite stays at 1 — its writes serialize on the file anyway, and the in-memory test storage must keep the driver default.
- `DATABASE_MAX_CONNECTIONS_PER_EVENT_LOOP` overrides both backends, validated as a positive integer with a clear startup error on garbage.
- The pool size appears in the `AppConfig loaded` startup summary and the Postgres path logs its effective value; `deploy/README.md` documents the knob with `max_connections` budgeting guidance (value × CPU cores, shared with the runner and any second server process).

**Deliberately not shipped from this issue's evaluate-list, with rationale (also being posted to #1159):**
- **Per-session `APIUser` cache** — unsafe as designed: Fluent models are mutable reference types, and `UserActivityMiddleware` writes `lastSeenAt` on the authenticated instance downstream. Caching instances across requests is a data race; a value-snapshot cache would change auth identity semantics and needs its own design.
- **Hoisting the JupyterLite config/index middlewares above the session chain** — those responses are currently decorated on the way back by the bundle-cache and cross-origin-isolation middlewares; moving them up strips the COEP/cache headers the editor's SharedArrayBuffer isolation depends on (#574 lineage). High regression risk in the most sensitive subsystem for a handful of requests per notebook boot — and the editor-smoke CI gate doesn't even run on middleware-only diffs.

**Tests:** new `DatabasePoolSizingTests` (unset → nil/default, parses for both backends, rejects `0`/negative/garbage, `configureDatabase` accepts an explicit size); existing `DatabaseConfigurationTests` and `AppConfigTests` green.

Part of the 2026-07 performance audit series (#1151–#1160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_