### PR TITLE
Fix personal-data export stuck "pending" after interrupted generation

### DIFF
--- a/Sources/APIServer/Bootstrap/AppServices.swift
+++ b/Sources/APIServer/Bootstrap/AppServices.swift
@@ -30,6 +30,9 @@ func bootstrapAppServices(_ app: Application, appConfig: AppConfig) throws {
         PeriodicSweepLifecycleHandler { $0.auditLogReaperMonitor(maxAge: auditLogMaxAge) }
     )
     app.lifecycle.use(PeriodicSweepLifecycleHandler { $0.dataExportReaperMonitor })
+    // Unstick personal-data exports orphaned in `pending` by a restart mid-
+    // generation, so the account page's status poll can resolve (#557).
+    app.lifecycle.use(PeriodicSweepLifecycleHandler { $0.staleDataExportReaperMonitor })
     app.lifecycle.use(ServerHealthAlertLifecycleHandler())
 
     // One-time best-effort cleanup of pre-v0.4 notebook working-copy

--- a/Sources/APIServer/Services/DataExportRecoveryService.swift
+++ b/Sources/APIServer/Services/DataExportRecoveryService.swift
@@ -1,0 +1,117 @@
+// APIServer/Services/DataExportRecoveryService.swift
+//
+// Liveness backstop for the personal-data export pipeline (#557).
+//
+// Export generation runs in a detached background task inside the server
+// process (`DataExportManager` → `generateDataExport`).  That task cannot
+// survive the process: a blue-green redeploy, crash, or OOM while an export
+// is still generating leaves its `data_exports` row stuck `pending` forever.
+// Nothing in the next process owns that orphaned row, and the account page's
+// status poll (`account-export.js`) only stops when the row leaves `pending`
+// — so the user watches "your export is being prepared … this page will
+// refresh when it is ready" indefinitely and is never told their data is
+// ready or that it failed.
+//
+// `generateDataExport` already funnels every in-process error to a terminal
+// `failed` state, so the ONLY way a row lingers in `pending` is an
+// interrupted generation.  This sweep is the recovery for exactly that: it
+// flips such orphaned rows to `failed`, which lets the poll resolve, surfaces
+// the "last export attempt failed — please try again" notice, and re-exposes
+// the request button (`dataExportCanBeRequested` already treats a `failed`
+// row as re-requestable).  Retention of the generated zips is a separate
+// concern in `DataExportRetentionService.swift`.
+//
+// Periodic scaffolding lives in `PeriodicSweepMonitor` (leader-leased, so
+// multi-process deployments sweep once per tick) — same pattern as the
+// stuck-submission reaper this mirrors.
+
+import Fluent
+import Foundation
+import Vapor
+
+/// Sweep every minute so an interrupted export is unstuck promptly once it
+/// crosses the staleness threshold, rather than lingering until the hourly
+/// retention pass.
+private let staleDataExportSweepInterval: TimeInterval = 60
+
+/// Flips `pending` export rows older than `maxAge` to `failed`.
+///
+/// `maxAge` defaults to `dataExportStalePendingAge` — the same threshold at
+/// which `dataExportCanBeRequested` re-opens the request button — so a stuck
+/// row becomes "failed, try again" and re-requestable at the same instant,
+/// keeping the state machine coherent.
+///
+/// The flip is a single conditional `UPDATE … WHERE status = 'pending'`, so it
+/// cannot clobber a very slow but genuine generation that completes between
+/// the read and the write: the database re-checks `status` at execution time,
+/// and a row that has since reached `complete` is excluded.  Returns the
+/// number of rows failed (for tests / logging).
+@discardableResult
+func failStalePendingDataExports(
+    on db: Database,
+    logger: Logger,
+    maxAge: TimeInterval = dataExportStalePendingAge,
+    now: Date = Date()
+) async throws -> Int {
+    let cutoff = now.addingTimeInterval(-maxAge)
+
+    func scoped() -> QueryBuilder<APIDataExport> {
+        APIDataExport.query(on: db)
+            .filter(\.$status == DataExportStatus.pending.rawValue)
+            .filter(\.$requestedAt <= cutoff)
+    }
+
+    // Read the orphaned (id, user) pairs first so each failure can be logged
+    // by owner, then flip the whole set in one conditional UPDATE.  A row that
+    // ages past the cutoff between the read and the UPDATE is caught by the
+    // next sweep; a row that completes in that window is excluded by the
+    // UPDATE's `status = 'pending'` predicate — benign either way.
+    let stale = try await scoped().field(\.$id).field(\.$userID).all()
+    guard !stale.isEmpty else { return 0 }
+
+    let minutes = Int((maxAge / 60).rounded())
+    try await scoped()
+        .set(\.$status, to: DataExportStatus.failed.rawValue)
+        .set(\.$completedAt, to: now)
+        .set(
+            \.$failureReason,
+            to: "Generation did not complete within \(minutes) minutes "
+                + "(interrupted — most likely a server restart during generation)."
+        )
+        .update()
+
+    for export in stale {
+        logger.warning(
+            "data_export reaper: failed stale pending export \(export.id?.uuidString ?? "<nil>") for user \(export.userID.uuidString); user can now request a fresh export"
+        )
+    }
+    return stale.count
+}
+
+struct StaleDataExportReaperMonitorKey: StorageKey {
+    typealias Value = PeriodicSweepMonitor
+}
+
+extension Application {
+    var staleDataExportReaperMonitor: PeriodicSweepMonitor {
+        get {
+            if let existing = storage[StaleDataExportReaperMonitorKey.self] { return existing }
+            let created = PeriodicSweepMonitor(
+                name: "Stale data-export reaper",
+                interval: staleDataExportSweepInterval,
+                minimumInterval: 1,
+                runImmediately: true
+            ) { application in
+                _ = try await failStalePendingDataExports(
+                    on: application.db,
+                    logger: application.logger
+                )
+            }
+            storage[StaleDataExportReaperMonitorKey.self] = created
+            return created
+        }
+        set {
+            storage[StaleDataExportReaperMonitorKey.self] = newValue
+        }
+    }
+}

