### PR TITLE
MCP: one authoring-voice guide per course (inherited default) + RFC 9207 iss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,15 +175,19 @@ source for discovery + DCR). Access tokens are short-lived ES256 JWTs minted by
 `MCPBearerAuthMiddleware`. An hourly reaper drops dead OAuth rows. The consent
 POST is deliberately cookie-independent (identity + CSRF ride the single-use
 consent token) so it survives Safari/ITP cross-site cookie blocking.
-The `initialize` instructions end with the house **authoring-voice guide**
-(`MCPServerInstructions.authoringVoice` — see "Voice and Register" below), and
-per-course guidance an instructor sets on the `/instructor` MCP tab
-(`courses.mcp_instructions`) is appended per authorable course at initialize
-(`MCPCourseGuidance.swift`). Both are also live MCP resources
-(`chickadee://docs/authoring-voice`, `chickadee://course/<code>/authoring-guidance`)
-so agents can re-read them mid-session — the initialize copy is frozen per
-connection. Advisory text only — it never alters tools, scopes, or the admin
-surface.
+The `initialize` instructions end with the default **authoring-voice guide**
+(`MCPServerInstructions.authoringVoice` — see "Voice and Register" below).
+Every course inherits that guide; a course's instructors can take it over on
+the `/instructor` MCP tab, which seeds one editable box with the default and
+stores the edited copy in `courses.mcp_instructions` (nil = still inheriting).
+A customized course's guide **replaces** the default for that course's content
+and is appended as a labelled block at initialize (`MCPCourseGuidance.swift`);
+an inheriting course adds nothing, since the default is already in the base
+text. Both are live MCP resources too (`chickadee://docs/authoring-voice`,
+`chickadee://course/<code>/authoring-guidance` — which serves whichever guide
+is in force) so agents can re-read them mid-session; the initialize copy is
+frozen per connection. Advisory text only — it never alters tools, scopes, or
+the admin surface.
 
 **Pattern-generated test families (v0.4.75+).** Instructors can define a
 `PatternFamily` (Core/) — one function, shared defaults, a table of cases —
@@ -503,9 +507,9 @@ agent through the MCP tools. The guide is served verbatim to MCP agents in the
 `initialize` instructions (`MCPServerInstructions.authoringVoice` in
 `Sources/APIServer/MCP/Protocol/InitializeTypes.swift`); this section and that
 constant are deliberately identical — keep them in sync when editing either.
-Instructors can layer per-course guidance on top via the instructor MCP tab
-(`/instructor/mcp`); where the two conflict, the course's own guidance wins
-for that course.
+It is the **default**, not a floor: a course's instructors can take it over on
+the instructor MCP tab (`/instructor/mcp`), which seeds the editor with this
+text; the edited copy then replaces it for that course's content.
 
 ```text
 Authoring voice for Chickadee assignments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,8 +179,11 @@ The `initialize` instructions end with the house **authoring-voice guide**
 (`MCPServerInstructions.authoringVoice` — see "Voice and Register" below), and
 per-course guidance an instructor sets on the `/instructor` MCP tab
 (`courses.mcp_instructions`) is appended per authorable course at initialize
-(`MCPCourseGuidance.swift`). Advisory text only — it never alters tools,
-scopes, or the admin surface.
+(`MCPCourseGuidance.swift`). Both are also live MCP resources
+(`chickadee://docs/authoring-voice`, `chickadee://course/<code>/authoring-guidance`)
+so agents can re-read them mid-session — the initialize copy is frozen per
+connection. Advisory text only — it never alters tools, scopes, or the admin
+surface.
 
 **Pattern-generated test families (v0.4.75+).** Instructors can define a
 `PatternFamily` (Core/) — one function, shared defaults, a table of cases —

--- a/Resources/Views/instructor-mcp.leaf
+++ b/Resources/Views/instructor-mcp.leaf
@@ -12,7 +12,7 @@ MCP
 
 #if(!hasActiveCourse):
 <section class="mcp-panel-section">
-    <p class="empty">Select a course to manage its agent guidance.</p>
+    <p class="empty">Select a course to manage its authoring voice.</p>
 </section>
 #else:
 
@@ -24,18 +24,20 @@ MCP
 #endif
 
 <section class="mcp-panel-section">
-    <h2>Agent authoring guidance — #(courseCode)</h2>
+    <h2>Authoring voice — #(courseCode)</h2>
     <p class="mcp-panel-intro">
         Chickadee's MCP server lets a connected agent author assignment content on course
-        staff's behalf. Every agent receives the house authoring-voice guide below; this
-        panel adds your course's own guidance on top — tone, vocabulary, notation, and
-        conventions specific to #(courseCode). Where the two conflict, your course's
-        guidance wins for this course.
+        staff's behalf. The guide below is what agents receive when they author for
+        #(courseCode): it governs the register, vocabulary, and conventions of the
+        instructional prose they write. Every course starts on Chickadee's default guide.
+        Edit it to set your own — tone, notation, the textbook you refer to, the domain your
+        examples come from.
     </p>
+    <p class="mcp-panel-note">#(sourceNote)</p>
     #if(mcpDisabled):
     <p class="mcp-panel-note">
         The MCP server is currently disabled on this deployment, so no agents can connect.
-        Guidance saved here takes effect once it is enabled.
+        Changes saved here take effect once it is enabled.
     </p>
     #endif
     #if(readOnlyNote):
@@ -44,26 +46,22 @@ MCP
     <form method="post" action="/instructor/mcp" class="mcp-panel-form">
         #csrfFormField()
         <label class="form-label">
-            Course guidance
-            <textarea class="form-input mcp-panel-textarea" name="instructions" rows="12"
-                      maxlength="#(maxLength)"#if(!canEdit): disabled#endif
-                      placeholder="Example: Address students in the second person plural. Refer to the textbook as CP4. Draw examples from kinesiology datasets.">#(guidanceText)</textarea>
-            <span class="mcp-panel-hint">Plain text, up to #(maxLength) characters. Leave empty to
-                use only the house guide. Saved changes reach agents the next time they connect.</span>
+            Guide text
+            <textarea class="form-input mcp-panel-textarea" name="instructions" rows="24"
+                      maxlength="#(maxLength)"#if(!canEdit): disabled#endif>#(guidanceText)</textarea>
+            <span class="mcp-panel-hint">Plain text, up to #(maxLength) characters. Saved changes
+                reach agents the next time they connect. Emptying the box restores the Chickadee
+                default.</span>
         </label>
         #if(canEdit):
         <div class="mcp-panel-buttons">
-            <button class="btn btn-primary" type="submit">Save guidance</button>
+            <button class="btn btn-primary" type="submit">Save</button>
+            #if(showResetButton):
+            <button class="btn" type="submit" name="action" value="reset">Reset to Chickadee default</button>
+            #endif
         </div>
         #endif
     </form>
-</section>
-
-<section class="mcp-panel-section">
-    <details class="mcp-panel-house-guide">
-        <summary>House authoring-voice guide (always sent to agents)</summary>
-        <pre class="mcp-panel-house-guide-text">#(houseVoiceGuide)</pre>
-    </details>
 </section>
 
 #endif
@@ -73,10 +71,9 @@ MCP
 .mcp-panel-intro { margin: .75rem 0 1rem; color: var(--text-secondary); max-width: 60rem; }
 .mcp-panel-note { margin-bottom: 1rem; color: var(--text-secondary); font-style: italic; }
 .mcp-panel-form { display: flex; flex-direction: column; gap: 1rem; max-width: 60rem; }
-.mcp-panel-textarea { display: block; margin-top: .25rem; width: 100%; resize: vertical; }
+.mcp-panel-textarea { display: block; margin-top: .25rem; width: 100%; resize: vertical; font-family: var(--font-mono); font-size: var(--text-sm); }
 .mcp-panel-hint { display: block; margin-top: .25rem; color: var(--text-secondary); font-size: var(--text-sm); }
 .mcp-panel-buttons { display: flex; gap: .75rem; }
-.mcp-panel-house-guide-text { white-space: pre-wrap; color: var(--text-secondary); font-size: var(--text-sm); margin-top: .75rem; }
 </style>
 #endexport
 #endextend

--- a/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes+Authorize.swift
+++ b/Sources/APIServer/MCP/OAuth/MCPOAuthRoutes+Authorize.swift
@@ -43,19 +43,27 @@ extension MCPOAuthRoutes {
             SecurityHeadersMiddleware.cspOrigin(of: query.redirectURI), on: req)
         SecurityHeadersMiddleware.setOpenerPolicy("same-origin-allow-popups", on: req)
 
+        // Which resource is being authorized (content authoring vs admin
+        // diagnostics) — picks the scope ceiling, role gate, audience, signing
+        // authority, and the RFC 9207 `iss` self-identification on every
+        // redirect below. Resolved before the first redirecting guard so error
+        // responses carry `iss` too, as the RFC requires.
+        let surface = resolveSurface(req: req, resource: query.resource, scope: query.scope)
         guard query.responseType == "code" else {
-            return redirect(query.redirectURI, error: "unsupported_response_type", state: query.state)
+            return redirect(
+                query.redirectURI, error: "unsupported_response_type", state: query.state,
+                issuer: surface.issuer)
         }
         guard !query.codeChallenge.isEmpty, query.codeChallengeMethod == "S256" else {
-            return redirect(query.redirectURI, error: "invalid_request", state: query.state)
+            return redirect(
+                query.redirectURI, error: "invalid_request", state: query.state,
+                issuer: surface.issuer)
         }
