### PR TITLE
Apply personalization substitution on notebook reset

### DIFF
--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+StudentActions.swift
@@ -212,12 +212,12 @@ extension InstructorDashboardRoutes {
             )
         }
 
-        _ = try await ensureUserNotebookWorkingCopy(
+        _ = try await overwriteUserNotebookWithPersonalizedStarter(
             req: req,
+            setup: setup,
             setupID: setup.id ?? assignment.testSetupID,
             userID: studentID,
-            fallbackSetup: setup,
-            overwriteWith: starter
+            starter: starter
         )
 
         req.logger.info(

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -402,12 +402,12 @@ extension StudentCourseRoutes {
             )
         }
 
-        _ = try await ensureUserNotebookWorkingCopy(
+        _ = try await overwriteUserNotebookWithPersonalizedStarter(
             req: req,
+            setup: setup,
             setupID: setup.id ?? assignment.testSetupID,
             userID: action.studentID,
-            fallbackSetup: setup,
-            overwriteWith: starter
+            starter: starter
         )
 
         req.logger.info(

--- a/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
+++ b/Sources/APIServer/Routes/Web/WebRoutes+Notebook.swift
@@ -156,12 +156,12 @@ extension WebRoutes {
             throw Abort(.badRequest, reason: "This assignment has no starter notebook to reset to.")
         }
 
-        _ = try await ensureUserNotebookWorkingCopy(
+        _ = try await overwriteUserNotebookWithPersonalizedStarter(
             req: req,
+            setup: setup,
             setupID: setupID,
             userID: userID,
-            fallbackSetup: setup,
-            overwriteWith: starter
+            starter: starter
         )
 
         req.logger.info("student_self_notebook_reset setup=\(setupID) student=\(userID.uuidString)")

--- a/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
+++ b/Sources/APIServer/Services/NotebookWorkingCopyStore.swift
@@ -206,6 +206,38 @@ func ensureUserNotebookWorkingCopy(
     return processedData
 }
 
+/// Overwrites `userID`'s working copy with `starter` after applying the same
+/// per-student `{{name}}` personalization the first-open seeding path
+/// performs.  All three reset-notebook actions (student self-service and both
+/// instructor-driven ones) funnel through here: resetting a personalized
+/// assignment must land the student on their substituted starter, never the
+/// raw template (which would leave `name = {{name}}` cells that fail with
+/// NameError).  Substitution failures soft-fail to the raw starter, matching
+/// the seeding path.
+func overwriteUserNotebookWithPersonalizedStarter(
+    req: Request,
+    setup: APITestSetup,
+    setupID: String,
+    userID: UUID,
+    starter: Data
+) async throws -> Data {
+    let personalized = await applyNotebookSubstitutionsIfNeeded(
+        seedData: starter,
+        setup: setup,
+        userID: userID,
+        db: req.db,
+        supportFilesDirectory: req.application.testSetupsDirectory + "shared/\(setupID)/",
+        logger: req.logger
+    )
+    return try await ensureUserNotebookWorkingCopy(
+        req: req,
+        setupID: setupID,
+        userID: userID,
+        fallbackSetup: setup,
+        overwriteWith: personalized
+    )
+}
+
 /// Slice 1 + Slice 2: applies `{{name}}` substitutions to a notebook.
 /// Sources:
 ///   - `globalVariables` (Slice 1, literals)

--- a/Tests/APITests/AssignmentRoutesHelpers.swift
+++ b/Tests/APITests/AssignmentRoutesHelpers.swift
@@ -62,10 +62,15 @@ func arLoginAsStudent(on app: Application) async throws -> String {
 // MARK: - Seeding helpers
 
 @discardableResult
-func arInsertSetup(id: String, on app: Application) async throws -> APITestSetup {
-    let manifest = """
-        {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,"makefile":null}
-        """
+func arInsertSetup(
+    id: String,
+    manifest: String? = nil,
+    on app: Application
+) async throws -> APITestSetup {
+    let manifest =
+        manifest ?? """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10,"makefile":null}
+            """
     let courseID = try await app.testCourseID(enrollmentMode: .auto)
     let setup = APITestSetup(
         id: id, manifest: manifest, zipPath: app.testSetupsDirectory + "\(id).zip", courseID: courseID)

--- a/Tests/APITests/AssignmentRoutesNotebookTests.swift
+++ b/Tests/APITests/AssignmentRoutesNotebookTests.swift
@@ -108,6 +108,65 @@ import VaporTesting
         }
     }
 
+    /// Regression: resetting a *personalized* assignment must apply the same
+    /// `{{name}}` substitution the first-open seeding path performs.  The
+    /// reset used to write the raw template, leaving the student with
+    /// `patients = {{patients}}` — a NameError on the first cell and no way
+    /// to get their data back by resetting again.
+    @Test func resetStudentNotebookAppliesPersonalizationSubstitutions() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/instructor", cookie: cookie, on: app)
+
+            let manifest = """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null,"globalVariables":[{"name":"patients","value":[{"name":"Maria","age":42}]}]}
+                """
+            let setup = try await arInsertSetup(id: "setup_reset_personalized", manifest: manifest, on: app)
+            let starterBytes = Data(
+                #"""
+                {"nbformat":4,"nbformat_minor":5,"metadata":{"kernelspec":{"name":"python"}},"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":["patients = {{patients}}"]}]}
+                """#.utf8)
+            try await arAttachStarterNotebook(to: setup, bytes: starterBytes, on: app)
+            let assignment = try await arInsertAssignment(
+                testSetupID: "setup_reset_personalized", title: "Personalized Lab", isOpen: true, on: app
+            )
+            let assignmentID = assignment.publicID
+
+            let student = try await arInsertStudent(username: "reset_student_personalized", on: app)
+            try await arEnrollStudentInTestCourse(student, on: app)
+            let studentUUID = try student.requireID()
+
+            let workingCopyPath = try arSeedStudentWorkingCopy(
+                setupID: "setup_reset_personalized",
+                userID: studentUUID,
+                bytes: Data(#"{"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[]}"#.utf8),
+                on: app
+            )
+
+            try await app.asyncTest(
+                .POST,
+                "/instructor/\(assignmentID)/students/\(studentUUID.uuidString)/reset-notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                }
+            )
+
+            let resetText = try String(
+                contentsOf: URL(fileURLWithPath: workingCopyPath), encoding: .utf8)
+            #expect(
+                resetText.contains("{{patients}}") == false,
+                "Reset must substitute the {{patients}} placeholder — the raw template leaves the student with a NameError."
+            )
+            #expect(
+                resetText.contains("Maria"),
+                "Reset working copy must carry the substituted global-variable value.")
+        }
+    }
+
     /// The reset must NOT delete past submissions — they remain on disk
     /// and in the DB for instructor review.  Only the live working-copy
     /// notebook is overwritten.

--- a/Tests/APITests/NotebookWebRoutesTests.swift
+++ b/Tests/APITests/NotebookWebRoutesTests.swift
@@ -188,6 +188,14 @@ import VaporTesting
         """
     }
 
+    /// Single-code-cell notebook — personalization substitution only rewrites
+    /// code cells, so `{{name}}` fixtures need this shape.
+    private func notebookJSON(code: String) -> String {
+        """
+        {"nbformat":4,"nbformat_minor":5,"metadata":{},"cells":[{"cell_type":"code","execution_count":null,"metadata":{},"outputs":[],"source":[\(code.debugDescription)]}]}
+        """
+    }
+
     private func makeZipAt(zipPath: String, entries: [(name: String, content: String)]) throws {
         guard FileManager.default.fileExists(atPath: "/usr/bin/env") else {
             throw IssueRecorded("env not available")
@@ -591,6 +599,59 @@ import VaporTesting
 
             let restored = try String(contentsOf: URL(fileURLWithPath: copyPath), encoding: .utf8)
             #expect(restored.contains(starterMarker))
+            #expect(restored.contains("Broken edits") == false)
+        }
+    }
+
+    @Test func resetOwnNotebookAppliesPersonalizationSubstitutions() async throws {
+        try await withApp(app) { _ in
+            // Regression: a self-reset on a personalized assignment must hand
+            // back the *substituted* starter, exactly like first-open seeding.
+            // The reset used to write the raw template, so the student's first
+            // cell became `patients = {{patients}}` — a NameError with no
+            // self-service way back to their data.
+            let cookie = try await loginAsStudent()
+            let user = try await studentUser()
+            try await enroll(user)
+            let userID = try user.requireID()
+
+            let setupID = "setup_nb_self_reset_personalized"
+            let manifest = """
+                {"schemaVersion":1,"gradingMode":"browser","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null,"globalVariables":[{"name":"patients","value":[{"name":"Maria","age":42}]}]}
+                """
+            _ = try await insertSetup(
+                id: setupID,
+                notebookJSON: notebookJSON(code: "patients = {{patients}}"),
+                manifest: manifest
+            )
+            _ = try await insertAssignment(testSetupID: setupID, title: "Personalized Reset Lab", isOpen: true)
+
+            // Simulate the student having clobbered their own working copy.
+            let copyPath = workingCopyPath(setupID: setupID, userID: userID)
+            try FileManager.default.createDirectory(
+                atPath: (copyPath as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true)
+            try Data(notebookJSON(markdown: "Broken edits").utf8)
+                .write(to: URL(fileURLWithPath: copyPath))
+
+            let (csrf, sessionCookie) = try await csrfFields(for: "/account", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/testsetups/\(setupID)/reset-notebook",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                })
+
+            let restored = try String(contentsOf: URL(fileURLWithPath: copyPath), encoding: .utf8)
+            #expect(
+                restored.contains("{{patients}}") == false,
+                "Reset must substitute the {{patients}} placeholder — the raw template leaves the student with a NameError."
+            )
+            #expect(restored.contains("Maria"), "Reset working copy must carry the substituted value.")
             #expect(restored.contains("Broken edits") == false)
         }
     }

--- a/changelog.d/reset-notebook-personalization.md
+++ b/changelog.d/reset-notebook-personalization.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Reset-notebook now personalizes the restored starter.** All three
+  reset-notebook actions (student self-service, and the two instructor-driven
+  resets on the per-assignment roster and the course-student page) overwrote
+  the working copy with the raw starter template, skipping the `{{name}}`
+  personalization substitution that first-open seeding applies. On a
+  personalized assignment a reset left the student staring at
+  `patients = {{patients}}` and a `NameError`, with no self-service way back.
+  The three paths now funnel through one helper that substitutes global/section
+  variables and per-student expressions before writing, exactly like first
+  open.


### PR DESCRIPTION
## Problem

A student reported (via email) that after using "restart the assignment" on a personalized assignment, their notebook came back showing the raw template:

```
patients = {{patients}}
```

which fails with `NameError: name 'patients' is not defined` — the patient database was gone with no self-service way back.

## Root cause

All three reset-notebook actions fetched the canonical starter and passed it straight to `ensureUserNotebookWorkingCopy(overwriteWith:)`, which writes the provided bytes verbatim. The `{{name}}` personalization substitution (global/section variables + per-student expressions) only runs on the *seeding* branch, i.e. when a working copy doesn't exist yet. So a reset on a personalized assignment restored the un-substituted template:

- `resetOwnNotebook` — student self-service (`POST /testsetups/:id/reset-notebook`)
- `resetStudentNotebook` — instructor per-assignment roster
- `resetStudentAssignmentNotebook` — course-student page

## Fix

New helper `overwriteUserNotebookWithPersonalizedStarter` in `NotebookWorkingCopyStore.swift` applies `applyNotebookSubstitutionsIfNeeded` to the starter for the target student (same seed resolution, support-files directory, and soft-fail-to-raw semantics as first-open seeding), then performs the overwrite. All three reset paths now funnel through it.

Other `overwriteWith:` callers (submission views, instructor drafts, solution copies, browser saves) are intentionally untouched — those want exact bytes.

## Tests

- `resetOwnNotebookAppliesPersonalizationSubstitutions` (NotebookWebRoutesTests) — self-service reset on a `globalVariables` assignment: working copy must contain the substituted value and no `{{patients}}`.
- `resetStudentNotebookAppliesPersonalizationSubstitutions` (AssignmentRoutesNotebookTests) — same assertion through the instructor roster action (also covers the second starter-fetch variant, `notebookData(for:)`).
- `arInsertSetup` gained an optional `manifest:` parameter (defaulted; existing call sites unchanged).

Both fixtures are literal-only personalization, so no `python3` evaluator subprocess is involved.

**Note:** I could not run `swift build` / `swift test` in this sandbox — SwiftPM package resolution requires downloading the `SwiftLintBinary.artifactbundle.zip` from `github.com/realm/SwiftLint/releases/…`, which this session's egress policy blocks (403). Verification is delegated to CI on this PR; I'm watching it and will fix any failures.

## Operational note (recovering the affected student)

The fix changes only future resets. The affected student's working copy currently holds the raw template, so after this deploys, one more **Reset notebook** (by the student, or by staff from the roster) will restore their personalized starter. Their past submissions were never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8RgPrcvs6iDmgUXfnU8VL

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8RgPrcvs6iDmgUXfnU8VL)_