### PR TITLE
Time-limit editing in the web UI: default field + per-test override (#979)

### DIFF
--- a/Public/suite-table.js
+++ b/Public/suite-table.js
@@ -205,7 +205,14 @@
                     // Instructor hint (PR4a/PR4c). Carried on every item and
                     // re-emitted in buildPayload so a reorder/family-save push
                     // never wipes it (the server takes hint from the DTO).
-                    hint: s.hint == null ? '' : String(s.hint)
+                    hint: s.hint == null ? '' : String(s.hint),
+                    // Per-test time-limit override (#979). Same carry-and-
+                    // re-emit contract as hint: the server takes the DTO value
+                    // unconditionally, so dropping it here would wipe an
+                    // override on the next reorder. null = inherit the
+                    // assignment default.
+                    timeLimitSeconds: s.timeLimitSeconds != null
+                        ? Math.max(1, parseInt(s.timeLimitSeconds) || 0) : null
                 };
             });
         }
@@ -721,7 +728,9 @@
                         dependsOn:   (item.dependsOn || []).slice(),
                         // Always send the current hint so reorders preserve it
                         // (the server takes hint from the DTO unconditionally).
-                        hint:        (item.hint && item.hint.trim()) ? item.hint.trim() : null
+                        hint:        (item.hint && item.hint.trim()) ? item.hint.trim() : null,
+                        // Same contract for the per-test time-limit override.
+                        timeLimitSeconds: item.timeLimitSeconds != null ? item.timeLimitSeconds : null
                     };
                     // Only send the body when a fresh edit staged it; omitting
                     // it leaves the existing file untouched (a reorder/retier
@@ -1523,7 +1532,9 @@
         /// PR4c: persist a hand-written script (create or content/hint edit)
         /// through the single `PUT /suite` write path, replacing the legacy
         /// `POST /scripts` / `PUT /scripts/:name` endpoints in the script
-        /// editor. `spec` = { filename, content, hint, tier?, points?, isTest? }.
+        /// editor. `spec` = { filename, content, hint, timeLimitSeconds?,
+        /// tier?, points?, isTest? } (timeLimitSeconds: int, or null to
+        /// inherit the assignment default; omit the key to leave unchanged).
         /// The body rides on a transient `_content` that buildPayload emits and
         /// the post-push re-seed drops; `hint` persists via the DTO. New scripts
         /// land in the clicked section; an existing script keeps its tier /
@@ -1539,6 +1550,9 @@
             if (existing) {
                 if (spec.content != null) existing._content = spec.content;
                 existing.hint = spec.hint || '';
+                if (spec.timeLimitSeconds !== undefined) {
+                    existing.timeLimitSeconds = spec.timeLimitSeconds;
+                }
                 if (spec.tier) existing.tier = spec.tier;
                 if (spec.points != null) existing.points = Math.max(0, parseInt(spec.points) || 0);
             } else {
@@ -1554,6 +1568,7 @@
                     dependsOn: [],
                     sectionID: targetSid,
                     hint: spec.hint || '',
+                    timeLimitSeconds: spec.timeLimitSeconds != null ? spec.timeLimitSeconds : null,
                     _content: spec.content != null ? spec.content : ''
                 });
             }
@@ -1567,6 +1582,53 @@
                 })
                 .catch(function (err) { items = snapshot; renderTree(); throw err; });
         }
