### PR TITLE
Fix spurious "no runner" validation status when saving an assignment with a healthy fleet

### DIFF
--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -325,6 +325,9 @@ extension PublishedAssignmentRoutes {
             requirements: requirementSpec
         )
         guard hasEligibleRunner else {
+            req.logger.warning(
+                "Validation pre-check found no compatible active runner; marking assignment \(assignment.publicID) no-runner"
+            )
             assignment.validationStatus = "no-runner"
             assignment.validationSubmissionID = nil
             try await assignment.save(on: req.db)

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -278,6 +278,9 @@ func scheduleValidationAfterSuiteEdit(
             requirements: requirementSpec
         )
         guard hasRunner else {
+            req.logger.warning(
+                "Validation pre-check found no compatible active runner; marking assignment \(assignment.publicID) no-runner"
+            )
             assignment.validationStatus = "no-runner"
             try await assignment.save(on: req.db)
             return
@@ -517,10 +520,28 @@ func ensureValidationRunnerAvailability(req: Request) async {
     try? await Task.sleep(nanoseconds: 1_000_000_000)
 }
 
+/// Active window for the validation pre-check's DB-backed runner-liveness
+/// probe (`RunnerProfile.lastSeenAt` → `isActive`).
+///
+/// Must out-wait *persisted*-freshness lag, not true freshness: an unchanged
+/// runner check-in only persists `lastSeenAt` once per
+/// `RunnerProfileService.lastSeenPersistInterval` (60 s — the 2026-07
+/// poll-write audit), and a live runner can go ~30 s between check-ins
+/// (heartbeat cadence), so a perfectly healthy runner's stored timestamp
+/// runs up to ~90 s behind the clock. The pre-debounce window here (20 s)
+/// sat inside that lag: for most of every debounce cycle the whole fleet
+/// looked stale, so a metadata-only assignment save (e.g. a due-date edit)
+/// spuriously landed on `validationStatus = "no-runner"` — and flipped every
+/// live `RunnerProfile` inactive — while healthy runners were polling.
+/// Debounce + 60 s = 120 s, matching the diagnostics surface's
+/// `RUNNER_ACTIVE_WINDOW_SECONDS` default.
+let validationRunnerActiveWindowSeconds: TimeInterval =
+    RunnerProfileService.lastSeenPersistInterval + 60
+
 func hasCompatibleValidationRunner(
     req: Request,
     requirements: AssignmentRequirementSpec?,
-    activeWindowSeconds: TimeInterval = 20
+    activeWindowSeconds: TimeInterval = validationRunnerActiveWindowSeconds
 ) async throws -> Bool {
     try await req.application.runnerProfiles.refreshActiveFlags(
         activeWindowSeconds: activeWindowSeconds,
@@ -543,7 +564,7 @@ func hasCompatibleValidationRunner(
 func ensureCompatibleValidationRunnerAvailability(
     req: Request,
     requirements: AssignmentRequirementSpec?,
-    activeWindowSeconds: TimeInterval = 20,
+    activeWindowSeconds: TimeInterval = validationRunnerActiveWindowSeconds,
     attempts: Int = 3
 ) async throws -> Bool {
     if try await hasCompatibleValidationRunner(

--- a/Tests/APITests/ValidationRunnerAvailabilityTests.swift
+++ b/Tests/APITests/ValidationRunnerAvailabilityTests.swift
@@ -1,0 +1,98 @@
+// Tests/APITests/ValidationRunnerAvailabilityTests.swift
+//
+// Regression tests for the validation pre-check's runner-liveness window.
+// `RunnerProfile.lastSeenAt` is debounced (2026-07 poll-write audit): an
+// unchanged runner check-in persists freshness at most once per
+// `RunnerProfileService.lastSeenPersistInterval`, so a live runner's
+// persisted timestamp lags real time by up to ~90 s (debounce + heartbeat
+// gap). The pre-check used to probe that column with a 20 s window, so for
+// most of every debounce cycle a healthy fleet looked stale and a
+// metadata-only assignment save (e.g. a due-date edit) landed on
+// `validationStatus = "no-runner"` with runners online.
+
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+@testable import Core
+
+/// App-less invariant suite: the pre-check window must out-wait
+/// persisted-freshness lag — the `lastSeenAt` debounce plus the runner's
+/// worst-case check-in gap (~30 s heartbeat). Guards the window against
+/// being re-tightened below the debounce, which is what produced the
+/// spurious "no-runner".
+@Suite struct ValidationRunnerWindowInvariantTests {
+    @Test func defaultWindowExceedsPersistDebouncePlusHeartbeat() {
+        #expect(
+            validationRunnerActiveWindowSeconds
+                > RunnerProfileService.lastSeenPersistInterval + 30)
+    }
+}
+
+@Suite(.serialized) final class ValidationRunnerAvailabilityTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-valrunner")
+    }
+
+    private func makeProfile() -> RunnerCapabilityProfile {
+        RunnerCapabilityProfile(
+            platform: "linux",
+            architecture: "x86_64",
+            languageVersions: [LanguageVersion(language: "python", version: "3.11.8")],
+            capabilities: [RunnerCapability(name: "numpy")]
+        )
+    }
+
+    /// A runner whose *persisted* freshness is as stale as the debounce
+    /// allows for a live, polling runner must still count as available
+    /// under the default pre-check window.
+    @Test func liveRunnerWithDebouncedLastSeenCountsAsAvailable() async throws {
+        try await withApp(app) { _ in
+            // 85 s ago: past the 60 s debounce — a healthy runner's stored
+            // timestamp really does get this old — and well past the old
+            // 20 s window that spuriously failed here. 35 s of slack to the
+            // 120 s default keeps the test tolerant of a slow CI host.
+            let staleSeenAt = Date().addingTimeInterval(
+                -(RunnerProfileService.lastSeenPersistInterval + 25))
+            _ = try await app.runnerProfiles.registerOrUpdate(
+                runnerID: "val-live", displayName: "host-a",
+                profile: makeProfile(), seenAt: staleSeenAt, on: app.db)
+
+            let req = Request(application: app, on: app.eventLoopGroup.next())
+            let available = try await hasCompatibleValidationRunner(
+                req: req, requirements: nil)
+            #expect(available == true)
+
+            // The probe must not knock the live runner's profile inactive
+            // either — the pre-fix refresh flipped the whole fleet off as a
+            // side effect of every save.
+            let row = try #require(
+                try await RunnerProfile.query(on: app.db)
+                    .filter(\.$runnerID == "val-live").first())
+            #expect(row.isActive == true)
+        }
+    }
+
+    /// A genuinely dead runner — silent for far longer than the debounce
+    /// can explain — is still filtered out, so the pre-check keeps
+    /// catching real no-runner deployments.
+    @Test func longSilentRunnerStillCountsAsUnavailable() async throws {
+        try await withApp(app) { _ in
+            let deadSeenAt = Date().addingTimeInterval(-600)
+            _ = try await app.runnerProfiles.registerOrUpdate(
+                runnerID: "val-dead", displayName: "host-b",
+                profile: makeProfile(), seenAt: deadSeenAt, on: app.db)
+
+            let req = Request(application: app, on: app.eventLoopGroup.next())
+            let available = try await hasCompatibleValidationRunner(
+                req: req, requirements: nil)
+            #expect(available == false)
+        }
+    }
+}

--- a/changelog.d/validation-no-runner-staleness.md
+++ b/changelog.d/validation-no-runner-staleness.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Spurious "no runner" when saving an assignment with a healthy runner fleet.**
+  The validation pre-check probed runner liveness with a 20 s window against
+  `RunnerProfile.lastSeenAt`, but since the 2026-07 poll-write audit that
+  column is debounced — an unchanged runner check-in persists freshness at
+  most once every 60 s — so for most of each debounce cycle every live runner
+  looked stale. A metadata-only save (e.g. editing a due date) would then mark
+  the assignment `no-runner` instead of enqueueing validation, and flip every
+  live runner profile inactive as a side effect. Both the web Save path and
+  MCP content edits shared the race. The pre-check window is now derived from
+  the persist debounce (debounce + 60 s = 120 s, matching the diagnostics
+  `RUNNER_ACTIVE_WINDOW_SECONDS` default) so persisted-freshness lag can never
+  exceed it.


### PR DESCRIPTION
## Summary

Editing an assignment's metadata (e.g. only the due date) and clicking Save could land the assignment on `validationStatus = "no-runner"` while several healthy runners were online and actively polling. Reproduced in prod on HLTH 230 Assignment 4 with a 3-runner fleet; re-running the identical validation minutes later passed, confirming the status was spurious.

## Root cause

A staleness race between two windows introduced on opposite sides of the 2026-07 poll-write audit:

- `RunnerProfileService.lastSeenPersistInterval` (60 s) debounces persistence of `RunnerProfile.lastSeenAt`: an unchanged runner check-in skips the row UPDATE while the stored timestamp is under 60 s old. A live runner's *persisted* freshness therefore lags real time by up to ~90 s (debounce + worst-case ~30 s heartbeat gap). The debounce comment asserted this was safe against `RUNNER_ACTIVE_WINDOW_SECONDS` (default 120 s) — but that window is only used by the diagnostics surface.
- The validation pre-check (`hasCompatibleValidationRunner` / `ensureCompatibleValidationRunnerAvailability`) refreshed active flags with a hardcoded **20 s** window. For roughly two-thirds of every debounce cycle, every live runner's persisted timestamp exceeded 20 s, so the pre-check marked the whole fleet inactive and the save wrote `"no-runner"` instead of enqueueing validation.

Both the web Save path (`enqueueValidationForEditedAssignment`) and MCP content edits (`scheduleValidationAfterSuiteEdit`) shared the race. The worker claim path was unaffected — it matches the polling runner's own profile directly, never the `isActive` flags — which is why student grading kept working throughout.

## Fix

- Derive the pre-check window from the debounce it must out-wait: `validationRunnerActiveWindowSeconds = RunnerProfileService.lastSeenPersistInterval + 60` (= 120 s, matching the diagnostics `RUNNER_ACTIVE_WINDOW_SECONDS` default). Both helper defaults now use it.
- Log a warning at both `no-runner` sites so a future false negative is visible via `query_logs` (this incident logged nothing).

## Tests

- `ValidationRunnerWindowInvariantTests.defaultWindowExceedsPersistDebouncePlusHeartbeat` — pins the invariant window > debounce + heartbeat gap, guarding against re-tightening.
- `ValidationRunnerAvailabilityTests.liveRunnerWithDebouncedLastSeenCountsAsAvailable` — a runner whose persisted freshness is 85 s old (legitimately stale under the debounce) still counts as available and is not flipped inactive. Fails under the old 20 s window.
- `ValidationRunnerAvailabilityTests.longSilentRunnerStillCountsAsUnavailable` — a runner silent for 10 minutes is still filtered out, so the pre-check keeps catching genuinely dead fleets.

Local run: 10 tests in 3 suites passed (the new suites plus the existing `WorkerPollWriteReductionTests` debounce suite). SwiftLint could not run in the sandbox (binary artifact download blocked); relying on the CI `format-lint` job. `scripts/format.sh` + `scripts/lint.sh` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCcJKA8wVYXCSgFPdUKZoq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCcJKA8wVYXCSgFPdUKZoq)_