### PR TITLE
Host uploaded files on course content items (web + MCP)

### DIFF
--- a/Public/styles.css
+++ b/Public/styles.css
@@ -1396,6 +1396,14 @@ code { font-family: var(--font-mono); font-size: .9em; }
     margin-bottom: .5rem;
 }
 .content-item-link-pair { display: flex; gap: .35rem; }
+.content-item-attachment-list {
+    display: flex;
+    flex-direction: column;
+    gap: .35rem;
+    margin-top: .5rem;
+}
+.content-item-attachment { display: flex; align-items: center; gap: .5rem; }
+.content-item-attachment-size { font-size: var(--text-xs); }
 
 .text-muted { color: var(--gray-600); }
 

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -116,7 +116,7 @@
         <details class="add-section-details popup-anchor content-item-add">
             <summary class="btn action-btn btn-tiny summary-btn">+ Add material</summary>
             <div class="add-section-popup card">
-                <form method="post" action="/instructor/content-items" class="form popup-form content-item-form">
+                <form method="post" action="/instructor/content-items" enctype="multipart/form-data" class="form popup-form content-item-form">
                     #csrfFormField()
                     <input type="hidden" name="sectionID" value="#(section.sectionID)">
                     <label class="form-label">Title
@@ -153,6 +153,9 @@
                             <option value="true">Published</option>
                             <option value="false">Hidden</option>
                         </select>
+                    </label>
+                    <label class="form-label">Files (optional)
+                        <input class="form-input editor-input" type="file" name="attachmentFiles" multiple>
                     </label>
                     <button class="btn btn-primary btn-compact" type="submit">Add material</button>
                 </form>
@@ -191,13 +194,13 @@
                     </span>
                     #if(item.content.itemDescription):<div class="content-item-desc text-muted">#(item.content.itemDescription)</div>#endif
                 </td>
-                <td colspan="3" class="col-hide-phone content-item-links">#for(link in item.content.links):<a href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor</td>
+                <td colspan="3" class="col-hide-phone content-item-links">#for(link in item.content.links):<a href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor#for(att in item.content.attachments):<a href="#(att.downloadURL)">#(att.displayName)</a>#endfor</td>
                 <td class="col-hide-phone">#if(item.content.updatedLabel):#(item.content.updatedLabel)#else:<span class="text-muted">—</span>#endif</td>
                 <td class="content-item-actions">
                     <details class="popup-anchor content-item-edit-details">
                         <summary class="btn action-btn btn-tiny summary-btn">Edit</summary>
                         <div class="add-section-popup card">
-                            <form method="post" action="/instructor/content-items/#(item.content.id)/edit" class="form popup-form content-item-form">
+                            <form method="post" action="/instructor/content-items/#(item.content.id)/edit" enctype="multipart/form-data" class="form popup-form content-item-form">
                                 #csrfFormField()
                                 <label class="form-label">Title
                                     <input class="form-input editor-input" type="text" name="title" value="#(item.content.title)" required>
@@ -236,8 +239,25 @@
                                         <option value="false" #if(!item.content.isPublished):selected#endif>Hidden</option>
                                     </select>
                                 </label>
+                                <label class="form-label">Add files
+                                    <input class="form-input editor-input" type="file" name="attachmentFiles" multiple>
+                                </label>
                                 <button class="btn btn-primary btn-compact" type="submit">Save changes</button>
                             </form>
+                            #if(!item.content.attachments.isEmpty):
+                            <div class="content-item-attachment-list">
+                                #for(att in item.content.attachments):
+                                <div class="content-item-attachment">
+                                    <a href="#(att.downloadURL)">#(att.displayName)</a>
+                                    <span class="text-muted content-item-attachment-size">#(att.sizeLabel)</span>
+                                    <form method="post" action="/instructor/content-items/#(item.content.id)/attachments/#(att.id)/delete" onsubmit="return confirm('Remove this file?')">
+                                        #csrfFormField()
+                                        <button class="btn action-btn action-danger btn-tiny" type="submit">Remove</button>
+                                    </form>
+                                </div>
+                                #endfor
+                            </div>
+                            #endif
                         </div>
                     </details>
                     <form method="post" action="/instructor/content-items/#(item.content.id)/delete" class="content-item-delete-form" onsubmit="return confirm('Delete this material?')">
@@ -499,7 +519,7 @@
         <details class="add-section-details popup-anchor content-item-add">
             <summary class="btn action-btn btn-tiny summary-btn">+ Add material</summary>
             <div class="add-section-popup card">
-                <form method="post" action="/instructor/content-items" class="form popup-form content-item-form">
+                <form method="post" action="/instructor/content-items" enctype="multipart/form-data" class="form popup-form content-item-form">
                     #csrfFormField()
                     <input type="hidden" name="sectionID" value="">
                     <label class="form-label">Title
@@ -537,6 +557,9 @@
                             <option value="false">Hidden</option>
                         </select>
                     </label>
+                    <label class="form-label">Files (optional)
+                        <input class="form-input editor-input" type="file" name="attachmentFiles" multiple>
+                    </label>
                     <button class="btn btn-primary btn-compact" type="submit">Add material</button>
                 </form>
             </div>
@@ -568,13 +591,13 @@
                     </span>
                     #if(item.content.itemDescription):<div class="content-item-desc text-muted">#(item.content.itemDescription)</div>#endif
                 </td>
-                <td colspan="3" class="col-hide-phone content-item-links">#for(link in item.content.links):<a href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor</td>
+                <td colspan="3" class="col-hide-phone content-item-links">#for(link in item.content.links):<a href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor#for(att in item.content.attachments):<a href="#(att.downloadURL)">#(att.displayName)</a>#endfor</td>
                 <td class="col-hide-phone">#if(item.content.updatedLabel):#(item.content.updatedLabel)#else:<span class="text-muted">—</span>#endif</td>
                 <td class="content-item-actions">
                     <details class="popup-anchor content-item-edit-details">
                         <summary class="btn action-btn btn-tiny summary-btn">Edit</summary>
                         <div class="add-section-popup card">
-                            <form method="post" action="/instructor/content-items/#(item.content.id)/edit" class="form popup-form content-item-form">
+                            <form method="post" action="/instructor/content-items/#(item.content.id)/edit" enctype="multipart/form-data" class="form popup-form content-item-form">
                                 #csrfFormField()
                                 <label class="form-label">Title
                                     <input class="form-input editor-input" type="text" name="title" value="#(item.content.title)" required>
@@ -613,8 +636,25 @@
                                         <option value="false" #if(!item.content.isPublished):selected#endif>Hidden</option>
                                     </select>
                                 </label>
+                                <label class="form-label">Add files
+                                    <input class="form-input editor-input" type="file" name="attachmentFiles" multiple>
+                                </label>
                                 <button class="btn btn-primary btn-compact" type="submit">Save changes</button>
                             </form>
+                            #if(!item.content.attachments.isEmpty):
+                            <div class="content-item-attachment-list">
+                                #for(att in item.content.attachments):
+                                <div class="content-item-attachment">
+                                    <a href="#(att.downloadURL)">#(att.displayName)</a>
+                                    <span class="text-muted content-item-attachment-size">#(att.sizeLabel)</span>
+                                    <form method="post" action="/instructor/content-items/#(item.content.id)/attachments/#(att.id)/delete" onsubmit="return confirm('Remove this file?')">
+                                        #csrfFormField()
+                                        <button class="btn action-btn action-danger btn-tiny" type="submit">Remove</button>
+                                    </form>
+                                </div>
+                                #endfor
+                            </div>
+                            #endif
                         </div>
                     </details>
                     <form method="post" action="/instructor/content-items/#(item.content.id)/delete" class="content-item-delete-form" onsubmit="return confirm('Delete this material?')">

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -35,6 +35,7 @@
             </td>
             <td colspan="4" class="col-hide-phone content-item-links">
                 #for(link in item.content.links):<a class="content-item-link" href="#(link.url)" target="_blank" rel="noopener noreferrer">#(link.label)</a>#endfor
+                #for(att in item.content.attachments):<a class="content-item-link" href="#(att.downloadURL)">#(att.displayName)</a>#endfor
             </td>
             <td class="col-hide-phone">#if(item.content.updatedLabel):#(item.content.updatedLabel)#else:<span class="text-muted">—</span>#endif</td>
         </tr>

