### PR TITLE
Audit-log coverage for actor-driven LEARN sync actions

### DIFF
--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -130,6 +130,20 @@ enum AuditAction: String, Sendable, CaseIterable {
     case runnerSecretRotated = "runner.secret_rotated"
     case runnerAutostartChanged = "runner.autostart_changed"
 
+    // BrightSpace / LEARN grade sync (actor-driven actions only — individual
+    // grade pushes are background events recorded in `brightspace_sync_log`)
+    case brightspaceAdminAuthorized = "brightspace.admin_authorized"
+    case brightspaceAdminCleared = "brightspace.admin_cleared"
+    case brightspaceAccountConnected = "brightspace.account_connected"
+    case brightspaceAccountDisconnected = "brightspace.account_disconnected"
+    case brightspaceSyncIdentitySet = "brightspace.sync_identity_set"
+    case brightspaceOrgUnitBound = "brightspace.org_unit_bound"
+    case brightspaceOrgUnitCleared = "brightspace.org_unit_cleared"
+    case brightspaceGradeItemMapped = "brightspace.grade_item_mapped"
+    case brightspaceAutoMapped = "brightspace.auto_mapped"
+    case brightspaceSyncNow = "brightspace.sync_now"
+    case brightspacePushAll = "brightspace.push_all"
+
     // MCP / agents
     case mcpAccountCreated = "mcp.account_created"
     case mcpAccountDeleted = "mcp.account_deleted"
@@ -162,6 +176,11 @@ enum AuditAction: String, Sendable, CaseIterable {
             return .grading
         case .runnerSecretRotated, .runnerAutostartChanged:
             return .runner
+        case .brightspaceAdminAuthorized, .brightspaceAdminCleared, .brightspaceAccountConnected,
+            .brightspaceAccountDisconnected, .brightspaceSyncIdentitySet, .brightspaceOrgUnitBound,
+            .brightspaceOrgUnitCleared, .brightspaceGradeItemMapped, .brightspaceAutoMapped,
+            .brightspaceSyncNow, .brightspacePushAll:
+            return .brightspace
         case .mcpAccountCreated, .mcpAccountDeleted, .mcpTokenMinted, .mcpToolCalled,
             .mcpGrantRevoked, .mcpAccountEnrolled, .mcpAccountUnenrolled, .mcpClientRegistered,
             .mcpConsentGranted, .mcpTokenIssued, .mcpRefreshReuseDetected, .adminMcpToolCalled:
@@ -201,6 +220,17 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .gradeOverrideCleared: return "Grade override cleared"
         case .runnerSecretRotated: return "Runner secret rotated"
         case .runnerAutostartChanged: return "Runner autostart changed"
+        case .brightspaceAdminAuthorized: return "LEARN deployment key authorized"
+        case .brightspaceAdminCleared: return "LEARN deployment key cleared"
+        case .brightspaceAccountConnected: return "LEARN account connected"
+        case .brightspaceAccountDisconnected: return "LEARN account disconnected"
+        case .brightspaceSyncIdentitySet: return "LEARN sync identity set"
+        case .brightspaceOrgUnitBound: return "LEARN org unit linked"
+        case .brightspaceOrgUnitCleared: return "LEARN org unit unlinked"
+        case .brightspaceGradeItemMapped: return "LEARN grade item mapping changed"
+        case .brightspaceAutoMapped: return "LEARN grade items auto-mapped"
+        case .brightspaceSyncNow: return "LEARN manual sync"
+        case .brightspacePushAll: return "LEARN push all grades"
         case .mcpAccountCreated: return "MCP account created"
         case .mcpAccountDeleted: return "MCP account deleted"
         case .mcpTokenMinted: return "MCP token minted (admin)"
@@ -228,6 +258,7 @@ enum AuditCategory: String, Sendable, CaseIterable {
     case grading = "Grading"
     case runner = "Runner"
     case mcp = "MCP / agents"
+    case brightspace = "LEARN sync"
 }
 
 /// Resolves a stored (raw) action string to its display category + label,

--- a/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/AdminRoutes+BrightSpace.swift
@@ -162,6 +162,11 @@ extension AdminRoutes {
         req.application.brightSpaceSyncConfig = config
         req.application.brightSpaceClient = candidate
         req.logger.info("BrightSpace authorized by \(user.username) as \(identity)")
+        await AuditLogger.record(
+            action: .brightspaceAdminAuthorized,
+            metadata: ["identity": identity, "source": "valence_callback"],
+            on: req
+        )
 
         req.session.data["bs_flash_success"] = "BrightSpace authorized as \(identity)."
         let response = req.redirect(to: "/admin/brightspace")
@@ -175,16 +180,24 @@ extension AdminRoutes {
     func brightspaceClearAuthorization(req: Request) async throws -> Response {
         try await BrightSpaceCredentialStore.clearGlobal(on: req.db)
         // Fall back to an env-provided user key if one exists; otherwise disable.
+        let revertedTo: String
         if let envConfig = req.application.appConfig.brightspace {
             req.application.brightSpaceSyncConfig = envConfig
             req.application.brightSpaceClient = BrightSpaceAPIClient(config: envConfig)
+            revertedTo = "env"
             req.session.data["bs_flash_success"] =
                 "Authorization cleared — reverted to the BRIGHTSPACE_USER_KEY from env."
         } else {
             req.application.brightSpaceSyncConfig = nil
             req.application.brightSpaceClient = nil
+            revertedTo = "disabled"
             req.session.data["bs_flash_success"] = "Authorization cleared — grade sync is now disabled."
         }
+        await AuditLogger.record(
+            action: .brightspaceAdminCleared,
+            metadata: ["reverted_to": revertedTo],
+            on: req
+        )
         return req.redirect(to: "/admin/brightspace")
     }
 
@@ -242,6 +255,11 @@ extension AdminRoutes {
         req.application.brightSpaceSyncConfig = config
         req.application.brightSpaceClient = candidate
         req.logger.info("BrightSpace credentials set manually by \(user.username) as \(identity)")
+        await AuditLogger.record(
+            action: .brightspaceAdminAuthorized,
+            metadata: ["identity": identity, "source": "manual"],
+            on: req
+        )
 
         req.session.data["bs_flash_success"] = "BrightSpace credentials saved — connected as \(identity)."
         return req.redirect(to: "/admin/brightspace")

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+BrightSpace.swift
@@ -136,6 +136,13 @@ extension InstructorDashboardRoutes {
         }
 
         req.logger.info("BrightSpace connected by \(user.username) as \(identity)")
+        await AuditLogger.record(
+            action: .brightspaceAccountConnected,
+            targetType: .user,
+            targetID: userUUID.uuidString,
+            metadata: ["identity": identity, "claimed_course_identity": String(claimedCourse)],
+            on: req
+        )
         req.session.data["bs_flash_success"] =
             claimedCourse
             ? "Connected as \(identity). This course now syncs grades as your LEARN account."
@@ -171,6 +178,13 @@ extension InstructorDashboardRoutes {
         }
         course.brightspaceSyncUserID = userUUID
         try await course.save(on: req.db)
+        await AuditLogger.record(
+            action: .brightspaceSyncIdentitySet,
+            targetType: .course,
+            targetID: courseUUID.uuidString,
+            metadata: ["course_code": course.code],
+            on: req
+        )
         req.session.data["bs_flash_success"] = "This course now syncs grades as your LEARN account."
         return req.redirect(to: "/instructor/brightspace")
     }
@@ -189,6 +203,12 @@ extension InstructorDashboardRoutes {
         }
         try await BrightSpaceCredentialStore.clear(userID: userUUID, on: req.db)
         await req.application.brightSpaceClientRegistry.invalidate(userUUID.uuidString)
+        await AuditLogger.record(
+            action: .brightspaceAccountDisconnected,
+            targetType: .user,
+            targetID: userUUID.uuidString,
+            on: req
+        )
         req.session.data["bs_flash_success"] = "Your LEARN account has been disconnected."
         return req.redirect(to: "/instructor/brightspace")
     }
@@ -225,6 +245,13 @@ extension InstructorDashboardRoutes {
             course.brightspaceOrgUnitID = nil
             course.brightspaceOrgUnitName = nil
             try await course.save(on: req.db)
+            await AuditLogger.record(
+                action: .brightspaceOrgUnitCleared,
+                targetType: .course,
+                targetID: courseUUID.uuidString,
+                metadata: ["course_code": course.code],
+                on: req
+            )
             req.session.data["bs_flash_success"] = "Org-unit binding cleared."
             return req.redirect(to: "/instructor/brightspace")
         }
@@ -243,6 +270,13 @@ extension InstructorDashboardRoutes {
         course.brightspaceSyncUserID = userUUID
         course.brightspaceOrgUnitName = nil
         try await course.save(on: req.db)
+        await AuditLogger.record(
+            action: .brightspaceOrgUnitBound,
+            targetType: .course,
+            targetID: courseUUID.uuidString,
+            metadata: ["course_code": course.code, "org_unit": rawOrgUnit],
+            on: req
+        )
 
         guard let client = try await req.application.brightSpaceClient(forCourse: course) else {
             req.session.data["bs_flash_success"] = "Org unit \(rawOrgUnit) saved (unverified)."
@@ -337,6 +371,13 @@ extension InstructorDashboardRoutes {
             }
         }
 
+        await AuditLogger.record(
+            action: .brightspaceAutoMapped,
+            targetType: .course,
+            targetID: courseUUID.uuidString,
+            metadata: ["course_code": course.code, "mapped_count": String(mapped)],
+            on: req
+        )
         req.session.data["bs_flash_success"] =
             mapped == 0
             ? "No new matches — every assignment is already mapped or has no grade item with the same name."
@@ -361,6 +402,12 @@ extension InstructorDashboardRoutes {
             try await requeueErroredGradePushes(req: req, courseUUID: courseUUID)
         }
         await runImmediateBrightspaceSweep(req: req)
+        await AuditLogger.record(
+            action: .brightspaceSyncNow,
+            targetType: .course,
+            targetID: courseState.activeCourseUUID?.uuidString,
+            on: req
+        )
         return req.redirect(to: "/instructor/brightspace")
     }
 
@@ -475,6 +522,17 @@ extension InstructorDashboardRoutes {
             .all()
         try await requeueForImmediateSync(overrides, on: req.db)
         await runImmediateBrightspaceSweep(req: req)
+        await AuditLogger.record(
+            action: .brightspacePushAll,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: [
+                "assignment": assignment.publicID,
+                "requeued_results": String(results.count),
+                "requeued_overrides": String(overrides.count),
+            ],
+            on: req
+        )
         return req.redirect(to: "/instructor/brightspace")
     }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -319,17 +319,27 @@ struct InstructorDashboardRoutes: RouteCollection {
         }
         let body = try req.content.decode(BSBody.self)
         let raw = (body.gradeObjectID ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let mapping: String
         if raw == BrightspaceSync.doNotSyncToken {
             // The instructor picked the "Do not sync" option in the grade-item
             // dropdown — exclude this assignment from LEARN. The sweep then skips
             // it; the dropdown shows "Do not sync" until a real item is chosen.
             assignment.brightspaceSyncExcluded = true
             assignment.brightspaceGradeObjectID = nil
+            mapping = "do_not_sync"
         } else {
             assignment.brightspaceSyncExcluded = false
             assignment.brightspaceGradeObjectID = raw.isEmpty ? nil : raw
+            mapping = raw.isEmpty ? "cleared" : raw
         }
         try await assignment.save(on: req.db)
+        await AuditLogger.record(
+            action: .brightspaceGradeItemMapped,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: ["assignment": assignment.publicID, "grade_item": mapping],
+            on: req
+        )
         if body.returnTo == "brightspace" {
             return req.redirect(to: "/instructor/brightspace")
         }

--- a/Tests/APITests/BrightSpacePanelTests.swift
+++ b/Tests/APITests/BrightSpacePanelTests.swift
@@ -499,4 +499,129 @@ import VaporTesting
             #expect(found.attemptedAt != nil)
         }
     }
+
+    // MARK: - Audit trail for actor-driven LEARN actions
+
+    /// All audit rows recorded for one action, oldest first.
+    private func auditEntries(
+        _ action: AuditAction, on app: Application
+    ) async throws -> [APIAuditLogEntry] {
+        try await APIAuditLogEntry.query(on: app.db)
+            .filter(\.$action == action.rawValue)
+            .sort(\.$createdAt, .ascending)
+            .all()
+    }
+
+    @Test func syncNowWritesAuditEntry() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/sync-now",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in #expect(res.status == .seeOther) })
+
+            let entries = try await auditEntries(.brightspaceSyncNow, on: app)
+            let entry = try #require(entries.first)
+            #expect(entry.actorUsername == "testinstructor")
+            #expect(entry.targetID == courseID.uuidString)
+        }
+    }
+
+    @Test func gradeItemMappingWritesAuditEntries() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await arInsertSetup(id: "setup_bs_audit", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_bs_audit", title: "BS Audit", isOpen: true, on: app)
+
+            func postMapping(_ gradeObjectID: String) async throws {
+                try await app.asyncTest(
+                    .POST, "/instructor/\(assignment.publicID)/brightspace",
+                    beforeRequest: { req in
+                        req.headers.add(name: .cookie, value: sessionCookie)
+                        try req.content.encode(
+                            ["gradeObjectID": gradeObjectID, "returnTo": "brightspace", "_csrf": csrf],
+                            as: .urlEncodedForm)
+                    },
+                    afterResponse: { res in #expect(res.status == .seeOther) })
+            }
+            try await postMapping("78901")
+            try await postMapping(BrightspaceSync.doNotSyncToken)
+
+            let entries = try await auditEntries(.brightspaceGradeItemMapped, on: app)
+            #expect(entries.count == 2)
+            let mapped = try #require(entries.first)
+            #expect(mapped.actorUsername == "testinstructor")
+            #expect(mapped.targetID == assignment.id?.uuidString)
+            #expect((mapped.metadata ?? "").contains("78901"))
+            let excluded = try #require(entries.last)
+            #expect((excluded.metadata ?? "").contains("do_not_sync"))
+        }
+    }
+
+    @Test func bindAndClearOrgUnitWriteAuditEntries() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "testinstructor").first())
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "vu", valenceUserKey: "vk", identityName: "Test Instructor",
+                capturedByUserID: instructor.id, userID: instructor.id, on: app.db)
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            func postOrgUnit(_ orgUnitID: String) async throws {
+                try await app.asyncTest(
+                    .POST, "/instructor/brightspace/bind-org-unit",
+                    beforeRequest: { req in
+                        req.headers.add(name: .cookie, value: sessionCookie)
+                        req.headers.add(name: "x-csrf-token", value: csrf)
+                        try req.content.encode(["orgUnitID": orgUnitID], as: .urlEncodedForm)
+                    },
+                    afterResponse: { res in #expect(res.status == .seeOther) })
+            }
+            try await postOrgUnit("1106038")
+            try await postOrgUnit("")
+
+            let bound = try await auditEntries(.brightspaceOrgUnitBound, on: app)
+            let boundEntry = try #require(bound.first)
+            #expect(boundEntry.targetID == courseID.uuidString)
+            #expect((boundEntry.metadata ?? "").contains("1106038"))
+
+            let cleared = try await auditEntries(.brightspaceOrgUnitCleared, on: app)
+            #expect(cleared.count == 1)
+        }
+    }
+
+    @Test func disconnectWritesAuditEntry() async throws {
+        try await withAssignmentRoutesApp { app in
+            _ = try await app.testCourseID(enrollmentMode: .auto)
+            let cookie = try await arLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "testinstructor").first())
+            try await BrightSpaceCredentialStore.save(
+                valenceUserID: "vu", valenceUserKey: "vk", identityName: "Test Instructor",
+                capturedByUserID: instructor.id, userID: instructor.id, on: app.db)
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+            try await app.asyncTest(
+                .POST, "/instructor/brightspace/disconnect",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in #expect(res.status == .seeOther) })
+
+            let entries = try await auditEntries(.brightspaceAccountDisconnected, on: app)
+            let entry = try #require(entries.first)
+            #expect(entry.actorUsername == "testinstructor")
+            #expect(entry.targetID == instructor.id?.uuidString)
+        }
+    }
 }

