### PR TITLE
Add optional minimum-runner-version gate to the manifest

### DIFF
--- a/Sources/APIServer/Compatibility/CompatibilityMatcher.swift
+++ b/Sources/APIServer/Compatibility/CompatibilityMatcher.swift
@@ -14,6 +14,12 @@ struct VersionComparator {
         return .orderedSame
     }
 
+    /// Whether `raw` is a version string this comparator can parse.  Used to
+    /// reject a malformed `minimumRunnerVersion` at manifest-ingest time.
+    func canParse(_ raw: String) -> Bool {
+        parse(raw) != nil
+    }
+
     private func parse(_ raw: String) -> [Int]? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }

--- a/Sources/APIServer/Compatibility/RunnerVersionGate.swift
+++ b/Sources/APIServer/Compatibility/RunnerVersionGate.swift
@@ -1,0 +1,66 @@
+import Core
+import Foundation
+
+/// Server-side gate for the manifest's optional `minimumRunnerVersion`
+/// (`TestProperties.minimumRunnerVersion`): a submission is only handed to a
+/// native runner whose advertised version (`WorkerActivityPayload.runnerVersion`,
+/// i.e. `ChickadeeVersion.current`) is `>=` the manifest's minimum.
+///
+/// This is a *sibling* to `CompatibilityMatcher`, deliberately not folded into
+/// it: the capability matcher compares a `RunnerCapabilityProfile` against an
+/// `AssignmentRequirementSpec`, whereas this gate compares the runner's build
+/// version against a value carried on the manifest.  Keeping them separate
+/// avoids coupling the matcher to a manifest concern; `combine(_:_:)` merges the
+/// two verdicts into one `CompatibilityResult` at the claim seam so the existing
+/// guard / diagnostics / blocked-candidate path is reused unchanged.
+///
+/// Only bites the native worker path.  Browser (`gradingMode: .browser`) grading
+/// runs the server's own vended WASM bundle — there is no runner version to
+/// gate — so this never applies there.
+enum RunnerVersionGate {
+    /// Whether the manifest gate admits a runner advertising `runnerVersion`.
+    ///
+    /// A `nil`/blank minimum short-circuits to *compatible* **without inspecting
+    /// `runnerVersion` at all** — so an un-gated assignment is unaffected even
+    /// when the runner advertises a non-semver string (mock/third-party runners
+    /// do), and the existing byte-for-byte behaviour is preserved.  When a real
+    /// minimum is set and either side is unparseable, the gate fails *closed*:
+    /// we cannot prove the runner meets the floor, so we refuse rather than risk
+    /// grading on an unidentifiable runner.
+    static func evaluate(runnerVersion: String, minimumRunnerVersion: String?) -> CompatibilityResult {
+        let minimum = (minimumRunnerVersion ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !minimum.isEmpty else {
+            return CompatibilityResult(isCompatible: true)
+        }
+
+        guard let comparison = VersionComparator().compare(runnerVersion, minimum) else {
+            return CompatibilityResult(
+                isCompatible: false,
+                reasons: ["unparseable runner version '\(runnerVersion)' (required minimum \(minimum))"]
+            )
+        }
+
+        if comparison == .orderedAscending {
+            return CompatibilityResult(
+                isCompatible: false,
+                reasons: ["runner version \(runnerVersion) < required minimum \(minimum)"]
+            )
+        }
+
+        return CompatibilityResult(isCompatible: true)
+    }
+
+    /// Whether `version` is a semver the gate can compare — used to reject a
+    /// malformed `minimumRunnerVersion` at manifest-ingest time.
+    static func isParseable(_ version: String) -> Bool {
+        VersionComparator().canParse(version)
+    }
+
+    /// Fold two verdicts: compatible only when both are; reasons concatenated.
+    static func combine(_ lhs: CompatibilityResult, _ rhs: CompatibilityResult) -> CompatibilityResult {
+        CompatibilityResult(
+            isCompatible: lhs.isCompatible && rhs.isCompatible,
+            reasons: lhs.reasons + rhs.reasons
+        )
+    }
+}

--- a/Sources/APIServer/Helpers/ManifestFieldEdits.swift
+++ b/Sources/APIServer/Helpers/ManifestFieldEdits.swift
@@ -72,3 +72,26 @@ func setManifestTimeLimitSeconds(
     }
     return seconds
 }
+
+/// Sets (or clears) the test setup's `minimumRunnerVersion` gate, saving only
+/// when it actually changes.  A blank/nil `version` clears the gate (the key is
+/// removed, matching `TestProperties.encodeIfPresent` which omits a nil value).
+/// A gated setup is only handed to a native runner whose advertised version is
+/// `>=` this value — see docs/runner-capability-profiles.md.  Returns the
+/// effective value (nil when cleared).
+func setManifestMinimumRunnerVersion(
+    setup: APITestSetup, to version: String?, on db: any Database
+) async throws -> String? {
+    let normalized = version?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let effective = (normalized?.isEmpty == false) ? normalized : nil
+    let dict = (try? JSONSerialization.jsonObject(with: Data(setup.manifest.utf8))) as? [String: Any]
+    guard (dict?["minimumRunnerVersion"] as? String) != effective else { return effective }
+    try await mutateManifest(setup: setup, on: db) { dict in
+        if let effective {
+            dict["minimumRunnerVersion"] = effective
+        } else {
+            dict.removeValue(forKey: "minimumRunnerVersion")
+        }
+    }
+    return effective
+}

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -204,6 +204,8 @@ enum MCPServerInstructions {
         update_suite, on a pattern family via create_pattern_family / update_pattern_family \
         (family-wide defaultTimeLimitSeconds and/or per-case timeLimitSeconds), and on a notebook \
         check via author_notebook_check — 0 clears an override), \
+        set_minimum_runner_version (the optional minimum native-runner version that may grade the \
+        assignment; a semver like "0.5.0", or null to clear — worker path only), \
         update_suite (script metadata). To add or change a GRADED test, prefer Chickadee's native \
         check types — update_pattern_family (edit a family's defaults/cases) / create_pattern_family \
         (add a new family) and author_notebook_check (create/replace a notebook check) — over a \