-        // Which resource is being authorized (content authoring vs admin
-        // diagnostics) — picks the scope ceiling, role gate, audience, and
-        // signing authority for the rest of the flow.
-        let surface = resolveSurface(req: req, resource: query.resource, scope: query.scope)
         let scopes = resolveScopes(query.scope, ceiling: surface.scopeCeiling)
         guard !scopes.isEmpty else {
-            return redirect(query.redirectURI, error: "invalid_scope", state: query.state)
+            return redirect(
+                query.redirectURI, error: "invalid_scope", state: query.state,
+                issuer: surface.issuer)
         }
 
         guard let user = req.auth.get(APIUser.self) else {
@@ -166,13 +174,15 @@ extension MCPOAuthRoutes {
             throw Abort(.badRequest, reason: "Invalid client or redirect_uri.")
         }
         let state = record.state
-        guard form.decision == "authorize" else {
-            return redirect(record.redirectURI, error: "access_denied", state: state)
-        }
         // The surface is fixed by the frozen consent record's scope (its
         // namespace identifies content vs admin), so the role re-check uses the
-        // right gate.
+        // right gate and every redirect self-identifies with the right RFC 9207
+        // `iss`.
         let surface = surfaceForScope(record.scope, req: req)
+        guard form.decision == "authorize" else {
+            return redirect(
+                record.redirectURI, error: "access_denied", state: state, issuer: surface.issuer)
+        }
         // Re-check the role from the bound user at submit time: a downgrade
         // between rendering the consent screen and submitting it must stop here.
         guard
@@ -183,7 +193,8 @@ extension MCPOAuthRoutes {
         }
         let scopes = resolveScopes(record.scope, ceiling: surface.scopeCeiling)
         guard !scopes.isEmpty, !record.codeChallenge.isEmpty, record.codeChallengeMethod == "S256" else {
-            return redirect(record.redirectURI, error: "invalid_request", state: state)
+            return redirect(
+                record.redirectURI, error: "invalid_request", state: state, issuer: surface.issuer)
         }
 
         let code = Self.randomToken()
@@ -214,7 +225,7 @@ extension MCPOAuthRoutes {
             actorOverride: user,
             on: req
         )
-        return redirect(record.redirectURI, code: code, state: state)
+        return redirect(record.redirectURI, code: code, state: state, issuer: surface.issuer)
     }
 
     // MARK: - Consent-flow helpers
@@ -255,14 +266,20 @@ extension MCPOAuthRoutes {
         }
     }
 
