### PR TITLE
Install zip/unzip explicitly in the runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # System dependencies:
 #   - C runtime libs (Swift stdlib is statically linked)
+#   - zip / unzip: the server and worker shell out to /usr/bin/{zip,unzip}
+#     for test-setup extract/publish, course-bundle import/export, and the
+#     personal-data export (ZipArchiver, TestSetupZipHelpers). They were only
+#     ever present transitively; installed explicitly so a future base-image
+#     change can't silently drop them and break those paths.
 #   - Python 3 + common scientific packages (for Python test scripts / submissions)
 #   - R base (for R test scripts / submissions)
 #
@@ -85,6 +90,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         curl \
         file \
         tzdata \
+        unzip \
+        zip \
         libsqlite3-0 \
         libssl3 \
         libcurl4 \

--- a/changelog.d/dockerfile-zip-unzip.md
+++ b/changelog.d/dockerfile-zip-unzip.md
@@ -1,0 +1,8 @@
+### Changed
+
+- **Install `zip`/`unzip` explicitly in the runtime image.** The server and
+  worker shell out to `/usr/bin/{zip,unzip}` for test-setup extract/publish,
+  course-bundle import/export, and the personal-data export, but those
+  binaries were only ever present transitively in the `ubuntu:24.04` base.
+  They are now an explicit apt dependency so a future base-image change can't
+  silently drop them and break those paths.


### PR DESCRIPTION
## Summary

Follow-up hardening surfaced while fixing the data-export bug (#1191).

The server and worker shell out to `/usr/bin/zip` and `/usr/bin/unzip` on several core paths:

- **test-setup extract/publish** (`TestSetupZipHelpers`, `ZipEntryListCache`),
- **course-bundle import/export** (`ZipArchiver`),
- **personal-data export** (`ZipArchiver`),
- notebook extraction (`NotebookContentHelpers`).

These are hard dependencies, but the runtime image (`ubuntu:24.04`) never installed them explicitly — they've only ever been present *transitively*. If a future base-image or dependency change dropped them, all of the above would break (extraction paths would `throw executableNotFound`, and creation paths would fail), with no signal until runtime.

This adds `zip` and `unzip` to the runtime image's apt install list so the dependency is explicit and can't be silently dropped.

## Not the cause of #1191

Worth stating plainly: this is **preventive**, not the fix for the stuck-export bug. A missing `zip`/`unzip` would make an export fail *fast* (→ `failed`), which is a different symptom from the stuck-`pending` state that #1191 addressed. Since the app runs in production today, the binaries are currently present (transitively); this just removes the reliance on that being accidental.

## Changes

- `Dockerfile` — add `unzip` and `zip` to the runtime `apt-get install` list, with a comment explaining why.
- `changelog.d/dockerfile-zip-unzip.md` — changelog fragment (Changed).

## Testing

No code change; nothing to unit-test. The image builds via the existing `docker-build.yml` pipeline on merge. `zip`/`unzip` are small, well-known packages with no version pin, so the layer change is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUPEMwo6xKAvESXMmV1gdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUPEMwo6xKAvESXMmV1gdi)_