### PR TITLE
Make the runner version-skew alert advisory instead of a page

### DIFF
--- a/Resources/Views/alerts.leaf
+++ b/Resources/Views/alerts.leaf
@@ -120,11 +120,15 @@ Server Health Alerts
                 </td>
                 <td>#(firing.summary)</td>
                 <td>
-                    #if(firing.delivered):
-                        delivered
+                    #if(firing.paged):
+                        #if(firing.delivered):
+                            delivered
+                        #else:
+                            <span class="alerts-delivery-failed">failed</span>
+                            #if(firing.deliveryError):<br><code class="alerts-delivery-error">#(firing.deliveryError)</code>#endif
+                        #endif
                     #else:
-                        <span class="alerts-delivery-failed">failed</span>
-                        #if(firing.deliveryError):<br><code class="alerts-delivery-error">#(firing.deliveryError)</code>#endif
+                        advisory — not paged
                     #endif
                 </td>
             </tr>

--- a/Sources/APIServer/Services/AlertNotifier.swift
+++ b/Sources/APIServer/Services/AlertNotifier.swift
@@ -26,13 +26,24 @@ enum HealthRule: String, CaseIterable, Codable, Sendable {
         switch self {
         case .databaseUnreachable: return "critical"
         case .runnerOffline: return "warning"
-        case .runnerVersionSkew: return "warning"
+        // Advisory, not an outage: a runner a release behind is already protected
+        // by the #1210 minimum-runner-version gate (it queues rather than
+        // mis-grades). Surfaces on the dashboard but doesn't page — see
+        // `pagesOperator`.
+        case .runnerVersionSkew: return "info"
         case .queueBackedUp: return "warning"
         case .errorRateSpike: return "warning"
         case .editorKernelUnrecoverable: return "warning"
         case .brightspaceSyncFailing: return "warning"
         }
     }
