### PR TITLE
Record the runner version that ran each job, and report it on validation results

### DIFF
--- a/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
+++ b/Sources/APIServer/Diagnostics/OperationalDiagnostics+Recording.swift
@@ -256,6 +256,7 @@ extension OperationalDiagnosticsService {
 
     func recordJobAssigned(
         submission: APISubmission,
+        runnerVersion: String? = nil,
         on db: Database,
         logger: Logger
     ) async {
@@ -269,6 +270,10 @@ extension OperationalDiagnosticsService {
             )
             diagnostics.assignedAt = submission.assignedAt ?? diagnostics.assignedAt
             diagnostics.runnerID = submission.workerID ?? diagnostics.runnerID
+            // Stamped from the claim payload, not looked up later: this must be
+            // the version that actually ran the job, which is not necessarily
+            // what the runner is running by the time anyone asks.
+            diagnostics.runnerVersion = runnerVersion ?? diagnostics.runnerVersion
             try await diagnostics.save(on: db)
 
             let metric = try await findOrCreateJobExecutionMetric(

--- a/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
+++ b/Sources/APIServer/MCP/Tools/GetValidationResultTool.swift
@@ -64,6 +64,12 @@ struct GetValidationResultTool: ContentTool {
         let warnings: [String]
         let outcomes: [OutcomeDTO]
         let counts: Counts?
+        /// Which runner produced this result, and the version it was running.
+        /// A suite that depends on a newer runner build fails on a lagging
+        /// runner and passes on a current one; without these, that reads as a
+        /// content bug rather than version skew.
+        let runnerID: String?
+        let runnerVersion: String?
     }
 
     static let name = "get_validation_result"
@@ -75,7 +81,10 @@ struct GetValidationResultTool: ContentTool {
         + "Validation runs only — it resolves the instructor's own reference-solution run from the "
         + "assignment and never accepts or returns a student submission, identity, or grade. All tiers "
         + "(public/release/secret/student) are included so secret-tier failures are visible. A pending or "
-        + "missing run returns the current validationStatus with empty outcomes."
+        + "missing run returns the current validationStatus with empty outcomes. Also reports runnerID "
+        + "and runnerVersion — which runner produced the result and the build it was running — so a "
+        + "failure caused by a runner lagging behind the suite's requirements is distinguishable from "
+        + "a content bug."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -97,6 +106,8 @@ struct GetValidationResultTool: ContentTool {
             ]),
             "outcomes": .object(["type": .string("array")]),
             "counts": .object(["type": .array([.string("object"), .string("null")])]),
+            "runnerID": .object(["type": .array([.string("string"), .string("null")])]),
+            "runnerVersion": .object(["type": .array([.string("string"), .string("null")])]),
         ]),
         "required": .array([
             .string("assignmentPublicID"), .string("validationStatus"), .string("outcomes"),
@@ -115,6 +126,7 @@ struct GetValidationResultTool: ContentTool {
         // (e.g. a missing SELECT grant for the least-privilege MCP role) instead
         // of an opaque protocol-level internal error.
         let collectionJSON: String?
+        var runnerID: String?
         do {
             if let submission = try await MCPStudentDataBoundary.validationSubmission(
                 for: assignment, on: context.db),
@@ -122,6 +134,7 @@ struct GetValidationResultTool: ContentTool {
                     forSubmissionID: submission.requireID(), on: context.db)
             {
                 collectionJSON = try await result.loadCollectionJSON(on: context.db)
+                runnerID = submission.workerID
             } else {
                 collectionJSON = nil
             }
@@ -163,7 +176,12 @@ struct GetValidationResultTool: ContentTool {
                 pass: collection.passCount,
                 fail: collection.failCount,
                 error: collection.errorCount,
-                timeout: collection.timeoutCount))
+                timeout: collection.timeoutCount),
+            runnerID: runnerID,
+            // The version carried on the result itself, so it is the build that
+            // actually produced these outcomes rather than whatever that runner
+            // happens to be running now.
+            runnerVersion: collection.runnerVersion)
     }
 
     /// The pending / no-result-yet response: the current status with no outcomes
@@ -177,6 +195,8 @@ struct GetValidationResultTool: ContentTool {
             compilerOutput: nil,
             warnings: [],
             outcomes: [],
-            counts: nil)
+            counts: nil,
+            runnerID: nil,
+            runnerVersion: nil)
     }
 }

