### PR TITLE
Re-derive assignment language when the starter notebook is replaced

### DIFF
--- a/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
+++ b/Sources/APIServer/Routes/Web/ManifestFileHelpers.swift
@@ -167,6 +167,68 @@ func updateManifestRemovingScript(manifestJSON: String, filename: String) -> Str
     )
 }
 
+/// Returns manifest JSON identical to `manifestJSON` except for its recorded
+/// `language`, rebuilt through the canonical `makeWorkerManifestJSON` writer so
+/// every other field is preserved. Returns nil if the manifest can't be decoded.
+func updateManifestLanguage(manifestJSON: String, language: AssignmentLanguage?) -> String? {
+    guard let props = decodeManifest(fromJSON: manifestJSON) else { return nil }
+    let entries = props.testSuites.enumerated().map { idx, e in
+        ConfiguredSuiteEntry(
+            script: e.script,
+            tier: e.tier.rawValue,
+            order: idx + 1,
+            dependsOn: e.dependsOn,
+            points: e.points,
+            displayName: e.name,
+            generatedBy: e.generatedBy,
+            generatedByCheck: e.generatedByCheck,
+            sectionID: e.sectionID,
+            hint: e.hint,
+            timeLimitSeconds: e.timeLimitSeconds
+        )
+    }
+    return try? makeWorkerManifestJSON(
+        testSuites: entries,
+        includeMakefile: props.makefile != nil,
+        gradingMode: props.gradingMode.rawValue,
+        timeLimitSeconds: props.timeLimitSeconds,
+        starterNotebook: props.starterNotebook,
+        patternFamilies: props.patternFamilies,
+        notebookChecks: props.notebookChecks,
+        sections: props.sections,
+        globalVariables: props.globalVariables,
+        globalExpressions: props.globalExpressions,
+        achievements: props.achievements,
+        disabledBuiltInAwardIDs: props.disabledBuiltInAwardIDs,
+        builtInAchievementsSeeded: props.builtInAchievementsSeeded,
+        datasets: props.datasets,
+        language: language,
+        minimumRunnerVersion: props.minimumRunnerVersion
+    )
+}
+
+/// Re-derives the assignment language from a freshly-written starter notebook,
+/// treating the recorded manifest `language` as a memo of what was last resolved
+/// rather than a fixed declaration. Returns updated manifest JSON when the
+/// recorded language no longer matches what the new notebook implies (e.g. a
+/// cloned Python assignment whose starter notebook is replaced with an R one),
+/// or nil when nothing needs to change:
+///   - no language was ever recorded — lazy `resolve(…notebookData:)` already
+///     re-derives that case from the notebook on every read, so there is nothing
+///     sticky to correct and no reason to churn the manifest bytes;
+///   - the recorded language still matches the notebook (the common case: a
+///     Python notebook re-saved on a Python assignment stays `.python`).
+func manifestWithRederivedLanguage(manifestJSON: String, notebookData: Data) -> String? {
+    guard let props = decodeManifest(fromJSON: manifestJSON),
+        let recorded = props.language
+    else {
+        return nil
+    }
+    let rederived = AssignmentLanguage.rederive(manifest: props, notebookData: notebookData)
+    guard recorded != rederived else { return nil }
+    return updateManifestLanguage(manifestJSON: manifestJSON, language: rederived)
+}
+
 func makeWorkerManifestJSON(
     testSuites: [ConfiguredSuiteEntry],
     includeMakefile: Bool,

--- a/Sources/APIServer/Services/AssignmentAuthoringService.swift
+++ b/Sources/APIServer/Services/AssignmentAuthoringService.swift
@@ -257,6 +257,18 @@ enum AssignmentAuthoringService {
             throw AssignmentAuthoringError.setupCopyFailed(reason: "\(error)")
         }
         setup.notebookPath = path
+        // Replacing the starter notebook re-derives the assignment language: a
+        // recorded language is a memo of what was last resolved, so a Python
+        // assignment converted to R (new R notebook, no `.R` script yet) must
+        // stop rendering `.py`. A no-op (byte-stable) when the language is
+        // unchanged or was never recorded — see `manifestWithRederivedLanguage`.
+        // Derives from the normalized bytes just written, which future reads see
+        // (R kernels normalize to `xr`, still detected as R).
+        if let updatedManifest = manifestWithRederivedLanguage(
+            manifestJSON: setup.manifest, notebookData: normalized)
+        {
+            setup.manifest = updatedManifest
+        }
         try await setup.save(on: db)
     }
 

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -82,6 +82,43 @@ extension AssignmentLanguage {
                 as? String
         )
     }
