### PR TITLE
Add secret reveal tokens: one per student per assignment

### DIFF
--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -145,6 +145,26 @@
     </div>
 </form>
 
+<!-- ── Student Options ─────────────────────────────────────────────────
+     Per-assignment student-facing policy toggles.  Lives OUTSIDE the
+     multipart Save & Validate form (nested forms are stripped by the
+     browser) and persists via its own lightweight endpoint so a
+     mid-semester flip doesn't close/re-validate the assignment. -->
+<section class="editor-block">
+    <div class="editor-block-head">
+        <h2>Student Options</h2>
+    </div>
+    <form method="post" action="/instructor/#(assignmentID)/secret-reveal">
+        #csrfFormField()
+        <label class="form-label">
+            <input type="checkbox" name="enabled" #if(secretRevealEnabled):checked#endif>
+            Allow each student to spend their one reveal token to see this assignment&rsquo;s secret test results
+        </label>
+        <p class="field-note text-muted">Spending is permanent for the student (staff can re-grant from the submissions page). Revealed secret tests show like public ones — names, output, and hints. Grades are unaffected.</p>
+        <button class="btn action-btn" type="submit">Save</button>
+    </form>
+</section>
+
 <!-- ── Global Inputs (Slice 1 of #461) ─────────────────────────────────
      Assignment-scope named values, inlined at save time everywhere they
      can be referenced: pattern-family case args (`$name`), prepended to

--- a/Resources/Views/assignment-submissions.leaf
+++ b/Resources/Views/assignment-submissions.leaf
@@ -36,7 +36,7 @@
         <tr>
             <td>#(row.surname)</td>
             <td>#(row.givenNames)</td>
-            <td class="col-hide-phone"><strong>#(row.studentID)</strong></td>
+            <td class="col-hide-phone"><strong>#(row.studentID)</strong>#if(secretRevealEnabled):#if(row.secretRevealSpent): <span title="Student spent their secret-reveal token — secret test results are visible to them">🔓</span>#endif#endif</td>
             <td>#(row.gradeText)#if(row.gradeIsOverridden):<span class="grade-override-tag" title="Grade manually overridden by an instructor">overridden</span>#endif</td>
             <td class="col-hide-phone" data-ts="#(row.latestSubmittedAtEpoch)">
                 #if(row.submissionCount > 0):
@@ -95,6 +95,16 @@
                             <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
                         </button>
                     </form>
+                    #if(secretRevealEnabled):#if(row.secretRevealSpent):
+                    <form method="post" action="/instructor/#(assignmentID)/students/#(row.studentUUID)/regrant-reveal-token" onsubmit="return confirm('Re-grant this student’s secret-reveal token? Secret test results will be hidden from them again until they spend it.')" class="form-flush">
+                        #csrfFormField()
+                        <input type="hidden" name="returnTo" value="/instructor/#(assignmentID)/submissions">
+                        <button class="btn action-btn action-btn-tight" type="submit"
+                                aria-label="Re-grant secret-reveal token" title="Re-grant secret-reveal token (student spent theirs)">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/></svg>
+                        </button>
+                    </form>
+                    #endif#endif
                 </div>
             </td>
         </tr>

--- a/Resources/Views/submission.leaf
+++ b/Resources/Views/submission.leaf
@@ -13,6 +13,9 @@ Submission #(submissionID)
 .class-goal-progress { width: 100%; height: 0.6rem; }
 .class-goal-status { font-size: var(--text-base); margin-top: 0.15rem; }
 .class-goal-detail { font-size: var(--text-base); margin: 0.15rem 0 0; }
+.reveal-token-banner { margin: 1rem 0; padding: .75rem; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-muted); font-size: var(--text-base); }
+.reveal-token-offer { margin: 1rem 0; padding: .75rem; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-muted); }
+.reveal-token-text { margin: 0 0 .5rem; font-size: var(--text-base); }
 </style>
 <div id="submission-root"
      data-submission-id="#(submissionID)"
@@ -96,6 +99,22 @@ Submission #(submissionID)
 </div>
 
 #else:
+#if(secretRevealActive):
+<div class="reveal-token-banner">
+    🔓 <strong>Secret tests revealed</strong> — you used your reveal token for this assignment, so hidden-test details are shown on all of your submissions.
+</div>
+#endif
+#if(secretRevealAvailable):
+<div class="reveal-token-offer">
+    <p class="reveal-token-text">You have <strong>one reveal token</strong> for this assignment. Spending it permanently shows the secret (hidden) test results — names, output, and hints — on all of your past and future submissions here.</p>
+    <form method="post" action="/testsetups/#(testSetupID)/reveal-secret"
+          onsubmit="return confirm('Use your one reveal token for this assignment? This permanently reveals the secret test results for all of your submissions on this assignment and cannot be undone.')">
+        #csrfFormField()
+        <input type="hidden" name="submissionID" value="#(submissionID)">
+        <button class="btn action-btn" type="submit">Reveal secret tests</button>
+    </form>
+</div>
+#endif
 #for(sec in sectionedOutcomes):
 <section class="submission-section-block">
     #if(sec.sectionName):

--- a/Sources/APIServer/Helpers/TierFilter.swift
+++ b/Sources/APIServer/Helpers/TierFilter.swift
@@ -10,7 +10,9 @@
 //              they're failing), but the per-test output is hidden until the
 //              deadline passes (or immediately when there is no deadline)
 //   secret   — never itemized; shown to students only as an aggregate pass/fail
-//              count.  Always fully visible to instructors/admins.
+//              count, unless the student has spent their secret-reveal token
+//              on an assignment with the reveal option enabled.  Always fully
+//              visible to instructors/admins.
 
 import Core
 import Foundation
@@ -82,7 +84,9 @@ extension TestOutcomeCollection {
 ///
 /// - Instructors and admins always see all three tiers.
 /// - Students see `public` always, `release` after the deadline passes
-///   (or immediately when there is no deadline), and never `secret`.
+///   (or immediately when there is no deadline), and `secret` only when
+///   `secretRevealed` — the student spent their secret-reveal token on an
+///   assignment whose reveal option is enabled (see `SecretRevealState`).
 ///
 /// `effectiveDueAt` is the deadline that actually applies to the student whose
 /// submission is being viewed — the *later* of the assignment-wide due date and
@@ -94,24 +98,31 @@ extension TestOutcomeCollection {
 /// The student *web* view is more nuanced — it lists release tests by name
 /// before the deadline but redacts their output — so it uses `itemizedTiers`
 /// and `releaseOutputVisible` instead.
-func visibleTiers(isStaff: Bool, effectiveDueAt: Date?, now: Date = Date()) -> Set<String> {
+func visibleTiers(
+    isStaff: Bool, effectiveDueAt: Date?, secretRevealed: Bool, now: Date = Date()
+) -> Set<String> {
     if isStaff {
         return ["public", "release", "secret"]
     }
     // nil effectiveDueAt → no deadline → release is immediately visible.
     let releaseVisible = effectiveDueAt.map { $0 <= now } ?? true
-    return releaseVisible ? ["public", "release"] : ["public"]
+    var tiers: Set<String> = releaseVisible ? ["public", "release"] : ["public"]
+    if secretRevealed {
+        tiers.insert("secret")
+    }
+    return tiers
 }
 
 /// Tiers whose individual test rows are itemized (listed by name) in the
 /// student submission view.  Students always see `public` and `release` rows —
 /// release names are shown even before the deadline so a student knows which
-/// hidden tests they are failing — but `secret` is never itemized.  Instructors
-/// see every tier.  The grade is computed over *all* tiers regardless of this
-/// set, so the number is stable across the deadline; only release *output* is
-/// additionally gated (see `releaseOutputVisible`).
-func itemizedTiers(isStaff: Bool) -> Set<String> {
-    isStaff ? ["public", "release", "secret"] : ["public", "release"]
+/// hidden tests they are failing — but `secret` is only itemized for staff or
+/// for a student who spent their secret-reveal token (`secretRevealed`).  The
+/// grade is computed over *all* tiers regardless of this set, so the number is
+/// stable across the deadline; only release *output* is additionally gated
+/// (see `releaseOutputVisible` — the reveal token does not affect it).
+func itemizedTiers(isStaff: Bool, secretRevealed: Bool) -> Set<String> {
+    (isStaff || secretRevealed) ? ["public", "release", "secret"] : ["public", "release"]
 }
 
 /// Whether release-tier *output* (the result message + stderr/traceback panel)
@@ -137,6 +148,15 @@ func decodedCollection(from collectionJSON: String) -> TestOutcomeCollection? {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
     return try? decoder.decode(TestOutcomeCollection.self, from: data)
+}
+
+/// Whether the manifest contains any secret-tier test.  Pattern-family and
+/// notebook-check cases both materialize into `testSuites` entries at save
+/// time, so scanning the suite list covers every kind.  Gates the student
+/// "spend your reveal token" offer — an assignment with nothing secret has
+/// nothing to reveal.
+func hasSecretTierTests(_ props: TestProperties?) -> Bool {
+    props?.testSuites.contains { $0.tier == .secret } ?? false
 }
 
 func gradePercent(from collection: TestOutcomeCollection) -> Int? {

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -35,7 +35,10 @@ struct GetAssignmentTool: ContentTool {
         let sectionID: String?
         let sectionName: String?
         /// Whether students may spend their one secret-reveal token here to
-        /// see secret-tier test results. Set with update_assignment.
+        /// see secret-tier test results. Set via the assignment-update tool.
+        /// (The write tool's name must not appear in this read tool's
+        /// serialized description: the read-only-mode contract tests assert
+        /// the whole tools/list JSON never contains a write tool's name.)
         let secretRevealEnabled: Bool
     }
 
@@ -48,7 +51,7 @@ struct GetAssignmentTool: ContentTool {
         + "\"browser\" = graded in-browser via Pyodide), the course section (assignment group "
         + "like \"Labs\") it belongs to (sectionID/sectionName, null when ungrouped), and "
         + "secretRevealEnabled (whether students may spend their one secret-reveal token to see "
-        + "secret-tier test results; set with update_assignment)."
+        + "secret-tier test results; set via the assignment-update tool)."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -34,6 +34,9 @@ struct GetAssignmentTool: ContentTool {
         /// belongs to, or nil when ungrouped. Manage with set_assignment_course_section.
         let sectionID: String?
         let sectionName: String?
+        /// Whether students may spend their one secret-reveal token here to
+        /// see secret-tier test results. Set with update_assignment.
+        let secretRevealEnabled: Bool
     }
 
     static let name = "get_assignment"
@@ -42,8 +45,10 @@ struct GetAssignmentTool: ContentTool {
         + "visibility (closed/preview/open; preview is a staff-only beta state), the "
         + "derived isOpen flag, due date (ISO 8601), scheduled open date (ISO 8601, if any), "
         + "runner validation status, gradingMode (\"worker\" = graded by the native runner, "
-        + "\"browser\" = graded in-browser via Pyodide), and the course section (assignment group "
-        + "like \"Labs\") it belongs to (sectionID/sectionName, null when ungrouped)."
+        + "\"browser\" = graded in-browser via Pyodide), the course section (assignment group "
+        + "like \"Labs\") it belongs to (sectionID/sectionName, null when ungrouped), and "
+        + "secretRevealEnabled (whether students may spend their one secret-reveal token to see "
+        + "secret-tier test results; set with update_assignment)."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -71,11 +76,12 @@ struct GetAssignmentTool: ContentTool {
             "gradingMode": MCPSchema.string,
             "sectionID": MCPSchema.string,
             "sectionName": MCPSchema.string,
+            "secretRevealEnabled": MCPSchema.boolean,
         ]),
         "required": .array([
             .string("publicID"), .string("title"), .string("slug"), .string("courseCode"),
             .string("isOpen"), .string("visibility"), .string("deadlineOverrideActive"),
-            .string("gradingMode"),
+            .string("gradingMode"), .string("secretRevealEnabled"),
         ]),
     ])
     static let requiredScopes: Set<ContentScope> = [.read]
@@ -113,7 +119,8 @@ struct GetAssignmentTool: ContentTool {
             deadlineOverrideActive: assignment.deadlineOverrideActive ?? false,
             gradingMode: gradingMode,
             sectionID: assignment.sectionID?.uuidString,
-            sectionName: sectionName
+            sectionName: sectionName,
+            secretRevealEnabled: assignment.secretRevealEnabled == true
         )
     }
 }

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -18,10 +18,12 @@ struct UpdateAssignmentTool: ContentTool {
         let startsAt: String?
         let isOpen: Bool?
         let visibility: String?
+        let secretRevealEnabled: Bool?
 
         init(
             assignmentPublicID: String, title: String? = nil, dueAt: String? = nil,
-            startsAt: String? = nil, isOpen: Bool? = nil, visibility: String? = nil
+            startsAt: String? = nil, isOpen: Bool? = nil, visibility: String? = nil,
+            secretRevealEnabled: Bool? = nil
         ) {
             self.assignmentPublicID = assignmentPublicID
             self.title = title
@@ -29,6 +31,7 @@ struct UpdateAssignmentTool: ContentTool {
             self.startsAt = startsAt
             self.isOpen = isOpen
             self.visibility = visibility
+            self.secretRevealEnabled = secretRevealEnabled
         }
     }
 
@@ -42,6 +45,8 @@ struct UpdateAssignmentTool: ContentTool {
         let dueAt: String?
         let startsAt: String?
         let validationStatus: String?
+        /// Whether students may spend their one secret-reveal token here.
+        let secretRevealEnabled: Bool
     }
 
     static let name = "update_assignment"
@@ -55,7 +60,11 @@ struct UpdateAssignmentTool: ContentTool {
         + "visibility is the three-state form of isOpen and wins if both are given: \"preview\" is a "
         + "staff-only state where course staff see and use the assignment exactly like open while "
         + "students see it as closed. Switching to preview is a pure visibility change (no validation, "
-        + "no close); only opening to students is refused until validation passes. Does not change "
+        + "no close); only opening to students is refused until validation passes. "
+        + "secretRevealEnabled (true/false) controls the secret-reveal token: when true, each student "
+        + "may permanently spend their one token on this assignment to see secret-tier test results "
+        + "(itemized like public tests) on all of their submissions; false (the default) keeps secret "
+        + "results hidden. Display-only — grades are unaffected. Does not change "
         + "test content, so it never triggers a regrade."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
@@ -89,6 +98,14 @@ struct UpdateAssignmentTool: ContentTool {
                     "Three-state visibility. \"preview\" is a staff-only beta state. Wins over "
                         + "isOpen if both are given. open → preview is refused (close first)."),
             ]),
+            "secretRevealEnabled": .object([
+                "type": .string("boolean"),
+                "description": .string(
+                    "true to let each student spend their one secret-reveal token on this "
+                        + "assignment (permanently revealing secret-tier test results across all "
+                        + "their submissions); false (the default) keeps secret results hidden. "
+                        + "Display-only — grades are unaffected."),
+            ]),
         ]),
         "required": .array([.string("assignmentPublicID")]),
         "additionalProperties": .bool(false),
