### PR TITLE
Background query cleanups: achievement sweep, claim zip hash, enrollment scoping

### DIFF
--- a/Sources/APIServer/Helpers/PreferredResultsBySubmissionID.swift
+++ b/Sources/APIServer/Helpers/PreferredResultsBySubmissionID.swift
@@ -39,3 +39,35 @@ func preferredResultsBySubmissionID(
     }
     return preferredResultBySubmissionID
 }
+
+/// Blob-free variant of the worker-preferred fold (#1160): identical
+/// preference rule over `GradeResultSummary` rows, for consumers that only
+/// read grade values (the class-goal achievement sweep). Groups are
+/// re-sorted newest-first before folding because the summary loader's
+/// legacy-row fallback can append out of order.
+func preferredGradeSummariesBySubmissionID(
+    for submissionIDs: [String],
+    on db: Database
+) async throws -> [String: GradeResultSummary] {
+    let grouped = try await gradeSummariesBySubmissionID(for: submissionIDs, on: db)
+
+    var preferredBySubmissionID: [String: GradeResultSummary] = [:]
+    for (key, unsorted) in grouped {
+        let results = unsorted.sorted {
+            ($0.receivedAt ?? .distantPast) > ($1.receivedAt ?? .distantPast)
+        }
+        for result in results {
+            if let existing = preferredBySubmissionID[key] {
+                let existingSource = existing.source ?? "worker"
+                let candidateSource = result.source ?? "worker"
+                if existingSource == "worker" { continue }
+                if candidateSource == "worker" {
+                    preferredBySubmissionID[key] = result
+                }
+            } else {
+                preferredBySubmissionID[key] = result
+            }
+        }
+    }
+    return preferredBySubmissionID
+}

--- a/Sources/APIServer/Routes/Web/CourseRosterCounts.swift
+++ b/Sources/APIServer/Routes/Web/CourseRosterCounts.swift
@@ -31,9 +31,23 @@ func studentUserIDsInCourse(_ courseID: UUID, on db: Database) async throws -> S
 /// Map of `courseID → enrolled-student count` for every course that has
 /// at least one student or pre-enrollment.  Courses with no roster do not
 /// appear in the map; callers should fall back to 0.
