### PR TITLE
Fix every escape in the R runtime's JSON result formatter, and add an R-support handoff doc

### DIFF
--- a/Sources/Worker/TestRuntimeSources.swift
+++ b/Sources/Worker/TestRuntimeSources.swift
@@ -437,11 +437,11 @@ private let testRuntimeRHelpers = #"""
 
     .chickadee_json_str <- function(x) {
         x <- as.character(x)
-        x <- gsub("\\\\", "\\\\\\\\", x, fixed = TRUE)
-        x <- gsub('"',    '\\\\"',    x, fixed = TRUE)
-        x <- gsub("\n",   "\\\\n",    x, fixed = TRUE)
-        x <- gsub("\r",   "\\\\r",    x, fixed = TRUE)
-        x <- gsub("\t",   "\\\\t",    x, fixed = TRUE)
+        x <- gsub("\\", "\\\\", x, fixed = TRUE)
+        x <- gsub('"',    '\\"',    x, fixed = TRUE)
+        x <- gsub("\n",   "\\n",    x, fixed = TRUE)
+        x <- gsub("\r",   "\\r",    x, fixed = TRUE)
+        x <- gsub("\t",   "\\t",    x, fixed = TRUE)
         paste0('"', x, '"')
     }
 

--- a/Tests/WorkerTests/RRuntimeJSONEscapingTests.swift
+++ b/Tests/WorkerTests/RRuntimeJSONEscapingTests.swift
@@ -1,0 +1,115 @@
+// Tests/WorkerTests/RRuntimeJSONEscapingTests.swift
+//
+// The R runtime hand-formats its result JSON (base R has no jsonlite), so
+// `.chickadee_json_str` is the only thing standing between a test message and a
+// malformed result line. It had two bugs that hid for months because they only
+// bite on particular characters:
+//
+//   * the backslash escape searched for a DOUBLE backslash, so a single `\` in
+//     a message passed through unescaped and the line was invalid JSON. The
+//     interpreter then fell back to "last line as plain text" and the student
+//     saw the whole `{"status":...}` blob as their result. Regex-based
+//     `cell_contains` checks put backslashes in messages routinely.
+//   * the quote / newline / CR / tab replacements were each one backslash too
+//     many, because `gsub(..., fixed = TRUE)` uses the replacement LITERALLY —
+//     no backreference processing. A quote emitted `\\"`, which terminates the
+//     JSON string early; a newline emitted `\\n`, which parses but renders to
+//     the student as a literal "\n" instead of a line break.
+//
+// These run the real canonical runtime under Rscript and parse what it prints,
+// so the assertions are about observable output rather than the source text.
+
+import Foundation
+import Testing
+
+@testable import chickadee_runner
+
+@Suite(.serialized, .timeLimit(.minutes(2))) struct RRuntimeJSONEscapingTests {
+
+    private static var hasRscript: Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["Rscript", "--version"]
+        proc.standardOutput = Pipe()
+        proc.standardError = Pipe()
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+            return proc.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    /// Runs `passed(<message>)` under the composed runtime and returns the
+    /// decoded last stdout line — i.e. exactly what the result interpreter sees.
+    private func emit(_ rMessageLiteral: String) throws -> [String: Any]? {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("ck-rjson-\(UUID().uuidString)")
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: dir) }
+
+        try testRuntimeR.write(
+            to: dir.appendingPathComponent("test_runtime.R"), atomically: true, encoding: .utf8)
+        let script = "source(\"test_runtime.R\")\npassed(\(rMessageLiteral))\n"
+        let scriptURL = dir.appendingPathComponent("probe.R")
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["Rscript", scriptURL.path]
+        proc.currentDirectoryURL = dir
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = Pipe()
+        try proc.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+
+        guard
+            let text = String(data: data, encoding: .utf8),
+            let last = text.split(separator: "\n").last(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+        else { return nil }
+        return try JSONSerialization.jsonObject(with: Data(last.utf8)) as? [String: Any]
+    }
+
+    /// The regression that surfaced it: a regex in the message. Before the fix
+    /// this printed invalid JSON and the student saw the raw blob.
+    @Test func backslashesSurviveAsValidJSON() throws {
+        guard Self.hasRscript else { return }
+        let decoded = try #require(try emit(#""Found 1 cell(s) containing `is\\.numeric|summary\\s*\\(`""#))
+        #expect(
+            decoded["shortResult"] as? String
+                == #"Found 1 cell(s) containing `is\.numeric|summary\s*\(`"#)
+    }
+
+    /// A quote used to emit `\\"`, which closes the JSON string early.
+    @Test func embeddedQuotesDoNotTerminateTheString() throws {
+        guard Self.hasRscript else { return }
+        let decoded = try #require(try emit(#""expected \"underweight\" here""#))
+        #expect(decoded["shortResult"] as? String == #"expected "underweight" here"#)
+    }
+
+    /// A newline used to emit `\\n` — valid JSON, but the student saw a literal
+    /// backslash-n instead of a line break. Most R failure messages are
+    /// multi-line, so this was visible on nearly every failure.
+    @Test func newlinesTabsAndCarriageReturnsDecodeToRealControlCharacters() throws {
+        guard Self.hasRscript else { return }
+        let decoded = try #require(try emit(#""line one\n  indented\ttabbed\r""#))
+        let result = try #require(decoded["shortResult"] as? String)
+        #expect(result.contains("\n"))
+        #expect(result.contains("\t"))
+        #expect(result.contains("\r"))
+        #expect(!result.contains("\\n"), "a literal backslash-n means the escape is doubled")
+        #expect(result == "line one\n  indented\ttabbed\r")
+    }
+
+    /// Everything at once, since the passes run in sequence and an ordering
+    /// mistake (escaping quotes before backslashes) only shows when combined.
+    @Test func allEscapesCompose() throws {
+        guard Self.hasRscript else { return }
+        let decoded = try #require(try emit(#""a\\b \"q\" \n\t end""#))
+        #expect(decoded["shortResult"] as? String == "a\\b \"q\" \n\t end")
+        #expect(decoded["status"] as? String == "pass")
+    }
+}