@@ -107,10 +124,11 @@ struct UpdateAssignmentTool: ContentTool {
             "dueAt": MCPSchema.string,
             "startsAt": MCPSchema.string,
             "validationStatus": MCPSchema.string,
+            "secretRevealEnabled": MCPSchema.boolean,
         ]),
         "required": .array([
             .string("publicID"), .string("title"), .string("slug"), .string("isOpen"),
-            .string("visibility"),
+            .string("visibility"), .string("secretRevealEnabled"),
         ]),
     ])
     static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
@@ -125,9 +143,12 @@ struct UpdateAssignmentTool: ContentTool {
         guard
             newTitle != nil || input.isOpen != nil || visibilityUpdate != nil
                 || dueUpdate != .unchanged || startsUpdate != .unchanged
+                || input.secretRevealEnabled != nil
         else {
             throw MCPToolError.invalidArguments(
-                tool: Self.name, detail: "Specify at least one of: title, dueAt, startsAt, isOpen, visibility.")
+                tool: Self.name,
+                detail: "Specify at least one of: title, dueAt, startsAt, isOpen, visibility, "
+                    + "secretRevealEnabled.")
         }
 
         // Title / due date / open state are lifecycle — instructor-level (#417).
@@ -139,7 +160,8 @@ struct UpdateAssignmentTool: ContentTool {
             // wins).
             try await AssignmentAuthoringService.updateMetadata(
                 assignment, title: newTitle, dueAt: dueUpdate, startsAt: startsUpdate,
-                open: visibilityUpdate == nil ? input.isOpen : nil, on: context.db)
+                open: visibilityUpdate == nil ? input.isOpen : nil,
+                secretRevealEnabled: input.secretRevealEnabled, on: context.db)
             if let visibilityUpdate {
                 try await AssignmentAuthoringService.setVisibility(
                     assignment, visibilityUpdate, on: context.db)
@@ -159,7 +181,8 @@ struct UpdateAssignmentTool: ContentTool {
             visibility: assignment.visibility.rawValue,
             dueAt: assignment.dueAt.map { formatter.string(from: $0) },
             startsAt: assignment.startsAt.map { formatter.string(from: $0) },
-            validationStatus: assignment.validationStatus
+            validationStatus: assignment.validationStatus,
+            secretRevealEnabled: assignment.secretRevealEnabled == true
         )
     }
 

--- a/Sources/APIServer/Migrations/AddAssignmentSecretRevealEnabled.swift
+++ b/Sources/APIServer/Migrations/AddAssignmentSecretRevealEnabled.swift
@@ -1,0 +1,28 @@
+// APIServer/Migrations/AddAssignmentSecretRevealEnabled.swift
+//
+// Adds the optional `secret_reveal_enabled` column to the assignments table:
+// the per-assignment instructor toggle that lets each student spend their one
+// secret-reveal token to see secret-tier test results. nil/false = off (the
+// default) — secret results stay aggregate-only for students.
+//
+// Shipped as a standalone Add* migration (not folded into CreateAssignments)
+// for the same reason as AddAssignmentStartsAt: production databases have
+// already applied CreateAssignments without this column and would never pick
+// it up from a body change. Fresh deploys run CreateAssignments then this
+// migration; existing prod runs only this one.
+
+import Fluent
+
+struct AddAssignmentSecretRevealEnabled: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignments")
+            .field("secret_reveal_enabled", .bool)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("assignments")
+            .deleteField("secret_reveal_enabled")
+            .update()
+    }
+}

