### PR TITLE
Gate the UW important-dates integration behind UW_IMPORTANT_DATES_ENABLED (#278)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,17 @@ SSO_ADMIN_USERS=
 # LOG_LEVEL=info
 
 # ----------------------------------------------------------------
+# UWaterloo important-dates integration (on by default)
+# ----------------------------------------------------------------
+# Instructor due-date pickers warn when a due date lands on a UWaterloo
+# holiday, closure, or exam period, fed by the public UW important-dates
+# iCal feed (fetched server-side, cached 24 h). This is deliberately
+# UW-specific (issue #278). Deployments outside UWaterloo should set this
+# to false: the /api/v1/uw-dates endpoint is then not registered and the
+# due-date warnings simply never appear. Nothing else changes.
+# UW_IMPORTANT_DATES_ENABLED=false
+
+# ----------------------------------------------------------------
 # MCP content-authoring server (off by default)
 # ----------------------------------------------------------------
 # The /mcp endpoint lets an authorized AI agent author course content on an

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -130,7 +130,8 @@ private func resolveAppConfig(
                 diagnostics: preloaded.diagnostics,
                 alerts: preloaded.alerts,
                 outboundProxy: preloaded.outboundProxy,
-                mcp: preloaded.mcp
+                mcp: preloaded.mcp,
+                uwDates: preloaded.uwDates
             )
         } ?? preloaded
     }

--- a/Sources/APIServer/Configuration/AppConfig.swift
+++ b/Sources/APIServer/Configuration/AppConfig.swift
@@ -27,6 +27,9 @@ struct AppConfig: Sendable {
     let alerts: ServerHealthAlertConfiguration
     let outboundProxy: OutboundProxyConfig?
     let mcp: MCPConfig
+    /// UWaterloo important-dates due-date warnings — an optional institutional
+    /// integration, on by default (#278). See UWDatesConfig.
+    let uwDates: UWDatesConfig
 
     /// Loads the entire config tree from `Environment.get(...)`.
     ///
@@ -59,7 +62,8 @@ struct AppConfig: Sendable {
             diagnostics: DiagnosticsConfiguration.fromEnvironment(),
             alerts: ServerHealthAlertConfiguration.fromEnvironment(),
             outboundProxy: OutboundProxyConfig.fromEnvironment(),
-            mcp: MCPConfig.fromEnvironment(workDir: workDir)
+            mcp: MCPConfig.fromEnvironment(workDir: workDir),
+            uwDates: UWDatesConfig.fromEnvironment()
         )
     }
 