--- a/Tools/runner-support/test_runtime.R
+++ b/Tools/runner-support/test_runtime.R
@@ -21,11 +21,11 @@
 
 .chickadee_json_str <- function(x) {
     x <- as.character(x)
-    x <- gsub("\\\\", "\\\\\\\\", x, fixed = TRUE)
-    x <- gsub('"',    '\\\\"',    x, fixed = TRUE)
-    x <- gsub("\n",   "\\\\n",    x, fixed = TRUE)
-    x <- gsub("\r",   "\\\\r",    x, fixed = TRUE)
-    x <- gsub("\t",   "\\\\t",    x, fixed = TRUE)
+    x <- gsub("\\", "\\\\", x, fixed = TRUE)
+    x <- gsub('"',    '\\"',    x, fixed = TRUE)
+    x <- gsub("\n",   "\\n",    x, fixed = TRUE)
+    x <- gsub("\r",   "\\r",    x, fixed = TRUE)
+    x <- gsub("\t",   "\\t",    x, fixed = TRUE)
     paste0('"', x, '"')
 }
 

--- a/changelog.d/r-runtime-json-escaping.md
+++ b/changelog.d/r-runtime-json-escaping.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **R test results containing a backslash, a quote, or a newline are no longer
+  mangled.** The R runtime hand-formats its result JSON (base R has no
+  jsonlite), and `.chickadee_json_str` got every escape wrong in one of two
+  ways, each hidden until a message happened to contain the offending
+  character. The backslash pass searched for a *double* backslash, so a single
+  `\` passed through unescaped and the result line was invalid JSON — the
+  interpreter fell back to "last line as plain text" and the student saw the
+  raw `{"status":...}` blob as their result. This bit every regex-based
+  `cell_contains` check, which puts backslashes in messages routinely.
+  Separately, the quote / newline / CR / tab replacements were each one
+  backslash too many, because `gsub(..., fixed = TRUE)` uses its replacement
+  literally with no backreference processing: a quote emitted `\\"`, which
+  terminates the JSON string early, and a newline emitted `\\n`, which parses
+  but renders to the student as a literal `\n` instead of a line break — so
+  nearly every multi-line R failure message displayed wrong. All five escapes
+  are now correct and pinned by tests that run the real runtime under `Rscript`
+  and parse what it prints.