-    /// 303 redirect carrying `code` + `state` query items (empty ones dropped).
-    private func redirect(_ uri: String, code: String, state: String) -> Response {
-        redirect(uri, items: [("code", code), ("state", state)])
+    /// 303 redirect carrying `code` + `state` + `iss` query items (empty ones
+    /// dropped). `iss` is the RFC 9207 issuer-identification parameter
+    /// (SEP-2468 in the MCP 2026-07-28 revision): the authorization server
+    /// self-identifies on every authorization response so a client can detect
+    /// mix-up attacks. The value is the resolved surface's issuer — the same
+    /// identifier the minted access token's `iss` claim will carry.
+    private func redirect(_ uri: String, code: String, state: String, issuer: String) -> Response {
+        redirect(uri, items: [("code", code), ("state", state), ("iss", issuer)])
     }
 
-    /// 303 redirect carrying `error` + `state` query items.
-    private func redirect(_ uri: String, error: String, state: String) -> Response {
-        redirect(uri, items: [("error", error), ("state", state)])
+    /// 303 redirect carrying `error` + `state` + `iss` query items — RFC 9207
+    /// requires `iss` on error responses too.
+    private func redirect(_ uri: String, error: String, state: String, issuer: String) -> Response {
+        redirect(uri, items: [("error", error), ("state", state), ("iss", issuer)])
     }
 
     private func redirect(_ uri: String, items: [(String, String)]) -> Response {

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -317,7 +317,11 @@ enum MCPServerInstructions {
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \
         is the verbatim canonical JSON, useful to read the full authoring spec into context. \
         Authoring guides are exposed the same way under chickadee://docs/* — e.g. the per-student \
-        solution-notebook recipe above.
+        solution-notebook recipe above. The house authoring-voice guide (the block these \
+        instructions end with) is chickadee://docs/authoring-voice, and a course whose instructors \
+        set per-course authoring guidance exposes it at chickadee://course/<code>/authoring-guidance. \
+        Re-read that resource before authoring in a course: the copy embedded in these instructions \
+        is frozen when the connection initializes, while the resource always serves the live text.
         """
 
     /// The house authoring-voice guide, appended verbatim to the operational

--- a/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
+++ b/Sources/APIServer/MCP/Protocol/InitializeTypes.swift
@@ -317,11 +317,13 @@ enum MCPServerInstructions {
         chickadee://assignment/<publicID>/manifest). get_suite is the structured view; the resource \
         is the verbatim canonical JSON, useful to read the full authoring spec into context. \
         Authoring guides are exposed the same way under chickadee://docs/* — e.g. the per-student \
-        solution-notebook recipe above. The house authoring-voice guide (the block these \
-        instructions end with) is chickadee://docs/authoring-voice, and a course whose instructors \
-        set per-course authoring guidance exposes it at chickadee://course/<code>/authoring-guidance. \
-        Re-read that resource before authoring in a course: the copy embedded in these instructions \
-        is frozen when the connection initializes, while the resource always serves the live text.
+        solution-notebook recipe above. The default authoring-voice guide (the block these \
+        instructions end with) is chickadee://docs/authoring-voice, and every course you can author \
+        in serves the voice actually in force for it at chickadee://course/<code>/authoring-guidance \
+        — its instructors' own guide when they have replaced the default, otherwise the default \
+        itself. Read that resource before authoring in a course: the copy embedded in these \
+        instructions is frozen when the connection initializes, while the resource always serves \
+        the live text.
         """
 
     /// The house authoring-voice guide, appended verbatim to the operational

--- a/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
+++ b/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
@@ -67,9 +67,11 @@ struct MCPResourceProvider: Sendable {
         InlineDocResource(
             slug: "authoring-voice",
             name: "Guide — authoring voice for Chickadee assignments",
-            description: "The house authoring-voice guide, identical to the block the "
-                + "initialize instructions end with: the register instructional prose is "
-                + "written in, the required and prohibited patterns, and a worked example.",
+            description: "Chickadee's default authoring-voice guide, identical to the block "
+                + "the initialize instructions end with: the register instructional prose is "
+                + "written in, the required and prohibited patterns, and a worked example. "
+                + "Every course starts on this guide; a course whose instructors have "
+                + "replaced it serves its own at chickadee://course/<code>/authoring-guidance.",
             text: MCPServerInstructions.authoringVoice)
     ]
 
@@ -132,14 +134,20 @@ struct MCPResourceProvider: Sendable {
         let guidanceEntries: [JSONValue] = try await mcpCourseGuidance(
             forSubject: context.subject, db: context.db
         ).map { guidance in
-            .object([
+            let origin =
+                guidance.isCustomized
+                ? "The course's own guide, set by its instructors"
+                : "Chickadee's default guide, which this course has not customized"
+            return .object([
                 "uri": .string(Self.courseGuidanceURI(courseCode: guidance.courseCode)),
-                "name": .string("\(guidance.courseCode) — course authoring guidance"),
+                "name": .string("\(guidance.courseCode) — authoring voice"),
                 "description": .string(
-                    "Instructor-set authoring guidance for \(guidance.courseCode) (tone, "
-                        + "vocabulary, conventions). Also embedded in the initialize "
-                        + "instructions, but the initialize copy is frozen per connection — "
-                        + "re-read this resource before authoring in the course."),
+                    "The authoring voice in force for \(guidance.courseCode): the register, "
+                        + "vocabulary, and conventions to write its instructional prose in. "
+                        + "\(origin). Read this before authoring in the course — a customized "
+                        + "guide replaces the house guide in the initialize instructions, and "
+                        + "the initialize copy is frozen per connection while this resource "
+                        + "always serves the live text."),
                 "mimeType": .string("text/markdown"),
             ])
         }

--- a/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
+++ b/Sources/APIServer/MCP/Resources/MCPResourceProvider.swift
@@ -48,6 +48,50 @@ struct MCPResourceProvider: Sendable {
                 + "full recipe the server instructions reference.")
     ]
 
+    /// An authoring guide served from an in-binary constant rather than a file
+    /// on disk, exposed read-only at the same `chickadee://docs/<slug>`
+    /// namespace. Keeps the source of truth in code — the authoring-voice
+    /// guide below is the very constant the `initialize` instructions embed —
+    /// so the resource can never drift from what initialize serves.
+    struct InlineDocResource: Sendable {
+        let slug: String
+        let name: String
+        let description: String
+        let text: String
+
+        var uri: String { "chickadee://docs/\(slug)" }
+    }
+
+    /// Constant-backed guides, always present regardless of the docs tree.
+    static let inlineDocResources: [InlineDocResource] = [
+        InlineDocResource(
+            slug: "authoring-voice",
+            name: "Guide — authoring voice for Chickadee assignments",
+            description: "The house authoring-voice guide, identical to the block the "
+                + "initialize instructions end with: the register instructional prose is "
+                + "written in, the required and prohibited patterns, and a worked example.",
+            text: MCPServerInstructions.authoringVoice)
+    ]
+
+    /// `chickadee://course/<code>/authoring-guidance` — the per-course guidance
+    /// a course's instructors set on the instructor MCP panel. Unlike the
+    /// initialize embedding (frozen per connection), the resource re-reads the
+    /// live value, so an agent can pick up edits mid-session.
+    static func courseGuidanceURI(courseCode: String) -> String {
+        "chickadee://course/\(courseCode)/authoring-guidance"
+    }
+
+    /// Parses a course code out of a guidance resource URI, or nil if `uri` is
+    /// not a well-formed guidance URI.
+    static func courseGuidanceCode(fromURI uri: String) -> String? {
+        let prefix = "chickadee://course/"
+        let suffix = "/authoring-guidance"
+        guard uri.hasPrefix(prefix), uri.hasSuffix(suffix) else { return nil }
+        let inner = String(uri.dropFirst(prefix.count).dropLast(suffix.count))
+        guard !inner.isEmpty, !inner.contains("/") else { return nil }
+        return inner
+    }
+
     /// `chickadee://assignment/<publicID>/manifest`
     static func manifestURI(publicID: String) -> String {
         "chickadee://assignment/\(publicID)/manifest"
@@ -82,10 +126,27 @@ struct MCPResourceProvider: Sendable {
         let courseByID = Dictionary(
             courses.compactMap { course in course.id.map { ($0, course) } },
             uniquingKeysWith: { first, _ in first })
+        // Per-course authoring guidance, for the courses the subject can
+        // author in (same resolver the initialize embedding uses, so the two
+        // surfaces can't disagree about who sees which course's guidance).
+        let guidanceEntries: [JSONValue] = try await mcpCourseGuidance(
+            forSubject: context.subject, db: context.db
+        ).map { guidance in
+            .object([
+                "uri": .string(Self.courseGuidanceURI(courseCode: guidance.courseCode)),
+                "name": .string("\(guidance.courseCode) — course authoring guidance"),
+                "description": .string(
+                    "Instructor-set authoring guidance for \(guidance.courseCode) (tone, "
+                        + "vocabulary, conventions). Also embedded in the initialize "
+                        + "instructions, but the initialize copy is frozen per connection — "
+                        + "re-read this resource before authoring in the course."),
+                "mimeType": .string("text/markdown"),
+            ])
+        }
         // The guides are not course-scoped: a subject with no enrolments yet
         // still sees them.
         guard !courseByID.isEmpty else {
-            return .object(["resources": .array(docEntries(context: context))])
+            return .object(["resources": .array(docEntries(context: context) + guidanceEntries)])
         }
 
         let assignments = try await APIAssignment.query(on: context.db)
@@ -105,14 +166,24 @@ struct MCPResourceProvider: Sendable {
                 "mimeType": .string("application/json"),
             ])
         }
-        return .object(["resources": .array(docEntries(context: context) + resources)])
+        return .object(
+            ["resources": .array(docEntries(context: context) + guidanceEntries + resources)])
     }
 
     // MARK: - Authoring-guide docs
 
-    /// Listing entries for the curated guides whose files exist on disk.
+    /// Listing entries for the constant-backed guides (always present) and the
+    /// curated file-backed guides whose files exist on disk.
     private func docEntries(context: ToolContext) -> [JSONValue] {
-        Self.docResources.compactMap { doc in
+        let inline: [JSONValue] = Self.inlineDocResources.map { doc in
+            .object([
+                "uri": .string(doc.uri),
+                "name": .string(doc.name),
+                "description": .string(doc.description),
+                "mimeType": .string("text/markdown"),
+            ])
+        }
+        let fileBacked: [JSONValue] = Self.docResources.compactMap { doc in
             guard FileManager.default.fileExists(atPath: Self.docPath(doc, context: context)) else {
                 return nil
             }
@@ -123,16 +194,21 @@ struct MCPResourceProvider: Sendable {
                 "mimeType": .string("text/markdown"),
             ])
         }
+        return inline + fileBacked
     }
 
     private static func docPath(_ doc: DocResource, context: ToolContext) -> String {
         context.request.application.directory.workingDirectory + doc.relativePath
     }
 
-    /// Reads a curated guide, or throws the same "unknown resource" error the
-    /// manifest path uses when the slug is unknown or the file is unreadable.
+    /// Reads a curated guide — constant-backed first, then file-backed — or
+    /// throws the same "unknown resource" error the manifest path uses when
+    /// the slug is unknown or the file is unreadable.
     private func readDoc(uri: String, context: ToolContext) async throws -> JSONValue {
         try await context.requireEligibleSubject(tool: "resources/read")
+        if let inline = Self.inlineDocResources.first(where: { $0.uri == uri }) {
+            return Self.textContents(uri: uri, text: inline.text)
+        }
         guard let doc = Self.docResources.first(where: { $0.uri == uri }),
             let data = FileManager.default.contents(atPath: Self.docPath(doc, context: context)),
             let text = String(data: data, encoding: .utf8)
@@ -140,7 +216,29 @@ struct MCPResourceProvider: Sendable {
             throw MCPToolError.invalidArguments(
                 tool: "resources/read", detail: "Unknown or inaccessible resource: \(uri)")
         }
-        return .object([
+        return Self.textContents(uri: uri, text: text)
+    }
+
+    /// Reads a course's authoring guidance. Resolved through the same
+    /// `mcpCourseGuidance` scoping the listing and the initialize embedding
+    /// use, so "not enrolled", "no authoring authority", "archived", and "no
+    /// guidance set" all collapse into the manifest path's anti-enumeration
+    /// "unknown resource" answer.
+    private func readCourseGuidance(
+        courseCode: String, uri: String, context: ToolContext
+    ) async throws -> JSONValue {
+        try await context.requireEligibleSubject(tool: "resources/read")
+        let guidance = try await mcpCourseGuidance(forSubject: context.subject, db: context.db)
+        guard let match = guidance.first(where: { $0.courseCode == courseCode }) else {
+            throw MCPToolError.invalidArguments(
+                tool: "resources/read", detail: "Unknown or inaccessible resource: \(uri)")
+        }
+        return Self.textContents(uri: uri, text: match.text)
+    }
+
+    /// The `resources/read` result envelope for a single markdown/text body.
+    private static func textContents(uri: String, text: String) -> JSONValue {
+        .object([
             "contents": .array([
                 .object([
                     "uri": .string(uri),
@@ -159,6 +257,9 @@ struct MCPResourceProvider: Sendable {
     func read(uri: String, context: ToolContext) async throws -> JSONValue {
         if uri.hasPrefix("chickadee://docs/") {
             return try await readDoc(uri: uri, context: context)
+        }
+        if let courseCode = Self.courseGuidanceCode(fromURI: uri) {
+            return try await readCourseGuidance(courseCode: courseCode, uri: uri, context: context)
         }
         guard let publicID = Self.manifestPublicID(fromURI: uri),
             let assignment = try await assignmentByPublicID(publicID, on: context.db)

--- a/Sources/APIServer/MCP/Transport/MCPCourseGuidance.swift
+++ b/Sources/APIServer/MCP/Transport/MCPCourseGuidance.swift
@@ -1,49 +1,57 @@
 // APIServer/MCP/Transport/MCPCourseGuidance.swift
 //
-// Per-course authoring guidance layered onto the content MCP server's
-// `initialize` instructions.  Instructors write the text on the instructor MCP
-// panel (courses.mcp_instructions); at initialize the dispatcher resolves the
-// connecting account's authorable courses and appends each course's guidance
-// under a labelled block, so an agent picks up the course's own tone and style
-// preferences alongside the house authoring-voice guide.  Advisory by design —
-// it shapes authored prose and changes no tool behaviour or scope.
+// Per-course authoring voice for the content MCP server.  Every course starts
+// out on Chickadee's house authoring-voice guide; a course's instructors can
+// take that text over on the instructor MCP panel and edit it into their own
+// (`courses.mcp_instructions`, nil while the course is still inheriting).  At
+// initialize the dispatcher resolves the connecting account's authorable
+// courses and appends a labelled block for each course that has customized its
+// voice — the house guide already carries the default, so an inheriting course
+// adds nothing.  Advisory by design: it shapes authored prose and changes no
+// tool behaviour or scope.
 
 import Core
 import Fluent
 import Foundation
 
-/// One course's authoring guidance, as appended to the initialize instructions.
+/// One course's effective authoring voice.
 struct MCPCourseGuidance: Equatable, Sendable {
     let courseCode: String
+    /// The voice guide in force for this course: the instructors' own text when
+    /// they have customized it, otherwise Chickadee's default.
     let text: String
+    /// False when `text` is the inherited default rather than course-authored.
+    let isCustomized: Bool
 }
 
 extension MCPServerInstructions {
     /// The complete instructions string for a connection whose account can
-    /// author in courses carrying custom guidance.  With no guidance this is
-    /// exactly `text`, so accounts without any per-course text see the same
-    /// bytes as before.
+    /// author in courses that have customized their voice.  Only customized
+    /// courses contribute — an inheriting course is already covered by the
+    /// house guide inside `text` — so a connection with no customizations gets
+    /// exactly `text`, byte for byte.
     static func text(withCourseGuidance guidance: [MCPCourseGuidance]) -> String {
-        guard !guidance.isEmpty else { return text }
+        let customized = guidance.filter(\.isCustomized)
+        guard !customized.isEmpty else { return text }
         let header = """
-            Course-specific authoring guidance
+            Course-specific authoring voice
 
-            The instructors of the courses below have set additional guidance for content \
-            authored in their course. It applies only when authoring in that course and \
-            supplements the house authoring-voice guide above; where the two conflict, the \
-            course's own guidance takes precedence for that course's content.
+            The courses below have replaced the authoring-voice guide above with their own. \
+            When authoring content for one of these courses, follow that course's guide in \
+            place of the house guide; the house guide still governs every other course.
             """
-        let blocks = guidance.map { "Course \($0.courseCode):\n\($0.text)" }
+        let blocks = customized.map { "Course \($0.courseCode):\n\($0.text)" }
         return ([text, header] + blocks).joined(separator: "\n\n")
     }
 }
 
-/// Resolves the per-course guidance blocks for the token subject: the
-/// non-archived courses the account is enrolled in with authoring authority
-/// (per-course role of TA or higher; admins qualify through any enrollment,
-/// matching `evaluateCourseWrite`'s bypass) whose `mcp_instructions` is
-/// non-empty, in course-code order.  An unknown subject resolves to no
-/// guidance rather than an error — initialize must succeed regardless.
+/// Resolves the effective authoring voice of every course the token subject can
+/// author in: the non-archived enrolled courses where the account holds a
+/// per-course role of TA or higher (admins qualify through any enrollment,
+/// matching `evaluateCourseWrite`'s bypass), in course-code order.  A course
+/// that has not customized its voice comes back carrying the house default with
+/// `isCustomized == false`.  An unknown subject resolves to nothing rather than
+/// an error — initialize must succeed regardless.
 func mcpCourseGuidance(forSubject subject: String, db: any Database) async throws -> [MCPCourseGuidance] {
     guard
         let user = try await APIUser.query(on: db)
@@ -53,10 +61,24 @@ func mcpCourseGuidance(forSubject subject: String, db: any Database) async throw
     else { return [] }
     return try await enrolledCoursesWithRoles(for: userID, on: db)
         .filter { user.isAdmin || $0.role >= .ta }
-        .compactMap { enrolled in
-            let text = (enrolled.course.mcpInstructions ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else { return nil }
-            return MCPCourseGuidance(courseCode: enrolled.course.code, text: text)
+        .map { enrolled in
+            MCPCourseGuidance(
+                courseCode: enrolled.course.code,
+                text: courseAuthoringVoice(enrolled.course),
+                isCustomized: courseHasCustomAuthoringVoice(enrolled.course))
         }
+}
+
+/// The voice guide in force for `course`: its own text when customized, else
+/// Chickadee's default.  The single resolver behind the MCP surfaces and the
+/// instructor panel, so the text an instructor edits is the text agents get.
+func courseAuthoringVoice(_ course: APICourse) -> String {
+    let custom = (course.mcpInstructions ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    return custom.isEmpty ? MCPServerInstructions.authoringVoice : custom
+}
+
+/// True when `course` carries its own voice guide rather than inheriting the
+/// default.
+func courseHasCustomAuthoringVoice(_ course: APICourse) -> Bool {
+    !(course.mcpInstructions ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 }

--- a/Sources/APIServer/MCP/Transport/MCPMetadataRoutes.swift
+++ b/Sources/APIServer/MCP/Transport/MCPMetadataRoutes.swift
@@ -56,6 +56,10 @@ struct MCPMetadataRoutes: RouteCollection {
             "grant_types_supported": .array([.string("authorization_code"), .string("refresh_token")]),
             "code_challenge_methods_supported": .array([.string("S256")]),
             "token_endpoint_auth_methods_supported": .array([.string("none")]),
+            // RFC 9207: the authorize endpoint appends `iss` to every
+            // authorization response (success and error), and this flag tells
+            // clients they may — and per SEP-2468 must — validate it.
+            "authorization_response_iss_parameter_supported": .bool(true),
         ])
         return try jsonResponse(metadata)
     }

--- a/Sources/APIServer/Models/APICourse.swift
+++ b/Sources/APIServer/Models/APICourse.swift
@@ -63,11 +63,13 @@ final class APICourse: Model, Content, @unchecked Sendable {
     @OptionalField(key: "brightspace_section_category_id")
     var brightspaceSectionCategoryID: String?
 
-    /// Per-course authoring guidance for MCP agents, set by the course's
-    /// instructors on the instructor MCP panel. Appended to the content MCP
-    /// server's `initialize` instructions for accounts with authoring authority
-    /// in this course, so a connected agent picks up the course's own tone and
-    /// style preferences. Nil = no course-specific guidance.
+    /// This course's own authoring-voice guide for MCP agents, set by its
+    /// instructors on the instructor MCP panel. When present it REPLACES
+    /// Chickadee's default guide for content authored in this course (the
+    /// panel seeds the editor with the default, so a course's guide starts as
+    /// an edited copy of it). Nil = the course inherits the default, which is
+    /// also what the panel stores when the text is reset, emptied, or left
+    /// matching the default verbatim. Resolved via `courseAuthoringVoice`.
     @OptionalField(key: "mcp_instructions")
     var mcpInstructions: String?
 

--- a/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentListContexts.swift
@@ -360,17 +360,25 @@ struct AssignmentStudentRow: Encodable {
     let secretRevealSpent: Bool
 }
 
-/// MCP tab (`GET /instructor/mcp`): the active course's authoring guidance for
+/// MCP tab (`GET /instructor/mcp`): the active course's authoring voice for
 /// connected agents, editable by the course's instructors.
 struct InstructorMCPContext: Encodable {
     let currentUser: CurrentUserContext?
     let activeInstructorTab: String
     let hasActiveCourse: Bool
     let courseCode: String
-    /// The stored per-course guidance ("" when unset) — the textarea's value.
+    /// The course's effective voice guide — its own text when customized, else
+    /// Chickadee's default — as the textarea's value. The default is seeded
+    /// into the box so the instructor edits a real starting point rather than
+    /// composing an addendum against an invisible baseline.
     let guidanceText: String
-    /// The fixed house authoring-voice guide, rendered read-only for reference.
-    let houseVoiceGuide: String
+    /// True when `guidanceText` is course-authored rather than the default.
+    let isCustomized: Bool
+    /// `canEdit && isCustomized` — folded so the template gates the Reset
+    /// button on one flag (LeafKit 1.14.2 mis-parses `&&`).
+    let showResetButton: Bool
+    /// One-line statement of where the current text comes from.
+    let sourceNote: String
     let maxLength: Int
     /// True when the viewer may save: a per-course instructor or an admin, and
     /// the course is not archived. TAs pass the `/instructor` gate but see the

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+MCP.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+MCP.swift
@@ -1,14 +1,15 @@
 // APIServer/Routes/Web/InstructorDashboardRoutes+MCP.swift
 //
-// Instructor MCP panel: per-course authoring guidance for connected agents.
+// Instructor MCP panel: the active course's authoring voice for connected agents.
 //
-//   GET  /instructor/mcp   → instructor-mcp.leaf (view / edit the active course's guidance)
-//   POST /instructor/mcp   → save (per-course instructor only) → redirect back with a flash
+//   GET  /instructor/mcp   → instructor-mcp.leaf (view / edit the course's voice guide)
+//   POST /instructor/mcp   → save or reset (per-course instructor only) → redirect with a flash
 //
-// The saved text (`courses.mcp_instructions`) is layered onto the content MCP
-// server's `initialize` instructions for accounts with authoring authority in
-// the course (MCP/Transport/MCPCourseGuidance.swift), so an instructor can set
-// the tone agents use when authoring content for their course. Advisory
+// One editable guide per course, seeded from Chickadee's house authoring-voice
+// guide: the box starts out showing the default, and saving an edited copy
+// takes the course off the default (`courses.mcp_instructions`, nil while
+// inheriting). The content MCP server serves each course's effective guide to
+// agents authoring in it (MCP/Transport/MCPCourseGuidance.swift). Advisory
 // voice/tone guidance only — it never changes tool behaviour or scopes.
 
 import Core
@@ -17,9 +18,10 @@ import Foundation
 import Vapor
 
 extension InstructorDashboardRoutes {
-    /// Server-side cap on the stored guidance. Generous for a page of prose,
-    /// small enough that every `initialize` payload stays lightweight.
-    static let mcpGuidanceMaxLength = 4000
+    /// Server-side cap on the stored guide. Roomy next to the ~2 KB default so
+    /// an instructor can expand on it, small enough that every `initialize`
+    /// payload stays lightweight.
+    static let mcpGuidanceMaxLength = 8000
 
     @Sendable
     func mcpPanelPage(req: Request) async throws -> View {
@@ -40,16 +42,23 @@ extension InstructorDashboardRoutes {
         } else if isArchived {
             readOnlyNote = "This course is archived and is read-only."
         } else {
-            readOnlyNote = "Only this course's instructors can edit its guidance."
+            readOnlyNote = "Only this course's instructors can edit its authoring voice."
         }
 
-        let flashSuccess: String? =
-            req.query[String.self, at: "saved"] != nil
-            ? "Guidance saved. Connected agents pick it up the next time they connect." : nil
+        let flashSuccess: String? = {
+            switch req.query[String.self, at: "saved"] {
+            case "1":
+                return "Saved. Connected agents pick it up the next time they connect."
+            case "reset":
+                return "Reset to the Chickadee default."
+            default:
+                return nil
+            }
+        }()
         let flashError: String? = {
             switch req.query[String.self, at: "error"] {
             case "length":
-                return "Guidance is limited to \(Self.mcpGuidanceMaxLength) characters."
+                return "The guide is limited to \(Self.mcpGuidanceMaxLength) characters."
             case "course":
                 return "No active course."
             default:
@@ -57,13 +66,20 @@ extension InstructorDashboardRoutes {
             }
         }()
 
+        let isCustomized = course.map(courseHasCustomAuthoringVoice) ?? false
         let ctx = InstructorMCPContext(
             currentUser: try await req.courseAwareUserContext(),
             activeInstructorTab: "mcp",
             hasActiveCourse: course != nil,
             courseCode: course?.code ?? "",
-            guidanceText: course?.mcpInstructions ?? "",
-            houseVoiceGuide: MCPServerInstructions.authoringVoice,
+            guidanceText: course.map(courseAuthoringVoice) ?? MCPServerInstructions.authoringVoice,
+            isCustomized: isCustomized,
+            // Precomputed so the template branches on flat bools (LeafKit
+            // 1.14.2 mis-parses compound conditions).
+            showResetButton: canEdit && isCustomized,
+            sourceNote: isCustomized
+                ? "This course uses its own authoring voice."
+                : "This course uses the Chickadee default. Edit the text below to make it your own.",
             maxLength: Self.mcpGuidanceMaxLength,
             canEdit: canEdit,
             readOnlyNote: readOnlyNote,
@@ -89,23 +105,41 @@ extension InstructorDashboardRoutes {
 
         struct GuidanceForm: Content {
             let instructions: String?
+            /// "reset" from the Reset button; absent for a normal save.
+            let action: String?
         }
-        let raw = (try req.content.decode(GuidanceForm.self).instructions ?? "")
+        let form = try req.content.decode(GuidanceForm.self)
+        // Browsers submit textarea content with CRLF line endings; normalize so
+        // stored text (and the compare against the default below) is \n-only.
+        let raw = (form.instructions ?? "")
+            .replacingOccurrences(of: "\r\n", with: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard raw.count <= Self.mcpGuidanceMaxLength else {
             return req.redirect(to: "/instructor/mcp?error=length")
         }
 
-        course.mcpInstructions = raw.isEmpty ? nil : raw
+        // The course inherits the default again when it is explicitly reset,
+        // when the box is emptied, or when the submitted text still matches the
+        // default verbatim — storing an unedited copy would only freeze the
+        // course against future changes to the house guide.
+        let isReset = form.action == "reset"
+        let matchesDefault =
+            raw == MCPServerInstructions.authoringVoice.trimmingCharacters(in: .whitespacesAndNewlines)
+        let inherits = isReset || raw.isEmpty || matchesDefault
+        course.mcpInstructions = inherits ? nil : raw
         try await course.save(on: req.db)
         // Audit the change without recording the text itself (the MCP surface
-        // never logs content bodies); the length distinguishes set vs cleared.
+        // never logs content bodies); the length distinguishes edit vs inherit.
         await AuditLogger.record(
             action: .mcpCourseInstructionsUpdated,
             targetType: .course,
             targetID: courseUUID.uuidString,
-            metadata: ["course_code": course.code, "length": String(raw.count)],
+            metadata: [
+                "course_code": course.code,
+                "length": String(inherits ? 0 : raw.count),
+                "source": inherits ? "default" : "course",
+            ],
             on: req)
-        return req.redirect(to: "/instructor/mcp?saved=1")
+        return req.redirect(to: inherits ? "/instructor/mcp?saved=reset" : "/instructor/mcp?saved=1")
     }
 }

--- a/Tests/APITests/InstructorMCPPanelTests.swift
+++ b/Tests/APITests/InstructorMCPPanelTests.swift
@@ -1,8 +1,9 @@
 // Tests/APITests/InstructorMCPPanelTests.swift
 //
-// The instructor MCP tab (per-course authoring guidance for connected agents):
-// staff-only visibility, TA read-only rendering, the instructor save/clear
-// round-trip (with the length guard), and the TA save refusal.
+// The instructor MCP tab (the course's authoring voice for connected agents):
+// staff-only visibility, the default seeded into the editor, TA read-only
+// rendering, the instructor save / reset round-trip (with the length guard and
+// the unedited-default shortcut), and the TA save refusal.
 
 import Core
 import Fluent
@@ -53,7 +54,7 @@ import VaporTesting
         }
     }
 
-    @Test func instructorSeesEditablePanelWithHouseGuide() async throws {
+    @Test func instructorSeesEditorSeededWithTheDefault() async throws {
         try await withAssignmentRoutesApp { app in
             let cookie = try await arLoginAsInstructor(on: app)
             try await app.asyncTest(
@@ -62,11 +63,14 @@ import VaporTesting
                 afterResponse: { res in
                     #expect(res.status == .ok)
                     let html = res.body.string
-                    #expect(html.contains("Agent authoring guidance"))
-                    #expect(html.contains("Save guidance"))
-                    // The fixed house guide is shown for reference.
-                    #expect(html.contains("House authoring-voice guide"))
+                    #expect(html.contains("Authoring voice"))
+                    #expect(html.contains(">Save<"))
+                    // An uncustomized course starts on the Chickadee default,
+                    // seeded into the one editable box.
                     #expect(html.contains("Authoring voice for Chickadee assignments"))
+                    #expect(html.contains("uses the Chickadee default"))
+                    // Nothing to reset while the course is still inheriting.
+                    #expect(!html.contains("Reset to Chickadee default"))
                 })
         }
     }
@@ -82,15 +86,78 @@ import VaporTesting
                     let html = res.body.string
                     // Leaf escapes the apostrophe in "course's", so match an
                     // apostrophe-free slice of the read-only note.
-                    #expect(html.contains("instructors can edit its guidance"))
-                    #expect(!html.contains("Save guidance"))
+                    #expect(html.contains("instructors can edit its authoring voice"))
+                    // No save/reset controls at all for a TA; the box renders
+                    // with the disabled attribute.
+                    #expect(!html.contains(">Save<"))
+                    #expect(!html.contains("Reset to Chickadee default"))
+                    #expect(html.contains(" disabled>"))
                 })
         }
     }
 
     // MARK: - Save round-trip
 
-    @Test func instructorSavesAndClearsGuidance() async throws {
+    @Test func instructorCustomizesThenResetsTheVoice() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/mcp", cookie: cookie, on: app)
+            // An edited copy of the default: the realistic shape of the edit,
+            // and it exercises the CRLF normalization browsers submit with.
+            let edited = MCPServerInstructions.authoringVoice + "\n\nUse metric units throughout."
+            let asBrowserSubmits = edited.replacingOccurrences(of: "\n", with: "\r\n")
+
+            try await app.asyncTest(
+                .POST, "/instructor/mcp",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["instructions": asBrowserSubmits, "_csrf": csrf], as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=1")
+                })
+            var course = try await activeCourse(on: app)
+            // Stored with \n line endings, and now the course's own voice.
+            #expect(course.mcpInstructions == edited)
+            #expect(courseHasCustomAuthoringVoice(course))
+
+            // The saved text renders back into the box, now offering a reset.
+            try await app.asyncTest(
+                .GET, "/instructor/mcp",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: sessionCookie) },
+                afterResponse: { res in
+                    let html = res.body.string
+                    #expect(html.contains("Use metric units throughout."))
+                    #expect(html.contains("uses its own authoring voice"))
+                    #expect(html.contains("Reset to Chickadee default"))
+                })
+
+            // Reset drops back to inheriting the default.
+            try await app.asyncTest(
+                .POST, "/instructor/mcp",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    try req.content.encode(
+                        ["instructions": asBrowserSubmits, "action": "reset", "_csrf": csrf],
+                        as: .urlEncodedForm)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .seeOther)
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=reset")
+                })
+            course = try await activeCourse(on: app)
+            #expect(course.mcpInstructions == nil)
+            #expect(courseAuthoringVoice(course) == MCPServerInstructions.authoringVoice)
+        }
+    }
+
+    @Test func savingTheUneditedDefaultKeepsTheCourseInheriting() async throws {
+        // Opening the panel and pressing Save without editing must not freeze a
+        // verbatim copy of the default onto the course — it stays on the
+        // default so later changes to the house guide still flow through.
         try await withAssignmentRoutesApp { app in
             let cookie = try await arLoginAsInstructor(on: app)
             let (csrf, sessionCookie) = try await csrfFields(
@@ -101,25 +168,29 @@ import VaporTesting
                 beforeRequest: { req in
                     req.headers.add(name: .cookie, value: sessionCookie)
                     try req.content.encode(
-                        ["instructions": "  Use metric units throughout.  ", "_csrf": csrf],
-                        as: .urlEncodedForm)
+                        [
+                            "instructions": MCPServerInstructions.authoringVoice
+                                .replacingOccurrences(of: "\n", with: "\r\n"),
+                            "_csrf": csrf,
+                        ], as: .urlEncodedForm)
                 },
                 afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=1")
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=reset")
                 })
-            var course = try await activeCourse(on: app)
-            #expect(course.mcpInstructions == "Use metric units throughout.")
+            let course = try await activeCourse(on: app)
+            #expect(course.mcpInstructions == nil)
+        }
+    }
 
-            // The saved text renders back into the panel's textarea.
-            try await app.asyncTest(
-                .GET, "/instructor/mcp",
-                beforeRequest: { req in req.headers.add(name: .cookie, value: sessionCookie) },
-                afterResponse: { res in
-                    #expect(res.body.string.contains("Use metric units throughout."))
-                })
+    @Test func emptyingTheBoxRestoresTheDefault() async throws {
+        try await withAssignmentRoutesApp { app in
+            let cookie = try await arLoginAsInstructor(on: app)
+            let course = try await activeCourse(on: app)
+            course.mcpInstructions = "Terse and technical."
+            try await course.save(on: app.db)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/mcp", cookie: cookie, on: app)
 
-            // A blank submit clears the guidance back to nil.
             try await app.asyncTest(
                 .POST, "/instructor/mcp",
                 beforeRequest: { req in
@@ -127,11 +198,10 @@ import VaporTesting
                     try req.content.encode(["instructions": "   ", "_csrf": csrf], as: .urlEncodedForm)
                 },
                 afterResponse: { res in
-                    #expect(res.status == .seeOther)
-                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=1")
+                    #expect(res.headers.first(name: .location) == "/instructor/mcp?saved=reset")
                 })
-            course = try await activeCourse(on: app)
-            #expect(course.mcpInstructions == nil)
+            let reloaded = try await activeCourse(on: app)
+            #expect(reloaded.mcpInstructions == nil)
         }
     }
 

--- a/Tests/APITests/MCP/MCPCourseGuidanceTests.swift
+++ b/Tests/APITests/MCP/MCPCourseGuidanceTests.swift
@@ -35,15 +35,29 @@ import Vapor
         #expect(text.contains("not stiff or joyless"))
     }
 
-    @Test func courseGuidanceComposesLabelledBlocks() {
+    @Test func customizedCoursesComposeLabelledBlocks() {
         let composed = MCPServerInstructions.text(withCourseGuidance: [
-            MCPCourseGuidance(courseCode: "CS136", text: "Use metric units."),
-            MCPCourseGuidance(courseCode: "HLTH204", text: "Prefer health-data examples."),
+            MCPCourseGuidance(courseCode: "CS136", text: "Use metric units.", isCustomized: true),
+            MCPCourseGuidance(
+                courseCode: "HLTH204", text: "Prefer health-data examples.", isCustomized: true),
         ])
         #expect(composed.hasPrefix(MCPServerInstructions.text))
-        #expect(composed.contains("Course-specific authoring guidance"))
+        #expect(composed.contains("Course-specific authoring voice"))
         #expect(composed.contains("Course CS136:\nUse metric units."))
         #expect(composed.contains("Course HLTH204:\nPrefer health-data examples."))
+        // The course guide replaces the house guide for that course, rather
+        // than stacking on top of it.
+        #expect(composed.contains("in place of the house guide"))
+    }
+
+    @Test func inheritingCoursesAddNothingToTheInstructions() {
+        // A course still on the default is already covered by the house guide
+        // inside `text` — repeating it per course would only bloat initialize.
+        let composed = MCPServerInstructions.text(withCourseGuidance: [
+            MCPCourseGuidance(
+                courseCode: "CS136", text: MCPServerInstructions.authoringVoice, isCustomized: false)
+        ])
+        #expect(composed == MCPServerInstructions.text)
     }
 
     @Test func emptyGuidanceLeavesInstructionsByteIdentical() {
@@ -81,13 +95,37 @@ import Vapor
             let guidance = try await mcpCourseGuidance(forSubject: "guidance_user", db: app.db)
             #expect(
                 guidance == [
-                    MCPCourseGuidance(courseCode: "ACS101", text: "Address students in the plural."),
-                    MCPCourseGuidance(courseCode: "ZCHEM301", text: "Cite lab-safety rules."),
+                    MCPCourseGuidance(
+                        courseCode: "ACS101", text: "Address students in the plural.",
+                        isCustomized: true),
+                    MCPCourseGuidance(
+                        courseCode: "ZCHEM301", text: "Cite lab-safety rules.", isCustomized: true),
                 ])
         }
     }
 
-    @Test func studentRoleArchivedAndUnsetCoursesContributeNothing() async throws {
+    @Test func uncustomizedAuthorableCoursesResolveToTheDefault() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let user = try await makeTestUser(on: app, username: "guidance_user")
+            let userID = try user.requireID()
+
+            // No text at all, and whitespace-only text, both mean "inheriting".
+            let unset = try await makeTestCourse(on: app, code: "UNSET1")
+            try await enroll(userID, in: unset, as: .instructor, on: app)
+            let blank = try await makeTestCourse(on: app, code: "BLANK1")
+            blank.mcpInstructions = "   \n  "
+            try await blank.save(on: app.db)
+            try await enroll(userID, in: blank, as: .instructor, on: app)
+
+            let guidance = try await mcpCourseGuidance(forSubject: "guidance_user", db: app.db)
+            #expect(guidance.count == 2)
+            #expect(guidance.allSatisfy { !$0.isCustomized })
+            #expect(guidance.allSatisfy { $0.text == MCPServerInstructions.authoringVoice })
+        }
+    }
+
+    @Test func coursesWithoutAuthoringAuthorityResolveToNothing() async throws {
         let app = try await makeTestApp()
         try await withApp(app) { app in
             let user = try await makeTestUser(on: app, username: "guidance_user")
@@ -105,16 +143,6 @@ import Vapor
             archived.mcpInstructions = "Stale guidance."
             try await archived.save(on: app.db)
             try await enroll(userID, in: archived, as: .instructor, on: app)
-
-            // Instructor course with only whitespace text — excluded.
-            let blank = try await makeTestCourse(on: app, code: "BLANK1")
-            blank.mcpInstructions = "   \n  "
-            try await blank.save(on: app.db)
-            try await enroll(userID, in: blank, as: .instructor, on: app)
-
-            // Instructor course with no text at all — excluded.
-            let unset = try await makeTestCourse(on: app, code: "UNSET1")
-            try await enroll(userID, in: unset, as: .instructor, on: app)
 
             let guidance = try await mcpCourseGuidance(forSubject: "guidance_user", db: app.db)
             #expect(guidance.isEmpty)
@@ -141,7 +169,11 @@ import Vapor
             try await unenrolled.save(on: app.db)
 
             let guidance = try await mcpCourseGuidance(forSubject: "guidance_admin", db: app.db)
-            #expect(guidance == [MCPCourseGuidance(courseCode: "ADM101", text: "Admin-visible guidance.")])
+            #expect(
+                guidance == [
+                    MCPCourseGuidance(
+                        courseCode: "ADM101", text: "Admin-visible guidance.", isCustomized: true)
+                ])
         }
     }
 
@@ -190,7 +222,7 @@ import Vapor
 
             let instructions = try await initializeInstructions(app, subject: "guidance_user")
             #expect(instructions.hasPrefix(MCPServerInstructions.text))
-            #expect(instructions.contains("Course-specific authoring guidance"))
+            #expect(instructions.contains("Course-specific authoring voice"))
             #expect(instructions.contains("Course CS136:\nRefer to the textbook as CP4."))
         }
     }
@@ -199,6 +231,20 @@ import Vapor
         let app = try await makeTestApp()
         try await withApp(app) { app in
             _ = try await makeTestUser(on: app, username: "guidance_user")
+            let instructions = try await initializeInstructions(app, subject: "guidance_user")
+            #expect(instructions == MCPServerInstructions.text)
+        }
+    }
+
+    @Test func initializeIsUnchangedForACourseStillOnTheDefault() async throws {
+        // An authorable course that has not customized its voice must not add
+        // a redundant copy of the default to the handshake.
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let user = try await makeTestUser(on: app, username: "guidance_user")
+            let course = try await makeTestCourse(on: app, code: "CS136")
+            try await enroll(try user.requireID(), in: course, as: .instructor, on: app)
+
             let instructions = try await initializeInstructions(app, subject: "guidance_user")
             #expect(instructions == MCPServerInstructions.text)
         }

--- a/Tests/APITests/MCP/MCPMetadataRoutesTests.swift
+++ b/Tests/APITests/MCP/MCPMetadataRoutesTests.swift
@@ -72,6 +72,9 @@ import VaporTesting
                 #expect((object?["registration_endpoint"] as? String)?.hasSuffix("/oauth/register") == true)
                 #expect((object?["code_challenge_methods_supported"] as? [String])?.contains("S256") == true)
                 #expect((object?["scopes_supported"] as? [String]) == ["content:read", "content:write"])
+                // RFC 9207 (SEP-2468): clients validate `iss` on authorization
+                // responses; the metadata must advertise that we emit it.
+                #expect((object?["authorization_response_iss_parameter_supported"] as? Bool) == true)
             }
         }
     }