+
+    /// Re-derive the language from scratch, **ignoring any recorded
+    /// `manifest.language`**.
+    ///
+    /// `resolve` treats a recorded language as an authoritative answer (step 0),
+    /// which is what a stable render needs — but it also makes the recorded value
+    /// a one-way door: a Python assignment cloned and converted to R keeps
+    /// rendering `.py` forever, because the sticky `.python` outranks the new R
+    /// notebook. When the starter notebook is *replaced* the recorded value is a
+    /// stale memo, not a declaration, so re-derivation must skip it. Precedence
+    /// is otherwise identical to `resolve`: an `.R`/`.r` graded script wins, else
+    /// an R notebook kernel (`kernelspec.name` in `rKernelNames`, or
+    /// `language_info.name == "r"`), else `.python`.
+    public static func rederive(
+        manifest: TestProperties,
+        notebookData: @autoclosure () -> Data?
+    ) -> AssignmentLanguage {
+        let hasRScript = manifest.testSuites.contains {
+            URL(fileURLWithPath: $0.script).pathExtension.lowercased() == "r"
+        }
+        if hasRScript { return .r }
+        guard let data = notebookData(),
+            let notebook = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            let metadata = notebook["metadata"] as? [String: Any]
+        else {
+            return .python
+        }
+        if let kernel = (metadata["kernelspec"] as? [String: Any])?["name"] as? String,
+            rKernelNames.contains(kernel.lowercased())
+        {
+            return .r
+        }
+        if ((metadata["language_info"] as? [String: Any])?["name"] as? String)?.lowercased() == "r" {
+            return .r
+        }
+        return .python
+    }
 }
 
 // MARK: - Per-language rendering / delivery strategy