@@ -260,7 +262,8 @@ enum MCPServerInstructions {
         validation-only: it resolves the instructor's own reference-solution run and never exposes a \
         student submission, identity, or grade. \
         Metadata-only edits (update_assignment, set_grading_mode, set_time_limit, set_dataset, \
-        update_achievements, the section-organization tools) never trigger a regrade or a close. \
+        set_minimum_runner_version, update_achievements, the section-organization tools) never trigger \
+        a regrade or a close. \
         update_global_inputs and update_section_variables re-inline the shared inputs into the \
         affected scripts in place and likewise neither close nor regrade (matching the web Global \
         Inputs panel); re-run validate_assignment yourself after changing inputs that graded \

--- a/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetAssignmentTool.swift
@@ -30,6 +30,10 @@ struct GetAssignmentTool: ContentTool {
         /// (in-browser Pyodide). Read from the test setup's manifest
         /// (`TestProperties.gradingMode`, default "worker").
         let gradingMode: String
+        /// Optional minimum native-runner version required to grade this
+        /// assignment (semver, e.g. "0.5.0"); null when ungated. A submission is
+        /// only handed to a runner at or above this version. Worker path only.
+        let minimumRunnerVersion: String?
         /// The course section (assignment group, e.g. "Labs") this assignment
         /// belongs to, or nil when ungrouped. Manage with set_assignment_course_section.
         let sectionID: String?
@@ -51,7 +55,8 @@ struct GetAssignmentTool: ContentTool {
         + "\"browser\" = graded in-browser via Pyodide), the course section (assignment group "
         + "like \"Labs\") it belongs to (sectionID/sectionName, null when ungrouped), and "
         + "secretRevealEnabled (whether students may spend their one secret-reveal token to see "
-        + "secret-tier test results; set via the assignment-update tool)."
+        + "secret-tier test results; set via the assignment-update tool), and minimumRunnerVersion "
+        + "(the optional minimum native-runner version required to grade it, null when ungated)."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -77,6 +82,7 @@ struct GetAssignmentTool: ContentTool {
             "validationStatus": MCPSchema.string,
             "deadlineOverrideActive": MCPSchema.boolean,
             "gradingMode": MCPSchema.string,
+            "minimumRunnerVersion": MCPSchema.string,
             "sectionID": MCPSchema.string,
             "sectionName": MCPSchema.string,
             "secretRevealEnabled": MCPSchema.boolean,
@@ -96,11 +102,12 @@ struct GetAssignmentTool: ContentTool {
             throw MCPToolError.invalidArguments(
                 tool: Self.name, detail: "The assignment's course could not be found.")
         }
-        // Grading mode lives in the test setup's manifest; default to "worker"
-        // (TestProperties' own default) when the setup or manifest is missing.
-        let gradingMode =
-            (try await APITestSetup.find(assignment.testSetupID, on: context.db))?
-            .decodedManifest()?.gradingMode.rawValue ?? "worker"
+        // Grading mode + the minimum-runner-version gate live in the test setup's
+        // manifest; default to "worker" (TestProperties' own default) when the
+        // setup or manifest is missing.
+        let manifest = (try await APITestSetup.find(assignment.testSetupID, on: context.db))?
+            .decodedManifest()
+        let gradingMode = manifest?.gradingMode.rawValue ?? "worker"
 
         // Resolve the course section (assignment group) the assignment is in.
         var sectionName: String?
@@ -121,6 +128,7 @@ struct GetAssignmentTool: ContentTool {
             validationStatus: assignment.validationStatus,
             deadlineOverrideActive: assignment.deadlineOverrideActive ?? false,
             gradingMode: gradingMode,
+            minimumRunnerVersion: manifest?.minimumRunnerVersion,
             sectionID: assignment.sectionID?.uuidString,
             sectionName: sectionName,
             secretRevealEnabled: assignment.secretRevealEnabled == true

--- a/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetSuiteTool.swift
@@ -83,6 +83,9 @@ struct GetSuiteTool: ContentTool {
         /// The assignment-wide default per-test execution time limit (seconds).
         /// Every item without its own `timeLimitSeconds` override uses this.
         let timeLimitSeconds: Int
+        /// Optional minimum native-runner version required to grade this
+        /// assignment (semver, e.g. "0.5.0"); null when ungated. Worker path only.
+        let minimumRunnerVersion: String?
     }
 
     static let name = "get_suite"
@@ -97,7 +100,8 @@ struct GetSuiteTool: ContentTool {
         + "`author_script` / `update_suite`; generated rows list the file(s) they produce in "
         + "`generatedFilenames` (read-only — edit the family/check instead). The response also "
         + "reports the assignment's default per-test execution time limit (`timeLimitSeconds` at the "
-        + "top level) and any per-script override (`timeLimitSeconds` on a script item). Read-only — "
+        + "top level), any per-script override (`timeLimitSeconds` on a script item), and the optional "
+        + "minimum native-runner version gate (`minimumRunnerVersion`, null when ungated). Read-only — "
         + "use this to inspect exactly what each test checks (e.g. to explain why a submission lost "
         + "points) before editing the suite."
     static let inputSchema: JSONValue = .object([
@@ -117,6 +121,12 @@ struct GetSuiteTool: ContentTool {
                 "description": .string(
                     "The assignment-wide default per-test execution time limit (seconds); every item "
                         + "without its own override uses this."),
+            ]),
+            "minimumRunnerVersion": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Optional minimum native-runner version (semver) required to grade this "
+                        + "assignment; null when ungated."),
             ]),
             "sections": .object([
                 "type": .string("array"),
@@ -250,7 +260,8 @@ struct GetSuiteTool: ContentTool {
         let defaultTimeLimit = manifest?.timeLimitSeconds ?? 10
         return Output(
             assignmentPublicID: assignment.publicID, sections: sections, items: items,
-            timeLimitSeconds: defaultTimeLimit)
+            timeLimitSeconds: defaultTimeLimit,
+            minimumRunnerVersion: manifest?.minimumRunnerVersion)
     }
 
     private static func item(

--- a/Sources/APIServer/MCP/Tools/SetMinimumRunnerVersionTool.swift
+++ b/Sources/APIServer/MCP/Tools/SetMinimumRunnerVersionTool.swift
@@ -1,0 +1,92 @@
+// APIServer/MCP/Tools/SetMinimumRunnerVersionTool.swift
+//
+// Write tool: set (or clear) an assignment's minimum native-runner version
+// gate, by assignment public ID. content:write, course-scoped.
+//
+// The gate lives in the test setup's manifest (`minimumRunnerVersion`). When
+// set, the server only hands a submission for this assignment to a native
+// runner whose advertised version is >= the gate; otherwise the job waits in
+// the queue until a new-enough runner polls. Use it for a suite that depends on
+// behaviour only present in a newer runner build. Like set_time_limit and
+// set_grading_mode this is a grading-environment knob, not a change to what the
+// tests check, so it does NOT re-grade existing submissions, re-run validation,
+// or close the assignment. It gates only the native worker path — browser
+// grading runs the server's own vended bundle and has no runner version.
+//
+// Setting the gate can stall grading fleet-wide until a new-enough runner is
+// deployed, so it is an instructor-level operational knob (matching
+// set_grading_mode), not TA-level content authoring.
+
+import Core
+import Fluent
+import Foundation
+
+struct SetMinimumRunnerVersionTool: ContentTool {
+    struct Input: Decodable, Sendable {
+        let assignmentPublicID: String
+        /// Minimum runner version as a semver string (e.g. "0.5.0"). Null or an
+        /// empty string CLEARS the gate.
+        let minimumRunnerVersion: String?
+    }
+
+    struct Output: Encodable, Sendable {
+        let assignmentPublicID: String
+        /// The gate after the edit, or null when the assignment is ungated.
+        let minimumRunnerVersion: String?
+    }
+
+    static let name = "set_minimum_runner_version"
+    static let description =
+        "Set (or clear) an assignment's minimum native-runner version gate by its public ID. When "
+        + "set, a submission is only graded by a runner whose version is >= this value; otherwise it "
+        + "waits in the queue until a new-enough runner is available. Use it for a suite that relies "
+        + "on behaviour only present in a newer runner build. minimumRunnerVersion is a semver string "
+        + "like \"0.5.0\"; pass null or an empty string to clear the gate. Changing it is a "
+        + "grading-environment knob, not a change to what the tests check, so it does NOT re-grade "
+        + "existing submissions, re-run validation, or change the open/closed state (matching "
+        + "set_time_limit and set_grading_mode). It gates only the native worker path — browser-graded "
+        + "assignments have no runner version and are never gated. get_suite and get_assignment report "
+        + "the current value."
+    static let inputSchema: JSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.assignmentPublicID,
+            "minimumRunnerVersion": .object([
+                "type": .string("string"),
+                "description": .string(
+                    "Minimum runner version as a semver string (e.g. \"0.5.0\"). Null or an empty "
+                        + "string clears the gate."),
+            ]),
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+        "additionalProperties": .bool(false),
+    ])
+    static let outputSchema: JSONValue? = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "assignmentPublicID": MCPSchema.string,
+            "minimumRunnerVersion": MCPSchema.string,
+        ]),
+        "required": .array([.string("assignmentPublicID")]),
+    ])
+    static let annotations: MCPToolAnnotations? = MCPToolAnnotations(
+        readOnlyHint: false, destructiveHint: false, idempotentHint: true)
+    static let requiredScopes: Set<ContentScope> = [.write]
+
+    func execute(_ input: Input, _ context: ToolContext) async throws -> Output {
+        // Validate before the auth-load so a malformed version fails fast. A
+        // blank/nil value is not an error — it means "clear the gate".
+        let requested = input.minimumRunnerVersion?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let requested, !requested.isEmpty, !RunnerVersionGate.isParseable(requested) {
+            throw MCPToolError.invalidArguments(
+                tool: Self.name,
+                detail: "minimumRunnerVersion must be a version like \"0.5.0\" (got \"\(requested)\"); "
+                    + "pass null or an empty string to clear the gate.")
+        }
+        let (assignment, setup) = try await context.authorizedAssignmentAndSetupForWrite(
+            publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
+        let effective = try await setManifestMinimumRunnerVersion(
+            setup: setup, to: requested, on: context.db)
+        return Output(assignmentPublicID: assignment.publicID, minimumRunnerVersion: effective)
+    }
+}

--- a/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
+++ b/Sources/APIServer/MCP/Transport/MCPServerRegistration.swift
@@ -34,6 +34,7 @@ enum MCPToolCatalog {
             SetGradingModeTool().erased(),
             SetTimeLimitTool().erased(),
             SetDatasetTool().erased(),
+            SetMinimumRunnerVersionTool().erased(),
             UpdateSuiteTool().erased(),
             UpdateGlobalInputsTool().erased(),
             UpdateAchievementsTool().erased(),

--- a/Sources/APIServer/Routes/TestSetupRoutes.swift
+++ b/Sources/APIServer/Routes/TestSetupRoutes.swift
@@ -75,6 +75,18 @@ struct TestSetupRoutes: RouteCollection {
             throw AppError.unprocessable(reason: "Unsupported schemaVersion \(manifest.schemaVersion); expected 1")
         }
 
+        // Reject a malformed minimum-runner-version gate at the authoring seam so
+        // a typo can never silently strand submissions at claim time.  A blank
+        // value means "no gate" (matching `RunnerVersionGate`), so only a
+        // non-blank, unparseable string is an error.
+        if let minimumRunnerVersion = manifest.minimumRunnerVersion,
+            !minimumRunnerVersion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            !RunnerVersionGate.isParseable(minimumRunnerVersion)
+        {
+            throw AppError.unprocessable(
+                reason: "Invalid minimumRunnerVersion \"\(minimumRunnerVersion)\"; expected a version like \"0.5.0\"")
+        }
+
         // Validate the dependency graph (reference integrity + cycle detection).
         try validateManifestDependencies(manifest)
 

--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -107,7 +107,9 @@ func updateManifestAddingScript(
         datasets: props.datasets,
         // Preserve the recorded language: rebuilding the manifest to add or
         // remove one script must never silently drop it back to "unrecorded".
-        language: props.language
+        language: props.language,
+        // Likewise preserve the minimum-runner-version gate across the rebuild.
+        minimumRunnerVersion: props.minimumRunnerVersion
     )
 }
 
@@ -159,7 +161,9 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
         datasets: props.datasets,
         // Preserve the recorded language: rebuilding the manifest to add or
         // remove one script must never silently drop it back to "unrecorded".
-        language: props.language
+        language: props.language,
+        // Likewise preserve the minimum-runner-version gate across the rebuild.
+        minimumRunnerVersion: props.minimumRunnerVersion
     )
 }
 