--- a/Sources/APIServer/Migrations/CreateSecretRevealUnlocks.swift
+++ b/Sources/APIServer/Migrations/CreateSecretRevealUnlocks.swift
@@ -1,0 +1,35 @@
+// APIServer/Migrations/CreateSecretRevealUnlocks.swift
+//
+// Secret-reveal token spends: one row per (user, assignment) recording that
+// the student cashed in their one reveal token, unlocking itemized secret-tier
+// results on all of their submissions for that assignment. Row existence is
+// the spent state; staff re-grant by deleting the row. Cascade-deletes follow
+// the parent user / assignment.
+
+import Fluent
+
+struct CreateSecretRevealUnlocks: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("secret_reveal_unlocks")
+            .id()
+            .field(
+                "user_id",
+                .uuid,
+                .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field(
+                "assignment_id",
+                .uuid,
+                .required,
+                .references("assignments", "id", onDelete: .cascade)
+            )
+            .field("spent_at", .datetime)
+            .unique(on: "user_id", "assignment_id")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("secret_reveal_unlocks").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignment.swift
+++ b/Sources/APIServer/Models/APIAssignment.swift
@@ -103,6 +103,12 @@ final class APIAssignment: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_sync_excluded")
     var brightspaceSyncExcluded: Bool?
 
+    /// When true, students may spend their one secret-reveal token on this
+    /// assignment to see secret-tier test results itemized. nil/false = off
+    /// (the default): secret results stay aggregate-only for students.
+    @OptionalField(key: "secret_reveal_enabled")
+    var secretRevealEnabled: Bool?
+
     /// The course this assignment belongs to.
     @Field(key: "course_id")
     var courseID: UUID

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -126,6 +126,11 @@ enum AuditAction: String, Sendable, CaseIterable {
     case gradeOverrideSet = "grade_override.set"
     case gradeOverrideCleared = "grade_override.cleared"
 
+    // Secret reveal tokens
+    case secretRevealSpent = "secret_reveal.spent"
+    case secretRevealRegranted = "secret_reveal.regranted"
+    case secretRevealToggled = "secret_reveal.toggle_changed"
+
     // Runner / worker
     case runnerSecretRotated = "runner.secret_rotated"
     case runnerAutostartChanged = "runner.autostart_changed"
@@ -172,7 +177,8 @@ enum AuditAction: String, Sendable, CaseIterable {
             return .enrollment
         case .submissionsPurged, .submissionRetestAll, .submissionRetestForStudent:
             return .submissions
-        case .extensionGranted, .extensionRevoked, .gradeOverrideSet, .gradeOverrideCleared:
+        case .extensionGranted, .extensionRevoked, .gradeOverrideSet, .gradeOverrideCleared,
+            .secretRevealSpent, .secretRevealRegranted, .secretRevealToggled:
             return .grading
         case .runnerSecretRotated, .runnerAutostartChanged:
             return .runner
@@ -218,6 +224,9 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .extensionRevoked: return "Extension revoked"
         case .gradeOverrideSet: return "Grade override set"
         case .gradeOverrideCleared: return "Grade override cleared"
+        case .secretRevealSpent: return "Reveal token spent"
+        case .secretRevealRegranted: return "Reveal token re-granted"
+        case .secretRevealToggled: return "Reveal token setting changed"
         case .runnerSecretRotated: return "Runner secret rotated"
         case .runnerAutostartChanged: return "Runner autostart changed"
         case .brightspaceAdminAuthorized: return "LEARN deployment key authorized"

--- a/Sources/APIServer/Models/APISecretRevealUnlock.swift
+++ b/Sources/APIServer/Models/APISecretRevealUnlock.swift
@@ -1,0 +1,39 @@
+// APIServer/Models/APISecretRevealUnlock.swift
+//
+// Durable per-(user, assignment) secret-reveal token spend.
+//
+// Each student holds one reveal token per assignment (when the assignment's
+// `secret_reveal_enabled` toggle is on). Spending it is recorded here; the
+// row's *existence* is the spent state, and secret-tier test results are then
+// itemized on all of that student's submissions for the assignment. Course
+// staff re-grant the token by deleting the row. Unrelated to auth/OAuth
+// tokens — this is a gamified display unlock only; grades are unaffected
+// (they already span every tier).
+
+import Fluent
+import Vapor
+
+final class APISecretRevealUnlock: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context.
+    static let schema = "secret_reveal_unlocks"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "user_id")
+    var userID: UUID
+
+    @Field(key: "assignment_id")
+    var assignmentID: UUID
+
+    @Timestamp(key: "spent_at", on: .create)
+    var spentAt: Date?
+
+    init() {}
+
+    init(id: UUID? = nil, userID: UUID, assignmentID: UUID) {
+        self.id = id
+        self.userID = userID
+        self.assignmentID = assignmentID
+    }
+}

--- a/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
+++ b/Sources/APIServer/Routes/SubmissionQueryRoutes.swift
@@ -119,15 +119,19 @@ struct SubmissionQueryRoutes: RouteCollection {
             .first()
         let releaseDeadline = try await releaseVisibilityDeadline(
             for: assignment, user: caller, on: req.db)
+        let reveal = try await SecretRevealState.resolve(
+            assignment: assignment, userID: caller.id, isStaff: access.isStaff, on: req.db)
         let callerVisibleTiers = visibleTiers(
-            isStaff: access.isStaff, effectiveDueAt: releaseDeadline)
+            isStaff: access.isStaff, effectiveDueAt: releaseDeadline,
+            secretRevealed: reveal.revealed)
 
         // A stored result is immutable, so the response bytes are fully
         // determined by (result row, visible tier set, ?tiers= slice).  The
         // tier set is part of the key because it changes when the release
-        // deadline passes — the same result id must then produce a fresh
-        // response.  Repeat views (the common case: a student re-opening
-        // their grade) get a 304 without decoding the collection blob.
+        // deadline passes or a secret-reveal token is spent / re-granted /
+        // toggled — the same result id must then produce a fresh response.
+        // Repeat views (the common case: a student re-opening their grade)
+        // get a 304 without decoding the collection blob.
         let requestedTiersParam = req.query[String.self, at: "tiers"]
         let etagKey = [
             result.id ?? "",
@@ -155,8 +159,9 @@ struct SubmissionQueryRoutes: RouteCollection {
         }
 
         // `fullCollection` carries the real grade across every tier.  The
-        // caller may only *inspect* certain outcomes: secret never, release
-        // after the deadline (instructors see all tiers).
+        // caller may only *inspect* certain outcomes: secret only with a
+        // spent reveal token, release after the deadline (instructors see
+        // all tiers).
         let visible = fullCollection.filtering(tiers: callerVisibleTiers)
 
         let responseCollection: TestOutcomeCollection

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -142,6 +142,9 @@ struct EditAssignmentContext: Encodable {
     let achievementSignalOptions: [AchievementSignalOption]
     let brightspaceSyncEnabled: Bool
     let brightspaceGradeObjectID: String?
+    /// The per-assignment secret-reveal toggle: whether students may spend
+    /// their one reveal token here.  Renders the "Student Options" checkbox.
+    let secretRevealEnabled: Bool
     let notice: String?
     let error: String?
 }

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -295,6 +295,10 @@ struct AssignmentSubmissionsContext: Encodable {
     let assignmentTitle: String
     let metrics: [AssignmentStatCard]
     let rows: [AssignmentStudentRow]
+    /// The assignment's secret-reveal toggle.  Gates the whole reveal-token
+    /// affordance on this page (spent tag + re-grant action) — when off the
+    /// page renders identically to the pre-feature layout.
+    let secretRevealEnabled: Bool
 }
 
 struct AssignmentStudentRow: Encodable {
@@ -320,4 +324,8 @@ struct AssignmentStudentRow: Encodable {
     let additionalSubmissionCount: Int
     let fullHistoryURL: String
     let bestGradePercent: Int?
+    /// True when this student has spent their secret-reveal token on the
+    /// assignment (always false when the assignment's toggle is off — the
+    /// affordance is hidden entirely then).
+    let secretRevealSpent: Bool
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
@@ -333,6 +333,46 @@ extension InstructorDashboardRoutes {
         return req.redirect(to: redirectPath)
     }
 
+    // MARK: - POST /instructor/:assignmentID/students/:studentID/regrant-reveal-token
+
+    /// Staff re-grant of a student's secret-reveal token: deletes the spend
+    /// row, so secret results are hidden again for the student until they
+    /// spend the (restored) token. TA+ — a grading-support action, same rung
+    /// as reset-notebook and grade overrides.
+    @Sendable
+    func regrantSecretRevealToken(req: Request) async throws -> Response {
+        struct RegrantBody: Content { var returnTo: String? }
+
+        _ = try req.auth.require(APIUser.self)
+        let assignment = try await loadAssignmentForWrite(req, atLeast: .ta)
+        let assignmentIDRaw = assignment.publicID
+        let student = try await resolveEnrolledStudent(req: req, assignment: assignment)
+        guard let studentUUID = student.id else {
+            throw WebAssignmentError.notFound(resource: "Student")
+        }
+
+        if try await SecretRevealStore.regrantToken(
+            userID: studentUUID, assignmentID: assignment.requireID(), on: req.db)
+        {
+            await AuditLogger.record(
+                action: .secretRevealRegranted,
+                targetType: .assignment,
+                targetID: assignment.id?.uuidString,
+                metadata: [
+                    "assignment": assignmentIDRaw,
+                    "student_username": student.username,
+                ],
+                on: req
+            )
+        }
+
+        let body = try? req.content.decode(RegrantBody.self)
+        let fallbackPath = "/instructor/\(assignmentIDRaw)/submissions"
+        let redirectPath = sanitizedAssignmentReturnPath(
+            body?.returnTo, assignmentIDRaw: assignmentIDRaw, fallbackPath: fallbackPath)
+        return req.redirect(to: redirectPath)
+    }
+
     /// Resolves the `:studentID` UUID parameter to a `role == "student"` user
     /// enrolled in the assignment's course.  Throws `notFound` when the
     /// parameter is missing/invalid, the user doesn't exist or isn't a

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -48,6 +48,16 @@ extension InstructorDashboardRoutes {
             overrideByStudentID[key.userID] = pct
         }
 
+        // Reveal-token spends, fetched only when the assignment's toggle is
+        // on — with it off the affordance is hidden and the page renders
+        // identically to the pre-feature layout.
+        let secretRevealEnabled = assignment.secretRevealEnabled == true
+        var spentRevealUserIDs: Set<UUID> = []
+        if secretRevealEnabled {
+            spentRevealUserIDs = try await SecretRevealStore.spentUserIDs(
+                assignmentID: assignment.requireID(), on: req.db)
+        }
+
         let fmt = waterlooDateTimeFormatter()
         let rows = students.compactMap { student -> AssignmentStudentRow? in
             buildAssignmentStudentRow(
@@ -55,6 +65,7 @@ extension InstructorDashboardRoutes {
                 submissionsByStudentID: submissionsByStudentID,
                 bestPercentBySubmissionID: bestPercentBySubmissionID,
                 overrideByStudentID: overrideByStudentID,
+                spentRevealUserIDs: spentRevealUserIDs,
                 assignmentIDRaw: assignmentIDRaw,
                 fmt: fmt
             )
@@ -74,7 +85,8 @@ extension InstructorDashboardRoutes {
                 assignmentID: assignmentIDRaw,
                 assignmentTitle: assignment.title,
                 metrics: metrics,
-                rows: rows
+                rows: rows,
+                secretRevealEnabled: secretRevealEnabled
             )
         )
     }
@@ -122,6 +134,7 @@ extension InstructorDashboardRoutes {
         submissionsByStudentID: [UUID: [APISubmission]],
         bestPercentBySubmissionID: [String: Int],
         overrideByStudentID: [UUID: Int],
+        spentRevealUserIDs: Set<UUID>,
         assignmentIDRaw: String,
         fmt: DateFormatter
     ) -> AssignmentStudentRow? {
@@ -163,7 +176,8 @@ extension InstructorDashboardRoutes {
             latestSubmittedAtEpoch: latest?.submittedAt.map { Int($0.timeIntervalSince1970) } ?? 0,
             additionalSubmissionCount: max(history.count - 1, 0),
             fullHistoryURL: "/instructor/\(assignmentIDRaw)/students/\(studentID.uuidString)/history",
-            bestGradePercent: bestGradePercent
+            bestGradePercent: bestGradePercent,
+            secretRevealSpent: spentRevealUserIDs.contains(studentID)
         )
     }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Submissions.swift
@@ -58,14 +58,16 @@ extension InstructorDashboardRoutes {
                 assignmentID: assignment.requireID(), on: req.db)
         }
 
+        let lookups = StudentRowLookups(
+            submissionsByStudentID: submissionsByStudentID,
+            bestPercentBySubmissionID: bestPercentBySubmissionID,
+            overrideByStudentID: overrideByStudentID,
+            spentRevealUserIDs: spentRevealUserIDs)
         let fmt = waterlooDateTimeFormatter()
         let rows = students.compactMap { student -> AssignmentStudentRow? in
             buildAssignmentStudentRow(
                 student: student,
-                submissionsByStudentID: submissionsByStudentID,
-                bestPercentBySubmissionID: bestPercentBySubmissionID,
-                overrideByStudentID: overrideByStudentID,
-                spentRevealUserIDs: spentRevealUserIDs,
+                lookups: lookups,
                 assignmentIDRaw: assignmentIDRaw,
                 fmt: fmt
             )
@@ -129,23 +131,29 @@ extension InstructorDashboardRoutes {
         return submissionsByStudentID
     }
 
+    /// Per-assignment lookup tables shared by every roster row build, bundled
+    /// so `buildAssignmentStudentRow` stays within the parameter-count limit.
+    private struct StudentRowLookups {
+        let submissionsByStudentID: [UUID: [APISubmission]]
+        let bestPercentBySubmissionID: [String: Int]
+        let overrideByStudentID: [UUID: Int]
+        let spentRevealUserIDs: Set<UUID>
+    }
+
     private func buildAssignmentStudentRow(
         student: APIUser,
-        submissionsByStudentID: [UUID: [APISubmission]],
-        bestPercentBySubmissionID: [String: Int],
-        overrideByStudentID: [UUID: Int],
-        spentRevealUserIDs: Set<UUID>,
+        lookups: StudentRowLookups,
         assignmentIDRaw: String,
         fmt: DateFormatter
     ) -> AssignmentStudentRow? {
         guard let studentID = student.id else { return nil }
-        let history = submissionsByStudentID[studentID] ?? []
+        let history = lookups.submissionsByStudentID[studentID] ?? []
         let latest = history.first
         let runnerBestGradePercent: Int? = {
             var best = -1
             for submission in history {
                 guard let subID = submission.id,
-                    let pct = bestPercentBySubmissionID[subID]
+                    let pct = lookups.bestPercentBySubmissionID[subID]
                 else {
                     continue
                 }
@@ -155,7 +163,7 @@ extension InstructorDashboardRoutes {
         }()
         // An instructor override is the student's effective grade — it feeds
         // both the displayed grade and the median metric.
-        let override = overrideByStudentID[studentID]
+        let override = lookups.overrideByStudentID[studentID]
         let bestGradePercent = override ?? runnerBestGradePercent
         let inferredName =
             splitHumanName(student.displayName)
@@ -177,7 +185,7 @@ extension InstructorDashboardRoutes {
             additionalSubmissionCount: max(history.count - 1, 0),
             fullHistoryURL: "/instructor/\(assignmentIDRaw)/students/\(studentID.uuidString)/history",
             bestGradePercent: bestGradePercent,
-            secretRevealSpent: spentRevealUserIDs.contains(studentID)
+            secretRevealSpent: lookups.spentRevealUserIDs.contains(studentID)
         )
     }
 

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -64,6 +64,9 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post(
             ":assignmentID", "students", ":studentID", "grade-override", "delete",
             use: deleteStudentGradeOverride)
+        r.post(
+            ":assignmentID", "students", ":studentID", "regrant-reveal-token",
+            use: regrantSecretRevealToken)
         // Draft-assignment authoring (create page, save, publish, draft
         // suite / family / check / script / suite-section CRUD) lives on
         // `DraftAssignmentRoutes` (registered in routes.swift).
@@ -72,6 +75,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         // `CourseAdminRoutes` (registered in routes.swift).
         r.get(":assignmentID", "edit", use: editPage)
         r.post(":assignmentID", "brightspace", use: saveBrightSpaceGradeObjectID)
+        r.post(":assignmentID", "secret-reveal", use: saveSecretRevealSetting)
         r.post(":assignmentID", "brightspace", "push-all", use: brightspacePushAllForAssignment)
         r.post(":assignmentID", "status", use: updateStatus)
         r.post(":assignmentID", "open", use: openAssignment)
@@ -346,6 +350,36 @@ struct InstructorDashboardRoutes: RouteCollection {
         return req.redirect(to: "/instructor/\(assignment.publicID)/edit?notice=BrightSpace+grade+item+ID+saved")
     }
 
+    // MARK: - POST /instructor/:assignmentID/secret-reveal
+
+    /// Saves the per-assignment secret-reveal toggle. A dedicated lightweight
+    /// endpoint rather than a field on the main Save form: `saveEditedAssignment`
+    /// closes the assignment and re-enqueues validation on every save, which
+    /// would make a mid-semester toggle flip needlessly destructive. Display
+    /// policy only — no manifest change, no regrade, no close.
+    @Sendable
+    func saveSecretRevealSetting(req: Request) async throws -> Response {
+        let assignment = try await loadAssignmentForWrite(req, atLeast: .instructor)
+        struct ToggleBody: Content {
+            // Checkbox: "on" when checked, absent from the body when not —
+            // decode as optional and treat absence as false, so unchecking
+            // actually turns the toggle off.
+            var enabled: String?
+        }
+        let enabled = ((try? req.content.decode(ToggleBody.self))?.enabled) != nil
+        try await AssignmentAuthoringService.updateMetadata(
+            assignment, secretRevealEnabled: enabled, on: req.db)
+        await AuditLogger.record(
+            action: .secretRevealToggled,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: ["assignment": assignment.publicID, "enabled": String(enabled)],
+            on: req
+        )
+        return req.redirect(
+            to: "/instructor/\(assignment.publicID)/edit?notice=Secret+reveal+token+setting+saved")
+    }
+
     // MARK: - POST /instructor/:assignmentID/delete
 
     @Sendable
@@ -487,6 +521,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             achievementSignalOptions: AchievementSignalPresentation.all,
             brightspaceSyncEnabled: req.application.brightSpaceAppCredentials != nil,
             brightspaceGradeObjectID: assignment.brightspaceGradeObjectID,
+            secretRevealEnabled: assignment.secretRevealEnabled == true,
             notice: q?.notice,
             error: q?.error
         )

--- a/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
+++ b/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
@@ -336,9 +336,9 @@ extension WebRoutes {
         processed: ProcessedCollection,
         sectionedOutcomes: [SectionedOutcomes],
         decorations: SubmissionDecorations,
-        delta: DeltaBanner,
-        secretReveal: SecretRevealBanner
+        delta: DeltaBanner
     ) -> SubmissionContext {
+        let secretReveal = decorations.secretReveal
         let overrideGradePercent = decorations.overrideGradePercent
         let badges = decorations.badges
         let currentUser = decorations.currentUser
@@ -603,4 +603,6 @@ struct SubmissionDecorations {
     let overrideGradePercent: Int?
     /// Class-goal progress views for the "Achievements" section.
     let classGoals: [ClassGoalView]
+    /// Secret-reveal offer/active state for the reveal-token UI.
+    let secretReveal: SecretRevealBanner
 }

--- a/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
+++ b/Sources/APIServer/Routes/Web/SubmissionResultPresenter.swift
@@ -107,9 +107,9 @@ extension WebRoutes {
     /// #1173): computes the all-tier grade (so the number matches the
     /// dashboard and is stable across the deadline), and renders each
     /// *itemized* outcome into an `OutcomeRow`. Students see public + release
-    /// rows; release output is redacted until the deadline. Secret never
-    /// appears as a row — for non-instructors it is surfaced as an aggregate
-    /// pass/fail `TierSummary` instead.
+    /// rows; release output is redacted until the deadline. Secret appears as
+    /// rows only for staff or a student with a spent secret-reveal token —
+    /// otherwise it is surfaced as an aggregate pass/fail `TierSummary`.
     func processDisplayResult(
         result: APIResult,
         collection maybeCollection: TestOutcomeCollection?,
@@ -124,11 +124,14 @@ extension WebRoutes {
             return processed
         }
 
-        // Secret tests count toward the grade but are never itemized for
-        // students; they are bucketed into per-section aggregate pass/fail
-        // summaries by `buildSectionedOutcomes`.  Kept in collection order so
-        // the section correlation lines up with the secret manifest entries.
-        if !viewer.isStaff {
+        // Secret tests count toward the grade but are not itemized for
+        // students (unless they spent their secret-reveal token); they are
+        // bucketed into per-section aggregate pass/fail summaries by
+        // `buildSectionedOutcomes`.  Kept in collection order so the section
+        // correlation lines up with the secret manifest entries.  When
+        // revealed, secret outcomes flow through the itemized rows below
+        // instead, and this stays empty — so the aggregate never doubles up.
+        if !viewer.isStaff && !viewer.secretRevealed {
             processed.secretOutcomes = collection.outcomes.filter { $0.tier == .secret }
         }
 
@@ -333,7 +336,8 @@ extension WebRoutes {
         processed: ProcessedCollection,
         sectionedOutcomes: [SectionedOutcomes],
         decorations: SubmissionDecorations,
-        delta: DeltaBanner
+        delta: DeltaBanner,
+        secretReveal: SecretRevealBanner
     ) -> SubmissionContext {
         let overrideGradePercent = decorations.overrideGradePercent
         let badges = decorations.badges
@@ -376,7 +380,9 @@ extension WebRoutes {
             badges: badges,
             currentUser: currentUser,
             classGoals: decorations.classGoals,
-            hasClassGoals: !decorations.classGoals.isEmpty
+            hasClassGoals: !decorations.classGoals.isEmpty,
+            secretRevealAvailable: secretReveal.available,
+            secretRevealActive: secretReveal.active
         )
     }
 }
@@ -553,11 +559,17 @@ struct SubmissionViewer {
     /// Slice G, per-course; was the global `user.isInstructor`).
     let isStaff: Bool
     /// Tiers rendered as individual rows (public + release for students; all
-    /// tiers for instructors).  Secret is never itemized for students.
+    /// tiers for instructors).  Secret is itemized for students only when
+    /// `secretRevealed`.
     let itemizedTiers: Set<String>
     /// Whether release-tier output is shown (true after the deadline / for
     /// instructors).  Release rows are listed by name either way.
     let releaseOutputVisible: Bool
+    /// True when this student has spent their secret-reveal token on an
+    /// assignment whose reveal option is enabled — secret rows are then
+    /// itemized like public rows instead of aggregated.  Always false for
+    /// staff (they itemize secret regardless).
+    let secretRevealed: Bool
 }
 
 // Internal (was private): constructed by `submissionPage` in
@@ -567,6 +579,16 @@ struct SubmissionViewer {
 struct DeltaBanner {
     let hasDelta: Bool
     let headerText: String?
+}
+
+// Internal: constructed by `submissionPage` in WebRoutes+Submission.swift.
+/// Secret-reveal display state for the submission page.  `available` renders
+/// the "spend your reveal token" offer box; `active` renders the "secret
+/// tests revealed" info banner (and secret rows itemize via the viewer's
+/// tier set).  Both are always false for staff.
+struct SecretRevealBanner {
+    let available: Bool
+    let active: Bool
 }
 
 // Internal (was private): constructed by `submissionPage` in

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -393,6 +393,13 @@ struct SubmissionContext: Encodable {
     /// `!classGoals.isEmpty` in Leaf, so an empty goal list never leaks a bare
     /// heading regardless of how the Leaf encoder represents an empty array.
     let hasClassGoals: Bool
+    /// True when this viewer may spend their secret-reveal token here:
+    /// toggle on, manifest has secret tests, viewer is the (non-staff)
+    /// owner, token not yet spent.  Renders the offer box + POST form.
+    let secretRevealAvailable: Bool
+    /// True when the reveal is active (toggle on + token spent): secret
+    /// rows are itemized and the "revealed" info banner shows.
+    let secretRevealActive: Bool
 }
 
 /// One class-goal achievement's display state for the submission page.

--- a/Sources/APIServer/Routes/Web/WebRoutes+SecretReveal.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+SecretReveal.swift
@@ -1,0 +1,94 @@
+// APIServer/Routes/Web/WebRoutes+SecretReveal.swift
+//
+// Student "spend your secret-reveal token" endpoint.
+//
+//   POST /testsetups/:testSetupID/reveal-secret
+//
+// Spending is permanent from the student's side (the form carries a JS
+// confirm); course staff can re-grant from the assignment roster
+// (`regrantSecretRevealToken` in InstructorDashboardRoutes+StudentActions).
+// The spend row unlocks itemized secret-tier results across all of the
+// student's submissions for the assignment — display only, grades are
+// unaffected (they already span every tier).
+
+import Fluent
+import Vapor
+
+extension WebRoutes {
+
+    /// Handles the spend POST. Refusals redirect back without writing a row:
+    /// the offer form only renders when the spend is allowed, so a refused
+    /// POST is either a stale page or hand-crafted — never worth burning the
+    /// student's token over (e.g. an assignment with no secret tests has
+    /// nothing to reveal).
+    @Sendable
+    func spendSecretRevealToken(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        guard let userID = user.id else { throw Abort(.unauthorized) }
+        guard
+            let setupID = req.parameters.get("testSetupID"),
+            let setup = try await APITestSetup.find(setupID, on: req.db)
+        else {
+            throw Abort(.notFound)
+        }
+        // Cross-tenant guard: only members of the setup's course may interact
+        // with it (same gate as the submit form).
+        try await requireCourseEnrollment(caller: user, courseID: setup.courseID, db: req.db)
+
+        guard
+            let assignment = try await APIAssignment.query(on: req.db)
+                .filter(\.$testSetupID == setupID)
+                .first(),
+            let assignmentID = assignment.id
+        else {
+            throw Abort(.notFound)
+        }
+
+        let redirectTarget = try await spendRedirectTarget(
+            req: req, setupID: setupID, userID: userID)
+
+        // All three gates mirror the offer-rendering conditions on the
+        // submission page. Staff spending is refused (their view already
+        // itemizes every tier; a spend row would only corrupt the roster).
+        let isStaff = try await isCourseStaff(user, inCourse: setup.courseID, db: req.db)
+        guard
+            assignment.secretRevealEnabled == true,
+            !isStaff,
+            hasSecretTierTests(setup.decodedManifest())
+        else {
+            return req.redirect(to: redirectTarget)
+        }
+
+        try await SecretRevealStore.spendToken(
+            userID: userID, assignmentID: assignmentID, on: req.db)
+        await AuditLogger.record(
+            action: .secretRevealSpent,
+            targetType: .assignment,
+            targetID: assignmentID.uuidString,
+            metadata: ["assignment": assignment.publicID],
+            on: req)
+        req.logger.info(
+            "secret_reveal_spent assignment=\(assignment.publicID) student=\(userID.uuidString)")
+        return req.redirect(to: redirectTarget)
+    }
+
+    /// Where to land after the POST: the submission page the form was on
+    /// (validated — must exist, belong to this setup, and be the caller's
+    /// own), else the setup's submission history.
+    private func spendRedirectTarget(
+        req: Request, setupID: String, userID: UUID
+    ) async throws -> String {
+        struct SpendBody: Content {
+            var submissionID: String?
+        }
+        let body = try? req.content.decode(SpendBody.self)
+        if let submissionID = body?.submissionID,
+            let submission = try await APISubmission.find(submissionID, on: req.db),
+            submission.testSetupID == setupID,
+            submission.userID == userID
+        {
+            return "/submissions/\(submissionID)"
+        }
+        return "/testsetups/\(setupID)/history"
+    }
+}

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -259,17 +259,22 @@ extension WebRoutes {
         let setup = try await APITestSetup.find(submission.testSetupID, on: req.db)
         let setupProps = setup?.decodedManifest()
         // Students see public + release rows itemized (release output is gated
-        // on the deadline); secret is never itemized.  The grade itself spans
-        // every tier — see `processDisplayResult` — so it is stable across the
-        // deadline and matches the dashboard.
+        // on the deadline); secret is itemized only after the student spends
+        // their secret-reveal token (toggle + spend row, see
+        // `SecretRevealState`).  The grade itself spans every tier — see
+        // `processDisplayResult` — so it is stable across the deadline and
+        // matches the dashboard.
         //
         // Release *output* is gated on the *effective* deadline — the later of
         // the assignment due date and the viewer's own per-student extension —
         // so a student with an active extension keeps the hidden release output
         // redacted until their extended window closes.  A non-instructor may
         // only view their own submission (guarded above), so `user` is the
-        // submission owner; instructors see release output regardless.
-        let itemized = itemizedTiers(isStaff: isStaff)
+        // submission owner (which is why resolving the reveal state by viewer
+        // ID is correct); instructors see release output regardless.
+        let reveal = try await SecretRevealState.resolve(
+            assignment: submissionAssignment, userID: user.id, isStaff: isStaff, on: req.db)
+        let itemized = itemizedTiers(isStaff: isStaff, secretRevealed: reveal.revealed)
         let releaseDeadline = try await releaseVisibilityDeadline(
             for: submissionAssignment, user: user, on: req.db)
         let releaseOutput = releaseOutputVisible(isStaff: isStaff, effectiveDueAt: releaseDeadline)
@@ -290,7 +295,8 @@ extension WebRoutes {
                 collection: displayCollection,
                 viewer: SubmissionViewer(
                     user: user, isStaff: isStaff, itemizedTiers: itemized,
-                    releaseOutputVisible: releaseOutput),
+                    releaseOutputVisible: releaseOutput,
+                    secretRevealed: reveal.revealed),
                 submission: submission,
                 priorAttempt: priorAttempt,
                 manifestDisplay: manifestDisplay
@@ -368,7 +374,11 @@ extension WebRoutes {
                 overrideGradePercent: overrideGradePercent,
                 classGoals: classGoals
             ),
-            delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText)
+            delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText),
+            secretReveal: SecretRevealBanner(
+                available: reveal.enabled && !reveal.spent && !isStaff
+                    && hasSecretTierTests(setupProps),
+                active: reveal.revealed)
         )
         return try await req.view.render("submission", ctx)
     }

--- a/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Submission.swift
@@ -303,38 +303,13 @@ extension WebRoutes {
             )
         }
 
-        // Class-goal bonus: extra credit on the autograded grade, capped at 100%
-        // (no-op unless the assignment has a points-rewarded class goal).
-        if processed.totalPoints > 0 {
-            let bonus = try await classGoalBonusPoints(
-                testSetupID: submission.testSetupID, props: setupProps, on: req.db)
-            if bonus > 0 {
-                let bonused = earnedWithClassGoalBonus(
-                    earned: processed.rawEarnedPoints,
-                    total: Double(processed.totalPoints),
-                    bonus: bonus)
-                processed.gradePercent = Int(
-                    (bonused / Double(processed.totalPoints) * 100).rounded())
-                processed.earnedPoints = formatPoints(bonused)
-            }
-        }
+        try await applyClassGoalBonus(
+            to: &processed, setupProps: setupProps,
+            testSetupID: submission.testSetupID, on: req.db)
 
-        // Append class-wide achievement badges held by this specific submission.
-        let classAchievements = try await APIClassAchievement.query(on: req.db)
-            .filter(\.$submissionID == subID)
-            .all()
-        // Authorable individual badges (threshold / test), earned per-student
-        // from this submission's result (evaluated over all tiers so a
-        // secret-test badge works without revealing the test).
-        let individualBadges = earnedIndividualBadgesForDisplay(
-            collection: displayCollection, props: setupProps,
-            gradePercent: processed.gradePercent)
-        let badges =
-            builtInBadgesForSubmission(
-                badgeContext: processed.badgeContext,
-                classAchievements: classAchievements,
-                setup: setup)
-            + individualBadges
+        let badges = try await submissionBadges(
+            req: req, subID: subID, displayCollection: displayCollection,
+            setupProps: setupProps, setup: setup, processed: processed)
 
         let sectionedOutcomes = buildSectionedOutcomes(
             outcomes: processed.outcomes,
@@ -372,18 +347,65 @@ extension WebRoutes {
                 badges: badges,
                 currentUser: req.currentUserContext,
                 overrideGradePercent: overrideGradePercent,
-                classGoals: classGoals
+                classGoals: classGoals,
+                secretReveal: SecretRevealBanner(
+                    available: reveal.enabled && !reveal.spent && !isStaff
+                        && hasSecretTierTests(setupProps),
+                    active: reveal.revealed)
             ),
-            delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText),
-            secretReveal: SecretRevealBanner(
-                available: reveal.enabled && !reveal.spent && !isStaff
-                    && hasSecretTierTests(setupProps),
-                active: reveal.revealed)
+            delta: DeltaBanner(hasDelta: hasDelta, headerText: deltaHeaderText)
         )
         return try await req.view.render("submission", ctx)
     }
 
     // MARK: - submissionPage helpers
+
+    /// Class-goal bonus: extra credit on the autograded grade, capped at 100%
+    /// (no-op unless the assignment has a points-rewarded class goal).
+    private func applyClassGoalBonus(
+        to processed: inout ProcessedCollection,
+        setupProps: TestProperties?,
+        testSetupID: String,
+        on db: Database
+    ) async throws {
+        guard processed.totalPoints > 0 else { return }
+        let bonus = try await classGoalBonusPoints(
+            testSetupID: testSetupID, props: setupProps, on: db)
+        guard bonus > 0 else { return }
+        let bonused = earnedWithClassGoalBonus(
+            earned: processed.rawEarnedPoints,
+            total: Double(processed.totalPoints),
+            bonus: bonus)
+        processed.gradePercent = Int(
+            (bonused / Double(processed.totalPoints) * 100).rounded())
+        processed.earnedPoints = formatPoints(bonused)
+    }
+
+    /// Assembles the badge strip for one submission: class-wide achievement
+    /// badges held by this specific submission, built-in badges, and
+    /// authorable individual badges (threshold / test) earned per-student from
+    /// this submission's result — the latter evaluated over all tiers so a
+    /// secret-test badge works without revealing the test.
+    private func submissionBadges(
+        req: Request,
+        subID: String,
+        displayCollection: TestOutcomeCollection?,
+        setupProps: TestProperties?,
+        setup: APITestSetup?,
+        processed: ProcessedCollection
+    ) async throws -> [AchievementBadge] {
+        let classAchievements = try await APIClassAchievement.query(on: req.db)
+            .filter(\.$submissionID == subID)
+            .all()
+        let individualBadges = earnedIndividualBadgesForDisplay(
+            collection: displayCollection, props: setupProps,
+            gradePercent: processed.gradePercent)
+        return builtInBadgesForSubmission(
+            badgeContext: processed.badgeContext,
+            classAchievements: classAchievements,
+            setup: setup)
+            + individualBadges
+    }
 
     /// Selects the result row to render on the submission page: the worker
     /// result is preferred (official grade); the browser result is the

--- a/Sources/APIServer/Routes/Web/WebRoutes.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes.swift
@@ -25,6 +25,7 @@ struct WebRoutes: RouteCollection {
         routes.get("testsetups", ":testSetupID", "notebook", use: notebookPage)
         routes.get("testsetups", ":testSetupID", "notebook", "source", use: notebookSource)
         routes.post("testsetups", ":testSetupID", "reset-notebook", use: resetOwnNotebook)
+        routes.post("testsetups", ":testSetupID", "reveal-secret", use: spendSecretRevealToken)
         // Self-service "clear cached editor data" page for a wedged kernel
         // (Clear-Site-Data: cache + storage; see WebRoutes+EditorReset.swift).
         routes.get("reset-editor", use: editorResetPage)

--- a/Sources/APIServer/Services/AssignmentAuthoringService.swift
+++ b/Sources/APIServer/Services/AssignmentAuthoringService.swift
@@ -62,23 +62,28 @@ enum AssignmentAuthoringService {
         try await assignment.save(on: db)
     }
 
-    /// Applies any combination of title / due-date / open-state changes in a
-    /// single save, with the same side effects as the instructor editor: a
-    /// due-date change re-normalises `deadlineOverrideActive`, and opening
-    /// re-derives it from the (possibly just-changed) due date. Metadata-only —
-    /// never touches the manifest, so it does not trigger a regrade. Throws
-    /// `validationNotPassed` if `open` is true before validation has passed.
+    /// Applies any combination of title / due-date / open-state /
+    /// secret-reveal-toggle changes in a single save, with the same side
+    /// effects as the instructor editor: a due-date change re-normalises
+    /// `deadlineOverrideActive`, and opening re-derives it from the (possibly
+    /// just-changed) due date. Metadata-only — never touches the manifest, so
+    /// it does not trigger a regrade. Throws `validationNotPassed` if `open`
+    /// is true before validation has passed.
     static func updateMetadata(
         _ assignment: APIAssignment,
         title: String? = nil,
         dueAt: DueDateUpdate = .unchanged,
         startsAt: OpenDateUpdate = .unchanged,
         open: Bool? = nil,
+        secretRevealEnabled: Bool? = nil,
         on db: Database,
         now: Date = Date()
     ) async throws {
         if let title {
             assignment.title = title
+        }
+        if let secretRevealEnabled {
+            assignment.secretRevealEnabled = secretRevealEnabled
         }
         switch dueAt {
         case .unchanged:

--- a/Sources/APIServer/Services/SecretRevealStore.swift
+++ b/Sources/APIServer/Services/SecretRevealStore.swift
@@ -1,0 +1,127 @@
+// APIServer/Services/SecretRevealStore.swift
+//
+// Reads/writes the per-(user, assignment) secret-reveal token spend.
+//
+// Each student gets one reveal token per assignment (when the assignment's
+// `secretRevealEnabled` toggle is on). Spending it inserts a row into
+// `secret_reveal_unlocks`; the row's existence is the spent state, and staff
+// re-grant by deleting it. `spendToken` is idempotent and race-safe: the
+// UNIQUE(user_id, assignment_id) constraint means a lost INSERT race is
+// swallowed (the winner's row already exists).
+//
+// - Important: Do NOT call these inside an enclosing `db.transaction { … }`.
+//   On Postgres a failed INSERT aborts the entire transaction, so the
+//   recover-by-re-check in `spendToken`'s `catch` would itself throw ("current
+//   transaction is aborted"). Every current caller passes a plain pooled
+//   `Database`; keep it that way.
+
+import Fluent
+import Foundation
+
+enum SecretRevealStore {
+
+    /// Record that `userID` spent their reveal token on `assignmentID`. No-op
+    /// if a row already exists. Safe under concurrent double-submits.
+    static func spendToken(
+        userID: UUID,
+        assignmentID: UUID,
+        on db: Database
+    ) async throws {
+        if try await hasSpentToken(userID: userID, assignmentID: assignmentID, on: db) {
+            return
+        }
+        let row = APISecretRevealUnlock(userID: userID, assignmentID: assignmentID)
+        do {
+            try await row.save(on: db)
+        } catch {
+            // UNIQUE constraint race: another request inserted first. The row
+            // we wanted now exists, so the spend is still recorded.
+            if try await hasSpentToken(userID: userID, assignmentID: assignmentID, on: db) {
+                return
+            }
+            throw error
+        }
+    }
+
+    /// Whether a spend row exists for `(userID, assignmentID)`.
+    static func hasSpentToken(
+        userID: UUID,
+        assignmentID: UUID,
+        on db: Database
+    ) async throws -> Bool {
+        try await APISecretRevealUnlock.query(on: db)
+            .filter(\.$userID == userID)
+            .filter(\.$assignmentID == assignmentID)
+            .count() > 0
+    }
+
+    /// Staff re-grant: deletes the spend row so the student's token is
+    /// available again. Returns true when a row existed.
+    static func regrantToken(
+        userID: UUID,
+        assignmentID: UUID,
+        on db: Database
+    ) async throws -> Bool {
+        let existing = try await APISecretRevealUnlock.query(on: db)
+            .filter(\.$userID == userID)
+            .filter(\.$assignmentID == assignmentID)
+            .first()
+        guard let existing else { return false }
+        try await existing.delete(on: db)
+        return true
+    }
+
+    /// All user IDs that have spent their token on this assignment (for the
+    /// instructor roster page).
+    static func spentUserIDs(
+        assignmentID: UUID,
+        on db: Database
+    ) async throws -> Set<UUID> {
+        let rows = try await APISecretRevealUnlock.query(on: db)
+            .filter(\.$assignmentID == assignmentID)
+            .all()
+        return Set(rows.map(\.userID))
+    }
+}
+
+/// The viewer-facing secret-reveal state for one (assignment, user) pair.
+///
+/// `revealed` is the single reveal gate consulted by both visibility surfaces
+/// (web submission page + results JSON API): the toggle must be on AND the
+/// token spent. An instructor turning the toggle off therefore re-hides
+/// secret results without touching the spend row — re-enabling restores the
+/// reveal.
+struct SecretRevealState: Sendable {
+    /// The assignment's `secretRevealEnabled` toggle.
+    let enabled: Bool
+    /// Whether the student's spend row exists.
+    let spent: Bool
+
+    var revealed: Bool { enabled && spent }
+
+    static let none = SecretRevealState(enabled: false, spent: false)
+
+    /// Resolve the reveal state for `userID` viewing `assignment`.
+    ///
+    /// Staff short-circuit to `.none` — they see all tiers regardless, so no
+    /// DB hit. A nil assignment (setup with no published assignment) or nil
+    /// user also resolves to `.none`. When the toggle is off the spend query
+    /// is skipped: both the reveal and the spend offer are gated on `enabled`,
+    /// so `spent` is never consulted in that case.
+    static func resolve(
+        assignment: APIAssignment?,
+        userID: UUID?,
+        isStaff: Bool,
+        on db: Database
+    ) async throws -> SecretRevealState {
+        guard !isStaff, let assignment, let assignmentID = assignment.id, let userID else {
+            return .none
+        }
+        guard assignment.secretRevealEnabled == true else {
+            return .none
+        }
+        let spent = try await SecretRevealStore.hasSpentToken(
+            userID: userID, assignmentID: assignmentID, on: db)
+        return SecretRevealState(enabled: true, spent: spent)
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -431,4 +431,10 @@ func registerMigrations(on app: Application) {
     // AddResultGradeColumns — its backfill reads the column this migration
     // drops.
     app.migrations.add(CreateResultCollections())
+
+    // Secret reveal tokens: per-assignment instructor toggle plus one
+    // spent-token row per (student, assignment). Column-only + new table;
+    // no migration full-queries APIAssignment, so ordering is unconstrained.
+    app.migrations.add(AddAssignmentSecretRevealEnabled())
+    app.migrations.add(CreateSecretRevealUnlocks())
 }

--- a/Tests/APITests/MCP/GetAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/GetAssignmentToolTests.swift
@@ -34,6 +34,26 @@ import Vapor
             #expect(output.isOpen == false)
             // The default fixture manifest is browser-graded.
             #expect(output.gradingMode == "browser")
+            #expect(output.secretRevealEnabled == false, "off by default")
+        }
+    }
+
+    @Test func reportsSecretRevealEnabled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS246", name: "OOP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "tester", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            try await makeTestSetup(on: app, id: "setup_sr", courseID: courseID)
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: "setup_sr", courseID: courseID, title: "Tasks")
+            assignment.secretRevealEnabled = true
+            try await assignment.save(on: app.db)
+
+            let output = try await GetAssignmentTool().execute(
+                GetAssignmentTool.Input(assignmentPublicID: assignment.publicID), context(app))
+            #expect(output.secretRevealEnabled)
         }
     }
 

--- a/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
+++ b/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
@@ -110,7 +110,8 @@ import Testing
                 UpdateAssignmentTool.Output(
                     publicID: "abc123", title: "T", slug: "t", isOpen: true,
                     visibility: "open", dueAt: "2026-01-01T00:00:00Z",
-                    startsAt: "2026-01-01T00:00:00Z", validationStatus: "passed")
+                    startsAt: "2026-01-01T00:00:00Z", validationStatus: "passed",
+                    secretRevealEnabled: false)
             ),
         ]
 