-func enrolledStudentCountsByCourse(on db: Database) async throws -> [UUID: Int] {
-    async let enrollmentsFetch = APICourseEnrollment.query(on: db).all()
-    async let preEnrollmentsFetch = APIPreEnrollment.query(on: db).all()
+///
+/// Pass `courseIDs` to scope the fetch (#1160) — the class-goal achievement
+/// sweep only needs the courses that carry goals, and the unscoped fetch
+/// grows with every past term. nil keeps the deployment-wide behaviour the
+/// admin dashboard needs.
+func enrolledStudentCountsByCourse(
+    courseIDs: [UUID]? = nil, on db: Database
+) async throws -> [UUID: Int] {
+    let enrollmentQuery = APICourseEnrollment.query(on: db)
+    let preEnrollmentQuery = APIPreEnrollment.query(on: db)
+    if let courseIDs {
+        guard !courseIDs.isEmpty else { return [:] }
+        _ = enrollmentQuery.filter(\.$course.$id ~~ courseIDs)
+        _ = preEnrollmentQuery.filter(\.$course.$id ~~ courseIDs)
+    }
+    async let enrollmentsFetch = enrollmentQuery.all()
+    async let preEnrollmentsFetch = preEnrollmentQuery.all()
     let (enrollments, preEnrollments) = try await (enrollmentsFetch, preEnrollmentsFetch)
 
     var counts: [UUID: Int] = [:]

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+GradesCSV.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+GradesCSV.swift
@@ -121,9 +121,18 @@ extension InstructorDashboardRoutes {
         }
         // No active course: every student across the deployment — the union of
         // all `.student`-role enrollments (#417 Slice G2; the global role no
-        // longer distinguishes students).
-        let allEnrollments = try await APICourseEnrollment.query(on: req.db).all()
-        let studentUserIDs = Set(allEnrollments.filter { $0.role == .student }.map(\.userID))
+        // longer distinguishes students). Filtered DB-side (#1160): the
+        // unscoped fetch grows with every past term. NULL role means
+        // pre-migration student (the computed `role` accessor's default), so
+        // the predicate must keep NULL rows.
+        let studentEnrollments = try await APICourseEnrollment.query(on: req.db)
+            .group(.or) { or in
+                or.filter(\.$roleRaw == CourseRole.student.rawValue)
+                or.filter(\.$roleRaw == .null)
+            }
+            .field(\.$userID)
+            .all()
+        let studentUserIDs = Set(studentEnrollments.map(\.userID))
         guard !studentUserIDs.isEmpty else { return [] }
         return try await APIUser.query(on: req.db)
             .filter(\.$id ~~ Array(studentUserIDs))

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -607,7 +607,7 @@ private func testSetupDownloadVersion(for setup: APITestSetup, req: Request) asy
     let digest =
         (try? await runBlocking(on: req) {
             sha256HexDigest(prefix: prefix, contentsOfFile: zipPath)
-        }) ?? nil
+        }).flatMap { $0 }
     let version = String((digest ?? sha256HexDigest(Data(manifest.utf8))).prefix(16))
     await TestSetupDownloadVersionCache.shared.store(setupID: setupID, key: key, version: version)
     return version

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -244,7 +244,7 @@ struct WorkerJobRoutes: RouteCollection {
         guard let submissionID = submission.id, let setupID = setup.id else {
             throw WorkerJobError.internalInconsistency(reason: "Claimed submission or test setup missing id")
         }
-        let downloadVersion = await testSetupDownloadVersion(for: setup)
+        let downloadVersion = await testSetupDownloadVersion(for: setup, req: req)
         guard
             let submissionURL = URL(string: "\(base)/api/v1/worker/submissions/\(submissionID)/download"),
             let testSetupURL = URL(
@@ -559,39 +559,58 @@ private func normalizedWorkerBindHost(_ raw: String) -> String {
 private actor TestSetupDownloadVersionCache {
     static let shared = TestSetupDownloadVersionCache()
 
-    private struct Key: Hashable {
+    private var entries: [String: (key: Key, version: String)] = [:]
+
+    func cachedVersion(setupID: String, key: Key) -> String? {
+        guard let cached = entries[setupID], cached.key == key else { return nil }
+        return cached.version
+    }
+
+    func store(setupID: String, key: Key, version: String) {
+        entries[setupID] = (key, version)
+    }
+
+    static func makeKey(manifest: String, zipPath: String) -> Key {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: zipPath)
+        return Key(
+            manifest: manifest,
+            zipPath: zipPath,
+            zipSize: (attributes?[.size] as? UInt64) ?? 0,
+            zipModified: (attributes?[.modificationDate] as? Date) ?? .distantPast)
+    }
+
+    struct Key: Hashable, Sendable {
         let manifest: String
         let zipPath: String
         let zipSize: UInt64
         let zipModified: Date
     }
-
-    private var entries: [String: (key: Key, version: String)] = [:]
-
-    func version(for setup: APITestSetup) -> String {
-        let setupID = setup.id ?? setup.zipPath
-        let attributes = try? FileManager.default.attributesOfItem(atPath: setup.zipPath)
-        let key = Key(
-            manifest: setup.manifest,
-            zipPath: setup.zipPath,
-            zipSize: (attributes?[.size] as? UInt64) ?? 0,
-            zipModified: (attributes?[.modificationDate] as? Date) ?? .distantPast)
-
-        if let cached = entries[setupID], cached.key == key { return cached.version }
-
-        var material = Data(setup.manifest.utf8)
-        if let zipData = try? Data(contentsOf: URL(fileURLWithPath: setup.zipPath)) {
-            material.append(Data("|zip=".utf8))
-            material.append(zipData)
-        }
-        let version = String(sha256HexDigest(material).prefix(16))
-        entries[setupID] = (key, version)
-        return version
-    }
 }
 
-private func testSetupDownloadVersion(for setup: APITestSetup) async -> String {
-    await TestSetupDownloadVersionCache.shared.version(for: setup)
+private func testSetupDownloadVersion(for setup: APITestSetup, req: Request) async -> String {
+    let setupID = setup.id ?? setup.zipPath
+    let manifest = setup.manifest
+    let zipPath = setup.zipPath
+    let key = TestSetupDownloadVersionCache.makeKey(manifest: manifest, zipPath: zipPath)
+
+    if let cached = await TestSetupDownloadVersionCache.shared.cachedVersion(setupID: setupID, key: key) {
+        return cached
+    }
+
+    // Cache miss (first claim after any suite edit): the zip is hashed in
+    // streamed 1 MiB chunks on the thread pool (#1160) — the old
+    // Data(contentsOf:) pulled a whole dataset-heavy setup zip into heap
+    // inside the actor, on the claim path. Digest is byte-identical to the
+    // old manifest+"|zip="+bytes concatenation, so versions (and runner
+    // download caches) carry across the change.
+    let prefix = Data(manifest.utf8) + Data("|zip=".utf8)
+    let digest =
+        (try? await runBlocking(on: req) {
+            sha256HexDigest(prefix: prefix, contentsOfFile: zipPath)
+        }) ?? nil
+    let version = String((digest ?? sha256HexDigest(Data(manifest.utf8))).prefix(16))
+    await TestSetupDownloadVersionCache.shared.store(setupID: setupID, key: key, version: version)
+    return version
 }
 
 // MARK: - Application-level claim serializer

--- a/Sources/APIServer/Services/AchievementEvaluationService.swift
+++ b/Sources/APIServer/Services/AchievementEvaluationService.swift
@@ -59,14 +59,25 @@ func evaluateClassGoalAchievements(
         }
     }
 
-    for assignment in assignments {
+    // Pre-resolve which assignments actually carry class goals, so the
+    // enrollment denominator is ONE scoped map for the whole sweep instead
+    // of a per-assignment roster query (#1160 — many assignments share a
+    // course, and this loop runs on a timer forever).
+    let goalCarrying = assignments.compactMap { assignment -> (APIAssignment, APITestSetup, [Achievement])? in
         guard let setup = setupByID[assignment.testSetupID],
-            let setupID = setup.id,
             let props = try? JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
-        else { continue }
-
+        else { return nil }
         let goals = props.achievements.filter { $0.isClassGoal }
-        guard !goals.isEmpty else { continue }
+        guard !goals.isEmpty else { return nil }
+        return (assignment, setup, goals)
+    }
+    guard !goalCarrying.isEmpty else { return 0 }
+
+    let goalCourseIDs = Array(Set(goalCarrying.map { $0.0.courseID }))
+    let countsByCourse = try await enrolledStudentCountsByCourse(courseIDs: goalCourseIDs, on: db)
+
+    for (assignment, setup, goals) in goalCarrying {
+        guard let setupID = setup.id else { continue }
 
         let existing = try await APIAchievementResult.query(on: db)
             .filter(\.$testSetupID == setupID)
@@ -77,7 +88,7 @@ func evaluateClassGoalAchievements(
         // Every goal here already frozen → nothing to recompute for this setup.
         if goals.allSatisfy({ rowByAchievement[$0.id]?.locked == true }) { continue }
 
-        let denominator = try await enrolledStudentCount(forCourse: assignment.courseID, on: db)
+        let denominator = countsByCourse[assignment.courseID] ?? 0
         let locked = assignment.dueAt.map { $0 <= now } ?? false
         let bestByStudent = try await bestAssignmentGradeByStudent(testSetupID: setupID, on: db)
 
@@ -134,7 +145,8 @@ func bestAssignmentGradeByStudent(testSetupID: String, on db: Database) async th
         guard let id = sub.id, let userID = sub.userID else { return nil }
         return (id, userID)
     }
-    let preferred = try await preferredResultsBySubmissionID(for: identified.map(\.id), on: db)
+    // Blob-free (#1160): the fold only reads gradePercentValue.
+    let preferred = try await preferredGradeSummariesBySubmissionID(for: identified.map(\.id), on: db)
 
     var best: [UUID: Double] = [:]
     for sub in identified {

--- a/Sources/Core/Hashing.swift
+++ b/Sources/Core/Hashing.swift
@@ -19,3 +19,22 @@ public func sha256HexDigest(_ data: Data) -> String {
 public func sha256HexDigest(_ string: String) -> String {
     sha256HexDigest(Data(string.utf8))
 }
+
+/// Lowercase-hex SHA-256 of `prefix` followed by the contents of the file at
+/// `path`, streamed in 1 MiB chunks so the file is never fully resident
+/// (#1160 — the job-claim path previously read a whole dataset-heavy setup
+/// zip into memory to fingerprint it). Byte-identical to
+/// `sha256HexDigest(prefix + fileBytes)`; returns nil when the file cannot
+/// be opened, letting callers fall back to hashing the prefix alone —
+/// matching the historical `try? Data(contentsOf:)` behaviour.
+public func sha256HexDigest(prefix: Data, contentsOfFile path: String) -> String? {
+    guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+    defer { try? handle.close() }
+    var hasher = SHA256()
+    hasher.update(data: prefix)
+    while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+        hasher.update(data: chunk)
+    }
+    let digest = hasher.finalize()
+    return digest.map { String(format: "%02x", $0) }.joined()
+}

--- a/Tests/CoreTests/HashingTests.swift
+++ b/Tests/CoreTests/HashingTests.swift
@@ -50,3 +50,33 @@ struct HashingTests {
         #expect(a != b)
     }
 }
+
+// MARK: - Streamed digest parity (#1160)
+
+@Suite struct StreamedDigestTests {
+    /// The claim-path version fingerprint must be byte-identical whether the
+    /// zip is hashed in-memory (historical) or streamed — versions carry
+    /// runner download caches across deploys.
+    @Test func streamedDigestMatchesInMemoryConcatenation() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hash-stream-\(UUID().uuidString).bin")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        // Big enough to span multiple 1 MiB chunks.
+        var bytes = Data(count: 2_500_000)
+        bytes.withUnsafeMutableBytes { buffer in
+            for index in 0..<buffer.count { buffer[index] = UInt8(index % 251) }
+        }
+        try bytes.write(to: tmp)
+
+        let prefix = Data("manifest|zip=".utf8)
+        let streamed = sha256HexDigest(prefix: prefix, contentsOfFile: tmp.path)
+        let inMemory = sha256HexDigest(prefix + bytes)
+        #expect(streamed == inMemory)
+    }
+
+    @Test func streamedDigestReturnsNilForMissingFile() {
+        let digest = sha256HexDigest(
+            prefix: Data("x".utf8), contentsOfFile: "/nonexistent/\(UUID().uuidString)")
+        #expect(digest == nil)
+    }
+}

--- a/changelog.d/background-misc-1160.md
+++ b/changelog.d/background-misc-1160.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Background query cleanups from the 2026-07 audit (#1160).** The
+  class-goal achievement sweep resolves the enrolled-student denominator
+  with one course-scoped query pair per tick instead of a roster query per
+  assignment, and reads grades through the blob-free summary loader; the
+  job-claim path fingerprints an edited setup zip by streaming it in 1 MiB
+  chunks on the thread pool instead of reading the whole archive into heap
+  (digest unchanged, so runner download caches carry over); and the
+  deployment-wide enrollment fetches behind the grades CSV student list and
+  the roster-counts map are now filtered database-side / scopeable by
+  course.


### PR DESCRIPTION
Closes #1160 — the final PR of the 2026-07 performance audit series (#1151–#1160).

**1. Class-goal achievement sweep stops fanning out.** The sweep ran an enrollment roster query per goal-carrying assignment, every tick, forever — O(assignments × roster) even though many assignments share a course. Now: assignments are pre-filtered to goal carriers, the sweep exits early when there are none, and the enrolled-student denominator comes from **one** course-scoped `enrolledStudentCountsByCourse` call per tick. `bestAssignmentGradeByStudent` also switches to the blob-free grade-summary loader from #1157, through a new `preferredGradeSummariesBySubmissionID` fold with identical worker-preferred semantics — including a per-group newest-first re-sort, because the summary loader's legacy fallback can append out of order and the preference rule depends on ordering.

**2. Claim-path zip fingerprinting streams.** On a cache miss (first claim after any suite edit), `TestSetupDownloadVersionCache` read the entire setup zip into heap via `Data(contentsOf:)` inside the actor — tens of MB for dataset-heavy setups, on the claim path. The hash now streams the file in 1 MiB chunks on the thread pool via a new Core `sha256HexDigest(prefix:contentsOfFile:)`. Crucially, the digest is **byte-identical** to the old `manifest + "|zip=" + bytes` concatenation (pinned by a parity test spanning multiple chunks), so download versions — and therefore runner-side setup caches — carry across the change instead of mass-invalidating on deploy.

**3. Enrollment fetches scope down.** `enrolledStudentCountsByCourse` accepts an optional `courseIDs` filter (the sweep passes its goal courses; the admin dashboard keeps the deployment-wide default). The grades CSV's no-active-course student list now filters student-role enrollments database-side with a `userID` projection — preserving the constraint the audit flagged as easy to get wrong: `role` is computed over nullable `roleRaw` where NULL means pre-migration student, so the predicate is `roleRaw = 'student' OR roleRaw IS NULL`, not a naive equality.

**Tests:** streamed-digest parity + missing-file tests; the full achievement suite family (display/authoring/seed/unified/class-goal), `WorkerRoutesTests`, `AdminRoutesTests`, `GradesCSV`, and roster suites — 100+ tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_