### PR TITLE
Fix silent MCP validation skip, MCP result_collections grant, and scheduled-open hardening

### DIFF
--- a/Sources/APIServer/MCP/Admin/AdminMCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Admin/AdminMCPDispatcher.swift
@@ -103,6 +103,9 @@ struct AdminMCPDispatcher: Sendable {
             outcome = MCPToolOutcome(error).rawValue
             response = .success(id: id, result: mcpToolErrorResult(error))
         } catch {
+            // A non-MCPToolError throw is opaque to the agent (bare -32603);
+            // log the underlying error so the failure is diagnosable.
+            context.request.logger.error("Admin MCP tool \(call.name) failed: \(error)")
             outcome = MCPToolOutcome.failed.rawValue
             response = .failure(id: id, error: .internalError("Tool \(call.name) failed."))
         }

--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -102,6 +102,12 @@ func finalizeContentEdit(
     if retest {
         await retestSubmissionsAfterContentEdit(setup: setup, context: context)
     }
-    await scheduleValidationAfterSuiteEdit(req: context.request, assignment: assignment)
+    // Pass the acting subject explicitly: an MCP request is bearer-authenticated
+    // with no session `APIUser`, so the helper's `req.auth` fallback would throw
+    // 401 inside its swallow-all catch and the re-validation would silently
+    // never be enqueued (the assignment kept its stale validationStatus).
+    let submitterUserID = try? await context.requireEligibleSubject(tool: "validate").id
+    await scheduleValidationAfterSuiteEdit(
+        req: context.request, assignment: assignment, submitterUserID: submitterUserID)
     return closed
 }

--- a/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
@@ -111,19 +111,29 @@ struct GetValidationResultTool: ContentTool {
             publicID: input.assignmentPublicID, tool: Self.name)
         let status = assignment.validationStatus ?? "none"
 