--- a/Tests/APITests/MCP/UpdateAssignmentToolTests.swift
+++ b/Tests/APITests/MCP/UpdateAssignmentToolTests.swift
@@ -259,6 +259,29 @@ import Vapor
         }
     }
 
+    @Test func setsAndClearsSecretRevealEnabled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await enrolledAssignment(on: app)
+
+            let enabled = try await UpdateAssignmentTool().execute(
+                UpdateAssignmentTool.Input(
+                    assignmentPublicID: assignment.publicID, secretRevealEnabled: true),
+                context(app))
+            #expect(enabled.secretRevealEnabled)
+            var reloaded = try await assignmentByPublicID(assignment.publicID, on: app.db)
+            #expect(reloaded?.secretRevealEnabled == true)
+
+            let disabled = try await UpdateAssignmentTool().execute(
+                UpdateAssignmentTool.Input(
+                    assignmentPublicID: assignment.publicID, secretRevealEnabled: false),
+                context(app))
+            #expect(disabled.secretRevealEnabled == false)
+            reloaded = try await assignmentByPublicID(assignment.publicID, on: app.db)
+            #expect(reloaded?.secretRevealEnabled == false)
+        }
+    }
+
     @Test func deniesWhenSubjectNotEnrolled() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in

--- a/Tests/APITests/SecretRevealStoreTests.swift
+++ b/Tests/APITests/SecretRevealStoreTests.swift
@@ -1,0 +1,232 @@
+// Tests/APITests/SecretRevealStoreTests.swift
+//
+// Exercises the per-(user, assignment) secret-reveal token store: idempotent
+// spend, staff re-grant, roster query, cascade delete, and the
+// `SecretRevealState` resolver's gating rules.
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class SecretRevealStoreTests {
+
+    let app: Application
+
+    init() async throws {
+        app = try await makeTestingApplication { app in
+            try await configureTestDatabase(app)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeUser(username: String) async throws -> APIUser {
+        let user = APIUser(username: username, passwordHash: "x", role: "student")
+        try await user.save(on: app.db)
+        return user
+    }
+
+    private func makeAssignment(
+        courseID: UUID, secretRevealEnabled: Bool = false
+    ) async throws
+        -> APIAssignment
+    {
+        let setupID = UUID().uuidString
+        let testSetup = APITestSetup(
+            id: setupID,
+            manifest: "{}",
+            zipPath: "/tmp/\(setupID).zip",
+            courseID: courseID
+        )
+        try await testSetup.save(on: app.db)
+
+        let assignment = APIAssignment(
+            testSetupID: setupID,
+            title: "Test Assignment \(setupID.prefix(6))",
+            courseID: courseID
+        )
+        if secretRevealEnabled {
+            assignment.secretRevealEnabled = true
+        }
+        try await assignment.save(on: app.db)
+        return assignment
+    }
+
+    private func makeCourse() async throws -> APICourse {
+        let course = APICourse(code: "TEST-\(UUID().uuidString.prefix(6))", name: "Test Course")
+        try await course.save(on: app.db)
+        return course
+    }
+
+    // MARK: - Store
+
+    @Test func spendToken_createsRowAndIsIdempotent() async throws {
+        try await withApp(app) { _ in
+            let user = try await makeUser(username: "alice")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(courseID: try course.requireID())
+            let userID = try user.requireID()
+            let assignmentID = try assignment.requireID()
+
+            let before = try await SecretRevealStore.hasSpentToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            #expect(before == false)
+
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+
+            let spent = try await SecretRevealStore.hasSpentToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            #expect(spent)
+            let rowCount = try await APISecretRevealUnlock.query(on: app.db)
+                .filter(\.$userID == userID)
+                .filter(\.$assignmentID == assignmentID)
+                .count()
+            #expect(rowCount == 1, "double-spend must not create a second row")
+        }
+    }
+
+    @Test func regrantToken_deletesRowAndReportsExistence() async throws {
+        try await withApp(app) { _ in
+            let user = try await makeUser(username: "bob")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(courseID: try course.requireID())
+            let userID = try user.requireID()
+            let assignmentID = try assignment.requireID()
+
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+
+            let first = try await SecretRevealStore.regrantToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            #expect(first, "re-grant of a spent token reports the deleted row")
+            let second = try await SecretRevealStore.regrantToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            #expect(second == false, "re-grant with no spend row is a no-op")
+
+            let spent = try await SecretRevealStore.hasSpentToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            #expect(spent == false)
+        }
+    }
+
+    @Test func spentUserIDs_returnsExactlyTheSpenders() async throws {
+        try await withApp(app) { _ in
+            let alice = try await makeUser(username: "alice2")
+            let bob = try await makeUser(username: "bob2")
+            let carol = try await makeUser(username: "carol2")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(courseID: try course.requireID())
+            let other = try await makeAssignment(courseID: try course.requireID())
+            let assignmentID = try assignment.requireID()
+
+            try await SecretRevealStore.spendToken(
+                userID: try alice.requireID(), assignmentID: assignmentID, on: app.db)
+            try await SecretRevealStore.spendToken(
+                userID: try bob.requireID(), assignmentID: assignmentID, on: app.db)
+            // Carol spends on a different assignment — must not appear.
+            try await SecretRevealStore.spendToken(
+                userID: try carol.requireID(), assignmentID: try other.requireID(), on: app.db)
+
+            let spenders = try await SecretRevealStore.spentUserIDs(
+                assignmentID: assignmentID, on: app.db)
+            #expect(spenders == Set([try alice.requireID(), try bob.requireID()]))
+        }
+    }
+
+    @Test func spendRows_cascadeDeleteWithAssignment() async throws {
+        try await withApp(app) { _ in
+            let user = try await makeUser(username: "dave")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(courseID: try course.requireID())
+            let userID = try user.requireID()
+            let assignmentID = try assignment.requireID()
+
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: assignmentID, on: app.db)
+            try await assignment.delete(on: app.db)
+
+            let rowCount = try await APISecretRevealUnlock.query(on: app.db)
+                .filter(\.$assignmentID == assignmentID)
+                .count()
+            #expect(rowCount == 0, "spend rows follow their assignment on delete")
+        }
+    }
+
+    // MARK: - SecretRevealState.resolve
+
+    @Test func resolve_revealedOnlyWhenEnabledAndSpent() async throws {
+        try await withApp(app) { _ in
+            let user = try await makeUser(username: "erin")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(
+                courseID: try course.requireID(), secretRevealEnabled: true)
+            let userID = try user.requireID()
+
+            let unspent = try await SecretRevealState.resolve(
+                assignment: assignment, userID: userID, isStaff: false, on: app.db)
+            #expect(unspent.enabled)
+            #expect(unspent.spent == false)
+            #expect(unspent.revealed == false)
+
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: try assignment.requireID(), on: app.db)
+            let spent = try await SecretRevealState.resolve(
+                assignment: assignment, userID: userID, isStaff: false, on: app.db)
+            #expect(spent.revealed)
+        }
+    }
+
+    @Test func resolve_toggleOffHidesEvenWithSpendRow() async throws {
+        try await withApp(app) { _ in
+            let user = try await makeUser(username: "frank")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(
+                courseID: try course.requireID(), secretRevealEnabled: true)
+            let userID = try user.requireID()
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: try assignment.requireID(), on: app.db)
+
+            // Instructor turns the toggle off: the reveal stops, but the spend
+            // row survives so re-enabling restores it.
+            assignment.secretRevealEnabled = false
+            try await assignment.save(on: app.db)
+
+            let state = try await SecretRevealState.resolve(
+                assignment: assignment, userID: userID, isStaff: false, on: app.db)
+            #expect(state.revealed == false)
+            let stillSpent = try await SecretRevealStore.hasSpentToken(
+                userID: userID, assignmentID: try assignment.requireID(), on: app.db)
+            #expect(stillSpent, "toggle-off must not consume or delete the spend row")
+        }
+    }
+
+    @Test func resolve_staffAndMissingInputsShortCircuit() async throws {
+        try await withApp(app) { _ in
+            let user = try await makeUser(username: "grace")
+            let course = try await makeCourse()
+            let assignment = try await makeAssignment(
+                courseID: try course.requireID(), secretRevealEnabled: true)
+            let userID = try user.requireID()
+            try await SecretRevealStore.spendToken(
+                userID: userID, assignmentID: try assignment.requireID(), on: app.db)
+
+            let staff = try await SecretRevealState.resolve(
+                assignment: assignment, userID: userID, isStaff: true, on: app.db)
+            #expect(staff.revealed == false, "staff itemize secret anyway — state is .none")
+
+            let noAssignment = try await SecretRevealState.resolve(
+                assignment: nil, userID: userID, isStaff: false, on: app.db)
+            #expect(noAssignment.revealed == false)
+
+            let noUser = try await SecretRevealState.resolve(
+                assignment: assignment, userID: nil, isStaff: false, on: app.db)
+            #expect(noUser.revealed == false)
+        }
+    }
+}