--- a/Tests/APITests/MCP/MCPOAuthFlowTests.swift
+++ b/Tests/APITests/MCP/MCPOAuthFlowTests.swift
@@ -141,6 +141,8 @@ import VaporTesting
             #expect(consentRes.status == .seeOther)
             let location = consentRes.headers.first(name: .location)
             #expect(queryValue("state", in: location) == "xyz")
+            // RFC 9207: every authorization response self-identifies its issuer.
+            #expect(queryValue("iss", in: location) == issuer)
             let code = try #require(queryValue("code", in: location))
 
             // Code → access + refresh.
@@ -284,6 +286,8 @@ import VaporTesting
                 app, cookie: cookie, scope: "content:read", decision: "deny")
             #expect(res.status == .seeOther)
             #expect(queryValue("error", in: res.headers.first(name: .location)) == "access_denied")
+            // RFC 9207 requires `iss` on error responses too.
+            #expect(queryValue("iss", in: res.headers.first(name: .location)) == issuer)
         }
     }
 

--- a/Tests/APITests/MCP/MCPResourcesTests.swift
+++ b/Tests/APITests/MCP/MCPResourcesTests.swift
@@ -252,8 +252,13 @@ import Vapor
             let listing = try await MCPResourceProvider().list(context: context(app, subject: "tutor"))
             let uris = Self.resourceURIs(listing)
             #expect(!uris.contains(MCPResourceProvider.courseGuidanceURI(courseCode: "GUID01")))