@@ -178,7 +182,8 @@ func makeWorkerManifestJSON(
     disabledBuiltInAwardIDs: [String] = [],
     builtInAchievementsSeeded: Bool = false,
     datasets: [DatasetSpec] = [],
-    language: AssignmentLanguage? = nil
+    language: AssignmentLanguage? = nil,
+    minimumRunnerVersion: String? = nil
 ) throws -> String {
     // Topologically sort so the runner can process dependencies with a single
     // linear pass (parents always appear before children in the array).
@@ -201,6 +206,12 @@ func makeWorkerManifestJSON(
     // it — Python included — so the answer is stated, not re-inferred later.
     if let language {
         manifest["language"] = language.rawValue
+    }
+    // Optional minimum-runner-version gate.  Threaded through like `language`
+    // so a suite/script/family rebuild never silently un-gates an assignment;
+    // omitted (no gate) when nil/blank, matching `TestProperties.encodeIfPresent`.
+    if let minimumRunnerVersion, !minimumRunnerVersion.isEmpty {
+        manifest["minimumRunnerVersion"] = minimumRunnerVersion
     }
     try spliceEncodedArray(into: &manifest, key: "patternFamilies", values: patternFamilies)
     try spliceEncodedArray(into: &manifest, key: "notebookChecks", values: notebookChecks)

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -522,9 +522,21 @@ extension WorkerJobRoutes {
                 logger: req.logger
             )
 
-            let compatibilityResult = evaluator.compatibilityMatcher.evaluate(
+            let capabilityResult = evaluator.compatibilityMatcher.evaluate(
                 runnerProfile: runnerProfile,
                 requirements: requirementSpec
+            )
+            // Fold the manifest's optional `minimumRunnerVersion` gate into the
+            // same verdict so a version block rides the existing diagnostics /
+            // guard / blocked-candidate path.  Use the *merged* result below,
+            // not `capabilityResult`, or the diagnostics would report
+            // "compatible" while the job is actually blocked on version.
+            let compatibilityResult = RunnerVersionGate.combine(
+                capabilityResult,
+                RunnerVersionGate.evaluate(
+                    runnerVersion: body.runnerVersion,
+                    minimumRunnerVersion: manifest.minimumRunnerVersion
+                )
             )
             await req.application.diagnostics.recordCompatibilityDecision(
                 submission: submission,

--- a/Sources/APIServer/Utilities/PatternFamilyApplication.swift
+++ b/Sources/APIServer/Utilities/PatternFamilyApplication.swift
@@ -661,7 +661,9 @@ func applyPatternFamilies(  // swiftlint:disable:this function_body_length cyclo
         // which re-keys the runner's TestSetupCache and triggers one
         // revision-retest fan-out for that assignment — a bounded, one-time
         // cost accepted in exchange for the language never being re-inferred.
-        language: assignmentLanguage
+        language: assignmentLanguage,
+        // Preserve the minimum-runner-version gate across the family rebuild.
+        minimumRunnerVersion: props.minimumRunnerVersion
     )
 
     // Belt-and-suspenders: the post-expansion manifest is the one the runner

--- a/Sources/Core/TestProperties.swift
+++ b/Sources/Core/TestProperties.swift
@@ -332,6 +332,22 @@ public struct TestProperties: Codable, Equatable, Sendable {
     /// next save stamps a value.
     public let language: AssignmentLanguage?
 
+    /// Optional minimum `chickadee-runner` version required to grade this
+    /// assignment on the native worker path.  When set, the server only hands a
+    /// submission for this setup to a runner whose advertised
+    /// `ChickadeeVersion.current` is `>=` this value; otherwise the job stays
+    /// `pending` until a new-enough runner polls.  Use it for a suite that
+    /// depends on behaviour only present in a newer runner build.
+    ///
+    /// A plain semver string (e.g. `"0.5.0"`), parsed by the server's
+    /// `VersionComparator`.  `nil` — the default, and every manifest written
+    /// before this field existed — means no gate, and the enclosing manifest is
+    /// then byte-for-byte unchanged.  Purely a server-side dispatch gate: the
+    /// runner never needs it, so `runnerSanitized()` strips it via the memberwise
+    /// default (like `datasets` / `graderOnlyFiles`).  Does not apply to browser
+    /// grading (no runner version there); it only bites the worker path.
+    public let minimumRunnerVersion: String?
+
     public init(
         schemaVersion: Int = 1,
         gradingMode: GradingMode = .worker,
@@ -341,6 +357,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         makefile: MakefileConfig? = nil,
         starterNotebook: String? = nil,
         language: AssignmentLanguage? = nil,
+        minimumRunnerVersion: String? = nil,
         patternFamilies: [PatternFamily] = [],
         notebookChecks: [NotebookCheck] = [],
         sections: [TestSuiteSection] = [],
@@ -361,6 +378,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         self.makefile = makefile
         self.starterNotebook = starterNotebook
         self.language = language
+        self.minimumRunnerVersion = minimumRunnerVersion
         // `testItems` wins when supplied; otherwise synthesize it from the
         // legacy `patternFamilies` / `notebookChecks` arguments (families
         // first, then checks) so every existing call site keeps working.
@@ -390,6 +408,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         // Absent on every manifest written before the language became
         // first-class; nil falls back to sniffing the suite.
         language = try c.decodeIfPresent(AssignmentLanguage.self, forKey: .language)
+        minimumRunnerVersion = try c.decodeIfPresent(String.self, forKey: .minimumRunnerVersion)
         // `testItems` is the canonical unified list when present.  A legacy
         // manifest carries the separate `patternFamilies` / `notebookChecks`
         // arrays instead — migrate them on read.  (An explicitly-empty
@@ -431,6 +450,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         case makefile
         case starterNotebook
         case language
+        case minimumRunnerVersion
         case testItems
         case patternFamilies
         case notebookChecks
@@ -456,6 +476,7 @@ public struct TestProperties: Codable, Equatable, Sendable {
         // encodeIfPresent, not encode: an assignment with no recorded language
         // must produce the exact bytes it always has.
         try c.encodeIfPresent(language, forKey: .language)
+        try c.encodeIfPresent(minimumRunnerVersion, forKey: .minimumRunnerVersion)
         try c.encode(testItems, forKey: .testItems)
         // Mirror the legacy arrays (derived from `testItems`, so they can
         // never drift) for cross-version readers that predate `testItems`.

--- a/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
+++ b/Tests/APITests/ArchivedCourseLifecycleRouteTests.swift
@@ -258,6 +258,49 @@ import VaporTesting
         }
     }
 
+    @Test func uploadRejectsUnparseableMinimumRunnerVersion() async throws {
+        try await withApp(app) { _ in
+            let fx = try await setupInstructorWithBothCourses(activeCode: "LCMV", archivedCode: "LCMW")
+
+            // Auth passes for the active course, so manifest validation runs: an
+            // unparseable minimumRunnerVersion gate is rejected (422) before the
+            // zip is even written — mirroring the schemaVersion guard beside it.
+            let boundary = "LCMinVer"
+            let manifest =
+                #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"t.sh"}],"timeLimitSeconds":10,"minimumRunnerVersion":"not-a-version","makefile":null}"#
+            var body = ByteBufferAllocator().buffer(capacity: 512)
+            body.writeString("--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"_csrf\"\r\n\r\n")
+            body.writeString(fx.csrf)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"manifest\"\r\n\r\n")
+            body.writeString(manifest)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString("Content-Disposition: form-data; name=\"courseID\"\r\n\r\n")
+            body.writeString(fx.active.courseID.uuidString)
+            body.writeString("\r\n--\(boundary)\r\n")
+            body.writeString(
+                "Content-Disposition: form-data; name=\"files\"; filename=\"setup.zip\"\r\n"
+                    + "Content-Type: application/zip\r\n\r\n")
+            body.writeString("PK")
+            body.writeString("\r\n--\(boundary)--\r\n")
+
+            try await app.asyncTest(
+                .POST, "/api/v1/testsetups",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: fx.sessionCookie)
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data", parameters: ["boundary": boundary])
+                    req.body = .init(buffer: body)
+                },
+                afterResponse: { res in
+                    #expect(
+                        res.status == .unprocessableEntity,
+                        "unparseable minimumRunnerVersion must be rejected, got \(res.status)")
+                })
+        }
+    }
+
     // MARK: - updateNewAssignmentDraft — a foreign/archived course's draft by draftID
 
     @Test func updateNewAssignmentDraftBlockedForArchivedCourseDraft() async throws {

--- a/Tests/APITests/AssignmentHelpersManifestTests.swift
+++ b/Tests/APITests/AssignmentHelpersManifestTests.swift
@@ -235,6 +235,42 @@ final class AssignmentHelpersManifestTests {
         #expect(props.testSuites.first(where: { $0.script == "01_public.py" })?.sectionID == "sec-1")
     }
 
+    // Regression: rebuilding the manifest to add or remove a script must preserve
+    // the optional minimumRunnerVersion gate. makeWorkerManifestJSON builds a
+    // fresh dict, so an un-threaded field would silently un-gate the assignment
+    // on the next script edit.
+    @Test func updateManifestScriptEditsPreserveMinimumRunnerVersion() throws {
+        let original = try makeWorkerManifestJSON(
+            testSuites: [
+                ConfiguredSuiteEntry(
+                    script: "01_public.py", tier: "public", order: 1,
+                    dependsOn: [], points: 1, displayName: nil)
+            ],
+            includeMakefile: false,
+            minimumRunnerVersion: "0.5.0"
+        )
+        // Sanity: the builder emitted the gate.
+        #expect(
+            try JSONDecoder().decode(TestProperties.self, from: Data(original.utf8))
+                .minimumRunnerVersion == "0.5.0")
+
+        let added = try #require(
+            updateManifestAddingScript(
+                manifestJSON: original,
+                entry: ConfiguredSuiteEntry(
+                    script: "02_public.py", tier: "public", order: 99,
+                    dependsOn: [], points: 1, displayName: nil)))
+        #expect(
+            try JSONDecoder().decode(TestProperties.self, from: Data(added.utf8))
+                .minimumRunnerVersion == "0.5.0")
+
+        let removed = try #require(
+            updateManifestRemovingScript(manifestJSON: added, filename: "02_public.py"))
+        #expect(
+            try JSONDecoder().decode(TestProperties.self, from: Data(removed.utf8))
+                .minimumRunnerVersion == "0.5.0")
+    }
+
     @Test func detectRequirementSuggestionsIgnoresSolutionNotebookImports() throws {
         let zipPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("detect-requirements-\(UUID().uuidString).zip")

--- a/Tests/APITests/MCP/MCPContentEditCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPContentEditCoverageTests.swift
@@ -64,6 +64,9 @@ import Testing
         "SetGradingModeTool.swift",
         // Time limits are enforced at run time; no content change.
         "SetTimeLimitTool.swift",
+        // Minimum-runner-version gate: changes which runner may grade, not what
+        // the suite grades; enforced server-side at claim time. No close/regrade.
+        "SetMinimumRunnerVersionTool.swift",
         // Dataset marks change delivery (per-student slices), not the graded
         // suite; mirrors the web PUT /datasets endpoint, which neither closes
         // nor regrades. Slices apply on the next (re)grade.

--- a/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
+++ b/Tests/APITests/MCP/MCPOutputSchemaSyncTests.swift
@@ -70,6 +70,11 @@ import Testing
                     datasets: [SetDatasetTool.DatasetEntry(file: "cases.csv", sampleSize: 100)])
             ),
             (
+                SetMinimumRunnerVersionTool.name, SetMinimumRunnerVersionTool.outputSchema,
+                SetMinimumRunnerVersionTool.Output(
+                    assignmentPublicID: "abc123", minimumRunnerVersion: "0.5.0")
+            ),
+            (
                 AuthorScriptTool.name, AuthorScriptTool.outputSchema,
                 AuthorScriptTool.Output(
                     assignmentPublicID: "abc123", filename: "test_x.py", tier: "public",

--- a/Tests/APITests/MCP/SetMinimumRunnerVersionToolTests.swift
+++ b/Tests/APITests/MCP/SetMinimumRunnerVersionToolTests.swift
@@ -1,0 +1,151 @@
+// Tests for SetMinimumRunnerVersionTool (set/clear an assignment's minimum
+// native-runner version gate), backed by a real test database. Mirrors
+// SetTimeLimitToolTests: metadata-only (no close), validation, enrollment +
+// the `.instructor` role floor, and the get_suite / get_assignment read echo.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct SetMinimumRunnerVersionToolTests {
+    private func context(_ app: Application) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: "tester",
+            grantedScopes: [.read, .write]
+        )
+    }
+
+    private let manifest =
+        #"{"schemaVersion":1,"gradingMode":"worker","testSuites":[],"timeLimitSeconds":10}"#
+
+    /// A live course + setup + assignment, with `tester` (a *global student*)
+    /// enrolled at the given per-course role.
+    private func fixture(
+        on app: Application, role: CourseRole = .instructor, enroll: Bool = true
+    ) async throws -> APIAssignment {
+        let course = try await makeTestCourse(on: app, code: "CS241", name: "Systems")
+        let courseID = try course.requireID()
+        let tester = try await makeTestUser(on: app, username: "tester", role: "student")
+        if enroll {
+            try await APICourseEnrollment(userID: try tester.requireID(), courseID: courseID, role: role)
+                .save(on: app.db)
+        }
+        try await makeTestSetup(on: app, id: "setup_mrv", courseID: courseID, manifest: manifest)
+        return try await makeTestAssignment(
+            on: app, testSetupID: "setup_mrv", courseID: courseID, title: "Lab")
+    }
+
+    @Test func setsGateWithoutClosing() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            #expect(assignment.visibility == .open)
+
+            let out = try await SetMinimumRunnerVersionTool().execute(
+                .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "0.5.0"),
+                context(app))
+            #expect(out.minimumRunnerVersion == "0.5.0")
+
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(setup.decodedManifest()?.minimumRunnerVersion == "0.5.0")
+            // Metadata-style edit: the assignment stays open, not closed.
+            let reloaded = try #require(try await APIAssignment.find(assignment.id, on: app.db))
+            #expect(reloaded.visibility == .open)
+        }
+    }
+
+    @Test func clearsGateOnNull() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await SetMinimumRunnerVersionTool().execute(
+                .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "0.5.0"),
+                context(app))
+
+            let cleared = try await SetMinimumRunnerVersionTool().execute(
+                .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: nil),
+                context(app))
+            #expect(cleared.minimumRunnerVersion == nil)
+
+            let setup = try #require(try await APITestSetup.find(assignment.testSetupID, on: app.db))
+            #expect(setup.decodedManifest()?.minimumRunnerVersion == nil)
+            // The key is removed entirely, not written as null/empty.
+            let dict = try #require(
+                try JSONSerialization.jsonObject(with: Data(setup.manifest.utf8)) as? [String: Any])
+            #expect(!dict.keys.contains("minimumRunnerVersion"))
+        }
+    }
+
+    @Test func clearsGateOnBlankString() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await SetMinimumRunnerVersionTool().execute(
+                .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "0.5.0"),
+                context(app))
+            let cleared = try await SetMinimumRunnerVersionTool().execute(
+                .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "  "),
+                context(app))
+            #expect(cleared.minimumRunnerVersion == nil)
+        }
+    }
+
+    @Test func rejectsUnparseableVersion() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetMinimumRunnerVersionTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "not-a-version"),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesWhenSubjectNotEnrolled() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, enroll: false)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetMinimumRunnerVersionTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "0.5.0"),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func deniesTABelowInstructorFloor() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app, role: .ta)
+            await #expect(throws: MCPToolError.self) {
+                _ = try await SetMinimumRunnerVersionTool().execute(
+                    .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "0.5.0"),
+                    context(app))
+            }
+        }
+    }
+
+    @Test func readToolsEchoTheGate() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            _ = try await SetMinimumRunnerVersionTool().execute(
+                .init(assignmentPublicID: assignment.publicID, minimumRunnerVersion: "0.5.0"),
+                context(app))
+
+            let suite = try await GetSuiteTool().execute(
+                .init(assignmentPublicID: assignment.publicID), context(app))
+            #expect(suite.minimumRunnerVersion == "0.5.0")
+
+            let info = try await GetAssignmentTool().execute(
+                .init(assignmentPublicID: assignment.publicID), context(app))
+            #expect(info.minimumRunnerVersion == "0.5.0")
+        }
+    }
+}

