### PR TITLE
Harden notebook-check validation for regex and R names

### DIFF
--- a/Sources/APIServer/Utilities/IdentifierValidation.swift
+++ b/Sources/APIServer/Utilities/IdentifierValidation.swift
@@ -27,6 +27,33 @@ func isValidPythonIdentifier(_ s: String) -> Bool {
     return true
 }
 
+/// R reserved words (`?Reserved`), which are not syntactic names.
+let rReservedWords: Set<String> = [
+    "if", "else", "repeat", "while", "function", "for", "in", "next", "break",
+    "TRUE", "FALSE", "NULL", "Inf", "NaN", "NA", "NA_integer_", "NA_real_",
+    "NA_complex_", "NA_character_",
+]
+
+/// Whether `s` is a syntactically valid R name — the R analogue of
+/// `isValidPythonIdentifier`, so an idiomatic name like `my.df` is accepted on
+/// an R assignment instead of being rejected against Python's rules.
+///
+/// R names may start with a letter or a dot and may contain letters, digits,
+/// `.` and `_`. Two differences from Python: a leading underscore is *not*
+/// allowed, and a name beginning with a dot followed by a digit (e.g. `.2x`) is
+/// reserved by R and is not a syntactic name. Reserved words are excluded.
+func isValidRIdentifier(_ s: String) -> Bool {
+    guard !s.isEmpty, !rReservedWords.contains(s) else { return false }
+    let chars = Array(s)
+    let first = chars[0]
+    guard first.isLetter || first == "." else { return false }
+    if first == ".", chars.count > 1, chars[1].isNumber { return false }
+    for ch in chars.dropFirst() {
+        guard ch.isLetter || ch.isNumber || ch == "." || ch == "_" else { return false }
+    }
+    return true
+}
+
 /// Stricter than Python identifier: lowercase-preferred alphanumeric +
 /// underscore, allowed to start with a digit (for case keys like "01").
 /// Used to validate filename-fragment safety for generated test scripts.

--- a/Sources/APIServer/Utilities/NotebookCheckKindHandler.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckKindHandler.swift
@@ -33,8 +33,10 @@ protocol NotebookCheckKindHandler: Sendable {
     /// test script.  Default: none.
     func sidecars(_ check: NotebookCheck) -> [String: String]
 
-    /// Validates the kind-specific required fields.
-    func validate(_ check: NotebookCheck) throws
+    /// Validates the kind-specific required fields. `language` selects the
+    /// identifier grammar for name fields (Python vs R) so an R assignment's
+    /// idiomatic names (`my.df`) aren't held to Python's rules.
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws
 }
 
 extension NotebookCheckKindHandler {
@@ -67,21 +69,40 @@ func notebookCheckKindHandler(for kind: NotebookCheckKind) -> any NotebookCheckK
 /// `(kind_name)` infix and `field` names the offending field in the message
 /// (some kinds call it a "variable name", `.functionExists` a "function name").
 private func validateRequiredIdentifier(
-    _ value: String?, check: NotebookCheck, kindLabel: String, field: String
+    _ value: String?, check: NotebookCheck, kindLabel: String, field: String,
+    language: AssignmentLanguage
 ) throws -> String {
     guard let value, !value.isEmpty else {
         throw Abort(
             .unprocessableEntity,
             reason: "Notebook check '\(check.id)' (\(kindLabel)): \(field) is required")
     }
-    guard isValidPythonIdentifier(value) else {
+    guard isValidIdentifier(value, language: language) else {
         throw Abort(
             .unprocessableEntity,
             reason:
-                "Notebook check '\(check.id)' (\(kindLabel)): \(field) '\(value)' is not a valid Python identifier"
+                "Notebook check '\(check.id)' (\(kindLabel)): \(field) '\(value)' is not a valid \(identifierKindName(language))"
         )
     }
     return value
+}
+
+/// Identifier grammar for `language`. Keeps name fields (`variable`, function
+/// names) held to the right language's rules, so an R name like `my.df` passes
+/// on an R assignment while Python assignments are unchanged.
+private func isValidIdentifier(_ value: String, language: AssignmentLanguage) -> Bool {
+    switch language {
+    case .python: return isValidPythonIdentifier(value)
+    case .r: return isValidRIdentifier(value)
+    }
+}
+
+/// Human-readable name of the identifier grammar, for validation messages.
+private func identifierKindName(_ language: AssignmentLanguage) -> String {
+    switch language {
+    case .python: return "Python identifier"
+    case .r: return "R name"
+    }
 }
 
 /// rtol / atol bounds check shared by the float-comparison kinds.
@@ -98,6 +119,46 @@ private func validateTolerances(_ check: NotebookCheck, kindLabel: String) throw
     }
 }
 