--- a/Sources/APIServer/APIServerApp.swift
+++ b/Sources/APIServer/APIServerApp.swift
@@ -154,6 +154,9 @@ struct SubmissionsDirectoryKey: StorageKey {
 struct DataExportsDirectoryKey: StorageKey {
     typealias Value = String
 }
+struct ContentFilesDirectoryKey: StorageKey {
+    typealias Value = String
+}
 struct DeployStateDirectoryKey: StorageKey {
     typealias Value = String
 }
@@ -222,6 +225,14 @@ extension Application {
     var dataExportsDirectory: String {
         get { storage[DataExportsDirectoryKey.self] ?? "data-exports/" }
         set { storage[DataExportsDirectoryKey.self] = newValue }
+    }
+    /// Where hosted content-item file attachments live (PR B). Gated content:
+    /// like submissions and data exports it is never served statically — only
+    /// streamed through the enrollment-gated `/content-files` route — and its
+    /// files are deleted with their item or attachment.
+    var contentFilesDirectory: String {
+        get { storage[ContentFilesDirectoryKey.self] ?? "content-files/" }
+        set { storage[ContentFilesDirectoryKey.self] = newValue }
     }
     /// Directory holding the auto-deploy daemon's IPC files (status.json,
     /// history.jsonl), mounted read-only into the container. Read by the

--- a/Sources/APIServer/Bootstrap/AppDirectories.swift
+++ b/Sources/APIServer/Bootstrap/AppDirectories.swift
@@ -21,8 +21,9 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     let setupsDir = workDir + "testsetups/"
     let submissionsDir = workDir + "submissions/"
     let dataExportsDir = workDir + "data-exports/"
+    let contentFilesDir = workDir + "content-files/"
 
-    for dir in [resultsDir, setupsDir, submissionsDir, dataExportsDir] {
+    for dir in [resultsDir, setupsDir, submissionsDir, dataExportsDir, contentFilesDir] {
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
     }
 
@@ -32,6 +33,7 @@ func bootstrapAppDirectories(_ app: Application, workDir: String, cliWorkerSecre
     app.storage[TestSetupsDirectoryKey.self] = setupsDir
     app.storage[SubmissionsDirectoryKey.self] = submissionsDir
     app.storage[DataExportsDirectoryKey.self] = dataExportsDir
+    app.storage[ContentFilesDirectoryKey.self] = contentFilesDir
     // Read-only mount of the auto-deploy daemon's IPC dir (status.json /
     // history.jsonl); absolute host path, not under the data volume.  Read
     // through AppConfig like every other env var (#1129) so it shows up in

--- a/Sources/APIServer/Helpers/ContentAttachmentStore.swift
+++ b/Sources/APIServer/Helpers/ContentAttachmentStore.swift
@@ -1,0 +1,100 @@
+// APIServer/Helpers/ContentAttachmentStore.swift
+//
+// Validates and stores hosted file attachments for course content items — the
+// shared core behind the web upload (multipart File bytes) and the MCP fetch
+// (SSRF-guarded URL → Data). Files land at
+// `contentFilesDirectory/<itemID>/<attachmentID>` under a server-generated
+// name, so a hostile original filename can never escape the directory; the
+// untrusted name is validated (bare filename, allowed extension, size cap) and
+// kept only as display / download metadata.
+
+import Core
+import Foundation
+import Vapor
+
+enum ContentAttachmentStore {
+    /// Extensions instructors may host: reference material — documents,
+    /// notebooks, images, small data. No executables or code archives.
+    static let allowedExtensions: Set<String> = [
+        "pdf", "ipynb", "png", "jpg", "jpeg", "gif", "svg", "webp",
+        "txt", "md", "csv", "tsv", "json", "py", "docx", "pptx", "xlsx",
+    ]
+    /// Per-file cap. The upload route's body limit is set higher so a few files
+    /// plus form fields fit in one multipart request.
+    static let maxFileBytes = 25 * 1024 * 1024
+
+    enum StoreError: Error, Equatable {
+        case unsafeName(String)
+        case disallowedType(String)
+        case tooLarge(name: String)
+
+        /// Human-readable reason for a web `WebAssignmentError.invalidParameter`
+        /// or an MCP `invalidArguments` detail.
+        var reason: String {
+            switch self {
+            case .unsafeName(let name):
+                return "File name \"\(name)\" is not a valid bare filename."
+            case .disallowedType(let ext):
+                let list = ContentAttachmentStore.allowedExtensions.sorted().joined(separator: ", ")
+                return "File type \".\(ext)\" is not allowed. Allowed: \(list)."
+            case .tooLarge(let name):
+                return "File \"\(name)\" exceeds the \(maxFileBytes / (1024 * 1024)) MB limit."
+            }
+        }
+    }
+
+    /// Absolute directory holding one item's attachment files.
+    static func directory(_ app: Application, itemID: UUID) -> String {
+        app.contentFilesDirectory + itemID.uuidString + "/"
+    }
+
+    /// Absolute on-disk path of one attachment file.
+    static func path(_ app: Application, itemID: UUID, attachmentID: UUID) -> String {
+        directory(app, itemID: itemID) + attachmentID.uuidString
+    }
+
+    /// Validates the name / extension / size WITHOUT writing, returning the
+    /// sanitized bare filename. Lets a caller pre-check every file in a batch
+    /// before writing any, so a partial batch never leaves files on disk.
+    @discardableResult
+    static func validate(bytes: Data, originalName rawName: String) throws -> String {
+        let trimmed = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let safeName = FilenameSafety.bareFilename(trimmed) else {
+            throw StoreError.unsafeName(trimmed)
+        }
+        let ext = (safeName as NSString).pathExtension.lowercased()
+        guard allowedExtensions.contains(ext) else { throw StoreError.disallowedType(ext) }
+        guard bytes.count <= maxFileBytes else { throw StoreError.tooLarge(name: safeName) }
+        return safeName
+    }
+
+    /// Validates then writes the bytes under a freshly generated attachment id,
+    /// returning the metadata to append to the item.
+    static func store(
+        bytes: Data, originalName rawName: String, label: String?, sortOrder: Int,
+        itemID: UUID, on req: Request
+    ) async throws -> ContentAttachment {
+        let safeName = try validate(bytes: bytes, originalName: rawName)
+
+        let attachmentID = UUID()
+        let dir = directory(req.application, itemID: itemID)
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try await req.fileio.writeFile(.init(data: bytes), at: dir + attachmentID.uuidString)
+
+        let cleanLabel = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ContentAttachment(
+            id: attachmentID, originalName: safeName, sizeBytes: bytes.count,
+            sortOrder: sortOrder, label: (cleanLabel?.isEmpty == false) ? cleanLabel : nil)
+    }
+
+    /// Best-effort removal of one attachment's file (a missing file is fine).
+    static func removeFile(_ app: Application, itemID: UUID, attachmentID: UUID) {
+        try? FileManager.default.removeItem(
+            atPath: path(app, itemID: itemID, attachmentID: attachmentID))
+    }
+
+    /// Best-effort removal of an item's entire attachment directory (on delete).
+    static func removeDirectory(_ app: Application, itemID: UUID) {
+        try? FileManager.default.removeItem(atPath: directory(app, itemID: itemID))
+    }
+}

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -132,8 +132,10 @@ enum MCPServerInstructions {
         courseSectionID; isPublished:false hides it from students as a draft), edit or move with \
         update_content_item, remove with delete_content_item, and order it among the section's items \
         (interleaved with assignments) with reorder_section_items, or reorder_content_items for a \
-        content-only section. Distinct from assignments (list_assignments) and test-suite items \
-        (get_suite).
+        content-only section. It can also host files: pass attachments:[{sourceUrl}] (an https URL \
+        the server fetches under the SSRF guard) to create_content_item / update_content_item, and \
+        they serve to enrolled students through the gated /content-files route. Distinct from \
+        assignments (list_assignments) and test-suite items (get_suite).
         - Test suite — the ordered checks that grade an assignment. Each item is a hand-written \
         script, a generated pattern family, or a notebook check, and carries a tier \
         (public/release/secret/student), points, an optional section, prerequisites (dependsOn), and \

--- a/Sources/APIServer/MCP/Tools/CourseContentItemTools.swift
+++ b/Sources/APIServer/MCP/Tools/CourseContentItemTools.swift
@@ -25,6 +25,15 @@ struct ContentItemDTO: Encodable, Sendable {
         let label: String
         let url: String
     }
+    /// One hosted file attachment (metadata + the gated download path).
+    struct Attachment: Encodable, Sendable {
+        let attachmentID: String
+        let originalName: String
+        let sizeBytes: Int
+        let label: String?
+        /// Enrollment-gated download path: /content-files/<itemID>/<attachmentID>.
+        let downloadPath: String
+    }
     let contentItemID: String
     /// The owning section's id, or "" when ungrouped.
     let courseSectionID: String
@@ -32,6 +41,7 @@ struct ContentItemDTO: Encodable, Sendable {
     let kind: String
     let description: String?
     let links: [Link]
+    let attachments: [Attachment]
     let updatedLabel: String?
     let isPublished: Bool
     let sortOrder: Int
@@ -43,17 +53,75 @@ struct ContentLinkInput: Decodable, Sendable {
     let url: String
 }
 
+/// One attachment to fetch by URL and host, as accepted on input.
+struct ContentAttachmentInput: Decodable, Sendable {
+    let label: String?
+    let sourceUrl: String
+}
+
 func contentItemDTO(from item: APICourseContentItem) -> ContentItemDTO {
-    ContentItemDTO(
-        contentItemID: item.id?.uuidString ?? "",
+    let itemID = item.id?.uuidString ?? ""
+    return ContentItemDTO(
+        contentItemID: itemID,
         courseSectionID: item.sectionID?.uuidString ?? "",
         title: item.title,
         kind: item.kind.rawValue,
         description: item.itemDescription,
         links: item.links.map { ContentItemDTO.Link(label: $0.label, url: $0.url) },
+        attachments: item.attachments.map { attachment in
+            ContentItemDTO.Attachment(
+                attachmentID: attachment.id.uuidString,
+                originalName: attachment.originalName,
+                sizeBytes: attachment.sizeBytes,
+                label: attachment.label,
+                downloadPath: "/content-files/\(itemID)/\(attachment.id.uuidString)")
+        },
         updatedLabel: item.updatedLabel,
         isPublished: item.isPublished,
         sortOrder: item.sortOrder)
+}
+
+/// Derives a bare filename from an attachment's source URL (its last path
+/// component, percent-decoded); the store then validates the extension + size.
+func attachmentFilename(fromURL urlString: String) -> String {
+    guard let comps = URLComponents(string: urlString) else { return "attachment" }
+    let last = (comps.path as NSString).lastPathComponent
+    let decoded = last.removingPercentEncoding ?? last
+    return decoded.isEmpty || decoded == "/" ? "attachment" : decoded
+}
+
+/// Fetches each attachment's sourceUrl under the SSRF guard and stores it on the
+/// item, appending to any existing attachments. Order mirrors author_script's
+/// materialize: authz (already done by the caller) → cheap validate → fetch →
+/// store. A fetch or validation failure surfaces as an `invalidArguments`
+/// detail so the agent learns why.
+func fetchAndStoreContentAttachments(
+    _ inputs: [ContentAttachmentInput], for item: APICourseContentItem,
+    tool: String, context: ToolContext
+) async throws {
+    guard !inputs.isEmpty, let itemID = item.id else { return }
+    var attachments = item.attachments
+    var nextOrder = (attachments.map(\.sortOrder).max() ?? 0) + 1
+    for input in inputs {
+        let bytes: Data
+        do {
+            bytes = try await SupportFileURLFetcher.fetchData(
+                urlString: input.sourceUrl, on: context.request)
+        } catch let error as SupportFileFetchError {
+            throw MCPToolError.invalidArguments(tool: tool, detail: error.toolDetail)
+        }
+        do {
+            let attachment = try await ContentAttachmentStore.store(
+                bytes: bytes, originalName: attachmentFilename(fromURL: input.sourceUrl),
+                label: input.label, sortOrder: nextOrder, itemID: itemID, on: context.request)
+            attachments.append(attachment)
+            nextOrder += 1
+        } catch let error as ContentAttachmentStore.StoreError {
+            throw MCPToolError.invalidArguments(tool: tool, detail: error.reason)
+        }
+    }
+    item.attachments = attachments
+    try await item.save(on: context.db)
 }
 
 /// http(s) or site-relative only — the URLs render as `href`s, so `javascript:`
@@ -177,14 +245,60 @@ private let contentItemObjectSchema: JSONValue = .object([
                 "required": .array([.string("label"), .string("url")]),
             ]),
         ]),
+        "attachments": .object([
+            "type": .string("array"),
+            "items": .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "attachmentID": MCPSchema.string,
+                    "originalName": MCPSchema.string,
+                    "sizeBytes": MCPSchema.integer,
+                    "label": MCPSchema.string,
+                    "downloadPath": MCPSchema.string,
+                ]),
+                "required": .array([
+                    .string("attachmentID"), .string("originalName"), .string("sizeBytes"),
+                    .string("downloadPath"),
+                ]),
+            ]),
+        ]),
         "updatedLabel": MCPSchema.string,
         "isPublished": MCPSchema.boolean,
         "sortOrder": MCPSchema.integer,
     ]),
     "required": .array([
         .string("contentItemID"), .string("courseSectionID"), .string("title"),
-        .string("kind"), .string("links"), .string("isPublished"), .string("sortOrder"),
+        .string("kind"), .string("links"), .string("attachments"), .string("isPublished"),
+        .string("sortOrder"),
     ]),
