### PR TITLE
Issue-review cleanups: stale per-student kind messages (#814) + renderer type-check dedup (#497)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -972,8 +972,10 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
   generated script is byte-identical across students (cache + `spec_hash`
   unchanged); only the resolved-values map differs.  Authorable via the browser
   editor (type `$name` in an arg/Expected cell) and MCP (`update_pattern_family`
-  `expectedVarRef`); `preview_personalization` audits the refs.  Restricted to
-  `boundary_equality` families for now.  Doc:
+  `expectedVarRef`); `preview_personalization` audits the refs.  Supported in
+  the equality kinds (`boundary_equality`, `approximate_equality`,
+  `unordered_equality` — the `kindSupportsPerStudentRefs` allowlist in
+  `PatternFamilyValidator.swift`).  Doc:
   `docs/personalization-pattern-families.md`.
 
 - **Notebook checks, BrightSpace grade sync, AppScan/security hardening,
@@ -1108,8 +1110,8 @@ Per-version detail in `CHANGELOG.md`; the arcs a fresh session should know:
   (Render tests catch this — they prove templates *resolve*; they don't
   exercise page JS, so a JS-driven widget still wants a manual check.)
 - **Feature backlog:** continued personalization / notebook-check
-  expansion (e.g. per-student refs in pattern kinds beyond
-  `boundary_equality`); pattern kinds beyond the eight shipped
+  expansion (e.g. per-student refs in pattern kinds beyond the three
+  equality kinds); pattern kinds beyond the eight shipped
   (`boundaryEquality` / `approximateEquality` / `variableEquality` /
   `returnTypeCheck` / `exceptionExpected` / `performanceThreshold` /
   `stdoutEquality` / `unorderedEquality`); multi-provider SSO testing beyond UWaterloo DUO;

--- a/Sources/APIServer/Utilities/NotebookCheckRenderer+Code.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckRenderer+Code.swift
@@ -102,39 +102,6 @@ func defaultVariableExistsLabel(_ check: NotebookCheck) -> String {
     return "`\(name)` is defined"
 }
 