--- a/Tests/APITests/ManifestLanguageRederiveTests.swift
+++ b/Tests/APITests/ManifestLanguageRederiveTests.swift
@@ -1,0 +1,76 @@
+// Tests/APITests/ManifestLanguageRederiveTests.swift
+//
+// `manifestWithRederivedLanguage` — the notebook-replacement half of the
+// "recorded language is a one-way door" fix. Replacing a starter notebook
+// re-derives the recorded language (a memo, not a declaration), so a Python
+// assignment converted to R stops rendering `.py`. Byte-stable (returns nil)
+// when the language is unchanged or was never recorded.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct ManifestLanguageRederiveTests {
+
+    private func ipynb(kernel: String?) -> Data {
+        let kernelField = kernel.map { "\"kernelspec\":{\"name\":\"\($0)\"}" } ?? ""
+        return Data("{\"metadata\":{\(kernelField)},\"cells\":[]}".utf8)
+    }
+
+    private func manifestJSON(language: String?, rScript: Bool = false) -> String {
+        let langField = language.map { "\"language\":\"\($0)\"," } ?? ""
+        let suite = rScript ? "{\"tier\":\"public\",\"script\":\"publictest_x.R\"}" : ""
+        return
+            "{\"schemaVersion\":1,\(langField)\"requiredFiles\":[],\"testSuites\":[\(suite)],\"timeLimitSeconds\":10}"
+    }
+
+    @Test func flipsPythonToR_whenNotebookBecomesR() throws {
+        let json = manifestJSON(language: "python")
+        let updated = try #require(
+            manifestWithRederivedLanguage(manifestJSON: json, notebookData: ipynb(kernel: "xr")))
+        #expect(try #require(decodeManifest(fromJSON: updated)).language == .r)
+    }
+
+    @Test func flipsRToPython_whenNotebookBecomesPython() throws {
+        let json = manifestJSON(language: "r")
+        let updated = try #require(
+            manifestWithRederivedLanguage(manifestJSON: json, notebookData: ipynb(kernel: "python")))
+        #expect(try #require(decodeManifest(fromJSON: updated)).language == .python)
+    }
+
+    @Test func rScriptForcesR_evenOnPythonRecordAndPythonNotebook() throws {
+        // A recorded .python alongside an .R graded script is itself wrong;
+        // rederive corrects it regardless of the notebook kernel.
+        let json = manifestJSON(language: "python", rScript: true)
+        let updated = try #require(
+            manifestWithRederivedLanguage(manifestJSON: json, notebookData: ipynb(kernel: "python")))
+        #expect(try #require(decodeManifest(fromJSON: updated)).language == .r)
+    }
+
+    @Test func returnsNil_whenLanguageUnchanged() {
+        // Common case: a Python notebook re-saved on a Python assignment. No
+        // change, so the manifest bytes must not churn.
+        let json = manifestJSON(language: "python")
+        #expect(
+            manifestWithRederivedLanguage(manifestJSON: json, notebookData: ipynb(kernel: "python"))
+                == nil)
+    }
+
+    @Test func returnsNil_whenNoRecordedLanguage() {
+        // A nil recorded language is never sticky — lazy resolution already
+        // re-derives it from the notebook — so there is nothing to correct even
+        // when the notebook is R.
+        let json = manifestJSON(language: nil)
+        #expect(
+            manifestWithRederivedLanguage(manifestJSON: json, notebookData: ipynb(kernel: "xr"))
+                == nil)
+    }
+
+    @Test func returnsNil_whenManifestUndecodable() {
+        #expect(
+            manifestWithRederivedLanguage(manifestJSON: "not json", notebookData: ipynb(kernel: "xr"))
+                == nil)
+    }
+}

--- a/Tests/CoreTests/AssignmentLanguageTests.swift
+++ b/Tests/CoreTests/AssignmentLanguageTests.swift
@@ -40,4 +40,44 @@ import Testing
         #expect(AssignmentLanguage.resolve(manifest: m, notebookLanguageInfoName: "r") == .r)
         #expect(AssignmentLanguage.resolve(manifest: m) == .python)
     }
+
+    // MARK: - rederive (ignores the recorded language memo)
+
+    private func ipynb(kernel: String?) -> Data {
+        let kernelField = kernel.map { "\"kernelspec\":{\"name\":\"\($0)\"}" } ?? ""
+        return Data("{\"metadata\":{\(kernelField)},\"cells\":[]}".utf8)
+    }
+
+    @Test func rederive_rScriptWinsOverRecordedPythonAndPythonKernel() throws {
+        // Recorded .python + a Python notebook kernel, but an .R graded script:
+        // rederive skips the recorded memo and the suite wins.
+        let m = try manifest(
+            #"{"schemaVersion":1,"language":"python","requiredFiles":[],"testSuites":[{"tier":"public","script":"publictest_x.R"}],"timeLimitSeconds":10}"#
+        )
+        #expect(AssignmentLanguage.rederive(manifest: m, notebookData: ipynb(kernel: "python")) == .r)
+    }
+
+    @Test func rederive_rNotebookKernelWinsOverRecordedPython() throws {
+        // The one-way-door case: recorded .python, no .R script, but the new
+        // notebook is an R kernel — rederive returns .r where resolve stays .python.
+        let m = try manifest(
+            #"{"schemaVersion":1,"language":"python","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
+        )
+        #expect(AssignmentLanguage.rederive(manifest: m, notebookData: ipynb(kernel: "xr")) == .r)
+        #expect(AssignmentLanguage.resolve(manifest: m, notebookData: ipynb(kernel: "xr")) == .python)
+    }
+
+    @Test func rederive_pythonNotebookIgnoresRecordedR() throws {
+        let m = try manifest(
+            #"{"schemaVersion":1,"language":"r","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
+        )
+        #expect(AssignmentLanguage.rederive(manifest: m, notebookData: ipynb(kernel: "python")) == .python)
+    }
+
+    @Test func rederive_noNotebookDefaultsPython() throws {
+        let m = try manifest(
+            #"{"schemaVersion":1,"language":"r","requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#
+        )
+        #expect(AssignmentLanguage.rederive(manifest: m, notebookData: nil) == .python)
+    }
 }