--- a/Tests/APITests/RunnerCompatibilityTests.swift
+++ b/Tests/APITests/RunnerCompatibilityTests.swift
@@ -227,15 +227,83 @@ import VaporTesting
         }
     }
 
+    // MARK: - Minimum runner-version gate (manifest `minimumRunnerVersion`)
+
+    @Test func oldRunnerBelowMinimumVersionIsNotClaimed() async throws {
+        try await withApp(app) { _ in
+            let setup = try await makeSetup(id: "compat_minver_blocked", minimumRunnerVersion: "0.5.0")
+            _ = try await makeAssignment(setupID: setup.requireID(), title: "Needs New Runner")
+            let submission = try await makeSubmission(id: "compat_minver_sub_blocked", setupID: setup.requireID())
+
+            let response = try await requestJob(
+                workerID: "runner-old", profile: nil, runnerVersion: "0.4.0")
+            #expect(response.status == .noContent)
+
+            let reloaded = try await APISubmission.find(try submission.requireID(), on: app.db)
+            #expect(reloaded?.status == "pending")
+
+        }
+    }
+
+    @Test func runnerAtOrAboveMinimumVersionClaimsJob() async throws {
+        try await withApp(app) { _ in
+            let setup = try await makeSetup(id: "compat_minver_ok", minimumRunnerVersion: "0.5.0")
+            _ = try await makeAssignment(setupID: setup.requireID(), title: "Needs New Runner OK")
+            let submission = try await makeSubmission(id: "compat_minver_sub_ok", setupID: setup.requireID())
+
+            let response = try await requestJob(
+                workerID: "runner-new", profile: nil, runnerVersion: "0.5.0")
+            #expect(response.status == .ok)
+            #expect(try response.content.decode(Job.self).submissionID == submission.id)
+
+        }
+    }
+
+    @Test func ungatedAssignmentClaimsRegardlessOfRunnerVersion() async throws {
+        try await withApp(app) { _ in
+            // No `minimumRunnerVersion`: the gate short-circuits before parsing,
+            // so even a non-semver runner version claims (byte-for-byte-unchanged
+            // behaviour for existing assignments).
+            let setup = try await makeSetup(id: "compat_minver_none")
+            _ = try await makeAssignment(setupID: setup.requireID(), title: "Ungated")
+            let submission = try await makeSubmission(id: "compat_minver_sub_none", setupID: setup.requireID())
+
+            let response = try await requestJob(
+                workerID: "runner-weirdver", profile: nil, runnerVersion: "runner-tests/1.0")
+            #expect(response.status == .ok)
+            #expect(try response.content.decode(Job.self).submissionID == submission.id)
+
+        }
+    }
+
+    @Test func oldRunnerSkipsThenNewRunnerClaimsGatedJob() async throws {
+        try await withApp(app) { _ in
+            let setup = try await makeSetup(id: "compat_minver_seq", minimumRunnerVersion: "0.5.0")
+            _ = try await makeAssignment(setupID: setup.requireID(), title: "Sequential Gate")
+            let submission = try await makeSubmission(id: "compat_minver_sub_seq", setupID: setup.requireID())
+
+            let first = try await requestJob(
+                workerID: "runner-old-seq", profile: nil, runnerVersion: "0.4.999")
+            #expect(first.status == .noContent)
+
+            let second = try await requestJob(
+                workerID: "runner-new-seq", profile: nil, runnerVersion: "0.5.0")
+            #expect(second.status == .ok)
+            #expect(try second.content.decode(Job.self).submissionID == submission.id)
+
+        }
+    }
+
     private func requestJob(
         workerID: String,
-        profile: RunnerCapabilityProfile?
+        profile: RunnerCapabilityProfile?,
+        runnerVersion: String = "runner-tests/1.0"
     ) async throws -> TestingHTTPResponse {
         let path = "/api/v1/worker/request"
         let payload = WorkerActivityPayload(
             workerID: workerID,
             hostname: "\(workerID).local",
-            runnerVersion: "runner-tests/1.0",
+            runnerVersion: runnerVersion,
             maxConcurrentJobs: 1,
             activeJobs: 0,
             profile: profile
@@ -268,13 +336,17 @@ import VaporTesting
             })
     }
 