-/// Maps an instructor-typed Python type name to a runtime check
-/// expression against an arbitrary value variable.  Mirrors
-/// `PatternFamilyRenderer.returnTypeCheckExpression` byte-for-byte
-/// (parameterised by the value variable so we don't have to import a
-/// shared helper; the comment at the bottom of this file calls out the
-/// duplication convention).  Builtins use `isinstance` directly; library
-/// types are matched by walking the MRO by class name so we don't have to
-/// import pandas/numpy at the top of the generated test.
-func variableExistsTypeCheckExpression(typeName: String, valueExpr: String) -> String {
-    switch typeName {
-    case "int": return "isinstance(\(valueExpr), int) and not isinstance(\(valueExpr), bool)"
-    case "float": return "isinstance(\(valueExpr), float)"
-    case "bool": return "isinstance(\(valueExpr), bool)"
-    case "str": return "isinstance(\(valueExpr), str)"
-    case "list": return "isinstance(\(valueExpr), list)"
-    case "tuple": return "isinstance(\(valueExpr), tuple)"
-    case "dict": return "isinstance(\(valueExpr), dict)"
-    case "set": return "isinstance(\(valueExpr), set)"
-    case "NoneType": return "\(valueExpr) is None"
-    case "DataFrame":
-        return #"any(getattr(b, "__name__", "") == "DataFrame" for b in type(\#(valueExpr)).__mro__)"#
-    case "Series":
-        return #"any(getattr(b, "__name__", "") == "Series" for b in type(\#(valueExpr)).__mro__)"#
-    case "ndarray":
-        return #"any(getattr(b, "__name__", "") == "ndarray" for b in type(\#(valueExpr)).__mro__)"#
-    default:
-        // Fallback: treat the name as a class to MRO-walk.  Catches
-        // student-defined classes referenced by name and lets new
-        // library types work without a Swift edit.
-        return "any(getattr(b, \"__name__\", \"\") == \"\(typeName)\" for b in type(\(valueExpr)).__mro__)"
-    }
-}
-
 func renderVariableExists(_ check: NotebookCheck, specHash: String) -> String {
     let name = check.variable ?? "variable"
     let label = check.name ?? defaultVariableExistsLabel(check)
@@ -144,7 +111,9 @@ func renderVariableExists(_ check: NotebookCheck, specHash: String) -> String {
     let passMessage: String
     if let typeName = check.expectedType, !typeName.isEmpty {
         let typeNameLiteral = "\"" + escapeForPythonStringLiteral(typeName) + "\""
-        let typeCheckExpr = variableExistsTypeCheckExpression(typeName: typeName, valueExpr: "actual")
+        // Type-name → check-expression mapping is shared with the
+        // pattern-family `.returnTypeCheck` renderer (PythonScriptHelpers.swift).
+        let typeCheckExpr = pythonTypeCheckExpression(typeName: typeName, valueExpr: "actual")
         typeCheck = """
             expected_type_name = \(typeNameLiteral)
             if not (\(typeCheckExpr)):

--- a/Sources/APIServer/Utilities/PatternFamilyRenderer+ReturnTypeCheck.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyRenderer+ReturnTypeCheck.swift
@@ -7,40 +7,6 @@ import Core
 
 // MARK: - returnTypeCheck
 
-/// Maps the instructor-typed type name to a runtime check expression.
-/// For Python builtins, `isinstance(result, <name>)` works directly.  For
-/// pandas / numpy types, the renderer walks the result's class MRO so
-/// the check works without forcing those imports at the top of the
-/// generated test (matters for Pyodide grading where loadPackagesFromImports
-/// drives package availability).
-private func returnTypeCheckExpression(typeName: String) -> String {
-    switch typeName {
-    // Python builtins — straightforward isinstance.
-    case "int": return "isinstance(result, int) and not isinstance(result, bool)"
-    case "float": return "isinstance(result, float)"
-    case "bool": return "isinstance(result, bool)"
-    case "str": return "isinstance(result, str)"
-    case "list": return "isinstance(result, list)"
-    case "tuple": return "isinstance(result, tuple)"
-    case "dict": return "isinstance(result, dict)"
-    case "set": return "isinstance(result, set)"
-    case "NoneType": return "result is None"
-    // Library types — walk the MRO by class name so we don't have to
-    // import the library to do the check.  Same trick as
-    // `is_matplotlib_figure` in notebook_runtime.
-    case "DataFrame":
-        return #"any(getattr(b, "__name__", "") == "DataFrame" for b in type(result).__mro__)"#
-    case "Series":
-        return #"any(getattr(b, "__name__", "") == "Series" for b in type(result).__mro__)"#
-    case "ndarray":
-        return #"any(getattr(b, "__name__", "") == "ndarray" for b in type(result).__mro__)"#
-    default:
-        // Fallback: treat as a class name to MRO-walk.  Catches
-        // student-defined classes referenced by name.
-        return "any(getattr(b, \"__name__\", \"\") == \"\(typeName)\" for b in type(result).__mro__)"
-    }
-}
-
 func renderReturnTypeCheck(
     family: PatternFamily,
     case c: PatternCase,
@@ -55,7 +21,9 @@ func renderReturnTypeCheck(
         return "object"
     }()
     let typeNameLiteral = "\"" + escapeForPythonStringLiteral(typeName) + "\""
-    let typeCheckExpr = returnTypeCheckExpression(typeName: typeName)
+    // Type-name → check-expression mapping is shared with the notebook-check
+    // `.variableExists` renderer (PythonScriptHelpers.swift).
+    let typeCheckExpr = pythonTypeCheckExpression(typeName: typeName, valueExpr: "result")
 
     let variableDecls = combinedVariableDecls(sectionVariables: sectionVariables, family: family)
     let variableBlock = variableDecls.isEmpty ? "" : variableDecls + "\n\n"

--- a/Sources/APIServer/Utilities/PatternFamilyValidator.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyValidator.swift
@@ -105,12 +105,12 @@ private func validateFamilyVariablesAndArgRefs(
                 throw Abort(
                     .unprocessableEntity,
                     reason:
-                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in boundary_equality and approximate_equality families for now."
+                        "Pattern family '\(family.id)': case '\(c.key)' references per-student input '$\(ref)', which is only supported in \(perStudentCapableKindsDescription) families for now."
                 )
             }
         }
         // A per-student expected ref must name a declared `=` expression and
-        // is (for now) supported only in the equality kinds (boundary/approximate).
+        // is (for now) supported only in the equality kinds.
         if let eref = c.expectedVarRef {
             guard perStudentExpressionNames.contains(eref) else {
                 throw Abort(
@@ -123,7 +123,7 @@ private func validateFamilyVariablesAndArgRefs(
                 throw Abort(
                     .unprocessableEntity,
                     reason:
-                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in boundary_equality and approximate_equality families for now."
+                        "Pattern family '\(family.id)': case '\(c.key)' uses a per-student expected, which is only supported in \(perStudentCapableKindsDescription) families for now."
                 )
             }
         }
@@ -133,7 +133,8 @@ private func validateFamilyVariablesAndArgRefs(
 /// Whether a kind's generated cases bind per-student `_ck_inputs` (so `$name`
 /// arg refs and `expectedVarRef` resolve at grading time).  Extend as renderers
 /// gain the personalization preamble (`personalizationPreambleForCase`).  An
-/// exhaustive switch — a new `PatternKind` must opt in or out here explicitly.
+/// exhaustive switch — a new `PatternKind` must opt in or out here explicitly,
+/// and `perStudentCapableKindsDescription` below must name the same set.
 private func kindSupportsPerStudentRefs(_ kind: PatternKind) -> Bool {
     switch kind {
     case .boundaryEquality, .approximateEquality, .unorderedEquality: return true
@@ -142,6 +143,11 @@ private func kindSupportsPerStudentRefs(_ kind: PatternKind) -> Bool {
         return false
     }
 }
+
+/// Human-readable list of the kinds `kindSupportsPerStudentRefs` allows, for
+/// validation error messages.  Keep in lockstep with the switch above.
+private let perStudentCapableKindsDescription =
+    "boundary_equality, approximate_equality, and unordered_equality"
 
 /// Validates the family `id`, `functionName`, and `paramNames` fields
 /// — the structural header of one `PatternFamily` before its cases are

--- a/Sources/APIServer/Utilities/PythonScriptHelpers.swift
+++ b/Sources/APIServer/Utilities/PythonScriptHelpers.swift
@@ -39,3 +39,37 @@ func tierFilenamePrefix(_ tier: TestTier) -> String {
     case .secret: return "secret"
     }
 }
+
+/// Maps an instructor-typed Python type name to a runtime type-check
+/// expression against `valueExpr`.  Python builtins use `isinstance`
+/// directly (`int` also rejects `bool`, which is an `int` subclass in
+/// Python); pandas / numpy types and unknown names are matched by walking
+/// the value's class MRO by name, so the generated test never imports the
+/// library itself (matters for Pyodide grading, where
+/// loadPackagesFromImports drives package availability).  Shared by the
+/// pattern-family `.returnTypeCheck` renderer (`valueExpr` "result") and
+/// the notebook-check `.variableExists` renderer (`valueExpr` "actual").
+func pythonTypeCheckExpression(typeName: String, valueExpr: String) -> String {
+    switch typeName {
+    case "int": return "isinstance(\(valueExpr), int) and not isinstance(\(valueExpr), bool)"
+    case "float": return "isinstance(\(valueExpr), float)"
+    case "bool": return "isinstance(\(valueExpr), bool)"
+    case "str": return "isinstance(\(valueExpr), str)"
+    case "list": return "isinstance(\(valueExpr), list)"
+    case "tuple": return "isinstance(\(valueExpr), tuple)"
+    case "dict": return "isinstance(\(valueExpr), dict)"
+    case "set": return "isinstance(\(valueExpr), set)"
+    case "NoneType": return "\(valueExpr) is None"
+    case "DataFrame":
+        return #"any(getattr(b, "__name__", "") == "DataFrame" for b in type(\#(valueExpr)).__mro__)"#
+    case "Series":
+        return #"any(getattr(b, "__name__", "") == "Series" for b in type(\#(valueExpr)).__mro__)"#
+    case "ndarray":
+        return #"any(getattr(b, "__name__", "") == "ndarray" for b in type(\#(valueExpr)).__mro__)"#
+    default:
+        // Fallback: treat the name as a class to MRO-walk.  Catches
+        // student-defined classes referenced by name and lets new
+        // library types work without a Swift edit.
+        return "any(getattr(b, \"__name__\", \"\") == \"\(typeName)\" for b in type(\(valueExpr)).__mro__)"
+    }
+}

--- a/Tests/APITests/PatternFamilyRendererTests.swift
+++ b/Tests/APITests/PatternFamilyRendererTests.swift
@@ -537,7 +537,7 @@ import Vapor
 
     @Test func validation_rejectsPerStudentRefOnUnsupportedKind() throws {
         // performance_threshold has no personalization preamble, so a per-student
-        // arg ref is still rejected (boundary + approximate are the supported set).
+        // arg ref is still rejected (the equality kinds are the supported set).
         let c = PatternCase(
             key: "01", label: "X", args: [.null], expected: .double(100.0),
             argVarRefs: ["patients"])
@@ -548,7 +548,10 @@ import Vapor
             try validatePatternFamilies(
                 [family], testSuites: [], perStudentExpressionNames: ["patients"])
         } throws: { error in
-            #expect("\(error)".contains("only supported in boundary_equality and approximate_equality"))
+            #expect(
+                "\(error)".contains(
+                    "only supported in boundary_equality, approximate_equality, and unordered_equality"
+                ))
             return true
         }
     }

--- a/changelog.d/personalization-kinds-message.md
+++ b/changelog.d/personalization-kinds-message.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Per-student pattern-family validation messages name the full supported
+  set.** The validator's error for a per-student `$name` / `expectedVarRef`
+  on an unsupported kind still claimed only `boundary_equality` and
+  `approximate_equality` were allowed; `unordered_equality` gained the
+  personalization preamble but the messages (and docs) were never updated.
+  The messages now derive from a single description constant kept next to
+  the `kindSupportsPerStudentRefs` allowlist, and the design doc / CLAUDE.md
+  status notes for #814 were refreshed (both previously-listed follow-ups —
+  `expectedVarRef` on the `get_suite` DTO and the `preview_personalization`
+  test-script audit — had already shipped).

--- a/changelog.d/renderer-typecheck-dedup.md
+++ b/changelog.d/renderer-typecheck-dedup.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **Type-check expression rendering deduplicated (#497).** The
+  byte-for-byte duplicate type-name → check-expression mappings in the
+  pattern-family `.returnTypeCheck` renderer and the notebook-check
+  `.variableExists` renderer are now one shared
+  `pythonTypeCheckExpression(typeName:valueExpr:)` helper in
+  `PythonScriptHelpers.swift`, alongside the helpers extracted in
+  v0.4.170. Generated script bytes are unchanged, so `spec_hash` and
+  `TestSetupCache` keys are stable. This was the last tracked item on
+  #497.

--- a/docs/personalization-pattern-families.md
+++ b/docs/personalization-pattern-families.md
@@ -196,9 +196,16 @@ So the feature's strongest wins are for **worker-graded** assignments and for
   expression names (so per-student refs validate + highlight rather than being
   red-flagged), serializes the Expected ref as `expectedVarRef`, and skips
   Pyodide auto-compute for per-student rows — mirroring the existing arg-cell
-  `$name` UX. Follow-ups (not blocking): surfacing `expectedVarRef` on the
-  `get_suite` read DTO, and extending the `preview_personalization` placeholder
-  audit to test scripts.
+  `$name` UX. The two follow-ups originally noted here have both since shipped:
+  `get_suite` returns each case's `expectedVarRef` (the read DTO embeds the
+  full `PatternFamily` spec), and the `preview_personalization` placeholder
+  audit covers test-script refs (`argVarRefs` / `expectedVarRef` on every
+  family case), not just the notebook.
+
+Since the initial `.boundaryEquality`-only MVP, per-student refs have expanded
+to `.approximateEquality` and `.unorderedEquality` — the supported set is the
+`kindSupportsPerStudentRefs` allowlist in `PatternFamilyValidator.swift`
+(the equality kinds; the remaining kinds are future work).
 
 ## Open questions
 


### PR DESCRIPTION
## What

Two small cleanups from tonight's open-issue review sweep.

**Commit 1 — finish the #814 (per-student pattern families) paper trail:**
- **Validator messages named the wrong supported set.** `kindSupportsPerStudentRefs` allows `boundary_equality`, `approximate_equality`, **and** `unordered_equality` (the unordered renderer emits the personalization preamble), but both validation errors — per-student `$name` arg ref and per-student `expectedVarRef` on an unsupported kind — still told instructors only boundary/approximate were allowed. The messages now interpolate a `perStudentCapableKindsDescription` constant declared next to the allowlist switch so the two can't drift apart. Matching test expectation updated.
- **Design-doc follow-ups were already shipped.** `docs/personalization-pattern-families.md` listed two "not blocking" follow-ups that are in fact done on `main`: `get_suite` returns each case's `expectedVarRef` (the read DTO embeds the full `PatternFamily`, whose synthesized encoding includes it), and the `preview_personalization` placeholder audit covers family-case refs (`PreviewPersonalizationTool.swift:184-194`). The doc now records both as shipped, and the CLAUDE.md digest no longer claims per-student families are `boundary_equality`-only.

**Commit 2 — the last item tracked by #497:**
- `returnTypeCheckExpression` (`PatternFamilyRenderer+ReturnTypeCheck.swift`) and `variableExistsTypeCheckExpression` (`NotebookCheckRenderer+Code.swift`) were byte-for-byte copies of the same type-name → Python check-expression mapping, differing only in the value variable. Hoisted the parameterised form to `pythonTypeCheckExpression(typeName:valueExpr:)` in `PythonScriptHelpers.swift` — the same home as the v0.4.170 shared helpers — called from both renderers with `"result"` / `"actual"`.

## Testing

- `swift test --filter "PatternFamilyRendererTests|NotebookCheckVariableExistsTests|NotebookCheckRuntimeStateTests"` — 60/60 pass.
- `swift test --filter PatternFamilyKindsTests` (pins `.returnTypeCheck` rendered output) — 22/22 pass.
- `scripts/lint.sh` clean.
- Rendered script bytes are unchanged in both commits, so `spec_hash` values and `TestSetupCache` keys stay stable.

Closes #497. (#814 already closed — commit 1 is its final paper-trail fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2tUNemXvKk5V2Hmee3V1b