@@ -102,6 +106,9 @@ struct AppConfig: Sendable {
         }
         if scanMode.enabled {
             logger.warning("SCAN_MODE=true — destructive POST endpoints are returning 503.")
+        }
+        if !uwDates.enabled {
+            logger.info("uwDates: disabled — /api/v1/uw-dates not registered")
         }
         if let bs = brightspace {
             logger.info(
@@ -185,7 +192,8 @@ extension AppConfig {
     static func testDefaults(
         authMode: AuthMode = .local,
         database: DatabaseSettings = .sqliteInMemory(),
-        mcp: MCPConfig = .default
+        mcp: MCPConfig = .default,
+        uwDates: UWDatesConfig = .default
     ) -> AppConfig {
         let auth = AuthConfig(
             mode: authMode,
@@ -219,7 +227,8 @@ extension AppConfig {
             ),
             alerts: .default,
             outboundProxy: nil,
-            mcp: mcp
+            mcp: mcp,
+            uwDates: uwDates
         )
     }
 }

--- a/Sources/APIServer/Configuration/UWDatesConfig.swift
+++ b/Sources/APIServer/Configuration/UWDatesConfig.swift
@@ -1,0 +1,21 @@
+// APIServer/Configuration/UWDatesConfig.swift
+//
+// Gate for the UWaterloo important-dates integration (the #278 decision:
+// this feature is UW-only by design, kept as an optional institutional
+// integration rather than generalized). The feed URL and event-relevance
+// keywords in UWImportantDatesService stay UWaterloo-specific; deployments
+// outside UWaterloo set UW_IMPORTANT_DATES_ENABLED=false, which leaves
+// GET /api/v1/uw-dates unregistered so the assignment editors' due-date
+// warning fetch silently no-ops.
+
+struct UWDatesConfig: Sendable {
+    /// Whether GET /api/v1/uw-dates is registered. Defaults to true — this is
+    /// a UWaterloo-aligned codebase, so the UW deployment needs no env change.
+    let enabled: Bool
+
+    static let `default` = UWDatesConfig(enabled: true)
+
+    static func fromEnvironment() -> Self {
+        UWDatesConfig(enabled: environmentBool("UW_IMPORTANT_DATES_ENABLED") ?? true)
+    }
+}

--- a/Sources/APIServer/Routes/UWDatesRoute.swift
+++ b/Sources/APIServer/Routes/UWDatesRoute.swift
@@ -3,6 +3,11 @@
 // GET /api/v1/uw-dates
 // Returns upcoming UWaterloo important dates as JSON for client-side due-date warnings.
 // Registered under the instructor middleware group (only instructors set due dates).
+//
+// This is a deliberately UW-only institutional integration (#278) — not a
+// generalized "important dates" feature. Registration is gated by
+// UW_IMPORTANT_DATES_ENABLED (default on; see UWDatesConfig), so non-UW
+// deployments disable it with one env var and the endpoint 404s.
 
 import Vapor
 

--- a/Sources/APIServer/Services/UWImportantDatesService.swift
+++ b/Sources/APIServer/Services/UWImportantDatesService.swift
@@ -3,6 +3,12 @@
 // Fetches and caches the University of Waterloo important dates iCalendar feed.
 // Results are cached for 24 hours to avoid hammering the UW server on every
 // instructor due-date change.
+//
+// The hardcoded feed URL and the UW/Ontario-flavoured relevance keywords are
+// intentional (#278): this is an optional institutional integration, not a
+// general calendar feature. Deployments outside UWaterloo turn it off with
+// UW_IMPORTANT_DATES_ENABLED=false (see UWDatesConfig), which unregisters
+// the /api/v1/uw-dates route that fronts this cache.
 
 import Foundation
 import Vapor

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -66,7 +66,12 @@ func routes(_ app: Application) throws {
     try instructor.register(collection: StudentCourseRoutes())
     // Worker job polling is instructor-tier: only the server operator runs workers.
     try instructor.register(collection: SubmissionRoutes())
-    try instructor.register(collection: UWDatesRoute())
+    // Optional UWaterloo-only integration (#278): when disabled the route is
+    // simply absent (404) and the assignment editors' due-date warning fetch
+    // treats the non-OK response as "no warnings".
+    if app.appConfig.uwDates.enabled {
+        try instructor.register(collection: UWDatesRoute())
+    }
     // MCP "Connected agents" management page (instructor sees own grants; admin all).
     try instructor.register(collection: MCPAgentsRoutes())
 

--- a/Tests/APITests/AppConfigTests.swift
+++ b/Tests/APITests/AppConfigTests.swift
@@ -22,6 +22,7 @@ import Vapor
         #expect(cfg.workers.publicBaseURL == nil)
         #expect(cfg.brightspace == nil)
         #expect(cfg.scanMode.enabled == false)
+        #expect(cfg.uwDates.enabled == true)
         #expect(cfg.oidc.callbackPath == "/auth/sso/callback")
         #expect(cfg.oidc.usernameClaim == "preferred_username")
         #expect(cfg.oidc.emailClaim == "email")
@@ -44,6 +45,7 @@ import Vapor
             "LOGIN_RATE_LIMIT_PER_MIN": "20",
             "LOGIN_LOCKOUT_THRESHOLD": "8",
             "JOB_METRIC_RETENTION_DAYS": "7",
+            "UW_IMPORTANT_DATES_ENABLED": "false",
             // Clear DB-backend overrides so the assertion-of-default branch
             // (`.sqlite`) isn't accidentally redirected to postgres by an
             // earlier test's leaked env.
@@ -68,6 +70,7 @@ import Vapor
             #expect(cfg.lockout.perMinute == 20)
             #expect(cfg.lockout.lockoutThreshold == 8)
             #expect(cfg.diagnostics.jobMetricRetentionDays == 7)
+            #expect(cfg.uwDates.enabled == false)
         }
     }
 
@@ -135,7 +138,8 @@ import Vapor
             diagnostics: seed.diagnostics,
             alerts: seed.alerts,
             outboundProxy: seed.outboundProxy,
-            mcp: seed.mcp
+            mcp: seed.mcp,
+            uwDates: seed.uwDates
         )
         app.preloadedAppConfig = seed
         // Smoke: configure() picks up the preloaded config without env reads.
@@ -171,7 +175,8 @@ import Vapor
             diagnostics: AppConfig.testDefaults().diagnostics,
             alerts: .default,
             outboundProxy: nil,
-            mcp: .default
+            mcp: .default,
+            uwDates: .default
         )
         let captured = CapturedLogger()
         cfg.logSummary(to: captured.logger)

