### PR TITLE
Add MCP authoring-voice guide + per-course agent guidance panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,12 @@ source for discovery + DCR). Access tokens are short-lived ES256 JWTs minted by
 `MCPBearerAuthMiddleware`. An hourly reaper drops dead OAuth rows. The consent
 POST is deliberately cookie-independent (identity + CSRF ride the single-use
 consent token) so it survives Safari/ITP cross-site cookie blocking.
+The `initialize` instructions end with the house **authoring-voice guide**
+(`MCPServerInstructions.authoringVoice` — see "Voice and Register" below), and
+per-course guidance an instructor sets on the `/instructor` MCP tab
+(`courses.mcp_instructions`) is appended per authorable course at initialize
+(`MCPCourseGuidance.swift`). Advisory text only — it never alters tools,
+scopes, or the admin surface.
 
 **Pattern-generated test families (v0.4.75+).** Instructors can define a
 `PatternFamily` (Core/) — one function, shared defaults, a table of cases —
@@ -482,6 +488,55 @@ a bundled wheel means a sha cascade (wheel → `all.json` digest →
 `pipliteUrls` sha); `verify-jupyterlite.sh` asserts that chain is consistent
 so a mismatch (which would make piplite reject the kernel) is a build
 failure, not a browser surprise.
+
+---
+
+## Voice and Register (assignment content)
+
+Instructional prose in assignment/course content — starter notebooks, hints,
+content items, generated-test messages — follows the house authoring-voice
+guide below, whether authored by hand, from a Claude Code session, or by an
+agent through the MCP tools. The guide is served verbatim to MCP agents in the
+`initialize` instructions (`MCPServerInstructions.authoringVoice` in
+`Sources/APIServer/MCP/Protocol/InitializeTypes.swift`); this section and that
+constant are deliberately identical — keep them in sync when editing either.
+Instructors can layer per-course guidance on top via the instructor MCP tab
+(`/instructor/mcp`); where the two conflict, the course's own guidance wins
+for that course.
+
+```text
+Authoring voice for Chickadee assignments
+
+Assignments authored through this server are university course materials. Write
+instructional prose in the register of a well-written textbook: clear, direct, and
+addressed to capable students as adults. State what each task is and why it matters.
+Do not narrate the student's experience of the task, and do not cheerlead.
+
+Required:
+- Use the imperative and the declarative. Write "Compute the standard deviation of
+  `systolic`." rather than "Now it's time to find the standard deviation!"
+- Motivate with specifics. Name what a technique accomplishes in a health-data
+  context rather than reaching for adjectives like "powerful," "exciting," or
+  "useful."
+- Keep the register professional but not cold. Warmth belongs in how difficulty is
+  acknowledged — that a concept is genuinely hard, that beginners commonly struggle
+  with a particular step — not in punctuation or filler. Clear and respectful is the
+  target, not stiff or joyless.
+
+Prohibited in instructional text:
+- Exclamation marks.
+- Emoji.
+- Second-person emotional narration: "Now it's time to…", "That's all there is to
+  it", "Your turn!", "Don't worry".
+- Chatty parentheticals and winking qualifiers: "(reasonably) easy (with practice)".
+- Vague enthusiasm as motivation: "incredibly powerful", "super useful".
+
+Example.
+Before: "A tradition in computing is to write 'Hello, World!' as your first program.
+That's all there is to it!"
+After: "By convention, the first program written in a new language prints a fixed
+greeting. The example below does so in R."
+```
 
 ---
 

--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -7,6 +7,7 @@
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
+    <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>
 </nav>
 #if(currentUser.activeCourse):
 <h1>#(currentUser.activeCourse.code) — #(currentUser.activeCourse.name)</h1>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -7,6 +7,7 @@ LEARN
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
+    <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>
 </nav>
 
 #if(hasActiveCourse):

--- a/Resources/Views/instructor-mcp.leaf
+++ b/Resources/Views/instructor-mcp.leaf
@@ -1,0 +1,82 @@
+#extend("base"):
+#export("title"):
+MCP
+#endexport
+#export("content"):
+<nav class="instructor-tabs" aria-label="Instructor sections">
+    <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
+    <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
+    <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>
+</nav>
+
+#if(!hasActiveCourse):
+<section class="mcp-panel-section">
+    <p class="empty">Select a course to manage its agent guidance.</p>
+</section>
+#else:
+
+#if(flashSuccess):
+<div class="notice-banner mcp-panel-flash"><p>#(flashSuccess)</p></div>
+#endif
+#if(flashError):
+<div class="form-error mcp-panel-flash">#(flashError)</div>
+#endif
+
+<section class="mcp-panel-section">
+    <h2>Agent authoring guidance — #(courseCode)</h2>
+    <p class="mcp-panel-intro">
+        Chickadee's MCP server lets a connected agent author assignment content on course
+        staff's behalf. Every agent receives the house authoring-voice guide below; this
+        panel adds your course's own guidance on top — tone, vocabulary, notation, and
+        conventions specific to #(courseCode). Where the two conflict, your course's
+        guidance wins for this course.
+    </p>
+    #if(mcpDisabled):
+    <p class="mcp-panel-note">
+        The MCP server is currently disabled on this deployment, so no agents can connect.
+        Guidance saved here takes effect once it is enabled.
+    </p>
+    #endif
+    #if(readOnlyNote):
+    <p class="mcp-panel-note">#(readOnlyNote)</p>
+    #endif
+    <form method="post" action="/instructor/mcp" class="mcp-panel-form">
+        #csrfFormField()
+        <label class="form-label">
+            Course guidance
+            <textarea class="form-input mcp-panel-textarea" name="instructions" rows="12"
+                      maxlength="#(maxLength)"#if(!canEdit): disabled#endif
+                      placeholder="Example: Address students in the second person plural. Refer to the textbook as CP4. Draw examples from kinesiology datasets.">#(guidanceText)</textarea>
+            <span class="mcp-panel-hint">Plain text, up to #(maxLength) characters. Leave empty to
+                use only the house guide. Saved changes reach agents the next time they connect.</span>
+        </label>
+        #if(canEdit):
+        <div class="mcp-panel-buttons">
+            <button class="btn btn-primary" type="submit">Save guidance</button>
+        </div>
+        #endif
+    </form>
+</section>
+
+<section class="mcp-panel-section">
+    <details class="mcp-panel-house-guide">
+        <summary>House authoring-voice guide (always sent to agents)</summary>
+        <pre class="mcp-panel-house-guide-text">#(houseVoiceGuide)</pre>
+    </details>
+</section>
+
+#endif
+<style>
+.mcp-panel-section { margin-top: 1.5rem; }
+.mcp-panel-flash { margin-top: 1rem; }
+.mcp-panel-intro { margin: .75rem 0 1rem; color: var(--text-secondary); max-width: 60rem; }
+.mcp-panel-note { margin-bottom: 1rem; color: var(--text-secondary); font-style: italic; }
+.mcp-panel-form { display: flex; flex-direction: column; gap: 1rem; max-width: 60rem; }
+.mcp-panel-textarea { display: block; margin-top: .25rem; width: 100%; resize: vertical; }
+.mcp-panel-hint { display: block; margin-top: .25rem; color: var(--text-secondary); font-size: var(--text-sm); }
+.mcp-panel-buttons { display: flex; gap: .75rem; }
+.mcp-panel-house-guide-text { white-space: pre-wrap; color: var(--text-secondary); font-size: var(--text-sm); margin-top: .75rem; }
+</style>
+#endexport
+#endextend

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -7,6 +7,7 @@ Students
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
+    <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>
 </nav>
 
 #if(flashSuccess):