-        guard
-            let submission = try await MCPStudentDataBoundary.validationSubmission(
-                for: assignment, on: context.db)
-        else {
-            return Self.empty(assignmentPublicID: assignment.publicID, validationStatus: status)
+        // Map database failures to executionFailed so the agent sees the reason
+        // (e.g. a missing SELECT grant for the least-privilege MCP role) instead
+        // of an opaque protocol-level internal error.
+        let collectionJSON: String?
+        do {
+            if let submission = try await MCPStudentDataBoundary.validationSubmission(
+                for: assignment, on: context.db),
+                let result = try await MCPStudentDataBoundary.latestResult(
+                    forSubmissionID: submission.requireID(), on: context.db)
+            {
+                collectionJSON = try await result.loadCollectionJSON(on: context.db)
+            } else {
+                collectionJSON = nil
+            }
+        } catch {
+            throw MCPToolError.executionFailed(
+                tool: Self.name, detail: "Could not read the validation result: \(error)")
         }
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         guard
-            let result = try await MCPStudentDataBoundary.latestResult(
-                forSubmissionID: submission.requireID(), on: context.db),
-            let collectionJSON = try await result.loadCollectionJSON(on: context.db),
+            let collectionJSON,
             let collection = try? decoder.decode(
                 TestOutcomeCollection.self, from: Data(collectionJSON.utf8))
         else {

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -192,6 +192,11 @@ struct MCPDispatcher: Sendable {
             outcome = MCPToolOutcome(error)
             response = .success(id: id, result: mcpToolErrorResult(error))
         } catch {
+            // A non-MCPToolError throw is opaque to the agent (bare -32603), so
+            // the underlying error must at least reach the log ring buffer —
+            // this is how a Postgres permission-denied on the least-privilege
+            // MCP role surfaces (e.g. the missing result_collections grant).
+            context.logger.error("MCP tool \(call.name) failed: \(error)")
             outcome = .failed
             response = .failure(id: id, error: .internalError("Tool \(call.name) failed."))
         }

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -42,8 +42,10 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
 
     /// Optional automatic open date. nil = open as soon as published.
     /// When set and still in the future, students cannot access or submit
-    /// even if `isOpen` is true; the assignment becomes submittable on its
-    /// own once this time passes (gated live, no background job).
+    /// even if `isOpen` is true. Once the time arrives, a `.closed`/`.preview`
+    /// assignment is published by `openScheduledAssignment` — via the periodic
+    /// deadline sweep, the dashboard load, and the submission gate (the latter
+    /// two as lazy safety nets) — which consumes this field (sets it nil).
     @OptionalField(key: "starts_at")
     var startsAt: Date?
 

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -247,9 +247,16 @@ private func resolveAndCacheValidationMaterialization(
 ///
 /// Errors are swallowed: this is a nice-to-have trigger from live-edit
 /// endpoints and must not block the edit save.
+///
+/// `submitterUserID` attributes the validation submission. Web callers omit it
+/// (the session user is resolved from `req.auth`); MCP callers MUST pass the
+/// acting subject's id — bearer-authenticated requests carry no session
+/// `APIUser`, so the `req.auth` fallback throws 401 and the validation is
+/// silently never enqueued.
 func scheduleValidationAfterSuiteEdit(
     req: Request,
-    assignment: APIAssignment
+    assignment: APIAssignment,
+    submitterUserID: UUID? = nil
 ) async {
     do {
         let existingPending = try await APISubmission.query(on: req.db)
@@ -280,7 +287,8 @@ func scheduleValidationAfterSuiteEdit(
             req: req,
             setupID: assignment.testSetupID,
             solutionNotebookData: solution.data,
-            filename: solution.filename
+            filename: solution.filename,
+            submitterUserID: submitterUserID
         )
         assignment.validationSubmissionID = subID
         assignment.validationStatus = "pending"

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -91,6 +91,18 @@ struct WebRoutes: RouteCollection {
         let allAssignments = try await APIAssignment.query(on: req.db)
             .filter(\.$courseID == activeCourseUUID)
             .all()
+
+        // Lazy safety net for scheduled opens, mirroring the lazy deadline
+        // close in requireOpenStudentAssignment: if the periodic sweep missed
+        // an assignment whose open date has arrived, the very dashboard load
+        // that would otherwise show it stuck (a TA checking why the lab isn't
+        // up, a student looking for it) repairs the state instead of just
+        // observing it. Row-wise on the already-loaded list; every guard
+        // short-circuits in memory, so this writes nothing unless a scheduled
+        // open is actually due.
+        for assignment in allAssignments {
+            _ = try? await openScheduledAssignment(assignment, on: req.db, logger: req.logger)
+        }
         let assignmentBySetup = Dictionary(
             allAssignments.map { ($0.testSetupID, $0) },
             uniquingKeysWith: { first, _ in first }

--- a/Sources/APIServer/Services/AssignmentDeadlineService.swift
+++ b/Sources/APIServer/Services/AssignmentDeadlineService.swift
@@ -285,7 +285,17 @@ func openScheduledAssignment(
     // already been consumed.
     guard assignment.visibility == .closed || assignment.visibility == .preview else { return false }
     guard let startsAt = assignment.startsAt, startsAt <= now else { return false }
-    guard assignment.validationStatus == nil || assignment.validationStatus == "passed" else { return false }
+    guard assignment.validationStatus == nil || assignment.validationStatus == "passed" else {
+        // The open date has arrived but validation is blocking the publish.
+        // This state used to be completely silent — the sweep just skipped the
+        // row every minute while students stayed locked out and nobody was
+        // told why (the Lab 6 incident). One warning per tick keeps the
+        // blockage visible in the log buffer until it is resolved.
+        logger.warning(
+            "Scheduled open blocked for '\(assignment.title)' (\(assignment.publicID)): open date \(startsAt) has arrived but validationStatus is '\(assignment.validationStatus ?? "nil")' — it stays \(assignment.visibility.rawValue) until validation passes"
+        )
+        return false
+    }
     if let dueAt = assignment.dueAt, dueAt <= now { return false }
 
     assignment.visibility = .open
@@ -339,6 +349,12 @@ func requireOpenStudentAssignment(
     // `requireCourseEnrollment`'s own short-circuit.
     try await requireCourseEnrollment(caller: user, courseID: assignment.courseID, db: req.db)
 
+    // Lazy schedule enforcement, both directions. The close has always been
+    // enforced here as a safety net under the periodic sweep; the open gets
+    // the same treatment so a student following a direct link to a scheduled
+    // assignment whose open date has arrived is let in even if the background
+    // sweep is not running (the dashboard loader applies the same repair).
+    _ = try await openScheduledAssignment(assignment, on: req.db, logger: req.logger, now: now)
     _ = try await closeAssignmentIfExpired(assignment, on: req.db, logger: req.logger, now: now)
 
     // Preview is open for course staff and closed for students — handled

--- a/Tests/APITests/AssignmentRoutesDashboardTests.swift
+++ b/Tests/APITests/AssignmentRoutesDashboardTests.swift
@@ -136,6 +136,41 @@ import VaporTesting
         }
     }
 
+    /// Regression for the Lab 6 incident: the periodic sweep is the only thing
+    /// that publishes a scheduled assignment, so if it silently isn't running
+    /// (dead task, lease wedged), a `.preview` lab never opens and students are
+    /// locked out with no error anywhere. The submission gate now repairs the
+    /// state lazily — the mirror of the lazy deadline close it has always done —
+    /// so a student following a direct link gets in once the open date arrives.
+    @Test func submissionGateLazilyOpensScheduledAssignment() async throws {
+        try await withAssignmentRoutesApp { app in
+            let courseID = try await app.testCourseID(enrollmentMode: .auto)
+            _ = try await arInsertSetup(id: "setup_lazy_open", on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_lazy_open", title: "Lazy open",
+                isOpen: false,
+                dueAt: Date().addingTimeInterval(86_400),
+                startsAt: Date().addingTimeInterval(-60),
+                validationStatus: "passed", on: app
+            )
+            assignment.visibility = .preview
+            try await assignment.save(on: app.db)
+
+            let student = try await arInsertStudent(username: "lazy_open_student", on: app)
+            try await makeTestEnrollment(on: app, userID: student.requireID(), courseID: courseID)
+
+            // No periodic sweep runs in tests — the gate itself must open it.
+            let req = Request(application: app, on: app.eventLoopGroup.any())
+            let gated = try await requireOpenStudentAssignment(
+                for: "setup_lazy_open", user: student, on: req)
+            #expect(gated != nil, "The gate must let the student in once the open date has arrived")
+
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(reloaded.visibility == .open, "The gate lazily publishes the scheduled assignment")
+            #expect(reloaded.startsAt == nil, "Open date is consumed once it fires")
+        }
+    }
+
     @Test func openSweepDoesNotReopenAfterScheduleConsumed() async throws {
         try await withAssignmentRoutesApp { app in
             // Mirrors the state after auto-open + a manual close: isOpen false,

--- a/Tests/APITests/MCP/MCPLeastPrivilegeGrantSyncTests.swift
+++ b/Tests/APITests/MCP/MCPLeastPrivilegeGrantSyncTests.swift
@@ -1,0 +1,71 @@
+// Keeps deploy/sql/mcp-least-privilege-role.sql in sync with the tables the
+// MCP read path actually touches.
+//
+// The least-privilege `chickadee_mcp` Postgres role is deny-by-omission: any
+// table the MCP tools read must carry an explicit GRANT in that file, or every
+// affected tool call fails in production with "permission denied" — invisible
+// to the SQLite/owner-role test runs. That is exactly how #1176's
+// `result_collections` side table broke `get_validation_result` (the grants
+// file predated the table). This suite fails the build when a table read
+// through `MCPStudentDataBoundary` (or its blob side table) is missing a
+// SELECT grant or its row-level-security policy.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct MCPLeastPrivilegeGrantSyncTests {
+    /// `deploy/sql/mcp-least-privilege-role.sql`, resolved from this test
+    /// file's location (same technique as MCPStudentDataWallTests).
+    private static var grantsFile: URL {
+        var url = URL(fileURLWithPath: #filePath)  // .../Tests/APITests/MCP/<thisFile>
+        for _ in 0..<4 { url.deleteLastPathComponent() }  // -> repo root
+        return url.appendingPathComponent("deploy/sql/mcp-least-privilege-role.sql")
+    }
+
+    /// Student-data tables the MCP read path queries: the two the boundary
+    /// accessors filter to validation rows, plus the collection-blob side
+    /// table `loadCollectionJSON` joins in. Grown deliberately by hand — a new
+    /// table here must come with a grant AND an RLS policy in the SQL file.
+    private static let readTables: [String] = [
+        APISubmission.schema,
+        APIResult.schema,
+        APIResultCollection.schema,
+    ]
+
+    @Test func everyMCPReadTableHasSelectGrant() throws {
+        let sql = try String(contentsOf: Self.grantsFile, encoding: .utf8)
+        // Collapse whitespace so multi-line GRANT statements parse the same.
+        let flat = sql.replacingOccurrences(
+            of: "\\s+", with: " ", options: .regularExpression)
+
+        let grantedTables =
+            flat
+            .components(separatedBy: "GRANT SELECT ON ")
+            .dropFirst()
+            .compactMap { $0.components(separatedBy: " TO chickadee_mcp").first }
+            .flatMap { $0.components(separatedBy: ",") }
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+
+        for table in Self.readTables {
+            #expect(
+                grantedTables.contains(table),
+                "\(table) is read by the MCP tool surface but has no SELECT grant in deploy/sql/mcp-least-privilege-role.sql — every call reading it will fail in production with a permission-denied the tests cannot see"
+            )
+        }
+    }
+
+    @Test func everyMCPReadTableHasRowLevelSecurityPolicy() throws {
+        let sql = try String(contentsOf: Self.grantsFile, encoding: .utf8)
+        for table in Self.readTables {
+            #expect(
+                sql.contains("ALTER TABLE \(table) ENABLE ROW LEVEL SECURITY"),
+                "\(table) is granted to chickadee_mcp but has no RLS enablement — the role would see student rows, defeating the student-data wall"
+            )
+            #expect(
+                sql.contains("ON \(table)\n    FOR SELECT TO chickadee_mcp"),
+                "\(table) has no SELECT policy for chickadee_mcp in the grants file")
+        }
+    }
+}

--- a/Tests/APITests/MCP/UpdateNotebookToolTests.swift
+++ b/Tests/APITests/MCP/UpdateNotebookToolTests.swift
@@ -86,6 +86,63 @@ import Vapor
         }
     }
 
+    /// Regression: an MCP content edit must re-enqueue validation even though
+    /// the request carries no session `APIUser` (bearer auth only). Pre-fix,
+    /// `scheduleValidationAfterSuiteEdit` fell back to `req.auth.require(...)`,
+    /// threw 401 inside its swallow-all catch, and the edit silently kept the
+    /// assignment's stale validationStatus with no validation enqueued.
+    @Test func enqueuesValidationWithoutSessionUser() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let tester = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "tester").first())
+
+            // An active compatible runner, so the availability pre-check passes
+            // and the flow reaches the enqueue (where the 401 used to fire).
+            let profile = RunnerProfile()
+            profile.runnerID = "runner-mcp-validation"
+            profile.displayName = "Runner MCP Validation"
+            profile.platform = "linux"
+            profile.architecture = "x86_64"
+            profile.languageVersionsJSON = "[]"
+            profile.capabilitiesJSON = "[]"
+            profile.lastRegisteredAt = Date()
+            profile.lastSeenAt = Date().addingTimeInterval(3600)
+            profile.isActive = true
+            try await profile.save(on: app.db)
+
+            // A prior (complete) validation submission provides the solution
+            // notebook `scheduleValidationAfterSuiteEdit` re-validates with.
+            try await makeTestSubmission(
+                on: app, id: "sub_nb_prior_validation", setupID: "setup_nb",
+                userID: tester.requireID(), kind: APISubmission.Kind.validation,
+                filename: "solution.ipynb")
+            assignment.validationSubmissionID = "sub_nb_prior_validation"
+            try await assignment.save(on: app.db)
+
+            let output = try await UpdateNotebookTool().execute(
+                UpdateNotebookTool.Input(
+                    assignmentPublicID: assignment.publicID, notebook: try json(twoCellNotebook)),
+                context(app))
+
+            #expect(output.validationStatus == "pending")
+
+            let enqueued = try await APISubmission.query(on: app.db)
+                .filter(\.$testSetupID == "setup_nb")
+                .filter(\.$kind == APISubmission.Kind.validation)
+                .filter(\.$status == "pending")
+                .first()
+            let pending = try #require(
+                enqueued, "The notebook edit must enqueue a fresh validation submission")
+            #expect(pending.userID == tester.id, "The validation is attributed to the acting subject")
+
+            let after = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(after.validationStatus == "pending")
+            #expect(after.validationSubmissionID == pending.id)
+        }
+    }
+
     @Test func rejectsNonObjectNotebook() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/WebRoutesIndexTests.swift