-    private func makeSetup(id: String) async throws -> APITestSetup {
+    private func makeSetup(id: String, minimumRunnerVersion: String? = nil) async throws -> APITestSetup {
         let course = APICourse(code: "COMP_\(id)", name: "Compatibility", enrollmentMode: .closed)
         try await course.save(on: app.db)
+        var fields =
+            #""schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10"#
+        if let minimumRunnerVersion {
+            fields += #","minimumRunnerVersion":"\#(minimumRunnerVersion)""#
+        }
         let setup = APITestSetup(
             id: id,
-            manifest:
-                #"{"schemaVersion":1,"gradingMode":"worker","requiredFiles":[],"testSuites":[{"tier":"public","script":"test.sh"}],"timeLimitSeconds":10}"#,
+            manifest: "{\(fields)}",
             zipPath: "/tmp/\(id).zip",
             courseID: try course.requireID()
         )

--- a/Tests/APITests/RunnerVersionGateTests.swift
+++ b/Tests/APITests/RunnerVersionGateTests.swift
@@ -1,0 +1,74 @@
+// Tests/APITests/RunnerVersionGateTests.swift
+//
+// Unit tests for the manifest minimumRunnerVersion gate (RunnerVersionGate):
+// a nil/blank minimum short-circuits without parsing the runner version (the
+// property that keeps un-gated assignments — and non-semver mock runners —
+// unaffected), the numeric comparison, fail-closed on an unparseable version
+// when a gate is set, isParseable, and the combine() merge used at the claim
+// seam.
+
+import Core
+import Testing
+
+@testable import APIServer
+
+@Suite struct RunnerVersionGateTests {
+
+    @Test func nilMinimumIsCompatibleWithoutParsingRunnerVersion() {
+        // A non-semver runner version must still pass when there's no gate — the
+        // short-circuit is what keeps existing/mock runners unaffected.
+        let result = RunnerVersionGate.evaluate(
+            runnerVersion: "runner/1.0", minimumRunnerVersion: nil)
+        #expect(result.isCompatible)
+        #expect(result.reasons.isEmpty)
+    }
+
+    @Test func blankMinimumIsCompatible() {
+        #expect(
+            RunnerVersionGate.evaluate(runnerVersion: "0.4.0", minimumRunnerVersion: "   ").isCompatible)
+        #expect(
+            RunnerVersionGate.evaluate(runnerVersion: "0.4.0", minimumRunnerVersion: "").isCompatible)
+    }
+
+    @Test func runnerAtOrAboveMinimumIsCompatible() {
+        #expect(
+            RunnerVersionGate.evaluate(runnerVersion: "0.5.0", minimumRunnerVersion: "0.5.0").isCompatible)
+        #expect(
+            RunnerVersionGate.evaluate(runnerVersion: "0.6.1", minimumRunnerVersion: "0.5.0").isCompatible)
+        #expect(
+            RunnerVersionGate.evaluate(runnerVersion: "1.0.0", minimumRunnerVersion: "0.5.0").isCompatible)
+    }
+
+    @Test func runnerBelowMinimumIsIncompatibleWithReason() {
+        let result = RunnerVersionGate.evaluate(
+            runnerVersion: "0.4.639", minimumRunnerVersion: "0.5.0")
+        #expect(!result.isCompatible)
+        #expect(result.reasons.contains { $0.contains("0.4.639") && $0.contains("0.5.0") })
+    }
+
+    @Test func unparseableRunnerVersionFailsClosed() {
+        let result = RunnerVersionGate.evaluate(
+            runnerVersion: "runner/1.0", minimumRunnerVersion: "0.5.0")
+        #expect(!result.isCompatible)
+        #expect(result.reasons.contains { $0.contains("unparseable") })
+    }
+
+    @Test func isParseableMatchesVersionComparator() {
+        #expect(RunnerVersionGate.isParseable("0.5.0"))
+        #expect(RunnerVersionGate.isParseable("1.2.3.4"))
+        #expect(!RunnerVersionGate.isParseable("runner/1.0"))
+        #expect(!RunnerVersionGate.isParseable(""))
+        #expect(!RunnerVersionGate.isParseable("v1.2"))
+    }
+
+    @Test func combineMergesCompatibilityAndReasons() {
+        let ok = CompatibilityResult(isCompatible: true)
+        #expect(RunnerVersionGate.combine(ok, ok).isCompatible)
+
+        let merged = RunnerVersionGate.combine(
+            CompatibilityResult(isCompatible: false, reasons: ["a"]),
+            CompatibilityResult(isCompatible: false, reasons: ["nope"]))
+        #expect(!merged.isCompatible)
+        #expect(merged.reasons == ["a", "nope"])
+    }
+}

