### PR TITLE
Add personal-data export for FIPPA/PIPEDA subject access (#557)

### DIFF
--- a/Public/account-export.js
+++ b/Public/account-export.js
@@ -1,0 +1,20 @@
+// Account page: personal-data export status poll (#557).
+//
+// Loaded only while the page shows an in-progress export. Polls the status
+// endpoint and reloads the page once generation reaches a terminal state so
+// the download button (or failure notice) appears without a manual refresh.
+(function () {
+    "use strict";
+    if (!document.getElementById("export-pending")) { return; }
+    var timer = setInterval(function () {
+        fetch("/account/export/status", { headers: { "Accept": "application/json" } })
+            .then(function (res) { return res.json(); })
+            .then(function (body) {
+                if (body.status !== "pending") {
+                    clearInterval(timer);
+                    window.location.replace("/account");
+                }
+            })
+            .catch(function () {});
+    }, 3000);
+})();

--- a/Resources/Views/account.leaf
+++ b/Resources/Views/account.leaf
@@ -30,6 +30,46 @@ My Account
     </dl>
 </section>
 
+<!-- ── Your data ──────────────────────────────────────────── -->
+<section class="admin-section">
+    <h2>Your data</h2>
+    #if(exportNotice == "started"):
+    <div class="notice-banner"><p>Your data export is being prepared. This page will refresh when it is ready.</p></div>
+    #elseif(exportNotice == "in_progress"):
+    <div class="notice-banner"><p>Your data export is already being prepared. This page will refresh when it is ready.</p></div>
+    #endif
+    #if(exportError == "rate_limited"):
+    <p class="form-error" role="alert">You can request one data export per day. Please try again later.</p>
+    #elseif(exportError == "not_ready"):
+    <p class="form-error" role="alert">Your data export is not ready to download yet.</p>
+    #endif
+    <p>Request a copy of the personal information Chickadee holds about you:
+        your profile, course enrollments, submissions (including the files you
+        uploaded), grading results, and account activity records — delivered
+        as a single zip archive. Limit one export per day.</p>
+    #if(exportStatus == "pending"):
+    <p id="export-pending"><span class="badge badge-info">In progress</span>
+        Requested #(exportRequestedAtDisplay). Preparing your export can take
+        a few minutes.</p>
+    <script src="/account-export.js?v=#appVersion()"></script>
+    #elseif(exportStatus == "complete"):
+    <p>
+        <a class="btn btn-primary" href="/account/export/download">Download your export</a>
+    </p>
+    <p>Prepared #(exportCompletedAtDisplay). Downloads are available for three
+        days after the export is prepared, then the archive is deleted from
+        the server.</p>
+    #elseif(exportStatus == "failed"):
+    <p class="form-error" role="alert">Your last export attempt failed. Please try again.</p>
+    #endif
+    #if(exportCanRequest):
+    <form method="post" action="/account/export" class="inline-form">
+        #csrfFormField()
+        <button class="btn" type="submit">Request data export</button>
+    </form>
+    #endif
+</section>
+
 <!-- ── My Courses ─────────────────────────────────────────── -->
 <section class="admin-section">
     <h2>My courses</h2>

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -150,6 +150,9 @@ struct TestSetupsDirectoryKey: StorageKey {
 struct SubmissionsDirectoryKey: StorageKey {
     typealias Value = String
 }
+struct DataExportsDirectoryKey: StorageKey {
+    typealias Value = String
+}
 struct DeployStateDirectoryKey: StorageKey {
     typealias Value = String
 }
@@ -211,6 +214,13 @@ extension Application {
     var submissionsDirectory: String {
         get { storage[SubmissionsDirectoryKey.self] ?? "submissions/" }
         set { storage[SubmissionsDirectoryKey.self] = newValue }
+    }
+    /// Where generated personal-data export zips live (#557).  Contents are
+    /// bundled user PII: never served statically, only streamed through the
+    /// owner-gated download route, and reaped by `DataExportRetentionService`.
+    var dataExportsDirectory: String {
+        get { storage[DataExportsDirectoryKey.self] ?? "data-exports/" }
+        set { storage[DataExportsDirectoryKey.self] = newValue }
     }
     /// Directory holding the auto-deploy daemon's IPC files (status.json,
     /// history.jsonl), mounted read-only into the container. Read by the

--- a/Sources/APIServer/Bootstrap/AppDirectories.swift
+++ b/Sources/APIServer/Bootstrap/AppDirectories.swift
@@ -20,8 +20,9 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     let resultsDir = workDir + "results/"
     let setupsDir = workDir + "testsetups/"
     let submissionsDir = workDir + "submissions/"
+    let dataExportsDir = workDir + "data-exports/"
 
-    for dir in [resultsDir, setupsDir, submissionsDir] {
+    for dir in [resultsDir, setupsDir, submissionsDir, dataExportsDir] {
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
     }
 
@@ -30,6 +31,7 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     app.storage[ResultsDirectoryKey.self] = resultsDir
     app.storage[TestSetupsDirectoryKey.self] = setupsDir
     app.storage[SubmissionsDirectoryKey.self] = submissionsDir
+    app.storage[DataExportsDirectoryKey.self] = dataExportsDir
     // Read-only mount of the auto-deploy daemon's IPC dir (status.json /
     // history.jsonl); absolute host path, not under the data volume.  Read
     // through AppConfig like every other env var (#1129) so it shows up in
@@ -58,6 +60,7 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
         initialEnabled: localRunnerAutoStartEnabled
     )
     app.storage[LocalRunnerManagerKey.self] = LocalRunnerManager()
+    app.storage[DataExportManagerKey.self] = DataExportManager()
     app.authProvider = LocalAuthProvider()
 }
 

--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -29,6 +29,7 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
     app.lifecycle.use(
         PeriodicSweepLifecycleHandler { $0.auditLogReaperMonitor(maxAge: auditLogMaxAge) }
     )
+    app.lifecycle.use(PeriodicSweepLifecycleHandler { $0.dataExportReaperMonitor })
     app.lifecycle.use(ServerHealthAlertLifecycleHandler())
 
     // One-time best-effort cleanup of pre-v0.4 notebook working-copy

--- a/Sources/APIServer/Migrations/CreateDataExports.swift
+++ b/Sources/APIServer/Migrations/CreateDataExports.swift
@@ -1,0 +1,33 @@
+// APIServer/Migrations/CreateDataExports.swift
+//
+// Personal-data export tracking (#557 — FIPPA / PIPEDA subject access).
+// One row per user (unique on user_id): the row is reset in place on a
+// re-request, so it doubles as the one-export-per-day rate-limit ledger.
+// Cascade-deletes follow the parent user.
+
+import Fluent
+
+struct CreateDataExports: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("data_exports")
+            .id()
+            .field(
+                "user_id",
+                .uuid,
+                .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field("status", .string, .required)
+            .field("requested_at", .datetime, .required)
+            .field("completed_at", .datetime)
+            .field("zip_path", .string)
+            .field("file_size_bytes", .int)
+            .field("failure_reason", .string)
+            .unique(on: "user_id")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("data_exports").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -101,6 +101,8 @@ enum AuditAction: String, Sendable, CaseIterable {
     case userProvisioned = "user.provisioned"
     case userRoleChanged = "user.role_changed"
     case userDeleted = "user.deleted"
+    case userDataExportRequested = "user.data_export_requested"
+    case userDataExportDownloaded = "user.data_export_downloaded"
 
     // Courses
     case courseCreated = "course.created"
@@ -168,7 +170,8 @@ enum AuditAction: String, Sendable, CaseIterable {
         switch self {
         case .loginSuccess, .loginFailure, .loginLocked, .logout, .sessionIdleTimeout:
             return .authentication
-        case .userRegistered, .userProvisioned, .userRoleChanged, .userDeleted:
+        case .userRegistered, .userProvisioned, .userRoleChanged, .userDeleted,
+            .userDataExportRequested, .userDataExportDownloaded:
             return .users
         case .courseCreated, .courseArchived, .courseUnarchived, .courseDeleted,
             .courseBundleImported, .courseBundleExported:
@@ -208,6 +211,8 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .userProvisioned: return "Account provisioned (SSO)"
         case .userRoleChanged: return "Role changed"
         case .userDeleted: return "User deleted"
+        case .userDataExportRequested: return "Data export requested"
+        case .userDataExportDownloaded: return "Data export downloaded"
         case .courseCreated: return "Course created"
         case .courseArchived: return "Course archived"
         case .courseUnarchived: return "Course unarchived"

--- a/Sources/APIServer/Models/APIDataExport.swift
+++ b/Sources/APIServer/Models/APIDataExport.swift
@@ -1,0 +1,87 @@
+// APIServer/Models/APIDataExport.swift
+//
+// Tracks a user's personal-data export (#557 — FIPPA / PIPEDA subject
+// access).  Exactly one row per user (unique on user_id): a new request
+// resets the existing row rather than accumulating history, so the table
+// doubles as the "one export per day" rate-limit ledger and the download
+// endpoint never has to disambiguate.  The audit log carries the durable
+// history of who exported when.
+//
+// The generated zip lives on disk at `zipPath` (under
+// `Application.dataExportsDirectory`) and is deleted by the retention
+// reaper (`DataExportRetentionService`) once the row expires — exported
+// personal data must not linger on the server indefinitely.
+
+import Fluent
+import Vapor
+
+/// Lifecycle states for a data-export row.  The `status` DB column stays a
+/// plain string; this enum is the authoritative vocabulary for it.
+enum DataExportStatus: String, Sendable {
+    /// Requested; generation is running (or was interrupted — see
+    /// `dataExportStalePendingAge` for the self-heal window).
+    case pending
+    case complete
+    case failed
+}
+
+final class APIDataExport: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: mutated only within Vapor's request context or the
+    // single generation task that owns the row while it is pending.
+    static let schema = "data_exports"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    /// The user this export belongs to.  Stored directly as UUID (not via
+    /// @Parent) — same convention as `APICourseEnrollment.userID`.
+    @Field(key: "user_id")
+    var userID: UUID
+
+    /// `DataExportStatus` raw value; column stays a string.
+    @Field(key: "status")
+    var status: String
+
+    /// When the user requested this export.  A plain field (not a
+    /// `@Timestamp(.create)`) because a re-request resets the same row.
+    @Field(key: "requested_at")
+    var requestedAt: Date
+
+    @OptionalField(key: "completed_at")
+    var completedAt: Date?
+
+    /// Absolute path of the generated zip; nil until generation completes.
+    @OptionalField(key: "zip_path")
+    var zipPath: String?
+
+    @OptionalField(key: "file_size_bytes")
+    var fileSizeBytes: Int?
+
+    /// Short operator-facing failure description.  Never rendered to the
+    /// user (the UI only says the export failed).
+    @OptionalField(key: "failure_reason")
+    var failureReason: String?
+
+    init() {}
+
+    init(id: UUID? = nil, userID: UUID, requestedAt: Date = Date()) {
+        self.id = id
+        self.userID = userID
+        self.status = DataExportStatus.pending.rawValue
+        self.requestedAt = requestedAt
+    }
+}
+
+// MARK: - Typed status accessors
+
+extension APIDataExport {
+    /// The export's status as a typed enum, or nil if the stored string is
+    /// outside the known vocabulary (defensive — should not happen).
+    var statusValue: DataExportStatus? { DataExportStatus(rawValue: status) }
+
+    /// Sets the status from the typed enum.  Prefer this over assigning a
+    /// raw string to `status`.
+    func setStatus(_ newStatus: DataExportStatus) {
+        status = newStatus.rawValue
+    }
+}

--- a/Sources/APIServer/Routes/Web/AccountExportRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AccountExportRoutes.swift
@@ -1,0 +1,149 @@
+// APIServer/Routes/Web/AccountExportRoutes.swift
+//
+// Personal-data export endpoints (#557 — FIPPA / PIPEDA subject access),
+// available to any authenticated user and always scoped to their own data
+// (there is no way to name another user's export).
+//
+//   POST /account/export           → reset/create the user's export row,
+//                                    kick off async generation → /account
+//   GET  /account/export/status    → tiny JSON poll for the account page
+//   GET  /account/export/download  → stream the finished zip
+//
+// Rate limiting is one export per day per user, enforced against the
+// row's `requestedAt` (DB-backed, so it holds across processes).  Both
+// the request and the download are audit-logged.
+
+import Fluent
+import Foundation
+import Vapor
+
+struct AccountExportRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.post("account", "export", use: requestExport)
+        routes.get("account", "export", "status", use: exportStatus)
+        routes.get("account", "export", "download", use: downloadExport)
+    }
+
+    // MARK: - POST /account/export
+
+    @Sendable
+    func requestExport(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let userID = try user.requireID()
+        let now = Date()
+
+        let existing = try await APIDataExport.query(on: req.db)
+            .filter(\.$userID == userID)
+            .first()
+        if !dataExportCanBeRequested(existing, now: now) {
+            // A live pending row means the export is already on its way —
+            // report progress rather than an error.
+            if existing?.statusValue == .pending {
+                return req.redirect(to: "/account?exportNotice=in_progress")
+            }
+            return req.redirect(to: "/account?exportError=rate_limited")
+        }
+
+        // One row per user: reset the existing row in place (or create the
+        // first one).  The previous zip is removed up front so a stale
+        // archive can't be downloaded while its replacement generates.
+        let export = existing ?? APIDataExport(userID: userID, requestedAt: now)
+        export.setStatus(.pending)
+        export.requestedAt = now
+        export.completedAt = nil
+        export.fileSizeBytes = nil
+        export.failureReason = nil
+        if let previousZip = export.zipPath {
+            try? FileManager.default.removeItem(atPath: previousZip)
+            export.zipPath = nil
+        }
+        try await export.save(on: req.db)
+
+        await AuditLogger.record(
+            action: .userDataExportRequested,
+            targetType: .user,
+            targetID: userID.uuidString,
+            on: req
+        )
+
+        await req.application.dataExportManager.startExport(
+            exportID: try export.requireID(), userID: userID, app: req.application)
+        return req.redirect(to: "/account?exportNotice=started")
+    }
+
+    // MARK: - GET /account/export/status
+
+    @Sendable
+    func exportStatus(req: Request) async throws -> DataExportStatusResponse {
+        let user = try req.auth.require(APIUser.self)
+        let userID = try user.requireID()
+        let export = try await APIDataExport.query(on: req.db)
+            .filter(\.$userID == userID)
+            .first()
+        return DataExportStatusResponse(status: export?.statusValue?.rawValue ?? "none")
+    }
+
+    // MARK: - GET /account/export/download
+
+    @Sendable
+    func downloadExport(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let userID = try user.requireID()
+
+        guard
+            let export = try await APIDataExport.query(on: req.db)
+                .filter(\.$userID == userID)
+                .first(),
+            export.statusValue == .complete,
+            let zipPath = export.zipPath,
+            FileManager.default.fileExists(atPath: zipPath)
+        else {
+            return req.redirect(to: "/account?exportError=not_ready")
+        }
+
+        // FIPPA accountability: record where the bundled personal data went
+        // (the actor is the owner, so the logged IP/user-agent are theirs).
+        await AuditLogger.record(
+            action: .userDataExportDownloaded,
+            targetType: .user,
+            targetID: userID.uuidString,
+            on: req
+        )
+
+        let stamp = downloadDateStamp(export.completedAt ?? Date())
+        let downloadName =
+            "chickadee-data-export-\(sanitizedDownloadComponent(user.username))-\(stamp).zip"
+        let response = try await req.fileio.asyncStreamFile(at: zipPath)
+        response.headers.replaceOrAdd(name: .contentType, value: "application/zip")
+        response.headers.replaceOrAdd(
+            name: .contentDisposition,
+            value: "attachment; filename=\"\(downloadName)\"")
+        return response
+    }
+}
+
+struct DataExportStatusResponse: Content {
+    let status: String
+}
+
+/// yyyy-MM-dd (UTC) for the download filename.
+private func downloadDateStamp(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.string(from: date)
+}
+
+/// Restricts a username to header-safe ASCII for the Content-Disposition
+/// filename; anything else becomes "-".
+private func sanitizedDownloadComponent(_ raw: String) -> String {
+    let mapped = raw.map { ch -> Character in
+        if ch.isASCII && (ch.isLetter || ch.isNumber || ch == "." || ch == "-" || ch == "_") {
+            return ch
+        }
+        return "-"
+    }
+    let cleaned = String(mapped)
+    return cleaned.isEmpty ? "user" : cleaned
+}

--- a/Sources/APIServer/Routes/Web/AccountRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AccountRoutes.swift
@@ -61,6 +61,12 @@ struct AccountRoutes: RouteCollection {
                     enrollmentMode: c.enrollmentMode.rawValue)
             }
 
+        // Personal-data export state (#557) for the "Your data" section.
+        let export = try await APIDataExport.query(on: req.db)
+            .filter(\.$userID == userID)
+            .first()
+        let dateFormatter = waterlooDateTimeFormatter()
+
         return try await req.view.render(
             "account",
             AccountContext(
@@ -71,7 +77,13 @@ struct AccountRoutes: RouteCollection {
                 email: user.email,
                 enrolledCourses: enrolledRows,
                 availableCourses: availableRows,
-                error: req.query[String.self, at: "error"]
+                error: req.query[String.self, at: "error"],
+                exportStatus: export?.statusValue?.rawValue ?? "none",
+                exportRequestedAtDisplay: export.map { dateFormatter.string(from: $0.requestedAt) },
+                exportCompletedAtDisplay: export?.completedAt.map(dateFormatter.string(from:)),
+                exportCanRequest: dataExportCanBeRequested(export),
+                exportNotice: req.query[String.self, at: "exportNotice"],
+                exportError: req.query[String.self, at: "exportError"]
             ))
     }
 
@@ -152,6 +164,14 @@ private struct AccountContext: Encodable {
     let enrolledCourses: [AccountCourseRow]
     let availableCourses: [AccountCourseRow]
     let error: String?
+    /// Personal-data export state (#557): "none" | "pending" | "complete" |
+    /// "failed", plus display timestamps and whether the request button shows.
+    let exportStatus: String
+    let exportRequestedAtDisplay: String?
+    let exportCompletedAtDisplay: String?
+    let exportCanRequest: Bool
+    let exportNotice: String?
+    let exportError: String?
 }
 
 private struct AccountCourseRow: Encodable {

--- a/Sources/APIServer/Services/DataExportContent.swift
+++ b/Sources/APIServer/Services/DataExportContent.swift
@@ -1,0 +1,513 @@
+// APIServer/Services/DataExportContent.swift
+//
+// What goes *inside* a personal-data export (#557 — FIPPA / PIPEDA subject
+// access): the Sendable snapshot types for each JSON file in the zip, the
+// DB gather queries that populate them, and the README manifest text.
+// The pipeline that stages, zips, and tracks the export lives in
+// `DataExportService.swift`.
+//
+// Privacy rules encoded here:
+//   • Test outcomes are tier-filtered with the same policy as the results
+//     API (`visibleTiers`) — the export contains exactly what the user can
+//     already see, never hidden secret/release detail.
+//   • Audit entries where the user is the *actor* include their own
+//     IP / user-agent; entries where they are only the *subject* omit
+//     those fields (they belong to whoever performed the action).
+//   • `passwordHash` and per-assignment personalization seeds are never
+//     exported (credentials and server-side grading secrets).
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+// MARK: - Snapshot types (one per JSON file in the zip)
+
+struct DataExportProfile: Codable, Sendable {
+    let accountID: String
+    let username: String
+    let preferredName: String?
+    let displayName: String?
+    let email: String?
+    let userIdentifier: String?
+    let studentID: String?
+    let deploymentRole: String
+    let authProvider: String?
+    let ssoSubject: String?
+    let accountCreatedAt: Date?
+    let lastLoginAt: Date?
+    let lastSeenAt: Date?
+}
+
+struct DataExportEnrollment: Codable, Sendable {
+    let courseCode: String
+    let courseName: String
+    let role: String
+    let enrolledAt: Date?
+    let learnSection: String?
+}
+
+struct DataExportSubmission: Codable, Sendable {
+    let submissionID: String
+    let courseCode: String?
+    let assignmentTitle: String?
+    let kind: String
+    let status: String
+    let attemptNumber: Int?
+    let submittedAt: Date?
+    let originalFilename: String?
+    /// Path of the uploaded file inside this zip, nil when the file was no
+    /// longer on disk at export time.
+    let filePath: String?
+    /// Path of the grading results JSON inside this zip, nil when the
+    /// submission has no stored result yet.
+    let resultsPath: String?
+}
+
+struct DataExportAuditEntry: Codable, Sendable {
+    let occurredAt: Date?
+    let action: String
+    let actionLabel: String
+    /// "actor" when the user performed the action themselves, "subject"
+    /// when someone else's action was about them (e.g. they were enrolled).
+    let involvement: String
+    let targetType: String?
+    let targetID: String?
+    /// Only on "subject" rows: who performed the action.
+    let performedBy: String?
+    /// Only on "actor" rows — the IP / user-agent belong to the actor.
+    let ipAddress: String?
+    let userAgent: String?
+    let details: [String: String]?
+}
+
+struct DataExportGradingAdjustments: Codable, Sendable {
+    struct Extension: Codable, Sendable {
+        let assignmentTitle: String?
+        let extendedDueAt: Date
+        let note: String?
+        let grantedAt: Date?
+    }
+    struct GradeOverride: Codable, Sendable {
+        let assignmentTitle: String?
+        let overridePercent: Int
+        let note: String?
+        let grantedAt: Date?
+    }
+    struct SecretRevealSpend: Codable, Sendable {
+        let assignmentTitle: String?
+        let spentAt: Date?
+    }
+    let deadlineExtensions: [Extension]
+    let gradeOverrides: [GradeOverride]
+    let secretRevealTokensSpent: [SecretRevealSpend]
+}
+
+/// Everything gathered from the database for one export, in Sendable form,
+/// plus the on-disk submission files to copy into the zip.
+struct DataExportContent: Sendable {
+    let profile: DataExportProfile
+    let enrollments: [DataExportEnrollment]
+    let submissions: [DataExportSubmission]
+    /// Tier-filtered results JSON bytes keyed by in-zip relative path.
+    let resultFiles: [String: Data]
+    let auditEntries: [DataExportAuditEntry]
+    let gradingAdjustments: DataExportGradingAdjustments
+    /// (absolute source path, in-zip relative path) submission file copies.
+    let fileCopies: [(sourcePath: String, relativePath: String)]
+}
+
+// MARK: - Gather
+
+/// Loads every piece of the export for `user` from the database.  Read-only;
+/// all file I/O happens later on the thread pool (`DataExportService`).
+func gatherDataExportContent(
+    for user: APIUser, on db: Database, now: Date = Date()
+) async throws -> DataExportContent {
+    let userID = try user.requireID()
+
+    let enrollments = try await gatherEnrollments(userID: userID, on: db)
+    let submissionData = try await gatherSubmissions(user: user, on: db, now: now)
+    let auditEntries = try await gatherAuditEntries(for: user, on: db)
+    let adjustments = try await gatherGradingAdjustments(userID: userID, on: db)
+
+    return DataExportContent(
+        profile: DataExportProfile(
+            accountID: userID.uuidString,
+            username: user.username,
+            preferredName: user.preferredName,
+            displayName: user.displayName,
+            email: user.email,
+            userIdentifier: user.userIdentifier,
+            studentID: user.studentID,
+            deploymentRole: user.role,
+            authProvider: user.authProvider,
+            ssoSubject: user.externalSubject,
+            accountCreatedAt: user.createdAt,
+            lastLoginAt: user.lastLoginAt,
+            lastSeenAt: user.lastSeenAt
+        ),
+        enrollments: enrollments,
+        submissions: submissionData.submissions,
+        resultFiles: submissionData.resultFiles,
+        auditEntries: auditEntries,
+        gradingAdjustments: adjustments,
+        fileCopies: submissionData.fileCopies
+    )
+}
+
+private func gatherEnrollments(
+    userID: UUID, on db: Database
+) async throws -> [DataExportEnrollment] {
+    let rows = try await APICourseEnrollment.query(on: db)
+        .filter(\.$userID == userID)
+        .with(\.$course)
+        .all()
+    return
+        rows
+        .map { row in
+            DataExportEnrollment(
+                courseCode: row.course.code,
+                courseName: row.course.name,
+                role: row.role.rawValue,
+                enrolledAt: row.enrolledAt,
+                learnSection: row.brightspaceSection
+            )
+        }
+        .sorted { $0.courseCode < $1.courseCode }
+}
+
+private struct GatheredSubmissions: Sendable {
+    let submissions: [DataExportSubmission]
+    let resultFiles: [String: Data]
+    let fileCopies: [(sourcePath: String, relativePath: String)]
+}
+
+private func gatherSubmissions(
+    user: APIUser, on db: Database, now: Date
+) async throws -> GatheredSubmissions {
+    let userID = try user.requireID()
+    let submissions = try await APISubmission.query(on: db)
+        .filter(\.$userID == userID)
+        .sort(\.$submittedAt, .ascending)
+        .all()
+    guard !submissions.isEmpty else {
+        return GatheredSubmissions(submissions: [], resultFiles: [:], fileCopies: [])
+    }
+
+    let setupIDs = Array(Set(submissions.map(\.testSetupID)))
+    let setups = try await APITestSetup.query(on: db).filter(\.$id ~~ setupIDs).all()
+    let setupByID = Dictionary(setups.compactMap { s in s.id.map { ($0, s) } }) { first, _ in first }
+    let assignments = try await APIAssignment.query(on: db)
+        .filter(\.$testSetupID ~~ setupIDs)
+        .all()
+    let assignmentBySetupID = Dictionary(assignments.map { ($0.testSetupID, $0) }) { first, _ in
+        first
+    }
+    let courseIDs = Array(Set(setups.map(\.courseID)))
+    let courses =
+        courseIDs.isEmpty
+        ? [] : try await APICourse.query(on: db).filter(\.$id ~~ courseIDs).all()
+    let courseByID = Dictionary(courses.compactMap { c in c.id.map { ($0, c) } }) { first, _ in
+        first
+    }
+
+    let visibleTiersBySetupID = try await resolveVisibleTiers(
+        user: user, setups: setups, assignmentBySetupID: assignmentBySetupID, on: db, now: now)
+    let latestResults = try await latestResultBySubmissionID(
+        submissionIDs: submissions.compactMap(\.id), on: db)
+    let collectionJSONs = try await collectionJSONByResultID(
+        for: latestResults.values.compactMap(\.id), on: db)
+
+    var rows: [DataExportSubmission] = []
+    var resultFiles: [String: Data] = [:]
+    var fileCopies: [(sourcePath: String, relativePath: String)] = []
+    for submission in submissions {
+        guard let subID = submission.id else { continue }
+        let setup = setupByID[submission.testSetupID]
+        let course = setup.flatMap { courseByID[$0.courseID] }
+
+        let onDiskName = URL(fileURLWithPath: submission.zipPath).lastPathComponent
+        let filePath = "submissions/\(subID)/\(onDiskName)"
+        let fileOnDisk = FileManager.default.fileExists(atPath: submission.zipPath)
+        if fileOnDisk {
+            fileCopies.append((sourcePath: submission.zipPath, relativePath: filePath))
+        }
+
+        var resultsPath: String?
+        if let result = latestResults[subID], let resultID = result.id,
+            let json = collectionJSONs[resultID],
+            let tiers = visibleTiersBySetupID[submission.testSetupID],
+            let data = tierFilteredCollectionData(collectionJSON: json, visibleTiers: tiers)
+        {
+            let path = "submissions/\(subID)/results.json"
+            resultFiles[path] = data
+            resultsPath = path
+        }
+
+        rows.append(
+            DataExportSubmission(
+                submissionID: subID,
+                courseCode: course?.code,
+                assignmentTitle: assignmentBySetupID[submission.testSetupID]?.title,
+                kind: submission.kind,
+                status: submission.status,
+                attemptNumber: submission.attemptNumber,
+                submittedAt: submission.submittedAt,
+                originalFilename: submission.filename,
+                filePath: fileOnDisk ? filePath : nil,
+                resultsPath: resultsPath
+            ))
+    }
+    return GatheredSubmissions(
+        submissions: rows, resultFiles: resultFiles, fileCopies: fileCopies)
+}
+
+/// The tier set the user may inspect for each test setup, mirroring
+/// `SubmissionQueryRoutes.getResults`: staff of the setup's course see all
+/// tiers; otherwise release is gated on the user's own effective deadline
+/// and secret on a spent reveal token.
+private func resolveVisibleTiers(
+    user: APIUser,
+    setups: [APITestSetup],
+    assignmentBySetupID: [String: APIAssignment],
+    on db: Database,
+    now: Date
+) async throws -> [String: Set<String>] {
+    var staffByCourseID: [UUID: Bool] = [:]
+    var tiersBySetupID: [String: Set<String>] = [:]
+    for setup in setups {
+        guard let setupID = setup.id else { continue }
+        if staffByCourseID[setup.courseID] == nil {
+            staffByCourseID[setup.courseID] = try await isCourseStaff(
+                user, inCourse: setup.courseID, db: db)
+        }
+        let isStaff = staffByCourseID[setup.courseID] ?? false
+        let assignment = assignmentBySetupID[setupID]
+        let releaseDeadline = try await releaseVisibilityDeadline(
+            for: assignment, user: user, on: db)
+        let reveal = try await SecretRevealState.resolve(
+            assignment: assignment, userID: user.id, isStaff: isStaff, on: db)
+        tiersBySetupID[setupID] = visibleTiers(
+            isStaff: isStaff, effectiveDueAt: releaseDeadline,
+            secretRevealed: reveal.revealed, now: now)
+    }
+    return tiersBySetupID
+}
+
+private func latestResultBySubmissionID(
+    submissionIDs: [String], on db: Database
+) async throws -> [String: APIResult] {
+    guard !submissionIDs.isEmpty else { return [:] }
+    let results = try await APIResult.query(on: db)
+        .filter(\.$submissionID ~~ submissionIDs)
+        .all()
+    var latest: [String: APIResult] = [:]
+    for result in results {
+        if let existing = latest[result.submissionID],
+            (existing.receivedAt ?? .distantPast) >= (result.receivedAt ?? .distantPast)
+        {
+            continue
+        }
+        latest[result.submissionID] = result
+    }
+    return latest
+}
+
+/// Decodes a stored collection, filters it to the visible tier set the same
+/// way the results API does (real all-tier grade aggregates, only
+/// inspectable outcomes), and re-encodes it for the zip.
+private func tierFilteredCollectionData(
+    collectionJSON: String, visibleTiers: Set<String>
+) -> Data? {
+    guard let full = decodedCollection(from: collectionJSON) else { return nil }
+    let visible = full.filtering(tiers: visibleTiers)
+    let filtered = full.replacingOutcomes(with: visible.outcomes)
+    return try? dataExportJSONEncoder().encode(filtered)
+}
+
+// MARK: - Audit entries
+
+/// Actions whose audit rows identify the affected user only inside
+/// `metadata` (`student_username`) rather than via `target_id`; candidates
+/// are fetched by action and confirmed against the decoded metadata.
+private let metadataSubjectActions: [String] = [
+    AuditAction.extensionGranted, .extensionRevoked,
+    .gradeOverrideSet, .gradeOverrideCleared,
+    .secretRevealRegranted, .submissionRetestForStudent,
+].map(\.rawValue)
+
+private func gatherAuditEntries(
+    for user: APIUser, on db: Database
+) async throws -> [DataExportAuditEntry] {
+    let userID = try user.requireID()
+    let uuidString = userID.uuidString
+
+    // Entries the user performed, or whose target is the user directly
+    // (user.* actions, enrollment.* actions — both stamp target_id with the
+    // user's UUID).
+    let direct = try await APIAuditLogEntry.query(on: db)
+        .group(.or) { or in
+            or.filter(\.$actorUserID == userID)
+            or.filter(\.$targetID == uuidString)
+        }
+        .all()
+
+    // Entries about the user that only name them in metadata (extensions,
+    // grade overrides, reveal re-grants, per-student retests target the
+    // assignment). Candidates by action, confirmed in Swift.
+    let metadataCandidates = try await APIAuditLogEntry.query(on: db)
+        .filter(\.$action ~~ metadataSubjectActions)
+        .all()
+
+    var byID: [UUID: APIAuditLogEntry] = [:]
+    for entry in direct {
+        if let id = entry.id { byID[id] = entry }
+    }
+    for entry in metadataCandidates {
+        guard let id = entry.id, byID[id] == nil else { continue }
+        let details = decodeAuditMetadata(entry.metadata)
+        if details["student_username"] == user.username
+            || details["subject_username"] == user.username
+            || details["subject_user_id"] == uuidString
+        {
+            byID[id] = entry
+        }
+    }
+
+    return byID.values
+        .sorted { ($0.createdAt ?? .distantPast) < ($1.createdAt ?? .distantPast) }
+        .map { entry in
+            let isActor = entry.actorUserID == userID
+            let display = AuditActionDisplay.categoryLabel(forRaw: entry.action)
+            let details = decodeAuditMetadata(entry.metadata)
+            return DataExportAuditEntry(
+                occurredAt: entry.createdAt,
+                action: entry.action,
+                actionLabel: display.label,
+                involvement: isActor ? "actor" : "subject",
+                targetType: entry.targetType,
+                targetID: entry.targetID,
+                performedBy: isActor ? nil : entry.actorUsername,
+                ipAddress: isActor ? entry.remoteAddr : nil,
+                userAgent: isActor ? entry.userAgent : nil,
+                details: details.isEmpty ? nil : details
+            )
+        }
+}
+
+private func decodeAuditMetadata(_ json: String?) -> [String: String] {
+    guard let json, let data = json.data(using: .utf8) else { return [:] }
+    return ((try? JSONSerialization.jsonObject(with: data)) as? [String: String]) ?? [:]
+}
+
+// MARK: - Grading adjustments
+
+private func gatherGradingAdjustments(
+    userID: UUID, on db: Database
+) async throws -> DataExportGradingAdjustments {
+    let extensions = try await APIAssignmentExtension.query(on: db)
+        .filter(\.$userID == userID)
+        .all()
+    let overrides = try await APIGradeOverride.query(on: db)
+        .filter(\.$userID == userID)
+        .all()
+    let unlocks = try await APISecretRevealUnlock.query(on: db)
+        .filter(\.$userID == userID)
+        .all()
+
+    // Resolve assignment titles for everything referenced above.
+    let assignmentIDs = Array(Set(extensions.map(\.assignmentID) + unlocks.map(\.assignmentID)))
+    let assignmentsByID: [UUID: APIAssignment] =
+        assignmentIDs.isEmpty
+        ? [:]
+        : Dictionary(
+            try await APIAssignment.query(on: db).filter(\.$id ~~ assignmentIDs).all()
+                .compactMap { a in a.id.map { ($0, a) } }
+        ) { first, _ in first }
+    let setupIDs = Array(Set(overrides.map(\.testSetupID)))
+    let assignmentsBySetupID: [String: APIAssignment] =
+        setupIDs.isEmpty
+        ? [:]
+        : Dictionary(
+            try await APIAssignment.query(on: db).filter(\.$testSetupID ~~ setupIDs).all()
+                .map { ($0.testSetupID, $0) }
+        ) { first, _ in first }
+
+    return DataExportGradingAdjustments(
+        deadlineExtensions: extensions.map {
+            .init(
+                assignmentTitle: assignmentsByID[$0.assignmentID]?.title,
+                extendedDueAt: $0.extendedDueAt, note: $0.note, grantedAt: $0.grantedAt)
+        },
+        gradeOverrides: overrides.map {
+            .init(
+                assignmentTitle: assignmentsBySetupID[$0.testSetupID]?.title,
+                overridePercent: $0.overridePercent, note: $0.note, grantedAt: $0.grantedAt)
+        },
+        secretRevealTokensSpent: unlocks.map {
+            .init(assignmentTitle: assignmentsByID[$0.assignmentID]?.title, spentAt: $0.spentAt)
+        }
+    )
+}
+
+// MARK: - Encoding + README
+
+/// Human-readable, deterministic JSON for everything inside the export.
+func dataExportJSONEncoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+}
+
+/// The manifest at the root of the zip, explaining each file.  Plain
+/// Markdown, addressed to the account owner.
+func dataExportReadme(username: String, generatedAt: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    return """
+        # Your Chickadee data export
+
+        Generated for account **\(username)** on \(formatter.string(from: generatedAt)) \
+        by Chickadee v\(ChickadeeVersion.current).
+
+        This archive contains a copy of the personal information Chickadee
+        holds about you, provided in support of your right of access under
+        Ontario's FIPPA and Canada's PIPEDA.
+
+        ## Contents
+
+        - `profile.json` — your account profile: username, names, email,
+          student ID, sign-in provider, and account timestamps. Passwords are
+          stored only as one-way hashes and are never included.
+        - `enrollments.json` — the courses you are enrolled in, your role in
+          each, and when you enrolled.
+        - `submissions.json` — an index of every submission you have made:
+          course, assignment, attempt number, timestamps, and where in this
+          archive to find the uploaded file and its grading results.
+        - `submissions/<id>/` — one folder per submission, holding the file
+          you uploaded (under its stored name) and `results.json`, the test
+          outcomes for that submission. Results reflect what is visible to
+          you at export time: details of hidden (secret-tier) tests, and of
+          release-tier tests before their deadline, are not itemized —
+          matching what you see on the site. Aggregate counts and grades
+          always cover every test.
+        - `grading-adjustments.json` — per-student grading records: deadline
+          extensions, grade overrides, and secret-test reveal tokens you have
+          spent.
+        - `audit-log.json` — activity records involving your account.
+          Entries marked `actor` are actions you performed (with the IP
+          address and browser they came from); entries marked `subject` are
+          actions performed about your account (e.g. being enrolled in a
+          course), without the performer's connection details. Audit records
+          are retained for a limited period, so older activity may no longer
+          exist.
+
+        Not included: uploaded files that have since been purged from the
+        server, and code-execution artifacts that are not retained after
+        grading.
+
+        If anything here looks wrong, contact your course instructor or the
+        service operator.
+        """
+}

--- a/Sources/APIServer/Services/DataExportRetentionService.swift
+++ b/Sources/APIServer/Services/DataExportRetentionService.swift
@@ -1,0 +1,82 @@
+// APIServer/Services/DataExportRetentionService.swift
+//
+// Periodic cleanup of generated personal-data exports (#557).  Each export
+// zip is a bundle of one user's personal information sitting on disk;
+// leaving it there indefinitely defeats the point of careful retention
+// elsewhere (audit-log reaper, submission retention).  Exports are kept
+// long enough for the requester to download at leisure, then the zip and
+// its tracking row are deleted — the user can always request a fresh one.
+//
+// Periodic scaffolding lives in `PeriodicSweepMonitor` (leader-leased, so
+// multi-process deployments sweep once per tick).
+
+import Fluent
+import Foundation
+import Vapor
+
+/// How long a generated export remains downloadable.  Three days comfortably
+/// covers "requested Friday, downloaded Monday" while keeping bundled
+/// personal data short-lived; it also exceeds the one-per-day request
+/// interval, so an expired row never extends the rate limit.
+let dataExportRetentionMaxAge: TimeInterval = 72 * 60 * 60
+
+/// Hourly: export disposal is retention hygiene, not correctness.
+private let dataExportReaperSweepInterval: TimeInterval = 3600
+
+/// Deletes export rows requested more than `maxAge` ago, removing each
+/// row's generated zip first.  Terminal-state agnostic: an expired pending
+/// or failed row is just as dead as a complete one.
+func reapExpiredDataExports(
+    on db: Database,
+    logger: Logger,
+    maxAge: TimeInterval = dataExportRetentionMaxAge,
+    now: Date = Date()
+) async throws {
+    guard maxAge > 0 else { return }
+    let cutoff = now.addingTimeInterval(-maxAge)
+    let expired = try await APIDataExport.query(on: db)
+        .filter(\.$requestedAt < cutoff)
+        .all()
+    guard !expired.isEmpty else { return }
+
+    var removed = 0
+    for export in expired {
+        if let zipPath = export.zipPath, FileManager.default.fileExists(atPath: zipPath) {
+            do {
+                try FileManager.default.removeItem(atPath: zipPath)
+            } catch {
+                // Keep the row so the next sweep retries the file delete —
+                // dropping the row first would orphan the zip forever.
+                logger.warning(
+                    "Data-export reaper could not delete \(zipPath): \(error.localizedDescription)"
+                )
+                continue
+            }
+        }
+        try await export.delete(on: db)
+        removed += 1
+    }
+    logger.info("Data-export reaper removed \(removed) expired export(s)")
+}
+
+struct DataExportReaperMonitorKey: StorageKey {
+    typealias Value = PeriodicSweepMonitor
+}
+
+extension Application {
+    var dataExportReaperMonitor: PeriodicSweepMonitor {
+        if let existing = storage[DataExportReaperMonitorKey.self] { return existing }
+        let created = PeriodicSweepMonitor(
+            name: "Data-export reaper",
+            interval: dataExportReaperSweepInterval,
+            runImmediately: true
+        ) { application in
+            try await reapExpiredDataExports(
+                on: application.db,
+                logger: application.logger
+            )
+        }
+        storage[DataExportReaperMonitorKey.self] = created
+        return created
+    }
+}

--- a/Sources/APIServer/Services/DataExportService.swift
+++ b/Sources/APIServer/Services/DataExportService.swift
@@ -1,0 +1,250 @@
+// APIServer/Services/DataExportService.swift
+//
+// Personal-data export pipeline (#557 — FIPPA / PIPEDA subject access).
+// A request (POST /account/export) resets the user's `data_exports` row to
+// pending and hands generation to `DataExportManager`, which runs it in a
+// background task: gather from the DB (`gatherDataExportContent`), stage
+// files + copies on the thread pool, zip, install the zip under
+// `Application.dataExportsDirectory`, and mark the row complete/failed.
+// Generation is asynchronous by design — a submission-heavy account can
+// take well over the few seconds a request should hold.
+//
+// What goes inside the zip is defined in `DataExportContent.swift`;
+// retention of the generated zips is `DataExportRetentionService.swift`.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// One export per user per day (#557).  Enforced against the row's
+/// `requestedAt`, which the request handler resets in place.
+let dataExportMinRequestInterval: TimeInterval = 24 * 60 * 60
+
+/// A pending row older than this is treated as interrupted (e.g. the server
+/// restarted mid-generation, orphaning the row) and may be re-requested.
+let dataExportStalePendingAge: TimeInterval = 15 * 60
+
+/// Whether a new export may be requested given the user's current row
+/// (nil = no row yet).  Shared by the POST handler (enforcement) and the
+/// account page (whether to render the request button).
+func dataExportCanBeRequested(_ export: APIDataExport?, now: Date = Date()) -> Bool {
+    guard let export else { return true }
+    switch export.statusValue {
+    case .pending:
+        return now.timeIntervalSince(export.requestedAt) >= dataExportStalePendingAge
+    case .complete:
+        return now.timeIntervalSince(export.requestedAt) >= dataExportMinRequestInterval
+    case .failed, nil:
+        return true
+    }
+}
+
+// MARK: - Manager
+
+/// Serializes export generation per user on this process: a second request
+/// for a user whose generation is still in flight is a no-op (the DB row is
+/// already pending and the running task will complete it).
+actor DataExportManager {
+    private var inFlightUserIDs: Set<UUID> = []
+
+    /// Starts generation for `userID` unless one is already running here.
+    /// Returns whether a new generation task was started.
+    @discardableResult
+    func startExport(exportID: UUID, userID: UUID, app: Application) -> Bool {
+        guard !inFlightUserIDs.contains(userID) else { return false }
+        inFlightUserIDs.insert(userID)
+        Task {
+            await generateDataExport(exportID: exportID, userID: userID, app: app)
+            markFinished(userID: userID)
+        }
+        return true
+    }
+
+    private func markFinished(userID: UUID) {
+        inFlightUserIDs.remove(userID)
+    }
+}
+
+struct DataExportManagerKey: StorageKey {
+    typealias Value = DataExportManager
+}
+
+extension Application {
+    var dataExportManager: DataExportManager {
+        get {
+            if let existing = storage[DataExportManagerKey.self] {
+                return existing
+            }
+            let created = DataExportManager()
+            storage[DataExportManagerKey.self] = created
+            return created
+        }
+        set {
+            storage[DataExportManagerKey.self] = newValue
+        }
+    }
+}
+
+// MARK: - Generation
+
+/// Runs one export end-to-end and stamps the row's terminal state.  Never
+/// throws — a failure marks the row failed (with an operator-facing reason)
+/// and logs; the user sees a generic "failed, try again".
+func generateDataExport(exportID: UUID, userID: UUID, app: Application) async {
+    do {
+        try await buildDataExport(exportID: exportID, userID: userID, app: app)
+        app.logger.info("data_export complete user=\(userID.uuidString)")
+    } catch {
+        app.logger.error(
+            "data_export generation failed user=\(userID.uuidString): \(String(reflecting: error))"
+        )
+        await markExportFailed(exportID: exportID, error: error, app: app)
+    }
+}
+
+private func buildDataExport(exportID: UUID, userID: UUID, app: Application) async throws {
+    let db = app.db
+    guard let user = try await APIUser.find(userID, on: db) else {
+        throw Abort(.notFound, reason: "User \(userID.uuidString) not found for data export")
+    }
+
+    let generatedAt = Date()
+    let content = try await gatherDataExportContent(for: user, on: db, now: generatedAt)
+    let files = try stagedExportFiles(
+        content: content, username: user.username, generatedAt: generatedAt)
+    let copies = content.fileCopies.map {
+        DataExportStagedCopy(sourcePath: $0.sourcePath, relativePath: $0.relativePath)
+    }
+
+    let stagingDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("chickadee-data-export-\(UUID().uuidString)")
+    let tempZipPath = stagingDir.path + ".zip"
+    let finalZipPath = app.dataExportsDirectory + "\(userID.uuidString).zip"
+    defer {
+        try? FileManager.default.removeItem(at: stagingDir)
+        if FileManager.default.fileExists(atPath: tempZipPath) {
+            try? FileManager.default.removeItem(atPath: tempZipPath)
+        }
+    }
+
+    let logger = app.logger
+    try await runBlocking(app: app) {
+        try writeDataExportStaging(
+            stagingDir: stagingDir, files: files, copies: copies, logger: logger)
+    }
+    try await createZipArchive(sourceDir: stagingDir, outputPath: tempZipPath)
+    let fileSize = try await runBlocking(app: app) {
+        try installDataExportZip(tempZipPath: tempZipPath, finalZipPath: finalZipPath)
+    }
+
+    guard let row = try await APIDataExport.find(exportID, on: db) else { return }
+    row.setStatus(.complete)
+    row.completedAt = Date()
+    row.zipPath = finalZipPath
+    row.fileSizeBytes = fileSize
+    row.failureReason = nil
+    try await row.save(on: db)
+}
+
+/// The fixed JSON/Markdown files at the root of the zip, plus one
+/// `results.json` per submission that has stored outcomes.
+private func stagedExportFiles(
+    content: DataExportContent, username: String, generatedAt: Date
+) throws -> [DataExportStagedFile] {
+    let encoder = dataExportJSONEncoder()
+    var files: [DataExportStagedFile] = [
+        .init(
+            relativePath: "README.md",
+            data: Data(dataExportReadme(username: username, generatedAt: generatedAt).utf8)),
+        .init(relativePath: "profile.json", data: try encoder.encode(content.profile)),
+        .init(relativePath: "enrollments.json", data: try encoder.encode(content.enrollments)),
+        .init(relativePath: "submissions.json", data: try encoder.encode(content.submissions)),
+        .init(
+            relativePath: "grading-adjustments.json",
+            data: try encoder.encode(content.gradingAdjustments)),
+        .init(relativePath: "audit-log.json", data: try encoder.encode(content.auditEntries)),
+    ]
+    for (path, data) in content.resultFiles.sorted(by: { $0.key < $1.key }) {
+        files.append(.init(relativePath: path, data: data))
+    }
+    return files
+}
+
+private func markExportFailed(exportID: UUID, error: Error, app: Application) async {
+    guard let row = try? await APIDataExport.find(exportID, on: app.db),
+        row.statusValue == .pending
+    else { return }
+    row.setStatus(.failed)
+    row.completedAt = Date()
+    row.failureReason = String(String(reflecting: error).prefix(500))
+    do {
+        try await row.save(on: app.db)
+    } catch {
+        app.logger.error(
+            "data_export failed-state save failed for \(exportID): \(error.localizedDescription)"
+        )
+    }
+}
+
+// MARK: - Staging (thread-pool file I/O over Sendable primitives)
+
+struct DataExportStagedFile: Sendable {
+    let relativePath: String
+    let data: Data
+}
+
+struct DataExportStagedCopy: Sendable {
+    let sourcePath: String
+    let relativePath: String
+}
+
+/// Builds the staging tree: writes every in-memory file and copies every
+/// on-disk submission file, creating intermediate directories as needed.
+/// Free function over Sendable values so it can run on the thread pool
+/// (same shape as the course-bundle export's `writeExportStaging`).
+private func writeDataExportStaging(
+    stagingDir: URL,
+    files: [DataExportStagedFile],
+    copies: [DataExportStagedCopy],
+    logger: Logger
+) throws {
+    let fm = FileManager.default
+    try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+
+    for file in files {
+        let dst = stagingDir.appendingPathComponent(file.relativePath)
+        try fm.createDirectory(
+            at: dst.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try file.data.write(to: dst)
+    }
+
+    for copy in copies {
+        let src = URL(fileURLWithPath: copy.sourcePath)
+        let dst = stagingDir.appendingPathComponent(copy.relativePath)
+        try fm.createDirectory(
+            at: dst.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fm.fileExists(atPath: src.path) {
+            try fm.copyItem(at: src, to: dst)
+        } else {
+            // Listed as included at gather time but gone now (e.g. purged
+            // concurrently) — skip; the index entry simply points at a
+            // missing path, matching the course-bundle export's behaviour.
+            logger.warning("data_export: submission file missing at \(src.path), skipping")
+        }
+    }
+}
+
+/// Moves the freshly-built zip into its final location, replacing any
+/// previous export, and returns its size in bytes.  `zip -r` appends into
+/// an existing archive, so the build always targets a fresh temp path and
+/// installs with remove + move.
+private func installDataExportZip(tempZipPath: String, finalZipPath: String) throws -> Int {
+    let fm = FileManager.default
+    if fm.fileExists(atPath: finalZipPath) {
+        try fm.removeItem(atPath: finalZipPath)
+    }
+    try fm.moveItem(atPath: tempZipPath, toPath: finalZipPath)
+    let attributes = try fm.attributesOfItem(atPath: finalZipPath)
+    return (attributes[.size] as? Int) ?? 0
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -437,4 +437,9 @@ func registerMigrations(on app: Application) {
     // no migration full-queries APIAssignment, so ordering is unconstrained.
     app.migrations.add(AddAssignmentSecretRevealEnabled())
     app.migrations.add(CreateSecretRevealUnlocks())
+
+    // Personal-data export tracking (#557): one row per user, doubling as
+    // the one-export-per-day rate-limit ledger. FK to users; no ordering
+    // constraints beyond CreateUsers.
+    app.migrations.add(CreateDataExports())
 }

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -40,6 +40,7 @@ func routes(_ app: Application) throws {
     try auth.register(collection: WebRoutes())
     try auth.register(collection: EnrollmentRoutes())
     try auth.register(collection: AccountRoutes())
+    try auth.register(collection: AccountExportRoutes())
     try auth.register(collection: SubmissionDownloadRoute())
     try auth.register(collection: SubmissionQueryRoutes())
     try auth.register(collection: BrowserResultRoutes())

--- a/Tests/APITests/DataExportRoutesTests.swift
+++ b/Tests/APITests/DataExportRoutesTests.swift
@@ -1,0 +1,403 @@
+// Tests/APITests/DataExportRoutesTests.swift
+//
+// Integration tests for the personal-data export (#557):
+//   POST /account/export           — request, async generation, rate limit
+//   GET  /account/export/status    — poll JSON
+//   GET  /account/export/download  — owner-scoped zip download
+//
+// Key behaviours under test:
+//   - Requesting an export generates a downloadable zip containing the
+//     README manifest, profile, enrollments, submission metadata, the
+//     uploaded submission file, and tier-filtered results
+//   - Secret-tier outcomes are NOT itemized in the exported results
+//   - One export per day per user (second request is rejected)
+//   - The export contains only the requesting user's data
+//   - Request + download are audit-logged
+//   - Unauthenticated access redirects to /login
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized, .timeLimit(.minutes(3))) final class DataExportRoutesTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-dexp")
+    }
+
+    // MARK: - Helpers
+
+    private struct ExportTimeout: Error {}
+
+    /// Polls the user's export row until generation reaches a terminal
+    /// state (the POST handler runs it in a background task).
+    private func waitForTerminalExport(
+        userID: UUID, timeoutSeconds: Double = 30
+    ) async throws -> APIDataExport {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if let row = try await APIDataExport.query(on: app.db)
+                .filter(\.$userID == userID)
+                .first(),
+                row.statusValue != .pending
+            {
+                return row
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        throw ExportTimeout()
+    }
+
+    private func requestExport(cookie: String) async throws -> String? {
+        let (token, newCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
+        var location: String?
+        try await app.asyncTest(
+            .POST, "/account/export",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: newCookie)
+                try req.content.encode(["_csrf": token], as: .urlEncodedForm)
+            },
+            afterResponse: { res in
+                #expect(res.status == .seeOther)
+                location = res.headers.first(name: .location)
+            })
+        return location
+    }
+
+    /// Downloads the caller's export and extracts it into a temp dir the
+    /// caller is responsible for deleting.
+    private func downloadAndExtract(cookie: String) async throws -> URL {
+        var body = Data()
+        try await app.asyncTest(
+            .GET, "/account/export/download",
+            beforeRequest: { req in
+                req.headers.add(name: .cookie, value: cookie)
+            },
+            afterResponse: { res in
+                #expect(res.status == .ok)
+                #expect(res.headers.first(name: .contentType) == "application/zip")
+                let disposition = res.headers.first(name: .contentDisposition) ?? ""
+                #expect(disposition.contains("attachment"))
+                #expect(disposition.contains("chickadee-data-export-"))
+                body = Data(res.body.readableBytesView)
+            })
+        #expect(!body.isEmpty)
+
+        let scratch = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dexp-extract-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+        let zipURL = scratch.appendingPathComponent("export.zip")
+        try body.write(to: zipURL)
+        let contents = scratch.appendingPathComponent("contents")
+        try await extractZipArchive(zipPath: zipURL.path, into: contents)
+        return scratch
+    }
+
+    private func auditCount(action: AuditAction, actorUserID: UUID) async throws -> Int {
+        try await APIAuditLogEntry.query(on: app.db)
+            .filter(\.$action == action.rawValue)
+            .filter(\.$actorUserID == actorUserID)
+            .count()
+    }
+
+    // MARK: - Unauthenticated access
+
+    @Test func requestExport_unauthenticated_redirectsToLogin() async throws {
+        try await withApp(app) { _ in
+            try await app.asyncTest(.POST, "/account/export") { res in
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: .location) == "/login")
+            }
+            try await app.asyncTest(.GET, "/account/export/download") { res in
+                #expect(res.status == .seeOther)
+                #expect(res.headers.first(name: .location) == "/login")
+            }
+        }
+    }
+
+    // MARK: - Happy path
+
+    @Test func requestExport_generatesDownloadableZip() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            let studentID = try student.requireID()
+            try await wrEnrollUser(student, on: app)
+            try await wrInsertSetup(id: "setup_001", on: app)
+            try await wrInsertAssignment(
+                testSetupID: "setup_001", title: "Warmup Lab", isOpen: true, on: app)
+            let submission = try await wrInsertSubmission(
+                id: "sub_export_1", testSetupID: "setup_001", userID: studentID,
+                filename: "warmup.py", on: app)
+            let sourceCode = "print('export me')\n"
+            try Data(sourceCode.utf8).write(to: URL(fileURLWithPath: submission.zipPath))
+            try await wrInsertResult(
+                submissionID: "sub_export_1",
+                outcomes: [
+                    wrMakeOutcome(name: "test_alpha", tier: .pub, status: .pass),
+                    wrMakeOutcome(name: "test_hidden_secret", tier: .secret, status: .fail),
+                ],
+                on: app)
+
+            let location = try await requestExport(cookie: cookie)
+            #expect(location == "/account?exportNotice=started")
+
+            let row = try await waitForTerminalExport(userID: studentID)
+            #expect(row.statusValue == .complete, "failure: \(row.failureReason ?? "nil")")
+            let zipPath = try #require(row.zipPath)
+            #expect(FileManager.default.fileExists(atPath: zipPath))
+            #expect((row.fileSizeBytes ?? 0) > 0)
+            #expect(row.completedAt != nil)
+            #expect(try await auditCount(action: .userDataExportRequested, actorUserID: studentID) == 1)
+
+            let scratch = try await downloadAndExtract(cookie: cookie)
+            defer { try? FileManager.default.removeItem(at: scratch) }
+            let contents = scratch.appendingPathComponent("contents")
+
+            let readme = try String(
+                contentsOf: contents.appendingPathComponent("README.md"), encoding: .utf8)
+            #expect(readme.contains("Chickadee data export"))
+            #expect(readme.contains("student1"))
+
+            let profile = try String(
+                contentsOf: contents.appendingPathComponent("profile.json"), encoding: .utf8)
+            #expect(profile.contains("\"username\" : \"student1\""))
+            #expect(!profile.contains("passwordHash"))
+
+            let enrollments = try String(
+                contentsOf: contents.appendingPathComponent("enrollments.json"), encoding: .utf8)
+            #expect(enrollments.contains("CS101"))
+
+            let submissionsIndex = try String(
+                contentsOf: contents.appendingPathComponent("submissions.json"), encoding: .utf8)
+            #expect(submissionsIndex.contains("sub_export_1"))
+            #expect(submissionsIndex.contains("Warmup Lab"))
+            #expect(submissionsIndex.contains("warmup.py"))
+
+            let copiedFile = contents.appendingPathComponent(
+                "submissions/sub_export_1/sub_export_1.py")
+            #expect(try String(contentsOf: copiedFile, encoding: .utf8) == sourceCode)
+
+            // Results are tier-filtered like the results API: the public
+            // outcome is itemized, the secret one is not (aggregate counts
+            // still reflect the full run).
+            let results = try String(
+                contentsOf: contents.appendingPathComponent(
+                    "submissions/sub_export_1/results.json"),
+                encoding: .utf8)
+            #expect(results.contains("test_alpha"))
+            #expect(!results.contains("test_hidden_secret"))
+            #expect(results.contains("\"totalTests\" : 2"))
+
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: contents.appendingPathComponent("audit-log.json").path))
+            #expect(
+                FileManager.default.fileExists(
+                    atPath: contents.appendingPathComponent("grading-adjustments.json").path))
+
+            #expect(
+                try await auditCount(action: .userDataExportDownloaded, actorUserID: studentID)
+                    == 1)
+        }
+    }
+
+    // MARK: - Rate limiting
+
+    @Test func requestExport_secondRequestSameDay_isRateLimited() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            let studentID = try student.requireID()
+
+            let first = try await requestExport(cookie: cookie)
+            #expect(first == "/account?exportNotice=started")
+            let row = try await waitForTerminalExport(userID: studentID)
+            #expect(row.statusValue == .complete)
+            let firstRequestedAt = row.requestedAt
+
+            let second = try await requestExport(cookie: cookie)
+            #expect(second == "/account?exportError=rate_limited")
+
+            // Still exactly one row, untouched by the rejected request.
+            let rows = try await APIDataExport.query(on: app.db)
+                .filter(\.$userID == studentID)
+                .all()
+            #expect(rows.count == 1)
+            #expect(rows.first?.statusValue == .complete)
+            #expect(rows.first?.requestedAt == firstRequestedAt)
+            #expect(try await auditCount(action: .userDataExportRequested, actorUserID: studentID) == 1)
+        }
+    }
+
+    // MARK: - Download gating
+
+    @Test func download_withNoExport_redirectsNotReady() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            try await app.asyncTest(
+                .GET, "/account/export/download",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: cookie)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(
+                        res.headers.first(name: .location) == "/account?exportError=not_ready")
+                })
+        }
+    }
+
+    // MARK: - Scoping
+
+    @Test func export_containsOnlyRequestingUsersData() async throws {
+        try await withApp(app) { _ in
+            // student1 owns a submission; the export is requested by someone else.
+            _ = try await wrLoginAsStudent(on: app)
+            let student1 = try await wrStudentUser(on: app)
+            try await wrEnrollUser(student1, on: app)
+            try await wrInsertSetup(id: "setup_001", on: app)
+            try await wrInsertSubmission(
+                id: "sub_other_user", testSetupID: "setup_001",
+                userID: try student1.requireID(), on: app)
+
+            let otherCookie = try await loginUser(
+                username: "exporter2", password: "pass", role: "student", on: app)
+            let other = try #require(
+                try await APIUser.query(on: app.db).filter(\.$username == "exporter2").first())
+            let otherID = try other.requireID()
+
+            _ = try await requestExport(cookie: otherCookie)
+            let row = try await waitForTerminalExport(userID: otherID)
+            #expect(row.statusValue == .complete)
+
+            let scratch = try await downloadAndExtract(cookie: otherCookie)
+            defer { try? FileManager.default.removeItem(at: scratch) }
+            let contents = scratch.appendingPathComponent("contents")
+
+            let profile = try String(
+                contentsOf: contents.appendingPathComponent("profile.json"), encoding: .utf8)
+            #expect(profile.contains("exporter2"))
+            #expect(!profile.contains("student1"))
+
+            let submissionsIndex = try String(
+                contentsOf: contents.appendingPathComponent("submissions.json"), encoding: .utf8)
+            #expect(!submissionsIndex.contains("sub_other_user"))
+            #expect(
+                !FileManager.default.fileExists(
+                    atPath: contents.appendingPathComponent("submissions").path))
+        }
+    }
+
+    // MARK: - Status endpoint + account page
+
+    @Test func exportStatus_reflectsRowState() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            let studentID = try student.requireID()
+
+            try await app.asyncTest(
+                .GET, "/account/export/status",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("\"status\":\"none\""))
+                })
+
+            _ = try await requestExport(cookie: cookie)
+            _ = try await waitForTerminalExport(userID: studentID)
+
+            try await app.asyncTest(
+                .GET, "/account/export/status",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("\"status\":\"complete\""))
+                })
+        }
+    }
+
+    @Test func accountPage_rendersExportSection() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            try await app.asyncTest(
+                .GET, "/account",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let page = res.body.string
+                    #expect(page.contains("Your data"))
+                    #expect(page.contains("Request data export"))
+                    #expect(page.contains("/account/export"))
+                })
+        }
+    }
+
+    // MARK: - Retention reaper
+
+    @Test func reaper_removesExpiredExportAndZip() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            let studentID = try student.requireID()
+
+            _ = try await requestExport(cookie: cookie)
+            let row = try await waitForTerminalExport(userID: studentID)
+            let zipPath = try #require(row.zipPath)
+            #expect(FileManager.default.fileExists(atPath: zipPath))
+
+            // Not yet expired: sweep with "now" inside the retention window.
+            try await reapExpiredDataExports(on: app.db, logger: app.logger, now: Date())
+            #expect(
+                try await APIDataExport.query(on: app.db).filter(\.$userID == studentID).count()
+                    == 1)
+
+            // Expired: sweep as if the retention window has passed.
+            let later = Date().addingTimeInterval(dataExportRetentionMaxAge + 60)
+            try await reapExpiredDataExports(on: app.db, logger: app.logger, now: later)
+            #expect(
+                try await APIDataExport.query(on: app.db).filter(\.$userID == studentID).count()
+                    == 0)
+            #expect(!FileManager.default.fileExists(atPath: zipPath))
+        }
+    }
+}
+
+/// Pure policy tests for the request gate — no app fixture needed.
+@Suite struct DataExportPolicyTests {
+
+    @Test func canBeRequested_stateMachine() {
+        let now = Date()
+        #expect(dataExportCanBeRequested(nil, now: now))
+
+        let userID = UUID()
+        let fresh = APIDataExport(userID: userID, requestedAt: now.addingTimeInterval(-60))
+        #expect(!dataExportCanBeRequested(fresh, now: now))
+
+        let stalePending = APIDataExport(
+            userID: userID, requestedAt: now.addingTimeInterval(-dataExportStalePendingAge - 1))
+        #expect(dataExportCanBeRequested(stalePending, now: now))
+
+        let completeToday = APIDataExport(
+            userID: userID, requestedAt: now.addingTimeInterval(-3600))
+        completeToday.setStatus(.complete)
+        #expect(!dataExportCanBeRequested(completeToday, now: now))
+
+        let completeYesterday = APIDataExport(
+            userID: userID,
+            requestedAt: now.addingTimeInterval(-dataExportMinRequestInterval - 1))
+        completeYesterday.setStatus(.complete)
+        #expect(dataExportCanBeRequested(completeYesterday, now: now))
+
+        let failed = APIDataExport(userID: userID, requestedAt: now.addingTimeInterval(-60))
+        failed.setStatus(.failed)
+        #expect(dataExportCanBeRequested(failed, now: now))
+    }
+}

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -310,13 +310,14 @@ func makeTestApp(
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(prefix)-\(UUID().uuidString)/")
             .path
-        let dirs = ["results/", "testsetups/", "submissions/"].map { tmpDir + $0 }
+        let dirs = ["results/", "testsetups/", "submissions/", "data-exports/"].map { tmpDir + $0 }
         for dir in dirs {
             try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         }
         app.resultsDirectory = dirs[0]
         app.testSetupsDirectory = dirs[1]
         app.submissionsDirectory = dirs[2]
+        app.dataExportsDirectory = dirs[3]
         // Seed the worker-secret and local-runner-autostart paths into the
         // per-test temp directory so admin/worker-management tests don't
         // collide with each other or with the dev .worker-secret on disk.

--- a/changelog.d/issue-557-student-data-export.md
+++ b/changelog.d/issue-557-student-data-export.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Personal-data export (#557).** Any signed-in user can request a copy of
+  the personal information Chickadee holds about them — profile, course
+  enrollments, submissions (including the uploaded files), grading results,
+  grading adjustments, and audit-log activity — from the account page,
+  delivered as a single zip with a README manifest (FIPPA / PIPEDA subject
+  access). Generation runs asynchronously; results are tier-filtered to
+  exactly what the user can already see; requests are limited to one per day
+  per user; both the request and the download are audit-logged; generated
+  archives are deleted after three days.


### PR DESCRIPTION
Closes #557.

Any signed-in user can now request a copy of the personal information Chickadee holds about them from the account page, delivered as a single zip with a `README.md` manifest.

## What's in the export

- `profile.json` — account profile (no password hash, ever)
- `enrollments.json` — courses, per-course role, enrollment date
- `submissions.json` + `submissions/<id>/` — submission metadata, the originally uploaded file, and `results.json` per submission
- `grading-adjustments.json` — deadline extensions, grade overrides, secret-reveal token spends
- `audit-log.json` — entries where the user was the **actor** (with their own IP/user-agent) and entries where they were the **subject** (e.g. enrolled/unenrolled; the performer's connection details are omitted, only their username is named)

## Design decisions

- **Tier policy = the results API's policy.** Exported `results.json` reuses `visibleTiers` / `filtering(tiers:)` exactly as `GET /api/v1/submissions/:id/results` does: full all-tier grade aggregates, but secret-tier outcomes are itemized only with a spent reveal token, and release-tier only after the (extension-aware) deadline. The export can never reveal more than the site does.
- **Always async.** `POST /account/export` resets the user's single `data_exports` row to `pending` and hands generation to a `DataExportManager` actor (per-user in-flight guard) running a background task — DB gather, staging + zip on the thread pool (`runBlocking`), install under the new `data-exports/` work dir. The account page polls `GET /account/export/status` (tiny JSON) and flips to a download button when ready.
- **One export per day per user**, enforced against the row's `requested_at` — DB-backed, so it holds across processes. Interrupted `pending` rows (server restart mid-generation) self-heal after 15 minutes. A rejected re-request never disturbs the existing row.
- **No IDOR surface.** `GET /account/export/download` takes no ID parameter — it resolves the session user's own row, streams the zip with `Content-Disposition: attachment`.
- **Audit trail.** New `user.data_export_requested` / `user.data_export_downloaded` audit actions record both ends (FIPPA accountability for where the bundled PII went).
- **Retention.** `DataExportRetentionService` (leader-leased `PeriodicSweepMonitor`, hourly) deletes export zips + rows 72 h after request — bundled personal data doesn't linger, and 72 h > 24 h so expiry never extends the rate limit.
- **Out of scope** per the issue: deletion-on-request, instructor bulk export, cross-student instructor exports. Inline code comments (#535) haven't shipped, so they're not included yet.

## Schema

New `data_exports` table (`CreateDataExports`, registered last): one row per user (`UNIQUE(user_id)`, FK cascade), `status` / `requested_at` / `completed_at` / `zip_path` / `file_size_bytes` / `failure_reason`.

## Tests

`DataExportRoutesTests` (9 tests): end-to-end request → async generation → download → unzip → content assertions (README, profile, enrollments, submission file bytes, tier-filtered results **excluding the secret-tier outcome**), 1/day rate limit, cross-user scoping, not-ready download gating, status endpoint, account-page render, retention reaper (file + row deletion), and the request-gate state machine. Format (`scripts/lint.sh`) and style guards (`scripts/check-styles.sh`, including the inline-`<script>` ratchet — the status poll lives in `Public/account-export.js`) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQPon9ggzLmhzLYdeRNbYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQPon9ggzLmhzLYdeRNbYr)_