--- a/Tests/APITests/TierFilterTests.swift
+++ b/Tests/APITests/TierFilterTests.swift
@@ -23,27 +23,30 @@ import Testing
         let now = Date()
         // Deadline far in the future — staff still see all three tiers.
         let tiers = visibleTiers(
-            isStaff: true, effectiveDueAt: now.addingTimeInterval(86_400), now: now)
+            isStaff: true, effectiveDueAt: now.addingTimeInterval(86_400), secretRevealed: false,
+            now: now)
         #expect(tiers == ["public", "release", "secret"])
     }
 
     @Test func visibleTiersStudentHidesReleaseBeforeEffectiveDeadline() {
         let now = Date()
         let tiers = visibleTiers(
-            isStaff: false, effectiveDueAt: now.addingTimeInterval(3600), now: now)
+            isStaff: false, effectiveDueAt: now.addingTimeInterval(3600), secretRevealed: false,
+            now: now)
         #expect(tiers == ["public"])
     }
 
     @Test func visibleTiersStudentShowsReleaseAfterEffectiveDeadline() {
         let now = Date()
         let tiers = visibleTiers(
-            isStaff: false, effectiveDueAt: now.addingTimeInterval(-3600), now: now)
+            isStaff: false, effectiveDueAt: now.addingTimeInterval(-3600), secretRevealed: false,
+            now: now)
         #expect(tiers == ["public", "release"])
     }
 
     @Test func visibleTiersStudentShowsReleaseWhenNoDeadline() {
         // nil effective deadline → no deadline → release immediately visible.
-        let tiers = visibleTiers(isStaff: false, effectiveDueAt: nil)
+        let tiers = visibleTiers(isStaff: false, effectiveDueAt: nil, secretRevealed: false)
         #expect(tiers == ["public", "release"])
     }
 
