### PR TITLE
Move results.collection_json to a result_collections side table

### DIFF
--- a/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
+++ b/Sources/APIServer/Helpers/AchievementBadgeEvaluation.swift
@@ -33,20 +33,17 @@ func earnedIndividualBadges(
     }
 }
 
-/// The individual badges to show for a submission's display result: decodes the
-/// stored collection (reusing the handler's date-aware decoder) and evaluates
-/// the authored individual badges.  Returns [] when there is no result.  Lifted
+/// The individual badges to show for a submission's display result — the
+/// handler passes the already-decoded collection (fetched once from the
+/// result_collections side table, #1173) and this evaluates the authored
+/// individual badges.  Returns [] when there is no decodable result.  Lifted
 /// out of the submission handler to keep that function within its length budget.
 func earnedIndividualBadgesForDisplay(
-    displayResult: APIResult?,
+    collection: TestOutcomeCollection?,
     props: TestProperties?,
-    gradePercent: Int,
-    decoder: JSONDecoder
+    gradePercent: Int
 ) -> [AchievementBadge] {
-    guard let result = displayResult,
-        let collection = try? decoder.decode(
-            TestOutcomeCollection.self, from: Data(result.collectionJSON.utf8))
-    else { return [] }
+    guard let collection else { return [] }
     return earnedIndividualBadges(
         props: props,
         gradePercent: gradePercent,

--- a/Sources/APIServer/Helpers/BestGradePercentBySubmissionID.swift
+++ b/Sources/APIServer/Helpers/BestGradePercentBySubmissionID.swift
@@ -129,15 +129,15 @@ func allResultsBySubmissionID(
 
 /// Blob-free loader (#1157): the grade projection of every result for the
 /// given submission IDs, grouped by submission ID. Selects only the
-/// denormalized grade columns + identity fields — never `collection_json`,
-/// which dominates the row size and is irrelevant to every grade fold.
-/// Chunked like `allResultsBySubmissionID`.
+/// denormalized grade columns + identity fields — never the collection
+/// blob, which since #1173 lives in the `result_collections` side table
+/// anyway. Chunked like `allResultsBySubmissionID`.
 ///
 /// Legacy fallback: rows whose four grade columns are all nil (written
 /// mid-deploy before `AddResultGradeColumns` backfilled, where the backfill
-/// couldn't parse the blob) are re-fetched WITH the blob — normally zero
-/// rows — and summarized via `APIResult`'s blob-parsing accessors so the
-/// projected and full paths can never disagree.
+/// couldn't parse the blob) get their blob fetched from the side table —
+/// normally zero rows — and are summarized via the blob-parsing helpers so
+/// the projected and full paths can never disagree.
 func gradeSummariesBySubmissionID(
     for submissionIDs: some Collection<String>,
     on db: Database
@@ -146,7 +146,7 @@ func gradeSummariesBySubmissionID(
     let chunkSize = 5_000
     let ids = Array(submissionIDs)
     var grouped: [String: [GradeResultSummary]] = [:]
-    var legacyRowIDs: [String] = []
+    var legacyRows: [APIResult] = []
 
     var index = ids.startIndex
     while index < ids.endIndex {
@@ -169,8 +169,8 @@ func gradeSummariesBySubmissionID(
             let allColumnsNil =
                 row.earnedPoints == nil && row.totalPoints == nil
                 && row.passCount == nil && row.totalTests == nil
-            if allColumnsNil, let rowID = row.id {
-                legacyRowIDs.append(rowID)
+            if allColumnsNil {
+                legacyRows.append(row)
                 continue
             }
             grouped[row.submissionID, default: []].append(
@@ -188,24 +188,24 @@ func gradeSummariesBySubmissionID(
         index = end
     }
 
-    // Rare path: hydrate column-less rows from the blob so their grades
-    // (if any) still participate in the folds.
-    if !legacyRowIDs.isEmpty {
-        let legacyRows = try await APIResult.query(on: db)
-            .filter(\.$id ~~ legacyRowIDs)
-            .all()
+    // Rare path: hydrate column-less rows from the blob (side table, #1173)
+    // so their grades (if any) still participate in the folds.
+    if !legacyRows.isEmpty {
+        let blobByID = try await collectionJSONByResultID(
+            for: legacyRows.compactMap(\.id), on: db)
         for row in legacyRows {
+            let blob = row.id.flatMap { blobByID[$0] }
             grouped[row.submissionID, default: []].append(
                 GradeResultSummary(
                     resultID: row.id,
                     submissionID: row.submissionID,
                     source: row.source,
                     receivedAt: row.receivedAt,
-                    earnedPoints: row.gradePointsValue,
-                    totalPoints: row.gradeTotalPointsValue,
+                    earnedPoints: blob.flatMap(gradePointsFromCollectionJSON),
+                    totalPoints: blob.flatMap(gradeTotalPointsFromCollectionJSON),
                     passCount: row.passCount,
                     totalTests: row.totalTests,
-                    legacyGradePercent: row.gradePercentValue
+                    legacyGradePercent: blob.flatMap(gradePercentFromCollectionJSON)
                 ))
         }
     }

--- a/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
@@ -123,8 +123,9 @@ struct GetValidationResultTool: ContentTool {
         guard
             let result = try await MCPStudentDataBoundary.latestResult(
                 forSubmissionID: submission.requireID(), on: context.db),
-            let data = result.collectionJSON.data(using: .utf8),
-            let collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+            let collectionJSON = try await result.loadCollectionJSON(on: context.db),
+            let collection = try? decoder.decode(
+                TestOutcomeCollection.self, from: Data(collectionJSON.utf8))
         else {
             return Self.empty(assignmentPublicID: assignment.publicID, validationStatus: status)
         }

--- a/Sources/APIServer/Migrations/CreateResultCollections.swift
+++ b/Sources/APIServer/Migrations/CreateResultCollections.swift
@@ -1,0 +1,96 @@
+// APIServer/Migrations/CreateResultCollections.swift
+//
+// Moves `results.collection_json` to the `result_collections` side table
+// (#1173). The blob dominated the row width (up to the 6 MB collection
+// budget) and the table's on-disk footprint, so every full-row load — the
+// preferred-result maps, per-student history, sweeps — dragged megabytes it
+// never read. After this migration the hot `results` row carries only
+// scalars; the blob is fetched explicitly by the few readers that need it.
+//
+// Shipped standalone (not folded into CreateResults) because production
+// databases already applied CreateResults with the column. Fresh deploys run
+// CreateResults (which still creates `collection_json`) and then this
+// migration relocates it — the same convention as
+// ChangeAssignmentIsOpenToVisibility.
+//
+// The backfill is chunked raw SQL (`INSERT … SELECT … LIMIT`): the copy
+// happens entirely inside the database, so a production table with tens of
+// thousands of multi-MB blobs never streams through Swift, and each pass is
+// bounded. `NOT EXISTS` keys each pass off what's already copied, so the
+// loop is also re-entrant if a previous attempt died midway.
+
+import Fluent
+import SQLKit
+
+struct CreateResultCollections: ChickadeeMigration {
+    /// Rows copied per backfill pass. Internal so the migration test can
+    /// prove multi-pass behaviour against a seeded multi-thousand-row table.
+    static let backfillChunkSize = 1_000
+
+    func prepare(on database: Database) async throws {
+        try await database.schema("result_collections")
+            .field(
+                "result_id",
+                .string,
+                .identifier(auto: false),
+                .references("results", "id", onDelete: .cascade)
+            )
+            .field("collection_json", .string, .required)
+            .create()
+
+        try await Self.backfill(on: database)
+
+        try await database.schema("results")
+            .deleteField("collection_json")
+            .update()
+    }
+
+    /// Copies every not-yet-copied blob into the side table, one bounded
+    /// chunk at a time, until none remain.
+    static func backfill(on database: Database, chunkSize: Int = backfillChunkSize) async throws {
+        guard let sql = database as? SQLDatabase else { return }
+        struct CountRow: Decodable { let remaining: Int }
+        while true {
+            let row = try await sql.raw(
+                """
+                SELECT COUNT(*) AS remaining FROM results r
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM result_collections rc WHERE rc.result_id = r.id
+                )
+                """
+            ).first(decoding: CountRow.self)
+            guard let remaining = row?.remaining, remaining > 0 else { return }
+
+            try await sql.raw(
+                """
+                INSERT INTO result_collections (result_id, collection_json)
+                SELECT r.id, r.collection_json FROM results r
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM result_collections rc WHERE rc.result_id = r.id
+                )
+                LIMIT \(bind: chunkSize)
+                """
+            ).run()
+        }
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "ALTER TABLE results ADD COLUMN collection_json TEXT NOT NULL DEFAULT '{}'"
+            ).run()
+            try await sql.raw(
+                """
+                UPDATE results SET collection_json = COALESCE(
+                    (SELECT rc.collection_json FROM result_collections rc
+                     WHERE rc.result_id = results.id),
+                    '{}'
+                )
+                """
+            ).run()
+        } else {
+            try await database.schema("results").field("collection_json", .string).update()
+        }
+        try await database.schema("result_collections").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIResult.swift
+++ b/Sources/APIServer/Models/APIResult.swift
@@ -14,8 +14,10 @@ final class APIResult: Model, Content, @unchecked Sendable {
     @Field(key: "submission_id")
     var submissionID: String
 
-    @Field(key: "collection_json")
-    var collectionJSON: String  // serialised TestOutcomeCollection
+    // The serialised TestOutcomeCollection blob lives in the
+    // `result_collections` side table (#1173) — see APIResultCollection.
+    // Create result rows via `saveWithCollection(json:on:)` so the two rows
+    // persist together; read the blob via `loadCollectionJSON(on:)`.
 
     /// "worker" (official, authoritative) or "browser" (student preview).
     /// Nil on rows created before this migration — treated as "worker".
@@ -65,18 +67,17 @@ final class APIResult: Model, Content, @unchecked Sendable {
 
     init() {}
 
-    init(id: String, submissionID: String, collectionJSON: String, source: String = "worker") {
+    init(id: String, submissionID: String, source: String = "worker") {
         self.id = id
         self.submissionID = submissionID
-        self.collectionJSON = collectionJSON
         self.source = source
-        populateGradeFields()
     }
 
-    /// Stamps the denormalized grade columns from `collectionJSON`. Called by
-    /// the designated initializer so every creation path (worker report,
-    /// browser report, bundle import) gets the columns without remembering to.
-    func populateGradeFields() {
+    /// Stamps the denormalized grade columns from a serialized collection.
+    /// Called by `saveWithCollection(json:on:)` so every creation path
+    /// (worker report, browser report, bundle import) gets the columns
+    /// without remembering to.
+    func stampGradeFields(from collectionJSON: String) {
         guard let data = collectionJSON.data(using: .utf8),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return }
@@ -91,18 +92,17 @@ final class APIResult: Model, Content, @unchecked Sendable {
 //
 // Same semantics as gradePercentFromCollectionJSON / gradePointsFromCollectionJSON
 // / gradeTotalPointsFromCollectionJSON in AssignmentHelpers.swift, but reading
-// the denormalized columns. Rows that predate the columns (all four nil — e.g.
-// written mid-deploy before AddResultGradeColumns ran) fall back to parsing the
-// blob, so the two paths can never disagree.
+// the denormalized columns. Since #1173 the blob is not on this row, so there
+// is no synchronous fallback: rows whose four columns are all nil report no
+// grade — which matches the old fallback in every reachable state, because
+// `AddResultGradeColumns` backfilled every parseable blob and a blob the
+// backfill couldn't parse yielded nil from the fallback too. Loaders that
+// must hydrate such rows anyway (gradeSummariesBySubmissionID's legacy path)
+// fetch the blob from the side table explicitly.
 extension APIResult {
-    private var hasGradeColumns: Bool {
-        earnedPoints != nil || totalPoints != nil || passCount != nil || totalTests != nil
-    }
-
     /// Whole-result grade percent: weighted (earned/total) when totalPoints > 0,
     /// else unweighted pass/total test counts. Nil when neither is available.
     var gradePercentValue: Int? {
-        guard hasGradeColumns else { return gradePercentFromCollectionJSON(collectionJSON) }
         if let earned = earnedPoints, let total = totalPoints, total > 0 {
             return Int((earned / total * 100).rounded())
         }
@@ -112,14 +112,12 @@ extension APIResult {
 
     /// Earned points (weighted when available, else pass count) for CSV/LEARN export.
     var gradePointsValue: Double? {
-        guard hasGradeColumns else { return gradePointsFromCollectionJSON(collectionJSON) }
         if let total = totalPoints, total > 0, let earned = earnedPoints { return earned }
         return passCount.map(Double.init)
     }
 
     /// Total possible weighted points; nil when the result predates weighted grading.
     var gradeTotalPointsValue: Double? {
-        guard hasGradeColumns else { return gradeTotalPointsFromCollectionJSON(collectionJSON) }
         if let total = totalPoints, total > 0 { return total }
         return nil
     }

--- a/Sources/APIServer/Models/APIResultCollection.swift
+++ b/Sources/APIServer/Models/APIResultCollection.swift
@@ -1,0 +1,81 @@
+// APIServer/Models/APIResultCollection.swift
+//
+// Side table carrying the serialized TestOutcomeCollection blob for each
+// result row (#1173). The blob is by far the widest thing that ever lived on
+// `results` (up to the 6 MB collection budget per row), and most queries —
+// grade folds, list pages, sweeps, the preferred-result maps — never want
+// it. Moving it here makes every full-row `APIResult` load blob-free by
+// construction; the handful of readers that genuinely need the collection
+// fetch it explicitly via `loadCollectionJSON(on:)` / `collectionJSONByResultID`.
+
+import Fluent
+import Vapor
+
+final class APIResultCollection: Model, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context,
+    // never across unstructured concurrency.
+    static let schema = "result_collections"
+
+    /// Same value as the owning `results.id` — one blob per result.
+    @ID(custom: "result_id", generatedBy: .user)
+    var id: String?
+
+    @Field(key: "collection_json")
+    var collectionJSON: String  // serialised TestOutcomeCollection
+
+    init() {}
+
+    init(resultID: String, collectionJSON: String) {
+        self.id = resultID
+        self.collectionJSON = collectionJSON
+    }
+}
+
+extension APIResult {
+    /// The ONE write path for a new result: stamps the denormalized grade
+    /// columns from the collection, then persists the result row and its
+    /// blob side-table row together in a transaction (composes with an
+    /// enclosing transaction — the Fluent drivers no-op a nested `BEGIN`).
+    func saveWithCollection(json: String, on db: Database) async throws {
+        stampGradeFields(from: json)
+        try await db.transaction { tx in
+            try await self.save(on: tx)
+            try await APIResultCollection(resultID: try self.requireID(), collectionJSON: json)
+                .save(on: tx)
+        }
+    }
+
+    /// This result's collection blob, or nil when the side-table row is
+    /// missing (should not happen for rows written after #1173 — the write
+    /// path is transactional and deletes cascade from `results`).
+    func loadCollectionJSON(on db: Database) async throws -> String? {
+        guard let id else { return nil }
+        return try await APIResultCollection.find(id, on: db)?.collectionJSON
+    }
+}
+
+/// Batch blob fetch, keyed by result ID. Chunked to stay under
+/// bind-parameter limits, like the loaders in BestGradePercentBySubmissionID.
+func collectionJSONByResultID(
+    for resultIDs: some Collection<String>,
+    on db: Database
+) async throws -> [String: String] {
+    guard !resultIDs.isEmpty else { return [:] }
+    let chunkSize = 5_000
+    let ids = Array(resultIDs)
+    var byID: [String: String] = [:]
+    var index = ids.startIndex
+    while index < ids.endIndex {
+        let end =
+            ids.index(index, offsetBy: chunkSize, limitedBy: ids.endIndex)
+            ?? ids.endIndex
+        let page = try await APIResultCollection.query(on: db)
+            .filter(\.$id ~~ Array(ids[index..<end]))
+            .all()
+        for row in page {
+            if let id = row.id { byID[id] = row.collectionJSON }
+        }
+        index = end
+    }
+    return byID
+}

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -127,14 +127,14 @@ struct BrowserResultRoutes: RouteCollection {
         let browserResult = APIResult(
             id: "res_\(UUID().uuidString.lowercased().prefix(8))",
             submissionID: subID,
-            collectionJSON: collectionJSON,
             source: "browser"
         )
         // Same transient-SQLite-lock guard as the submission insert above: this
         // second write can also lose a race with a concurrent commit (session
         // write / background monitor) and surface as a 500 otherwise.
+        // saveWithCollection is itself transactional (row + blob together).
         try await withTransientDatabaseLockRetry(on: req.db) {
-            try await browserResult.save(on: req.db)
+            try await browserResult.saveWithCollection(json: collectionJSON, on: req.db)
         }
 
         req.logger.info("Browser result stored for \(subID)")

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -141,8 +141,7 @@ struct ResultRoutes: RouteCollection {
 
         let result = APIResult(
             id: "res_\(UUID().uuidString.lowercased().prefix(8))",
-            submissionID: collection.submissionID,
-            collectionJSON: json
+            submissionID: collection.submissionID
         )
 
         // Mark for BrightSpace sync if the assignment is configured for it. Gate
@@ -164,7 +163,9 @@ struct ResultRoutes: RouteCollection {
             }
         }
 
-        try await result.save(on: db)
+        // Row + blob side-table row persist together; the caller's
+        // transaction (persist + submission status flip) encloses both.
+        try await result.saveWithCollection(json: json, on: db)
     }
 }
 

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -142,11 +142,14 @@ struct SubmissionQueryRoutes: RouteCollection {
             return Response(status: .notModified, headers: ["ETag": etag])
         }
 
+        // The blob lives in the result_collections side table (#1173) and is
+        // fetched only past the ETag short-circuit — a 304 never touches it.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard
-            let data = result.collectionJSON.data(using: .utf8),
-            let fullCollection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+            let collectionJSON = try await result.loadCollectionJSON(on: req.db),
+            let fullCollection = try? decoder.decode(
+                TestOutcomeCollection.self, from: Data(collectionJSON.utf8))
         else {
             throw AppError.internalFailure(reason: "Stored result is corrupt")
         }

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
@@ -492,10 +492,9 @@ private func importBundledResults(
         let result = APIResult(
             id: newResultID,
             submissionID: subID,
-            collectionJSON: bundledResult.collectionJSON,
             source: bundledResult.source
         )
-        try await result.save(on: db)
+        try await result.saveWithCollection(json: bundledResult.collectionJSON, on: db)
         tally.resultsImported += 1
     }
 }

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -165,6 +165,10 @@ struct CourseBundleRoutes: RouteCollection {
                 .filter(\.$submissionID ~~ subIDs)
                 .all()
         }
+        // The bundle carries the full collection blob per result (#1173:
+        // it lives in the result_collections side table, not on the row).
+        let resultCollectionJSONByID = try await collectionJSONByResultID(
+            for: results.compactMap(\.id), on: db)
 
         return ExportData(
             testSetups: testSetups,
@@ -173,7 +177,8 @@ struct CourseBundleRoutes: RouteCollection {
             enrolledUserIDs: enrolledUserIDs,
             allUsers: Array(allUsers),
             submissions: submissions,
-            results: results
+            results: results,
+            resultCollectionJSONByID: resultCollectionJSONByID
         )
     }
 
@@ -291,10 +296,13 @@ struct CourseBundleRoutes: RouteCollection {
         }
 
         let bundledResults = data.results.compactMap { r -> BundledResult? in
-            guard let subBid = bundleIDs.subBundleIDByID[r.submissionID] else { return nil }
+            guard let subBid = bundleIDs.subBundleIDByID[r.submissionID],
+                let rid = r.id,
+                let collectionJSON = data.resultCollectionJSONByID[rid]
+            else { return nil }
             return BundledResult(
                 submissionBundleID: subBid,
-                collectionJSON: r.collectionJSON,
+                collectionJSON: collectionJSON,
                 source: r.source ?? "worker",
                 receivedAt: r.receivedAt
             )
@@ -393,6 +401,8 @@ private struct ExportData {
     let allUsers: [APIUser]
     let submissions: [APISubmission]
     let results: [APIResult]
+    /// Collection blob per result id, batch-fetched from the side table.
+    let resultCollectionJSONByID: [String: String]
 }
 
 /// Maps from live DB ids to in-bundle synthetic identifiers used for cross-references.

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -478,12 +478,13 @@ func waitForRunnerValidation(
                     .filter(\.$submissionID == submissionID)
                     .sort(\.$receivedAt, .descending)
                     .first(),
-                let data = result.collectionJSON.data(using: .utf8)
+                let collectionJSON = try await result.loadCollectionJSON(on: req.db)
             else {
                 return .failed(summary: "no result payload")
             }
 
-            let collection = try decoder.decode(TestOutcomeCollection.self, from: data)
+            let collection = try decoder.decode(
+                TestOutcomeCollection.self, from: Data(collectionJSON.utf8))
             let summary = "\(collection.passCount)/\(collection.totalTests) passed"
             let passed =
                 collection.buildStatus == .passed && collection.failCount == 0 && collection.errorCount == 0

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -97,6 +97,14 @@ extension StudentCourseRoutes {
             for: submissions.compactMap(\.id),
             on: req.db
         )
+        // Badges need the collection (executionTimeMs) for each assignment's
+        // LATEST submission only — batch-fetch just those blobs from the
+        // result_collections side table (#1173).
+        let latestResultIDs = submissionsBySetupID.values.compactMap { history in
+            history.first?.id.flatMap { preferredResultBySubmissionID[$0]?.id }
+        }
+        let latestBlobs = try await collectionJSONByResultID(for: latestResultIDs, on: req.db)
+        let collectionByResultID = latestBlobs.compactMapValues(decodedCollection(from:))
 
         let fmt = waterlooDateTimeFormatter()
         let sortedAssignments = sortedByAssignmentDisplayOrder(assignments, setupsByID: setupsByID)
@@ -105,6 +113,7 @@ extension StudentCourseRoutes {
             courseCode: course.code,
             urlToken: try student.requireURLToken(),
             preferredResultBySubmissionID: preferredResultBySubmissionID,
+            collectionByResultID: collectionByResultID,
             bestPercentBySubmissionID: bestPercentBySubmissionID,
             student: student,
             fmt: fmt,
@@ -698,6 +707,10 @@ extension StudentCourseRoutes {
         let courseCode: String
         let urlToken: String
         let preferredResultBySubmissionID: [String: APIResult]
+        /// Decoded collection per latest-submission preferred result id —
+        /// pre-fetched from the result_collections side table (#1173) for
+        /// the badge path.
+        let collectionByResultID: [String: TestOutcomeCollection]
         /// "Highest grade wins" percent per submission (#1111) — feeds the
         /// grade cells; `preferredResultBySubmissionID` feeds the badges.
         let bestPercentBySubmissionID: [String: Int]
@@ -736,6 +749,7 @@ extension StudentCourseRoutes {
         var badges = submissionBadges(
             history: history,
             preferredResultBySubmissionID: preferredResultBySubmissionID,
+            collectionByResultID: context.collectionByResultID,
             achievements: context.perSubBySetup[assignment.testSetupID]
         ).filter { !disabledHere.contains($0.id) }
         badges.append(contentsOf: classBadges)
@@ -811,12 +825,14 @@ extension StudentCourseRoutes {
     fileprivate func submissionBadges(
         history: [APISubmission],
         preferredResultBySubmissionID: [String: APIResult],
+        collectionByResultID: [String: TestOutcomeCollection],
         achievements: [Achievement]?
     ) -> [AchievementBadge] {
         guard let latestSubmission = history.first,
             let latestSubID = latestSubmission.id,
             let result = preferredResultBySubmissionID[latestSubID],
-            let collection = decodedCollection(from: result.collectionJSON),
+            let resultID = result.id,
+            let collection = collectionByResultID[resultID],
             let gradePct = gradePercent(from: collection)
         else {
             return []

--- a/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
+++ b/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
@@ -102,25 +102,25 @@ extension WebRoutes {
     // MARK: - Result presentation
 
     // Internal (was private): called from `submissionPage` in WebRoutes+Submission.swift.
-    /// Decodes the chosen result's `TestOutcomeCollection`, computes the
-    /// all-tier grade (so the number matches the dashboard and is stable across
-    /// the deadline), and renders each *itemized* outcome into an `OutcomeRow`.
-    /// Students see public + release rows; release output is redacted until the
-    /// deadline.  Secret never appears as a row — for non-instructors it is
-    /// surfaced as an aggregate pass/fail `TierSummary` instead.
+    /// Renders the chosen result's already-decoded `TestOutcomeCollection`
+    /// (the caller fetches the blob from the result_collections side table,
+    /// #1173): computes the all-tier grade (so the number matches the
+    /// dashboard and is stable across the deadline), and renders each
+    /// *itemized* outcome into an `OutcomeRow`. Students see public + release
+    /// rows; release output is redacted until the deadline. Secret never
+    /// appears as a row — for non-instructors it is surfaced as an aggregate
+    /// pass/fail `TierSummary` instead.
     func processDisplayResult(
         result: APIResult,
+        collection maybeCollection: TestOutcomeCollection?,
         viewer: SubmissionViewer,
         submission: APISubmission,
         priorAttempt: PriorAttemptDelta,
-        manifestDisplay: ManifestDisplayData,
-        decoder: JSONDecoder
+        manifestDisplay: ManifestDisplayData
     ) -> ProcessedCollection {
         var processed = ProcessedCollection.empty
         processed.resultSource = result.source ?? "worker"
-        guard let data = result.collectionJSON.data(using: .utf8),
-            let collection = try? decoder.decode(TestOutcomeCollection.self, from: data)
-        else {
+        guard let collection = maybeCollection else {
             return processed
         }
 

--- a/Sources/APIServer/Routes/Web/WebRoutes+IndexRows.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+IndexRows.swift
@@ -138,12 +138,22 @@ extension WebRoutes {
             }
         }
 
+        // Badge evaluation needs the collection (executionTimeMs) for each
+        // LATEST submission's preferred result only — batch-fetch just those
+        // blobs from the side table (#1173), one per dashboard row at most.
+        let latestResultIDs = data.latestSubmissionBySetupID.values.compactMap {
+            preferredResultBySubmissionID[$0.submissionID]?.id
+        }
+        let latestBlobs = try await collectionJSONByResultID(for: latestResultIDs, on: req.db)
+        let collectionByResultID = latestBlobs.compactMapValues(decodedCollection(from:))
+
         let disabledBySetup = try await disabledFetch
         let perSubBySetup = try await perSubFetch
         for (setupID, latest) in data.latestSubmissionBySetupID {
             if let badges = latestSubmissionBadges(
                 setupID: setupID, latest: latest, grouped: grouped,
                 preferredResultBySubmissionID: preferredResultBySubmissionID,
+                collectionByResultID: collectionByResultID,
                 perSubmission: perSubBySetup[setupID],
                 disabled: disabledBySetup[setupID] ?? [])
             {
@@ -190,13 +200,15 @@ extension WebRoutes {
         latest: LatestSubmissionItem,
         grouped: [String: [APISubmission]],
         preferredResultBySubmissionID: [String: APIResult],
+        collectionByResultID: [String: TestOutcomeCollection],
         perSubmission: [Achievement]?,
         disabled: Set<String>
     ) -> [AchievementBadge]? {
         guard
             let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
             let result = preferredResultBySubmissionID[latest.submissionID],
-            let collection = decodedCollection(from: result.collectionJSON),
+            let resultID = result.id,
+            let collection = collectionByResultID[resultID],
             let gradePercent = gradePercent(from: collection)
         else { return nil }
         let latestAttempt = latestSubmission.attemptNumber ?? 1

--- a/Sources/APIServer/Routes/Web/WebRoutes+IndexRows.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+IndexRows.swift
@@ -145,15 +145,17 @@ extension WebRoutes {
             preferredResultBySubmissionID[$0.submissionID]?.id
         }
         let latestBlobs = try await collectionJSONByResultID(for: latestResultIDs, on: req.db)
-        let collectionByResultID = latestBlobs.compactMapValues(decodedCollection(from:))
+        let badgeResults = BadgeResultData(
+            preferredResultBySubmissionID: preferredResultBySubmissionID,
+            collectionByResultID: latestBlobs.compactMapValues(decodedCollection(from:))
+        )
 
         let disabledBySetup = try await disabledFetch
         let perSubBySetup = try await perSubFetch
         for (setupID, latest) in data.latestSubmissionBySetupID {
             if let badges = latestSubmissionBadges(
                 setupID: setupID, latest: latest, grouped: grouped,
-                preferredResultBySubmissionID: preferredResultBySubmissionID,
-                collectionByResultID: collectionByResultID,
+                badgeResults: badgeResults,
                 perSubmission: perSubBySetup[setupID],
                 disabled: disabledBySetup[setupID] ?? [])
             {
@@ -193,29 +195,36 @@ extension WebRoutes {
         return preferred
     }
 
+    /// The result-derived badge inputs that don't vary per setup: the
+    /// preferred result per submission, and the decoded collection per
+    /// latest-submission preferred result (side table, #1173).
+    private struct BadgeResultData {
+        let preferredResultBySubmissionID: [String: APIResult]
+        let collectionByResultID: [String: TestOutcomeCollection]
+    }
+
     /// The per-submission badges for one setup's latest submission, or nil
     /// when it has no decodable graded result.
     private static func latestSubmissionBadges(
         setupID: String,
         latest: LatestSubmissionItem,
         grouped: [String: [APISubmission]],
-        preferredResultBySubmissionID: [String: APIResult],
-        collectionByResultID: [String: TestOutcomeCollection],
+        badgeResults: BadgeResultData,
         perSubmission: [Achievement]?,
         disabled: Set<String>
     ) -> [AchievementBadge]? {
         guard
             let latestSubmission = grouped[setupID]?.first(where: { $0.id == latest.submissionID }),
-            let result = preferredResultBySubmissionID[latest.submissionID],
+            let result = badgeResults.preferredResultBySubmissionID[latest.submissionID],
             let resultID = result.id,
-            let collection = collectionByResultID[resultID],
+            let collection = badgeResults.collectionByResultID[resultID],
             let gradePercent = gradePercent(from: collection)
         else { return nil }
         let latestAttempt = latestSubmission.attemptNumber ?? 1
         let priorSub = grouped[setupID]?.first(where: { $0.attemptNumber == latestAttempt - 1 })
         let priorGradePercent: Int? = priorSub.flatMap { ps in
             guard let psID = ps.id,
-                let pr = preferredResultBySubmissionID[psID]
+                let pr = badgeResults.preferredResultBySubmissionID[psID]
             else { return nil }
             return pr.gradePercentValue
         }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -298,6 +298,15 @@ extension WebRoutes {
         decoder.dateDecodingStrategy = .iso8601
 
         let displayResult = try await loadPreferredDisplayResult(subID: subID, on: req.db)
+        // Fetch + decode the display result's blob ONCE (side table, #1173);
+        // the presenter and the individual-badge evaluation below share it.
+        var displayCollection: TestOutcomeCollection?
+        if let result = displayResult,
+            let json = try await result.loadCollectionJSON(on: req.db)
+        {
+            displayCollection = try? decoder.decode(
+                TestOutcomeCollection.self, from: Data(json.utf8))
+        }
         let priorAttempt = try await loadPriorAttemptDelta(
             submission: submission, decoder: decoder, on: req.db)
         let manifestDisplay = manifestDisplayData(from: setupProps)
@@ -306,13 +315,13 @@ extension WebRoutes {
         if let result = displayResult {
             processed = processDisplayResult(
                 result: result,
+                collection: displayCollection,
                 viewer: SubmissionViewer(
                     user: user, isStaff: isStaff, itemizedTiers: itemized,
                     releaseOutputVisible: releaseOutput),
                 submission: submission,
                 priorAttempt: priorAttempt,
-                manifestDisplay: manifestDisplay,
-                decoder: decoder
+                manifestDisplay: manifestDisplay
             )
         }
 
@@ -340,8 +349,8 @@ extension WebRoutes {
         // from this submission's result (evaluated over all tiers so a
         // secret-test badge works without revealing the test).
         let individualBadges = earnedIndividualBadgesForDisplay(
-            displayResult: displayResult, props: setupProps,
-            gradePercent: processed.gradePercent, decoder: decoder)
+            collection: displayCollection, props: setupProps,
+            gradePercent: processed.gradePercent)
         let badges =
             builtInBadgesForSubmission(
                 badgeContext: processed.badgeContext,
@@ -435,8 +444,9 @@ extension WebRoutes {
             .all()
         let priorResult = priorResults.first { ($0.source ?? "worker") == "worker" } ?? priorResults.first
         guard let priorResult,
-            let data = priorResult.collectionJSON.data(using: .utf8),
-            let priorCollection = try? decoder.decode(TestOutcomeCollection.self, from: data)
+            let priorJSON = try await priorResult.loadCollectionJSON(on: db),
+            let priorCollection = try? decoder.decode(
+                TestOutcomeCollection.self, from: Data(priorJSON.utf8))
         else {
             return .empty
         }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -297,16 +297,8 @@ extension WebRoutes {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
 
-        let displayResult = try await loadPreferredDisplayResult(subID: subID, on: req.db)
-        // Fetch + decode the display result's blob ONCE (side table, #1173);
-        // the presenter and the individual-badge evaluation below share it.
-        var displayCollection: TestOutcomeCollection?
-        if let result = displayResult,
-            let json = try await result.loadCollectionJSON(on: req.db)
-        {
-            displayCollection = try? decoder.decode(
-                TestOutcomeCollection.self, from: Data(json.utf8))
-        }
+        let (displayResult, displayCollection) = try await loadDisplayResultAndCollection(
+            subID: subID, decoder: decoder, on: req.db)
         let priorAttempt = try await loadPriorAttemptDelta(
             submission: submission, decoder: decoder, on: req.db)
         let manifestDisplay = manifestDisplayData(from: setupProps)
@@ -416,6 +408,22 @@ extension WebRoutes {
         let workerResult = allResults.first { ($0.source ?? "worker") == "worker" }
         let browserResult = allResults.first { $0.source == "browser" }
         return workerResult ?? browserResult
+    }
+
+    /// The preferred display result plus its collection, fetched from the
+    /// result_collections side table and decoded ONCE (#1173) — the presenter
+    /// and the individual-badge evaluation share the decoded value.
+    private func loadDisplayResultAndCollection(
+        subID: String, decoder: JSONDecoder, on db: Database
+    ) async throws -> (APIResult?, TestOutcomeCollection?) {
+        guard let result = try await loadPreferredDisplayResult(subID: subID, on: db) else {
+            return (nil, nil)
+        }
+        guard let json = try await result.loadCollectionJSON(on: db) else {
+            return (result, nil)
+        }
+        let collection = try? decoder.decode(TestOutcomeCollection.self, from: Data(json.utf8))
+        return (result, collection)
     }
 
     /// Fetches the immediately-prior attempt for per-test delta display and the

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -425,4 +425,10 @@ func registerMigrations(on app: Application) {
     // Leader leases so each periodic sweep runs on exactly one process
     // (#1155). New table, no ordering constraints.
     app.migrations.add(CreateSweepLeases())
+
+    // Relocates results.collection_json to the result_collections side table
+    // (#1173) so hot result-row queries never carry the blob. MUST run after
+    // AddResultGradeColumns — its backfill reads the column this migration
+    // drops.
+    app.migrations.add(CreateResultCollections())
 }

--- a/Tests/APITests/AchievementBonusTests.swift
+++ b/Tests/APITests/AchievementBonusTests.swift
@@ -57,9 +57,9 @@ import VaporTesting
                 userID: try student.requireID(), on: app)
             // Earned 18/20; the class reached the goal (progress 1.0) → +5 bonus.
             try await APIResult(
-                id: "csv_bonus_res", submissionID: "csv_bonus_sub",
-                collectionJSON: #"{"earnedPoints":18,"totalPoints":20,"passCount":18,"totalTests":20}"#
-            ).save(on: app.db)
+                id: "csv_bonus_res", submissionID: "csv_bonus_sub"
+            ).saveWithCollection(
+                json: #"{"earnedPoints":18,"totalPoints":20,"passCount":18,"totalTests":20}"#, on: app.db)
             try await APIAchievementResult(
                 testSetupID: "csv_bonus_setup", achievementID: "g_csv",
                 studentsMeeting: 8, denominator: 10, progress: 1.0, locked: false,

--- a/Tests/APITests/AchievementEvaluationTests.swift
+++ b/Tests/APITests/AchievementEvaluationTests.swift
@@ -65,15 +65,13 @@ import VaporTesting
             _ = try await arInsertSubmission(
                 id: "ag_sub_a", testSetupID: "ag_setup", userID: try a.requireID(), on: app)
             try await APIResult(
-                id: "ag_res_a", submissionID: "ag_sub_a",
-                collectionJSON: #"{"earnedPoints":4,"totalPoints":4}"#
-            ).save(on: app.db)
+                id: "ag_res_a", submissionID: "ag_sub_a"
+            ).saveWithCollection(json: #"{"earnedPoints":4,"totalPoints":4}"#, on: app.db)
             _ = try await arInsertSubmission(
                 id: "ag_sub_b", testSetupID: "ag_setup", userID: try b.requireID(), on: app)
             try await APIResult(
-                id: "ag_res_b", submissionID: "ag_sub_b",
-                collectionJSON: #"{"earnedPoints":2,"totalPoints":4}"#
-            ).save(on: app.db)
+                id: "ag_res_b", submissionID: "ag_sub_b"
+            ).saveWithCollection(json: #"{"earnedPoints":2,"totalPoints":4}"#, on: app.db)
 
             let written = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
             #expect(written >= 1)
@@ -106,9 +104,8 @@ import VaporTesting
             _ = try await arInsertSubmission(
                 id: "frz_sub_a", testSetupID: "frz_setup", userID: try a.requireID(), on: app)
             try await APIResult(
-                id: "frz_res_a", submissionID: "frz_sub_a",
-                collectionJSON: #"{"earnedPoints":4,"totalPoints":4}"#
-            ).save(on: app.db)
+                id: "frz_res_a", submissionID: "frz_sub_a"
+            ).saveWithCollection(json: #"{"earnedPoints":4,"totalPoints":4}"#, on: app.db)
 
             _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
             let row = try #require(
@@ -124,9 +121,8 @@ import VaporTesting
             _ = try await arInsertSubmission(
                 id: "frz_sub_b", testSetupID: "frz_setup", userID: try b.requireID(), on: app)
             try await APIResult(
-                id: "frz_res_b", submissionID: "frz_sub_b",
-                collectionJSON: #"{"earnedPoints":4,"totalPoints":4}"#
-            ).save(on: app.db)
+                id: "frz_res_b", submissionID: "frz_sub_b"
+            ).saveWithCollection(json: #"{"earnedPoints":4,"totalPoints":4}"#, on: app.db)
 
             _ = try await evaluateClassGoalAchievements(on: app.db, logger: app.logger)
             let after = try #require(

--- a/Tests/APITests/AssignmentSubmissionsSparklineTests.swift
+++ b/Tests/APITests/AssignmentSubmissionsSparklineTests.swift
@@ -32,10 +32,11 @@ struct AssignmentSubmissionsSparklineTests {
             // 3/4 → 75% → lands in the 70–79% grade bin.
             let result = APIResult(
                 id: "res_spark",
-                submissionID: "sub_spark",
-                collectionJSON: #"{"earnedPoints":3,"totalPoints":4,"passCount":3,"totalTests":4}"#
+                submissionID: "sub_spark"
             )
-            try await result.save(on: app.db)
+            try await result.saveWithCollection(
+                json: #"{"earnedPoints":3,"totalPoints":4,"passCount":3,"totalTests":4}"#,
+                on: app.db)
 
             try await app.asyncTest(
                 .GET, "/instructor/\(assignment.publicID)/submissions",

--- a/Tests/APITests/BestGradePolicyTests.swift
+++ b/Tests/APITests/BestGradePolicyTests.swift
@@ -20,10 +20,9 @@ import VaporTesting
     private func result(
         id: String, submissionID: String = "sub", source: String, pass: Int, total: Int
     ) -> APIResult {
-        APIResult(
-            id: id, submissionID: submissionID,
-            collectionJSON: #"{"passCount": \#(pass), "totalTests": \#(total)}"#,
-            source: source)
+        let result = APIResult(id: id, submissionID: submissionID, source: source)
+        result.stampGradeFields(from: #"{"passCount": \#(pass), "totalTests": \#(total)}"#)
+        return result
     }
 
     @Test func bestGradePercentTakesMaxAcrossSources() {
@@ -36,7 +35,7 @@ import VaporTesting
     }
 
     @Test func bestGradePercentNilWhenNoParseableGrade() {
-        let noGrade = APIResult(id: "r0", submissionID: "sub", collectionJSON: "{}", source: "worker")
+        let noGrade = APIResult(id: "r0", submissionID: "sub", source: "worker")
         #expect(bestGradePercent(of: [noGrade]) == nil)
         #expect(bestGradePercent(of: [APIResult]()) == nil)
     }
@@ -48,7 +47,7 @@ import VaporTesting
             result(id: "r3", source: "worker", pass: 4, total: 5),
         ]
         #expect(bestGradeResult(of: rows)?.id == "r2")
-        let noGrade = APIResult(id: "r0", submissionID: "sub", collectionJSON: "{}", source: "worker")
+        let noGrade = APIResult(id: "r0", submissionID: "sub", source: "worker")
         #expect(bestGradeResult(of: [noGrade]) == nil)
     }
 }
@@ -80,14 +79,12 @@ import VaporTesting
 
             try await APIResult(
                 id: "res_ddg_browser", submissionID: "sub_ddg",
-                collectionJSON: #"{"passCount": 5, "totalTests": 5}"#,
                 source: "browser"
-            ).save(on: app.db)
+            ).saveWithCollection(json: #"{"passCount": 5, "totalTests": 5}"#, on: app.db)
             try await APIResult(
                 id: "res_ddg_worker", submissionID: "sub_ddg",
-                collectionJSON: #"{"passCount": 4, "totalTests": 5}"#,
                 source: "worker"
-            ).save(on: app.db)
+            ).saveWithCollection(json: #"{"passCount": 4, "totalTests": 5}"#, on: app.db)
 
             try await app.asyncTest(
                 .GET, "/instructor/\(assignment.publicID)/students/\(studentID.uuidString)/history",

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -365,11 +365,10 @@ import VaporTesting
 
             // A previously-synced result (not pending, has a synced timestamp).
             let result = APIResult(
-                id: "res_bs_push", submissionID: "sub_bs_push",
-                collectionJSON: "{}", source: "worker")
+                id: "res_bs_push", submissionID: "sub_bs_push", source: "worker")
             result.brightspaceSyncPending = false
             result.brightspaceSyncedAt = Date()
-            try await result.save(on: app.db)
+            try await result.saveWithCollection(json: "{}", on: app.db)
 
             try await app.asyncTest(
                 .POST, "/instructor/\(assignment.publicID)/brightspace/push-all",
@@ -409,10 +408,10 @@ import VaporTesting
                 userID: try studentA.requireID(), on: app)
             for id in ["res_a1", "res_a2"] {
                 let synced = APIResult(
-                    id: id, submissionID: "sub_bs_a", collectionJSON: "{}", source: "worker")
+                    id: id, submissionID: "sub_bs_a", source: "worker")
                 synced.brightspaceSyncPending = false
                 synced.brightspaceSyncedAt = Date()
-                try await synced.save(on: app.db)
+                try await synced.saveWithCollection(json: "{}", on: app.db)
             }
 
             // Student B's only result errored → one failed student.
@@ -421,10 +420,10 @@ import VaporTesting
                 id: "sub_bs_b", testSetupID: "setup_bs_counts",
                 userID: try studentB.requireID(), on: app)
             let errored = APIResult(
-                id: "res_b1", submissionID: "sub_bs_b", collectionJSON: "{}", source: "worker")
+                id: "res_b1", submissionID: "sub_bs_b", source: "worker")
             errored.brightspaceSyncPending = false
             errored.brightspaceSyncError = "D2L rejected it"
-            try await errored.save(on: app.db)
+            try await errored.saveWithCollection(json: "{}", on: app.db)
 
             let cookie = try await arLoginAsInstructor(on: app)
             try await app.asyncTest(

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -579,8 +579,14 @@ import VaporTesting
                 .filter(\.$submissionID == submissionID)
                 .first()
             #expect(result != nil, "a result record should be stored for the submission")
+            let storedJSON: String?
+            if let result {
+                storedJSON = try await result.loadCollectionJSON(on: app.db)
+            } else {
+                storedJSON = nil
+            }
             #expect(
-                result?.collectionJSON.contains("prerequisite") == true,
+                storedJSON?.contains("prerequisite") == true,
                 "stored result JSON should contain the dependency-skip message")
 
         }

--- a/Tests/APITests/Fixtures.swift
+++ b/Tests/APITests/Fixtures.swift
@@ -191,9 +191,10 @@ func makeTestResult(
     let result = APIResult(
         id: "res_\(UUID().uuidString.lowercased().prefix(8))",
         submissionID: submissionID,
-        collectionJSON: collectionJSON ?? #"{"submissionID":"\#(submissionID)","outcomes":[]}"#,
         source: source
     )
-    try await result.save(on: app.db)
+    try await result.saveWithCollection(
+        json: collectionJSON ?? #"{"submissionID":"\#(submissionID)","outcomes":[]}"#,
+        on: app.db)
     return result
 }

--- a/Tests/APITests/GradeOverridesTests.swift
+++ b/Tests/APITests/GradeOverridesTests.swift
@@ -177,11 +177,12 @@ import VaporTesting
             )
             let result = APIResult(
                 id: "res_ovr_sync",
-                submissionID: "sub_ovr_sync",
-                collectionJSON: #"{"earnedPoints":1,"totalPoints":4,"passCount":1,"totalTests":4}"#
+                submissionID: "sub_ovr_sync"
             )
             result.brightspaceSyncPending = false
-            try await result.save(on: app.db)
+            try await result.saveWithCollection(
+                json: #"{"earnedPoints":1,"totalPoints":4,"passCount":1,"totalTests":4}"#,
+                on: app.db)
 
             try await app.asyncTest(
                 .POST,
@@ -256,10 +257,11 @@ import VaporTesting
             // Runner grade 25% (1/4) — should be replaced by the 90% override.
             let result = APIResult(
                 id: "res_ovr_roster",
-                submissionID: "sub_ovr_roster",
-                collectionJSON: #"{"earnedPoints":1,"totalPoints":4,"passCount":1,"totalTests":4}"#
+                submissionID: "sub_ovr_roster"
             )
-            try await result.save(on: app.db)
+            try await result.saveWithCollection(
+                json: #"{"earnedPoints":1,"totalPoints":4,"passCount":1,"totalTests":4}"#,
+                on: app.db)
             try await APIGradeOverride(
                 testSetupID: "ovr_roster_setup",
                 userID: try student.requireID(),
@@ -318,16 +320,16 @@ import VaporTesting
             try await APIResult(
                 id: "res_multi_src_browser",
                 submissionID: "sub_multi_src",
-                collectionJSON: #"{"earnedPoints":10,"totalPoints":10,"passCount":10,"totalTests":10}"#,
                 source: "browser"
-            ).save(on: app.db)
+            ).saveWithCollection(
+                json: #"{"earnedPoints":10,"totalPoints":10,"passCount":10,"totalTests":10}"#, on: app.db)
             // Worker result: 9/10 (one secret test fails) → 90 %.
             try await APIResult(
                 id: "res_multi_src_worker",
                 submissionID: "sub_multi_src",
-                collectionJSON: #"{"earnedPoints":9,"totalPoints":10,"passCount":9,"totalTests":10}"#,
                 source: "worker"
-            ).save(on: app.db)
+            ).saveWithCollection(
+                json: #"{"earnedPoints":9,"totalPoints":10,"passCount":9,"totalTests":10}"#, on: app.db)
 
             try await app.asyncTest(
                 .GET, "/instructor/grades.csv",
@@ -419,10 +421,11 @@ import VaporTesting
             )
             let result = APIResult(
                 id: "res_ovr_csv",
-                submissionID: "sub_ovr_csv",
-                collectionJSON: #"{"earnedPoints":4,"totalPoints":4,"passCount":4,"totalTests":4}"#
+                submissionID: "sub_ovr_csv"
             )
-            try await result.save(on: app.db)
+            try await result.saveWithCollection(
+                json: #"{"earnedPoints":4,"totalPoints":4,"passCount":4,"totalTests":4}"#,
+                on: app.db)
             try await APIGradeOverride(
                 testSetupID: "ovr_csv_setup",
                 userID: try student.requireID(),

--- a/Tests/APITests/GradeSummaryLoaderTests.swift
+++ b/Tests/APITests/GradeSummaryLoaderTests.swift
@@ -58,13 +58,11 @@ import VaporTesting
             try await seedSubmission(id: "sub_gs1")
             // Two results: browser 100 %, then a lower worker regrade.
             try await APIResult(
-                id: "res_gs1a", submissionID: "sub_gs1",
-                collectionJSON: collectionJSON(pass: 4, total: 4), source: "browser"
-            ).save(on: app.db)
+                id: "res_gs1a", submissionID: "sub_gs1", source: "browser"
+            ).saveWithCollection(json: collectionJSON(pass: 4, total: 4), on: app.db)
             try await APIResult(
-                id: "res_gs1b", submissionID: "sub_gs1",
-                collectionJSON: collectionJSON(pass: 3, total: 4), source: "worker"
-            ).save(on: app.db)
+                id: "res_gs1b", submissionID: "sub_gs1", source: "worker"
+            ).saveWithCollection(json: collectionJSON(pass: 3, total: 4), on: app.db)
 
             let viaSummaries = try await bestGradePercentBySubmissionID(
                 for: ["sub_gs1"], on: app.db)
@@ -81,15 +79,15 @@ import VaporTesting
     @Test func legacyColumnlessRowFallsBackToBlob() async throws {
         try await withApp(app) { _ in
             try await seedSubmission(id: "sub_gs2")
+            // Simulate the legacy shape: columns never populated, blob in
+            // the side table (exactly what the #1173 backfill produces for a
+            // pre-grade-columns row the AddResultGradeColumns backfill missed).
             let result = APIResult(
-                id: "res_gs2", submissionID: "sub_gs2",
-                collectionJSON: collectionJSON(pass: 1, total: 2), source: "worker")
-            // Simulate the legacy shape: columns never populated.
-            result.earnedPoints = nil
-            result.totalPoints = nil
-            result.passCount = nil
-            result.totalTests = nil
+                id: "res_gs2", submissionID: "sub_gs2", source: "worker")
             try await result.save(on: app.db)
+            try await APIResultCollection(
+                resultID: "res_gs2", collectionJSON: collectionJSON(pass: 1, total: 2)
+            ).save(on: app.db)
 
             let viaSummaries = try await bestGradePercentBySubmissionID(
                 for: ["sub_gs2"], on: app.db)
@@ -108,9 +106,8 @@ import VaporTesting
                 "runnerVersion":"shell-runner/1.0","timestamp":"2026-01-01T00:00:00Z"}
                 """
             try await APIResult(
-                id: "res_gs3", submissionID: "sub_gs3",
-                collectionJSON: json, source: "worker"
-            ).save(on: app.db)
+                id: "res_gs3", submissionID: "sub_gs3", source: "worker"
+            ).saveWithCollection(json: json, on: app.db)
 
             let summaries = try await gradeSummariesBySubmissionID(for: ["sub_gs3"], on: app.db)
             let best = try #require(bestGradeResult(of: Array(summaries.values.joined())))

--- a/Tests/APITests/ResultCollectionSideTableTests.swift
+++ b/Tests/APITests/ResultCollectionSideTableTests.swift
@@ -1,0 +1,167 @@
+// Tests/APITests/ResultCollectionSideTableTests.swift
+//
+// #1173: results.collection_json moves to the result_collections side table.
+// Pins the three load-bearing pieces: the migration's chunked backfill (every
+// pre-existing blob copied, column dropped, multiple chunk passes proven on a
+// multi-thousand-row table), the transactional write path (row + blob
+// persist together and cascade-delete together), and the batch blob loader.
+
+import Fluent
+import Foundation
+import SQLKit
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class ResultCollectionSideTableTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-rescol")
+    }
+
+    private func seedSubmission(id: String) async throws {
+        let setupID = "setup_rescol"
+        if try await APITestSetup.find(setupID, on: app.db) == nil {
+            let courseID = try await app.testCourseID()
+            let setup = APITestSetup(
+                id: setupID,
+                manifest:
+                    #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"tests.py"}],"timeLimitSeconds":10,"makefile":null}"#,
+                zipPath: app.testSetupsDirectory + "\(setupID).zip",
+                courseID: courseID
+            )
+            try await setup.save(on: app.db)
+        }
+        let sub = APISubmission(
+            id: id,
+            testSetupID: setupID,
+            zipPath: app.submissionsDirectory + "\(id).zip",
+            attemptNumber: 1,
+            status: SubmissionStatus.complete.rawValue
+        )
+        try await sub.save(on: app.db)
+    }
+
+    @Test func saveWithCollectionPersistsRowAndBlobTogether() async throws {
+        try await withApp(app) { _ in
+            try await seedSubmission(id: "sub_rc_write")
+            let json = #"{"earnedPoints":3,"totalPoints":4,"passCount":3,"totalTests":4}"#
+
+            let result = APIResult(id: "res_rc_write", submissionID: "sub_rc_write")
+            try await result.saveWithCollection(json: json, on: app.db)
+
+            // Blob row exists and round-trips byte-identically.
+            let loaded = try await result.loadCollectionJSON(on: app.db)
+            #expect(loaded == json)
+
+            // Grade columns were stamped from the blob on the way in.
+            let row = try #require(try await APIResult.find("res_rc_write", on: app.db))
+            #expect(row.earnedPoints == 3)
+            #expect(row.totalPoints == 4)
+            #expect(row.passCount == 3)
+            #expect(row.totalTests == 4)
+        }
+    }
+
+    @Test func deletingTheResultCascadesTheBlob() async throws {
+        try await withApp(app) { _ in
+            try await seedSubmission(id: "sub_rc_cascade")
+            let result = APIResult(id: "res_rc_cascade", submissionID: "sub_rc_cascade")
+            try await result.saveWithCollection(json: "{}", on: app.db)
+            #expect(try await APIResultCollection.find("res_rc_cascade", on: app.db) != nil)
+
+            try await result.delete(on: app.db)
+            #expect(try await APIResultCollection.find("res_rc_cascade", on: app.db) == nil)
+        }
+    }
+
+    @Test func batchLoaderReturnsBlobsKeyedByResultID() async throws {
+        try await withApp(app) { _ in
+            try await seedSubmission(id: "sub_rc_batch")
+            try await APIResult(id: "res_rc_b1", submissionID: "sub_rc_batch")
+                .saveWithCollection(json: #"{"passCount":1,"totalTests":2}"#, on: app.db)
+            try await APIResult(id: "res_rc_b2", submissionID: "sub_rc_batch")
+                .saveWithCollection(json: #"{"passCount":2,"totalTests":2}"#, on: app.db)
+
+            let byID = try await collectionJSONByResultID(
+                for: ["res_rc_b1", "res_rc_b2", "res_rc_missing"], on: app.db)
+            #expect(byID.count == 2)
+            #expect(byID["res_rc_b1"]?.contains(#""passCount":1"#) == true)
+            #expect(byID["res_rc_b2"]?.contains(#""passCount":2"#) == true)
+            #expect(byID["res_rc_missing"] == nil)
+        }
+    }
+}
+
+/// The migration itself, run against a legacy-shaped schema seeded with more
+/// rows than one backfill chunk — proving the chunked copy visits everything
+/// and the column drop lands. Uses a bare Application (not makeTestApp) so
+/// the schema can be created pre-migration.
+@Suite(.serialized) struct ResultCollectionBackfillMigrationTests {
+
+    @Test func chunkedBackfillCopiesEveryBlobAndDropsTheColumn() async throws {
+        let app = try await Application.make(.testing)
+        do {
+            try configureDatabase(app, settings: .sqliteInMemory())
+            let sql = try #require(app.db as? SQLDatabase)
+
+            // Legacy shape: minimal parents + a results table that still
+            // carries collection_json. Only the columns the migration touches
+            // are needed.
+            try await sql.raw("CREATE TABLE submissions (id TEXT PRIMARY KEY)").run()
+            try await sql.raw(
+                """
+                CREATE TABLE results (
+                    id TEXT PRIMARY KEY,
+                    submission_id TEXT NOT NULL REFERENCES submissions(id),
+                    collection_json TEXT NOT NULL,
+                    source TEXT
+                )
+                """
+            ).run()
+            try await sql.raw("INSERT INTO submissions (id) VALUES ('sub_bf')").run()
+
+            // 2,500 rows: three passes at the 1,000-row chunk size.
+            let totalRows = 2_500
+            let batchSize = 500
+            var rowID = 1
+            while rowID <= totalRows {
+                let values = (rowID..<min(rowID + batchSize, totalRows + 1))
+                    .map { i in
+                        #"('res_bf_\#(i)', 'sub_bf', '{"passCount":\#(i),"totalTests":\#(totalRows)}', 'worker')"#
+                    }
+                    .joined(separator: ",")
+                try await sql.raw(
+                    "INSERT INTO results (id, submission_id, collection_json, source) VALUES \(unsafeRaw: values)"
+                ).run()
+                rowID += batchSize
+            }
+
+            app.migrations.add(CreateResultCollections())
+            try await app.autoMigrate()
+
+            // Every blob copied, byte-identical.
+            let copied = try await APIResultCollection.query(on: app.db).count()
+            #expect(copied == totalRows)
+            let first = try await APIResultCollection.find("res_bf_1", on: app.db)
+            #expect(first?.collectionJSON == #"{"passCount":1,"totalTests":2500}"#)
+            let last = try await APIResultCollection.find("res_bf_2500", on: app.db)
+            #expect(last?.collectionJSON == #"{"passCount":2500,"totalTests":2500}"#)
+
+            // The column is gone from the hot table.
+            struct AnyRow: Decodable {}
+            await #expect(throws: (any Error).self) {
+                _ = try await sql.raw("SELECT collection_json FROM results LIMIT 1")
+                    .first(decoding: AnyRow.self)
+            }
+        } catch {
+            try? await app.asyncShutdown()
+            throw error
+        }
+        try await app.asyncShutdown()
+    }
+}

--- a/Tests/APITests/SubmissionQueryRoutesTests.swift
+++ b/Tests/APITests/SubmissionQueryRoutesTests.swift
@@ -79,10 +79,9 @@ import VaporTesting
         let json = try #require(String(data: encoder.encode(collection), encoding: .utf8))
         let result = APIResult(
             id: "res_\(UUID().uuidString.lowercased().prefix(8))",
-            submissionID: submissionID,
-            collectionJSON: json
+            submissionID: submissionID
         )
-        try await result.save(on: app.db)
+        try await result.saveWithCollection(json: json, on: app.db)
     }
 
     private func makeCollection(

--- a/Tests/APITests/WebRoutesHelpers.swift
+++ b/Tests/APITests/WebRoutesHelpers.swift
@@ -186,10 +186,9 @@ func wrInsertResult(
     let result = APIResult(
         id: "res_\(UUID().uuidString.lowercased().prefix(8))",
         submissionID: submissionID,
-        collectionJSON: json,
         source: source
     )
-    try await result.save(on: app.db)
+    try await result.saveWithCollection(json: json, on: app.db)
     return result
 }
 

--- a/changelog.d/results-blob-side-table-1173.md
+++ b/changelog.d/results-blob-side-table-1173.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **The result collection blob moved to a side table (#1173).** Every full
+  `results`-row load — the preferred-result maps behind the dashboard and
+  per-student history, submission detail, sweeps, bundle export — previously
+  dragged the serialized `TestOutcomeCollection` (up to the 6 MB budget per
+  row) whether or not it was read, and the blob dominated the table's
+  on-disk footprint. It now lives in `result_collections(result_id,
+  collection_json)`: hot result rows are blob-free by construction, and the
+  few readers that need the collection (result JSON endpoint past its ETag
+  check, submission detail render, validation results, bundle export) fetch
+  exactly the blobs they display. Writes stay atomic — the result row and
+  its blob persist in one transaction, and deletes cascade. The migration
+  backfills existing blobs in bounded chunks entirely inside the database,
+  then drops the old column.


### PR DESCRIPTION
Closes #1173 (follow-up noted on #1157 / PR #1167). The largest of the audit follow-ups — design first, then the diff.

## Design

**Problem.** The serialized `TestOutcomeCollection` (up to the 6 MB per-collection budget) lived on the hot `results` row. Every full-row load — the preferred-result maps behind the dashboard and per-student history, submission detail, sweeps, bundle export — dragged the blob whether or not it was read, and the column dominated the table's on-disk footprint. #1167 already made the *grade* folds blob-free via projection, but any full-row consumer still paid.

**Shape.** New side table `result_collections(result_id TEXT PK, FK → results.id ON DELETE CASCADE, collection_json TEXT NOT NULL)` with a matching `APIResultCollection` model.

- `APIResult` loses the stored `collectionJSON` property, so **every full-row load is blob-free by construction** — no query-shape audit can regress it, the column simply isn't on the model or the table.
- **Write path:** `saveWithCollection(json:on:)` is the one way to create a result — it stamps the denormalized grade columns from the blob, then persists row + blob in a single transaction. It composes with the enclosing worker-ingest and bundle-import transactions (the Fluent SQLite/Postgres drivers no-op a nested `BEGIN`; verified in the vendored sources).
- **Read path:** the few readers that genuinely need the collection fetch it explicitly — `loadCollectionJSON(on:)` for single results, chunked `collectionJSONByResultID(for:on:)` for batches:
  - `GET /submissions/:id/results` fetches past its ETag short-circuit, so a 304 never touches the blob at all.
  - Submission detail fetches + decodes once; the presenter and the individual-badge evaluation share the decoded collection.
  - Dashboard and history badge paths batch-fetch blobs for **each latest submission's preferred result only** (one per visible row at most — the blob is needed there solely for `executionTimeMs` in the badge context).
  - Bundle export batch-fetches by result id; import writes through `saveWithCollection` — the `.chickadee` round-trip carries collections unchanged (CourseBundleTests is the acceptance gate).
  - Prior-attempt delta, validation wait loop, and MCP `get_validation_result` each fetch their single blob.
- **Grade accessors:** the blob-parsing fallback on `APIResult` is gone. Post-backfill it was unreachable — a row whose four grade columns are all nil has a blob `AddResultGradeColumns` couldn't parse, which the fallback also graded as nil. `gradeSummariesBySubmissionID`'s legacy hydration path stays, now reading the side table.

**Migration.** `CreateResultCollections` creates the table, backfills in bounded 1,000-row chunks entirely inside the database (`INSERT … SELECT … LIMIT` keyed on `NOT EXISTS`, so it's re-entrant if interrupted), then drops the column via `deleteField` — the same convention `ChangeAssignmentIsOpenToVisibility` uses to relocate a column production DBs already have. Blobs never stream through Swift. `revert` restores the column and copies back.

**Deploy note.** This is a hard schema cut for old binaries: after the migration runs, a not-yet-cut-over process writing a result would fail loudly (the column is gone) and the runner retries against the new process. The blue-green window is seconds; result ingest already has retry semantics.

## Testing

- New `ResultCollectionSideTableTests`: transactional write path (row + blob + stamped grade columns), cascade delete, batch loader.
- New `ResultCollectionBackfillMigrationTests`: runs the real migration against a legacy-shaped schema seeded with **2,500 rows** — proves three chunk passes, byte-identical copies, and the column drop.
- `GradeSummaryLoaderTests`' legacy test now seeds the true post-migration legacy shape (nil columns + side-table blob).
- Acceptance gates green locally: `CourseBundleTests` round-trip, `SubmissionQueryRoutesTests`, plus `ResultRoutesTests`, `BrowserRunnerRoutesTests`, `WebRoutesSubmissionPageTests`, `WebRoutesIndexTests`, `AchievementEvaluationTests`, `AchievementBonusTests`, `AchievementDisplayTests`, `GradeOverridesTests`, `BrightSpacePanelTests`, `BrightSpaceGradeSyncTests`, `GetValidationResultToolTests`, `AssignmentSubmissionsSparklineTests`, `BestGradePolicyTests`.
- api-tests-postgres exercises the raw-SQL backfill + `deleteField` on Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqnuMoiWSzUj2TQku3Xsb5)_