--- a/Tests/CoreTests/MinimumRunnerVersionTests.swift
+++ b/Tests/CoreTests/MinimumRunnerVersionTests.swift
@@ -1,0 +1,45 @@
+// Tests/CoreTests/MinimumRunnerVersionTests.swift
+//
+// Pins the optional minimumRunnerVersion manifest gate: Codable back-compat (a
+// manifest without the key decodes to nil), the round-trip, that a nil gate
+// emits no key at all (byte-identity for un-gated manifests), and the
+// runnerSanitized() strip (the gate is a server-side dispatch concern the
+// runner never sees — enforcement runs at claim time before the Job is built).
+
+import Foundation
+import Testing
+
+@testable import Core
+
+@Suite struct MinimumRunnerVersionTests {
+
+    @Test func manifestWithoutMinimumRunnerVersionDecodesNil() throws {
+        let json = #"{"schemaVersion":1}"#
+        let decoded = try JSONDecoder().decode(TestProperties.self, from: Data(json.utf8))
+        #expect(decoded.minimumRunnerVersion == nil)
+    }
+
+    @Test func minimumRunnerVersionRoundTrips() throws {
+        let manifest = TestProperties(minimumRunnerVersion: "0.5.0")
+        let data = try JSONEncoder().encode(manifest)
+        let decoded = try JSONDecoder().decode(TestProperties.self, from: data)
+        #expect(decoded.minimumRunnerVersion == "0.5.0")
+    }
+
+    /// A nil gate must emit no `minimumRunnerVersion` key, so an un-gated
+    /// manifest is byte-for-byte what it always was (encodeIfPresent).
+    @Test func nilMinimumRunnerVersionEncodesNoKey() throws {
+        let data = try JSONEncoder().encode(TestProperties())
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(!object.keys.contains("minimumRunnerVersion"))
+    }
+
+    @Test func runnerSanitizedStripsMinimumRunnerVersion() {
+        let manifest = TestProperties(minimumRunnerVersion: "0.5.0")
+        #expect(manifest.runnerSanitized().minimumRunnerVersion == nil)
+    }
+
+    @Test func nilByDefault() {
+        #expect(TestProperties().minimumRunnerVersion == nil)
+    }
+}

