### PR TITLE
R runtime: centralize submission lookup, reserve _ck_inputs.R

### DIFF
--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -532,11 +532,19 @@ extension WorkerDaemon {
             } else {
                 try mergeDirectoryContents(from: paths.submissionDir, into: testSetupDir)
                 // A pure-R suite extracts every notebook to `.R` regardless of the
-                // submission's kernelspec (the in-browser editor can rewrite it).
+                // submission's kernelspec (the in-browser editor can rewrite it) —
+                // so the student-module hint has to name the `.R` file too, or it
+                // points at a path that was never written.
+                let targetsR = manifestTargetsRSubmission(manifest)
                 try extractNotebooksToCode(
                     in: testSetupDir,
-                    forcedLanguage: manifestTargetsRSubmission(manifest) ? "r" : nil)
-                return ([], legacyPreferredStudentModuleFilename(submissionFilename: job.submissionFilename))
+                    forcedLanguage: targetsR ? "r" : nil)
+                return (
+                    [],
+                    legacyPreferredStudentModuleFilename(
+                        submissionFilename: job.submissionFilename,
+                        language: targetsR ? .r : .python)
+                )
             }
         }
     }

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -98,17 +98,31 @@ func mergeDirectoryContents(from sourceDirectory: URL, into destinationDirectory
     }
 }
 
