### PR TITLE
Let TAs grant per-student extensions and keep the popover on-screen

### DIFF
--- a/Public/app.js
+++ b/Public/app.js
@@ -135,3 +135,87 @@ if (root) {
         if (e.key === 'Escape') closeAll(null);
     });
 }());
+
+// ── Floating action popovers (per-student extension / grade-override) ────────
+// The <details class="ext-details"> panels on the student-submissions page use
+// an absolutely-positioned .action-panel that opens downward. They live inside
+// .results-table, which clips its overflow (for the rounded corners), so a
+// panel on a row near the bottom of the table is cut off — the Save button
+// disappears below the table edge and can't even be scrolled to.
+//
+// When a panel opens, promote it to position:fixed and place it next to its
+// summary button, clamped to stay fully within the viewport: below the button
+// when it fits, flipped above when it doesn't, and height-capped with its own
+// scroll if it is somehow taller than the screen. position:fixed also escapes
+// the table's overflow clip. Phones keep the CSS static-flow panel (the
+// max-width:640px rule), which is in normal flow and never overflows.
+(function floatingActionPopovers() {
+    const details = Array.from(document.querySelectorAll('details.ext-details'))
+        .filter((d) => d.querySelector('.action-panel'));
+    if (details.length === 0) return;
+
+    const GAP = 6;      // px between the summary button and the panel
+    const MARGIN = 8;   // min px kept clear of every viewport edge
+    const isPhone = () => window.matchMedia('(max-width: 640px)').matches;
+    const FLOATED = ['position', 'left', 'top', 'right', 'maxHeight', 'overflowY'];
+
+    let active = null;  // the <details> whose panel is currently floated
+
+    const clear = (panel) => FLOATED.forEach((prop) => { panel.style[prop] = ''; });
+
+    function place(d) {
+        const summary = d.querySelector('summary');
+        const panel = d.querySelector('.action-panel');
+        if (!summary || !panel) return;
+        // On phones the CSS drops the panel into static flow — leave it there.
+        if (isPhone()) { clear(panel); return; }
+
+        // Float it, cap its height to the viewport, and measure at the cap.
+        panel.style.position = 'fixed';
+        panel.style.right = 'auto';
+        panel.style.overflowY = 'auto';
+        panel.style.maxHeight = (window.innerHeight - 2 * MARGIN) + 'px';
+        panel.style.left = '0px';
+        panel.style.top = '0px';
+
+        const s = summary.getBoundingClientRect();
+        const pw = panel.offsetWidth;
+        const ph = panel.offsetHeight;
+
+        // Right-align the panel under the button, then clamp horizontally.
+        const left = Math.min(Math.max(s.right - pw, MARGIN), window.innerWidth - pw - MARGIN);
+        // Prefer below the button; flip above if it would overflow the bottom;
+        // clamp to the top edge if it fits neither way.
+        let top = s.bottom + GAP;
+        if (top + ph > window.innerHeight - MARGIN) {
+            const above = s.top - GAP - ph;
+            top = above >= MARGIN ? above : Math.max(MARGIN, window.innerHeight - MARGIN - ph);
+        }
+        panel.style.left = Math.round(left) + 'px';
+        panel.style.top = Math.round(top) + 'px';
+    }
+
+    const reposition = () => { if (active && active.open) place(active); };
+
+    details.forEach((d) => {
+        d.addEventListener('toggle', () => {
+            if (d.open) {
+                // Native <details> allow several open at once; only float one.
+                if (active && active !== d) active.open = false;
+                active = d;
+                place(d);
+            } else {
+                clear(d.querySelector('.action-panel'));
+                if (active === d) active = null;
+            }
+        });
+    });
+
+    // Keep the floated panel glued to its button as the page scrolls/resizes.
+    // Capture phase so it also fires for scrolls inside nested scroll areas.
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && active) active.open = false;
+    });
+}());

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -177,10 +177,11 @@ enum CourseWriteDenial: Equatable {
 /// floor explicitly, there is no default):
 ///   - `.ta` — assignment CONTENT and grading: suite/scripts/families/checks,
 ///     notebook/solution edits, global inputs, datasets, achievements,
-///     retest/reset/grade-override.
+///     retest/reset/grade-override, and per-student deadline extensions (an
+///     individual accommodation, sibling to grade-override).
 ///   - `.instructor` — course LIFECYCLE and structure: enrollment/roster/staff,
-///     assignment create/delete/open/close/deadlines, sections, archive,
-///     BrightSpace binding.
+///     assignment create/delete/open/close and the assignment-wide due date,
+///     sections, archive, BrightSpace binding.
 func evaluateCourseWrite(
     user: APIUser, courseID: UUID, atLeast minimum: CourseRole, db: Database
 ) async throws -> CourseWriteDenial? {

--- a/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
+++ b/Sources/APIServer/Routes/Web/StudentCourseRoutes+History.swift
@@ -427,7 +427,7 @@ extension StudentCourseRoutes {
         }
 
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "grant deadline extensions", writeFloor: .instructor)
+            req: req, action: "grant deadline extensions", writeFloor: .ta)
         let (actor, student) = (action.actor, action.student)
         let assignmentIDRaw = action.assignment.publicID
         let studentUUID = action.studentID