--- a/Tests/CoreTests/RunnerSanitizedProjectionTests.swift
+++ b/Tests/CoreTests/RunnerSanitizedProjectionTests.swift
@@ -67,6 +67,9 @@ struct RunnerSanitizedProjectionTests {
             timeLimitSeconds: 30,
             makefile: MakefileConfig(target: "all"),
             starterNotebook: "assignment.ipynb",
+            // Non-nil so the strip is actually exercised: runnerSanitized() must
+            // drop this (server-side gate), keeping the key out of the pinned set.
+            minimumRunnerVersion: "0.5.0",
             patternFamilies: [
                 PatternFamily(
                     id: "fam", name: "Family", kind: .boundaryEquality,

--- a/changelog.d/runner-version-gate.md
+++ b/changelog.d/runner-version-gate.md
@@ -1,0 +1,13 @@
+### Added
+
+- **Optional minimum-runner-version gate in the manifest.** A test setup's
+  manifest may now carry an optional `minimumRunnerVersion`
+  (`TestProperties.minimumRunnerVersion`): when set, the server only hands a
+  submission to a native runner whose advertised version is at or above it, so a
+  suite that depends on a newer runner build is never graded by an older worker.
+  It is enforced server-side at job-claim time (a blocked job simply stays queued
+  until a new-enough runner polls) and stripped from the runner-facing manifest,
+  so existing un-gated assignments are byte-for-byte unchanged. Authorable over
+  MCP via the new `set_minimum_runner_version` tool and reported by `get_suite`
+  / `get_assignment`. Worker path only — browser-graded assignments have no
+  runner version and are never gated.

--- a/docs/mcp-authoring-roadmap.md
+++ b/docs/mcp-authoring-roadmap.md
@@ -51,6 +51,7 @@ The catalog:
 | `set_grading_mode` | `content:write` | Set an assignment's grading path (worker vs browser); no regrade/close |
 | `set_time_limit` | `content:write` | Set the assignment-wide (or per-test) execution time limit; no regrade/close |
 | `set_dataset` | `content:write` | Mark a support file as a per-student dataset (per-seed row sample under the same filename) or clear the mark; no regrade/close |
+| `set_minimum_runner_version` | `content:write` | Set (or clear) the minimum native-runner version that may grade the assignment (semver); server-side claim-time gate, worker path only; no regrade/close |
 | `update_suite` | `content:write` | Script metadata: tier, points, displayName, dependsOn, section |
 | `update_global_inputs` | `content:write` | Replace the assignment's global personalization variables/expressions |
 | `update_achievements` | `content:write` | Replace the assignment's composable awards (display-only; no regrade/close) |

--- a/docs/runner-capability-profiles.md
+++ b/docs/runner-capability-profiles.md
@@ -116,6 +116,43 @@ incompatible, for example:
 - `missing capability pandas`
 - `architecture arm64 != required x86_64`
 - `runner profile unavailable`
+- `runner version 0.4.639 < required minimum 0.5.0`
+
+## Minimum Runner Version Gate (manifest)
+
+Separate from the capability profile above, a test setup's **manifest** may carry
+an optional `minimumRunnerVersion` (`TestProperties.minimumRunnerVersion`). It
+gates on the runner's *Chickadee build version* — `ChickadeeVersion.current`,
+advertised as `runnerVersion` on every poll — rather than on installed platform /
+language / package capabilities. Use it when a suite depends on behaviour only
+present in a newer `chickadee-runner` build.
+
+- **Optional and opt-in.** `nil` (every manifest written before the field, and
+  every un-gated assignment) means no gate, and the manifest is byte-for-byte
+  unchanged. A plain semver string like `"0.5.0"` enables it.
+- **Enforced server-side at claim time.** The same `POST /api/v1/worker/request`
+  claim path that runs capability matching also compares the polling runner's
+  advertised version against the gate; the two verdicts are merged, so a version
+  block surfaces through the identical diagnostics
+  (`no_compatible_runner_available`) and leaves the submission `pending` until a
+  new-enough runner polls. It is deliberately *not* a runner-side check: an older
+  runner has no gate code, so only the server can reliably keep old runners off a
+  gated job.
+- **Fail-closed on an unparseable runner version**, but only when a gate is set;
+  a `nil`/blank gate short-circuits without parsing, so un-gated assignments —
+  and runners advertising a non-semver version — are unaffected.
+- **Worker path only.** Browser (`gradingMode: browser`) grading runs the
+  server's own vended WASM bundle, which has no runner version, so the gate never
+  applies there (it can still bite a browser submission that fails over to the
+  worker backstop).
+- **Stripped from the runner-facing manifest.** The gate is a server-side
+  dispatch concern; `runnerSanitized()` drops it, so the runner never receives it
+  and old runners can't choke on it.
+
+Authoring: set or clear it over MCP with `set_minimum_runner_version` (a
+metadata-only edit — no regrade or close), or include it in the uploaded manifest
+/ a `.chickadee` course bundle. A malformed value is rejected at upload time.
+`get_suite` and `get_assignment` report the current value.
 
 ## Rollout And Backwards Compatibility
 


### PR DESCRIPTION
## Summary

Adds an **optional** `minimumRunnerVersion` to the test-setup manifest (`TestProperties`). When set, a submission for that setup is only handed to a native runner whose advertised version (`ChickadeeVersion.current`) is `>=` the minimum; otherwise the job stays `pending` until a new-enough runner polls. When unset — the default, and every existing manifest — nothing is gated and the manifest is byte-for-byte unchanged.

Use it for a suite that depends on behaviour only present in a newer `chickadee-runner` build.

## Why server-side, at claim time

A runner *older* than the release that introduces this feature has no gate code, so a runner-side check couldn't exclude the very runners the gate exists to exclude (and would strand the job in `assigned` until the reaper). The server sees the runner's advertised version on every poll, so it is the only place that can gate reliably. The gate reuses the existing capability-matching seam (`evaluateAndClaimCandidate`): the version verdict is merged into the same `CompatibilityResult`, so a version block rides the identical `guard` / diagnostics (`no_compatible_runner_available`) / blocked-candidate path.

Scope: **native worker path only**. Browser (`gradingMode: browser`) grading runs the server's own vended WASM bundle, which has no runner version, so it is never gated.

## Changes

- **Core** (`TestProperties`): new optional `minimumRunnerVersion: String?`, mirroring `language` (memberwise default nil, `decodeIfPresent` / `encodeIfPresent`). Stripped by `runnerSanitized()` — a server-side dispatch concern the runner never sees, so old runners can't choke on it.
- **Server** (`RunnerVersionGate` + `WorkerJobRoutes`): a small gate reusing the existing `VersionComparator`. A `nil`/blank minimum short-circuits *without parsing* the runner version (so un-gated assignments and non-semver mock runners are unaffected); a set gate fails **closed** on an unparseable version. Malformed values are rejected at upload time (`TestSetupRoutes`).
- **MCP**: new metadata-only `set_minimum_runner_version` tool (`.instructor` floor; null/empty clears the gate); `get_suite` / `get_assignment` report the value. Instructions text, roadmap doc, and the close-on-edit / output-schema coverage guards are updated.
- **Manifest rebuild paths**: `makeWorkerManifestJSON` gains the field, threaded through the three rebuild-from-existing sites (script add/remove, `applyPatternFamilies`) so a suite edit can't silently drop a set gate. The raw-dict edit paths (MCP setters, dataset/notebook-scaffold endpoints) already preserve unknown keys.
- **Docs**: new section in `docs/runner-capability-profiles.md`; changelog fragment.

## Testing

All green locally (Postgres-backed suites included):

- Core codable: round-trip, decode-absent → nil, nil encodes no key (byte-identity), `runnerSanitized()` strip.
- `RunnerVersionGate` unit: nil short-circuit, numeric compare, fail-closed on unparseable, `combine`.
- Claim-path integration (`RunnerCompatibilityTests`): old runner → 204 and submission stays `pending`; at-or-above → claims; ungated + non-semver runner → claims; old-skips-then-new-claims.
- Upload ingest: an unparseable `minimumRunnerVersion` → 422.
- Rebuild preservation across a script add/remove.
- MCP tool: set/clear, assignment not closed, unparseable rejection, enrollment + `.instructor` role floor, `get_suite` / `get_assignment` echo.
- `swift-format` + SwiftLint `--strict` clean; the MCP catalog / instructions / roadmap sync guards pass.

Per the release process, this PR intentionally does not touch `VERSION`, `Sources/Core/ChickadeeVersion.swift`, or `CHANGELOG.md` — it adds a `changelog.d/` fragment instead.

## Follow-ups (out of scope)

- A proactive `no-runner` validation label when no *active* runner satisfies the gate (v1 relies on the existing `no_compatible_runner_available` claim-time signal; the claim gate is already the correctness guarantee).
- A web suite-editor field to set the gate in-browser (MCP + upload cover authoring for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzKTmdh69LLDCKxPw29heh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BzKTmdh69LLDCKxPw29heh)_