--- a/Tests/APITests/UWDatesRouteGatingTests.swift
+++ b/Tests/APITests/UWDatesRouteGatingTests.swift
@@ -1,0 +1,35 @@
+// Tests/APITests/UWDatesRouteGatingTests.swift
+//
+// The UW important-dates endpoint is an optional institutional integration
+// (#278): registered by default, absent entirely when
+// UW_IMPORTANT_DATES_ENABLED=false. These tests pin the mount behaviour
+// without touching the network — an unauthenticated /api/ request stops at
+// ActiveCourseStaffMiddleware (401) when the route exists, and 404s when it
+// was never registered.
+
+import Fluent
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct UWDatesRouteGatingTests {
+
+    @Test func routeIsRegisteredByDefault() async throws {
+        try await withApp(try await makeTestApp(prefix: "chickadee-uwdates")) { app in
+            try await app.testing().test(.GET, "/api/v1/uw-dates") { res async in
+                #expect(res.status == .unauthorized)
+            }
+        }
+    }
+
+    @Test func routeIsAbsentWhenDisabled() async throws {
+        let config = AppConfig.testDefaults(uwDates: UWDatesConfig(enabled: false))
+        try await withApp(try await makeTestApp(prefix: "chickadee-uwdates", appConfig: config)) {
+            app in
+            try await app.testing().test(.GET, "/api/v1/uw-dates") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+}

--- a/Tests/APITests/UWDatesRouteGatingTests.swift
+++ b/Tests/APITests/UWDatesRouteGatingTests.swift
@@ -25,8 +25,8 @@ import VaporTesting
 
     @Test func routeIsAbsentWhenDisabled() async throws {
         let config = AppConfig.testDefaults(uwDates: UWDatesConfig(enabled: false))
-        try await withApp(try await makeTestApp(prefix: "chickadee-uwdates", appConfig: config)) {
-            app in
+        let app = try await makeTestApp(prefix: "chickadee-uwdates", appConfig: config)
+        try await withApp(app) { app in
             try await app.testing().test(.GET, "/api/v1/uw-dates") { res async in
                 #expect(res.status == .notFound)
             }

--- a/changelog.d/issue-278-uw-dates-gate.md
+++ b/changelog.d/issue-278-uw-dates-gate.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **UW important-dates integration is now an explicitly optional institutional
+  feature (#278).** The due-date holiday/closure warnings fed by the UWaterloo
+  important-dates iCal feed stay UW-specific by design (not generalized), and
+  registration of `GET /api/v1/uw-dates` is now gated by
+  `UW_IMPORTANT_DATES_ENABLED` (default on — UW deployments need no change).
+  Non-UW deployments set it to `false` in `.env`; the endpoint is then absent
+  and the assignment editors' warning fetch silently no-ops. This closes the
+  last open half of #278 — the Marmoset-import half was already resolved by
+  removal.


### PR DESCRIPTION
Closes #278 with the **document-and-gate** decision: Chickadee is a UWaterloo-aligned codebase, so the important-dates integration stays UW-specific by design — it is now clearly documented as an optional institutional integration and gated behind an env var so other deployments can turn it off cleanly.

## Decision record (both halves of #278)

- **Marmoset import: one-time migration tool, removed.** Already resolved before this PR — `MarmosetImportParser.swift` / `MarmosetImportRoutes.swift` no longer exist; only historical comments remain.
- **UW important-dates: UW-only by design, documented and gated.** Not generalized; the feed URL and relevance keywords stay UWaterloo-specific.

## What changed

- New `UWDatesConfig` substruct on `AppConfig`, reading `UW_IMPORTANT_DATES_ENABLED` (all the usual bool spellings via `environmentBool`).
- **Default is ON** — deliberate: prod auto-deploys green merges, so the UW deployment keeps its due-date warnings with zero host-side env changes. This also matches the codebase's existing UW-shaped defaults (DUO claim names, retention windows). Non-UW deployments set `UW_IMPORTANT_DATES_ENABLED=false`.
- When disabled, `routes.swift` never registers `UWDatesRoute`, so `GET /api/v1/uw-dates` 404s. The assignment editors' `checkUWDates` fetch already treats any non-OK response as "no warnings", so the UI degrades silently with no template changes.
- `logSummary` notes the disabled state at startup; nothing is logged in the default case.
- Decision recorded in the `UWDatesRoute.swift` / `UWImportantDatesService.swift` headers and a new `.env.example` section.

## Tests

- `UWDatesRouteGatingTests`: route mounted by default (unauthenticated `/api/` request stops at `ActiveCourseStaffMiddleware` with 401 — no network touched), absent (404) when disabled via `makeTestApp(appConfig:)`.
- `AppConfigTests`: the substruct-sentinel test (`fromEnvironmentReadsAllSubstructs`) and `testDefaultsAreUsable` now cover `uwDates`.

Note: the sandbox's network policy blocks the SwiftLint binary-artifact download, so the full build/test run could not be executed locally — `swift-format`/`lint.sh` passed locally and the files parse clean; relying on CI for the compile + test verdict on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZb4zBryd4Eh3Y2yXnipqw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZb4zBryd4Eh3Y2yXnipqw)_