@@ -56,7 +59,8 @@ import Testing
         // Effective deadline = the student's future extension, not the past
         // class-wide due date.
         let extended = now.addingTimeInterval(86_400)
-        let tiers = visibleTiers(isStaff: false, effectiveDueAt: extended, now: now)
+        let tiers = visibleTiers(
+            isStaff: false, effectiveDueAt: extended, secretRevealed: false, now: now)
         #expect(tiers == ["public"], "release stays hidden until the student's own deadline passes")
     }
 
@@ -93,5 +97,67 @@ import Testing
         #expect(
             releaseOutputVisible(isStaff: false, effectiveDueAt: extended, now: now) == false,
             "an active extension keeps release output redacted past the class deadline")
+    }
+
+    // MARK: - secretRevealed (reveal-token unlock)
+
+    @Test func visibleTiersStudentSeesSecretWhenRevealedBeforeDeadline() {
+        let now = Date()
+        // Reveal unlocks secret independent of the release deadline gate:
+        // before the deadline release stays hidden but secret shows.
+        let tiers = visibleTiers(
+            isStaff: false, effectiveDueAt: now.addingTimeInterval(3600), secretRevealed: true,
+            now: now)
+        #expect(tiers == ["public", "secret"])
+    }
+
+    @Test func visibleTiersStudentSeesSecretWhenRevealedAfterDeadline() {
+        let now = Date()
+        let tiers = visibleTiers(
+            isStaff: false, effectiveDueAt: now.addingTimeInterval(-3600), secretRevealed: true,
+            now: now)
+        #expect(tiers == ["public", "release", "secret"])
+    }
+
+    @Test func visibleTiersStaffUnaffectedByRevealFlag() {
+        let now = Date()
+        let tiers = visibleTiers(
+            isStaff: true, effectiveDueAt: now.addingTimeInterval(86_400), secretRevealed: false,
+            now: now)
+        #expect(tiers == ["public", "release", "secret"])
+    }
+
+    @Test func itemizedTiersStudentIncludesSecretOnlyWhenRevealed() {
+        #expect(
+            itemizedTiers(isStaff: false, secretRevealed: false) == ["public", "release"])
+        #expect(
+            itemizedTiers(isStaff: false, secretRevealed: true)
+                == ["public", "release", "secret"])
+        #expect(
+            itemizedTiers(isStaff: true, secretRevealed: false)
+                == ["public", "release", "secret"])
+    }
+
+    // MARK: - hasSecretTierTests
+
+    @Test func hasSecretTierTestsDetectsSecretEntries() {
+        let withSecret = TestProperties(
+            schemaVersion: 1,
+            requiredFiles: [],
+            testSuites: [
+                TestSuiteEntry(tier: .pub, script: "publictest_a.py"),
+                TestSuiteEntry(tier: .secret, script: "secrettest_b.py"),
+            ],
+            timeLimitSeconds: 10)
+        #expect(hasSecretTierTests(withSecret))
+
+        let withoutSecret = TestProperties(
+            schemaVersion: 1,
+            requiredFiles: [],
+            testSuites: [TestSuiteEntry(tier: .pub, script: "publictest_a.py")],
+            timeLimitSeconds: 10)
+        #expect(hasSecretTierTests(withoutSecret) == false)
+
+        #expect(hasSecretTierTests(nil) == false)
     }
 }