--- a/Tests/APITests/DataExportRecoveryTests.swift
+++ b/Tests/APITests/DataExportRecoveryTests.swift
@@ -60,6 +60,13 @@ import VaporTesting
             let requestedAt = Date().addingTimeInterval(-(dataExportStalePendingAge + 60))
             let row = try await insertExport(
                 userID: userID, status: .pending, requestedAt: requestedAt)
+            // Baseline read so the requestedAt check below is DB-value vs
+            // DB-value: Postgres stores microsecond precision, so comparing a
+            // round-tripped timestamp against the raw in-memory Date is a
+            // false mismatch (renders identically, differs in sub-µs bits).
+            let storedRequestedAt = try #require(
+                try await APIDataExport.find(row.id, on: app.db)
+            ).requestedAt
 
             let failed = try await failStalePendingDataExports(on: app.db, logger: app.logger)
             #expect(failed == 1)
@@ -69,7 +76,7 @@ import VaporTesting
             #expect(reloaded.completedAt != nil)
             #expect(reloaded.failureReason != nil)
             // requestedAt is the rate-limit / re-request ledger — never rewritten.
-            #expect(reloaded.requestedAt == requestedAt)
+            #expect(reloaded.requestedAt == storedRequestedAt)
         }
     }
 

--- a/Tests/APITests/DataExportRecoveryTests.swift
+++ b/Tests/APITests/DataExportRecoveryTests.swift
@@ -1,0 +1,158 @@
+// Tests/APITests/DataExportRecoveryTests.swift
+//
+// Recovery for personal-data exports orphaned in `pending` by a server
+// restart mid-generation (#557).  Generation runs in a detached background
+// task, so a redeploy/crash while it is in flight leaves the `data_exports`
+// row stuck `pending` forever — and the account page's status poll only
+// stops when the row leaves `pending`, so the user is never told their data
+// is ready or that it failed.  `failStalePendingDataExports` is the backstop
+// that flips such rows to `failed` so the poll resolves and the request
+// button reappears.
+
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized, .timeLimit(.minutes(2))) final class DataExportRecoveryTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-dexp-recov")
+    }
+
+    /// Creates a persisted user (the `data_exports.user_id` FK cascades from
+    /// `users.id`, so a real row is required) and returns its ID.
+    private func makeUser() async throws -> UUID {
+        let user = APIUser(
+            username: "dexp-\(UUID().uuidString.prefix(8))",
+            passwordHash: "x", role: "user")
+        try await user.create(on: app.db)
+        return try user.requireID()
+    }
+
+    /// Inserts an export row for `userID` in a chosen state and age.
+    @discardableResult
+    private func insertExport(
+        userID: UUID,
+        status: DataExportStatus,
+        requestedAt: Date,
+        zipPath: String? = nil
+    ) async throws -> APIDataExport {
+        let row = APIDataExport(userID: userID, requestedAt: requestedAt)
+        row.setStatus(status)
+        if status != .pending {
+            row.completedAt = requestedAt.addingTimeInterval(1)
+        }
+        row.zipPath = zipPath
+        try await row.create(on: app.db)
+        return row
+    }
+
+    // MARK: - Sweep unit behaviour
+
+    @Test func failStalePending_flipsInterruptedRowToFailed() async throws {
+        try await withApp(app) { _ in
+            let userID = try await makeUser()
+            let requestedAt = Date().addingTimeInterval(-(dataExportStalePendingAge + 60))
+            let row = try await insertExport(
+                userID: userID, status: .pending, requestedAt: requestedAt)
+
+            let failed = try await failStalePendingDataExports(on: app.db, logger: app.logger)
+            #expect(failed == 1)
+
+            let reloaded = try #require(try await APIDataExport.find(row.id, on: app.db))
+            #expect(reloaded.statusValue == .failed)
+            #expect(reloaded.completedAt != nil)
+            #expect(reloaded.failureReason != nil)
+            // requestedAt is the rate-limit / re-request ledger — never rewritten.
+            #expect(reloaded.requestedAt == requestedAt)
+        }
+    }
+
+    @Test func failStalePending_leavesFreshPendingUntouched() async throws {
+        try await withApp(app) { _ in
+            let userID = try await makeUser()
+            // Just requested — a live generation task likely still owns it.
+            let row = try await insertExport(
+                userID: userID, status: .pending, requestedAt: Date())
+
+            let failed = try await failStalePendingDataExports(on: app.db, logger: app.logger)
+            #expect(failed == 0)
+
+            let reloaded = try #require(try await APIDataExport.find(row.id, on: app.db))
+            #expect(reloaded.statusValue == .pending)
+        }
+    }
+
+    @Test func failStalePending_neverClobbersACompletedExport() async throws {
+        try await withApp(app) { _ in
+            // A slow-but-genuine export that completed long ago must not be
+            // reaped even though its requestedAt is well past the threshold.
+            let userID = try await makeUser()
+            let requestedAt = Date().addingTimeInterval(-(dataExportStalePendingAge + 3600))
+            let row = try await insertExport(
+                userID: userID, status: .complete, requestedAt: requestedAt,
+                zipPath: "/tmp/does-not-matter.zip")
+
+            let failed = try await failStalePendingDataExports(on: app.db, logger: app.logger)
+            #expect(failed == 0)
+
+            let reloaded = try #require(try await APIDataExport.find(row.id, on: app.db))
+            #expect(reloaded.statusValue == .complete)
+            #expect(reloaded.zipPath == "/tmp/does-not-matter.zip")
+        }
+    }
+
+    // MARK: - End-to-end: the stuck UI resolves
+
+    @Test func stalePending_resolvesStatusPollAndReoffersRequest() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await wrLoginAsStudent(on: app)
+            let student = try await wrStudentUser(on: app)
+            let userID = try student.requireID()
+
+            // Simulate an export interrupted by a restart: a pending row older
+            // than the staleness threshold with no live generation task.
+            try await insertExport(
+                userID: userID, status: .pending,
+                requestedAt: Date().addingTimeInterval(-(dataExportStalePendingAge + 120)))
+
+            // Before recovery: the poll keeps the page waiting forever.
+            try await app.asyncTest(
+                .GET, "/account/export/status",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains("\"status\":\"pending\""))
+                })
+
+            let failed = try await failStalePendingDataExports(on: app.db, logger: app.logger)
+            #expect(failed == 1)
+
+            // After recovery: the poll sees a terminal state (so account-export.js
+            // reloads the page) ...
+            try await app.asyncTest(
+                .GET, "/account/export/status",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("\"status\":\"failed\""))
+                })
+
+            // ... and the reloaded account page shows the failure notice and a
+            // fresh request button.
+            try await app.asyncTest(
+                .GET, "/account",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let page = res.body.string
+                    #expect(page.contains("Your last export attempt failed"))
+                    #expect(page.contains("Request data export"))
+                })
+        }
+    }
+}