--- a/Sources/APIServer/Migrations/AddSubmissionDiagnosticsRunnerVersion.swift
+++ b/Sources/APIServer/Migrations/AddSubmissionDiagnosticsRunnerVersion.swift
@@ -1,0 +1,32 @@
+// APIServer/Migrations/AddSubmissionDiagnosticsRunnerVersion.swift
+//
+// Adds the `runner_version` column to submission_diagnostics: the version the
+// runner advertised when it claimed the job.
+//
+// `runner_id` already records *which* runner ran a submission, but the runner's
+// version was only ever live heartbeat state on the runner dashboard — so the
+// version for a historical job could only be found by joining to what that
+// runner is running *now*. During a rolling upgrade that join returns the wrong
+// answer, which is exactly when the question gets asked: a suite that depends on
+// a newer runner build fails on a lagging runner and passes on a current one,
+// and without the recorded version the failure reads as a content bug rather
+// than version skew.
+//
+// Shipped as a standalone Add* migration (not folded into
+// CreateSubmissionDiagnostics) because production databases have already applied
+// that migration and would never pick the column up from a model change. Fresh
+// deploys run CreateSubmissionDiagnostics then this; existing prod runs only
+// this. Nullable, so rows written before this shipped stay valid and simply
+// report no version.
+
+import Fluent
+
+struct AddSubmissionDiagnosticsRunnerVersion: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("submission_diagnostics").field("runner_version", .string).update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("submission_diagnostics").deleteField("runner_version").update()
+    }
+}

--- a/Sources/APIServer/Models/APISubmissionDiagnostics.swift
+++ b/Sources/APIServer/Models/APISubmissionDiagnostics.swift
@@ -47,6 +47,14 @@ final class APISubmissionDiagnostics: Model, Content, @unchecked Sendable {
     @OptionalField(key: "runner_id")
     var runnerID: String?
 
+    /// The version the runner advertised when it claimed this job. Recorded at
+    /// claim time rather than joined from the runner's live state, because a
+    /// runner's current version is not the version it ran a past job with —
+    /// during a rolling upgrade those differ, which is precisely when the
+    /// question matters. Nil for rows written before this was recorded.
+    @OptionalField(key: "runner_version")
+    var runnerVersion: String?
+
     @OptionalField(key: "timed_out")
     var timedOut: Bool?
 

--- a/Sources/APIServer/Routes/WorkerJobRoutes.swift
+++ b/Sources/APIServer/Routes/WorkerJobRoutes.swift
@@ -246,7 +246,8 @@ struct WorkerJobRoutes: RouteCollection {
         req: Request, body: WorkerActivityPayload, claimed: ClaimedJob
     ) async {
         await req.application.diagnostics.recordJobAssigned(
-            submission: claimed.submission, on: req.db, logger: req.logger
+            submission: claimed.submission, runnerVersion: body.runnerVersion,
+            on: req.db, logger: req.logger
         )
         req.application.diagnostics.recordCompatibleJobAssignment(
             submission: claimed.submission,

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -374,6 +374,7 @@ func registerMigrations(on app: Application) {
     // report, so a diagnostic can be attributed to a build (an old value flags a
     // stale browser tab / cached bundle, not a live regression).
     app.migrations.add(AddClientDiagnosticAppVersion())
+    app.migrations.add(AddSubmissionDiagnosticsRunnerVersion())
 
     // Per-(student, course) LEARN sync readiness on course_enrollments:
     // unconfirmed (default) → confirmed / unreachable, maintained by the

--- a/Tests/APITests/MCP/GetValidationResultToolTests.swift
+++ b/Tests/APITests/MCP/GetValidationResultToolTests.swift
@@ -49,7 +49,8 @@ import Vapor
     }
 
     private func collectionJSON(
-        submissionID: String, outcomes: [TestOutcome], buildStatus: BuildStatus = .passed
+        submissionID: String, outcomes: [TestOutcome], buildStatus: BuildStatus = .passed,
+        runnerVersion: String = "shell-runner/1.0"
     ) throws -> String {
         let collection = TestOutcomeCollection(
             submissionID: submissionID, testSetupID: "setup_val", attemptNumber: 1,
@@ -59,7 +60,7 @@ import Vapor
             failCount: outcomes.filter { $0.status == .fail }.count,
             errorCount: outcomes.filter { $0.status == .error }.count,
             timeoutCount: outcomes.filter { $0.status == .timeout }.count,
-            executionTimeMs: 5, runnerVersion: "shell-runner/1.0", timestamp: Date())
+            executionTimeMs: 5, runnerVersion: runnerVersion, timestamp: Date())
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(collection)
@@ -109,6 +110,50 @@ import Vapor
             let failing = try #require(output.outcomes.first { $0.status == "fail" })
             #expect(failing.tier == "secret")  // secret-tier failures are visible
             #expect(failing.longResult?.contains("got: 0") == true)
+        }
+    }
+
+    /// Runner attribution: which runner produced the result, and the build it
+    /// was running. Without these, a failure caused by a runner lagging behind
+    /// what the suite needs is indistinguishable from a content bug — which is
+    /// exactly how a mixed fleet burned a day of debugging.
+    @Test func reportsWhichRunnerProducedTheResultAndItsVersion() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let submission = try await makeTestSubmission(
+                on: app, id: "sub_val", setupID: "setup_val", userID: testerID(on: app),
+                kind: APISubmission.Kind.validation)
+            submission.workerID = "runner-abc123"
+            try await submission.save(on: app.db)
+            try await makeTestResult(
+                on: app, submissionID: "sub_val",
+                collectionJSON: collectionJSON(
+                    submissionID: "sub_val",
+                    outcomes: [outcome("df is loaded", .pass, short: "ok")],
+                    runnerVersion: "0.4.632"))
+            assignment.validationSubmissionID = "sub_val"
+            assignment.validationStatus = "passed"
+            try await assignment.save(on: app.db)
+
+            let output = try await run(app, publicID: assignment.publicID)
+
+            #expect(output.runnerID == "runner-abc123")
+            // The version carried on the result itself — the build that actually
+            // produced these outcomes, not whatever that runner is running now.
+            #expect(output.runnerVersion == "0.4.632")
+        }
+    }
+
+    /// A pending / no-result assignment reports no attribution rather than
+    /// inventing one.
+    @Test func reportsNoRunnerAttributionWhenThereIsNoResult() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let assignment = try await fixture(on: app)
+            let output = try await run(app, publicID: assignment.publicID)
+            #expect(output.runnerID == nil)
+            #expect(output.runnerVersion == nil)
         }
     }
 