--- a/Tests/APITests/WebRoutesHelpers.swift
+++ b/Tests/APITests/WebRoutesHelpers.swift
@@ -75,17 +75,30 @@ func wrEnrollUser(_ user: APIUser, on app: Application) async throws {
 }
 
 @discardableResult
-func wrInsertSetup(id: String, on app: Application) async throws -> APITestSetup {
-    let manifest = """
-        {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
-        """
+func wrInsertSetup(
+    id: String,
+    manifest: String? = nil,
+    on app: Application
+) async throws -> APITestSetup {
+    let manifestJSON =
+        manifest
+            ?? """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+            """
     let course = try await wrMakeCourse(on: app)
     let courseID = try course.requireID()
     let setup = APITestSetup(
-        id: id, manifest: manifest, zipPath: app.testSetupsDirectory + "\(id).zip", courseID: courseID)
+        id: id, manifest: manifestJSON, zipPath: app.testSetupsDirectory + "\(id).zip",
+        courseID: courseID)
     try await setup.save(on: app.db)
     return setup
 }
+
+/// A manifest with one public and one secret suite entry — the seed for
+/// secret-reveal-token tests (`wrInsertSetup(id:manifest:)`).
+let wrManifestWithSecretTier = """
+    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"},{"tier":"secret","script":"secrettest.sh"}],"timeLimitSeconds":10}
+    """
 
 @discardableResult
 func wrInsertAssignment(
@@ -93,11 +106,15 @@ func wrInsertAssignment(
     title: String,
     isOpen: Bool,
     dueAt: Date? = nil,
+    secretRevealEnabled: Bool = false,
     on app: Application
 ) async throws -> APIAssignment {
     let course = try await wrMakeCourse(on: app)
     let courseID = try course.requireID()
     let a = APIAssignment(testSetupID: testSetupID, title: title, dueAt: dueAt, isOpen: isOpen, courseID: courseID)
+    if secretRevealEnabled {
+        a.secretRevealEnabled = true
+    }
     try await a.save(on: app.db)
     return a
 }

--- a/Tests/APITests/WebRoutesSecretRevealTests.swift
+++ b/Tests/APITests/WebRoutesSecretRevealTests.swift
@@ -1,0 +1,380 @@
+// Tests/APITests/WebRoutesSecretRevealTests.swift
+//
+// Secret-reveal token flow, end to end over the web surface:
+//
+//   - the offer box renders only when (toggle on ∧ secret tests ∧ non-staff
+//     owner ∧ unspent)
+//   - POST /testsetups/:id/reveal-secret spends exactly once, and refuses
+//     (without writing a row) when the toggle is off or the caller is staff
+//   - after the spend, secret rows itemize with output while the aggregate
+//     "hidden tests" summary disappears; toggle-off re-hides them
+//   - the JSON results API includes secret outcomes post-spend, under a
+//     fresh ETag
+//   - staff re-grant deletes the spend row and restores the offer
+//   - the instructor edit-page toggle endpoint sets and clears the flag
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+@Suite struct WebRoutesSecretRevealTests {
+
+    /// Seeds course + secret-tier setup + assignment + one graded submission
+    /// for student1, returning the logged-in student cookie.
+    @discardableResult
+    private func seedRevealFixture(
+        app: Application,
+        setupID: String,
+        subID: String,
+        secretRevealEnabled: Bool = true,
+        manifest: String = wrManifestWithSecretTier
+    ) async throws -> (cookie: String, student: APIUser, assignment: APIAssignment) {
+        let cookie = try await wrLoginAsStudent(on: app)
+        let student = try await wrStudentUser(on: app)
+        try await wrEnrollUser(student, on: app)
+        try await wrInsertSetup(id: setupID, manifest: manifest, on: app)
+        let assignment = try await wrInsertAssignment(
+            testSetupID: setupID, title: "Reveal Lab", isOpen: true,
+            secretRevealEnabled: secretRevealEnabled, on: app)
+        try await wrInsertSubmission(
+            id: subID, testSetupID: setupID, userID: student.requireID(), on: app)
+        try await wrInsertResult(
+            submissionID: subID,
+            outcomes: [
+                wrMakeOutcome(name: "test.sh", tier: .pub, status: .pass),
+                wrMakeOutcome(
+                    name: "secrettest.sh", tier: .secret, status: .fail,
+                    shortResult: "secret case failed",
+                    longResult: "SecretTraceback: expected 42"),
+            ],
+            on: app)
+        return (cookie, student, assignment)
+    }
+
+    private func spendPOST(
+        app: Application, setupID: String, subID: String, cookie: String
+    ) async throws -> HTTPStatus {
+        let (csrf, sessionCookie) = try await csrfFields(
+            for: "/submissions/\(subID)", cookie: cookie, on: app)
+        var status = HTTPStatus.imATeapot
+        try await app.asyncTest(
+            .POST, "/testsetups/\(setupID)/reveal-secret",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: sessionCookie)
+                try req.content.encode(
+                    ["_csrf": csrf, "submissionID": subID], as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                status = res.status
+            })
+        return status
+    }
+
+    private func submissionPageHTML(
+        app: Application, subID: String, cookie: String
+    ) async throws -> String {
+        var html = ""
+        try await app.asyncTest(
+            .GET, "/submissions/\(subID)",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                #expect(res.status == .ok)
+                html = res.body.string
+            })
+        return html
+    }
+
+    // MARK: - Offer rendering
+
+    @Test func offerRendersForEligibleStudent() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, _, _) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr1", subID: "sub_sr1")
+            let html = try await submissionPageHTML(app: app, subID: "sub_sr1", cookie: cookie)
+            #expect(html.contains("/testsetups/setup_sr1/reveal-secret"))
+            #expect(html.contains("one reveal token"))
+            // Secret stays aggregated pre-spend.
+            #expect(html.contains("hidden tests in this section"))
+            #expect(!html.contains("SecretTraceback"))
+        }
+    }
+
+    @Test func offerHiddenWhenToggleOff() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, _, _) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr2", subID: "sub_sr2", secretRevealEnabled: false)
+            let html = try await submissionPageHTML(app: app, subID: "sub_sr2", cookie: cookie)
+            #expect(!html.contains("/testsetups/setup_sr2/reveal-secret"))
+        }
+    }
+
+    @Test func offerHiddenWhenNoSecretTests() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, _, _) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr3", subID: "sub_sr3",
+                manifest: """
+                    {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}
+                    """)
+            let html = try await submissionPageHTML(app: app, subID: "sub_sr3", cookie: cookie)
+            #expect(!html.contains("reveal-secret"))
+        }
+    }
+
+    @Test func offerHiddenForStaffViewer() async throws {
+        try await withWebRoutesApp { app in
+            let (_, _, _) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr4", subID: "sub_sr4")
+            let instructorCookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            let html = try await submissionPageHTML(
+                app: app, subID: "sub_sr4", cookie: instructorCookie)
+            #expect(!html.contains("reveal-secret"))
+            // Staff itemize secret regardless of any token.
+            #expect(html.contains("SecretTraceback"))
+        }
+    }
+
+    // MARK: - Spend POST
+
+    @Test func spendRevealsSecretRowsAndDropsAggregate() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, student, assignment) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr5", subID: "sub_sr5")
+            let status = try await spendPOST(
+                app: app, setupID: "setup_sr5", subID: "sub_sr5", cookie: cookie)
+            #expect(status == .seeOther)
+
+            let spent = try await SecretRevealStore.hasSpentToken(
+                userID: student.requireID(), assignmentID: assignment.requireID(), on: app.db)
+            #expect(spent)
+
+            let html = try await submissionPageHTML(app: app, subID: "sub_sr5", cookie: cookie)
+            #expect(html.contains("Secret tests revealed"), "active banner shows post-spend")
+            #expect(html.contains("secrettest.sh"), "secret row is itemized")
+            #expect(html.contains("SecretTraceback"), "secret output shows like public output")
+            #expect(!html.contains("hidden tests in this section"), "aggregate summary is gone")
+            #expect(!html.contains("reveal-secret"), "offer no longer renders once spent")
+        }
+    }
+
+    @Test func doubleSpendKeepsOneRow() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, student, assignment) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr6", subID: "sub_sr6")
+            _ = try await spendPOST(app: app, setupID: "setup_sr6", subID: "sub_sr6", cookie: cookie)
+            _ = try await spendPOST(app: app, setupID: "setup_sr6", subID: "sub_sr6", cookie: cookie)
+            let rowCount = try await APISecretRevealUnlock.query(on: app.db)
+                .filter(\.$userID == student.requireID())
+                .filter(\.$assignmentID == assignment.requireID())
+                .count()
+            #expect(rowCount == 1)
+        }
+    }
+
+    @Test func spendRefusedWhenToggleOff() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, student, assignment) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr7", subID: "sub_sr7", secretRevealEnabled: false)
+            let status = try await spendPOST(
+                app: app, setupID: "setup_sr7", subID: "sub_sr7", cookie: cookie)
+            #expect(status == .seeOther, "refusal is a redirect, not an error page")
+            let spent = try await SecretRevealStore.hasSpentToken(
+                userID: student.requireID(), assignmentID: assignment.requireID(), on: app.db)
+            #expect(spent == false, "a hand-crafted POST with the toggle off writes no row")
+        }
+    }
+
+    @Test func spendRefusedForStaff() async throws {
+        try await withWebRoutesApp { app in
+            _ = try await seedRevealFixture(app: app, setupID: "setup_sr8", subID: "sub_sr8")
+            let instructorCookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/submissions/sub_sr8", cookie: instructorCookie, on: app)
+            try await app.asyncTest(
+                .POST, "/testsetups/setup_sr8/reveal-secret",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+            let spendCount = try await APISecretRevealUnlock.query(on: app.db).count()
+            #expect(spendCount == 0, "staff spends are refused without a row")
+        }
+    }
+
+    // MARK: - Toggle-off after spend
+
+    @Test func toggleOffAfterSpendReAggregatesSecret() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, _, assignment) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr9", subID: "sub_sr9")
+            _ = try await spendPOST(app: app, setupID: "setup_sr9", subID: "sub_sr9", cookie: cookie)
+
+            assignment.secretRevealEnabled = false
+            try await assignment.save(on: app.db)
+
+            let html = try await submissionPageHTML(app: app, subID: "sub_sr9", cookie: cookie)
+            #expect(html.contains("hidden tests in this section"), "aggregate summary returns")
+            #expect(!html.contains("SecretTraceback"), "secret output is hidden again")
+            #expect(!html.contains("reveal-secret"), "no offer while the toggle is off")
+        }
+    }
+
+    // MARK: - JSON results API
+
+    @Test func resultsAPIIncludesSecretAfterSpendWithFreshETag() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, _, _) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr10", subID: "sub_sr10")
+
+            var etagBefore = ""
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_sr10/results",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    etagBefore = res.headers.first(name: .eTag) ?? ""
+                    let collection = try res.content.decode(TestOutcomeCollection.self)
+                    #expect(!collection.outcomes.contains { $0.tier == .secret })
+                })
+
+            _ = try await spendPOST(
+                app: app, setupID: "setup_sr10", subID: "sub_sr10", cookie: cookie)
+
+            try await app.asyncTest(
+                .GET, "/api/v1/submissions/sub_sr10/results",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                    // A cached pre-spend ETag must not produce a 304 now.
+                    req.headers.add(name: .ifNoneMatch, value: etagBefore)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "spend busts the pre-spend ETag")
+                    let etagAfter = res.headers.first(name: .eTag) ?? ""
+                    #expect(etagAfter != etagBefore)
+                    let collection = try res.content.decode(TestOutcomeCollection.self)
+                    #expect(collection.outcomes.contains { $0.tier == .secret })
+                })
+        }
+    }
+
+    // MARK: - Staff re-grant
+
+    @Test func regrantDeletesSpendAndRestoresOffer() async throws {
+        try await withWebRoutesApp { app in
+            let (cookie, student, assignment) = try await seedRevealFixture(
+                app: app, setupID: "setup_sr11", subID: "sub_sr11")
+            _ = try await spendPOST(
+                app: app, setupID: "setup_sr11", subID: "sub_sr11", cookie: cookie)
+
+            let instructorCookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+
+            // Roster shows the spent tag + re-grant action while spent.
+            let rosterPath = "/instructor/\(assignment.publicID)/submissions"
+            let (csrf, staffCookie) = try await csrfFields(
+                for: rosterPath, cookie: instructorCookie, on: app)
+            let studentUUID = try student.requireID().uuidString
+            try await app.asyncTest(
+                .GET, rosterPath,
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: staffCookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("regrant-reveal-token"))
+                })
+
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignment.publicID)/students/\(studentUUID)/regrant-reveal-token",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: staffCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+
+            let spent = try await SecretRevealStore.hasSpentToken(
+                userID: student.requireID(), assignmentID: assignment.requireID(), on: app.db)
+            #expect(spent == false)
+
+            let html = try await submissionPageHTML(app: app, subID: "sub_sr11", cookie: cookie)
+            #expect(html.contains("reveal-secret"), "offer returns after the re-grant")
+            #expect(!html.contains("SecretTraceback"), "secret output is hidden again")
+        }
+    }
+
+    // MARK: - Instructor toggle endpoint
+
+    @Test func toggleEndpointSetsAndClearsFlag() async throws {
+        try await withWebRoutesApp { app in
+            let instructorCookie = try await wrLoginAsInstructor(on: app)
+            let instructor = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "instructor1").first())
+            try await wrEnrollUser(instructor, on: app)
+            try await wrInsertSetup(id: "setup_sr12", manifest: wrManifestWithSecretTier, on: app)
+            let assignment = try await wrInsertAssignment(
+                testSetupID: "setup_sr12", title: "Toggle Lab", isOpen: false, on: app)
+
+            let editPath = "/instructor/\(assignment.publicID)/edit"
+            let (csrf, staffCookie) = try await csrfFields(
+                for: editPath, cookie: instructorCookie, on: app)
+
+            // Checked checkbox → enabled.
+            try await app.asyncTest(
+                .POST, "/instructor/\(assignment.publicID)/secret-reveal",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: staffCookie)
+                    try req.content.encode(["_csrf": csrf, "enabled": "on"], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+            let enabled = try await APIAssignment.find(assignment.requireID(), on: app.db)
+            #expect(enabled?.secretRevealEnabled == true)
+
+            // Edit page reflects the state.
+            try await app.asyncTest(
+                .GET, editPath,
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: staffCookie)
+                },
+                afterResponse: { res in
+                    #expect(res.body.string.contains("checked"))
+                })
+
+            // Absent checkbox (unchecked) → disabled.
+            try await app.asyncTest(
+                .POST, "/instructor/\(assignment.publicID)/secret-reveal",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: staffCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+            let disabled = try await APIAssignment.find(assignment.requireID(), on: app.db)
+            #expect(disabled?.secretRevealEnabled == false)
+        }
+    }
+}