--- a/changelog.d/learn-sync-audit-log.md
+++ b/changelog.d/learn-sync-audit-log.md
@@ -1,0 +1,10 @@
+### Added
+
+- **Actor-driven LEARN sync actions now appear in the admin audit log.** A new
+  "LEARN sync" audit category records who did what on the grade-sync surface:
+  deployment key authorized/cleared (admin), instructor LEARN account
+  connected/disconnected, course sync identity designated, org unit
+  bound/cleared, grade-item mapping changes (including "Do not sync"),
+  auto-map runs, manual "Sync now", and per-assignment "Push all". Individual
+  grade pushes remain in `brightspace_sync_log` — the audit log covers only
+  the human actions around them.


### PR DESCRIPTION
## What

Adds a **"LEARN sync"** audit category so the actor-driven grade-sync actions show up on `/admin/audit`. Individual grade pushes stay in `brightspace_sync_log` (background events, no actor); this covers the *human* actions around them, which previously left no trace.

**Admin (`AdminRoutes+BrightSpace`)**
- `brightspace.admin_authorized` — deployment key captured, via the Valence callback or a manual paste (`source` in metadata distinguishes them)
- `brightspace.admin_cleared` — key cleared, metadata records whether sync reverted to the env key or was disabled

**Instructor (`InstructorDashboardRoutes[+BrightSpace]`)**
- `brightspace.account_connected` / `account_disconnected` — per-instructor LEARN account, with the verified identity and whether connecting auto-claimed the course's sync identity
- `brightspace.sync_identity_set` — "Use my identity" designation
- `brightspace.org_unit_bound` / `org_unit_cleared` — course↔org-unit binding
- `brightspace.grade_item_mapped` — mapping set / cleared / "Do not sync" (token recorded as `do_not_sync`)
- `brightspace.auto_mapped` — auto-map runs, with mapped count
- `brightspace.sync_now` — manual sync (the errored-row requeue + immediate sweep)
- `brightspace.push_all` — per-assignment backfill, with requeued result/override counts

Deliberately **not** audited: `reconcile-now` (re-reads roster readiness from LEARN, changes no sync configuration) and the read-only connection tests.

## Why

Prod LEARN sync went live this week. When something looks off in the grade book, the first question is "who changed what, when" — org-unit rebinds, mapping changes, and manual pushes are exactly the actions you want an answer for, and none of them were recorded.

## How

All writes go through the existing `AuditLogger.record` chokepoint; new `AuditAction` cases + a `.brightspace` category drive the `/admin/audit` filter dropdown and display automatically (`CaseIterable`). No schema changes.

## Testing

- 4 new tests in `BrightSpacePanelTests` assert audit rows (actor, target, metadata) for sync-now, grade-item mapping (both mapped + do-not-sync), org-unit bind/clear, and disconnect
- `AuditActionDisplayTests` (existing) guards the new cases' category/label mappings and label uniqueness
- Full `BrightSpacePanelTests` + `AuditActionDisplayTests` suites pass locally (25 tests); `scripts/lint.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkH1tFwg8X3W8q9VrimYSh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkH1tFwg8X3W8q9VrimYSh)_