### PR TITLE
Add a runner version-skew health alert

### DIFF
--- a/Sources/APIServer/APIServerApp+Stores.swift
+++ b/Sources/APIServer/APIServerApp+Stores.swift
@@ -186,6 +186,18 @@ actor WorkerActivityStore {
         }
         return (anyRecent, anyKnown)
     }
+
+    /// Versions advertised by runners still known this session — seen within
+    /// `rememberSeconds`. Feeds the runner-version-skew alert. Entries whose
+    /// `runnerVersion` is empty (a runner touched only by an HMAC keep-alive that
+    /// never carried a version) are omitted, so they can't masquerade as skew.
+    /// Non-mutating like `runnerPresence`: it does not prune, so evaluating the
+    /// alert never races the dashboard's pruning in `snapshotsSortedByRecent`.
+    func knownRunnerVersions(rememberSeconds: TimeInterval, now: Date = Date()) -> [String] {
+        entries.values
+            .filter { now.timeIntervalSince($0.lastSeen) <= rememberSeconds && !$0.runnerVersion.isEmpty }
+            .map(\.runnerVersion)
+    }
 }
 
 actor LocalRunnerAutoStartStore {

--- a/Sources/APIServer/Services/AlertNotifier.swift
+++ b/Sources/APIServer/Services/AlertNotifier.swift
@@ -3,6 +3,7 @@ import Vapor
 
 enum HealthRule: String, CaseIterable, Codable, Sendable {
     case runnerOffline
+    case runnerVersionSkew
     case queueBackedUp
     case errorRateSpike
     case editorKernelUnrecoverable
@@ -12,6 +13,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
     var humanReadable: String {
         switch self {
         case .runnerOffline: return "Runner offline"
+        case .runnerVersionSkew: return "Runner version skew"
         case .queueBackedUp: return "Submission queue backed up"
         case .errorRateSpike: return "System-level failure rate spike"
         case .editorKernelUnrecoverable: return "Editor kernel unrecoverable"
@@ -24,6 +26,7 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
         switch self {
         case .databaseUnreachable: return "critical"
         case .runnerOffline: return "warning"
+        case .runnerVersionSkew: return "warning"
         case .queueBackedUp: return "warning"
         case .errorRateSpike: return "warning"
         case .editorKernelUnrecoverable: return "warning"

--- a/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertConfiguration.swift
@@ -9,6 +9,16 @@ struct ServerHealthAlertConfiguration: Sendable {
     /// this session has not checked in within this window, regardless of whether
     /// jobs are queued.
     let runnerOfflineSeconds: TimeInterval
+    /// Runner version-skew rule: fire when a runner still known this session
+    /// advertises a version behind the server's own `ChickadeeVersion.current`,
+    /// but only once the server itself has been up longer than this grace. The
+    /// grace exists because a blue/green deploy flips the server *before* it
+    /// refreshes the runner (`docs/zero-downtime-deploy.md` step 8), so every
+    /// deploy has an expected transient window where the runner is a release
+    /// behind; firing during it would page on every deploy. A persistently-behind
+    /// runner (a failed runner refresh, or an old runner rejoining the fleet)
+    /// outlives the grace and pages once.
+    let runnerVersionSkewGraceSeconds: TimeInterval
     let queueDepthThreshold: Int
     let oldestPendingSeconds: TimeInterval
     let errorRateThreshold: Double
@@ -37,6 +47,7 @@ struct ServerHealthAlertConfiguration: Sendable {
         checkIntervalSeconds: 60,
         cooldownSeconds: 1800,
         runnerOfflineSeconds: 300,
+        runnerVersionSkewGraceSeconds: 900,
         queueDepthThreshold: 25,
         oldestPendingSeconds: 600,
         errorRateThreshold: 0.30,
@@ -55,6 +66,8 @@ struct ServerHealthAlertConfiguration: Sendable {
             checkIntervalSeconds: TimeInterval(environmentInt("ALERT_CHECK_INTERVAL_SECONDS") ?? 60),
             cooldownSeconds: TimeInterval(environmentInt("ALERT_COOLDOWN_SECONDS") ?? 1800),
             runnerOfflineSeconds: TimeInterval(environmentInt("ALERT_RUNNER_OFFLINE_SECONDS") ?? 300),
+            runnerVersionSkewGraceSeconds: TimeInterval(
+                environmentInt("ALERT_RUNNER_VERSION_SKEW_GRACE_SECONDS") ?? 900),
             queueDepthThreshold: environmentInt("ALERT_QUEUE_DEPTH_THRESHOLD") ?? 25,
             oldestPendingSeconds: TimeInterval(environmentInt("ALERT_OLDEST_PENDING_SECONDS") ?? 600),
             errorRateThreshold: environmentDouble("ALERT_ERROR_RATE_THRESHOLD") ?? 0.30,

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -1,3 +1,4 @@
+import Core
 import Fluent
 import Foundation
 import SQLKit
@@ -32,6 +33,11 @@ func evaluateHealthRules(
         on: application,
         pending: pendingState,
         offlineThreshold: configuration.runnerOfflineSeconds,
+        now: now
+    )
+    results[.runnerVersionSkew] = await evaluateRunnerVersionSkew(
+        on: application,
+        configuration: configuration,
         now: now
     )
     results[.queueBackedUp] = evaluateQueueBackedUp(
@@ -145,6 +151,79 @@ private func evaluateRunnerOffline(
         pending: pending,
         presence: state,
         offlineSeconds: offlineThreshold
+    )
+}
+
+/// Decides the runner-version-skew rule purely, so the firing logic is
+/// table-testable without a Vapor app. Fire when a runner still known this
+/// session advertises a version *behind* `serverVersion` — but only once the
+/// server has been up longer than `graceSeconds`.
+///
+/// The grace is the crux. A blue/green deploy flips the server before it
+/// refreshes the runner (`docs/zero-downtime-deploy.md` step 8), so immediately
+/// after every deploy the runner is briefly a release behind. Gating on server
+/// uptime means that expected, transient skew never pages — the freshly-booted
+/// server's uptime is below the grace — while a runner that stays behind past
+/// the grace (a failed runner refresh, or an old runner rejoining the fleet)
+/// does. Correctness during the window is already protected independently by the
+/// per-assignment minimum-runner-version gate (#1210), which queues rather than
+/// mis-grades, so the alert can afford to wait for genuine, persistent skew.
+///
+/// Runner versions that don't parse as semver (a mock or third-party runner
+/// reporting e.g. `"runner/1.0"`) are skipped, never counted as behind —
+/// mirroring `RunnerVersionGate`'s tolerance so the fleet's odd one out can't
+/// page.
+func decideRunnerVersionSkew(
+    serverVersion: String,
+    runnerVersions: [String],
+    serverUptimeSeconds: TimeInterval,
+    graceSeconds: TimeInterval
+) -> RuleEvaluation {
+    guard serverUptimeSeconds >= graceSeconds else { return .ok }
+    let comparator = VersionComparator()
+    // A server version that itself doesn't parse can't ground a comparison; stay
+    // quiet rather than guess. `ChickadeeVersion.current` is always clean semver,
+    // so this is purely defensive.
+    guard comparator.canParse(serverVersion) else { return .ok }
+
+    let behind = runnerVersions.filter {
+        comparator.compare($0, serverVersion) == .orderedAscending
+    }
+    guard !behind.isEmpty else { return .ok }
+
+    let oldest =
+        behind.min { (comparator.compare($0, $1) ?? .orderedSame) == .orderedAscending } ?? behind[0]
+    let distinctBehind = Set(behind).sorted()
+    return RuleEvaluation(
+        isFiring: true,
+        summary:
+            "\(behind.count) runner(s) behind server v\(serverVersion) (oldest v\(oldest)) — "
+            + "grading against a stale test runtime; refresh the runner image",
+        details: [
+            "server_version": serverVersion,
+            "behind_count": String(behind.count),
+            "behind_versions": distinctBehind.joined(separator: ","),
+            "oldest_runner_version": oldest,
+            "grace_seconds": String(Int(graceSeconds)),
+        ]
+    )
+}
+
+private func evaluateRunnerVersionSkew(
+    on application: Application,
+    configuration: ServerHealthAlertConfiguration,
+    now: Date
+) async -> RuleEvaluation {
+    let uptime = now.timeIntervalSince(application.serverStartedAt)
+    let versions = await application.workerActivityStore.knownRunnerVersions(
+        rememberSeconds: runnerPresenceRememberSeconds,
+        now: now
+    )
+    return decideRunnerVersionSkew(
+        serverVersion: ChickadeeVersion.current,
+        runnerVersions: versions,
+        serverUptimeSeconds: uptime,
+        graceSeconds: configuration.runnerVersionSkewGraceSeconds
     )
 }
 
@@ -652,6 +731,10 @@ func writeAlertWebhookURLToDisk(value: String, filePath: String) {
 /// alerts-enabled flag (with its own log line when disabled).
 struct ServerHealthAlertLifecycleHandler: LifecycleHandler {
     func didBoot(_ application: Application) throws {
+        // Stamp the boot time unconditionally (before the enabled-guard) so the
+        // runner-version-skew deploy grace is accurate even when paging is off
+        // and only the read-only `get_health_alerts` view evaluates the rule.
+        application.serverStartedAt = Date()
         guard application.serverHealthAlertConfiguration.enabled else {
             application.logger.info("server_health_alerts_disabled")
             return
@@ -674,6 +757,10 @@ struct ServerHealthAlertSweepMonitorKey: StorageKey {
 
 struct ServerHealthAlertWebhookURLFilePathKey: StorageKey {
     typealias Value = String
+}
+
+struct ServerStartedAtKey: StorageKey {
+    typealias Value = Date
 }
 
 extension Application {
@@ -717,5 +804,20 @@ extension Application {
                 ?? (DirectoryConfiguration.detect().workingDirectory + ".alert-webhook-url")
         }
         set { storage[ServerHealthAlertWebhookURLFilePathKey.self] = newValue }
+    }
+
+    /// When this server process booted — used by the runner-version-skew alert's
+    /// deploy grace (see `decideRunnerVersionSkew`). Set explicitly at boot by
+    /// `ServerHealthAlertLifecycleHandler.didBoot`; the lazy fallback captures the
+    /// first read for paths that never ran the handler (e.g. a test app that
+    /// evaluates rules directly), so the value is always populated and stable.
+    var serverStartedAt: Date {
+        get {
+            if let existing = storage[ServerStartedAtKey.self] { return existing }
+            let now = Date()
+            storage[ServerStartedAtKey.self] = now
+            return now
+        }
+        set { storage[ServerStartedAtKey.self] = newValue }
     }
 }

--- a/Tests/APITests/ServerHealthAlertTests.swift
+++ b/Tests/APITests/ServerHealthAlertTests.swift
@@ -240,11 +240,115 @@ import Testing
         #expect(forgotten.anyKnown == false)
     }
 
+    // MARK: - decideRunnerVersionSkew
+
+    @Test func runnerVersionSkew_firesWhenRunnerBehindAndPastGrace() {
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: ["0.4.641", "0.4.635"],
+            serverUptimeSeconds: 1000,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring)
+        #expect(evaluation.details["behind_count"] == "1")
+        #expect(evaluation.details["server_version"] == "0.4.641")
+        #expect(evaluation.details["oldest_runner_version"] == "0.4.635")
+        #expect(evaluation.details["behind_versions"] == "0.4.635")
+    }
+
+    @Test func runnerVersionSkew_okWhenAllRunnersCurrent() {
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: ["0.4.641", "0.4.641"],
+            serverUptimeSeconds: 100_000,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring == false)
+    }
+
+    @Test func runnerVersionSkew_okWithinDeployGrace() {
+        // The crux: a runner is a release behind, but the server only just booted
+        // (still inside its refresh window). This must NOT page — otherwise every
+        // blue/green deploy fires while step 8 catches the runner up.
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: ["0.4.640"],
+            serverUptimeSeconds: 120,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring == false)
+    }
+
+    @Test func runnerVersionSkew_okWhenNoRunnersKnown() {
+        // A runner-less (e.g. browser-graded only) deployment never pages.
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: [],
+            serverUptimeSeconds: 100_000,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring == false)
+    }
+
+    @Test func runnerVersionSkew_skipsUnparseableRunnerVersions() {
+        // A mock / third-party runner reporting a non-semver version is not
+        // "behind" — it just can't be compared, so it must never page.
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: ["runner/1.0", "dev"],
+            serverUptimeSeconds: 100_000,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring == false)
+    }
+
+    @Test func runnerVersionSkew_countsOnlyBehindRunnersWhenFleetMixed() {
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: ["0.4.641", "0.4.638", "0.4.639"],
+            serverUptimeSeconds: 100_000,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring)
+        #expect(evaluation.details["behind_count"] == "2")
+        #expect(evaluation.details["oldest_runner_version"] == "0.4.638")
+        #expect(evaluation.details["behind_versions"] == "0.4.638,0.4.639")
+    }
+
+    @Test func runnerVersionSkew_okWhenRunnerAheadOfServer() {
+        // A runner ahead of the server (e.g. briefly mid-rollback) is not the
+        // "behind" case this rule targets, so it stays quiet.
+        let evaluation = decideRunnerVersionSkew(
+            serverVersion: "0.4.641",
+            runnerVersions: ["0.5.0"],
+            serverUptimeSeconds: 100_000,
+            graceSeconds: 900
+        )
+        #expect(evaluation.isFiring == false)
+    }
+
+    @Test func knownRunnerVersions_returnsOnlyRecentNonEmptyVersions() async {
+        let store = WorkerActivityStore()
+        let now = Date()
+        // Current runner, seen just now.
+        await store.markActive(workerID: "r1", hostname: "h1", runnerVersion: "0.4.641", at: now)
+        // Old runner, seen 2h ago — beyond the remember window, dropped.
+        await store.markActive(
+            workerID: "r2", hostname: "h2", runnerVersion: "0.4.635",
+            at: now.addingTimeInterval(-7200))
+        // A keep-alive-only touch that never carried a version — omitted.
+        await store.markActive(workerID: "r3", hostname: "h3", at: now)
+
+        let versions = await store.knownRunnerVersions(rememberSeconds: 3600, now: now)
+        #expect(versions == ["0.4.641"])
+    }
+
     // MARK: - Rule helpers
 
     @Test func healthRuleSeverity() {
         #expect(HealthRule.databaseUnreachable.severity == "critical")
         #expect(HealthRule.runnerOffline.severity == "warning")
+        #expect(HealthRule.runnerVersionSkew.severity == "warning")
         #expect(HealthRule.queueBackedUp.severity == "warning")
         #expect(HealthRule.errorRateSpike.severity == "warning")
         #expect(HealthRule.editorKernelUnrecoverable.severity == "warning")

--- a/changelog.d/runner-version-skew-alert.md
+++ b/changelog.d/runner-version-skew-alert.md
@@ -1,0 +1,12 @@
+### Added
+
+- **Runner version-skew health alert.** The server now raises a `warning`-level
+  health alert — surfaced on `/admin/alerts`, the `get_health_alerts` admin MCP
+  tool, and any configured webhook — when a runner still active in the fleet
+  advertises a build older than the server's own version. This is the silent,
+  intermittent failure mode where a stale runner grades against an out-of-date
+  test runtime (e.g. `could not find function "chickadee_..."`). A server-uptime
+  grace (`ALERT_RUNNER_VERSION_SKEW_GRACE_SECONDS`, default 900s) suppresses the
+  expected transient skew during a blue/green deploy's runner-refresh window, so
+  only a persistently-behind runner pages; non-semver runner versions (mock or
+  third-party runners) are ignored.

--- a/docs/zero-downtime-deploy.md
+++ b/docs/zero-downtime-deploy.md
@@ -198,7 +198,12 @@ mechanism without moving any student traffic:
    re-queued by the server's `StuckSubmissionReaperMonitor`. Best-effort: this
    runs only after the server swap is already verified healthy, so a runner hiccup
    is logged to `history.jsonl` (`runner-refresh`) but never rolls back the deploy.
-   Disable with `CHICKADEE_REFRESH_RUNNER=0`.
+   Disable with `CHICKADEE_REFRESH_RUNNER=0`. Because this step is best-effort, a
+   silently-failed refresh would leave the runner grading on a stale build; the
+   `runnerVersionSkew` health alert is the backstop — it pages once a runner stays
+   behind the server past `ALERT_RUNNER_VERSION_SKEW_GRACE_SECONDS` (default 900s),
+   which is set generously so the *expected* transient skew during this very step
+   never fires.
 9. Writes `status.json` / appends `history.jsonl` for the Phase 3 MCP surface.
 
 ### Configuration (env / `/etc/chickadee-deployer.env`)


### PR DESCRIPTION
## What

Adds a `runnerVersionSkew` health alert that fires when a runner still active in the fleet advertises a build **behind the server's own `ChickadeeVersion.current`**.

## Why

Runners advertise their version on every poll, but nothing compared it to the server's. A runner left on a stale build — most often because the blue/green deploy's best-effort runner-refresh (step 8) silently failed — keeps grading against an out-of-date test runtime. The failure is **silent and intermittent**: it surfaces only as confusing student-facing errors like `could not find function "chickadee_..."`, and (per the R-support handoff) a mixed fleet cost most of a session and produced three wrong conclusions before it was diagnosed. This is the highest-value item in that handoff's backlog.

## How

- **`decideRunnerVersionSkew` (pure, table-tested).** Compares each still-known runner's advertised version against the server via the existing `VersionComparator`, firing on any runner strictly behind. Unparseable versions (a mock or third-party runner reporting e.g. `runner/1.0`) are **skipped**, mirroring `RunnerVersionGate`'s tolerance so the fleet's odd one out can't page.
- **Deploy grace (the crux).** A blue/green deploy flips the server *before* refreshing the runner, so immediately after every deploy the runner is briefly a release behind. A server-uptime grace (`ALERT_RUNNER_VERSION_SKEW_GRACE_SECONDS`, default **900s**) keeps a freshly-booted server quiet through its refresh window; only a runner that stays behind *past* the grace pages. Correctness during that window is already protected independently by the #1210 minimum-runner-version gate, which queues rather than mis-grades — so the alert can afford to wait for genuine, persistent skew.
- **No migration.** Health alerts are live-evaluated rules, not stored rows, so `/admin/alerts`, the `get_health_alerts` admin MCP tool, the cooldown state machine, and webhook dispatch all pick up the new `warning`-severity case automatically via `HealthRule.allCases`.
- Supporting bits: a non-mutating `WorkerActivityStore.knownRunnerVersions(rememberSeconds:now:)` accessor (does not prune, so it never races the dashboard's pruning), and an `Application.serverStartedAt` boot timestamp driving the grace.

## Testing

- 8 new table tests for `decideRunnerVersionSkew` (fires past grace; stays quiet within grace / all-current / no-runners / unparseable / ahead-of-server; mixed-fleet counting) plus a `knownRunnerVersions` store test.
- `swift build`, targeted `swift test` (`ServerHealthAlert` + admin-MCP suites), `scripts/lint.sh`, and `scripts/swiftlint.sh --strict` (0 violations in 854 files) all clean locally. This path is pure Swift and fully exercised.

## Deployment note

`warning` severity; only pages when the alerts subsystem is enabled (`ALERT_ENABLED`). Tune or effectively disable via `ALERT_RUNNER_VERSION_SKEW_GRACE_SECONDS`. See the updated `docs/zero-downtime-deploy.md` step 8 for how it backstops a silently-failed runner refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD)_