--- a/changelog.d/notebook-language-rederive.md
+++ b/changelog.d/notebook-language-rederive.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Replacing a starter notebook re-derives the assignment language.** The
+  recorded manifest language was a one-way door: a Python assignment cloned and
+  converted to R kept rendering `.py`, because the sticky `.python` outranked the
+  new R notebook. Replacing the starter notebook (web Save or the
+  `update_notebook` MCP tool) now re-derives the language from the new notebook
+  via `AssignmentLanguage.rederive` and records it when it changed — a no-op
+  (byte-stable) when the language is unchanged or was never recorded.


### PR DESCRIPTION
## What

Fixes the "recorded manifest language is a one-way door" backlog item: replacing an assignment's starter notebook now re-derives the recorded language instead of preserving it forever.

## Why

`AssignmentLanguage.resolve` treats a recorded `manifest.language` as authoritative (precedence step 0) — correct for a *stable* render, but it makes the value sticky. Clone a Python assignment, replace its notebook with an R one, and it keeps rendering `.py` forever because the recorded `.python` outranks the new R kernel. The only workaround was to save a throwaway `.R` script so the language re-resolved and re-recorded (documented in the R-support handoff as a real trap). Sibling of #1208, which fixed *first-save* resolution from the kernelspec; this fixes *replacement*.

## How

- **`AssignmentLanguage.rederive(manifest:notebookData:)`** (Core) — same precedence as `resolve` **minus step 0**: an `.R`/`.r` graded script wins, else an R notebook kernel (`kernelspec.name` ∈ `{ir,r,webr,xr}` or `language_info.name == "r"`), else `.python`. Added standalone so the byte-critical `resolve` path is untouched.
- **`manifestWithRederivedLanguage(manifestJSON:notebookData:)`** (APIServer) — rebuilds the manifest through the canonical `makeWorkerManifestJSON` writer **only when a recorded language became wrong**, returning `nil` otherwise. So it is a no-op (byte-stable, no `TestSetupCache` churn) when the language is unchanged or was never recorded — a `nil` record isn't sticky, since lazy `resolve(…notebookData:)` already re-derives that case on every read.
- Wired into **`AssignmentAuthoringService.writeAssignmentNotebook`**, the one helper the web Save path and the `update_notebook` MCP tool both funnel through, so the two can't drift. It derives from the just-written *normalized* bytes (R kernels normalize to `xr`, still detected as R — verified against `normalizeNotebookForJupyterLite`).

## Scope

This corrects the recorded **memo**. Already-generated pattern-family / notebook-check scripts re-render in the new language the next time the suite / families / checks are saved — exactly as today; nothing regenerates them on notebook replacement, and this PR doesn't change that.

## Testing

10 new pure-Swift tests (no Rscript): `rederive` precedence + memo-ignoring (`AssignmentLanguageTests`), and `manifestWithRederivedLanguage` flip / no-op / `.R`-script-correction / nil-record / undecodable-manifest cases (`ManifestLanguageRederiveTests`). `swift build`, `swift test`, `scripts/lint.sh`, `scripts/swiftlint.sh --strict` (0 violations in 857 files) clean locally.

## Note for review

Unlike the smaller hardening PRs this session, this one touches the shared notebook-write path (web Save + `update_notebook` + `createAssignment` all call `writeAssignmentNotebook`), and its end-to-end R-rendering behaviour can't be exercised in CI (no Rscript). The re-derivation logic itself is fully unit-tested, and the change is a no-op for every assignment whose notebook language is unchanged. Flagging for a human look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD)_