-func legacyPreferredStudentModuleFilename(submissionFilename: String?) -> String? {
+/// Filename the extracted submission will have in the grading workspace, written
+/// to `.chickadee_student_module` so the runtimes can prefer it over guessing.
+///
+/// `language` matters because a notebook is extracted to its assignment's source
+/// language: an R job's `analysis.ipynb` becomes `analysis.R`, not `analysis.py`.
+/// Naming the Python file on an R job produced a hint pointing at a file that
+/// never exists, so `chickadee_student_file()` had nothing to prefer and fell
+/// back to scanning. Defaults to `.python`, so the Python path is unchanged.
+func legacyPreferredStudentModuleFilename(
+    submissionFilename: String?,
+    language: AssignmentLanguage = .python
+) -> String? {
     guard let submissionFilename, !submissionFilename.isEmpty else { return nil }
     let submittedName = URL(fileURLWithPath: submissionFilename).lastPathComponent
     guard !submittedName.isEmpty else { return nil }
 
     let ext = URL(fileURLWithPath: submittedName).pathExtension.lowercased()
-    if ext == "py" {
+    // A source file is already the module; the extension the student used wins
+    // over the assignment's language (an `.R` upload is an R module either way).
+    if ext == "py" || ext == "r" {
         return submittedName
     }
     if ext == "ipynb" {
-        return (submittedName as NSString).deletingPathExtension + ".py"
+        let sourceExtension = language == .r ? "R" : "py"
+        return (submittedName as NSString).deletingPathExtension + "." + sourceExtension
     }
     return nil
 }

--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -490,14 +490,99 @@ private let testRuntimeRHelpers = #"""
     }
     """#
 
-// The full R runtime = the helper library above + the per-student
-// personalization primitives (`chickadee_seed()` / `chickadee_inputs()`), whose
-// source lives in Core (`RPersonalizationRuntime`) so a grading script computes
-// the seed identically to the server-side expression driver. Composing from the
-// one Core source — rather than re-pasting the R here — is what guarantees the
-// two never drift. `Tools/runner-support/test_runtime.R` carries the same three
-// pieces for standalone/manual runs and is kept in sync by hand.
+// Locating the student's submission — the R mirror of `test_runtime.py`'s
+// `_preferred_student_module()` / `_candidate_student_files()`. Python reserves
+// its own workspace filenames inside the runtime; R had no equivalent, so every
+// assignment's helper hand-rolled the search and each one had to remember to
+// skip `_ck_inputs.R` on its own. Centralizing it here makes the reservation
+// real: the reserved inputs filename is interpolated straight from
+// `AssignmentLanguage`, so the skip list cannot drift from the file the worker
+// actually writes.
+private let testRuntimeRStudentFile = #"""
+    # --- Locating the student's submission --------------------------------------
+    # Filenames Chickadee itself writes into the grading workspace. None of them is
+    # ever the student's submission, so they are never candidates.
+    .chickadee_reserved_files <- c("test_runtime.R", "\#(AssignmentLanguage.r.inputsFileName)")
+
+    .chickadee_is_test_file <- function(names) {
+        grepl("^(publictest|releasetest|secrettest|studenttest)", names)
+    }
+
+    # The test script currently executing. It is itself a .R file sitting in the
+    # working directory, so it must never be mistaken for the submission - the
+    # tier-prefix rule above only covers the conventional names.
+    .chickadee_running_script <- function() {
+        args  <- commandArgs(trailingOnly = FALSE)
+        fargs <- args[startsWith(args, "--file=")]
+        if (length(fargs) > 0L) return(basename(sub("^--file=", "", fargs[[1L]])))
+        ""
+    }
+
+    # The student's submitted R file: solution.R during validation, the extracted
+    # notebook during grading. Prefers the runner's `.chickadee_student_module`
+    # hint when it names an R file that is actually present, then falls back to
+    # scanning the working directory. `extra_skip` lets an assignment exclude its
+    # own bundled helpers, e.g. chickadee_student_file(c("a2_helpers.R")).
+    # Returns NA_character_ when nothing looks like a submission.
+    chickadee_student_file <- function(extra_skip = character(0)) {
+        hint_path <- ".chickadee_student_module"
+        if (file.exists(hint_path)) {
+            hinted <- tryCatch(trimws(readLines(hint_path, warn = FALSE)),
+                               error = function(e) character(0))
+            hinted <- hinted[nzchar(hinted)]
+            if (length(hinted) > 0L) {
+                preferred <- basename(hinted[[1L]])
+                if (grepl("\\.[Rr]$", preferred) && file.exists(preferred)) return(preferred)
+            }
+        }
+        rfiles <- list.files(pattern = "\\.[Rr]$")
+        skip   <- c(.chickadee_reserved_files, .chickadee_running_script(), extra_skip)
+        cand   <- rfiles[!(rfiles %in% skip) & !.chickadee_is_test_file(rfiles)]
+        if (length(cand) == 0L) return(NA_character_)
+        if ("solution.R" %in% cand) return("solution.R")
+        cand[[1L]]
+    }
+
+    # Evaluate the submission expression-by-expression in a fresh environment, so a
+    # runtime error in one top-level line still leaves the function definitions
+    # that loaded before it available to the tests.
+    chickadee_load_student <- function(extra_skip = character(0)) {
+        f <- chickadee_student_file(extra_skip)
+        if (is.na(f)) errored("No R submission file was found to grade.")
+
+        env <- new.env(parent = globalenv())
+        grDevices::pdf(NULL)                 # swallow any plots the notebook draws
+        on.exit(try(grDevices::dev.off(), silent = TRUE), add = TRUE)
+
+        exprs <- tryCatch(parse(file = f), error = function(e) NULL)
+        if (is.null(exprs)) {
+            errored(paste0("Your submission (", f, ") could not be parsed as R - check for a syntax error."))
+        }
+        for (ex in exprs) tryCatch(eval(ex, envir = env), error = function(e) invisible(NULL))
+        env
+    }
+
+    # Fetch a function the student was asked to write; a clear error when it is
+    # missing or was overwritten with something that is not a function.
+    chickadee_require_fn <- function(env, name) {
+        fn <- tryCatch(get(name, envir = env, inherits = FALSE), error = function(e) NULL)
+        if (is.null(fn) || !is.function(fn)) {
+            errored(sprintf("Your submission must define a function called `%s()`.", name))
+        }
+        fn
+    }
+    """#
+
+// The full R runtime = the helper library above + submission location + the
+// per-student personalization primitives (`chickadee_seed()` /
+// `chickadee_inputs()`), whose source lives in Core (`RPersonalizationRuntime`)
+// so a grading script computes the seed identically to the server-side
+// expression driver. Composing from the one Core source — rather than
+// re-pasting the R here — is what guarantees the two never drift.
+// `Tools/runner-support/test_runtime.R` carries the same pieces for
+// standalone/manual runs and is kept in sync by hand.
 let testRuntimeR =
     testRuntimeRHelpers + "\n\n"
     + RPersonalizationRuntime.chickadeeSeedRSource + "\n\n"
-    + RPersonalizationRuntime.chickadeeInputsRSource + "\n"
+    + RPersonalizationRuntime.chickadeeInputsRSource + "\n\n"
+    + testRuntimeRStudentFile + "\n"

--- a/Tests/WorkerTests/WorkerTests.swift
+++ b/Tests/WorkerTests/WorkerTests.swift
@@ -1,3 +1,4 @@
+import Core
 import Foundation
 import RunnerCore
 import Testing
@@ -505,6 +506,137 @@ import Testing
         let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
         #expect(output.exitCode == 0)
         #expect(output.stdout.contains("passed"), "default passed() message should be 'passed'")
+    }
+
+    // MARK: - R runtime: locating the student's submission
+
+    /// The reserved-filename list is interpolated from `AssignmentLanguage`, so
+    /// the R runtime can't drift from the file the worker actually writes.
+    @Test func rRuntimeReservesTheInputsFilename() {
+        #expect(testRuntimeR.contains("\"\(AssignmentLanguage.r.inputsFileName)\""))
+        #expect(testRuntimeR.contains("chickadee_student_file"))
+    }
+
+    /// The bug this closes: `_ck_inputs.R` is an R file in the grading
+    /// workspace, so a helper that just scans `*.R` could grade Chickadee's own
+    /// per-student inputs as the submission. It must never be a candidate — and
+    /// with nothing else present there is simply nothing to grade.
+    @Test func rRuntimeNeverGradesTheInputsFileAsTheSubmission() async throws {
+        guard await rscriptAvailable() else { return }
+        try writeRRuntime()
+        try ".ck_inputs <- list(`x` = 1)\n".write(
+            to: tmpDir.appendingPathComponent("_ck_inputs.R"), atomically: true, encoding: .utf8)
+
+        let script = try writeScript(
+            """
+            source('test_runtime.R')
+            f <- chickadee_student_file()
+            if (!is.na(f)) failed(paste('picked a reserved file:', f))
+            passed('no submission found, as expected')
+            """,
+            name: "test.r"
+        )
+        let runner = UnsandboxedScriptRunner()
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
+        #expect(output.exitCode == 0, "chickadee_student_file() must skip _ck_inputs.R")
+    }
+
+    /// Reserved files, the assignment's own helper, and test scripts are all
+    /// skipped; `solution.R` wins when present (the validation path).
+    @Test func rRuntimeFindsSubmissionAmongReservedFiles() async throws {
+        guard await rscriptAvailable() else { return }
+        try writeRRuntime()
+        for (name, body) in [
+            ("_ck_inputs.R", ".ck_inputs <- list()\n"),
+            ("a2_helpers.R", "h <- function() 1\n"),
+            ("publictest_thing.R", "# a test\n"),
+            ("analysis.R", "f <- function() 1\n"),
+            ("solution.R", "g <- function() 2\n"),
+        ] {
+            try body.write(
+                to: tmpDir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+
+        let script = try writeScript(
+            """
+            source('test_runtime.R')
+            f <- chickadee_student_file(c('a2_helpers.R'))
+            if (!identical(f, 'solution.R')) failed(paste('expected solution.R, got', f))
+            passed('solution.R selected')
+            """,
+            name: "test.r"
+        )
+        let runner = UnsandboxedScriptRunner()
+        let output = await runScriptRobustly(runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
+        #expect(output.exitCode == 0, "\(output.stdout)")
+    }
+
+    /// A `.chickadee_student_module` hint naming a real R file wins; a stale
+    /// hint (the pre-fix `.py` name, or a file that was never written) must
+    /// fall back to scanning rather than leaving nothing to grade.
+    @Test func rRuntimeHonoursHintAndIgnoresStaleOnes() async throws {
+        guard await rscriptAvailable() else { return }
+        try writeRRuntime()
+        try "u <- 1\n".write(
+            to: tmpDir.appendingPathComponent("utils.R"), atomically: true, encoding: .utf8)
+        try "f <- function() 1\n".write(
+            to: tmpDir.appendingPathComponent("analysis.R"), atomically: true, encoding: .utf8)
+        let hint = tmpDir.appendingPathComponent(".chickadee_student_module")
+
+        try "utils.R".write(to: hint, atomically: true, encoding: .utf8)
+        var script = try writeScript(
+            """
+            source('test_runtime.R')
+            f <- chickadee_student_file()
+            if (!identical(f, 'utils.R')) failed(paste('hint ignored, got', f))
+            passed('hint honoured')
+            """,
+            name: "test.r"
+        )
+        let runner = UnsandboxedScriptRunner()
+        var output = await runScriptRobustly(
+            runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
+        #expect(output.exitCode == 0, "\(output.stdout)")
+
+        // Stale `.py` hint — what an R job produced before the language-aware fix.
+        try "analysis.py".write(to: hint, atomically: true, encoding: .utf8)
+        script = try writeScript(
+            """
+            source('test_runtime.R')
+            f <- chickadee_student_file()
+            if (is.na(f)) failed('stale hint left nothing to grade')
+            passed(paste('fell back to', f))
+            """,
+            name: "test.r"
+        )
+        output = await runScriptRobustly(
+            runner, script: script, workDir: tmpDir, timeLimitSeconds: 60)
+        #expect(output.exitCode == 0, "\(output.stdout)")
+    }
+
+    // MARK: - Student-module hint filename
+
+    /// A notebook is extracted to its assignment's source language, so an R
+    /// job's hint has to name the `.R` file. Naming `.py` (the pre-fix
+    /// behaviour) pointed at a path that was never written.
+    @Test func preferredStudentModuleFilenameIsLanguageAware() {
+        #expect(
+            legacyPreferredStudentModuleFilename(submissionFilename: "analysis.ipynb")
+                == "analysis.py")
+        #expect(
+            legacyPreferredStudentModuleFilename(
+                submissionFilename: "analysis.ipynb", language: .python) == "analysis.py")
+        #expect(
+            legacyPreferredStudentModuleFilename(submissionFilename: "analysis.ipynb", language: .r)
+                == "analysis.R")
+        // A source upload is already the module, whatever the assignment's language.
+        #expect(
+            legacyPreferredStudentModuleFilename(submissionFilename: "warmup.py") == "warmup.py")
+        #expect(
+            legacyPreferredStudentModuleFilename(submissionFilename: "warmup.R", language: .r)
+                == "warmup.R")
+        #expect(legacyPreferredStudentModuleFilename(submissionFilename: "data.csv") == nil)
+        #expect(legacyPreferredStudentModuleFilename(submissionFilename: nil) == nil)
     }
 
     // MARK: - ExponentialBackoff

--- a/Tools/runner-support/test_runtime.R
+++ b/Tools/runner-support/test_runtime.R
@@ -103,3 +103,78 @@ chickadee_inputs <- function() {
         list()
     }
 }
+
+# --- Locating the student's submission --------------------------------------
+# Mirror of the testRuntimeRStudentFile block in
+# Sources/Worker/TestRuntimeSources.swift (where the reserved inputs filename is
+# interpolated from AssignmentLanguage). Filenames Chickadee itself writes into
+# the grading workspace are never the student's submission.
+.chickadee_reserved_files <- c("test_runtime.R", "_ck_inputs.R")
+
+.chickadee_is_test_file <- function(names) {
+    grepl("^(publictest|releasetest|secrettest|studenttest)", names)
+}
+
+# The test script currently executing. It is itself a .R file sitting in the
+# working directory, so it must never be mistaken for the submission - the
+# tier-prefix rule above only covers the conventional names.
+.chickadee_running_script <- function() {
+    args  <- commandArgs(trailingOnly = FALSE)
+    fargs <- args[startsWith(args, "--file=")]
+    if (length(fargs) > 0L) return(basename(sub("^--file=", "", fargs[[1L]])))
+    ""
+}
+
+# The student's submitted R file: solution.R during validation, the extracted
+# notebook during grading. Prefers the runner's `.chickadee_student_module`
+# hint when it names an R file that is actually present, then falls back to
+# scanning the working directory. `extra_skip` lets an assignment exclude its
+# own bundled helpers, e.g. chickadee_student_file(c("a2_helpers.R")).
+# Returns NA_character_ when nothing looks like a submission.
+chickadee_student_file <- function(extra_skip = character(0)) {
+    hint_path <- ".chickadee_student_module"
+    if (file.exists(hint_path)) {
+        hinted <- tryCatch(trimws(readLines(hint_path, warn = FALSE)),
+                           error = function(e) character(0))
+        hinted <- hinted[nzchar(hinted)]
+        if (length(hinted) > 0L) {
+            preferred <- basename(hinted[[1L]])
+            if (grepl("\\.[Rr]$", preferred) && file.exists(preferred)) return(preferred)
+        }
+    }
+    rfiles <- list.files(pattern = "\\.[Rr]$")
+    skip   <- c(.chickadee_reserved_files, .chickadee_running_script(), extra_skip)
+    cand   <- rfiles[!(rfiles %in% skip) & !.chickadee_is_test_file(rfiles)]
+    if (length(cand) == 0L) return(NA_character_)
+    if ("solution.R" %in% cand) return("solution.R")
+    cand[[1L]]
+}
+
+# Evaluate the submission expression-by-expression in a fresh environment, so a
+# runtime error in one top-level line still leaves the function definitions
+# that loaded before it available to the tests.
+chickadee_load_student <- function(extra_skip = character(0)) {
+    f <- chickadee_student_file(extra_skip)
+    if (is.na(f)) errored("No R submission file was found to grade.")
+
+    env <- new.env(parent = globalenv())
+    grDevices::pdf(NULL)                 # swallow any plots the notebook draws
+    on.exit(try(grDevices::dev.off(), silent = TRUE), add = TRUE)
+
+    exprs <- tryCatch(parse(file = f), error = function(e) NULL)
+    if (is.null(exprs)) {
+        errored(paste0("Your submission (", f, ") could not be parsed as R - check for a syntax error."))
+    }
+    for (ex in exprs) tryCatch(eval(ex, envir = env), error = function(e) invisible(NULL))
+    env
+}
+
+# Fetch a function the student was asked to write; a clear error when it is
+# missing or was overwritten with something that is not a function.
+chickadee_require_fn <- function(env, name) {
+    fn <- tryCatch(get(name, envir = env, inherits = FALSE), error = function(e) NULL)
+    if (is.null(fn) || !is.function(fn)) {
+        errored(sprintf("Your submission must define a function called `%s()`.", name))
+    }
+    fn
+}

--- a/changelog.d/r-support.md
+++ b/changelog.d/r-support.md
@@ -1,0 +1,29 @@
+### Added
+
+- **First-class R support for personalization.** An assignment's language
+  (`AssignmentLanguage`, `.python | .r`) is resolved from the manifest and every
+  language-specific path dispatches through it, so per-student personalization
+  works fully in R as well as Python — transparently to the instructor. `=`
+  expressions are evaluated per-language on the server (`python3` or `Rscript`),
+  preserving the property that expression source and the reference solution
+  never reach the runner; resolved values reach grading as `_ck_inputs.R` and
+  `{{name}}` notebook placeholders receive R literals. The R grading runtime
+  gains `chickadee_seed()` and `chickadee_inputs()`, composed from one Core
+  source so the grader and the server driver cannot drift on the seed. Python
+  output is byte-for-byte unchanged. See `docs/r-support.md`.
+- **`chickadee_student_file()` in the R runtime.** Locating the student's
+  submission is now centralized, alongside `chickadee_load_student()` and
+  `chickadee_require_fn()`, instead of being hand-rolled in every assignment's
+  helper.
+
+### Fixed
+
+- **`_ck_inputs.R` could be graded as the student's submission.** The reserved
+  workspace filenames are enforced inside the R runtime (interpolated from
+  `AssignmentLanguage`, so the skip list can't drift), rather than depending on
+  each instructor helper to remember them.
+- **The student-module hint named a Python file on R jobs.** A notebook is
+  extracted to its assignment's source language, so `analysis.ipynb` on an R
+  assignment becomes `analysis.R`; `legacyPreferredStudentModuleFilename` was
+  still writing `analysis.py` into `.chickadee_student_module`, leaving a hint
+  that pointed at a path which was never written.

--- a/docs/r-support.md
+++ b/docs/r-support.md
@@ -98,12 +98,45 @@ literals.
 
 `Tools/runner-support/test_runtime.R` (mirrored inline as `testRuntimeR` in
 `Sources/Worker/TestRuntimeSources.swift`) is the helper library injected into
-every R test working directory: `passed()` / `failed()` / `errored()` (exit
-0/1/2, hand-formatted JSON so no `jsonlite` dependency), plus the two
-personalization primitives `chickadee_seed()` and `chickadee_inputs()`. The
-worker's `testRuntimeR` is *composed* from the one Core source
+every R test working directory:
+
+- `passed()` / `failed()` / `errored()` — exit 0/1/2, hand-formatted JSON so
+  there is no `jsonlite` dependency;
+- `chickadee_seed()` / `chickadee_inputs()` — the personalization primitives;
+- `chickadee_student_file()` / `chickadee_load_student()` /
+  `chickadee_require_fn()` — locating and loading the student's submission.
+
+The worker's `testRuntimeR` is *composed* from the one Core source
 (`RPersonalizationRuntime`) rather than re-pasting the R, which is what
 guarantees the grading runtime and the server driver never drift on the seed.
+`RuntimeSourceDriftTests` pins the inline copy against the canonical file.
+
+### Locating the submission (and why it is central)
+
+`chickadee_student_file(extra_skip)` is the R mirror of `test_runtime.py`'s
+`_preferred_student_module()` / `_candidate_student_files()`. Python reserves
+its own workspace filenames *inside the runtime*; R originally had no
+equivalent, so every assignment's helper hand-rolled the search — and each one
+had to remember, on its own, that `_ck_inputs.R` is an R file sitting right
+next to the submission. A helper that simply scanned `*.R` could grade
+Chickadee's per-student inputs as the student's code.
+
+The reservation is now real: `.chickadee_reserved_files` is built in Swift with
+the inputs filename interpolated straight from `AssignmentLanguage`, so the skip
+list cannot drift from the file the worker actually writes. Resolution order is
+
+1. the runner's `.chickadee_student_module` hint, when it names an `.R` file
+   that is actually present (this disambiguates a student who uploaded a stray
+   `.R` beside their notebook);
+2. otherwise a scan of `*.R`, skipping reserved files, `*test_*` scripts, and
+   any `extra_skip` the assignment passes for its own bundled helpers;
+3. `solution.R` wins when present — the validation path.
+
+A stale hint never wins: it must name an existing `.R` file or the scan takes
+over. That matters because the hint is produced by
+`legacyPreferredStudentModuleFilename`, which extracts a notebook to its
+assignment's source language — an R job's `analysis.ipynb` becomes `analysis.R`,
+not `analysis.py`.
 
 ## What is deliberately not (yet) in R
 


### PR DESCRIPTION
## Summary

Follow-up to #1204. Python reserves its own grading-workspace filenames **inside**
`test_runtime.py`. R had no equivalent, so every assignment's helper hand-rolled
the search for the student's submission — and each one had to remember, on its
own, that `_ck_inputs.R` is an R file sitting right next to the submission. A
helper that simply scanned `*.R` could grade Chickadee's own per-student inputs
as the student's code. The reservation was a convention, not a rule.

## What changed

**`chickadee_student_file()` / `chickadee_load_student()` / `chickadee_require_fn()`**
added to the injected R runtime. The reserved-filename list is built in Swift with
the inputs filename interpolated straight from `AssignmentLanguage`, so it cannot
drift from the file the worker actually writes. Resolution order:

1. the runner's `.chickadee_student_module` hint, when it names an `.R` file that
   is actually present (disambiguates a student who uploaded a stray `.R` beside
   their notebook);
2. otherwise a scan of `*.R`, skipping reserved files, **the running test script
   itself**, tier-prefixed tests, and any caller-supplied `extra_skip`;
3. `solution.R` wins when present — the validation path.

A stale hint never wins: it must name an existing `.R` file or the scan takes over.

**Fixed: the student-module hint named a Python file on R jobs.** A notebook is
extracted to its assignment's source language, so an R job's `analysis.ipynb`
becomes `analysis.R` — but `legacyPreferredStudentModuleFilename` still wrote
`analysis.py` into `.chickadee_student_module`, leaving a hint pointing at a path
that was never written. It now takes a `language` (defaulting to `.python`, so the
Python path is byte-for-byte unchanged).

Skipping the running test script matters beyond the tier-prefix convention: the
executing script is itself a `.R` file in the working directory, and only the
conventional `publictest_`/`releasetest_`/`secrettest_` names were excluded. A
test I wrote caught this — the implementation was fixed rather than the test.

## Compatibility

Existing assignment helpers keep working: the new functions are `chickadee_`-prefixed,
so nothing collides with a helper's own `load_student()` / `require_student_fn()`.

## Testing

- `swift build`, `scripts/lint.sh`, `scripts/swiftlint.sh --strict` (0 violations),
  full `WorkerTests` suite — **258 tests pass**.
- New real-`Rscript` coverage (guarded; silently skipped where R is absent, runs in
  the r-base container and locally on R 4.3.3): the reserved-file skip, a mixed
  workspace of reserved + helper + test + submission files, and hint
  honour/staleness. Plus language-aware hint assertions and an interpolation check
  that the reserved list carries `AssignmentLanguage.r.inputsFileName`.
- `RuntimeSourceDriftTests` pins the inline Swift copy against
  `Tools/runner-support/test_runtime.R`.

Also adds the `changelog.d/` fragment covering this and the #1204 engine work,
which I owed and had missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bx8pUeHnSwRG5hBq93kTC

---
_Generated by [Claude Code](https://claude.ai/code/session_017bx8pUeHnSwRG5hBq93kTC)_