+++ b/Tests/APITests/WebRoutesIndexTests.swift
@@ -50,6 +50,43 @@ import VaporTesting
         }
     }
 
+    /// Regression for the Lab 6 incident: a `.preview` assignment whose
+    /// scheduled open date has arrived (validation passed) must be published by
+    /// the dashboard load itself — the lazy safety net under the periodic
+    /// sweep. Pre-fix, a dead sweep meant the lab stayed staff-only preview
+    /// forever and every dashboard load just observed the stuck state.
+    @Test func indexLazilyOpensScheduledAssignment() async throws {
+        try await withWebRoutesApp { app in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let user = try await wrStudentUser(on: app)
+            try await wrEnrollUser(user, on: app)
+            try await wrInsertSetup(id: "setup_sched_open", on: app)
+            let assignment = try await wrInsertAssignment(
+                testSetupID: "setup_sched_open", title: "Scheduled Lab", isOpen: false,
+                dueAt: Date().addingTimeInterval(86_400), on: app)
+            assignment.visibility = .preview
+            assignment.startsAt = Date().addingTimeInterval(-60)
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: app.db)
+
+            try await app.asyncTest(
+                .GET, "/",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    // The dashboard load repaired the missed scheduled open, so
+                    // the student sees the lab on this very render.
+                    #expect(res.body.string.contains("Scheduled Lab"))
+                })
+
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(reloaded.visibility == .open, "Dashboard load publishes a due scheduled assignment")
+            #expect(reloaded.startsAt == nil, "Open date is consumed once it fires")
+        }
+    }
+
     @Test func indexShowsOpenAssignmentForStudent() async throws {
         try await withWebRoutesApp { app in
             let cookie = try await wrLoginAsStudent(on: app)

--- a/changelog.d/mcp-validation-fixes.md
+++ b/changelog.d/mcp-validation-fixes.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **MCP content edits re-enqueue validation again.** `finalizeContentEdit` now
+  passes the acting subject's user id into `scheduleValidationAfterSuiteEdit`;
+  previously the helper fell back to the session user, threw 401 inside its
+  swallow-all catch on bearer-authenticated MCP requests, and every MCP
+  notebook/suite edit silently skipped re-validation (the tool response
+  reported the stale `validationStatus`).
+- **`get_validation_result` works under the least-privilege MCP role.**
+  `deploy/sql/mcp-least-privilege-role.sql` now grants `chickadee_mcp` SELECT
+  on the `result_collections` side table (with a validation-only RLS policy)
+  — the table #1176 moved the collection blob into, after the grants file was
+  written, so every call failed with an opaque `-32603` on deployments using
+  the role. Operators must re-run section 4 of that file. A new
+  grant-sync test fails the build if a table the MCP read path touches is
+  ever missing a grant again.
+- **Opaque MCP tool failures are now diagnosable.** Both MCP dispatchers log
+  the underlying error before answering a bare `-32603` internal error, and
+  `get_validation_result` maps database failures to a structured
+  `executionFailed` result so the agent sees the reason.
+- **Scheduled assignment opens are hardened (the Lab 6 incident).** A
+  `.preview`/`.closed` assignment whose open date has arrived is now also
+  published lazily by the dashboard load and the submission gate — the same
+  safety-net treatment deadline *closes* have always had — so a stalled
+  periodic sweep can no longer leave a lab staff-only past its open time.
+  When the sweep refuses to open an overdue-scheduled assignment because
+  validation has not passed, it now logs a warning every tick instead of
+  skipping silently.

--- a/deploy/sql/mcp-least-privilege-role.sql
+++ b/deploy/sql/mcp-least-privilege-role.sql
@@ -47,7 +47,14 @@ GRANT SELECT ON users, course_enrollments TO chickadee_mcp;
 --    MCP query forgot the in-app kind filter, the database returns no student
 --    rows. The table owner (the main app role) bypasses RLS, so the web app and
 --    worker are unaffected.
-GRANT SELECT ON submissions, results TO chickadee_mcp;
+--
+--    result_collections (added by #1176, v0.4.587) holds the serialized
+--    TestOutcomeCollection blob that used to live on results.collection_json;
+--    get_validation_result reads it via loadCollectionJSON. Deployments that
+--    applied this file before v0.4.611 must re-run this section: without the
+--    grant, every get_validation_result call fails with "permission denied for
+--    table result_collections".
+GRANT SELECT ON submissions, results, result_collections TO chickadee_mcp;
 
 ALTER TABLE submissions ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS mcp_validation_submissions ON submissions;
@@ -62,6 +69,16 @@ CREATE POLICY mcp_validation_results ON results
     USING (EXISTS (
         SELECT 1 FROM submissions s
         WHERE s.id = results.submission_id AND s.kind = 'validation'
+    ));
+
+ALTER TABLE result_collections ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS mcp_validation_result_collections ON result_collections;
+CREATE POLICY mcp_validation_result_collections ON result_collections
+    FOR SELECT TO chickadee_mcp
+    USING (EXISTS (
+        SELECT 1 FROM results r
+        JOIN submissions s ON s.id = r.submission_id
+        WHERE r.id = result_collections.result_id AND s.kind = 'validation'
     ));
 
 -- 5. Everything else is DENIED by omission — no GRANT is issued, so the role


### PR DESCRIPTION
Three production bugs surfaced by the Lab 7 pre-open audit, all fixed with regression tests.

## 1. MCP content edits silently skipped re-validation

`finalizeContentEdit` called `scheduleValidationAfterSuiteEdit` without a submitter. That helper's fallback is `req.auth.require(APIUser.self)`, which throws `Abort.401` on bearer-authenticated MCP requests (no session user) — and the helper's swallow-all `catch` reduced it to a single log line (`scheduleValidationAfterSuiteEdit: Abort.401: Unauthorized`, observed in the production ring buffer). Every MCP notebook/suite edit therefore kept a stale `validationStatus` and enqueued no validation.

**Fix:** the helper takes an explicit `submitterUserID` (web callers unchanged), and `finalizeContentEdit` passes the acting subject — the same pattern `update_solution` already used, which is why that one tool worked.

**Test:** `UpdateNotebookToolTests.enqueuesValidationWithoutSessionUser` — a bare bearer-style `ToolContext` with an active runner must leave the assignment `pending` with a fresh validation submission attributed to the acting subject.

## 2. `get_validation_result` failed with an unlogged -32603 on every call

`deploy/sql/mcp-least-privilege-role.sql` predates #1176, which moved the collection blob into the `result_collections` side table — so the `chickadee_mcp` role gets *permission denied* on `loadCollectionJSON` for every assignment, invisible to tests (SQLite / owner role).

**Fixes:**
- The grants file now covers `result_collections` (SELECT + validation-only RLS policy joining through `results` → `submissions`).
- `MCPLeastPrivilegeGrantSyncTests` pins every table the MCP read path touches to a grant + RLS policy in that file, so the next side-table migration can't silently repeat this.
- Both MCP dispatchers log the underlying error before answering a bare `-32603` (the failure was previously swallowed with no trace anywhere).
- `get_validation_result` maps database failures to a structured `executionFailed` so the agent sees the reason.

**Operator step after merge:** re-run section 4 of `deploy/sql/mcp-least-privilege-role.sql` against the production database (the new `GRANT` + `CREATE POLICY` for `result_collections`).

## 3. Scheduled opens had no safety net (the Lab 6 incident)

Deadline *closes* are enforced lazily on student access, but a `.preview`/`.closed` assignment whose `startsAt` arrived was published **only** by the periodic sweep — and the sweep's validation-status refusal was completely silent, so a lab stuck in preview past its open time produced no signal anywhere. (A live probe confirmed the deployed sweep itself runs and publishes preview→open correctly, so the hardening targets the silent-refusal and dead-sweep failure modes.)

**Fixes:**
- The student dashboard load and the submission gate now repair a missed scheduled open in place (row-wise, in-memory guards short-circuit, so no extra writes unless an open is actually due) — the exact mirror of the lazy deadline close.
- `openScheduledAssignment` logs a warning on every tick an overdue scheduled open is blocked by validation status, instead of skipping silently.
- Stale `startsAt` doc comment on `APIAssignment` corrected ("gated live, no background job" predated the sweep).

**Tests:** `WebRoutesIndexTests.indexLazilyOpensScheduledAssignment` (dashboard publishes a due preview assignment and renders it to the student on that same load) and `AssignmentRoutesDashboardTests.submissionGateLazilyOpensScheduledAssignment` (direct-link path).

---

All 56 tests across the 7 affected suites pass locally; `swift-format` and `scripts/lint.sh` are clean. SwiftLint could not run locally (binary artifact blocked by the sandbox proxy) — relying on the CI `format-lint` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YY1u8i6i5CFvb1jVwDzHHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01YY1u8i6i5CFvb1jVwDzHHW)_