### PR TITLE
Fix personal-data export hang: zip subprocess pipe-buffer deadlock

### DIFF
--- a/Sources/Core/ZipArchiver.swift
+++ b/Sources/Core/ZipArchiver.swift
@@ -46,11 +46,17 @@ public enum ZipArchiverError: Error, CustomStringConvertible {
 /// Creates a ZIP archive from all contents of `sourceDir`.
 /// The resulting archive contains paths relative to `sourceDir` (no parent dir prefix).
 ///
-/// Equivalent to: cd <sourceDir> && /usr/bin/zip -r <outputPath> .
+/// Equivalent to: cd <sourceDir> && /usr/bin/zip -q -r <outputPath> .
+///
+/// `-q` (quiet) matters: without it `zip` prints one "adding: …" line per
+/// file, and for a large tree (e.g. a data-heavy personal-data export) that
+/// output is what used to overflow the discarded-output buffer.  The real
+/// deadlock guard is `runZipProcess` writing child output to the null device,
+/// but staying quiet avoids generating megabytes of output nobody reads.
 public func createZipArchive(sourceDir: URL, outputPath: String) async throws {
     try await runZipProcess(
         executablePath: "/usr/bin/zip",
-        arguments: ["-r", outputPath, "."],
+        arguments: ["-q", "-r", outputPath, "."],
         workingDirectory: sourceDir
     )
 }
@@ -149,8 +155,15 @@ private func runZipProcess(
         if let dir = workingDirectory {
             proc.currentDirectoryURL = dir
         }
-        proc.standardOutput = Pipe()  // discard stdout
-        proc.standardError = Pipe()  // discard stderr
+        // Discard child output to the NULL DEVICE, not an in-memory Pipe.
+        // A Pipe we never drain deadlocks once the child writes more than the
+        // OS pipe buffer (~64 KB): the child blocks on write, so it never
+        // exits, so `terminationHandler` never fires and this continuation
+        // never resumes. `zip -r` emits one line per file, so a large archive
+        // (a data-heavy personal-data export) hit exactly this and hung the
+        // export forever. `/dev/null` sinks any volume without blocking.
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
         proc.terminationHandler = { process in
             if process.terminationStatus == 0 {
                 continuation.resume()

--- a/Tests/APITests/ZipArchiverTests.swift
+++ b/Tests/APITests/ZipArchiverTests.swift
@@ -100,6 +100,38 @@ final class ZipArchiverTests {
         #expect(bContent == "world")
     }
 
+    // MARK: - Large archive (regression: unread-pipe deadlock)
+
+    /// `zip -r` emits one "adding: …" line per file. When the discarded child
+    /// output was an in-memory `Pipe` nobody drained, an archive whose output
+    /// exceeded the ~64 KB OS pipe buffer deadlocked — `zip` blocked on write,
+    /// never exited, and `runZipProcess`'s continuation never resumed. That
+    /// hung a data-heavy personal-data export forever in `pending`. Enough
+    /// files to blow past the buffer must still complete.
+    @Test(.timeLimit(.minutes(1)))
+    func createZipArchive_manyFiles_doesNotDeadlock() async throws {
+        guard FileManager.default.fileExists(atPath: "/usr/bin/zip"),
+            FileManager.default.fileExists(atPath: "/usr/bin/unzip")
+        else { return }
+
+        let srcDir = tmpDir.appendingPathComponent("many")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+        // ~3000 realistically-named files ≈ 180 KB of verbose zip output,
+        // comfortably past the 64 KB buffer that triggered the hang.
+        let fileCount = 3000
+        for i in 0..<fileCount {
+            let name = String(format: "submissions_sub_%08d_results_%d.json", i, i)
+            try Data("{}\n".utf8).write(to: srcDir.appendingPathComponent(name))
+        }
+
+        let zipPath = tmpDir.appendingPathComponent("many.zip").path
+        try await createZipArchive(sourceDir: srcDir, outputPath: zipPath)
+        #expect(FileManager.default.fileExists(atPath: zipPath))
+
+        let entries = try listZipContents(zipPath: zipPath)
+        #expect(entries.count >= fileCount, "every file should be archived")
+    }
+
     // MARK: - Path traversal detection
 
     @Test func dotDotTraversalThrows() async throws {

--- a/changelog.d/data-export-zip-deadlock.md
+++ b/changelog.d/data-export-zip-deadlock.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Personal-data export hung forever for data-heavy accounts.** The export's
+  zip step ran `zip -r` (verbose) with its output wired to an in-memory pipe
+  that was never drained, so once the "adding: …" output exceeded the ~64 KB
+  OS pipe buffer — i.e. an account with enough submissions/results — `zip`
+  blocked on write, never exited, and the export hung in `pending` forever
+  (small accounts fit the buffer and completed, which is why it only bit large
+  ones). `runZipProcess` now discards child output to the null device instead
+  of an undrained pipe, and `createZipArchive` runs `zip -q`. This is the
+  actual cause behind the stuck exports the v0.4.624 stale-export reaper only
+  papered over.


### PR DESCRIPTION
## Summary

This is the **actual root cause** of the stuck personal-data export (#557). The v0.4.624 stale-export reaper (#1191) was a backstop that only converted the hang into a `failed` state after 15 minutes — it never let generation complete, so a data-heavy account (e.g. the maintainer's) still got no export. This fixes generation itself.

## Root cause: a classic subprocess pipe-buffer deadlock

The export's zip step runs `zip -r` (verbose) with the child's stdout/stderr wired to in-memory `Pipe()`s that `runZipProcess` **never drains**:

```swift
// createZipArchive → runZipProcess
arguments: ["-r", outputPath, "."]   // no -q: one "adding: …" line per file
proc.standardOutput = Pipe()         // never read
proc.standardError  = Pipe()
```

Once `zip`'s output exceeds the ~64 KB OS pipe buffer — i.e. an account with enough submission/result files — `zip` **blocks on write**, never exits, so the `terminationHandler` never fires and the `withCheckedThrowingContinuation` never resumes. The export hangs forever in `pending`.

This is exactly why the bug is account-size-dependent:
- **Small accounts** (tests, normal students): output fits the buffer → `zip` finishes → export completes. ✅
- **Data-heavy accounts** (maintainer/admin): output overflows the buffer → deadlock → stuck forever. ❌

The sibling `repackZipFromDirectory` (test-setup publish) already passes `-q`, which is why that path was never affected.

## Fix

- **`runZipProcess`** (the robust fix): discard child output to `FileHandle.nullDevice` instead of an undrained `Pipe`. `/dev/null` sinks any volume without ever blocking, so no output size can deadlock — this also covers `extractZipArchive` and any future caller.
- **`createZipArchive`**: also pass `zip -q`, so we don't generate megabytes of output nobody reads (matches `repackZipFromDirectory`).

## Verification

Reproduced the deadlock directly against the exact `Process` + unread-`Pipe` + verbose-`zip` path on a 3000-file tree:

```
current code  (verbose + unread Pipe): HUNG (killed at 12s)
fix A         (verbose + nullDevice) : completed, status 0
fix B         (quiet   + unread Pipe): completed, status 0
```

Added `createZipArchive_manyFiles_doesNotDeadlock` (3000 files, `.timeLimit(.minutes(1))`) as a regression guard — it hangs on the old code and passes on the fixed code. Full run: `ZipArchiverTests`, `DataExportRecoveryTests`, `DataExportRoutesTests` → **29/29 pass**.

## Relationship to prior PRs

- #1191 (v0.4.624) — stale-export reaper. Still useful as a safety net for genuinely interrupted (restart mid-run) exports, but it was papering over this deadlock. Kept.
- #1193 (v0.4.625) — explicit `zip`/`unzip` in the image. Unrelated hardening. Kept.

## Files

- `Sources/Core/ZipArchiver.swift` — `nullDevice` for discarded child output; `-q` on `createZipArchive`.
- `Tests/APITests/ZipArchiverTests.swift` — large-archive regression test.
- `changelog.d/data-export-zip-deadlock.md` — changelog fragment (Fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUPEMwo6xKAvESXMmV1gdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUPEMwo6xKAvESXMmV1gdi)_