+
+    /// Whether a firing of this rule pages the operator webhook. Informational
+    /// rules (`info` severity) still surface on `/admin/alerts` and via the
+    /// `get_health_alerts` admin tool, but they are advisory and do not page — so
+    /// a low-stakes signal like a runner being a release behind never reads as an
+    /// outage.
+    var pagesOperator: Bool { severity != "info" }
 }
 
 struct AlertMessage: Content, Sendable {

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -497,6 +497,10 @@ struct AlertFiringRecord: Encodable, Sendable {
     let resolved: Bool
     let summary: String
     let firedAt: String
+    /// Whether this rule pages the operator webhook at all. Advisory (`info`)
+    /// rules are recorded here for the dashboard but never paged, so the view can
+    /// show "advisory" rather than mistaking a deliberate non-page for a failure.
+    let paged: Bool
     let delivered: Bool
     let deliveryError: String?
 }
@@ -575,6 +579,7 @@ actor ServerHealthAlertMonitor {
             resolved: false,
             summary: alert.summary,
             firedAt: alert.firedAt,
+            paged: true,
             delivered: false,
             deliveryError: nil
         )
@@ -585,6 +590,7 @@ actor ServerHealthAlertMonitor {
                 resolved: false,
                 summary: alert.summary,
                 firedAt: alert.firedAt,
+                paged: true,
                 delivered: true,
                 deliveryError: nil
             )
@@ -594,6 +600,7 @@ actor ServerHealthAlertMonitor {
                 resolved: false,
                 summary: alert.summary,
                 firedAt: alert.firedAt,
+                paged: true,
                 delivered: false,
                 deliveryError: String(describing: error)
             )
@@ -629,20 +636,26 @@ actor ServerHealthAlertMonitor {
                 firedAt: now,
                 application: application
             )
+            // Advisory (`info`-severity) rules are recorded and logged so they
+            // stay visible on `/admin/alerts` and via `get_health_alerts`, but
+            // they never page the operator webhook.
+            let pages = transition.rule.pagesOperator
             var delivered = false
             var deliveryError: String?
-            do {
-                try await activeNotifier.send(alert, on: application)
-                delivered = true
-            } catch {
-                deliveryError = String(describing: error)
-                application.logger.warning(
-                    "alert_delivery_failed",
-                    metadata: [
-                        "rule": .string(alert.rule),
-                        "resolved": .stringConvertible(alert.resolved),
-                        "error": .string(deliveryError ?? "unknown"),
-                    ])
+            if pages {
+                do {
+                    try await activeNotifier.send(alert, on: application)
+                    delivered = true
+                } catch {
+                    deliveryError = String(describing: error)
+                    application.logger.warning(
+                        "alert_delivery_failed",
+                        metadata: [
+                            "rule": .string(alert.rule),
+                            "resolved": .stringConvertible(alert.resolved),
+                            "error": .string(deliveryError ?? "unknown"),
+                        ])
+                }
             }
             application.logger.info(
                 "alert_emitted",
@@ -650,6 +663,7 @@ actor ServerHealthAlertMonitor {
                     "rule": .string(alert.rule),
                     "resolved": .stringConvertible(alert.resolved),
                     "summary": .string(alert.summary),
+                    "paged": .stringConvertible(pages),
                     "delivered": .stringConvertible(delivered),
                 ])
             appendFiring(
@@ -658,6 +672,7 @@ actor ServerHealthAlertMonitor {
                     resolved: alert.resolved,
                     summary: alert.summary,
                     firedAt: alert.firedAt,
+                    paged: pages,
                     delivered: delivered,
                     deliveryError: deliveryError
                 ))

--- a/Tests/APITests/ServerHealthAlertTests.swift
+++ b/Tests/APITests/ServerHealthAlertTests.swift
@@ -348,10 +348,22 @@ import Testing
     @Test func healthRuleSeverity() {
         #expect(HealthRule.databaseUnreachable.severity == "critical")
         #expect(HealthRule.runnerOffline.severity == "warning")
-        #expect(HealthRule.runnerVersionSkew.severity == "warning")
+        // Advisory: a runner a release behind is low-stakes (the #1210 gate
+        // queues rather than mis-grades), so it's info, not warning.
+        #expect(HealthRule.runnerVersionSkew.severity == "info")
         #expect(HealthRule.queueBackedUp.severity == "warning")
         #expect(HealthRule.errorRateSpike.severity == "warning")
         #expect(HealthRule.editorKernelUnrecoverable.severity == "warning")
+    }
+
+    @Test func healthRulePaging() {
+        // Runner version skew is advisory — it surfaces on /admin/alerts and via
+        // get_health_alerts but never pages the operator webhook. Every other rule
+        // pages.
+        #expect(HealthRule.runnerVersionSkew.pagesOperator == false)
+        for rule in HealthRule.allCases where rule != .runnerVersionSkew {
+            #expect(rule.pagesOperator, "\(rule.rawValue) should page the operator")
+        }
     }
 
     // MARK: - decideEditorKernelUnrecoverable

--- a/changelog.d/runner-version-skew-advisory.md
+++ b/changelog.d/runner-version-skew-advisory.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Runner version-skew alert is now advisory, not a page.** The
+  `runnerVersionSkew` health alert fired at `warning` severity and paged the
+  operator webhook like an outage. A runner a release behind is already
+  protected by the minimum-runner-version gate (it queues rather than
+  mis-grades), so it is now `info` severity: it still surfaces on `/admin/alerts`
+  and via the `get_health_alerts` admin tool, but no longer pages the webhook.
+  Info-severity alerts are dashboard-only, and the recent-firings view labels
+  them "advisory — not paged".


### PR DESCRIPTION
## What

Dials down the `runnerVersionSkew` health alert (added in v0.4.643). It was too loud: it fired at `warning` severity and paged the operator webhook on every transition, exactly like a real outage. A runner a release behind is low-stakes — the #1210 minimum-runner-version gate already protects correctness by queueing rather than mis-grading — so it shouldn't page.

## How

- **`info` severity** for `runnerVersionSkew` (was `warning`).
- **Webhook dispatch gated on a derived `HealthRule.pagesOperator`** (`severity != "info"`). Info-severity alerts are still evaluated, logged, and recorded in the recent-firings buffer, so they remain visible on `/admin/alerts` and via the `get_health_alerts` admin tool — they just don't page the webhook.
- **`paged` recorded on each firing** so the dashboard shows an advisory firing as `advisory — not paged` instead of mistaking a deliberate non-page for a delivery `failed`.

When the rule *fires* is unchanged — `decideRunnerVersionSkew` is untouched — only whether a firing pages.

## Testing

- Updated `healthRuleSeverity` (now asserts `info`) and added `healthRulePaging` (only `runnerVersionSkew` is non-paging; every other rule pages).
- `swift test` over `ServerHealthAlertTests` + `AdminRoutesTests` (the `/admin/alerts` render, covering the new advisory branch): **70 tests, 0 failures.**
- `scripts/lint.sh`, `scripts/swiftlint.sh --strict` (0 violations), and `scripts/check-styles.sh` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdN22pAcMc2aeCCfJaevvD)_