+])
+
+/// Reusable JSON-schema fragment for the `attachments` input array (files the
+/// server fetches by URL and hosts).
+private let attachmentsInputSchema: JSONValue = .object([
+    "type": .string("array"),
+    "items": .object([
+        "type": .string("object"),
+        "properties": .object([
+            "label": .object([
+                "type": .string("string"),
+                "description": .string("Optional label; falls back to the file name."),
+            ]),
+            "sourceUrl": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "https URL the server fetches under an SSRF guard (https only, no "
+                        + "private/loopback/metadata hosts, no redirects, 25 MB cap). The URL's last "
+                        + "path segment becomes the stored filename; its extension must be an allowed "
+                        + "type (pdf, ipynb, png/jpg/gif/svg/webp, txt/md/csv/tsv/json/py, "
+                        + "docx/pptx/xlsx)."),
+            ]),
+        ]),
+        "required": .array([.string("sourceUrl")]),
+    ]),
+    "description": .string(
+        "Files to host on this item — each fetched from an https URL and served to enrolled "
+            + "students through the gated /content-files route. Appended to any existing attachments."),
 ])
 
 private let kindEnumSchema: JSONValue = .object([
@@ -252,12 +366,33 @@ struct CreateContentItemTool: ContentTool {
         let title: String
         let kind: String?
         let links: [ContentLinkInput]?
+        /// Files to fetch by URL and host on the item.
+        let attachments: [ContentAttachmentInput]?
         let description: String?
         let updatedLabel: String?
         /// Course-section id (from list_course_sections); "" / omitted = ungrouped.
         let courseSectionID: String?
         /// Defaults to true (visible to students).
         let isPublished: Bool?
+
+        // Explicit init so the memberwise form keeps working with `attachments`
+        // defaulted (the synthesized Decodable init handles the wire decode).
+        init(
+            courseCode: String, title: String, kind: String? = nil,
+            links: [ContentLinkInput]? = nil, attachments: [ContentAttachmentInput]? = nil,
+            description: String? = nil, updatedLabel: String? = nil, courseSectionID: String? = nil,
+            isPublished: Bool? = nil
+        ) {
+            self.courseCode = courseCode
+            self.title = title
+            self.kind = kind
+            self.links = links
+            self.attachments = attachments
+            self.description = description
+            self.updatedLabel = updatedLabel
+            self.courseSectionID = courseSectionID
+            self.isPublished = isPublished
+        }
     }
 
     typealias Output = ContentItemDTO
@@ -268,8 +403,10 @@ struct CreateContentItemTool: ContentTool {
         + "outline, or heading) in a course, by course code. Provide a title and optionally a kind, "
         + "links (each {label, url}; http(s) or site-relative only), description, updatedLabel, "
         + "courseSectionID (from list_course_sections; omit to leave ungrouped), and isPublished "
-        + "(default true — set false to hide it from students). Appended to the end of its section's "
-        + "content lane. This is ungraded material: it creates no test setup and triggers no grading."
+        + "(default true — set false to hide it from students). attachments hosts files fetched from "
+        + "https URLs (served to enrolled students through the gated /content-files route). Appended "
+        + "to the end of its section's content lane. This is ungraded material: it creates no test "
+        + "setup and triggers no grading."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -280,6 +417,7 @@ struct CreateContentItemTool: ContentTool {
             ]),
             "kind": kindEnumSchema,
             "links": contentLinksSchema,
+            "attachments": attachmentsInputSchema,
             "description": .object([
                 "type": .string("string"),
                 "description": .string("Optional descriptive blurb shown under the title."),
@@ -330,6 +468,8 @@ struct CreateContentItemTool: ContentTool {
             updatedLabel: normalizedContentField(input.updatedLabel),
             isPublished: input.isPublished ?? true)
         try await item.save(on: context.db)
+        try await fetchAndStoreContentAttachments(
+            input.attachments ?? [], for: item, tool: Self.name, context: context)
         return contentItemDTO(from: item)
     }
 }
@@ -343,6 +483,9 @@ struct UpdateContentItemTool: ContentTool {
         let kind: String?
         /// When present (even empty), replaces the item's links entirely.
         let links: [ContentLinkInput]?
+        /// Files to fetch by URL and APPEND to the item's attachments (never
+        /// removes existing ones).
+        let attachments: [ContentAttachmentInput]?
         /// "" clears; omit to leave unchanged.
         let description: String?
         /// "" clears; omit to leave unchanged.
@@ -350,6 +493,25 @@ struct UpdateContentItemTool: ContentTool {
         let isPublished: Bool?
         /// "" / "none" ungroups; omit to leave unchanged.
         let courseSectionID: String?
+
+        // Explicit init so the memberwise form keeps working with `attachments`
+        // defaulted (the synthesized Decodable init handles the wire decode).
+        init(
+            contentItemID: String, title: String? = nil, kind: String? = nil,
+            links: [ContentLinkInput]? = nil, attachments: [ContentAttachmentInput]? = nil,
+            description: String? = nil, updatedLabel: String? = nil, isPublished: Bool? = nil,
+            courseSectionID: String? = nil
+        ) {
+            self.contentItemID = contentItemID
+            self.title = title
+            self.kind = kind
+            self.links = links
+            self.attachments = attachments
+            self.description = description
+            self.updatedLabel = updatedLabel
+            self.isPublished = isPublished
+            self.courseSectionID = courseSectionID
+        }
     }
 
     typealias Output = ContentItemDTO
@@ -359,8 +521,9 @@ struct UpdateContentItemTool: ContentTool {
         "Update an ungraded content item by id (from list_content_items). Any provided field is "
         + "changed; omitted fields are left unchanged. title/kind replace; links (when given, even "
         + "empty) replaces the whole link list; description/updatedLabel accept \"\" to clear; "
-        + "isPublished toggles student visibility; courseSectionID moves it (\"\"/\"none\" ungroups). "
-        + "Ungraded material — no test setup, no re-validation, no re-grade."
+        + "isPublished toggles student visibility; courseSectionID moves it (\"\"/\"none\" ungroups); "
+        + "attachments fetches more files by URL and appends them (to remove a hosted file, use the "
+        + "web editor). Ungraded material — no test setup, no re-validation, no re-grade."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -374,6 +537,7 @@ struct UpdateContentItemTool: ContentTool {
             ]),
             "kind": kindEnumSchema,
             "links": contentLinksSchema,
+            "attachments": attachmentsInputSchema,
             "description": .object([
                 "type": .string("string"),
                 "description": .string("New description; \"\" clears; omit to leave unchanged."),
@@ -403,8 +567,8 @@ struct UpdateContentItemTool: ContentTool {
     func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
         guard
             input.title != nil || input.kind != nil || input.links != nil
-                || input.description != nil || input.updatedLabel != nil || input.isPublished != nil
-                || input.courseSectionID != nil
+                || input.attachments != nil || input.description != nil || input.updatedLabel != nil
+                || input.isPublished != nil || input.courseSectionID != nil
         else {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "Provide at least one field to change.")
@@ -448,6 +612,8 @@ struct UpdateContentItemTool: ContentTool {
             }
         }
         try await item.save(on: context.db)
+        try await fetchAndStoreContentAttachments(
+            input.attachments ?? [], for: item, tool: Self.name, context: context)
         return contentItemDTO(from: item)
     }
 }
@@ -505,6 +671,9 @@ struct DeleteContentItemTool: ContentTool {
             return Output(contentItemID: raw, removed: false)
         }
         try await context.authorizeCourseWriteAccess(item.courseID, tool: Self.name, atLeast: .ta)
+        if let itemID = item.id {
+            ContentAttachmentStore.removeDirectory(context.request.application, itemID: itemID)
+        }
         try await item.delete(on: context.db)
         return Output(contentItemID: raw, removed: true)
     }

--- a/Sources/APIServer/MCP/Tools/SupportFileURLFetcher.swift
+++ b/Sources/APIServer/MCP/Tools/SupportFileURLFetcher.swift
@@ -113,8 +113,9 @@ enum SupportFileURLFetcher {
         return host
     }
 
-    /// Fetches the URL under the SSRF guards and returns the body as UTF-8 text.
-    static func fetch(urlString: String, on request: Request) async throws -> String {
+    /// Fetches the URL under the SSRF guards and returns the raw body bytes.
+    /// Shared by `fetch` (UTF-8 text) and `fetchData` (binary).
+    static func fetchBytes(urlString: String, on request: Request) async throws -> Data {
         let host = try validate(urlString)
 
         // Resolve + classify before connecting.  An IP literal is classified
@@ -154,12 +155,25 @@ enum SupportFileURLFetcher {
         try? await client.shutdown()
 
         let bytes = try outcome.get()
+        request.logger.info(
+            "mcp.support_file_fetch host=\(host) bytes=\(bytes.count) status=ok")
+        return bytes
+    }
+
+    /// Fetches the URL under the SSRF guards and returns the body as UTF-8 text.
+    static func fetch(urlString: String, on request: Request) async throws -> String {
+        let bytes = try await fetchBytes(urlString: urlString, on: request)
         guard let text = String(data: bytes, encoding: .utf8) else {
             throw SupportFileFetchError.notUTF8
         }
-        request.logger.info(
-            "mcp.support_file_fetch host=\(host) bytes=\(bytes.count) status=ok")
         return text
+    }
+
+    /// Fetches the URL under the SSRF guards and returns the raw bytes — for
+    /// binary content files (PDFs, images, notebooks) that need no UTF-8
+    /// requirement. Same guards as `fetch`.
+    static func fetchData(urlString: String, on request: Request) async throws -> Data {
+        try await fetchBytes(urlString: urlString, on: request)
     }
 
     private static func performFetch(_ client: HTTPClient, urlString: String) async throws -> Data {

--- a/Sources/APIServer/Migrations/AddContentItemAttachments.swift
+++ b/Sources/APIServer/Migrations/AddContentItemAttachments.swift
@@ -1,0 +1,28 @@
+// APIServer/Migrations/AddContentItemAttachments.swift
+//
+// Adds the optional `attachments_json` column to the course_content_items
+// table: a JSON-encoded `[ContentAttachment]` for instructor-uploaded (or
+// agent-fetched) files hosted on the server, served through the gated
+// /content-files route. Nullable — a NULL reads as `[]` through the model's
+// `attachments` accessor.
+//
+// Standalone Add* migration (not folded into CreateCourseContentItems) because
+// production databases have already applied CreateCourseContentItems without
+// this column and would never pick it up from a body change. Fresh deploys run
+// CreateCourseContentItems then this migration; existing prod runs only this.
+
+import Fluent
+
+struct AddContentItemAttachments: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("course_content_items")
+            .field("attachments_json", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("course_content_items")
+            .deleteField("attachments_json")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APICourseContentItem.swift
+++ b/Sources/APIServer/Models/APICourseContentItem.swift
@@ -71,6 +71,25 @@ final class APICourseContentItem: Model, Content, @unchecked Sendable {
         set { linksJSON = APICourseContentItem.encodeLinks(newValue) }
     }
 
+    /// JSON-encoded `[ContentAttachment]`. Nullable (added after the table
+    /// shipped); a NULL or malformed value reads as `[]` through the
+    /// `attachments` accessor. Files live at
+    /// `contentFilesDirectory/<itemID>/<attachmentID>`.
+    @OptionalField(key: "attachments_json")
+    var attachmentsJSON: String?
+
+    /// Decoded attachments. A malformed/absent stored value yields `[]` rather
+    /// than throwing at read time; every write path encodes valid JSON.
+    var attachments: [ContentAttachment] {
+        get {
+            guard let json = attachmentsJSON, let data = json.data(using: .utf8),
+                let decoded = try? JSONDecoder().decode([ContentAttachment].self, from: data)
+            else { return [] }
+            return decoded
+        }
+        set { attachmentsJSON = APICourseContentItem.encodeAttachments(newValue) }
+    }
+
     /// Instructor-set "Updated" label shown on the row (free text or an ISO date).
     @OptionalField(key: "updated_label")
     var updatedLabel: String?
@@ -93,6 +112,7 @@ final class APICourseContentItem: Model, Content, @unchecked Sendable {
         kind: ContentItemKind = .link,
         itemDescription: String? = nil,
         links: [ContentLink] = [],
+        attachments: [ContentAttachment] = [],
         updatedLabel: String? = nil,
         isPublished: Bool = true
     ) {
@@ -104,6 +124,7 @@ final class APICourseContentItem: Model, Content, @unchecked Sendable {
         self.kindRaw = kind.rawValue
         self.itemDescription = itemDescription
         self.linksJSON = APICourseContentItem.encodeLinks(links)
+        self.attachmentsJSON = APICourseContentItem.encodeAttachments(attachments)
         self.updatedLabel = updatedLabel
         self.isPublished = isPublished
     }
@@ -112,6 +133,12 @@ final class APICourseContentItem: Model, Content, @unchecked Sendable {
     /// array literal if encoding somehow fails (keeps the column non-null).
     static func encodeLinks(_ links: [ContentLink]) -> String {
         guard let data = try? JSONEncoder().encode(links) else { return "[]" }
+        return String(bytes: data, encoding: .utf8) ?? "[]"
+    }
+
+    /// Serialize attachments to the stored JSON string (same fallback as links).
+    static func encodeAttachments(_ attachments: [ContentAttachment]) -> String {
+        guard let data = try? JSONEncoder().encode(attachments) else { return "[]" }
         return String(bytes: data, encoding: .utf8) ?? "[]"
     }
 }

--- a/Sources/APIServer/Routes/Web/ContentFileRoutes.swift
+++ b/Sources/APIServer/Routes/Web/ContentFileRoutes.swift
@@ -1,0 +1,66 @@
+// APIServer/Routes/Web/ContentFileRoutes.swift
+//
+// Serves hosted file attachments on ungraded course content items to enrolled
+// students (and staff/admin), gated the same way support-file downloads are:
+// the caller must be enrolled in the item's course, and a draft (unpublished)
+// item's files are staff-only. Registered in the authenticated group (not the
+// /instructor group) so students can download.
+//
+// Attachments are stored under a server-generated UUID name at
+// contentFilesDirectory/<itemID>/<attachmentID>, so the path is never built
+// from an untrusted filename; the download name + Content-Type come from the
+// attachment's stored metadata.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+struct ContentFileRoutes: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        routes.get("content-files", ":itemID", ":attachmentID", use: downloadContentFile)
+    }
+
+    @Sendable
+    func downloadContentFile(req: Request) async throws -> Response {
+        let caller = try req.auth.require(APIUser.self)
+        guard let itemRaw = req.parameters.get("itemID"), let itemID = UUID(uuidString: itemRaw),
+            let attachRaw = req.parameters.get("attachmentID"),
+            let attachmentID = UUID(uuidString: attachRaw),
+            let item = try await APICourseContentItem.find(itemID, on: req.db)
+        else { throw Abort(.notFound) }
+
+        // Enrolled members of the item's course only (admins bypass inside the
+        // helper); mirrors downloadSupportFile.
+        try await requireCourseEnrollment(caller: caller, courseID: item.courseID, db: req.db)
+
+        // A draft item's files are staff-only, matching the dashboard visibility
+        // rule (students never see an unpublished item, so they can't have its
+        // link — but gate the bytes directly rather than trusting that).
+        if !item.isPublished {
+            let isStaff = try await isCourseStaff(caller, inCourse: item.courseID, db: req.db)
+            guard isStaff else { throw Abort(.notFound) }
+        }
+
+        guard let attachment = item.attachments.first(where: { $0.id == attachmentID }) else {
+            throw Abort(.notFound)
+        }
+        let path = ContentAttachmentStore.path(
+            req.application, itemID: itemID, attachmentID: attachmentID)
+        guard FileManager.default.fileExists(atPath: path) else { throw Abort(.notFound) }
+
+        let response = try await req.fileio.asyncStreamFile(at: path)
+        // The on-disk name is an extensionless UUID, so set the type + download
+        // name from the stored original filename.
+        let ext = (attachment.originalName as NSString).pathExtension.lowercased()
+        response.headers.contentType = HTTPMediaType.fileExtension(ext) ?? .binary
+        let safeDownloadName =
+            attachment.originalName
+            .replacingOccurrences(of: "\"", with: "")
+            .replacingOccurrences(of: "\r", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+        response.headers.replaceOrAdd(
+            name: .contentDisposition, value: "attachment; filename=\"\(safeDownloadName)\"")
+        return response
+    }
+}

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes+ContentItems.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes+ContentItems.swift
@@ -30,6 +30,9 @@ extension CourseAdminRoutes {
         var isPublished: String?
         var linkLabels: [String]?
         var linkURLs: [String]?
+        /// Uploaded file attachments (one bare `File` or a repeated `File[]`);
+        /// empty parts (untouched inputs) are ignored.
+        var attachmentFiles: MultipartFileList?
     }
 
     // MARK: - POST /instructor/content-items
@@ -66,6 +69,7 @@ extension CourseAdminRoutes {
             isPublished: body.isPublished != "false"
         )
         try await item.save(on: req.db)
+        try await storeUploadedAttachments(body.attachmentFiles, for: item, req: req)
         return req.redirect(to: "/instructor")
     }
 
@@ -86,6 +90,7 @@ extension CourseAdminRoutes {
         item.updatedLabel = normalizedOptional(body.updatedLabel)
         item.isPublished = body.isPublished != "false"
         try await item.save(on: req.db)
+        try await storeUploadedAttachments(body.attachmentFiles, for: item, req: req)
         return req.redirect(to: "/instructor")
     }
 
@@ -94,7 +99,29 @@ extension CourseAdminRoutes {
     @Sendable
     func deleteContentItem(req: Request) async throws -> Response {
         let item = try await loadContentItemForWrite(req)
+        if let itemID = item.id {
+            ContentAttachmentStore.removeDirectory(req.application, itemID: itemID)
+        }
         try await item.delete(on: req.db)
+        return req.redirect(to: "/instructor")
+    }
+
+    // MARK: - POST /instructor/content-items/:id/attachments/:attachmentID/delete
+
+    /// Removes one hosted attachment from the item (DB entry + file on disk).
+    @Sendable
+    func removeContentAttachment(req: Request) async throws -> Response {
+        let item = try await loadContentItemForWrite(req)
+        guard let attachmentRaw = req.parameters.get("attachmentID"),
+            let attachmentID = UUID(uuidString: attachmentRaw)
+        else {
+            throw WebAssignmentError.notFound(resource: "Attachment")
+        }
+        item.attachments = item.attachments.filter { $0.id != attachmentID }
+        try await item.save(on: req.db)
+        if let itemID = item.id {
+            ContentAttachmentStore.removeFile(req.application, itemID: itemID, attachmentID: attachmentID)
+        }
         return req.redirect(to: "/instructor")
     }
 
@@ -180,6 +207,40 @@ extension CourseAdminRoutes {
         try await requireCourseWriteAccess(
             caller: caller, courseID: item.courseID, atLeast: .ta, db: req.db)
         return item
+    }
+
+    /// Stores any uploaded attachment files on the item. Pre-validates the whole
+    /// batch (name / type / size) before writing any, so a bad file never leaves
+    /// partial files on disk, then appends to the item's existing attachments and
+    /// re-saves. No-op when no (non-empty) files were posted — an untouched file
+    /// input posts an empty part.
+    private func storeUploadedAttachments(
+        _ files: MultipartFileList?, for item: APICourseContentItem, req: Request
+    ) async throws {
+        guard let itemID = item.id, let files, !files.files.isEmpty else { return }
+        let candidates: [(name: String, bytes: Data)] = files.files.compactMap { file in
+            let bytes = Data(file.data.readableBytesView)
+            return bytes.isEmpty ? nil : (file.filename, bytes)
+        }
+        guard !candidates.isEmpty else { return }
+        do {
+            for candidate in candidates {
+                try ContentAttachmentStore.validate(bytes: candidate.bytes, originalName: candidate.name)
+            }
+        } catch let error as ContentAttachmentStore.StoreError {
+            throw WebAssignmentError.invalidParameter(name: "attachmentFiles", reason: error.reason)
+        }
+        var attachments = item.attachments
+        var nextOrder = (attachments.map(\.sortOrder).max() ?? 0) + 1
+        for candidate in candidates {
+            let attachment = try await ContentAttachmentStore.store(
+                bytes: candidate.bytes, originalName: candidate.name, label: nil,
+                sortOrder: nextOrder, itemID: itemID, on: req)
+            attachments.append(attachment)
+            nextOrder += 1
+        }
+        item.attachments = attachments
+        try await item.save(on: req.db)
     }
 
     /// Next sort order in the content-item lane of `(course, section)`.

--- a/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseAdminRoutes.swift
@@ -39,10 +39,15 @@ struct CourseAdminRoutes: RouteCollection {
         r.post("sections", ":sectionID", "delete", use: deleteSection)
         r.post(":assignmentID", "section", use: moveToSection)
         // Ungraded course content items (reference material) inside a section.
-        r.post("content-items", use: createContentItem)
+        // Create + edit accept multipart file uploads, so they carry an explicit
+        // body-collection cap (a few files at the per-file limit plus fields).
+        r.on(.POST, "content-items", body: .collect(maxSize: "60mb"), use: createContentItem)
         r.post("content-items", "reorder", use: reorderContentItems)
-        r.post("content-items", ":id", "edit", use: updateContentItem)
+        r.on(.POST, "content-items", ":id", "edit", body: .collect(maxSize: "60mb"), use: updateContentItem)
         r.post("content-items", ":id", "delete", use: deleteContentItem)
         r.post("content-items", ":id", "section", use: moveContentItemToSection)
+        r.post(
+            "content-items", ":id", "attachments", ":attachmentID", "delete",
+            use: removeContentAttachment)
     }
 }

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes+Import.swift
@@ -47,13 +47,15 @@ extension CourseBundleRoutes {
 
         let setupsDir = req.application.testSetupsDirectory
         let subsDir = req.application.submissionsDirectory
+        let contentFilesDir = req.application.contentFilesDirectory
 
         let tally = try await performImportTransaction(
             db: req.db,
             manifest: manifest,
             extractDir: extractDir,
             setupsDir: setupsDir,
-            subsDir: subsDir
+            subsDir: subsDir,
+            contentFilesDir: contentFilesDir
         )
 
         await AuditLogger.record(
@@ -143,6 +145,31 @@ extension CourseBundleRoutes {
                     reason: "Bundle is missing submission file: \(sub.submissionFilename)")
             }
         }
+        for item in manifest.contentItems ?? [] {
+            for att in item.attachments ?? [] {
+                guard
+                    let path = safeContentAttachmentSource(
+                        extractDir: extractDir, bundleFilename: att.bundleFilename),
+                    FileManager.default.fileExists(atPath: path.path)
+                else {
+                    throw Abort(
+                        .badRequest,
+                        reason:
+                            "Bundle is missing or has an invalid content attachment file: "
+                            + att.bundleFilename)
+                }
+            }
+        }
+    }
+
+    /// Resolves an attachment's in-bundle path to a safe source under the
+    /// extract dir: only `content/<uuid>` is accepted (its last component must be
+    /// a UUID), so a hostile `bundleFilename` can't traverse out of the extract
+    /// dir. Returns nil for anything else.
+    private func safeContentAttachmentSource(extractDir: URL, bundleFilename: String) -> URL? {
+        let name = (bundleFilename as NSString).lastPathComponent
+        guard UUID(uuidString: name) != nil else { return nil }
+        return extractDir.appendingPathComponent("content").appendingPathComponent(name)
     }
 
     // ── 6. Transactional import ───────────────────────────────────────
@@ -160,7 +187,8 @@ extension CourseBundleRoutes {
         manifest: CourseBundleManifest,
         extractDir: URL,
         setupsDir: String,
-        subsDir: String
+        subsDir: String,
+        contentFilesDir: String
     ) async throws -> ImportTally {
         try await db.transaction { (db) -> ImportTally in
             // 6a. Check for course code conflicts (moved inside transaction)
@@ -209,7 +237,8 @@ extension CourseBundleRoutes {
             // 6e-bis. Create ungraded content items, re-linked to the sections
             // recreated above (depends only on sectionIDMap).
             try await importBundledContentItems(
-                manifest: manifest, sectionIDMap: sectionIDMap, courseID: t.courseID, db: db)
+                manifest: manifest, sectionIDMap: sectionIDMap, courseID: t.courseID,
+                extractDir: extractDir, contentFilesDir: contentFilesDir, db: db)
 
             // 6f. Create test setups → setupIDMap[bundleID] = new live ID
             let setupIDMap = try await importBundledTestSetups(
@@ -425,6 +454,8 @@ private func importBundledContentItems(
     manifest: CourseBundleManifest,
     sectionIDMap: [String: UUID],
     courseID: UUID,
+    extractDir: URL,
+    contentFilesDir: String,
     db: Database
 ) async throws {
     for item in manifest.contentItems ?? [] {
@@ -440,6 +471,34 @@ private func importBundledContentItems(
             isPublished: item.isPublished
         )
         try await newItem.save(on: db)
+
+        // Re-host each attachment under freshly generated ids: copy the bundle
+        // file (content/<uuid>, validated safe) into the new item's directory.
+        guard let newItemID = newItem.id, let bundleAtts = item.attachments, !bundleAtts.isEmpty
+        else { continue }
+        let destDir = contentFilesDir + newItemID.uuidString + "/"
+        try FileManager.default.createDirectory(atPath: destDir, withIntermediateDirectories: true)
+        var stored: [ContentAttachment] = []
+        for att in bundleAtts {
+            let name = (att.bundleFilename as NSString).lastPathComponent
+            guard UUID(uuidString: name) != nil else { continue }
+            let src = extractDir.appendingPathComponent("content").appendingPathComponent(name)
+            guard FileManager.default.fileExists(atPath: src.path) else { continue }
+            let newAttachmentID = UUID()
+            try FileManager.default.copyItem(
+                atPath: src.path, toPath: destDir + newAttachmentID.uuidString)
+            stored.append(
+                ContentAttachment(
+                    id: newAttachmentID,
+                    originalName: FilenameSafety.bareFilename(att.originalName) ?? "attachment",
+                    sizeBytes: att.sizeBytes,
+                    sortOrder: att.sortOrder,
+                    label: att.label))
+        }
+        if !stored.isEmpty {
+            newItem.attachments = stored
+            try await newItem.save(on: db)
+        }
     }
 }
 

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -71,9 +71,8 @@ struct CourseBundleRoutes: RouteCollection {
         // Extracted to primitives here so the thread-pool closure captures no
         // Fluent models (#1158).
         let app = req.application
-        let contentFileCopies: [(src: String, bundleName: String)] = data.contentItems.flatMap {
-            item -> [(src: String, bundleName: String)] in
-            guard let itemID = item.id else { return [] }
+        let contentFileCopies: [(src: String, bundleName: String)] = data.contentItems.flatMap { item in
+            guard let itemID = item.id else { return [(src: String, bundleName: String)]() }
             return item.attachments.map { att in
                 (
                     src: ContentAttachmentStore.path(app, itemID: itemID, attachmentID: att.id),
@@ -283,29 +282,7 @@ struct CourseBundleRoutes: RouteCollection {
             )
         }
 
-        let bundledContentItems = data.contentItems.map { item -> BundledContentItem in
-            // Each attachment's global UUID doubles as its unique bundle
-            // filename (content/<id>); the bytes are copied in writeExportStaging.
-            let attachments = item.attachments.map { att in
-                BundledAttachment(
-                    originalName: att.originalName,
-                    sizeBytes: att.sizeBytes,
-                    label: att.label,
-                    sortOrder: att.sortOrder,
-                    bundleFilename: "content/\(att.id.uuidString)")
-            }
-            return BundledContentItem(
-                sectionBundleID: item.sectionID.flatMap { bundleIDs.sectionBundleIDByUUID[$0] },
-                title: item.title,
-                kind: item.kind.rawValue,
-                description: item.itemDescription,
-                links: item.links,
-                attachments: attachments.isEmpty ? nil : attachments,
-                updatedLabel: item.updatedLabel,
-                isPublished: item.isPublished,
-                sortOrder: item.sortOrder
-            )
-        }
+        let bundledContentItems = buildBundledContentItems(data: data, bundleIDs: bundleIDs)
 
         let bundledAssignments = data.assignments.compactMap { a -> BundledAssignment? in
             guard let aid = a.id, let bid = bundleIDs.assignBundleIDByID[aid],
@@ -370,6 +347,37 @@ struct CourseBundleRoutes: RouteCollection {
             submissions: bundledSubmissions,
             results: bundledResults
         )
+    }
+
+    /// Maps each course content item to its bundle representation, nesting the
+    /// attachment metadata. Each attachment's global UUID doubles as its unique
+    /// bundle filename (`content/<id>`); the bytes are copied in
+    /// writeExportStaging.
+    private func buildBundledContentItems(
+        data: ExportData,
+        bundleIDs: ExportBundleIDs
+    ) -> [BundledContentItem] {
+        data.contentItems.map { item in
+            let attachments = item.attachments.map { att in
+                BundledAttachment(
+                    originalName: att.originalName,
+                    sizeBytes: att.sizeBytes,
+                    label: att.label,
+                    sortOrder: att.sortOrder,
+                    bundleFilename: "content/\(att.id.uuidString)")
+            }
+            return BundledContentItem(
+                sectionBundleID: item.sectionID.flatMap { bundleIDs.sectionBundleIDByUUID[$0] },
+                title: item.title,
+                kind: item.kind.rawValue,
+                description: item.itemDescription,
+                links: item.links,
+                attachments: attachments.isEmpty ? nil : attachments,
+                updatedLabel: item.updatedLabel,
+                isPublished: item.isPublished,
+                sortOrder: item.sortOrder
+            )
+        }
     }
 
     // ── 4. Write staging directory ─────────────────────────────────────

--- a/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
+++ b/Sources/APIServer/Routes/Web/CourseBundleRoutes.swift
@@ -11,6 +11,7 @@
 //   bundle.json              — CourseBundleManifest (ISO8601 dates)
 //   testsetups/<id>.zip      — instructor test-setup archives
 //   submissions/<id>.<ext>   — student submission files
+//   content/<attachmentID>   — content-item hosted file attachments
 //
 // This file holds boot + the export pipeline; the import handler and its
 // phase helpers live in CourseBundleRoutes+Import.swift.
@@ -66,6 +67,20 @@ struct CourseBundleRoutes: RouteCollection {
             setup.id.map { (id: $0, zipPath: setup.zipPath) }
         }
         let submissionPaths = data.submissions.map(\.zipPath)
+        // Hosted content-item attachment files: (on-disk src, in-bundle name).
+        // Extracted to primitives here so the thread-pool closure captures no
+        // Fluent models (#1158).
+        let app = req.application
+        let contentFileCopies: [(src: String, bundleName: String)] = data.contentItems.flatMap {
+            item -> [(src: String, bundleName: String)] in
+            guard let itemID = item.id else { return [] }
+            return item.attachments.map { att in
+                (
+                    src: ContentAttachmentStore.path(app, itemID: itemID, attachmentID: att.id),
+                    bundleName: "content/\(att.id.uuidString)"
+                )
+            }
+        }
         let logger = req.logger
         try await runBlocking(on: req) {
             try writeExportStaging(
@@ -73,6 +88,7 @@ struct CourseBundleRoutes: RouteCollection {
                 manifestData: manifestData,
                 setupCopies: setupCopies,
                 submissionPaths: submissionPaths,
+                contentFileCopies: contentFileCopies,
                 logger: logger)
         }
 
@@ -268,12 +284,23 @@ struct CourseBundleRoutes: RouteCollection {
         }
 
         let bundledContentItems = data.contentItems.map { item -> BundledContentItem in
-            BundledContentItem(
+            // Each attachment's global UUID doubles as its unique bundle
+            // filename (content/<id>); the bytes are copied in writeExportStaging.
+            let attachments = item.attachments.map { att in
+                BundledAttachment(
+                    originalName: att.originalName,
+                    sizeBytes: att.sizeBytes,
+                    label: att.label,
+                    sortOrder: att.sortOrder,
+                    bundleFilename: "content/\(att.id.uuidString)")
+            }
+            return BundledContentItem(
                 sectionBundleID: item.sectionID.flatMap { bundleIDs.sectionBundleIDByUUID[$0] },
                 title: item.title,
                 kind: item.kind.rawValue,
                 description: item.itemDescription,
                 links: item.links,
+                attachments: attachments.isEmpty ? nil : attachments,
                 updatedLabel: item.updatedLabel,
                 isPublished: item.isPublished,
                 sortOrder: item.sortOrder
@@ -378,6 +405,7 @@ private func writeExportStaging(
     manifestData: Data,
     setupCopies: [(id: String, zipPath: String)],
     submissionPaths: [String],
+    contentFileCopies: [(src: String, bundleName: String)],
     logger: Logger
 ) throws {
     try FileManager.default.createDirectory(at: stagingDir, withIntermediateDirectories: true)
@@ -385,8 +413,22 @@ private func writeExportStaging(
         at: stagingDir.appendingPathComponent("testsetups"), withIntermediateDirectories: true)
     try FileManager.default.createDirectory(
         at: stagingDir.appendingPathComponent("submissions"), withIntermediateDirectories: true)
+    if !contentFileCopies.isEmpty {
+        try FileManager.default.createDirectory(
+            at: stagingDir.appendingPathComponent("content"), withIntermediateDirectories: true)
+    }
 
     try manifestData.write(to: stagingDir.appendingPathComponent("bundle.json"))
+
+    for copy in contentFileCopies {
+        let src = URL(fileURLWithPath: copy.src)
+        let dst = stagingDir.appendingPathComponent(copy.bundleName)
+        if FileManager.default.fileExists(atPath: src.path) {
+            try FileManager.default.copyItem(at: src, to: dst)
+        } else {
+            logger.warning("Export: content attachment missing at \(src.path), skipping")
+        }
+    }
 
     for setup in setupCopies {
         let src = URL(fileURLWithPath: setup.zipPath)

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -81,6 +81,15 @@ struct LatestSubmissionItem: Encodable {
 /// instructor view (all items; `isPublished == false` shows a "Hidden" marker).
 /// Ungraded, so it carries none of `TestSetupRow`'s grade / history / badge
 /// fields — just a title, a kind label, and its links.
+/// One hosted file attachment on a content item, ready for the download link
+/// (the gated `/content-files/:itemID/:attachmentID` route).
+struct ContentAttachmentView: Encodable {
+    let id: String
+    let displayName: String
+    let downloadURL: String
+    let sizeLabel: String  // e.g. "1.2 MB"
+}
+
 struct ContentItemRow: Encodable {
     let id: String
     let title: String
@@ -88,18 +97,29 @@ struct ContentItemRow: Encodable {
     let kindLabel: String  // human-facing label, e.g. "Notebook"
     let itemDescription: String?
     let links: [ContentLink]
+    /// Hosted file attachments, rendered as download links beside `links`.
+    let attachments: [ContentAttachmentView]
     let updatedLabel: String?
     /// False → a draft item hidden from students (surfaced only on the
     /// instructor dashboard as a "Hidden" marker).
     let isPublished: Bool
 
     init(from item: APICourseContentItem) {
-        self.id = item.id?.uuidString ?? ""
+        let itemID = item.id?.uuidString ?? ""
+        self.id = itemID
         self.title = item.title
         self.kind = item.kind.rawValue
         self.kindLabel = ContentItemRow.label(for: item.kind)
         self.itemDescription = item.itemDescription
         self.links = item.links
+        self.attachments = item.attachments.map { attachment in
+            ContentAttachmentView(
+                id: attachment.id.uuidString,
+                displayName: attachment.displayName,
+                downloadURL: "/content-files/\(itemID)/\(attachment.id.uuidString)",
+                sizeLabel: ByteCountFormatter.string(
+                    fromByteCount: Int64(attachment.sizeBytes), countStyle: .file))
+        }
         self.updatedLabel = item.updatedLabel
         self.isPublished = item.isPublished
     }

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -448,4 +448,7 @@ func registerMigrations(on app: Application) {
     // `course_sections`, both created by CreateCourses above, so no additional
     // ordering constraint.
     app.migrations.add(CreateCourseContentItems())
+    // Hosted file attachments on content items (served via the gated
+    // /content-files route). Additive column on the table created above.
+    app.migrations.add(AddContentItemAttachments())
 }

--- a/Sources/APIServer/routes.swift
+++ b/Sources/APIServer/routes.swift
@@ -50,6 +50,8 @@ func routes(_ app: Application) throws {
     // TestSetupRoutes is in the auth group so students can fetch/download notebooks.
     // Instructor-only handlers (upload, zip-download, save) guard themselves inline.
     try auth.register(collection: TestSetupRoutes())
+    // Gated download of hosted content-item file attachments (enrolled students).
+    try auth.register(collection: ContentFileRoutes())
     // Registered last so fixed-path routes always take precedence.
     try auth.register(collection: VanityURLRoutes())
 

--- a/Sources/Core/ContentAttachment.swift
+++ b/Sources/Core/ContentAttachment.swift
@@ -1,0 +1,41 @@
+// Core/ContentAttachment.swift
+//
+// A file attached to an ungraded course content item — an instructor-uploaded
+// PDF / notebook / image / slide deck, or a file an agent fetched by URL.
+// Unlike a `ContentLink` (which points at an external URL), an attachment's
+// bytes live on the server at `contentFilesDirectory/<itemID>/<id>` and are
+// served only to enrolled students through a gated route. The untrusted
+// `originalName` is kept for display and the download filename; the on-disk
+// name is the opaque `id`, so a hostile filename can never escape the
+// directory.
+
+import Foundation
+
+public struct ContentAttachment: Codable, Sendable, Equatable {
+    /// Server-generated; also the on-disk filename under the item's directory.
+    public let id: UUID
+    /// The uploader's filename, for display and the `Content-Disposition`
+    /// download name. Untrusted — validated as a bare filename before storage.
+    public let originalName: String
+    public let sizeBytes: Int
+    /// Order within the item's attachment list (lower = shown first).
+    public let sortOrder: Int
+    /// Optional instructor label; falls back to `originalName` for display.
+    public let label: String?
+
+    public init(
+        id: UUID, originalName: String, sizeBytes: Int, sortOrder: Int, label: String? = nil
+    ) {
+        self.id = id
+        self.originalName = originalName
+        self.sizeBytes = sizeBytes
+        self.sortOrder = sortOrder
+        self.label = label
+    }
+
+    /// Display name: the instructor label when set, otherwise the file name.
+    public var displayName: String {
+        if let label, !label.isEmpty { return label }
+        return originalName
+    }
+}

--- a/Sources/Core/CourseBundleManifest.swift
+++ b/Sources/Core/CourseBundleManifest.swift
@@ -6,6 +6,7 @@
 //   bundle.json                        — this manifest (JSON, iso8601 dates)
 //   testsetups/<originalSetupID>.zip   — instructor test-setup zips
 //   submissions/<originalSubID>.<ext>  — student submission files
+//   content/<exportAttachmentID>       — content-item hosted file attachments
 //
 // bundleID values are stable cross-references within a single bundle.
 // They are NEVER reused as DB primary keys on the target instance;
@@ -136,9 +137,32 @@ public struct BundledSection: Codable, Sendable {
     }
 }
 
+/// One hosted file attachment on a content item, carried in a bundle. Nested
+/// inside its `BundledContentItem` (no own bundleID — the import loop that
+/// re-creates the item copies its files), with the bytes stored in the ZIP at
+/// `bundleFilename` and re-hosted under a fresh id on import.
+public struct BundledAttachment: Codable, Sendable {
+    public let originalName: String
+    public let sizeBytes: Int
+    public let label: String?
+    public let sortOrder: Int
+    /// Relative path within the bundle ZIP: "content/<exportAttachmentID>".
+    public let bundleFilename: String
+
+    public init(
+        originalName: String, sizeBytes: Int, label: String?, sortOrder: Int, bundleFilename: String
+    ) {
+        self.originalName = originalName
+        self.sizeBytes = sizeBytes
+        self.label = label
+        self.sortOrder = sortOrder
+        self.bundleFilename = bundleFilename
+    }
+}
+
 /// An ungraded course content item (reference material) carried in a bundle.
-/// Content items carry no files (link-first), so — like sections — they are
-/// pure manifest rows. No own `bundleID`: nothing references a content item.
+/// No own `bundleID`: nothing references a content item; its hosted file
+/// attachments are nested (`attachments`) and copied by the import loop.
 public struct BundledContentItem: Codable, Sendable {
     /// References BundledSection.bundleID (nil = ungrouped, or a bundle
     /// exported before sections were carried).
@@ -148,19 +172,24 @@ public struct BundledContentItem: Codable, Sendable {
     public let kind: String
     public let description: String?
     public let links: [ContentLink]
+    /// Hosted file attachments (nil in bundles exported before files were
+    /// carried — decodes as nil, imported as none).
+    public let attachments: [BundledAttachment]?
     public let updatedLabel: String?
     public let isPublished: Bool
     public let sortOrder: Int
 
     public init(
         sectionBundleID: String?, title: String, kind: String, description: String?,
-        links: [ContentLink], updatedLabel: String?, isPublished: Bool, sortOrder: Int
+        links: [ContentLink], attachments: [BundledAttachment]? = nil, updatedLabel: String?,
+        isPublished: Bool, sortOrder: Int
     ) {
         self.sectionBundleID = sectionBundleID
         self.title = title
         self.kind = kind
         self.description = description
         self.links = links
+        self.attachments = attachments
         self.updatedLabel = updatedLabel
         self.isPublished = isPublished
         self.sortOrder = sortOrder

--- a/Tests/APITests/ContentAttachmentTests.swift
+++ b/Tests/APITests/ContentAttachmentTests.swift
@@ -1,0 +1,200 @@
+// Tests/APITests/ContentAttachmentTests.swift
+//
+// Hosted file attachments on course content items (PR B): the storage helper's
+// validation, the enrollment-gated download route, draft visibility, lifecycle
+// deletion, and the MCP SSRF guard on URL-fetched attachments.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class ContentAttachmentTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-attach")
+    }
+
+    // MARK: - Helpers
+
+    private func req() -> Request {
+        Request(application: app, on: app.eventLoopGroup.any())
+    }
+
+    @discardableResult
+    private func makeCourse(code: String) async throws -> APICourse {
+        let course = APICourse(code: code, name: "Course \(code)", enrollmentMode: .auto)
+        try await course.save(on: app.db)
+        return course
+    }
+
+    /// Creates a content item and stores one attachment (bytes on disk +
+    /// metadata on the item), returning both ids.
+    private func makeItemWithAttachment(
+        courseID: UUID, isPublished: Bool = true, name: String = "notes.pdf",
+        bytes: Data = Data("hello pdf".utf8)
+    ) async throws -> (item: APICourseContentItem, attachmentID: UUID) {
+        let item = APICourseContentItem(
+            courseID: courseID, sortOrder: 1, title: "Material", kind: .document,
+            isPublished: isPublished)
+        try await item.save(on: app.db)
+        let itemID = try item.requireID()
+        let attachment = try await ContentAttachmentStore.store(
+            bytes: bytes, originalName: name, label: nil, sortOrder: 1, itemID: itemID, on: req())
+        item.attachments = [attachment]
+        try await item.save(on: app.db)
+        return (item, attachment.id)
+    }
+
+    // MARK: - Store validation
+
+    @Test func storeRejectsDisallowedType() async throws {
+        try await withApp(app) { _ in
+            #expect(throws: ContentAttachmentStore.StoreError.self) {
+                _ = try ContentAttachmentStore.validate(
+                    bytes: Data("x".utf8), originalName: "malware.exe")
+            }
+        }
+    }
+
+    @Test func storeRejectsUnsafeName() async throws {
+        try await withApp(app) { _ in
+            #expect(throws: ContentAttachmentStore.StoreError.self) {
+                _ = try ContentAttachmentStore.validate(
+                    bytes: Data("x".utf8), originalName: "../escape.pdf")
+            }
+        }
+    }
+
+    @Test func storeRejectsOversize() async throws {
+        try await withApp(app) { _ in
+            let tooBig = Data(count: ContentAttachmentStore.maxFileBytes + 1)
+            #expect(throws: ContentAttachmentStore.StoreError.self) {
+                _ = try ContentAttachmentStore.validate(bytes: tooBig, originalName: "big.pdf")
+            }
+        }
+    }
+
+    @Test func storeWritesFileAndMetadata() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "AT_STORE")
+            let (item, attachmentID) = try await makeItemWithAttachment(
+                courseID: try course.requireID(), name: "lecture.pdf")
+            let itemID = try item.requireID()
+            let path = ContentAttachmentStore.path(app, itemID: itemID, attachmentID: attachmentID)
+            #expect(FileManager.default.fileExists(atPath: path))
+            let reloaded = try #require(try await APICourseContentItem.find(itemID, on: app.db))
+            #expect(reloaded.attachments.count == 1)
+            #expect(reloaded.attachments.first?.originalName == "lecture.pdf")
+        }
+    }
+
+    // MARK: - Gated serving
+
+    @Test func enrolledStudentDownloadsAttachment() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "AT_SERVE")
+            let (item, attachmentID) = try await makeItemWithAttachment(
+                courseID: try course.requireID(), bytes: Data("PDF-BYTES".utf8))
+            let itemID = try item.requireID()
+            // Auto-enroll a student on login into the .auto course.
+            let cookie = try await loginUser(username: "at_student", password: "pw", role: "student", on: app)
+
+            try await app.asyncTest(
+                .GET, "/content-files/\(itemID)/\(attachmentID)",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string == "PDF-BYTES")
+                    #expect((res.headers.first(name: .contentDisposition) ?? "").contains("attachment"))
+                })
+        }
+    }
+
+    @Test func outsiderIsDeniedAttachment() async throws {
+        try await withApp(app) { _ in
+            // The item's course is CLOSED so a stranger isn't auto-enrolled.
+            let course = APICourse(code: "AT_OUT", name: "Closed", enrollmentMode: .closed)
+            try await course.save(on: app.db)
+            let (item, attachmentID) = try await makeItemWithAttachment(courseID: try course.requireID())
+            let itemID = try item.requireID()
+            let cookie = try await loginUser(username: "at_outsider", password: "pw", role: "student", on: app)
+
+            try await app.asyncTest(
+                .GET, "/content-files/\(itemID)/\(attachmentID)",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .forbidden || res.status == .notFound)
+                })
+        }
+    }
+
+    @Test func draftAttachmentHiddenFromStudentButVisibleToStaff() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "AT_DRAFT")
+            let courseID = try course.requireID()
+            let (item, attachmentID) = try await makeItemWithAttachment(
+                courseID: courseID, isPublished: false)
+            let itemID = try item.requireID()
+            let path = "/content-files/\(itemID)/\(attachmentID)"
+
+            let studentCookie = try await loginUser(
+                username: "at_draft_student", password: "pw", role: "student", on: app)
+            try await app.asyncTest(
+                .GET, path,
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentCookie) },
+                afterResponse: { res in #expect(res.status == .notFound) })
+
+            let staffCookie = try await loginUser(
+                username: "at_draft_staff", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("at_draft_staff", on: app)
+            try await app.asyncTest(
+                .GET, path,
+                beforeRequest: { req in req.headers.add(name: .cookie, value: staffCookie) },
+                afterResponse: { res in #expect(res.status == .ok) })
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    @Test func deletingItemRemovesAttachmentFiles() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeCourse(code: "AT_DELETE")
+            let (item, attachmentID) = try await makeItemWithAttachment(courseID: try course.requireID())
+            let itemID = try item.requireID()
+            let path = ContentAttachmentStore.path(app, itemID: itemID, attachmentID: attachmentID)
+            #expect(FileManager.default.fileExists(atPath: path))
+
+            ContentAttachmentStore.removeDirectory(app, itemID: itemID)
+            #expect(!FileManager.default.fileExists(atPath: path))
+        }
+    }
+
+    // MARK: - MCP SSRF guard
+
+    @Test func mcpAttachRejectsPrivateAddress() async throws {
+        try await withApp(app) { app in
+            let course = try await makeCourse(code: "AT_MCP")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "at_mcp", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+            let context = ToolContext(
+                request: req(), subject: "at_mcp", grantedScopes: [.write])
+
+            // A loopback URL is refused by the SSRF guard before any fetch.
+            await #expect(throws: MCPToolError.self) {
+                _ = try await CreateContentItemTool().execute(
+                    .init(
+                        courseCode: "AT_MCP", title: "Doc", kind: "document", links: nil,
+                        attachments: [.init(label: nil, sourceUrl: "https://127.0.0.1/secret.pdf")],
+                        description: nil, updatedLabel: nil, courseSectionID: nil, isPublished: nil),
+                    context)
+            }
+        }
+    }
+}

--- a/Tests/APITests/CourseBundleTests.swift
+++ b/Tests/APITests/CourseBundleTests.swift
@@ -744,6 +744,75 @@ import VaporTesting
         }
     }
 
+    @Test func roundTripPreservesContentAttachments() async throws {
+        try await withApp(app) { _ in
+            let cookie = try await loginAsAdmin()
+            let course = try await makeTestCourse(code: "RT_ATTACH")
+            let courseID = try course.requireID()
+
+            let item = APICourseContentItem(
+                courseID: courseID, sortOrder: 1, title: "Slides", kind: .slides, isPublished: true)
+            try await item.save(on: app.db)
+            let itemID = try item.requireID()
+            let bytes = Data("SLIDE-DECK-BYTES".utf8)
+            let attachment = try await ContentAttachmentStore.store(
+                bytes: bytes, originalName: "week1.pdf", label: "Week 1", sortOrder: 1,
+                itemID: itemID, on: Request(application: app, on: app.eventLoopGroup.any()))
+            item.attachments = [attachment]
+            try await item.save(on: app.db)
+
+            var exportedZip = Data()
+            try await app.asyncTest(
+                .GET, "/admin/courses/\(courseID.uuidString)/export",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    exportedZip = Data(res.body.readableBytesView)
+                })
+
+            // Manifest carries the attachment metadata + the bytes are in the zip.
+            let extractDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("rt-attach-ext-\(UUID().uuidString)", isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: extractDir) }
+            let zipVerifyPath = FileManager.default.temporaryDirectory
+                .appendingPathComponent("rt-attach-\(UUID().uuidString).zip").path
+            defer { try? FileManager.default.removeItem(atPath: zipVerifyPath) }
+            try exportedZip.write(to: URL(fileURLWithPath: zipVerifyPath))
+            try await extractZipArchive(zipPath: zipVerifyPath, into: extractDir)
+            let manifestData = try Data(contentsOf: extractDir.appendingPathComponent("bundle.json"))
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let manifest = try decoder.decode(CourseBundleManifest.self, from: manifestData)
+            let bundledItem = try #require(manifest.contentItems?.first { $0.title == "Slides" })
+            let bundledAtt = try #require(bundledItem.attachments?.first)
+            #expect(bundledAtt.originalName == "week1.pdf")
+            #expect(bundledAtt.label == "Week 1")
+            let contentFile = extractDir.appendingPathComponent(bundledAtt.bundleFilename)
+            #expect(try Data(contentsOf: contentFile) == bytes)
+
+            // Archive + import into a fresh course; the file bytes survive under
+            // a regenerated attachment id.
+            course.isArchived = true
+            try await course.save(on: app.db)
+            let (status, body) = try await postImport(cookie: cookie, zipData: exportedZip)
+            #expect(status != .badRequest, "\(body.prefix(300))")
+            #expect(status != .conflict, "\(body.prefix(300))")
+
+            let imported = try #require(
+                try await APICourse.query(on: app.db)
+                    .filter(\.$code == "RT_ATTACH").filter(\.$isArchived == false).first())
+            let importedItem = try #require(
+                try await APICourseContentItem.query(on: app.db)
+                    .filter(\.$courseID == imported.requireID()).first())
+            let importedAtt = try #require(importedItem.attachments.first)
+            #expect(importedAtt.originalName == "week1.pdf")
+            #expect(importedAtt.id != attachment.id, "attachment id is regenerated on import")
+            let importedPath = ContentAttachmentStore.path(
+                app, itemID: try importedItem.requireID(), attachmentID: importedAtt.id)
+            #expect(try Data(contentsOf: URL(fileURLWithPath: importedPath)) == bytes)
+        }
+    }
+
     /// A bundle exported before content items existed omits the key entirely;
     /// it must decode (contentItems == nil) and import without error. Wrapped in
     /// `withApp` so the per-test app created in `init()` shuts down cleanly.

--- a/Tests/APITests/RouteAuthorizationMatrixTests.swift
+++ b/Tests/APITests/RouteAuthorizationMatrixTests.swift
@@ -113,6 +113,10 @@ import VaporTesting
                 "sectionID": try section.requireID().uuidString,
                 // The /instructor/content-items/:id/{edit,delete,section} routes.
                 "id": try contentItem.requireID().uuidString,
+                // The content-items/:id/attachments/:attachmentID/delete route
+                // resolves and authorizes the item by :id before it reads
+                // :attachmentID, so any valid UUID denies a non-owner.
+                "attachmentID": UUID().uuidString,
                 "preEnrollmentID": UUID().uuidString,
                 "filename": "publictest_authz.py",
             ],

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -310,7 +310,9 @@ func makeTestApp(
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("\(prefix)-\(UUID().uuidString)/")
             .path
-        let dirs = ["results/", "testsetups/", "submissions/", "data-exports/"].map { tmpDir + $0 }
+        let dirs = ["results/", "testsetups/", "submissions/", "data-exports/", "content-files/"].map {
+            tmpDir + $0
+        }
         for dir in dirs {
             try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         }
@@ -318,6 +320,7 @@ func makeTestApp(
         app.testSetupsDirectory = dirs[1]
         app.submissionsDirectory = dirs[2]
         app.dataExportsDirectory = dirs[3]
+        app.contentFilesDirectory = dirs[4]
         // Seed the worker-secret and local-runner-autostart paths into the
         // per-test temp directory so admin/worker-management tests don't
         // collide with each other or with the dev .worker-secret on disk.

--- a/changelog.d/content-item-hosted-files.md
+++ b/changelog.d/content-item-hosted-files.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Hosted files on course content items.** Instructors (TA+) can now upload
+  files to a reference-material item — PDFs, notebooks, images, slides, small
+  data — alongside its external links; an agent can attach one over MCP by
+  passing `attachments:[{sourceUrl}]` to `create_content_item` /
+  `update_content_item` (fetched under the existing SSRF guard: https-only, no
+  private/loopback/metadata hosts, no redirects, size-capped). Files are stored
+  under server-generated names, served only to enrolled students through the
+  gated `GET /content-files/:itemID/:attachmentID` route (a draft item's files
+  stay staff-only), deleted with their item or attachment, and carried in the
+  `.chickadee` course bundle (exported under `content/`, re-hosted with fresh
+  ids on import). A pre-attachment bundle still imports unchanged.


### PR DESCRIPTION
## What & why

This is **PR B** of the "make content items a complete feature" follow-up (PR A — unified interleave — shipped in #1197 / v0.4.629). Content items were **link-only**: an instructor could point at an external URL but not host a file in Chickadee. This adds **Chickadee-hosted file attachments** to a content item, over both the web UI and MCP, with gated per-student serving and full course-bundle round-tripping.

The grading pipeline is untouched — this is entirely on the content-item / course-structure side.

## What changed

**Data model**
- `Core/ContentAttachment` — `{ id, originalName, sizeBytes, sortOrder, label? }`. The on-disk filename is the server-generated `id`; the untrusted `originalName` is retained only for display/download.
- `APICourseContentItem` gains a nullable `attachments_json` column (accessor `attachments: [ContentAttachment]`), mirroring the existing `links_json`. Additive `AddContentItemAttachments` migration (nullable/default `[]`), so existing rows and older runners are unaffected.
- `contentFilesDirectory` (`APIServerApp` accessor + `AppDirectories` bootstrap, default `content-files/`) — gated storage, never served statically. Files live at `content-files/<itemID>/<attachmentID>`.

**Upload (web, TA+)**
- The "+ Add material" / edit forms are now `multipart/form-data` with a multiple-`File` input; the create/edit routes set an explicit `body: .collect(maxSize: "60mb")` cap.
- `ContentAttachmentStore` validates each file against an extension allowlist (pdf, ipynb, images, txt/md/csv/tsv/json/py, docx/pptx/xlsx) and a 25 MB per-file cap **before** any bytes are written, then stores under the generated id. Authoring stays gated at `requireCourseWriteAccess(atLeast: .ta)`.
- Edit popups list existing attachments with a Remove action (posted outside the form to avoid nested-form issues).

**Serving (gated)**
- `GET /content-files/:itemID/:attachmentID` in the authenticated group: require login → `requireCourseEnrollment` (admins bypass) → a draft item's files are staff-only (students get 404) → stream via `req.fileio.asyncStreamFile` with `Content-Type` from the extension (`HTTPMediaType.fileExtension(...) ?? .binary`) and a sanitized `Content-Disposition`.

**MCP parity**
- `SupportFileURLFetcher` gained a `Data`-returning variant that shares every existing guard (https-only, no credentials, `BlockedIPClassifier` resolve-then-classify, no-redirect, size cap, timeouts).
- `create_content_item` / `update_content_item` accept `attachments: [{ label?, sourceUrl }]`; each URL is fetched through that guarded variant and hosted under `contentFilesDirectory`. The content-item output schema and server `initialize` instructions document the field.

**Lifecycle + bundle**
- Deleting an item removes its whole attachment directory; removing a single attachment deletes just that file.
- The `.chickadee` bundle nests `attachments: [BundledAttachment]` inside `BundledContentItem`, exported under a `content/<attachmentID>` layout. Import copies the bytes back with **regenerated** ids (zip-slip-safe: only `content/<uuid>` sources are accepted). A pre-attachment bundle still imports unchanged (the manifest field is optional).

## Authorization

File upload/removal is **TA+** (consistent with existing content authoring and script/notebook editing). Serving requires enrollment in the item's course; unpublished-item files are staff-only.

## Testing

- `ContentAttachmentTests` (9) — store type/size/filename rejection; store writes file + metadata; enrolled student downloads; outsider denied; draft hidden from students but visible to staff; delete removes files; MCP `sourceUrl` attach rejects a private address (`https://127.0.0.1/...`) via `BlockedIPClassifier`.
- `CourseBundleTests` — added `roundTripPreservesContentAttachments` (manifest metadata + `content/<id>` bytes in the zip + regenerated id and surviving bytes on import); the existing pre-attachment round-trip still passes.
- Existing MCP content-item and web content-item suites still pass (57 tests / 8 suites green locally).
- `swift-format`, `check-styles.sh` (styles + tokens + css-vars) clean.

> Note: SwiftLint couldn't run in the sandbox (its binary artifact download is blocked by egress policy); CI will run it.

## Out of scope (unchanged)

Per-item start-date scheduling; per-language runner eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TynDW29qocDnWXi76ARw5j

---
_Generated by [Claude Code](https://claude.ai/code/session_01TynDW29qocDnWXi76ARw5j)_