### PR TITLE
Refresh the R-support handoff now that #1211 has landed

### DIFF
--- a/changelog.d/r-support-handoff-refresh.md
+++ b/changelog.d/r-support-handoff-refresh.md
@@ -1,0 +1,6 @@
+### Changed
+
+- **`docs/r-support-handoff.md` refreshed now that #1211 has landed.** The
+  remaining work is down to one blocked task (apply the
+  `set_minimum_runner_version` gates once an MCP client reconnect picks up the
+  new tool) plus a ranked backlog; there are no open PRs.

--- a/docs/r-support-handoff.md
+++ b/docs/r-support-handoff.md
@@ -1,7 +1,7 @@
 # Handoff: first-class R support (HLTH 230 → R)
 
 Written 2026-07-25. Repo `JimWallace/Chickadee`, branch
-`claude/hlth230-assignments-r-conversion-waxnqw`, server at v0.4.640.
+`claude/hlth230-assignments-r-conversion-waxnqw`, released through v0.4.641.
 
 ## Goal
 
@@ -13,7 +13,7 @@ rationale: [`docs/r-support.md`](r-support.md). This file is only the
 
 ## State: done and verified
 
-The engine is complete and merged (v0.4.635–v0.4.640). All five HLTH 230
+The engine is complete and merged (v0.4.635–v0.4.641). All five HLTH 230
 assignments are converted to R in course **TEST** and **validate green**:
 
 | Assignment | Public ID | Notes |
@@ -26,21 +26,11 @@ assignments are converted to R in course **TEST** and **validate green**:
 
 Notebook checks render in R for **every kind but `ast_structure`**.
 
-## Task 1 — drive PR #1211 to merge (only open item)
+There are **no open PRs**. #1211 (every escape in the R runtime's JSON result
+formatter) merged as v0.4.641; runners pick it up on the normal deploy path,
+after which student-visible R messages render correctly.
 
-[#1211](https://github.com/JimWallace/Chickadee/pull/1211) fixes every escape in
-the R runtime's JSON result formatter (`.chickadee_json_str`). It was open and
-in CI at handoff time.
-
-```
-gh-equivalent: mcp__github__pull_request_read  method=get  pullNumber=1211
-```
-
-If CI is green: mark it ready (`update_pull_request draft=false`), squash-merge,
-**wait for the `chore(release)` commit on main**, then reset the branch (see
-Trap 2). If red: diagnose and push a fix — do not leave it red.
-
-## Task 2 — apply minimum-runner-version gates (blocked on a client reconnect)
+## Task 1 — apply minimum-runner-version gates (blocked on a client reconnect)
 
 v0.4.640 added the MCP tool `set_minimum_runner_version` (#1210). It gates a
 submission to a runner at or above a given version; a job that doesn't qualify
@@ -65,7 +55,7 @@ All five are green today, so correct gates change nothing. If one starts
 **queueing**, that is the gate catching an old runner before it produces a
 misleading red — not a regression.
 
-## Task 3 — backlog (found this session, none started)
+## Task 2 — backlog (found this session, none started)
 
 Ordered by value. None is blocking.
 


### PR DESCRIPTION
Docs only.

`docs/r-support-handoff.md` shipped alongside #1211 and led with "Task 1 — drive PR #1211 to merge (**only open item**)". That went stale the moment #1211 merged as v0.4.641, and a handoff that misstates the current state is worse than no handoff.

- No open PRs; #1211 is recorded as merged, with the note that runners pick up the runtime fix on the normal deploy path.
- The `set_minimum_runner_version` gate work is promoted to Task 1 (still blocked on an MCP client reconnect — the server has the tool since v0.4.640, but a client's tool catalog is fixed for the life of its connection).
- The backlog renumbers to Task 2. Unchanged otherwise: it's still led by the runner version-skew alert, which is the item that would have saved the most time on this work.

The Traps section is untouched and is the part worth reading before picking this up.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bx8pUeHnSwRG5hBq93kTC)_