--- a/changelog.d/secret-reveal-tokens.md
+++ b/changelog.d/secret-reveal-tokens.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Secret reveal tokens.** Each student gets one token per assignment they can
+  permanently spend (with a confirmation step) to reveal secret-tier test
+  results — itemized rows with status, output, and hints, exactly like public
+  tests — across all their past and future submissions on that assignment.
+  Off by default; instructors enable it per assignment from the edit page's
+  new "Student Options" block or the `update_assignment` MCP tool
+  (`secretRevealEnabled`), and course staff can re-grant a spent token from
+  the assignment submissions roster. Display-only — grades already span every
+  tier, so nothing about grading, CSV export, or BrightSpace sync changes.
+  Spends, re-grants, and toggle changes are audit-logged.


### PR DESCRIPTION
## Summary

Each student gets **one reveal token per assignment** they can permanently cash in (with a confirmation step) to see **secret-tier test results** — itemized rows with status, output, and hints, exactly like public tests — across **all their past and future submissions** on that assignment.

Display-only by construction: the grade already spans every tier, so grading, the CSV export, and BrightSpace sync are untouched. Off by default; instructors opt in per assignment.

## How it works

- **Persistence** — new `secret_reveal_unlocks` table, one row per (user, assignment) with `UNIQUE(user_id, assignment_id)` + cascade FKs; row existence *is* the spent state. `SecretRevealStore` mirrors `AssignmentParticipationStore`'s race-safe find-else-insert-else-refetch pattern. A nullable `secret_reveal_enabled` bool on `assignments` carries the instructor toggle (standalone `Add*` migration).
- **Policy** — `visibleTiers` / `itemizedTiers` in `TierFilter.swift` gain a `secretRevealed: Bool` parameter (deliberately no default so the compiler surfaces every call site). The reveal gate is `toggle enabled && token spent` (`SecretRevealState.revealed`), so an instructor flipping the toggle off re-hides secret results without consuming anyone's spend. `releaseOutputVisible` is untouched — the token affects secret only.
- **Student flow** — the submission page shows an offer box (only when: toggle on, manifest has secret tests, non-staff owner, unspent) with a `confirm()`-guarded form posting to `POST /testsetups/:id/reveal-secret`. The endpoint re-checks all gates server-side and refuses without writing a row (a stale/hand-crafted POST can't waste the token). Once spent, secret rows flow through the ordinary itemized path (hints, output panels, section grouping) and the aggregate "N hidden tests" summary disappears.
- **JSON API** — `GET /api/v1/submissions/:id/results` widens the caller's tier set post-spend; the existing ETag key already includes the tier set, so spend / re-grant / toggle changes bust cached responses automatically.
- **Instructor surface** — new "Student Options" block on the assignment edit page with its own lightweight endpoint (`POST /instructor/:id/secret-reveal`) so a mid-semester flip doesn't close/re-validate the assignment; `secretRevealEnabled` on the `update_assignment` / `get_assignment` MCP tools via the shared `AssignmentAuthoringService.updateMetadata` chokepoint. The submissions roster shows a 🔓 tag for spenders and a TA+ re-grant action that deletes the spend row.
- **Audit** — `secret_reveal.spent` / `secret_reveal.regranted` / `secret_reveal.toggle_changed` actions recorded at each mutation site.

## Tests

- `SecretRevealStoreTests` — idempotent spend, re-grant semantics, roster query, cascade delete, `SecretRevealState` gating (incl. toggle-off keeps the spend row).
- `WebRoutesSecretRevealTests` — offer visibility matrix (toggle off / no secret tests / staff / already spent), spend POST + refusal paths, post-spend itemization with output + banner, toggle-off re-aggregation, ETag bust + secret outcomes on the results API, staff re-grant round trip, edit-page toggle set/clear.
- `TierFilterTests` — updated for the new signatures + secret-reveal cases and `hasSecretTierTests`.
- MCP: `update_assignment` set/clear round-trip, `get_assignment` reporting, output-schema sync fixture.

All new suites plus the adjacent affected suites (`WebRoutesSubmissionPageTests`, `SubmissionQueryRoutesTests`, `HintSurfacingTests`, `WebRoutesBadgeTests`, MCP tool suites) pass locally; `scripts/format.sh` and `scripts/check-styles.sh` are clean.

## Notes for review

- Naming avoids "token" collisions with auth/OAuth/CSRF: the model is `APISecretRevealUnlock`, the feature reads "secret reveal token" in UI copy only.
- For browser-graded assignments secret test scripts already ship to the client (documented in `BrowserRunnerRoutes`), so this feature changes only server-side display there — it exposes nothing new.
- Course bundle export/import deliberately does not carry the toggle; imported assignments default to off (the safe direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Euwwu3p4GbZ51xhTw7pqe

---
_Generated by [Claude Code](https://claude.ai/code/session_012Euwwu3p4GbZ51xhTw7pqe)_