--- a/Sources/APIServer/Helpers/CourseAccessHelpers.swift
+++ b/Sources/APIServer/Helpers/CourseAccessHelpers.swift
@@ -84,8 +84,10 @@ func enrolledCourses(for userID: UUID, on db: Database) async throws -> [APICour
 
 /// Like `enrolledCourses`, but pairs each course with the caller's per-course
 /// role from the enrollment row (Phase 2 of docs/multi-course-roles.md). The
-/// web read path carries this into the nav; the role is web-only and never
-/// widens the visible set, and MCP keeps using the role-free `enrolledCourses`.
+/// role never widens the visible set. The web read path carries it into the
+/// nav; MCP's listing surface keeps using the role-free `enrolledCourses`,
+/// while the MCP initialize guidance (`mcpCourseGuidance`) reads the role
+/// variant to pick the courses the account can author in.
 func enrolledCoursesWithRoles(
     for userID: UUID, on db: Database
 ) async throws -> [(course: APICourse, role: CourseRole)] {

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -98,7 +98,15 @@ struct MCPServerInfo: Encodable, Sendable {
 /// covers the domain vocabulary, the recommended workflow, and the
 /// validation/scope/safety rules that aren't obvious from any single tool.
 enum MCPServerInstructions {
-    static let text = """
+    /// The complete server-level string served from `initialize`: the
+    /// operational guide plus the house authoring-voice guide.  Per-course
+    /// guidance, when the connecting account has any, is layered on top via
+    /// `text(withCourseGuidance:)` (see MCPCourseGuidance.swift).
+    static let text = operationalGuide + "\n\n" + authoringVoice
+
+    /// The operational half: domain vocabulary, the read-before-write
+    /// workflow, and the validation/scope/safety rules.
+    static let operationalGuide = """
         Chickadee is a course-content authoring and autograding platform. This server lets an \
         authorized agent author assignment content on an instructor's behalf: assignment metadata, \
         test suites, starter notebooks, and reference solutions. It never exposes student data, \
@@ -310,5 +318,45 @@ enum MCPServerInstructions {
         is the verbatim canonical JSON, useful to read the full authoring spec into context. \
         Authoring guides are exposed the same way under chickadee://docs/* — e.g. the per-student \
         solution-notebook recipe above.
+        """
+
+    /// The house authoring-voice guide, appended verbatim to the operational
+    /// guide (only whitespace/escaping adapted to the string literal).  It
+    /// shapes the register of prose authored through this server's tools and
+    /// changes no tool behaviour.  Authoring surface only — the admin
+    /// diagnostic surface (AdminMCPServerInstructions) deliberately does not
+    /// carry it.
+    static let authoringVoice = """
+        Authoring voice for Chickadee assignments
+
+        Assignments authored through this server are university course materials. Write
+        instructional prose in the register of a well-written textbook: clear, direct, and
+        addressed to capable students as adults. State what each task is and why it matters.
+        Do not narrate the student's experience of the task, and do not cheerlead.
+
+        Required:
+        - Use the imperative and the declarative. Write "Compute the standard deviation of
+          `systolic`." rather than "Now it's time to find the standard deviation!"
+        - Motivate with specifics. Name what a technique accomplishes in a health-data
+          context rather than reaching for adjectives like "powerful," "exciting," or
+          "useful."
+        - Keep the register professional but not cold. Warmth belongs in how difficulty is
+          acknowledged — that a concept is genuinely hard, that beginners commonly struggle
+          with a particular step — not in punctuation or filler. Clear and respectful is the
+          target, not stiff or joyless.
+
+        Prohibited in instructional text:
+        - Exclamation marks.
+        - Emoji.
+        - Second-person emotional narration: "Now it's time to…", "That's all there is to
+          it", "Your turn!", "Don't worry".
+        - Chatty parentheticals and winking qualifiers: "(reasonably) easy (with practice)".
+        - Vague enthusiasm as motivation: "incredibly powerful", "super useful".
+
+        Example.
+        Before: "A tradition in computing is to write 'Hello, World!' as your first program.
+        That's all there is to it!"
+        After: "By convention, the first program written in a new language prints a fixed
+        greeting. The example below does so in R."
         """
 }

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -42,6 +42,17 @@ struct ToolContext {
         request.application.usesDedicatedMCPDatabase ? request.db(.mcp) : request.db
     }
 
+    /// True when the database `db` would resolve to is actually configured.
+    /// The MCP transport can be mounted on an app with no database at all
+    /// (transport-level unit tests), where touching `request.db` is a Fluent
+    /// `fatalError`, not a thrown error — so optional DB-touching paths (the
+    /// per-course guidance layered onto `initialize`) must check this first
+    /// instead of relying on `try?`.
+    var hasDatabase: Bool {
+        let id: DatabaseID? = request.application.usesDedicatedMCPDatabase ? .mcp : nil
+        return request.application.databases.configuration(for: id) != nil
+    }
+
     /// The privileged (owner) database pool — always the shared default pool,
     /// never the least-privilege `.mcp` pool. Use this for acting-user
     /// bookkeeping that is a *side effect* of an MCP call but is NOT

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -47,10 +47,18 @@ struct ToolContext {
     /// (transport-level unit tests), where touching `request.db` is a Fluent
     /// `fatalError`, not a thrown error — so optional DB-touching paths (the
     /// per-course guidance layered onto `initialize`) must check this first
-    /// instead of relying on `try?`.
+    /// instead of relying on `try?`. Probed via `Databases.ids()` — the one
+    /// accessor that never resolves the default id, which is itself the
+    /// fatalError (`configuration(for: nil)` traps on a database-less app
+    /// too). A non-empty id set implies a usable default here: FluentKit makes
+    /// the first registered database the default unless explicitly opted out,
+    /// and both of this app's registration sites pass `isDefault: true`.
     var hasDatabase: Bool {
-        let id: DatabaseID? = request.application.usesDedicatedMCPDatabase ? .mcp : nil
-        return request.application.databases.configuration(for: id) != nil
+        let databases = request.application.databases
+        if request.application.usesDedicatedMCPDatabase {
+            return databases.ids().contains(.mcp)
+        }
+        return !databases.ids().isEmpty
     }
 
     /// The privileged (owner) database pool — always the shared default pool,

--- a/Sources/APIServer/MCP/Transport/MCPCourseGuidance.swift
+++ b/Sources/APIServer/MCP/Transport/MCPCourseGuidance.swift
@@ -1,0 +1,62 @@
+// APIServer/MCP/Transport/MCPCourseGuidance.swift
+//
+// Per-course authoring guidance layered onto the content MCP server's
+// `initialize` instructions.  Instructors write the text on the instructor MCP
+// panel (courses.mcp_instructions); at initialize the dispatcher resolves the
+// connecting account's authorable courses and appends each course's guidance
+// under a labelled block, so an agent picks up the course's own tone and style
+// preferences alongside the house authoring-voice guide.  Advisory by design —
+// it shapes authored prose and changes no tool behaviour or scope.
+
+import Core
+import Fluent
+import Foundation
+
+/// One course's authoring guidance, as appended to the initialize instructions.
+struct MCPCourseGuidance: Equatable, Sendable {
+    let courseCode: String
+    let text: String
+}
+
+extension MCPServerInstructions {
+    /// The complete instructions string for a connection whose account can
+    /// author in courses carrying custom guidance.  With no guidance this is
+    /// exactly `text`, so accounts without any per-course text see the same
+    /// bytes as before.
+    static func text(withCourseGuidance guidance: [MCPCourseGuidance]) -> String {
+        guard !guidance.isEmpty else { return text }
+        let header = """
+            Course-specific authoring guidance
+
+            The instructors of the courses below have set additional guidance for content \
+            authored in their course. It applies only when authoring in that course and \
+            supplements the house authoring-voice guide above; where the two conflict, the \
+            course's own guidance takes precedence for that course's content.
+            """
+        let blocks = guidance.map { "Course \($0.courseCode):\n\($0.text)" }
+        return ([text, header] + blocks).joined(separator: "\n\n")
+    }
+}
+
+/// Resolves the per-course guidance blocks for the token subject: the
+/// non-archived courses the account is enrolled in with authoring authority
+/// (per-course role of TA or higher; admins qualify through any enrollment,
+/// matching `evaluateCourseWrite`'s bypass) whose `mcp_instructions` is
+/// non-empty, in course-code order.  An unknown subject resolves to no
+/// guidance rather than an error — initialize must succeed regardless.
+func mcpCourseGuidance(forSubject subject: String, db: any Database) async throws -> [MCPCourseGuidance] {
+    guard
+        let user = try await APIUser.query(on: db)
+            .filter(\.$username == subject)
+            .first(),
+        let userID = user.id
+    else { return [] }
+    return try await enrolledCoursesWithRoles(for: userID, on: db)
+        .filter { user.isAdmin || $0.role >= .ta }
+        .compactMap { enrolled in
+            let text = (enrolled.course.mcpInstructions ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            return MCPCourseGuidance(courseCode: enrolled.course.code, text: text)
+        }
+}

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -33,7 +33,7 @@ struct MCPDispatcher: Sendable {
 
         switch method {
         case .initialize:
-            return initializeResponse(id: id, params: request.params, context: context)
+            return await initializeResponse(id: id, params: request.params, context: context)
         case .ping:
             return .success(id: id, result: .object([:]))
         case .initialized:
@@ -252,13 +252,22 @@ struct MCPDispatcher: Sendable {
 
     private func initializeResponse(
         id: JSONRPCID, params: JSONValue?, context: ToolContext?
-    ) -> JSONRPCResponse {
-        mcpInitializeResponse(
+    ) async -> JSONRPCResponse {
+        // Layer any per-course authoring guidance for the authenticated subject
+        // onto the house instructions. Best-effort: a lookup failure (or a
+        // context-free dispatch, as in unit tests) degrades to the house text
+        // rather than failing the handshake.
+        var instructions = MCPServerInstructions.text
+        if let context {
+            let guidance = (try? await mcpCourseGuidance(forSubject: context.subject, db: context.db)) ?? []
+            instructions = MCPServerInstructions.text(withCourseGuidance: guidance)
+        }
+        return mcpInitializeResponse(
             id: id, params: params,
             surface: MCPInitializeSurface(
                 capabilities: .v1,
                 serverInfo: serverInfo,
-                instructions: MCPServerInstructions.text,
+                instructions: instructions,
                 logLabel: "MCP"),
             logger: context?.logger)
     }

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -254,11 +254,13 @@ struct MCPDispatcher: Sendable {
         id: JSONRPCID, params: JSONValue?, context: ToolContext?
     ) async -> JSONRPCResponse {
         // Layer any per-course authoring guidance for the authenticated subject
-        // onto the house instructions. Best-effort: a lookup failure (or a
-        // context-free dispatch, as in unit tests) degrades to the house text
-        // rather than failing the handshake.
+        // onto the house instructions. Best-effort: a lookup failure, a
+        // context-free dispatch, or an app with no database configured (the
+        // transport unit tests — where request.db would fatalError, hence the
+        // explicit hasDatabase check) degrades to the house text rather than
+        // failing the handshake.
         var instructions = MCPServerInstructions.text
-        if let context {
+        if let context, context.hasDatabase {
             let guidance = (try? await mcpCourseGuidance(forSubject: context.subject, db: context.db)) ?? []
             instructions = MCPServerInstructions.text(withCourseGuidance: guidance)
         }

--- a/Sources/APIServer/Migrations/AddCourseMCPInstructions.swift
+++ b/Sources/APIServer/Migrations/AddCourseMCPInstructions.swift
@@ -1,0 +1,22 @@
+// APIServer/Migrations/AddCourseMCPInstructions.swift
+//
+// Per-course authoring guidance for MCP agents.  Instructors edit it on the
+// instructor MCP panel; the content MCP server appends it to the `initialize`
+// instructions for accounts with authoring authority in the course.  Nil means
+// the course has no custom guidance and agents see only the house guide.
+
+import Fluent
+
+struct AddCourseMCPInstructions: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("courses")
+            .field("mcp_instructions", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("courses")
+            .deleteField("mcp_instructions")
+            .update()
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -163,6 +163,7 @@ enum AuditAction: String, Sendable, CaseIterable {
     case mcpConsentGranted = "mcp.consent_granted"
     case mcpTokenIssued = "mcp.token_issued"
     case mcpRefreshReuseDetected = "mcp.refresh_reuse_detected"
+    case mcpCourseInstructionsUpdated = "mcp.course_instructions_updated"
     case adminMcpToolCalled = "admin_mcp.tool_called"
 
     /// Coarse grouping shown as the "Category" column / filter on /admin/audit.
@@ -192,7 +193,8 @@ enum AuditAction: String, Sendable, CaseIterable {
             return .brightspace
         case .mcpAccountCreated, .mcpAccountDeleted, .mcpTokenMinted, .mcpToolCalled,
             .mcpGrantRevoked, .mcpAccountEnrolled, .mcpAccountUnenrolled, .mcpClientRegistered,
-            .mcpConsentGranted, .mcpTokenIssued, .mcpRefreshReuseDetected, .adminMcpToolCalled:
+            .mcpConsentGranted, .mcpTokenIssued, .mcpRefreshReuseDetected,
+            .mcpCourseInstructionsUpdated, .adminMcpToolCalled:
             return .mcp
         }
     }
@@ -256,6 +258,7 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .mcpConsentGranted: return "MCP access authorized"
         case .mcpTokenIssued: return "MCP token issued"
         case .mcpRefreshReuseDetected: return "MCP refresh-token reuse detected"
+        case .mcpCourseInstructionsUpdated: return "MCP course guidance updated"
         case .adminMcpToolCalled: return "Admin diagnostic tool called"
         }
     }

--- a/Sources/APIServer/Models/APICourse.swift
+++ b/Sources/APIServer/Models/APICourse.swift
@@ -63,6 +63,14 @@ final class APICourse: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_section_category_id")
     var brightspaceSectionCategoryID: String?
 
+    /// Per-course authoring guidance for MCP agents, set by the course's
+    /// instructors on the instructor MCP panel. Appended to the content MCP
+    /// server's `initialize` instructions for accounts with authoring authority
+    /// in this course, so a connected agent picks up the course's own tone and
+    /// style preferences. Nil = no course-specific guidance.
+    @OptionalField(key: "mcp_instructions")
+    var mcpInstructions: String?
+
     /// When this course was archived. Set by `toggleCourseArchive` when a
     /// course is archived (and cleared when un-archived). Archiving is
     /// Chickadee's "end of term" signal, so this is the anchor for the

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -359,3 +359,32 @@ struct AssignmentStudentRow: Encodable {
     /// affordance is hidden entirely then).
     let secretRevealSpent: Bool
 }
+
+/// MCP tab (`GET /instructor/mcp`): the active course's authoring guidance for
+/// connected agents, editable by the course's instructors.
+struct InstructorMCPContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let activeInstructorTab: String
+    let hasActiveCourse: Bool
+    let courseCode: String
+    /// The stored per-course guidance ("" when unset) — the textarea's value.
+    let guidanceText: String
+    /// The fixed house authoring-voice guide, rendered read-only for reference.
+    let houseVoiceGuide: String
+    let maxLength: Int
+    /// True when the viewer may save: a per-course instructor or an admin, and
+    /// the course is not archived. TAs pass the `/instructor` gate but see the
+    /// panel read-only, matching the Students tab (#417 Slice F).
+    let canEdit: Bool
+    /// Why the panel is read-only (nil when `canEdit`) — precomputed so the
+    /// template renders one flat string instead of branching (LeafKit 1.14.2
+    /// mis-parses compound conditions).
+    let readOnlyNote: String?
+    /// True when the MCP server is not mounted on this deployment (`MCP_MODE`
+    /// off/unresolvable) — the panel still saves, with a note that guidance
+    /// takes effect once MCP is enabled.
+    let mcpDisabled: Bool
+    /// Flash banners after the save POST redirect.
+    let flashSuccess: String?
+    let flashError: String?
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+MCP.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+MCP.swift
@@ -1,0 +1,111 @@
+// APIServer/Routes/Web/InstructorDashboardRoutes+MCP.swift
+//
+// Instructor MCP panel: per-course authoring guidance for connected agents.
+//
+//   GET  /instructor/mcp   → instructor-mcp.leaf (view / edit the active course's guidance)
+//   POST /instructor/mcp   → save (per-course instructor only) → redirect back with a flash
+//
+// The saved text (`courses.mcp_instructions`) is layered onto the content MCP
+// server's `initialize` instructions for accounts with authoring authority in
+// the course (MCP/Transport/MCPCourseGuidance.swift), so an instructor can set
+// the tone agents use when authoring content for their course. Advisory
+// voice/tone guidance only — it never changes tool behaviour or scopes.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+extension InstructorDashboardRoutes {
+    /// Server-side cap on the stored guidance. Generous for a page of prose,
+    /// small enough that every `initialize` payload stays lightweight.
+    static let mcpGuidanceMaxLength = 4000
+
+    @Sendable
+    func mcpPanelPage(req: Request) async throws -> View {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+
+        var course: APICourse?
+        if let courseUUID = courseState.activeCourseUUID {
+            course = try await APICourse.find(courseUUID, on: req.db)
+        }
+        let isArchived = course?.isArchived ?? false
+        let holdsInstructorRole = user.isAdmin || (courseState.active?.role ?? .student) >= .instructor
+        let canEdit = holdsInstructorRole && !isArchived
+
+        let readOnlyNote: String?
+        if canEdit {
+            readOnlyNote = nil
+        } else if isArchived {
+            readOnlyNote = "This course is archived and is read-only."
+        } else {
+            readOnlyNote = "Only this course's instructors can edit its guidance."
+        }
+
+        let flashSuccess: String? =
+            req.query[String.self, at: "saved"] != nil
+            ? "Guidance saved. Connected agents pick it up the next time they connect." : nil
+        let flashError: String? = {
+            switch req.query[String.self, at: "error"] {
+            case "length":
+                return "Guidance is limited to \(Self.mcpGuidanceMaxLength) characters."
+            case "course":
+                return "No active course."
+            default:
+                return nil
+            }
+        }()
+
+        let ctx = InstructorMCPContext(
+            currentUser: try await req.courseAwareUserContext(),
+            activeInstructorTab: "mcp",
+            hasActiveCourse: course != nil,
+            courseCode: course?.code ?? "",
+            guidanceText: course?.mcpInstructions ?? "",
+            houseVoiceGuide: MCPServerInstructions.authoringVoice,
+            maxLength: Self.mcpGuidanceMaxLength,
+            canEdit: canEdit,
+            readOnlyNote: readOnlyNote,
+            mcpDisabled: !req.application.appConfig.mcp.mode.isMounted,
+            flashSuccess: flashSuccess,
+            flashError: flashError)
+        return try await req.view.render("instructor-mcp", ctx)
+    }
+
+    @Sendable
+    func saveMCPGuidance(req: Request) async throws -> Response {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        guard let courseUUID = courseState.activeCourseUUID,
+            let course = try await APICourse.find(courseUUID, on: req.db)
+        else {
+            return req.redirect(to: "/instructor/mcp?error=course")
+        }
+        // A course-level setting → per-course instructor floor (admin bypass,
+        // archived-course block), scoped to the active course itself.
+        try await requireCourseWriteAccess(
+            caller: user, courseID: courseUUID, atLeast: .instructor, db: req.db)
+
+        struct GuidanceForm: Content {
+            let instructions: String?
+        }
+        let raw = (try req.content.decode(GuidanceForm.self).instructions ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard raw.count <= Self.mcpGuidanceMaxLength else {
+            return req.redirect(to: "/instructor/mcp?error=length")
+        }
+
+        course.mcpInstructions = raw.isEmpty ? nil : raw
+        try await course.save(on: req.db)
+        // Audit the change without recording the text itself (the MCP surface
+        // never logs content bodies); the length distinguishes set vs cleared.
+        await AuditLogger.record(
+            action: .mcpCourseInstructionsUpdated,
+            targetType: .course,
+            targetID: courseUUID.uuidString,
+            metadata: ["course_code": course.code, "length": String(raw.count)],
+            on: req)
+        return req.redirect(to: "/instructor/mcp?saved=1")
+    }
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -54,6 +54,9 @@ struct InstructorDashboardRoutes: RouteCollection {
         r.post("brightspace", "auto-map", use: brightspaceAutoMap)
         r.post("brightspace", "sync-now", use: brightspaceSyncNow)
         r.post("brightspace", "reconcile-now", use: brightspaceReconcileNow)
+        // MCP tab: the active course's authoring guidance for connected agents.
+        r.get("mcp", use: mcpPanelPage)
+        r.post("mcp", use: saveMCPGuidance)
         r.get("grades.csv", use: exportGradesCSV)
         r.get(":assignmentID", "submissions", use: assignmentSubmissionsPage)
         r.get(":assignmentID", "students", ":studentID", "history", use: studentSubmissionHistoryPage)

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -300,6 +300,9 @@ func registerMigrations(on app: Application) {
     // Same ordering constraint: brightspace_section_category_id must exist
     // before AddCourseArchivedAt (or any migration) queries the APICourse model.
     app.migrations.add(AddCourseBrightSpaceSectionCategoryID())
+    // Same ordering constraint: mcp_instructions must exist before any later
+    // migration queries the APICourse model.
+    app.migrations.add(AddCourseMCPInstructions())
     app.migrations.add(CreateCourseEnrollments())
     app.migrations.add(CreateTestSetups())
     app.migrations.add(CreateSubmissions())

--- a/Tests/APITests/InstructorMCPPanelTests.swift
+++ b/Tests/APITests/InstructorMCPPanelTests.swift
@@ -80,7 +80,9 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let html = res.body.string
-                    #expect(html.contains("Only this course's instructors can edit its guidance."))
+                    // Leaf escapes the apostrophe in "course's", so match an
+                    // apostrophe-free slice of the read-only note.
+                    #expect(html.contains("instructors can edit its guidance"))
                     #expect(!html.contains("Save guidance"))
                 })
         }

--- a/Tests/APITests/InstructorMCPPanelTests.swift
+++ b/Tests/APITests/InstructorMCPPanelTests.swift
@@ -1,0 +1,178 @@
+// Tests/APITests/InstructorMCPPanelTests.swift
+//
+// The instructor MCP tab (per-course authoring guidance for connected agents):
+// staff-only visibility, TA read-only rendering, the instructor save/clear
+// round-trip (with the length guard), and the TA save refusal.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite struct InstructorMCPPanelTests {
+
+    /// Logs in a per-course TA in the shared TEST101 course: a plain user whose
+    /// only staff standing is the `.ta` enrollment (upserted, since the `.auto`
+    /// course auto-enrolls them as `.student` at login).
+    private func loginAsTA(on app: Application) async throws -> String {
+        let cookie = try await loginUser(
+            username: "testta", password: "testpassword", role: "student", on: app)
+        let courseID = try await app.testCourseID(enrollmentMode: .auto)
+        let user = try #require(
+            try await APIUser.query(on: app.db).filter(\.$username == "testta").first())
+        let userID = try user.requireID()
+        if let existing = try await APICourseEnrollment.query(on: app.db)
+            .filter(\.$userID == userID).filter(\.$course.$id == courseID).first()
+        {
+            existing.role = .ta
+            try await existing.save(on: app.db)
+        } else {
+            try await APICourseEnrollment(userID: userID, courseID: courseID, role: .ta)
+                .save(on: app.db)
+        }
+        return cookie
+    }
+
+    private func activeCourse(on app: Application) async throws -> APICourse {
+        let courseID = try await app.testCourseID(enrollmentMode: .auto)
+        return try #require(try await APICourse.find(courseID, on: app.db))
+    }
+
+    // MARK: - Access + rendering
+
+    @Test func studentCannotAccessMCPTab() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsStudent(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/mcp",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in #expect(res.status == .forbidden) })
+        }
+    }
+
+    @Test func instructorSeesEditablePanelWithHouseGuide() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/mcp",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("Agent authoring guidance"))
+                    #expect(html.contains("Save guidance"))
+                    // The fixed house guide is shown for reference.
+                    #expect(html.contains("House authoring-voice guide"))
+                    #expect(html.contains("Authoring voice for Chickadee assignments"))
+                })
+        }
+    }
+
+    @Test func taSeesReadOnlyPanel() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await loginAsTA(on: app)
+            try await app.asyncTest(
+                .GET, "/instructor/mcp",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let html = res.body.string
+                    #expect(html.contains("Only this course's instructors can edit its guidance."))
+                    #expect(!html.contains("Save guidance"))
+                })
+        }
+    }
+
+    // MARK: - Save round-trip
+
+    @Test func instructorSavesAndClearsGuidance() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/mcp", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/instructor/mcp",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["instructions": "  Use metric units throughout.  ", "_csrf": csrf],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=1")
+                })
+            var course = try await activeCourse(on: app)
+            #expect(course.mcpInstructions == "Use metric units throughout.")
+
+            // The saved text renders back into the panel's textarea.
+            try await app.asyncTest(
+                .GET, "/instructor/mcp",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: sessionCookie) },
+                afterResponse: { res in
+                    #expect(res.body.string.contains("Use metric units throughout."))
+                })
+
+            // A blank submit clears the guidance back to nil.
+            try await app.asyncTest(
+                .POST, "/instructor/mcp",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(["instructions": "   ", "_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=1")
+                })
+            course = try await activeCourse(on: app)
+            #expect(course.mcpInstructions == nil)
+        }
+    }
+
+    @Test func oversizedGuidanceIsRejected() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/mcp", cookie: cookie, on: app)
+            let oversized = String(
+                repeating: "a", count: InstructorDashboardRoutes.mcpGuidanceMaxLength + 1)
+
+            try await app.asyncTest(
+                .POST, "/instructor/mcp",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["instructions": oversized, "_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?error=length")
+                })
+            let course = try await activeCourse(on: app)
+            #expect(course.mcpInstructions == nil)
+        }
+    }
+
+    @Test func taCannotSaveGuidance() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await loginAsTA(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/mcp", cookie: cookie, on: app)
+
+            try await app.asyncTest(
+                .POST, "/instructor/mcp",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["instructions": "TA tone takeover", "_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in #expect(res.status == .forbidden) })
+            let course = try await activeCourse(on: app)
+            #expect(course.mcpInstructions == nil)
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPCourseGuidanceTests.swift
+++ b/Tests/APITests/MCP/MCPCourseGuidanceTests.swift
@@ -203,4 +203,16 @@ import Vapor
             #expect(instructions == MCPServerInstructions.text)
         }
     }
+
+    @Test func initializeOnADatabaselessAppServesTheHouseText() async throws {
+        // The transport can be mounted on an app with no database at all
+        // (MCPEndpointTests' fixture). request.db is a Fluent fatalError there,
+        // so the guidance layer must skip the lookup entirely — regression
+        // guard for the ToolContext.hasDatabase check.
+        let app = try await Application.make(.testing)
+        try await withApp(app) { app in
+            let instructions = try await initializeInstructions(app, subject: "tester")
+            #expect(instructions == MCPServerInstructions.text)
+        }
+    }
 }

--- a/Tests/APITests/MCP/MCPCourseGuidanceTests.swift
+++ b/Tests/APITests/MCP/MCPCourseGuidanceTests.swift
@@ -1,0 +1,206 @@
+// Tests/APITests/MCP/MCPCourseGuidanceTests.swift
+//
+// The authoring-voice guide embedded in the content server's initialize
+// instructions, and the per-course guidance layered on top for the connecting
+// account: which enrollments contribute (authoring authority only, admins via
+// any enrollment), which never do (student role, archived, unset/blank text),
+// and the composed shape an agent actually receives from `initialize`.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+
+@testable import APIServer
+
+@Suite struct MCPCourseGuidanceTests {
+
+    // MARK: - House authoring-voice block (pure)
+
+    @Test func instructionsCarryTheAuthoringVoiceGuide() {
+        let text = MCPServerInstructions.text
+        // Appended to the operational guide, never replacing it.
+        #expect(text.hasPrefix(MCPServerInstructions.operationalGuide))
+        #expect(text.hasSuffix(MCPServerInstructions.authoringVoice))
+        #expect(text.contains("Authoring voice for Chickadee assignments"))
+        // Load-bearing rules survive verbatim.
+        #expect(text.contains("Do not narrate the student's experience of the task, and do not cheerlead."))
+        #expect(text.contains("Prohibited in instructional text:"))
+        #expect(text.contains("- Exclamation marks."))
+        #expect(text.contains("- Emoji."))
+        // The warmth-in-difficulty nuance is intact — the guide must not be
+        // reduced to "be formal".
+        #expect(text.contains("Warmth belongs in how difficulty is"))
+        #expect(text.contains("not stiff or joyless"))
+    }
+
+    @Test func courseGuidanceComposesLabelledBlocks() {
+        let composed = MCPServerInstructions.text(withCourseGuidance: [
+            MCPCourseGuidance(courseCode: "CS136", text: "Use metric units."),
+            MCPCourseGuidance(courseCode: "HLTH204", text: "Prefer health-data examples."),
+        ])
+        #expect(composed.hasPrefix(MCPServerInstructions.text))
+        #expect(composed.contains("Course-specific authoring guidance"))
+        #expect(composed.contains("Course CS136:\nUse metric units."))
+        #expect(composed.contains("Course HLTH204:\nPrefer health-data examples."))
+    }
+
+    @Test func emptyGuidanceLeavesInstructionsByteIdentical() {
+        #expect(MCPServerInstructions.text(withCourseGuidance: []) == MCPServerInstructions.text)
+    }
+
+    // MARK: - Guidance resolution (DB)
+
+    private func enroll(
+        _ userID: UUID, in course: APICourse, as role: CourseRole, on app: Application
+    ) async throws {
+        try await APICourseEnrollment(userID: userID, courseID: try course.requireID(), role: role)
+            .save(on: app.db)
+    }
+
+    @Test func staffCoursesWithTextContributeGuidanceInCodeOrder() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let user = try await makeTestUser(on: app, username: "guidance_user")
+            let userID = try user.requireID()
+
+            // Instructor course with text — later code, sorts second.
+            let chem = try await makeTestCourse(on: app, code: "ZCHEM301")
+            chem.mcpInstructions = "Cite lab-safety rules."
+            try await chem.save(on: app.db)
+            try await enroll(userID, in: chem, as: .instructor, on: app)
+
+            // TA course with text — earlier code, sorts first; stored text is
+            // trimmed on the way out.
+            let cs = try await makeTestCourse(on: app, code: "ACS101")
+            cs.mcpInstructions = "  Address students in the plural.  "
+            try await cs.save(on: app.db)
+            try await enroll(userID, in: cs, as: .ta, on: app)
+
+            let guidance = try await mcpCourseGuidance(forSubject: "guidance_user", db: app.db)
+            #expect(
+                guidance == [
+                    MCPCourseGuidance(courseCode: "ACS101", text: "Address students in the plural."),
+                    MCPCourseGuidance(courseCode: "ZCHEM301", text: "Cite lab-safety rules."),
+                ])
+        }
+    }
+
+    @Test func studentRoleArchivedAndUnsetCoursesContributeNothing() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let user = try await makeTestUser(on: app, username: "guidance_user")
+            let userID = try user.requireID()
+
+            // Enrolled as a student (no authoring authority) — excluded even
+            // though the course carries text.
+            let studentCourse = try await makeTestCourse(on: app, code: "STUD100")
+            studentCourse.mcpInstructions = "Never shown."
+            try await studentCourse.save(on: app.db)
+            try await enroll(userID, in: studentCourse, as: .student, on: app)
+
+            // Archived instructor course — excluded (writes are blocked there).
+            let archived = try await makeTestCourse(on: app, code: "OLD200", archived: true)
+            archived.mcpInstructions = "Stale guidance."
+            try await archived.save(on: app.db)
+            try await enroll(userID, in: archived, as: .instructor, on: app)
+
+            // Instructor course with only whitespace text — excluded.
+            let blank = try await makeTestCourse(on: app, code: "BLANK1")
+            blank.mcpInstructions = "   \n  "
+            try await blank.save(on: app.db)
+            try await enroll(userID, in: blank, as: .instructor, on: app)
+
+            // Instructor course with no text at all — excluded.
+            let unset = try await makeTestCourse(on: app, code: "UNSET1")
+            try await enroll(userID, in: unset, as: .instructor, on: app)
+
+            let guidance = try await mcpCourseGuidance(forSubject: "guidance_user", db: app.db)
+            #expect(guidance.isEmpty)
+        }
+    }
+
+    @Test func adminQualifiesThroughAnyEnrollment() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // Admins bypass the per-course role floor on writes
+            // (evaluateCourseWrite), so a student-role enrollment still counts
+            // for them — but enrollment is still required.
+            let admin = try await makeTestUser(on: app, username: "guidance_admin", role: "admin")
+            let adminID = try admin.requireID()
+
+            let enrolledCourse = try await makeTestCourse(on: app, code: "ADM101")
+            enrolledCourse.mcpInstructions = "Admin-visible guidance."
+            try await enrolledCourse.save(on: app.db)
+            try await enroll(adminID, in: enrolledCourse, as: .student, on: app)
+
+            // Not enrolled → not included, admin or not (agent scope ⊆ human scope).
+            let unenrolled = try await makeTestCourse(on: app, code: "FAR900")
+            unenrolled.mcpInstructions = "Out of reach."
+            try await unenrolled.save(on: app.db)
+
+            let guidance = try await mcpCourseGuidance(forSubject: "guidance_admin", db: app.db)
+            #expect(guidance == [MCPCourseGuidance(courseCode: "ADM101", text: "Admin-visible guidance.")])
+        }
+    }
+
+    @Test func unknownSubjectResolvesToNoGuidance() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let guidance = try await mcpCourseGuidance(forSubject: "nobody_here", db: app.db)
+            #expect(guidance.isEmpty)
+        }
+    }
+
+    // MARK: - initialize integration
+
+    private func toolContext(_ app: Application, subject: String) -> ToolContext {
+        ToolContext(
+            request: Request(application: app, on: app.eventLoopGroup.any()),
+            subject: subject,
+            grantedScopes: [.read, .write])
+    }
+
+    private func initializeInstructions(
+        _ app: Application, subject: String
+    ) async throws -> String {
+        let dispatcher = MCPDispatcher(
+            serverInfo: MCPServerInfo(name: "Chickadee MCP", version: "test"))
+        let request = JSONRPCRequest(jsonrpc: "2.0", id: .number(1), method: "initialize", params: nil)
+        let response = try #require(
+            await dispatcher.dispatch(request, context: toolContext(app, subject: subject)))
+        guard case .object(let result)? = response.result,
+            case .string(let instructions)? = result["instructions"]
+        else {
+            Issue.record("initialize result carried no instructions string")
+            return ""
+        }
+        return instructions
+    }
+
+    @Test func initializeCarriesPerCourseGuidanceForTheSubject() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let user = try await makeTestUser(on: app, username: "guidance_user")
+            let course = try await makeTestCourse(on: app, code: "CS136")
+            course.mcpInstructions = "Refer to the textbook as CP4."
+            try await course.save(on: app.db)
+            try await enroll(try user.requireID(), in: course, as: .instructor, on: app)
+
+            let instructions = try await initializeInstructions(app, subject: "guidance_user")
+            #expect(instructions.hasPrefix(MCPServerInstructions.text))
+            #expect(instructions.contains("Course-specific authoring guidance"))
+            #expect(instructions.contains("Course CS136:\nRefer to the textbook as CP4."))
+        }
+    }
+
+    @Test func initializeWithoutGuidanceServesTheHouseTextExactly() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "guidance_user")
+            let instructions = try await initializeInstructions(app, subject: "guidance_user")
+            #expect(instructions == MCPServerInstructions.text)
+        }
+    }
+}

--- a/changelog.d/mcp-authoring-voice-instructions.md
+++ b/changelog.d/mcp-authoring-voice-instructions.md
@@ -1,0 +1,17 @@
+### Added
+
+- **MCP authoring-voice guide + per-course agent guidance.** The content MCP
+  server's `initialize` instructions now end with a fixed house authoring-voice
+  guide (textbook register, imperative/declarative phrasing; no exclamation
+  marks, emoji, or cheerleading — warmth reserved for acknowledging genuine
+  difficulty), so agents authoring assignment content write in a consistent
+  university-level voice. On top of it, each course can set its own tone: a new
+  **MCP tab** on the instructor dashboard (`/instructor/mcp`) lets a course's
+  instructors edit per-course guidance (`courses.mcp_instructions`, 4000-char
+  cap, TAs see it read-only, saves audited), and the server appends each
+  authorable course's text — labelled by course code — to the `initialize`
+  instructions for accounts holding TA+ (or admin) in that course. Advisory by
+  design: no tool descriptions, scopes, capabilities, or grading behaviour
+  change, and the admin diagnostic MCP surface is untouched. The same voice
+  guide is mirrored into `CLAUDE.md` ("Voice and Register") so repo-side
+  authoring follows the identical standard.


### PR DESCRIPTION
## What

Two layers of authoring-voice guidance for agents connected to the content MCP server, plus the instructor UI to manage the per-course layer.

**1. House authoring-voice guide (fixed).** The `initialize` result's `instructions` string now ends with the authoring-voice block (verbatim from the brief): textbook register, imperative/declarative phrasing, motivate with specifics; no exclamation marks, emoji, second-person emotional narration, chatty parentheticals, or vague enthusiasm — with warmth deliberately preserved for acknowledging genuine difficulty. It lives as `MCPServerInstructions.authoringVoice` and is appended to the existing operational text (`MCPServerInstructions.text = operationalGuide + authoringVoice`), so nothing is replaced.

**2. Per-course guidance (instructor-editable).** New **MCP tab** on the instructor dashboard (`GET/POST /instructor/mcp`) where a course's instructors set the tone for their course:

- Stored in `courses.mcp_instructions` (new nullable column, `AddCourseMCPInstructions` migration; 4000-char server-side cap, trimmed, blank clears).
- Editing requires the per-course `instructor` role via `requireCourseWriteAccess` (admin bypass, archived-course block); TAs see the panel read-only, matching the Students-tab pattern. Saves are audited (`mcp.course_instructions_updated`, length only — never the text).
- At `initialize`, the dispatcher resolves the authenticated subject's authorable courses (enrollment role ≥ TA, or admin through any enrollment; archived excluded) and appends each course's guidance under a `Course <CODE>:` label (`MCPCourseGuidance.swift`), with a header stating that course guidance supplements the house guide and wins on conflict for that course. Best-effort: any lookup failure degrades to the house text, and accounts with no per-course guidance receive byte-identical instructions to before.

## Scope discipline (per the brief's DO NOT list)

- Authoring surface only — `AdminMCPServerInstructions` and the admin dispatcher are untouched.
- No tool descriptions, schemas, scopes, capabilities, or grading behaviour changed.
- Appended to the existing operational instructions, not replacing them.
- The warmth-in-difficulty nuance is kept verbatim.
- The same voice block is mirrored into `CLAUDE.md` ("Voice and Register") for the repo-side authoring path, kept deliberately identical to the constant.

## Tests

- `MCPCourseGuidanceTests`: voice block present verbatim (prefix/suffix composition), labelled-block composition, empty-guidance byte-identity; DB resolution (TA/instructor included in code order + trimming, student-role/archived/blank/unset excluded, admin-via-any-enrollment, unknown subject); end-to-end `initialize` dispatch with and without guidance.
- `InstructorMCPPanelTests`: student 403, instructor editable render (house guide shown), TA read-only render, save→clear round-trip with redirect + DB assertions, length-guard rejection, TA save 403.
- Existing guards stay green: `MCPInstructionsCatalogSyncTests` (every tool name still mentioned — the block only appends) and `scripts/check-styles.sh` (css-vars + design tokens) for the new template.

Versioning follows repo convention: one `changelog.d/` fragment, no `VERSION`/`CHANGELOG.md` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117LLAX1cFYt9RdnHQudhqL

---
_Generated by [Claude Code](https://claude.ai/code/session_0117LLAX1cFYt9RdnHQudhqL)_