--- a/changelog.d/data-export-stuck-pending.md
+++ b/changelog.d/data-export-stuck-pending.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Personal-data export stuck "in progress" forever.** Export generation
+  runs in a background task inside the server process, so a restart mid-run
+  (e.g. a blue-green redeploy) orphaned the request in the `pending` state:
+  the account page's status poll never resolved and the user was never told
+  their export was ready or had failed. A leader-leased sweep now flips a
+  `pending` export that has outlived the staleness window (15 min) to
+  `failed`, so the poll resolves and the "request data export" button
+  reappears for a fresh attempt.


### PR DESCRIPTION
## Summary

The student **data export** (`/account` → "Request data export", #557) could get stuck forever: you submit the request, the page says *"your export is being prepared… this page will refresh when it is ready"*, and it never does. You're never told your data is ready, and never told it failed. This matches the reported symptom exactly.

## Root cause

Export generation runs in a **detached background task inside the server process** (`DataExportManager` → `generateDataExport`). That task cannot outlive the process. On a restart mid-generation — most likely a **blue-green redeploy** (these happen on every merge to `main`), but also a crash or OOM — the `data_exports` row is left in `pending`:

- Nothing in the surviving/next process owns the orphaned row, so it is never driven to a terminal state.
- The account page's status poll (`Public/account-export.js`) only stops when the row leaves `pending`, so it polls `"pending"` forever and never reloads the page.
- The existing 15-minute self-heal (`dataExportStalePendingAge`, which re-enables the request button on a *fresh* page load) never helps, because the poll never triggers that fresh load.

`generateDataExport` already funnels every *in-process* error to a terminal `failed` state, so an interrupted generation is the only way a row lingers in `pending`. (Note: a missing `zip`/`unzip` binary would fail *fast* → `failed`, not this stuck-`pending` symptom, so that's not the cause here.)

## Fix

Add a leader-leased periodic sweep, `failStalePendingDataExports`, that flips a `pending` export older than the staleness window (`dataExportStalePendingAge`, 15 min) to `failed`:

- **Race-safe:** a single conditional `UPDATE … WHERE status = 'pending'` — it cannot clobber a slow-but-genuine generation that completes between the read and the write (the DB re-checks `status`; a row that reached `complete` is excluded, and a genuine completion's own save wins).
- **Same threshold as the re-request gate**, so a stuck row becomes "failed, try again" and re-requestable at the same instant — keeping the state machine coherent.
- Once terminal, the poll resolves → `account-export.js` reloads → the account page shows *"Your last export attempt failed. Please try again."* plus the request button (`dataExportCanBeRequested` already treats `failed` as re-requestable).

Wired into the app lifecycle beside the existing data-export retention reaper; mirrors the established `StuckSubmissionReaperService` pattern (60 s cadence, `runImmediately`, leader-leased so multi-process deploys sweep once per tick). No schema change.

## Files

- `Sources/APIServer/Services/DataExportRecoveryService.swift` — new sweep + `Application.staleDataExportReaperMonitor`.
- `Sources/APIServer/Bootstrap/AppServices.swift` — register the monitor.
- `Tests/APITests/DataExportRecoveryTests.swift` — new coverage.
- `changelog.d/data-export-stuck-pending.md` — changelog fragment.

## Testing

`swift test --filter 'DataExportRecoveryTests|DataExportRoutesTests|DataExportPolicyTests'` → **13/13 pass**. New `DataExportRecoveryTests`:

- flips a stale `pending` row to `failed` (with reason + `completedAt`, `requestedAt` untouched);
- leaves a fresh `pending` row untouched (doesn't kill a live generation);
- never clobbers a `completed` row (race safety);
- end-to-end: after the sweep, `GET /account/export/status` returns `failed` and `GET /account` re-offers the request button.

The existing `DataExportRoutesTests` suite still passes (no regression).

## Notes / trade-offs

- The orphaned case now self-resolves within ~1 minute of crossing the 15-minute staleness mark, rather than never. 15 minutes is kept deliberately (it's the documented "interrupted" threshold and matches the re-request gate) so a legitimately slow export is never failed prematurely; the conditional UPDATE means even the pathological "still generating at 15 min" case resolves to `complete`.
- Separately worth a look (out of scope here): the runtime `Dockerfile` relies on `zip`/`unzip` being present transitively — the app hard-depends on `/usr/bin/{zip,unzip}` (test-setup publish/extract, course-bundle + data-export zipping) but doesn't install them explicitly. Adding them to the apt list would harden against a future base-image change. Not the cause of this bug (that would surface as `failed`, not stuck), so left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUPEMwo6xKAvESXMmV1gdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUPEMwo6xKAvESXMmV1gdi)_