+
+        // ── Assignment-wide default per-test time limit (#979) ──
+        //
+        // Saved through its own endpoint (PUT /instructor/:id/time-limit)
+        // rather than PUT /suite, so changing it never closes, re-validates,
+        // or retests the assignment (parity with the set_time_limit MCP
+        // tool). The input only exists on the edit page; the URL is built
+        // from config.assignmentID, so the draft page (no assignmentID, no
+        // input) is a double no-op.
+        (function wireDefaultTimeLimit() {
+            var assignmentID = config.assignmentID;
+            if (!assignmentID) return;
+            var input  = document.getElementById('suite-default-time-limit');
+            var status = document.getElementById('suite-default-limit-status');
+            if (!input) return;
+            var putTimeLimitURL =
+                '/instructor/' + encodeURIComponent(assignmentID) + '/time-limit';
+            var lastSaved = input.value;
+            var timer = null;
+            function save() {
+                var raw = input.value.trim();
+                var seconds = parseInt(raw, 10);
+                if (raw === '' || isNaN(seconds) || seconds < 1 || seconds > 600) {
+                    global.ChickadeeUI.setStatus(status, '1–600 s', 'error');
+                    return;
+                }
+                if (String(seconds) === lastSaved) {
+                    global.ChickadeeUI.setStatus(status, '');
+                    return;
+                }
+                global.ChickadeeUI.fetchJSON(putTimeLimitURL, {
+                    method: 'PUT', csrfToken: csrfToken, body: { seconds: seconds }
+                }).then(function (payload) {
+                    lastSaved = String((payload && payload.seconds) || seconds);
+                    input.value = lastSaved;
+                    global.ChickadeeUI.setStatus(status, 'Saved', 'ok');
+                }).catch(function (err) {
+                    global.ChickadeeUI.setStatus(status,
+                        'Save failed: ' + ((err && err.message) || err), 'error');
+                });
+            }
+            input.addEventListener('input', function () {
+                if (timer) clearTimeout(timer);
+                timer = setTimeout(save, 600);
+            });
+            input.addEventListener('change', save);
+        })();
 
         // Reload on bfcache restore so the page always reflects server state.
         window.addEventListener('pageshow', function (e) {

--- a/Public/test-renderer-script.js
+++ b/Public/test-renderer-script.js
@@ -86,6 +86,7 @@ import {
     var applyBtn = null;
     var cmMount = null;
     var hintInput = null;
+    var timeLimitInput = null;
 
     var view = null;
     var mode = 'create';      // 'create' | 'edit' | 'uploadEdit'
@@ -146,12 +147,24 @@ import {
             cmMount = el('div', { id: 'cm-editor-mount' }, 'min-height:240px;border:1px solid var(--border);border-radius:.3rem;overflow:auto;font-size:.875rem');
             bodyEl.appendChild(cmMount);
 
-            // Hint (shown to students on failure) — visible in all modes.
-            var hintLabel = el('label', null, 'font-size:.8rem;display:flex;flex-direction:column;gap:.2rem');
+            // Hint (shown to students on failure) + per-test time limit —
+            // visible in all modes, side by side on one row.
+            var metaRow = el('div', null, 'display:flex;align-items:flex-end;gap:.6rem;flex-wrap:wrap');
+            var hintLabel = el('label', null, 'font-size:.8rem;display:flex;flex-direction:column;gap:.2rem;flex:1;min-width:16rem');
             hintLabel.appendChild(document.createTextNode('Hint (optional — shown to students when this test fails)'));
             hintInput = el('input', { type: 'text', 'class': 'form-input', placeholder: 'e.g. Re-read the function’s docstring for the expected return type.' }, 'padding:.25rem .5rem;font-size:.85rem');
             hintLabel.appendChild(hintInput);
-            bodyEl.appendChild(hintLabel);
+            metaRow.appendChild(hintLabel);
+            var limitLabel = el('label', null, 'font-size:.8rem;display:flex;flex-direction:column;gap:.2rem;width:11rem');
+            limitLabel.appendChild(document.createTextNode('Time limit (s, blank = default)'));
+            timeLimitInput = el('input', {
+                type: 'number', 'class': 'form-input', min: '1', max: '600',
+                placeholder: 'assignment default',
+                title: 'Seconds this one test may run before it is killed and recorded as a timeout. Blank inherits the assignment default.'
+            }, 'padding:.25rem .5rem;font-size:.85rem');
+            limitLabel.appendChild(timeLimitInput);
+            metaRow.appendChild(limitLabel);
+            bodyEl.appendChild(metaRow);
 
             // Keep the filename extension in sync with the chosen template lang.
             templateSel.addEventListener('change', function () {
@@ -189,6 +202,7 @@ import {
             if (newControls) newControls.style.display = 'flex';
             if (nameInput) { nameInput.value = ''; }
             if (hintInput) hintInput.value = '';
+            if (timeLimitInput) timeLimitInput.value = '';
             freshView('', '');
             setTimeout(function () { if (nameInput) nameInput.focus(); }, 0);
         },
@@ -201,6 +215,7 @@ import {
                 currentFilename = item.name;
                 if (newControls) newControls.style.display = 'none';
                 if (hintInput) hintInput.value = '';
+                if (timeLimitInput) timeLimitInput.value = '';
                 freshView(item.content || '', item.name || '');
                 return;
             }
@@ -209,6 +224,9 @@ import {
             currentFilename = item.script || item.id || '';
             if (newControls) newControls.style.display = 'none';
             if (hintInput) hintInput.value = item.hint || '';
+            if (timeLimitInput) {
+                timeLimitInput.value = item.timeLimitSeconds != null ? String(item.timeLimitSeconds) : '';
+            }
             freshView('Loading…', currentFilename);
             var urlFn = cfg().scriptContentURL;
             if (typeof urlFn === 'function') {
@@ -222,17 +240,26 @@ import {
         readSpec: function () {
             var content = docText();
             var hint = hintInput ? hintInput.value.trim() : '';
+            // Blank inherits the assignment default (null); out-of-range
+            // values are rejected here so the server never sees them.
+            var timeLimitSeconds = null;
+            if (timeLimitInput && timeLimitInput.value.trim() !== '') {
+                timeLimitSeconds = parseInt(timeLimitInput.value, 10);
+                if (isNaN(timeLimitSeconds) || timeLimitSeconds < 1 || timeLimitSeconds > 600) {
+                    throw new Error('Time limit must be between 1 and 600 seconds (or blank for the assignment default).');
+                }
+            }
             if (mode === 'uploadEdit') {
                 return { uploadEdit: true, name: uploadEditName, content: content };
             }
             if (mode === 'edit') {
                 if (!currentFilename) throw new Error('No script selected.');
-                return { filename: currentFilename, content: content, hint: hint };
+                return { filename: currentFilename, content: content, hint: hint, timeLimitSeconds: timeLimitSeconds };
             }
             // create
             var filename = (nameInput.value || '').trim();
             if (!filename) throw new Error('Enter a filename first.');
-            return { filename: filename, content: content, hint: hint, tier: 'public', points: 1, isTest: true };
+            return { filename: filename, content: content, hint: hint, timeLimitSeconds: timeLimitSeconds, tier: 'public', points: 1, isTest: true };
         },
 
         persistAndSync: function (spec) {

--- a/Resources/Views/assignment-edit.leaf
+++ b/Resources/Views/assignment-edit.leaf
@@ -234,6 +234,19 @@
     <div class="editor-block-head">
         <h2>Test Suite</h2>
         <div class="toolbar toolbar--end">
+            <!-- Assignment-wide default per-test time limit (#979).  Saved
+                 live via PUT /instructor/:id/time-limit (the web twin of the
+                 set_time_limit MCP tool) — no close, no re-validation, no
+                 retest.  Individual tests override it in the test editor. -->
+            <label class="suite-default-limit-label" for="suite-default-time-limit">
+                Default time limit
+                <input class="form-input input-compact suite-default-limit-input"
+                       type="number" min="1" max="600" step="1"
+                       id="suite-default-time-limit" value="#(timeLimitSeconds)"
+                       title="Seconds each test may run before it is killed and recorded as a timeout. Individual tests can override this in the test editor.">
+                s
+                <span id="suite-default-limit-status" class="upload-status-inline"></span>
+            </label>
             <!-- Add Section — form POST + full page reload.  Mirrors the
                  dashboard pattern (Resources/Views/assignments.leaf:29-51)
                  so section CRUD doesn't ride the fragile whole-state
@@ -837,6 +850,8 @@ function checkUWDates(dateTimeValue, warningEl) {
 <style>
 .bs-assess-row { display: flex; gap: .4rem; align-items: center; }
 .bs-assess-row input[type="text"] { flex: 1; }
+.suite-default-limit-label { display: inline-flex; align-items: center; gap: .3rem; font-size: var(--text-sm); color: var(--gray-500); }
+.suite-default-limit-input { width: 4.5rem; }
 </style>
 <script>
 (function () {

--- a/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentEditorContexts.swift
@@ -145,6 +145,11 @@ struct EditAssignmentContext: Encodable {
     /// The per-assignment secret-reveal toggle: whether students may spend
     /// their one reveal token here.  Renders the "Student Options" checkbox.
     let secretRevealEnabled: Bool
+    /// Assignment-wide default per-test execution limit (seconds) from the
+    /// manifest (`TestProperties.timeLimitSeconds`).  Renders the editable
+    /// "Default time limit" input in the Test Suite header, saved live via
+    /// `PUT /instructor/:assignmentID/time-limit` (#979).
+    let timeLimitSeconds: Int
     let notice: String?
     let error: String?
 }

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -522,6 +522,7 @@ struct InstructorDashboardRoutes: RouteCollection {
             brightspaceSyncEnabled: req.application.brightSpaceAppCredentials != nil,
             brightspaceGradeObjectID: assignment.brightspaceGradeObjectID,
             secretRevealEnabled: assignment.secretRevealEnabled == true,
+            timeLimitSeconds: manifest?.timeLimitSeconds ?? 10,
             notice: q?.notice,
             error: q?.error
         )

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Suite.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+Suite.swift
@@ -72,6 +72,38 @@ extension PublishedAssignmentRoutes {
         return try await payload.encodeResponse(for: req)
     }
 
+    // MARK: - PUT /instructor/:assignmentID/time-limit
+
+    /// Sets the assignment-wide default per-test execution time limit — the
+    /// web twin of the `set_time_limit` MCP tool, sharing its manifest helper
+    /// and accepted range. Like that tool this is a grading-environment knob,
+    /// not a change to what the tests check, so it deliberately does NOT
+    /// close the assignment, re-run validation, or retest submissions
+    /// (contrast `putSuite`). Per-test overrides ride the suite payload's
+    /// `timeLimitSeconds` entry field instead.
+    @Sendable
+    func putTimeLimit(req: Request) async throws -> Response {
+        let (_, setup) = try await loadAssignmentAndSetupForWrite(req, atLeast: .ta)
+
+        let body: TimeLimitPayload
+        do { body = try req.content.decode(TimeLimitPayload.self) } catch {
+            throw WebAssignmentError.invalidParameter(
+                name: "request body",
+                reason: "Invalid time-limit payload: \(error.localizedDescription)")
+        }
+        guard mcpTimeLimitRange.contains(body.seconds) else {
+            throw WebAssignmentError.invalidParameter(
+                name: "seconds",
+                reason:
+                    "seconds must be an integer between \(mcpTimeLimitRange.lowerBound) and "
+                    + "\(mcpTimeLimitRange.upperBound) (got \(body.seconds)).")
+        }
+
+        let effective = try await setManifestTimeLimitSeconds(
+            setup: setup, to: body.seconds, on: req.db)
+        return try await TimeLimitPayload(seconds: effective).encodeResponse(for: req)
+    }
+
 }
 
 // MARK: - Reconstitution (file-scope so other routes can reuse it)

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes.swift
@@ -57,6 +57,10 @@ struct PublishedAssignmentRoutes: RouteCollection {
         r.get(":assignmentID", "suite", use: getSuite)
         r.put(":assignmentID", "suite", use: putSuite)
 
+        // Assignment-wide default per-test time limit — web twin of the
+        // `set_time_limit` MCP tool (no close / re-validate / retest).
+        r.put(":assignmentID", "time-limit", use: putTimeLimit)
+
         // Suite-section CRUD — per-op, form-POST + redirect.
         r.post(":assignmentID", "suite-sections", use: createSuiteSection)
         r.post(":assignmentID", "suite-sections", "reorder", use: reorderSuiteSections)

--- a/Sources/APIServer/Routes/Web/SuitePayloadDTOs.swift
+++ b/Sources/APIServer/Routes/Web/SuitePayloadDTOs.swift
@@ -65,6 +65,12 @@ struct TestSuiteSectionDTO: Content {
     var name: String
 }
 
+/// Request and response body for `PUT /instructor/:assignmentID/time-limit`
+/// (the assignment-wide default per-test execution limit, in seconds).
+struct TimeLimitPayload: Content {
+    var seconds: Int
+}
+
 struct SuitePayload: Content {
     var items: [SuiteItemDTO]
     /// Ordered list of sections.  Clients predating v0.4.96 may omit

--- a/Tests/APITests/SuiteRouteTests.swift
+++ b/Tests/APITests/SuiteRouteTests.swift
@@ -847,4 +847,131 @@ import VaporTesting
 
         }
     }
+
+    // MARK: - PUT /suite per-test time-limit override (#979)
+
+    @Test func put_roundTripsPerTestTimeLimitOverride() async throws {
+        try await withApp(app) { _ in
+            let id = try await makeAssignment(withScripts: [
+                ("publictest_slow.py", "passed('slow')\n")
+            ])
+            let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
+            let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
+
+            let body = #"""
+                {"items":[
+                    {"kind":"script","script":{"script":"publictest_slow.py","tier":"public","points":1,"displayName":null,"dependsOn":[],"timeLimitSeconds":42}}
+                ]}
+                """#
+            try await app.asyncTest(
+                .PUT, "/instructor/\(id)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: body)
+                },
+                afterResponse: { res in #expect(res.status == .ok, "\(res.body.string)") })
+
+            // Persisted onto the manifest entry…
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db).filter(\.$publicID == id).first())
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            let entry = try #require(props.testSuites.first { $0.script == "publictest_slow.py" })
+            #expect(entry.timeLimitSeconds == 42)
+
+            // …and echoed back on GET so the editor round-trips it.
+            try await app.asyncTest(
+                .GET, "/instructor/\(id)/suite",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("\"timeLimitSeconds\":42"))
+                })
+        }
+    }
+
+    // MARK: - PUT /time-limit (assignment-wide default, #979)
+
+    @Test func putTimeLimit_setsManifestDefaultWithoutClosingAssignment() async throws {
+        try await withApp(app) { _ in
+            let id = try await makeAssignment()
+            let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
+            let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(id)/time-limit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"seconds":5}"#)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "\(res.body.string)")
+                    #expect(res.body.string.contains("\"seconds\":5"))
+                })
+
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db).filter(\.$publicID == id).first())
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.timeLimitSeconds == 5)
+            // Grading-environment knob (set_time_limit parity): the change
+            // must not close the assignment the way content edits do.
+            #expect(assignment.visibility == .open)
+        }
+    }
+
+    @Test(arguments: [0, 601]) func putTimeLimit_rejectsOutOfRange(seconds: Int) async throws {
+        try await withApp(app) { _ in
+            let id = try await makeAssignment()
+            let cookie = try await loginUser(username: "inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("inst", on: app)
+            let (csrf, sessionCookie) = try await csrfPair(for: id, cookie: cookie)
+
+            try await app.asyncTest(
+                .PUT, "/instructor/\(id)/time-limit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"seconds":\#(seconds)}"#)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .badRequest, "expected 400 for \(seconds)s, got \(res.status)")
+                })
+
+            // Manifest default is untouched (fixture default is 10).
+            let assignment = try #require(
+                try await APIAssignment.query(on: app.db).filter(\.$publicID == id).first())
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            let props = try JSONDecoder().decode(TestProperties.self, from: Data(setup.manifest.utf8))
+            #expect(props.timeLimitSeconds == 10)
+        }
+    }
+
+    @Test func putTimeLimit_studentForbidden() async throws {
+        try await withApp(app) { _ in
+            let id = try await makeAssignment()
+            let studentCookie = try await loginUser(username: "stu", password: "pw", role: "student", on: app)
+            let (csrf, sessionCookie) = try await csrfFields(for: "/", cookie: studentCookie, on: app)
+            try await app.asyncTest(
+                .PUT, "/instructor/\(id)/time-limit",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"seconds":5}"#)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden || res.status == .seeOther || res.status == .notFound,
+                        "Expected forbidden/redirect for student PUT, got \(res.status)")
+                })
+        }
+    }
 }

--- a/changelog.d/time-limit-editing-ui.md
+++ b/changelog.d/time-limit-editing-ui.md
@@ -1,0 +1,16 @@
+### Added
+
+- **Time-limit editing in the web UI (#979).** The assignment edit page's Test
+  Suite header gains an editable "Default time limit" field, saved live via a
+  new `PUT /instructor/:assignmentID/time-limit` endpoint — the web twin of the
+  `set_time_limit` MCP tool (no close, no re-validation, no retest). The Test
+  Editor modal gains a per-script "Time limit" field (blank inherits the
+  assignment default) riding the existing `timeLimitSeconds` suite DTO field.
+
+### Fixed
+
+- **Web suite edits no longer wipe per-test time-limit overrides.** The suite
+  editor dropped `timeLimitSeconds` when round-tripping rows, so any reorder or
+  points/tier edit in the browser silently erased overrides set via the
+  `author_script` / `update_suite` MCP tools. The field now rides the same
+  carry-and-re-emit contract as `hint`.


### PR DESCRIPTION
Completes the UI half of #979 (the MCP/manifest half shipped earlier as `set_time_limit` + the per-entry `timeLimitSeconds` DTO field), and fixes a data-loss bug found along the way.

## What's here

**New endpoint — `PUT /instructor/:assignmentID/time-limit`.** The web twin of the `set_time_limit` MCP tool: same `setManifestTimeLimitSeconds` helper, same 1–600 s range, TA+ write gate. Deliberately does **not** close the assignment, re-run validation, or retest submissions (a grading-environment knob, not a content edit — contrast `PUT /suite`).

**Edit page — editable "Default time limit" field** in the Test Suite header, seeded from the manifest (`EditAssignmentContext.timeLimitSeconds`), saved live with a 600 ms debounce and inline Saved/error status. Wiring lives in `suite-table.js` (no inline page JS; the ratchet stays at baseline).

**Test Editor modal — per-script "Time limit" field** next to Hint. Blank inherits the assignment default; values are validated 1–600 client-side and ride the existing `timeLimitSeconds` field on the suite DTO through the single `PUT /suite` write path.

**Bug fix: web suite edits wiped per-test overrides.** `suite-table.js` dropped `timeLimitSeconds` when normalising GET payload rows and when rebuilding the PUT payload, and the server takes the DTO value unconditionally — so any browser-side reorder or tier/points edit silently erased overrides set via the `author_script` / `update_suite` MCP tools. The field now follows the same carry-and-re-emit contract as `hint`.

## Tests

- `put_roundTripsPerTestTimeLimitOverride` — PUT /suite persists the override onto the manifest entry and GET echoes it back.
- `putTimeLimit_setsManifestDefaultWithoutClosingAssignment` — manifest default updated; assignment stays `.open` (set_time_limit parity).
- `putTimeLimit_rejectsOutOfRange` (parameterized 0 / 601) — 400, manifest untouched.
- `putTimeLimit_studentForbidden` — role gate.

All 41 tests in `SuiteRouteTests` + `AssignmentRoutesEditorTests` pass; `scripts/check-styles.sh` (css-vars, design tokens, inline-script ratchet) green; `scripts/format.sh` applied.

## Not in scope (noted on #979)

Per-test overrides on pattern families / notebook checks, and a time-limit field on the create/draft page.

Closes the "edit UI" checkboxes of #979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7GphVag1tHKS721GBooU6

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7GphVag1tHKS721GBooU6)_