@@ -489,7 +489,7 @@ extension StudentCourseRoutes {
     @Sendable
     func deleteStudentAssignmentExtension(req: Request) async throws -> Response {
         let action = try await resolveStudentAssignmentAction(
-            req: req, action: "revoke deadline extensions", writeFloor: .instructor)
+            req: req, action: "revoke deadline extensions", writeFloor: .ta)
         let student = action.student
         let assignmentIDRaw = action.assignment.publicID
         let studentUUID = action.studentID
@@ -671,9 +671,12 @@ extension StudentCourseRoutes {
     ///
     /// `writeFloor`, when non-nil, additionally authorizes a *write* on that
     /// course via `requireCourseWriteAccess` (archived-course block + the
-    /// action's minimum role): grading actions (retest / reset / grade-override)
-    /// pass `.ta`; deadline grants (extensions) pass `.instructor`. The read-only
-    /// history page leaves it nil so archived courses stay auditable.
+    /// action's minimum role): the per-student grading/accommodation actions
+    /// (retest / reset / grade-override / extension grant / extension revoke)
+    /// all pass `.ta`. A per-student extension is an individual accommodation,
+    /// not a change to the assignment-wide deadline — the assignment *lifecycle*
+    /// (open/close/set due date) stays `.instructor` on its own routes. The
+    /// read-only history page leaves it nil so archived courses stay auditable.
     ///
     /// Error semantics match the guard chain each handler previously
     /// inlined: `notFound("Assignment '<id>'")` when the assignment is

--- a/Tests/APITests/TARoleRouteTests.swift
+++ b/Tests/APITests/TARoleRouteTests.swift
@@ -57,6 +57,19 @@ import VaporTesting
             taUserID: try taUser.requireID(), csrf: csrf, sessionCookie: sessionCookie)
     }
 
+    /// A fresh student enrolled as `.student` in `courseID`, returned with their
+    /// URL token — the `:urlToken` path segment the per-student action routes
+    /// (extension grant/revoke) key off.
+    private func enrolledTarget(courseID: UUID) async throws -> (student: APIUser, urlToken: String) {
+        let target = APIUser(
+            username: "ext_target", passwordHash: try testPasswordHash("pw"), role: "student")
+        try await target.save(on: app.db)
+        try await APICourseEnrollment(
+            userID: try target.requireID(), courseID: courseID, role: .student
+        ).save(on: app.db)
+        return (target, try target.requireURLToken())
+    }
+
     // MARK: - TA CAN edit assignment content (floor .ta)
 
     @Test func taCanEditAssignmentSuite() async throws {
@@ -74,6 +87,60 @@ import VaporTesting
                     #expect(
                         res.status == .ok, "a TA may edit assignment content, got \(res.status): \(res.body.string)")
                 })