+/// Cheap sanity scan for a user-supplied `cell_contains` regex needle.  A full
+/// Python/R regex engine isn't available from Swift, so this only catches the
+/// common typos: unbalanced parentheses and a dangling trailing backslash.  It
+/// walks the pattern tracking escape state and character-class nesting, so an
+/// escaped `\(`, a literal `[(]`, or a literal `\\` at the end isn't
+/// miscounted — the bug this replaced compared raw `(`/`)` character counts and
+/// tested `hasSuffix("\\")`, both of which mis-flagged those cases.
+private func validateRegexSanity(_ needle: String, checkID: String) throws {
+    func unbalanced() -> Abort {
+        Abort(
+            .unprocessableEntity,
+            reason: "Notebook check '\(checkID)' (cell_contains): regex has unbalanced parentheses")
+    }
+    var depth = 0
+    var inClass = false
+    var escaped = false
+    for ch in needle {
+        if escaped {
+            escaped = false
+            continue
+        }
+        switch ch {
+        case "\\": escaped = true
+        case "[" where !inClass: inClass = true
+        case "]" where inClass: inClass = false
+        case "(" where !inClass: depth += 1
+        case ")" where !inClass:
+            guard depth > 0 else { throw unbalanced() }
+            depth -= 1
+        default: break
+        }
+    }
+    if escaped {
+        throw Abort(
+            .unprocessableEntity,
+            reason: "Notebook check '\(checkID)' (cell_contains): regex ends with a dangling backslash")
+    }
+    guard depth == 0 else { throw unbalanced() }
+}
+
 // MARK: - dataFrameShape
 
 struct DataFrameShapeKind: NotebookCheckKindHandler {
@@ -106,9 +167,9 @@ struct DataFrameShapeKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultDataFrameShapeLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         _ = try validateRequiredIdentifier(
-            check.variable, check: check, kindLabel: "data_frame_shape", field: "variable name")
+            check.variable, check: check, kindLabel: "data_frame_shape", field: "variable name", language: language)
         guard let rows = check.expectedRows, rows >= 0 else {
             throw Abort(
                 .unprocessableEntity,
@@ -132,9 +193,9 @@ struct DataFrameColumnsKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultDataFrameColumnsLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         _ = try validateRequiredIdentifier(
-            check.variable, check: check, kindLabel: "data_frame_columns", field: "variable name")
+            check.variable, check: check, kindLabel: "data_frame_columns", field: "variable name", language: language)
         guard let columns = check.expectedColumns, !columns.isEmpty else {
             throw Abort(
                 .unprocessableEntity,
@@ -178,9 +239,9 @@ struct DataFrameEqualityKind: NotebookCheckKindHandler {
         [expectedCSVSidecarFilename(checkID: check.id): check.expectedCSV ?? ""]
     }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         _ = try validateRequiredIdentifier(
-            check.variable, check: check, kindLabel: "data_frame_equality", field: "variable name")
+            check.variable, check: check, kindLabel: "data_frame_equality", field: "variable name", language: language)
         guard let csv = check.expectedCSV, !csv.isEmpty else {
             throw Abort(
                 .unprocessableEntity,
@@ -215,9 +276,9 @@ struct SeriesEqualityKind: NotebookCheckKindHandler {
         [expectedCSVSidecarFilename(checkID: check.id): check.expectedCSV ?? ""]
     }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         _ = try validateRequiredIdentifier(
-            check.variable, check: check, kindLabel: "series_equality", field: "variable name")
+            check.variable, check: check, kindLabel: "series_equality", field: "variable name", language: language)
         guard let csv = check.expectedCSV, !csv.isEmpty else {
             throw Abort(
                 .unprocessableEntity,
@@ -252,9 +313,9 @@ struct NumericArrayCloseKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultNumericArrayCloseLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         _ = try validateRequiredIdentifier(
-            check.variable, check: check, kindLabel: "numeric_array_close", field: "variable name")
+            check.variable, check: check, kindLabel: "numeric_array_close", field: "variable name", language: language)
         guard let array = check.expectedArray, !array.isEmpty else {
             throw Abort(
                 .unprocessableEntity,
@@ -274,7 +335,7 @@ struct FigureCountKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultFigureCountLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         guard let n = check.minFigures, n >= 0 else {
             throw Abort(
                 .unprocessableEntity,
@@ -291,28 +352,16 @@ struct CellContainsKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultCellContainsLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         guard let needle = check.containsText, !needle.isEmpty else {
             throw Abort(
                 .unprocessableEntity,
                 reason: "Notebook check '\(check.id)' (cell_contains): containsText must be a non-empty string")
         }
-        // If regex, sanity-check that it compiles.  We can't run a
-        // Python regex from Swift, but a simple parser catches the
-        // most common typos (unbalanced parens, dangling `\`).
+        // If regex, sanity-check that it compiles.  We can't run a Python/R
+        // regex from Swift, but a small scan catches the most common typos.
         if check.regex == true {
-            let openParens = needle.filter { $0 == "(" }.count
-            let closeParens = needle.filter { $0 == ")" }.count
-            guard openParens == closeParens else {
-                throw Abort(
-                    .unprocessableEntity,
-                    reason: "Notebook check '\(check.id)' (cell_contains): regex has unbalanced parentheses")
-            }
-            if needle.hasSuffix("\\") {
-                throw Abort(
-                    .unprocessableEntity,
-                    reason: "Notebook check '\(check.id)' (cell_contains): regex ends with a dangling backslash")
-            }
+            try validateRegexSanity(needle, checkID: check.id)
         }
     }
 }
@@ -325,7 +374,7 @@ struct FunctionExistsKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultFunctionExistsLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         // Inlined rather than routed through `validateRequiredIdentifier`:
         // this kind's two messages historically used different field
         // wording ("function name (variable)" when missing, "function
@@ -335,11 +384,11 @@ struct FunctionExistsKind: NotebookCheckKindHandler {
                 .unprocessableEntity,
                 reason: "Notebook check '\(check.id)' (function_exists): function name (variable) is required")
         }
-        guard isValidPythonIdentifier(name) else {
+        guard isValidIdentifier(name, language: language) else {
             throw Abort(
                 .unprocessableEntity,
                 reason:
-                    "Notebook check '\(check.id)' (function_exists): function name '\(name)' is not a valid Python identifier"
+                    "Notebook check '\(check.id)' (function_exists): function name '\(name)' is not a valid \(identifierKindName(language))"
             )
         }
         if let arity = check.expectedArity, arity < 0 {
@@ -358,9 +407,9 @@ struct VariableExistsKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultVariableExistsLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         _ = try validateRequiredIdentifier(
-            check.variable, check: check, kindLabel: "variable_exists", field: "variable name")
+            check.variable, check: check, kindLabel: "variable_exists", field: "variable name", language: language)
         // expectedType (if present) must be non-empty and non-whitespace.
         // Unknown type names fall through to the renderer's MRO-walk
         // fallback (same behaviour as `.returnTypeCheck`), so we don't
@@ -386,7 +435,7 @@ struct ASTStructureKind: NotebookCheckKindHandler {
     }
     func defaultLabel(_ check: NotebookCheck) -> String { defaultASTStructureLabel(check) }
 
-    func validate(_ check: NotebookCheck) throws {
+    func validate(_ check: NotebookCheck, language: AssignmentLanguage) throws {
         guard let constructs = check.requiredConstructs, !constructs.isEmpty else {
             throw Abort(
                 .unprocessableEntity,

--- a/Sources/APIServer/Utilities/NotebookCheckValidator.swift
+++ b/Sources/APIServer/Utilities/NotebookCheckValidator.swift
@@ -66,7 +66,7 @@ func validateNotebookChecks(
                 reason: "Notebook check '\(check.id)': points must be non-negative")
         }
 
-        try notebookCheckKindHandler(for: check.kind).validate(check)
+        try notebookCheckKindHandler(for: check.kind).validate(check, language: language)
     }
 
     // Filename collisions: every generated filename a check produces

--- a/Tests/APITests/NotebookCheckFormSchemaTests.swift
+++ b/Tests/APITests/NotebookCheckFormSchemaTests.swift
@@ -64,7 +64,7 @@ import Testing
             #expect(
                 throws: Never.self,
                 "Valid sample for \(kind.rawValue) should pass its validator"
-            ) { try handler.validate(sample) }
+            ) { try handler.validate(sample, language: .python) }
 
             // Negative: clearing each schema-required field trips the validator.
             let required = (schema.kinds[kind.rawValue] ?? []).filter(\.required).map(\.name)
@@ -73,7 +73,7 @@ import Testing
                 #expect(
                     throws: (any Error).self,
                     "Clearing required field '\(field)' for \(kind.rawValue) must fail validation"
-                ) { try handler.validate(broken) }
+                ) { try handler.validate(broken, language: .python) }
             }
         }
     }

--- a/Tests/APITests/NotebookCheckValidationHardeningTests.swift
+++ b/Tests/APITests/NotebookCheckValidationHardeningTests.swift
@@ -1,0 +1,120 @@
+// Tests/APITests/NotebookCheckValidationHardeningTests.swift
+//
+// Two notebook-check validation hardening fixes:
+//
+//   1. `cell_contains` regex sanity understood raw `(`/`)` counts and a
+//      `hasSuffix("\\")` test, so an escaped `\(`, a paren inside a `[...]`
+//      character class, or a literal trailing `\\` were wrongly rejected as
+//      "unbalanced parentheses" / "dangling backslash". The scan now tracks
+//      escape state and character-class nesting. (Affects Python authors too.)
+//
+//   2. Name fields (`variable`, function names) were validated as *Python*
+//      identifiers on every assignment, so an idiomatic R name like `my.df`
+//      was refused on an R assignment. Validation now dispatches on the
+//      assignment language via `isValidRIdentifier`.
+
+import Core
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct NotebookCheckValidationHardeningTests {
+
+    // MARK: - item 1: cell_contains regex sanity
+
+    private func cellContains(_ needle: String, regex: Bool) -> [NotebookCheck] {
+        [NotebookCheck(id: "c", kind: .cellContains, containsText: needle, regex: regex)]
+    }
+
+    @Test func regex_acceptsEscapedParen() throws {
+        // `\(` is an escaped literal, not an opening group — the naive counter
+        // saw one `(` and zero `)` and rejected it. This is the real-world
+        // needle from the R Assignment 4 conversion.
+        try validateNotebookChecks(cellContains(#"summary\s*\("#, regex: true))
+    }
+
+    @Test func regex_acceptsParenInsideCharacterClass() throws {
+        try validateNotebookChecks(cellContains("[()]+", regex: true))
+    }
+
+    @Test func regex_acceptsBalancedGroups() throws {
+        try validateNotebookChecks(cellContains("(a|b)(c)", regex: true))
+    }
+
+    @Test func regex_acceptsLiteralTrailingBackslashPair() throws {
+        // `\\` is an escaped backslash, not a dangling escape.
+        try validateNotebookChecks(cellContains(#"path\\"#, regex: true))
+    }
+
+    @Test func regex_rejectsUnbalancedOpen() {
+        #expect(throws: (any Error).self) {
+            try validateNotebookChecks(cellContains("(a", regex: true))
+        }
+    }
+
+    @Test func regex_rejectsUnbalancedClose() {
+        #expect(throws: (any Error).self) {
+            try validateNotebookChecks(cellContains("a)", regex: true))
+        }
+    }
+
+    @Test func regex_rejectsDanglingBackslash() {
+        #expect(throws: (any Error).self) {
+            try validateNotebookChecks(cellContains(#"abc\"#, regex: true))
+        }
+    }
+
+    @Test func nonRegex_skipsParenSanity() throws {
+        // A plain substring needle is not a regex, so unbalanced parens in it
+        // (matching literal source like `f(x`) must not be rejected.
+        try validateNotebookChecks(cellContains("f(x", regex: false))
+    }
+
+    // MARK: - item 2: R identifier names
+
+    @Test func isValidRIdentifier_acceptsIdiomaticNames() {
+        for name in ["x", "my.df", "df2", ".hidden", "a_b.c", "T"] {
+            #expect(isValidRIdentifier(name), "\(name) should be a valid R name")
+        }
+    }
+
+    @Test func isValidRIdentifier_rejectsInvalidNames() {
+        // Empty, Python-style leading underscore, leading digit, dot-then-digit,
+        // a hyphen, and R reserved words.
+        for name in ["", "_x", "1df", ".2way", "a-b", "function", "if", "NULL"] {
+            #expect(!isValidRIdentifier(name), "\(name) should not be a valid R name")
+        }
+    }
+
+    @Test func variableName_dotName_passesOnRAssignment() throws {
+        let checks = [NotebookCheck(id: "c", kind: .variableExists, variable: "my.df")]
+        try validateNotebookChecks(checks, language: .r)
+    }
+
+    @Test func variableName_dotName_rejectedOnPythonAssignment() throws {
+        let checks = [NotebookCheck(id: "c", kind: .variableExists, variable: "my.df")]
+        let error = try #require(
+            throws: (any Error).self
+        ) {
+            try validateNotebookChecks(checks, language: .python)
+        }
+        #expect("\(error)".contains("not a valid Python identifier"))
+    }
+
+    @Test func variableName_leadingUnderscore_rejectedOnRAssignment() throws {
+        let checks = [NotebookCheck(id: "c", kind: .variableExists, variable: "_x")]
+        let error = try #require(
+            throws: (any Error).self
+        ) {
+            try validateNotebookChecks(checks, language: .r)
+        }
+        #expect("\(error)".contains("not a valid R name"))
+    }
+
+    @Test func functionName_dotName_passesOnRAssignment() throws {
+        let checks = [NotebookCheck(id: "c", kind: .functionExists, variable: "my.func")]
+        try validateNotebookChecks(checks, language: .r)
+    }
+}

--- a/changelog.d/notebook-check-validation-hardening.md
+++ b/changelog.d/notebook-check-validation-hardening.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Notebook-check validation hardening.** `cell_contains` regex validation no
+  longer rejects an escaped `\(`, a parenthesis inside a `[...]` character
+  class, or a literal trailing `\\` as unbalanced/dangling — it tracks escape
+  state and character-class nesting instead of counting raw parentheses (this
+  affected Python authors too). Name fields (`variable`, function names) on an R
+  assignment now accept idiomatic R names such as `my.df` via a new
+  `isValidRIdentifier`, instead of being held to Python's identifier rules.


### PR DESCRIPTION
## What

Two authoring-time false-rejections in notebook-check validation, both surfaced by the HLTH 230 R conversion.

## 1. `cell_contains` regex sanity (also affects Python authors)

The regex sanity check counted raw `(`/`)` characters and tested `hasSuffix("\\")`, so it wrongly rejected:
- an escaped `\(` or `\)` (e.g. the real needle `summary\s*\(` from R Assignment 4 — one `(`, zero `)` → "unbalanced");
- a parenthesis inside a `[...]` character class (`[()]`);
- a literal trailing `\\` (an escaped backslash) flagged as a "dangling backslash".

Replaced with a small scan (`validateRegexSanity`) that walks the pattern tracking escape state and character-class nesting. Genuinely unbalanced parens (`(a`, `a)`) and a genuinely dangling escape (`abc\`) are still rejected; non-regex needles skip the check entirely.

## 2. R identifier names

Name fields (`variable`, function names) were validated as **Python** identifiers on every assignment, so an idiomatic R name like `my.df` was refused on an R assignment. `validateNotebookChecks` already had the assignment language in scope; it now threads it into each handler's `validate`, and validation dispatches to a new `isValidRIdentifier` for R (leading letter or dot, no leading underscore, `.`/`_` allowed, R reserved words excluded). **Python assignments are unchanged** — the `not a valid Python identifier` message and rules are preserved verbatim.

## Testing

14 new tests (`NotebookCheckValidationHardeningTests`): the regex scan (escaped / character-class / trailing-backslash-pair accepted; unbalanced-open, unbalanced-close, dangling-backslash rejected; non-regex needle skips), R-name acceptance on R assignments vs Python rejection, and direct `isValidRIdentifier` accept/reject tables. Existing `NotebookCheckFormSchemaTests` and `NotebookCheckVariableExistsTests` pass unchanged. `swift build`, targeted `swift test`, `scripts/lint.sh`, and `scripts/swiftlint.sh --strict` (0 violations in 855 files) clean locally; pure-Swift paths, no Rscript required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD)_