--- a/Tests/APITests/ObservabilityTests.swift
+++ b/Tests/APITests/ObservabilityTests.swift
@@ -40,6 +40,53 @@ import VaporTesting
         }
     }
 
+    /// The runner's version is stamped from the claim payload, not looked up
+    /// later: a runner's *current* version is not the version it ran a past job
+    /// with, and during a rolling upgrade those differ — which is exactly when
+    /// the question gets asked. Without this, a suite failing on a lagging
+    /// runner is indistinguishable from a content bug.
+    @Test func claimStampsTheRunnerVersionThatRanTheJob() async throws {
+        try await withApp(app) { _ in
+            let (_, submission) = try await makeSubmission(submissionID: "sub_runner_version")
+            submission.workerID = "runner-lagging"
+            submission.assignedAt = Date()
+            submission.status = "assigned"
+            try await submission.update(on: app.db)
+
+            await app.diagnostics.recordJobAssigned(
+                submission: submission, runnerVersion: "0.4.632", on: app.db, logger: app.logger)
+
+            let row = try await APISubmissionDiagnostics.find("sub_runner_version", on: app.db)
+            #expect(row?.runnerID == "runner-lagging")
+            #expect(row?.runnerVersion == "0.4.632")
+        }
+    }
+
+    /// A runner that advertises no version (or a caller that omits it) leaves
+    /// the column null rather than recording something invented — and must not
+    /// clobber a version already recorded for that job.
+    @Test func absentRunnerVersionLeavesTheRecordedOneIntact() async throws {
+        try await withApp(app) { _ in
+            let (_, submission) = try await makeSubmission(submissionID: "sub_no_version")
+            submission.workerID = "runner-quiet"
+            submission.assignedAt = Date()
+            submission.status = "assigned"
+            try await submission.update(on: app.db)
+
+            await app.diagnostics.recordJobAssigned(
+                submission: submission, on: app.db, logger: app.logger)
+            #expect(try await APISubmissionDiagnostics.find("sub_no_version", on: app.db)?.runnerVersion == nil)
+
+            await app.diagnostics.recordJobAssigned(
+                submission: submission, runnerVersion: "0.4.642", on: app.db, logger: app.logger)
+            await app.diagnostics.recordJobAssigned(
+                submission: submission, on: app.db, logger: app.logger)
+            #expect(
+                try await APISubmissionDiagnostics.find("sub_no_version", on: app.db)?.runnerVersion
+                    == "0.4.642")
+        }
+    }
+
     @Test func executionDurationAndFinalStatusPersistence() async throws {
         try await withApp(app) { _ in
             let (_, submission) = try await makeSubmission(submissionID: "sub_exec_metric")

--- a/changelog.d/runner-attribution-per-submission.md
+++ b/changelog.d/runner-attribution-per-submission.md
@@ -1,0 +1,16 @@
+### Added
+
+- **Every job now records the runner version that ran it, and validation
+  results report it.** `submission_diagnostics` already stored *which* runner
+  took a submission (`runner_id`), but the runner's version was only ever live
+  heartbeat state on the runner dashboard — so the version for a past job could
+  only be found by joining to what that runner is running *now*. During a
+  rolling upgrade that join gives the wrong answer, which is precisely when the
+  question gets asked: a suite that depends on a newer runner build fails on a
+  lagging runner and passes on a current one, and without the recorded version
+  the failure reads as a content bug rather than version skew. A new nullable
+  `runner_version` column is stamped from the claim payload, so it is also the
+  only record for a job that never reported a result (timed out, or the runner
+  died). `get_validation_result` now returns `runnerID` and `runnerVersion`
+  alongside the outcomes — the version taken from the result document itself, so
+  it is the build that actually produced those outcomes.

--- a/docs/operational-diagnostics.md
+++ b/docs/operational-diagnostics.md
@@ -20,6 +20,13 @@ Captured fields include:
 - `assignment_id`
 - `user_id`
 - `runner_id`
+- `runner_version` — the version the runner advertised when it *claimed* this
+  job. Recorded at claim time rather than joined from the runner's live state:
+  a runner's current version is not the version it ran a past job with, and
+  during a rolling upgrade those differ — which is exactly when the question
+  gets asked. It is also the only record for a job that never reported a result
+  (timed out, or the runner died), since there is no result document to read a
+  version off. Null for rows written before v0.4.643.
 - `kind`
 - `attempt_number`
 - `enqueued_at`


### PR DESCRIPTION
## Why

`submission_diagnostics.runner_id` already recorded *which* runner took a submission. The runner's **version**, though, lived only as live heartbeat state for the runner dashboard — so the version for a past job could only be obtained by joining to what that runner is running *now*.

During a rolling upgrade that join returns the wrong answer, which is exactly when anyone asks. A suite that depends on a newer runner build fails on a lagging runner and passes on a current one; without the recorded version, that reads as a content bug.

This is not hypothetical — it cost most of a session on the R work, and three wrong conclusions. Two validation runs 34 seconds apart returned 13/13 and 0/13, and there was no way to attribute either.

## What

**`runner_version` on `submission_diagnostics`** (nullable, standalone `Add*` migration mirroring `AddClientDiagnosticAppVersion`). Stamped from the claim payload, where `body.runnerVersion` is already in scope.

Claim time rather than result time is deliberate: it makes this the *only* record for a job that never reported a result — timed out, or the runner died — because there is no result document to read a version off. It also means the value can be queried/aggregated without decoding every result blob, which is what a future version-skew alert would need.

**`runnerID` + `runnerVersion` on `get_validation_result`.** The version here comes from the result document itself (`TestOutcomeCollection.runnerVersion`, which the worker sets to `ChickadeeVersion.current`), so it is the build that actually produced those outcomes rather than a claim-time approximation. Worth noting this was *already in the payload* and simply never surfaced — the tool needed no new query.

## Deliberately not done

Not added to the student submission page. `SubmissionContext` is student-facing — badges, class goals, secret reveal — and runner internals don't belong there. Which staff surface should carry it (the instructor drilldown, or the existing admin runner detail page, which already links submissions) is a separate call I didn't want to make unilaterally.

## Tests

`ObservabilityTests` (+2): the claim stamps the version that ran the job; an absent version leaves the column null and does not clobber an already-recorded one.

`GetValidationResultToolTests` (+2): a result reports the runner and the build that produced it; a pending assignment reports no attribution rather than inventing one. The seeded `runnerVersion` is now a parameter so a test can pin attribution to a specific build.

Regression run over observability, validation-result, MCP schema-sync, migration, diagnostics and worker-job suites: **61 tests in 13 suites, green.** `scripts/lint.sh` and `scripts/swiftlint.sh --strict` clean. `docs/operational-diagnostics.md` documents the new column and why it's stamped at claim time.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bx8pUeHnSwRG5hBq93kTC)_