+        }
+    }
+
+    // A per-student deadline extension is an individual accommodation — a
+    // sibling of grade-override, floored at `.ta`, NOT the assignment-wide
+    // deadline. Regression for the reported 403: these endpoints used to
+    // require `.instructor`, so a TA got a 403 on Save even though the
+    // student-submissions page shows them the extension button right beside
+    // retest / grade-override (both `.ta`), which they can use.
+    @Test func taCanGrantAndRevokeExtension() async throws {
+        try await withApp(app) { _ in
+            let fx = try await fixture(role: .ta)
+            let target = try await enrolledTarget(courseID: fx.courseID)
+            let targetID = try target.student.requireID()
+
+            let fmt = DateFormatter()
+            fmt.locale = Locale(identifier: "en_US_POSIX")
+            fmt.timeZone = TimeZone(identifier: "America/Toronto")
+            fmt.dateFormat = "yyyy-MM-dd'T'HH:mm"
+            let futureInput = fmt.string(from: Date().addingTimeInterval(86_400))
+
+            // Grant → 303 redirect, exactly one row created.
+            try await app.asyncTest(
+                .POST, "/TAROLE/students/\(target.urlToken)/assignments/\(fx.assignmentID)/extension",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": fx.csrf, "extendedDueAt": futureInput, "note": "Accommodation"],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .seeOther,
+                        "a TA may grant a per-student extension, got \(res.status): \(res.body.string)")
+                })
+            let afterGrant = try await APIAssignmentExtension.query(on: app.db)
+                .filter(\.$userID == targetID).count()
+            #expect(afterGrant == 1, "the extension row must be created")
+
+            // Revoke → 303 redirect, row removed.
+            try await app.asyncTest(
+                .POST,
+                "/TAROLE/students/\(target.urlToken)/assignments/\(fx.assignmentID)/extension/delete",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    try req.content.encode(["_csrf": fx.csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .seeOther, "a TA may revoke a per-student extension, got \(res.status)")
+                })
+            let afterRevoke = try await APIAssignmentExtension.query(on: app.db)
+                .filter(\.$userID == targetID).count()
+            #expect(afterRevoke == 0, "the extension row must be removed")
         }
     }
 
@@ -178,6 +245,29 @@ import VaporTesting
                     #expect(
                         res.status == .forbidden,
                         "a student must not retest submissions, got \(res.status)")
+                })
+        }
+    }
+
+    @Test func studentCannotGrantExtension() async throws {
+        try await withApp(app) { _ in
+            // Lowering the extension floor to `.ta` must not leak down to a
+            // per-course student — the `/instructor` staff gate (role >= .ta)
+            // still shuts them out before the handler runs.
+            let fx = try await fixture(role: .student)
+            let target = try await enrolledTarget(courseID: fx.courseID)
+            try await app.asyncTest(
+                .POST, "/TAROLE/students/\(target.urlToken)/assignments/\(fx.assignmentID)/extension",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    try req.content.encode(
+                        ["_csrf": fx.csrf, "extendedDueAt": "2099-01-01T00:00", "note": ""],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .forbidden,
+                        "a student must not grant extensions, got \(res.status)")
                 })
         }
     }

--- a/changelog.d/extension-grant-403-error.md
+++ b/changelog.d/extension-grant-403-error.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **TAs can now grant per-student deadline extensions.** The extension
+  grant/revoke endpoints required a per-course `.instructor` role, so a TA
+  clicking Save on the extension form (shown to them on the student-submissions
+  page, right beside Retest and Grade override — both TA actions) got a 403. A
+  per-student extension is an individual accommodation, a sibling of
+  grade-override, so it now floors at `.ta` like the other per-student grading
+  actions. The assignment-wide deadline (open/close/due date) stays
+  instructor-only.
+- **Extension/grade-override popovers no longer get cut off at the bottom of
+  the page.** On the per-student submissions page these `<details>` panels sit
+  inside the results table, which clips its overflow for its rounded corners —
+  so on a row near the bottom the downward-opening panel (and its Save button)
+  was clipped and couldn't be scrolled to. The open panel is now floated
+  (`position: fixed`) and clamped to stay fully within the viewport — placed
+  below its button when it fits, flipped above when it doesn't. Phones keep the
+  existing in-flow panel.