--- a/docs/r-support-handoff.md
+++ b/docs/r-support-handoff.md
@@ -1,0 +1,159 @@
+# Handoff: first-class R support (HLTH 230 → R)
+
+Written 2026-07-25. Repo `JimWallace/Chickadee`, branch
+`claude/hlth230-assignments-r-conversion-waxnqw`, server at v0.4.640.
+
+## Goal
+
+Chickadee supports assignments authored and graded in **R** as well as Python,
+including per-student personalization, **transparently to instructors** — an R
+instructor should never have to think about Python underneath. Design and
+rationale: [`docs/r-support.md`](r-support.md). This file is only the
+*remaining work* plus the traps that will cost you hours if you don't know them.
+
+## State: done and verified
+
+The engine is complete and merged (v0.4.635–v0.4.640). All five HLTH 230
+assignments are converted to R in course **TEST** and **validate green**:
+
+| Assignment | Public ID | Notes |
+|---|---|---|
+| A0 warm-up | `DEJr2f` | hand-written R tests |
+| A1 BMI | `FpY4wz` | pattern families |
+| A2 DNA/k-mers | `OImnr8` | per-student expressions, `{{name}}` substitution |
+| A3 health records | `PKPkxL` | 4 pattern families with per-student `expectedVarRef`, `dbgen.R` |
+| A4 VitalDB EDA | `I4nUW0` | 6 notebook checks; **6/6 pass** as of 19:46Z |
+
+Notebook checks render in R for **every kind but `ast_structure`**.
+
+## Task 1 — drive PR #1211 to merge (only open item)
+
+[#1211](https://github.com/JimWallace/Chickadee/pull/1211) fixes every escape in
+the R runtime's JSON result formatter (`.chickadee_json_str`). It was open and
+in CI at handoff time.
+
+```
+gh-equivalent: mcp__github__pull_request_read  method=get  pullNumber=1211
+```
+
+If CI is green: mark it ready (`update_pull_request draft=false`), squash-merge,
+**wait for the `chore(release)` commit on main**, then reset the branch (see
+Trap 2). If red: diagnose and push a fix — do not leave it red.
+
+## Task 2 — apply minimum-runner-version gates (blocked on a client reconnect)
+
+v0.4.640 added the MCP tool `set_minimum_runner_version` (#1210). It gates a
+submission to a runner at or above a given version; a job that doesn't qualify
+**stays queued** rather than being graded by a too-old runner.
+
+**It is not callable from the session that wrote this** — the server has it, but
+the MCP tool catalog is fixed for the life of a client connection, so it needs
+the Chickadee connector reconnected (or a fresh session). Verify with:
+
+```
+ToolSearch  "select:mcp__Chickadee__set_minimum_runner_version"
+```
+
+Once it resolves, apply:
+
+| Assignment | Gate | Why |
+|---|---|---|
+| `DEJr2f`, `FpY4wz`, `OImnr8`, `PKPkxL` | `0.4.635` | `chickadee_load_student` |
+| `I4nUW0` | `0.4.639` | `chickadee_student_cells` |
+
+All five are green today, so correct gates change nothing. If one starts
+**queueing**, that is the gate catching an old runner before it produces a
+misleading red — not a regression.
+
+## Task 3 — backlog (found this session, none started)
+
+Ordered by value. None is blocking.
+
+1. **Runner version-skew alert.** Runners already advertise `runnerVersion` on
+   every poll and nothing compares it to the server's. A mixed fleet cost most
+   of a session and produced three wrong conclusions before it was diagnosed;
+   the failure mode is silent *and* intermittent. A health alert when a runner
+   falls behind is the single highest-value item here.
+2. **The recorded manifest language is a one-way door.** `TestProperties.language`
+   outranks every other signal, so cloning a Python assignment and converting it
+   to R leaves it rendering `.py` forever — the workaround is saving one
+   throwaway `.R` script (see Trap 6). The principled fix: the recorded language
+   is a *memo* of what was resolved, not a declaration, so replacing the starter
+   notebook should re-derive it. Sibling of the bug fixed in #1208.
+3. **`cell_contains` regex validator counts parens naively.**
+   `NotebookCheckKindHandler.swift` compares raw `(` and `)` character counts, so
+   `\(` or `[(]` is rejected as "unbalanced". Affects Python authors identically.
+4. **Check `variable` is validated as a *Python* identifier**
+   (`validateRequiredIdentifier`), so an idiomatic R name like `my.df` is refused
+   on an R assignment. The handler's `validate` has no language in scope; thread
+   one through.
+5. **`ast_structure` in R.** A design question, not a port: `for_loop` /
+   `while_loop` / `recursion` / `lambda` / `import:` all have analogues but
+   `list_comprehension` has none, so the predicate vocabulary must become
+   language-scoped first (R would want `apply_family`, `pipe`, `vectorized`).
+
+## Traps
+
+These each cost real time. Read before starting.
+
+1. **A `changelog.d/` fragment is mandatory on every PR.** With an empty
+   `changelog.d/`, `auto-release.yml` exits **0** and reports success without
+   releasing — a silent deploy stall. This cost 3 hours. Preview with
+   `scripts/assemble-release.sh --dry-run`. Never edit `VERSION`,
+   `ChickadeeVersion.swift`, or `CHANGELOG.md` directly.
+2. **Reset the branch only *after* the release commit lands.** Merging consumes
+   your fragment into `CHANGELOG.md` and deletes it. If you reset onto `main`
+   before `chore(release): vX.Y.Z` appears, you carry the consumed fragment back
+   and duplicate the entry. Wait for it, then
+   `git checkout -B <branch> origin/main`.
+3. **Validation results are cached.** `validate_assignment` only *watches* — it
+   returns the last terminal status. Reading a stale result as current produced
+   two wrong conclusions this session. To force a fresh run you need a real
+   content edit (re-authoring a check with a changed hint works).
+4. **A red validation may be the fleet, not your content.** If `longResult` says
+   `could not find function "chickadee_..."`, that is runner version skew.
+   Re-run before debugging; the fleet has been mixed, and consecutive runs 34
+   seconds apart returned 13/13 and 0/13.
+5. **CI has no R.** Every R renderer test guards on `Rscript` and *silently
+   skips* in CI. R work is only really verified on a host that has R — so run
+   `swift test --filter 'RendererR|RRuntime'` locally and don't trust a green CI
+   as proof the R paths work.
+6. **Clone-and-convert needs a language flip.** Until backlog item 2 is fixed:
+   save one throwaway `.R` test script, which re-resolves and *records* `language: r`;
+   the record persists, so delete the script immediately after.
+7. **Python's generated bytes must never move.** They feed `spec_hash` and
+   `TestSetupCache` keys. Add R *alongside* the Python renderers, never as
+   branches inside them. Tests assert this — keep them.
+8. **`Tools/runner-support/test_runtime.R` is a byte-for-byte mirror** of the
+   composed Swift string in `Sources/Worker/TestRuntimeSources.swift`. Edit both
+   or `RuntimeSourceDriftTests` fails. It cannot interpolate Swift constants,
+   which is why the cell-marker contract has a dedicated pin test.
+9. **The stop hook will flag two commits as "Unverified"** whenever the branch
+   sits at `origin/main`. They are GitHub's own — the auto-release bot and the
+   squash-merge. Do **not** amend or rebase them; that rewrites merged history
+   behind a force-push. Only act if a commit is genuinely yours.
+10. **`mcp__github__actions_list` returns payloads too large to read.** It saves
+    to a file; parse that with `python3 -c 'import json; ...'`.
+
+## Before every push
+
+```
+scripts/format.sh
+scripts/lint.sh
+scripts/swiftlint.sh
+swift test --filter 'RendererR|NotebookCheck|PatternFamily|Runtime|Personalization'
+```
+
+Commit as `noreply@anthropic.com` / `Claude`
+(`git config user.email noreply@anthropic.com && git config user.name Claude`).
+
+## Reference
+
+- [`docs/r-support.md`](r-support.md) — the design: language resolution, the
+  per-language strategy, personalization in R, the R renderers, the cell-boundary
+  marker, and what is deliberately deferred.
+- [`docs/personalization-eval-runtime.md`](personalization-eval-runtime.md) —
+  why expressions are evaluated per-language **on the server**.
+- [`docs/zero-downtime-deploy.md`](zero-downtime-deploy.md) — the deploy daemon;
+  step 8 is the runner refresh, and its failures are logged to `history.jsonl`
+  without rolling back the deploy (relevant to backlog item 1).


### PR DESCRIPTION
Found while validating the R conversion of HLTH 230 Assignment 4. Two of its three `cell_contains` checks passed but rendered their result as a raw JSON blob:

```
{"status":"pass","shortResult":"Found 1 cell(s) containing `is\.numeric|summary\s*\(`","test":"publiccheck_uses_summary_all_numeric"}
```

while the third — whose regex was `aggregate|tapply` — rendered cleanly. The difference is backslashes.

## Two bugs, both in `.chickadee_json_str`

The R runtime hand-formats its result JSON (base R has no jsonlite), so this one function is all that stands between a test message and a malformed result line.

**1. The backslash escape was too narrow.** `gsub("\\\\", "\\\\\\\\", x, fixed = TRUE)` — under `fixed = TRUE` that searches for a *two-character* `\\`, so a single `\` passed through unescaped. The line was then invalid JSON, the interpreter fell back to "last line as plain text", and the student saw the whole blob. Regex-based `cell_contains` checks put backslashes in messages routinely, which is how it surfaced.

**2. The quote / newline / CR / tab escapes were each one backslash too many.** `gsub(..., fixed = TRUE)` uses its replacement **literally** — no backreference processing — so R source `"\\\\n"` emits `\\n`, not `\n`. Consequences:

- a quote emitted `\\"`, which terminates the JSON string early → invalid JSON;
- a newline emitted `\\n`, which *parses* but renders to the student as a literal `\n` instead of a line break.

Nearly every R failure message is multi-line, so (2) was visible almost everywhere and read as cosmetic noise — it appeared in this session's own earlier output (`"...older than this test suite.\\n  present: ..."`) and went unregistered at the time.

## Verification

Rather than assert on the source text — where the bug was invisible, because the R string literals look plausible — the new tests run the real composed runtime under `Rscript` and parse what it actually prints:

- backslashes survive as valid JSON (the regression that surfaced this)
- an embedded quote doesn't terminate the string
- `\n` / `\t` / `\r` decode to real control characters, explicitly asserting the result does *not* contain a literal `\n`
- all escapes compose, since the passes run in sequence and an ordering mistake (quotes before backslashes) only shows when combined

Both the canonical `Tools/runner-support/test_runtime.R` and its `TestRuntimeSources.swift` mirror are fixed together, so `RuntimeSourceDriftTests` stays green.

Regression run over the R renderers, notebook checks, pattern families, runtime and personalization suites: **274 tests in 35 suites, green.** `scripts/lint.sh` and `scripts/swiftlint.sh --strict` clean.

**Deployment note:** this changes the worker-injected R runtime, so runners need the new image before student-visible R messages render correctly. That happens on the normal deploy path.

## Also included: `docs/r-support-handoff.md`

A second, unrelated commit adds a handoff document for the R-support work — what remains (drive this PR to merge; apply the `set_minimum_runner_version` gates once the MCP catalog refreshes; a ranked backlog led by a runner version-skew alert) and the traps that cost real time: an empty `changelog.d/` making `auto-release.yml` exit 0 without releasing, cached validation results reading as current, a mixed runner fleet producing intermittent reds that look like content bugs, and CI having no R at all so every R renderer test silently skips there.

Split it out if you'd rather this PR stay single-purpose.