-            // A course with no guidance set lists nothing either.
-            #expect(!uris.contains(MCPResourceProvider.courseGuidanceURI(courseCode: "STAFF01")))
+            // The staffed course lists even though it has not customized its
+            // voice — it serves the inherited Chickadee default.
+            #expect(uris.contains(MCPResourceProvider.courseGuidanceURI(courseCode: "STAFF01")))
+            let inherited = try await MCPResourceProvider().read(
+                uri: MCPResourceProvider.courseGuidanceURI(courseCode: "STAFF01"),
+                context: context(app, subject: "tutor"))
+            #expect(Self.firstContentText(inherited) == MCPServerInstructions.authoringVoice)
 
             await #expect(throws: MCPToolError.self) {
                 _ = try await MCPResourceProvider().read(

--- a/Tests/APITests/MCP/MCPResourcesTests.swift
+++ b/Tests/APITests/MCP/MCPResourcesTests.swift
@@ -200,6 +200,81 @@ import Vapor
         }
     }
 
+    // MARK: - Authoring-guidance resources
+
+    @Test func voiceGuideAndCourseGuidanceListAndRead() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            let course = try await makeTestCourse(on: app, code: "CS136", name: "Intro")
+            course.mcpInstructions = "  Refer to the textbook as CP4.  "
+            try await course.save(on: app.db)
+            let prof = try await makeTestUser(on: app, username: "prof")
+            try await APICourseEnrollment(
+                userID: try prof.requireID(), courseID: try course.requireID(), role: .instructor
+            ).save(on: app.db)
+
+            let listing = try await MCPResourceProvider().list(context: context(app, subject: "prof"))
+            let uris = Self.resourceURIs(listing)
+            #expect(uris.contains("chickadee://docs/authoring-voice"))
+            #expect(uris.contains(MCPResourceProvider.courseGuidanceURI(courseCode: "CS136")))
+
+            // The voice guide serves the exact constant initialize embeds.
+            let guide = try await MCPResourceProvider().read(
+                uri: "chickadee://docs/authoring-voice", context: context(app, subject: "prof"))
+            #expect(Self.firstContentText(guide) == MCPServerInstructions.authoringVoice)
+
+            // The course guidance serves the live (trimmed) stored text.
+            let guidance = try await MCPResourceProvider().read(
+                uri: MCPResourceProvider.courseGuidanceURI(courseCode: "CS136"),
+                context: context(app, subject: "prof"))
+            #expect(Self.firstContentText(guidance) == "Refer to the textbook as CP4.")
+        }
+    }
+
+    @Test func courseGuidanceScopedToAuthoringAuthority() async throws {
+        let app = try await makeTestApp()
+        try await withApp(app) { app in
+            // "tutor" is staff in STAFF01 (so MCP-eligible) but only a student
+            // in GUID01, the course carrying guidance — GUID01's guidance must
+            // neither list nor read for them.
+            let staffCourse = try await makeTestCourse(on: app, code: "STAFF01", name: "Staffed")
+            let guarded = try await makeTestCourse(on: app, code: "GUID01", name: "Guarded")
+            guarded.mcpInstructions = "Secret tone notes."
+            try await guarded.save(on: app.db)
+            let tutor = try await makeTestUser(on: app, username: "tutor")
+            try await APICourseEnrollment(
+                userID: try tutor.requireID(), courseID: try staffCourse.requireID(), role: .ta
+            ).save(on: app.db)
+            try await APICourseEnrollment(
+                userID: try tutor.requireID(), courseID: try guarded.requireID(), role: .student
+            ).save(on: app.db)
+
+            let listing = try await MCPResourceProvider().list(context: context(app, subject: "tutor"))
+            let uris = Self.resourceURIs(listing)
+            #expect(!uris.contains(MCPResourceProvider.courseGuidanceURI(courseCode: "GUID01")))
+            // A course with no guidance set lists nothing either.
+            #expect(!uris.contains(MCPResourceProvider.courseGuidanceURI(courseCode: "STAFF01")))
+
+            await #expect(throws: MCPToolError.self) {
+                _ = try await MCPResourceProvider().read(
+                    uri: MCPResourceProvider.courseGuidanceURI(courseCode: "GUID01"),
+                    context: context(app, subject: "tutor"))
+            }
+        }
+    }
+
+    @Test func courseGuidanceURIRoundTrips() {
+        #expect(
+            MCPResourceProvider.courseGuidanceCode(
+                fromURI: MCPResourceProvider.courseGuidanceURI(courseCode: "CS136")) == "CS136")
+        #expect(
+            MCPResourceProvider.courseGuidanceCode(fromURI: "chickadee://course//authoring-guidance")
+                == nil)
+        #expect(
+            MCPResourceProvider.courseGuidanceCode(
+                fromURI: "chickadee://course/a/b/authoring-guidance") == nil)
+    }
+
     // MARK: - URI round-trip
 
     @Test func manifestURIRoundTrips() {

--- a/changelog.d/mcp-course-authoring-voice.md
+++ b/changelog.d/mcp-course-authoring-voice.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **One authoring-voice guide per course, inherited from the Chickadee
+  default.** The instructor MCP tab no longer shows a fixed house guide plus a
+  separate "additional guidance" box. It now shows a single editable guide,
+  seeded with Chickadee's default authoring voice: a course starts on the
+  default, and an instructor edits that text into the course's own. A
+  customized guide *replaces* the default for content authored in that course
+  (it is appended as a labelled block at `initialize`, where an inheriting
+  course adds nothing, since the default is already there), and
+  `chickadee://course/<code>/authoring-guidance` now resolves for every
+  authorable course, serving whichever guide is in force. Resetting, emptying
+  the box, or saving text that still matches the default verbatim returns the
+  course to inheriting, so later changes to the default keep flowing through.

--- a/changelog.d/mcp-iss-and-guidance-resources.md
+++ b/changelog.d/mcp-iss-and-guidance-resources.md
@@ -1,0 +1,22 @@
+### Security
+
+- **RFC 9207 `iss` on OAuth authorization responses (#1218, SEP-2468).** Every
+  `/oauth/authorize` redirect — success and error, content and admin surface —
+  now carries the `iss` parameter with the resolved surface's issuer, and the
+  RFC 8414 authorization-server metadata advertises
+  `authorization_response_iss_parameter_supported: true`, so updated MCP
+  clients can validate the issuer and detect mix-up attacks. The value always
+  matches the `iss` claim of the token subsequently minted for that surface.
+
+### Added
+
+- **Authoring guidance exposed as live MCP resources.** The house
+  authoring-voice guide is now readable at `chickadee://docs/authoring-voice`
+  (served from the same constant the `initialize` instructions embed, so the
+  two can never drift), and a course whose instructors set per-course guidance
+  exposes it at `chickadee://course/<code>/authoring-guidance`, scoped by the
+  same authoring-authority resolver as the initialize embedding. Unlike the
+  initialize copy (frozen per connection), the resources serve the live text,
+  so guidance edits reach connected agents without a reconnect — and resources
+  are untouched by the MCP 2026-07-28 stateless revision, making this the
+  forward-stable delivery path (`docs/mcp-2026-07-28-revision.md`).

--- a/changelog.d/mcp-iss-and-guidance-resources.md
+++ b/changelog.d/mcp-iss-and-guidance-resources.md
@@ -10,12 +10,13 @@
 
 ### Added
 
-- **Authoring guidance exposed as live MCP resources.** The house
+- **Authoring guidance exposed as live MCP resources.** The default
   authoring-voice guide is now readable at `chickadee://docs/authoring-voice`
   (served from the same constant the `initialize` instructions embed, so the
-  two can never drift), and a course whose instructors set per-course guidance
-  exposes it at `chickadee://course/<code>/authoring-guidance`, scoped by the
-  same authoring-authority resolver as the initialize embedding. Unlike the
+  two can never drift), and every course an agent can author in serves the
+  guide actually in force for it at
+  `chickadee://course/<code>/authoring-guidance`, scoped by the same
+  authoring-authority resolver as the initialize embedding. Unlike the
   initialize copy (frozen per connection), the resources serve the live text,
   so guidance edits reach connected agents without a reconnect — and resources
   are untouched by the MCP 2026-07-28 stateless revision, making this the

--- a/docs/mcp-2026-07-28-revision.md
+++ b/docs/mcp-2026-07-28-revision.md
@@ -1,9 +1,13 @@
 # MCP 2026-07-28 specification revision — impact & adoption plan
 
-**Status:** planning. Tracked for adoption in
-[#1218](https://github.com/jimwallace/chickadee/issues/1218), scheduled for the
-week the spec finalizes (2026-07-28). No production change is required to keep
-working; see [Backward compatibility](#backward-compatibility).
+**Status:** in progress. The spec published as final on 2026-07-28 (the dated
+revision is live at `modelcontextprotocol.io/specification/2026-07-28`), and
+the "do first" slice — RFC 9207 `iss` — has landed, together with the
+guidance-delivery groundwork below. The version-adoption slice waits on the
+connector SDK; tracked in
+[#1218](https://github.com/jimwallace/chickadee/issues/1218). No production
+change is required to keep working; see
+[Backward compatibility](#backward-compatibility).
 
 ## TL;DR
 
@@ -122,6 +126,12 @@ requires and SEP-2468 makes clients validate.
 This stands alone from the rest of the revision work; a strict updated client
 could begin requiring it independently of the stateless changes.
 
+**Shipped** (week of 2026-07-28): both halves — `iss` appended to every
+authorize redirect, success and error alike, carrying the resolved surface's
+issuer (so it always matches the minted token's `iss` claim, content or admin),
+plus the `authorization_response_iss_parameter_supported: true` advertisement —
+with assertions in the OAuth flow and metadata tests.
+
 ## Optional / forward-looking
 
 Do these at our own pace, once the spec is final and SDKs ship — none is a
@@ -148,12 +158,35 @@ correctness blocker:
    shift), and that the SDK the Claude connector uses has shipped 2026-07-28
    support.
 2. Land the RFC 9207 `iss` hardening (can go earlier — it does not depend on the
-   revision).
+   revision). **Done** — see "The one gap worth closing now" above.
 3. Add `"2026-07-28"` to the supported-version set + `_meta`-carried version +
    `server/discover`, keeping `initialize` as the fallback.
 4. Verify the roots/sampling/logging deprecations are a no-op for us.
 5. Evaluate the Tasks extension for `validate_assignment` and JSON Schema
    2020-12 for the tool catalog as separate follow-ups.
+
+## Authoring-guidance delivery across the transition
+
+The house authoring-voice guide and the per-course instructor guidance
+(`courses.mcp_instructions`, edited on the instructor MCP tab) reach agents
+through one composition point — `MCPServerInstructions.text(withCourseGuidance:)`
+— so the delivery surface can move without the content forking:
+
+- **2025-11-25 clients (today):** embedded in `initialize.instructions`,
+  frozen per connection.
+- **Now, spec-stable:** also exposed as live MCP resources —
+  `chickadee://docs/authoring-voice` (the constant the instructions embed) and
+  `chickadee://course/<code>/authoring-guidance` (scoped by the same
+  `mcpCourseGuidance` resolver as the initialize embedding). Resources are
+  untouched by the stateless revision, re-readable mid-session, and
+  course-addressable, so guidance edits reach agents without a reconnect.
+- **When `server/discover` is adopted here:** serve the same composed text from
+  the discover handler (on-demand, so the reconnect caveat disappears
+  entirely). Confirm where the final schema carries server instructions when
+  doing that slice.
+- **Watch:** the official "Skills over MCP" extension (structured instructions
+  discovered and consumed through MCP) is the natural long-term convergence
+  point for this kind of guidance; evaluate once the connector supports it.
 
 ## References
 

--- a/docs/mcp-2026-07-28-revision.md
+++ b/docs/mcp-2026-07-28-revision.md
@@ -167,10 +167,12 @@ correctness blocker:
 
 ## Authoring-guidance delivery across the transition
 
-The house authoring-voice guide and the per-course instructor guidance
-(`courses.mcp_instructions`, edited on the instructor MCP tab) reach agents
-through one composition point — `MCPServerInstructions.text(withCourseGuidance:)`
-— so the delivery surface can move without the content forking:
+The default authoring-voice guide and each course's own guide
+(`courses.mcp_instructions` — the instructor MCP tab seeds one editable box
+with the default, and a course that edits it replaces the default for its own
+content) reach agents through one composition point —
+`MCPServerInstructions.text(withCourseGuidance:)` — so the delivery surface can
+move without the content forking:
 
 - **2025-11-25 clients (today):** embedded in `initialize.instructions`,
   frozen per connection.


### PR DESCRIPTION
Two pieces: a revision to how per-course authoring voice is presented and stored, plus the #1218 work that is actionable on spec-publication day.

## One authoring-voice guide per course, inherited from the Chickadee default

Revises the panel shipped in #1221. It showed a fixed, read-only house guide *plus* a separate box for additional course guidance — two texts the instructor had to reconcile in their head. It is now **one editable guide per course, seeded with Chickadee's default**: the course starts on the default, and the instructor edits that text into their own at their leisure.

- **Storage semantics:** `courses.mcp_instructions` nil = inheriting the default; non-nil = the course's own guide, which **replaces** the default for that course's content.
- **Returning to the default** happens three ways: the Reset button (shown only once customized), emptying the box, or saving text that still matches the default verbatim. That last case matters — opening the panel and pressing Save without editing would otherwise freeze a copy of the default onto the course and cut it off from future changes to the house guide. Textarea CRLF line endings are normalized so that comparison actually holds.
- **At `initialize`:** only customized courses contribute a labelled block, under a header saying to follow that course's guide *in place of* the house guide. An inheriting course adds nothing (the default is already in the base text), so a connection with no customizations gets byte-identical instructions.
- **`chickadee://course/<code>/authoring-guidance`** now resolves for **every** authorable course, serving whichever guide is in force, instead of reporting "unknown resource" for a course still on the default — which would have been confusing for an agent following the pointer in the instructions.
- One resolver (`courseAuthoringVoice`) backs the panel, the initialize embedding, and the resource, so the text an instructor edits is exactly the text agents receive. Cap raised 4 000 → 8 000 characters, since the box now starts with ~2 KB of default text.

## RFC 9207 `iss` on OAuth authorization responses (#1218, SEP-2468)

- Every `/oauth/authorize` redirect — success **and** error, content **and** admin surface — appends `iss` carrying the resolved surface's issuer, so it always matches the `iss` claim of the token subsequently minted for that surface. The surface is resolved before the first redirecting guard in both handlers so error responses comply too.
- The RFC 8414 metadata advertises `authorization_response_iss_parameter_supported: true`.
- Assertions in `MCPOAuthFlowTests` (success + `access_denied`) and `MCPMetadataRoutesTests`. Meets the issue's stated acceptance for its first slice.

## Also

- `chickadee://docs/authoring-voice` serves the default guide from the **same constant** the initialize instructions embed, so the two cannot drift.
- `docs/mcp-2026-07-28-revision.md`: final-spec publication recorded, `iss` slice marked shipped, and a new section on guidance delivery across the transition (initialize today → resources now → `server/discover` when adopted → the official "Skills over MCP" extension long-term).
- `CLAUDE.md` reframes the voice block as the *default* rather than a floor; changelog fragments for both changes.

No tool-catalog, scope, capability, or grading-behaviour changes. Verified locally: 113 tests green across the eight affected suites, swift-format + SwiftLint + style guards clean.

#1218 stays open for the version-adoption tier (tracked there with the revisit plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117LLAX1cFYt9RdnHQudhqL