--- a/docs/multi-course-roles.md
+++ b/docs/multi-course-roles.md
@@ -188,10 +188,13 @@ representable and creatable.
   default `atLeast` values** — every call site states its floor explicitly:
   - **`.ta`** — assignment *content* and grading: suite/scripts/families/
     checks, notebook/solution edits, global inputs, datasets, achievements,
-    retest/reset/grade-override.
+    retest/reset/grade-override, and per-student deadline extensions (an
+    individual accommodation, sibling to grade-override — *not* the
+    assignment-wide deadline).
   - **`.instructor`** — course *lifecycle* and structure: enrollment/roster/
-    staff management, assignment create/delete/open/close/deadlines, course
-    sections, archive, BrightSpace binding, test-setup upload.
+    staff management, assignment create/delete/open/close and the
+    assignment-wide due date, course sections, archive, BrightSpace binding,
+    test-setup upload.
 
 ### 3.5 UI touchpoints
 


### PR DESCRIPTION
## Summary

A TA reported a **403 when granting a deadline extension**. Two fixes, both on the per-student submissions page.

### 1. Authorization — TAs can now grant/revoke per-student extensions

`saveStudentAssignmentExtension` / `deleteStudentAssignmentExtension` required a per-course `.instructor` role, while **every sibling per-student action** — retest, reset-notebook, grade-override — floors at `.ta`. The extension form is rendered to TAs right beside those (same `student-row-actions` block, no instructor-only gate), and TAs pass the `ActiveCourseStaffMiddleware` gate on the route group — so a TA could open the form but got `Abort(.forbidden)` (403) on Save from the handler's write-floor check.

A per-student extension is an individual accommodation — a sibling of grade-override — not a change to the assignment-wide deadline. Both endpoints now floor at `.ta`. The assignment-wide deadline **lifecycle** (create/delete/open/close/set due date) stays `.instructor` on its own routes.

- `StudentCourseRoutes+History.swift`: `.instructor` → `.ta` on the two endpoints; updated the `resolveStudentAssignmentAction` docstring.
- `CourseAccessHelpers.swift` + `docs/multi-course-roles.md`: moved extensions into the `.ta` bucket in the authoritative role-floor convention; clarified `.instructor` "deadlines" means the assignment-wide due date.

### 2. UI — the extension / grade-override popover no longer gets cut off

These `<details>` panels live inside `.results-table`, which sets `overflow: hidden` for its rounded corners. The `.action-panel` opens downward (`position: absolute`), so on a row near the bottom of the page the panel — including the **Save** button — was clipped by the table and couldn't even be scrolled to.

When a panel opens it's now floated (`position: fixed`, which escapes the table's overflow clip) and clamped to stay **fully within the viewport**: below its button when it fits, flipped above when it doesn't, height-capped with its own scroll as a backstop. It stays glued to its button on scroll/resize and closes on Escape. Phones keep the existing in-flow panel.

## Testing

- `swift test --filter TARoleRouteTests --filter AssignmentExtensionsTests` — **21 tests pass**, including two new cases: a TA can grant **and** revoke an extension (row created then removed), and a per-course student still gets a 403.
- `swift format lint --strict` clean on the changed Swift files.
- `scripts/eslint.sh` clean (`Public/app.js`).
- Popover positioning verified in headless Chromium against a faithful DOM harness (real `.results-table { overflow:hidden }` + absolute `.action-panel`): bottom row flips above and is fully on-screen, top row opens below and is on-screen, phone width stays static/in-flow.

## Notes

- No `VERSION` / `ChickadeeVersion` / `CHANGELOG.md` edits — added a `changelog.d/` fragment per the release process.
- SwiftLint could not be run in this environment (its binary artifact download is blocked by egress policy); the Swift change is two enum literals plus comments and a test that mirrors existing patterns in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSK5TdDtvdUPHd8dtbmEPV)_