### PR TITLE
Assignment versioning: design + snapshot storage core (slice 1)

### DIFF
--- a/Sources/APIServer/Migrations/CreateAssignmentVersions.swift
+++ b/Sources/APIServer/Migrations/CreateAssignmentVersions.swift
@@ -1,0 +1,70 @@
+// APIServer/Migrations/CreateAssignmentVersions.swift
+//
+// Append-only content-snapshot history for assignments
+// (docs/assignment-versioning.md).
+//
+// Two deliberate schema choices, both explained at length on the model:
+//
+//   - `test_setup_id` has NO foreign key. `deleteAssignment` hard-deletes the
+//     `test_setups` row, so an FK would cascade the history away exactly when
+//     recovery matters. `assignment_id` is likewise unconstrained + nullable.
+//   - `course_id` cascades. Version rows are instructor content scoped to a
+//     course; when the course goes, so does its history (the blobs they
+//     reference are reclaimed by a later sweep).
+//
+// `actor_user_id` sets null rather than cascading: a deleted staff account must
+// not take the edit history with it, and `actor_username` is denormalized at
+// write time so the attribution survives — same pattern as `audit_log`.
+
+import Fluent
+import SQLKit
+
+struct CreateAssignmentVersions: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("assignment_versions")
+            .id()
+            .field("test_setup_id", .string, .required)
+            .field("assignment_id", .uuid)
+            .field(
+                "course_id",
+                .uuid,
+                .required,
+                .references("courses", "id", onDelete: .cascade)
+            )
+            .field("version_number", .int, .required)
+            .field("manifest", .string, .required)
+            .field("manifest_hash", .string, .required)
+            .field("file_map", .string, .required)
+            .field("notebook_hash", .string)
+            .field("snapshot_hash", .string, .required)
+            .field(
+                "actor_user_id",
+                .uuid,
+                .references("users", "id", onDelete: .setNull)
+            )
+            .field("actor_username", .string)
+            .field("origin", .string, .required)
+            .field("summary", .string)
+            .field("restored_from_version", .int)
+            .field("created_at", .datetime)
+            // Makes concurrent snapshots of the same setup collide on insert
+            // instead of silently duplicating a version number; the store
+            // retries on the conflict.
+            .unique(on: "test_setup_id", "version_number")
+            .create()
+
+        // The one hot query: "newest version for this setup" (the dedupe check
+        // on every content edit) and "this setup's history, newest first".
+        guard let sql = database as? SQLDatabase else { return }
+        try await sql.raw(
+            "CREATE INDEX IF NOT EXISTS idx_assignment_versions_setup_number ON assignment_versions(test_setup_id, version_number)"
+        ).run()
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_assignment_versions_setup_number").run()
+        }
+        try await database.schema("assignment_versions").delete()
+    }
+}

--- a/Sources/APIServer/Models/APIAssignmentVersion.swift
+++ b/Sources/APIServer/Models/APIAssignmentVersion.swift
@@ -1,0 +1,144 @@
+// APIServer/Models/APIAssignmentVersion.swift
+//
+// One immutable snapshot of an assignment's *content* — the manifest, the
+// setup zip's contents, and the starter notebook — taken after a content edit.
+// Together the rows for one `test_setup_id` form a linear, append-only history
+// that is never rewritten and never deleted; see docs/assignment-versioning.md.
+//
+// Byte storage is external: `file_map` and `notebook_hash` name content-addressed
+// blobs in `AssignmentVersionBlobStore`, so an unchanged dataset or notebook is
+// stored once no matter how many versions reference it. Only the manifest is
+// inline, because it is small, always differs, and is what most reads want.
+//
+// `test_setup_id` deliberately carries NO foreign key. `deleteAssignment`
+// hard-deletes the `test_setups` row along with the zip and notebook, so an FK
+// would cascade the history away at exactly the moment recovery matters. The
+// FK is on `course_id` alone (history dies with its course, per the retention
+// rules) and `assignment_id` is nullable so a version can outlive its assignment.
+
+import Fluent
+import Vapor
+
+final class APIAssignmentVersion: Model, Content, @unchecked Sendable {
+    // @unchecked Sendable: all mutations happen within Vapor's request context,
+    // never across unstructured concurrency.
+    static let schema = "assignment_versions"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    /// The test setup whose content this snapshots. Plain string, no FK — see
+    /// the file comment.
+    @Field(key: "test_setup_id")
+    var testSetupID: String
+
+    /// The assignment that published the setup at snapshot time. Nullable: a
+    /// version outlives a deleted assignment, and hidden drafts have none.
+    @OptionalField(key: "assignment_id")
+    var assignmentID: UUID?
+
+    /// Scoping and retention key. The only FK on this table.
+    @Field(key: "course_id")
+    var courseID: UUID
+
+    /// 1-based, monotone per `test_setup_id`. Unique with `test_setup_id`, so
+    /// two concurrent edits can't both claim the same number.
+    @Field(key: "version_number")
+    var versionNumber: Int
+
+    /// The full `TestProperties` JSON as it stood at snapshot time, inline.
+    @Field(key: "manifest")
+    var manifest: String
+
+    /// SHA-256 of `manifest`, via the shared `manifestHash(_:)` helper.
+    @Field(key: "manifest_hash")
+    var manifestHash: String
+
+    /// JSON object mapping a zip entry path to its blob hash. Read through
+    /// `decodedFileMap()`.
+    @Field(key: "file_map")
+    var fileMapJSON: String
+
+    /// Blob hash of the starter notebook; nil when the setup has none.
+    @OptionalField(key: "notebook_hash")
+    var notebookHash: String?
+
+    /// Digest over the whole snapshot (manifest + file map + notebook). The
+    /// dedupe key: a record whose hash matches the newest version is skipped.
+    @Field(key: "snapshot_hash")
+    var snapshotHash: String
+
+    /// Who caused the edit. Nil for system-originated snapshots (baseline,
+    /// import). Set null rather than cascade if the user is deleted — the
+    /// history survives, and `actorUsername` preserves the attribution.
+    @OptionalField(key: "actor_user_id")
+    var actorUserID: UUID?
+
+    /// Denormalized at write time so a deleted user doesn't orphan the
+    /// attribution — same reasoning as `audit_log.actor_username`.
+    @OptionalField(key: "actor_username")
+    var actorUsername: String?
+
+    /// What produced this version, e.g. `mcp:update_suite`, `web:save_edit`,
+    /// `clone`, `baseline`, `restore:7`. See `AssignmentVersionOrigin`.
+    @Field(key: "origin")
+    var origin: String
+
+    /// One short human-readable line describing the change, when the caller
+    /// can cheaply produce one.
+    @OptionalField(key: "summary")
+    var summary: String?
+
+    /// Set when this version was produced by restoring an earlier one. History
+    /// stays linear: a restore appends, it never rewinds the counter.
+    @OptionalField(key: "restored_from_version")
+    var restoredFromVersion: Int?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        testSetupID: String,
+        assignmentID: UUID?,
+        courseID: UUID,
+        versionNumber: Int,
+        snapshot: AssignmentVersionSnapshot,
+        actorUserID: UUID? = nil,
+        actorUsername: String? = nil,
+        origin: String,
+        summary: String? = nil,
+        restoredFromVersion: Int? = nil
+    ) {
+        self.id = id
+        self.testSetupID = testSetupID
+        self.assignmentID = assignmentID
+        self.courseID = courseID
+        self.versionNumber = versionNumber
+        self.manifest = snapshot.manifest
+        self.manifestHash = snapshot.manifestHash
+        self.fileMapJSON = snapshot.encodedFileMap()
+        self.notebookHash = snapshot.notebookHash
+        self.snapshotHash = snapshot.snapshotHash
+        self.actorUserID = actorUserID
+        self.actorUsername = actorUsername
+        self.origin = origin
+        self.summary = summary
+        self.restoredFromVersion = restoredFromVersion
+    }
+}
+
+extension APIAssignmentVersion {
+    /// Decodes `fileMapJSON` back into a path → blob-hash map. Returns an empty
+    /// map if the column is malformed — a corrupt map must not crash a history
+    /// listing, and every consumer treats "no files" as a recoverable state it
+    /// can report rather than a fatal one.
+    func decodedFileMap() -> [String: String] {
+        guard let data = fileMapJSON.data(using: .utf8),
+            let map = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return map
+    }
+}

--- a/Sources/APIServer/Services/AssignmentVersionBlobStore.swift
+++ b/Sources/APIServer/Services/AssignmentVersionBlobStore.swift
@@ -1,0 +1,164 @@
+// APIServer/Services/AssignmentVersionBlobStore.swift
+//
+// Content-addressed byte storage for assignment version snapshots
+// (docs/assignment-versioning.md).
+//
+// Blobs are keyed by the SHA-256 of their own bytes and stored at
+// `{testSetupsDirectory}/versions/blobs/{first-2-hex}/{sha256}`. Writing the
+// same bytes twice is a no-op, so a snapshot only ever costs the bytes that
+// actually changed.
+//
+// Why per FILE rather than per zip: `/usr/bin/zip` embeds timestamps, so
+// repacking byte-identical content yields a different archive every time —
+// hashing whole archives would dedupe nothing at all, and "snapshot every edit,
+// never delete" would become a disk-fill incident. Hashing entries means an
+// untouched 3 MB dataset costs nothing across a 200-edit authoring session.
+//
+// Nothing here deletes. Reclamation happens only when a course is purged, as a
+// separate sweep that drops blobs no surviving version references.
+
+import Core
+import Foundation
+
+enum AssignmentVersionBlobError: Error, CustomStringConvertible {
+    case invalidHash(String)
+    case notFound(String)
+    case writeFailed(hash: String, reason: String)
+
+    var description: String {
+        switch self {
+        case .invalidHash(let hash):
+            return "Not a SHA-256 hex digest: \(hash.prefix(80))"
+        case .notFound(let hash):
+            return "No stored blob for \(hash)"
+        case .writeFailed(let hash, let reason):
+            return "Could not store blob \(hash): \(reason)"
+        }
+    }
+}
+
+/// Reads and writes the content-addressed blobs backing version snapshots.
+/// Immutable value type; safe to construct per call.
+struct AssignmentVersionBlobStore: Sendable {
+    /// `{testSetupsDirectory}/versions/blobs/`, with a trailing slash.
+    let rootDirectory: String
+
+    init(testSetupsDirectory: String) {
+        let base =
+            testSetupsDirectory.hasSuffix("/") ? testSetupsDirectory : testSetupsDirectory + "/"
+        self.rootDirectory = base + "versions/blobs/"
+    }
+
+    // MARK: - Paths
+
+    /// True iff `hash` is exactly 64 lowercase hex characters.
+    ///
+    /// Every path this type builds is derived from a hash, and hashes arrive
+    /// from a database column. Validating the shape before it reaches the
+    /// filesystem is what stops a malformed or tampered row from walking out of
+    /// the blob directory with `../`.
+    static func isValidHash(_ hash: String) -> Bool {
+        hash.count == 64 && hash.allSatisfy { $0.isHexDigit && !$0.isUppercase }
+    }
+
+    /// On-disk location for `hash`. Throws rather than returning a path built
+    /// from an unvalidated string.
+    func path(for hash: String) throws -> String {
+        guard Self.isValidHash(hash) else {
+            throw AssignmentVersionBlobError.invalidHash(hash)
+        }
+        return rootDirectory + String(hash.prefix(2)) + "/" + hash
+    }
+
+    func exists(_ hash: String) -> Bool {
+        guard let path = try? path(for: hash) else { return false }
+        return FileManager.default.fileExists(atPath: path)
+    }
+
+    // MARK: - Writing
+
+    /// Stores `data` and returns its hash. A no-op when the blob is already
+    /// present — identical content is identical bytes, by construction.
+    @discardableResult
+    func put(_ data: Data) throws -> String {
+        let hash = sha256HexDigest(data)
+        try store(hash: hash) { destination in
+            try data.write(to: destination)
+        }
+        return hash
+    }
+
+    /// Stores the file at `sourcePath` and returns its hash. The file is
+    /// streamed for hashing (never fully resident), then copied — datasets in a
+    /// setup zip can be hundreds of megabytes.
+    @discardableResult
+    func putFile(at sourcePath: String) throws -> String {
+        guard let hash = sha256HexDigest(prefix: Data(), contentsOfFile: sourcePath) else {
+            throw AssignmentVersionBlobError.writeFailed(
+                hash: "?", reason: "could not read \(sourcePath)")
+        }
+        try store(hash: hash) { destination in
+            try FileManager.default.copyItem(
+                at: URL(fileURLWithPath: sourcePath), to: destination)
+        }
+        return hash
+    }
+
+    /// Writes a blob via `write`, into a temp file that is then atomically
+    /// renamed into place. The rename is what makes a concurrent reader see
+    /// either no blob or a complete one, never a half-written one — two
+    /// requests snapshotting the same unchanged dataset race here routinely.
+    private func store(hash: String, write: (URL) throws -> Void) throws {
+        let finalPath = try path(for: hash)
+        guard !FileManager.default.fileExists(atPath: finalPath) else { return }
+
+        let directory = (finalPath as NSString).deletingLastPathComponent
+        do {
+            try FileManager.default.createDirectory(
+                atPath: directory, withIntermediateDirectories: true)
+        } catch {
+            throw AssignmentVersionBlobError.writeFailed(hash: hash, reason: "\(error)")
+        }
+
+        let temp = URL(fileURLWithPath: directory + "/.tmp-\(UUID().uuidString)")
+        do {
+            try write(temp)
+        } catch {
+            try? FileManager.default.removeItem(at: temp)
+            throw AssignmentVersionBlobError.writeFailed(hash: hash, reason: "\(error)")
+        }
+        do {
+            try FileManager.default.moveItem(at: temp, to: URL(fileURLWithPath: finalPath))
+        } catch {
+            try? FileManager.default.removeItem(at: temp)
+            // A rename losing to a concurrent writer of the SAME hash is a
+            // success: the bytes are there and they are the bytes we wanted.
+            guard FileManager.default.fileExists(atPath: finalPath) else {
+                throw AssignmentVersionBlobError.writeFailed(hash: hash, reason: "\(error)")
+            }
+        }
+    }
+
+    // MARK: - Reading
+
+    func read(_ hash: String) throws -> Data {
+        let path = try path(for: hash)
+        guard let data = FileManager.default.contents(atPath: path) else {
+            throw AssignmentVersionBlobError.notFound(hash)
+        }
+        return data
+    }
+
+    /// Copies the blob to `destination`, creating intermediate directories.
+    /// Used when rebuilding a setup directory from a snapshot's file map.
+    func materialize(_ hash: String, to destination: URL) throws {
+        let path = try path(for: hash)
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw AssignmentVersionBlobError.notFound(hash)
+        }
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? FileManager.default.removeItem(at: destination)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: path), to: destination)
+    }
+}

--- a/Sources/APIServer/Services/AssignmentVersionSnapshot.swift
+++ b/Sources/APIServer/Services/AssignmentVersionSnapshot.swift
@@ -1,0 +1,147 @@
+// APIServer/Services/AssignmentVersionSnapshot.swift
+//
+// The in-memory form of one content snapshot, plus the builder that produces it
+// from a live test setup (docs/assignment-versioning.md).
+//
+// A snapshot is exactly the three artifacts that make up an assignment's
+// content — the manifest, the setup zip's entries, and the starter notebook.
+// Everything else the server keeps for an assignment (`shared/{setupID}/`, the
+// generated `solution.py`, per-student notebook materializations, runner cache
+// entries) re-derives from those three, so capturing them is unnecessary and
+// would only create a second source of truth.
+
+import Core
+import Foundation
+
+/// One captured content state. Byte payloads live in the blob store; this holds
+/// the manifest inline plus the hashes that name the blobs.
+struct AssignmentVersionSnapshot: Sendable, Equatable {
+    let manifest: String
+    let manifestHash: String
+    /// Zip entry path → blob hash.
+    let fileMap: [String: String]
+    /// Blob hash of the starter notebook, nil when the setup has none.
+    let notebookHash: String?
+    /// Digest over the whole snapshot; the dedupe key.
+    let snapshotHash: String
+
+    init(manifest: String, fileMap: [String: String], notebookHash: String?) {
+        self.manifest = manifest
+        // Module-qualified: the stored property shadows the free function of
+        // the same name inside this initializer.
+        self.manifestHash = APIServer.manifestHash(manifest)
+        self.fileMap = fileMap
+        self.notebookHash = notebookHash
+        self.snapshotHash = Self.digest(
+            manifestHash: self.manifestHash, fileMap: fileMap, notebookHash: notebookHash)
+    }
+
+    /// Stable digest over the snapshot's identity.
+    ///
+    /// The serialization is canonical — file entries sorted by path, fixed
+    /// separators — so two snapshots of identical content always produce the
+    /// same digest regardless of directory-walk order. That is what makes the
+    /// dedupe check in `AssignmentVersionStore.record` reliable rather than
+    /// merely usually-right.
+    private static func digest(
+        manifestHash: String, fileMap: [String: String], notebookHash: String?
+    ) -> String {
+        var canonical = "manifest:\(manifestHash)\n"
+        canonical += "notebook:\(notebookHash ?? "-")\n"
+        for path in fileMap.keys.sorted() {
+            canonical += "file:\(path)\u{0}\(fileMap[path] ?? "")\n"
+        }
+        return sha256HexDigest(canonical)
+    }
+
+    /// The file map as the JSON stored in `assignment_versions.file_map`.
+    /// Sorted keys so the column bytes are stable for identical content.
+    func encodedFileMap() -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(fileMap),
+            let json = String(data: data, encoding: .utf8)
+        else { return "{}" }
+        return json
+    }
+}
+
+enum AssignmentVersionSnapshotError: Error, CustomStringConvertible {
+    case zipUnreadable(path: String, reason: String)
+
+    var description: String {
+        switch self {
+        case .zipUnreadable(let path, let reason):
+            return "Could not read setup zip at \(path): \(reason)"
+        }
+    }
+}
+
+enum AssignmentVersionSnapshotBuilder {
+    /// Captures `setup`'s current content into blobs and returns the snapshot
+    /// describing it.
+    ///
+    /// The zip is extracted once into a temp directory and walked, rather than
+    /// shelling out to `unzip -p` per entry: a suite with fifty generated
+    /// scripts would otherwise spawn fifty subprocesses on every content edit.
+    ///
+    /// A missing zip yields an empty file map rather than throwing. An
+    /// assignment with no test setup zip on disk is a legitimate (if degraded)
+    /// state, and refusing to snapshot it would mean the one state you most
+    /// want a record of is the one state that produces none.
+    static func build(
+        setup: APITestSetup, blobs: AssignmentVersionBlobStore
+    ) async throws -> AssignmentVersionSnapshot {
+        let fileMap = try await captureZipEntries(zipPath: setup.zipPath, blobs: blobs)
+
+        var notebookHash: String?
+        if let notebookPath = setup.notebookPath, !notebookPath.isEmpty,
+            FileManager.default.fileExists(atPath: notebookPath)
+        {
+            notebookHash = try blobs.putFile(at: notebookPath)
+        }
+
+        return AssignmentVersionSnapshot(
+            manifest: setup.manifest, fileMap: fileMap, notebookHash: notebookHash)
+    }
+
+    /// Extracts the zip to a temp directory, stores every regular file as a
+    /// blob, and returns the path → hash map.
+    private static func captureZipEntries(
+        zipPath: String, blobs: AssignmentVersionBlobStore
+    ) async throws -> [String: String] {
+        guard FileManager.default.fileExists(atPath: zipPath) else { return [:] }
+
+        let fileManager = FileManager.default
+        let workDir = fileManager.temporaryDirectory
+            .appendingPathComponent("chickadee-version-snapshot-\(UUID().uuidString)")
+        defer { try? fileManager.removeItem(at: workDir) }
+
+        do {
+            try await extractZipArchive(zipPath: zipPath, into: workDir)
+        } catch {
+            throw AssignmentVersionSnapshotError.zipUnreadable(
+                path: zipPath, reason: "\(error)")
+        }
+
+        let rootPath = workDir.standardized.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard
+            let walker = fileManager.enumerator(
+                at: workDir, includingPropertiesForKeys: [.isRegularFileKey])
+        else { return [:] }
+
+        var map: [String: String] = [:]
+        for case let url as URL in walker {
+            // Directories and symlinks carry no content worth versioning, and a
+            // symlink's target is either already captured as its own entry or
+            // points outside the snapshot entirely.
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            guard values?.isRegularFile == true else { continue }
+            let full = url.standardized.path
+            guard full.hasPrefix(prefix) else { continue }
+            map[String(full.dropFirst(prefix.count))] = try blobs.putFile(at: full)
+        }
+        return map
+    }
+}

--- a/Sources/APIServer/Services/AssignmentVersionStore.swift
+++ b/Sources/APIServer/Services/AssignmentVersionStore.swift
@@ -1,0 +1,249 @@
+// APIServer/Services/AssignmentVersionStore.swift
+//
+// The single entry point for recording an assignment content snapshot
+// (docs/assignment-versioning.md). Every capture point — the web save paths and
+// the MCP write tools alike — goes through `record` / `ensureBaseline` so the
+// dedupe, numbering, and draft rules are written down exactly once.
+//
+// Two properties make the capture points cheap to wire:
+//
+//   - `record` is SELF-DEDUPING. It captures the setup's current state and
+//     returns `.unchanged` when that state matches the newest version. So a
+//     save that changed nothing costs one hash and no row, and a call site may
+//     be generous: over-calling is free, under-calling is the only real failure
+//     mode.
+//   - `ensureBaseline` is a no-op once any version exists. Called before a
+//     mutation, it makes the pre-edit state recoverable; after the first one it
+//     is a single indexed count.
+//
+// Snapshots record the POST-edit state, so version N always names a state that
+// actually existed and the newest version always equals current content. That
+// is what makes "restore to N" unambiguous.
+
+import Core
+import Fluent
+import Foundation
+import Vapor
+
+/// What produced a version. Free-form on the wire; these factories keep the
+/// vocabulary consistent across call sites.
+enum AssignmentVersionOrigin {
+    /// The pre-edit state captured lazily on a setup with no history yet.
+    static let baseline = "baseline"
+    /// Seeded at creation by clone / copy-course.
+    static let clone = "clone"
+    /// Seeded at creation by a from-scratch assignment.
+    static let create = "create"
+    /// Seeded at creation by `.chickadee` bundle import.
+    static let bundleImport = "import"
+
+    /// An edit made through an MCP tool, e.g. `mcp:update_suite`.
+    static func mcp(tool: String) -> String { "mcp:\(tool)" }
+    /// An edit made through the web UI, e.g. `web:save_edit`.
+    static func web(action: String) -> String { "web:\(action)" }
+    /// A restore of version `version`.
+    static func restore(of version: Int) -> String { "restore:\(version)" }
+}
+
+/// Everything about a snapshot that isn't the content itself. Bundled so the
+/// entry points stay within the parameter budget, the same reason
+/// `GlobalInputsService.Inputs` exists.
+struct AssignmentVersionRequest: Sendable {
+    let origin: String
+    let summary: String?
+    let restoredFromVersion: Int?
+    let actorUserID: UUID?
+    let actorUsername: String?
+
+    init(
+        origin: String,
+        summary: String? = nil,
+        restoredFromVersion: Int? = nil,
+        actor: APIUser? = nil
+    ) {
+        self.origin = origin
+        self.summary = summary
+        self.restoredFromVersion = restoredFromVersion
+        self.actorUserID = actor?.id
+        self.actorUsername = actor?.username
+    }
+}
+
+/// Why a snapshot wasn't taken. Both reasons are ordinary, not failures.
+enum AssignmentVersionSkipReason: String, Sendable {
+    /// The setup has no published assignment — a hidden authoring draft, whose
+    /// edits aren't yet anyone's content.
+    case draft
+    /// `ensureBaseline` found existing history, so there is nothing to seed.
+    case historyExists
+}
+
+enum AssignmentVersionOutcome: Sendable, Equatable {
+    case recorded(version: Int)
+    /// Content matched the newest version; no row written.
+    case unchanged(version: Int)
+    case skipped(reason: AssignmentVersionSkipReason)
+
+    /// The version number this outcome refers to, if any.
+    var version: Int? {
+        switch self {
+        case .recorded(let version), .unchanged(let version): return version
+        case .skipped: return nil
+        }
+    }
+
+    var didRecord: Bool {
+        if case .recorded = self { return true }
+        return false
+    }
+}
+
+enum AssignmentVersionStore {
+
+    /// Records `setup`'s CURRENT content as the next version.
+    ///
+    /// Call AFTER the edit has persisted. Returns `.unchanged` when the content
+    /// matches the newest version, and `.skipped(.draft)` for a setup with no
+    /// published assignment.
+    @discardableResult
+    static func record(
+        setup: APITestSetup,
+        request: AssignmentVersionRequest,
+        testSetupsDirectory: String,
+        on db: any Database
+    ) async throws -> AssignmentVersionOutcome {
+        guard let setupID = setup.id else { return .skipped(reason: .draft) }
+        guard let assignment = try await publishedAssignment(setupID: setupID, on: db) else {
+            return .skipped(reason: .draft)
+        }
+
+        let blobs = AssignmentVersionBlobStore(testSetupsDirectory: testSetupsDirectory)
+        let snapshot = try await AssignmentVersionSnapshotBuilder.build(
+            setup: setup, blobs: blobs)
+
+        if let newest = try await newestVersion(setupID: setupID, on: db),
+            newest.snapshotHash == snapshot.snapshotHash
+        {
+            return .unchanged(version: newest.versionNumber)
+        }
+
+        let version = try await insert(
+            snapshot: snapshot, setupID: setupID, assignment: assignment,
+            courseID: setup.courseID, request: request, on: db)
+        return .recorded(version: version)
+    }
+
+    /// Records `setup`'s current content as version 1 iff it has no history yet.
+    ///
+    /// Call BEFORE mutating, so the pre-edit state is recoverable. Without this,
+    /// the first edit on every assignment that predates versioning is precisely
+    /// the one that can't be undone — and seeding it lazily avoids a migration
+    /// that would have to walk and hash every setup on disk at deploy time.
+    @discardableResult
+    static func ensureBaseline(
+        setup: APITestSetup,
+        testSetupsDirectory: String,
+        on db: any Database
+    ) async throws -> AssignmentVersionOutcome {
+        guard let setupID = setup.id else { return .skipped(reason: .draft) }
+        let existing = try await APIAssignmentVersion.query(on: db)
+            .filter(\.$testSetupID == setupID)
+            .count()
+        guard existing == 0 else { return .skipped(reason: .historyExists) }
+
+        return try await record(
+            setup: setup,
+            request: AssignmentVersionRequest(origin: AssignmentVersionOrigin.baseline),
+            testSetupsDirectory: testSetupsDirectory,
+            on: db)
+    }
+
+    /// Best-effort wrapper for call sites where a versioning failure must not
+    /// fail the edit itself. The content change has already persisted by the
+    /// time this runs; losing a history row is bad, losing the instructor's
+    /// save because history couldn't be written is worse.
+    @discardableResult
+    static func recordBestEffort(
+        setup: APITestSetup,
+        request: AssignmentVersionRequest,
+        testSetupsDirectory: String,
+        logger: Logger,
+        on db: any Database
+    ) async -> AssignmentVersionOutcome? {
+        do {
+            return try await record(
+                setup: setup, request: request, testSetupsDirectory: testSetupsDirectory, on: db)
+        } catch {
+            logger.warning(
+                "assignment version snapshot failed",
+                metadata: [
+                    "setup": .string(setup.id ?? "?"),
+                    "origin": .string(request.origin),
+                    "error": .string("\(error)"),
+                ])
+            return nil
+        }
+    }
+
+    // MARK: - Queries
+
+    /// The newest version for a setup, or nil when it has no history.
+    static func newestVersion(
+        setupID: String, on db: any Database
+    ) async throws -> APIAssignmentVersion? {
+        try await APIAssignmentVersion.query(on: db)
+            .filter(\.$testSetupID == setupID)
+            .sort(\.$versionNumber, .descending)
+            .first()
+    }
+
+    /// The published assignment for a setup, or nil for a hidden draft.
+    private static func publishedAssignment(
+        setupID: String, on db: any Database
+    ) async throws -> APIAssignment? {
+        try await APIAssignment.query(on: db)
+            .filter(\.$testSetupID == setupID)
+            .first()
+    }
+
+    // MARK: - Insert
+
+    /// Maximum attempts to claim a version number. Two concurrent edits on one
+    /// setup can compute the same next number; the unique index on
+    /// `(test_setup_id, version_number)` turns that into an insert conflict,
+    /// and re-reading the max resolves it — the same discipline as
+    /// `createAssignmentWithUniquePublicID`.
+    private static let numberingAttempts = 5
+
+    private static func insert(
+        snapshot: AssignmentVersionSnapshot,
+        setupID: String,
+        assignment: APIAssignment,
+        courseID: UUID,
+        request: AssignmentVersionRequest,
+        on db: any Database
+    ) async throws -> Int {
+        var lastError: (any Error)?
+        for _ in 0..<numberingAttempts {
+            let next = (try await newestVersion(setupID: setupID, on: db)?.versionNumber ?? 0) + 1
+            let row = APIAssignmentVersion(
+                testSetupID: setupID,
+                assignmentID: assignment.id,
+                courseID: courseID,
+                versionNumber: next,
+                snapshot: snapshot,
+                actorUserID: request.actorUserID,
+                actorUsername: request.actorUsername,
+                origin: request.origin,
+                summary: request.summary,
+                restoredFromVersion: request.restoredFromVersion)
+            do {
+                try await row.create(on: db)
+                return next
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? Abort(.internalServerError, reason: "Could not assign a version number")
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -348,6 +348,9 @@ func registerMigrations(on app: Application) {
     // Per-user activity pings behind the admin dashboard's "active users over
     // time" chart. FK references `users`.
     app.migrations.add(CreateUserActivityEvents())
+    // Append-only assignment content-snapshot history. FK references `courses`
+    // and `users`; deliberately none on `test_setups` (see the migration).
+    app.migrations.add(CreateAssignmentVersions())
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.
     app.migrations.add(CreateHotPathIndexes())

--- a/Tests/APITests/AssignmentVersionBlobStoreTests.swift
+++ b/Tests/APITests/AssignmentVersionBlobStoreTests.swift
@@ -1,0 +1,160 @@
+// Tests/APITests/AssignmentVersionBlobStoreTests.swift
+//
+// The content-addressed blob store behind assignment version snapshots
+// (docs/assignment-versioning.md): identical bytes collapse to one blob,
+// hashes are validated before they reach the filesystem, and writes land
+// atomically so a concurrent reader never sees a partial blob.
+
+import Core
+import Foundation
+import Testing
+
+@testable import APIServer
+
+// final class so deinit can remove the per-test temp directory.
+@Suite final class AssignmentVersionBlobStoreTests {
+
+    private let root: URL
+    private let store: AssignmentVersionBlobStore
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chickadee-blobs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        store = AssignmentVersionBlobStore(testSetupsDirectory: root.path)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    // MARK: - Round trip
+
+    @Test func putThenReadReturnsTheSameBytes() throws {
+        let payload = Data("print('hello')\n".utf8)
+        let hash = try store.put(payload)
+
+        #expect(hash == sha256HexDigest(payload))
+        #expect(store.exists(hash))
+        #expect(try store.read(hash) == payload)
+    }
+
+    @Test func putFileStreamsAndReturnsTheContentHash() throws {
+        let source = root.appendingPathComponent("dataset.csv")
+        let payload = Data("id,value\n1,42\n".utf8)
+        try payload.write(to: source)
+
+        let hash = try store.putFile(at: source.path)
+
+        #expect(hash == sha256HexDigest(payload))
+        #expect(try store.read(hash) == payload)
+    }
+
+    /// The whole point of content addressing: the same bytes stored twice
+    /// occupy one blob, so an untouched dataset costs nothing across a long
+    /// authoring session.
+    @Test func identicalContentIsStoredOnce() throws {
+        let payload = Data(repeating: 0xAB, count: 4096)
+        let first = try store.put(payload)
+        let second = try store.put(payload)
+
+        #expect(first == second)
+        let path = try store.path(for: first)
+        let shard = (path as NSString).deletingLastPathComponent
+        let entries = try FileManager.default.contentsOfDirectory(atPath: shard)
+        #expect(entries == [first])
+    }
+
+    @Test func differentContentProducesDifferentBlobs() throws {
+        let a = try store.put(Data("a".utf8))
+        let b = try store.put(Data("b".utf8))
+        #expect(a != b)
+        #expect(try store.read(a) == Data("a".utf8))
+        #expect(try store.read(b) == Data("b".utf8))
+    }
+
+    // MARK: - Hash validation
+
+    /// Blob paths are built from a database column. A row carrying traversal
+    /// components must not walk out of the blob directory — the shape check is
+    /// what stops it, so it is checked directly rather than trusted.
+    @Test(arguments: [
+        "../../../etc/passwd",
+        "..",
+        "",
+        "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789",
+        "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+        "abc123",
+    ])
+    func rejectsAnythingThatIsNotASha256Digest(_ candidate: String) throws {
+        #expect(!AssignmentVersionBlobStore.isValidHash(candidate))
+        #expect(throws: AssignmentVersionBlobError.self) { try store.path(for: candidate) }
+        #expect(!store.exists(candidate))
+    }
+
+    @Test func acceptsALowercaseSha256Digest() throws {
+        let hash = sha256HexDigest(Data("x".utf8))
+        #expect(AssignmentVersionBlobStore.isValidHash(hash))
+        #expect(try store.path(for: hash).hasSuffix("/\(hash.prefix(2))/\(hash)"))
+    }
+
+    // MARK: - Reads of absent blobs
+
+    @Test func readingAnUnstoredBlobThrowsNotFound() throws {
+        let hash = sha256HexDigest(Data("never stored".utf8))
+        #expect(throws: AssignmentVersionBlobError.self) { try store.read(hash) }
+    }
+
+    @Test func materializeCopiesTheBlobToTheRequestedPath() throws {
+        let payload = Data("solution\n".utf8)
+        let hash = try store.put(payload)
+        let destination = root.appendingPathComponent("nested/dir/solution.py")
+
+        try store.materialize(hash, to: destination)
+
+        #expect(FileManager.default.contents(atPath: destination.path) == payload)
+    }
+
+    /// Restoring over an existing working directory must overwrite, not fail —
+    /// a rebuild repopulates paths that already hold the current content.
+    @Test func materializeOverwritesAnExistingFile() throws {
+        let destination = root.appendingPathComponent("overwrite.txt")
+        try Data("old".utf8).write(to: destination)
+        let hash = try store.put(Data("new".utf8))
+
+        try store.materialize(hash, to: destination)
+
+        #expect(FileManager.default.contents(atPath: destination.path) == Data("new".utf8))
+    }
+
+    @Test func materializingAnUnstoredBlobThrows() throws {
+        let hash = sha256HexDigest(Data("absent".utf8))
+        #expect(throws: AssignmentVersionBlobError.self) {
+            try store.materialize(hash, to: root.appendingPathComponent("out"))
+        }
+    }
+
+    // MARK: - Concurrency
+
+    /// Concurrent snapshots of the same unchanged dataset race on the identical
+    /// blob routinely. The temp-file-plus-rename write means every writer
+    /// succeeds and the final bytes are correct.
+    @Test func concurrentWritesOfTheSameBlobAllSucceed() async throws {
+        let payload = Data(repeating: 0x5A, count: 64 * 1024)
+        // Captured as a local so the tasks don't reach through `self` (a class
+        // suite instance, not Sendable) to get at it.
+        let store = self.store
+        let hashes = await withTaskGroup(of: String?.self) { group in
+            for _ in 0..<12 {
+                group.addTask { try? store.put(payload) }
+            }
+            var seen: [String] = []
+            for await hash in group { if let hash { seen.append(hash) } }
+            return seen
+        }
+
+        #expect(hashes.count == 12)
+        #expect(Set(hashes).count == 1)
+        #expect(try store.read(sha256HexDigest(payload)) == payload)
+    }
+}

--- a/Tests/APITests/AssignmentVersionStoreTests.swift
+++ b/Tests/APITests/AssignmentVersionStoreTests.swift
@@ -1,0 +1,358 @@
+// Tests/APITests/AssignmentVersionStoreTests.swift
+//
+// The record/dedupe/numbering contract for assignment content snapshots
+// (docs/assignment-versioning.md).
+//
+// These pin the properties the capture points in later slices depend on:
+// recording is self-deduping (so a call site may be generous), numbering
+// survives concurrent edits, hidden drafts are skipped, and the lazy baseline
+// makes the pre-edit state recoverable without a backfill migration.
+//
+// `.serialized`: each test spawns `zip` / `unzip` subprocesses, which hit the
+// Foundation posix_spawn EFAULT race under within-suite parallelism — the same
+// reason `ZipArchiverTests` is serialized.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class AssignmentVersionStoreTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-versions")
+    }
+
+    // MARK: - Fixtures
+
+    private struct Fixture {
+        let setup: APITestSetup
+        let assignment: APIAssignment
+        let courseID: UUID
+    }
+
+    /// A published assignment whose setup zip holds one test script, plus a
+    /// starter notebook on disk.
+    private func fixture(
+        _ app: Application,
+        entries: [(String, String)] = [("publictest_a.py", "passed('ok')\n")],
+        notebook: String? = "{\"cells\":[]}",
+        publish: Bool = true
+    ) async throws -> Fixture {
+        let course = APICourse(code: "AV\(Int.random(in: 1000...9999))", name: "Versions", enrollmentMode: .auto)
+        try await course.save(on: app.db)
+        let courseID = try course.requireID()
+
+        let setupID = "av_\(UUID().uuidString.prefix(8))"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        try writeZip(at: zipPath, entries: entries)
+
+        var notebookPath: String?
+        if let notebook {
+            notebookPath = app.testSetupsDirectory + setupID + ".ipynb"
+            try Data(notebook.utf8).write(to: URL(fileURLWithPath: notebookPath ?? ""))
+        }
+
+        let manifest = """
+            {"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10,"makefile":null}
+            """
+        let setup = APITestSetup(
+            id: setupID, manifest: manifest, zipPath: zipPath,
+            notebookPath: notebookPath, courseID: courseID)
+        try await setup.save(on: app.db)
+
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: "Lab", dueAt: nil, isOpen: true,
+            deadlineOverrideActive: false, courseID: courseID)
+        if publish { try await assignment.save(on: app.db) }
+        return Fixture(setup: setup, assignment: assignment, courseID: courseID)
+    }
+
+    /// Packs `entries` into a zip at `zipPath`.
+    ///
+    /// `modified` stamps every entry's mtime. zip records mtimes at 2-second
+    /// granularity, so two packs of identical content inside the same window
+    /// come out byte-identical — passing distinct values is how a test makes
+    /// "same content, different archive bytes" deterministic instead of
+    /// depending on how fast the machine is.
+    private func writeZip(
+        at zipPath: String, entries: [(String, String)], modified: Date? = nil
+    ) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("av-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            let target = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: target.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data(content.utf8).write(to: target)
+            if let modified {
+                try FileManager.default.setAttributes(
+                    [.modificationDate: modified], ofItemAtPath: target.path)
+            }
+        }
+        try? FileManager.default.removeItem(atPath: zipPath)
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+        #expect(zip.terminationStatus == 0)
+    }
+
+    private func record(
+        _ app: Application, _ setup: APITestSetup, origin: String = "test"
+    ) async throws -> AssignmentVersionOutcome {
+        try await AssignmentVersionStore.record(
+            setup: setup,
+            request: AssignmentVersionRequest(origin: origin),
+            testSetupsDirectory: app.testSetupsDirectory,
+            on: app.db)
+    }
+
+    // MARK: - Recording
+
+    @Test func firstRecordCapturesManifestFilesAndNotebook() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+
+            let outcome = try await record(app, fx.setup, origin: "mcp:update_suite")
+            #expect(outcome == .recorded(version: 1))
+
+            let setupID = try #require(fx.setup.id)
+            let version = try #require(
+                try await AssignmentVersionStore.newestVersion(setupID: setupID, on: app.db))
+            #expect(version.versionNumber == 1)
+            #expect(version.origin == "mcp:update_suite")
+            #expect(version.manifest == fx.setup.manifest)
+            #expect(version.notebookHash != nil)
+            #expect(version.decodedFileMap().keys.contains("publictest_a.py"))
+            #expect(version.assignmentID == fx.assignment.id)
+            #expect(version.courseID == fx.courseID)
+        }
+    }
+
+    /// Recording twice with nothing changed in between must not write a second
+    /// row. This is what lets a capture point be generous about when it calls.
+    @Test func recordingUnchangedContentIsANoOp() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+            #expect(try await record(app, fx.setup) == .unchanged(version: 1))
+
+            let count = try await APIAssignmentVersion.query(on: app.db)
+                .filter(\.$testSetupID == (fx.setup.id ?? ""))
+                .count()
+            #expect(count == 1)
+        }
+    }
+
+    /// A repack of byte-identical content produces a different archive (zip
+    /// embeds timestamps) — the snapshot must still dedupe, which is exactly
+    /// why blobs are per-entry rather than per-archive.
+    @Test func repackingIdenticalContentStillDedupes() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+
+            let before = try #require(FileManager.default.contents(atPath: fx.setup.zipPath))
+            try writeZip(
+                at: fx.setup.zipPath, entries: [("publictest_a.py", "passed('ok')\n")],
+                modified: Date(timeIntervalSince1970: 1_600_000_000))
+            let after = try #require(FileManager.default.contents(atPath: fx.setup.zipPath))
+            // Guard the premise: if zip ever became reproducible this test
+            // would silently stop testing anything.
+            #expect(before != after)
+
+            #expect(try await record(app, fx.setup) == .unchanged(version: 1))
+        }
+    }
+
+    @Test func changingAScriptRecordsANewVersion() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+
+            try writeZip(
+                at: fx.setup.zipPath, entries: [("publictest_a.py", "failed('nope')\n")])
+            #expect(try await record(app, fx.setup) == .recorded(version: 2))
+        }
+    }
+
+    @Test func changingTheManifestRecordsANewVersion() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+
+            fx.setup.manifest = """
+                {"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":30,"makefile":null}
+                """
+            try await fx.setup.save(on: app.db)
+            #expect(try await record(app, fx.setup) == .recorded(version: 2))
+        }
+    }
+
+    @Test func changingTheNotebookRecordsANewVersion() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+
+            let path = try #require(fx.setup.notebookPath)
+            try Data("{\"cells\":[{\"cell_type\":\"code\"}]}".utf8)
+                .write(to: URL(fileURLWithPath: path))
+            #expect(try await record(app, fx.setup) == .recorded(version: 2))
+        }
+    }
+
+    // MARK: - Drafts
+
+    /// Hidden authoring drafts have no published assignment. Their edits aren't
+    /// yet anyone's content, so they must not accumulate history.
+    @Test func aSetupWithNoPublishedAssignmentIsSkipped() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app, publish: false)
+
+            #expect(try await record(app, fx.setup) == .skipped(reason: .draft))
+            let count = try await APIAssignmentVersion.query(on: app.db).count()
+            #expect(count == 0)
+        }
+    }
+
+    // MARK: - Baseline
+
+    /// The pre-edit state has to be captured before the first mutation, or the
+    /// very first edit on a pre-existing assignment is the one that can't be
+    /// undone.
+    @Test func ensureBaselineSeedsVersionOneThenNeverAgain() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+
+            let first = try await AssignmentVersionStore.ensureBaseline(
+                setup: fx.setup, testSetupsDirectory: app.testSetupsDirectory, on: app.db)
+            #expect(first == .recorded(version: 1))
+
+            let setupID = try #require(fx.setup.id)
+            let version = try #require(
+                try await AssignmentVersionStore.newestVersion(setupID: setupID, on: app.db))
+            #expect(version.origin == AssignmentVersionOrigin.baseline)
+
+            // Even after the content moves on, a baseline is never seeded twice.
+            try writeZip(at: fx.setup.zipPath, entries: [("publictest_a.py", "changed\n")])
+            let second = try await AssignmentVersionStore.ensureBaseline(
+                setup: fx.setup, testSetupsDirectory: app.testSetupsDirectory, on: app.db)
+            #expect(second == .skipped(reason: .historyExists))
+        }
+    }
+
+    // MARK: - Numbering
+
+    /// Two concurrent edits on one setup can compute the same next number. The
+    /// unique index turns that into an insert conflict and the store retries,
+    /// so the history stays gap-free and collision-free.
+    @Test func concurrentRecordsProduceDistinctVersionNumbers() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            let setupID = try #require(fx.setup.id)
+
+            // Distinct content per writer, so none of them dedupe away.
+            await withTaskGroup(of: Void.self) { group in
+                for index in 0..<4 {
+                    group.addTask {
+                        let setup = APITestSetup(
+                            id: setupID, manifest: "{\"schemaVersion\":1,\"n\":\(index)}",
+                            zipPath: fx.setup.zipPath, notebookPath: fx.setup.notebookPath,
+                            courseID: fx.courseID)
+                        _ = try? await AssignmentVersionStore.record(
+                            setup: setup,
+                            request: AssignmentVersionRequest(origin: "concurrent"),
+                            testSetupsDirectory: app.testSetupsDirectory,
+                            on: app.db)
+                    }
+                }
+            }
+
+            let numbers = try await APIAssignmentVersion.query(on: app.db)
+                .filter(\.$testSetupID == setupID)
+                .all()
+                .map(\.versionNumber)
+                .sorted()
+            #expect(numbers.count == 4)
+            #expect(numbers == Array(1...4))
+        }
+    }
+
+    // MARK: - Attribution
+
+    @Test func attributionIsDenormalizedOntoTheRow() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            let user = APIUser(username: "ta_kim", passwordHash: "x", role: "user")
+            try await user.save(on: app.db)
+
+            _ = try await AssignmentVersionStore.record(
+                setup: fx.setup,
+                request: AssignmentVersionRequest(
+                    origin: AssignmentVersionOrigin.mcp(tool: "author_script"),
+                    summary: "added publictest_b.py",
+                    actor: user),
+                testSetupsDirectory: app.testSetupsDirectory,
+                on: app.db)
+
+            let setupID = try #require(fx.setup.id)
+            let version = try #require(
+                try await AssignmentVersionStore.newestVersion(setupID: setupID, on: app.db))
+            #expect(version.actorUserID == user.id)
+            #expect(version.actorUsername == "ta_kim")
+            #expect(version.origin == "mcp:author_script")
+            #expect(version.summary == "added publictest_b.py")
+        }
+    }
+
+    // MARK: - Degraded inputs
+
+    /// An assignment whose zip is missing on disk is a degraded but real state.
+    /// Refusing to snapshot it would mean the one state you most want a record
+    /// of is the one that produces none.
+    @Test func aMissingZipSnapshotsAsAnEmptyFileMap() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(app)
+            try FileManager.default.removeItem(atPath: fx.setup.zipPath)
+
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+            let setupID = try #require(fx.setup.id)
+            let version = try #require(
+                try await AssignmentVersionStore.newestVersion(setupID: setupID, on: app.db))
+            #expect(version.decodedFileMap().isEmpty)
+            #expect(version.manifest == fx.setup.manifest)
+        }
+    }
+
+    @Test func nestedZipEntriesKeepTheirRelativePaths() async throws {
+        try await withApp(app) { app in
+            let fx = try await fixture(
+                app,
+                entries: [
+                    ("publictest_a.py", "passed('ok')\n"),
+                    ("data/cases.csv", "id\n1\n"),
+                ])
+
+            #expect(try await record(app, fx.setup) == .recorded(version: 1))
+            let setupID = try #require(fx.setup.id)
+            let version = try #require(
+                try await AssignmentVersionStore.newestVersion(setupID: setupID, on: app.db))
+            let map = version.decodedFileMap()
+            #expect(map.keys.contains("data/cases.csv"))
+            #expect(map.keys.contains("publictest_a.py"))
+        }
+    }
+}

--- a/changelog.d/assignment-versioning-plan.md
+++ b/changelog.d/assignment-versioning-plan.md
@@ -1,8 +1,12 @@
 ### Added
 
-- **Assignment versioning and recovery — design doc.** `docs/assignment-versioning.md`
-  specifies immutable per-edit content snapshots (manifest + zip + starter
-  notebook) with content-addressed per-file blobs, a linear append-only history
-  that is never deleted, and three MCP tools (`list_assignment_versions`,
-  `get_assignment_version`, `restore_assignment_version`). Planning only — no
-  behaviour change.
+- **Assignment versioning and recovery — storage core (slice 1).** Content edits
+  can now be snapshotted: a new `assignment_versions` table records an
+  assignment's manifest, setup-zip contents, and starter notebook as an
+  immutable, append-only history, with bytes held in a content-addressed
+  per-file blob store so unchanged datasets and notebooks are stored once
+  regardless of how many versions reference them. `AssignmentVersionStore`
+  is self-deduping (an edit that changed nothing writes no row) and seeds a
+  lazy pre-edit baseline so the first edit on an existing assignment stays
+  recoverable. No capture points are wired yet and no behaviour changes;
+  design in `docs/assignment-versioning.md`.

--- a/changelog.d/assignment-versioning-plan.md
+++ b/changelog.d/assignment-versioning-plan.md
@@ -1,0 +1,8 @@
+### Added
+
+- **Assignment versioning and recovery — design doc.** `docs/assignment-versioning.md`
+  specifies immutable per-edit content snapshots (manifest + zip + starter
+  notebook) with content-addressed per-file blobs, a linear append-only history
+  that is never deleted, and three MCP tools (`list_assignment_versions`,
+  `get_assignment_version`, `restore_assignment_version`). Planning only — no
+  behaviour change.

--- a/docs/assignment-versioning.md
+++ b/docs/assignment-versioning.md
@@ -91,11 +91,16 @@ state that actually existed, and the newest version always equals current
 content — which makes "restore to *N*" unambiguous and makes verification a
 straight equality check.
 
-On the first snapshot for a setup that has no rows yet, record the **pre-edit**
-state as `v1` (`origin: baseline`) before recording the edit as `v2`. Without
-this, the first agent edit on every assignment that predates the feature is
-precisely the one you cannot undo. It also avoids a migration that would have to
-walk and hash every existing setup on the disk at deploy time.
+The pre-edit state is captured by a separate `ensureBaseline` call made
+**before** the mutation: it records the current state as `v1` (`origin:
+baseline`) if and only if the setup has no history yet, and is a single indexed
+count once it does. Without it, the first agent edit on every assignment that
+predates the feature is precisely the one you cannot undo. It also avoids a
+migration that would have to walk and hash every existing setup on disk at
+deploy time.
+
+So a capture point does two calls — `ensureBaseline` before the edit, `record`
+after — and both are no-ops in the steady state.
 
 ### 3.2 Self-deduping
 

--- a/docs/assignment-versioning.md
+++ b/docs/assignment-versioning.md
@@ -1,0 +1,324 @@
+# Assignment versioning and recovery — design
+
+**Status:** planning (decisions locked, not yet implemented).
+
+Every persisted change to an assignment's *content* records an immutable
+snapshot. Snapshots are never deleted. A course-staff member — via MCP, in this
+first cut — can list an assignment's history, read any past version without
+disturbing the live one, and restore one when an edit goes wrong.
+
+This exists because agent-driven authoring makes content edits cheap and fast,
+and a fast wrong edit is indistinguishable from a fast right one until a student
+hits it. Today there is no way back: `applyPatternFamilies` overwrites the
+manifest, the zip is repacked in place, and the previous bytes are gone.
+
+---
+
+## 1. What gets versioned
+
+An assignment's content is exactly three artifacts:
+
+| Artifact | Where it lives | What it carries |
+|---|---|---|
+| `manifest` | `test_setups.manifest` (TEXT) | suite list, pattern families, notebook checks, test-suite sections, global inputs, section variables, datasets, achievements, time limit, grading mode, language |
+| setup zip | `testsetups/{setupID}.zip` | test scripts, support files, `solution.ipynb`, dataset files |
+| starter notebook | `testsetups/{setupID}.ipynb` | the notebook students open |
+
+Everything else is **derived** and re-materializes from those three:
+`shared/{setupID}/` (via `extractSupportFilesToSharedDirectory`),
+`shared/{setupID}/solution.py` (via `SolutionNotebookExtractor.writeSolutionPy`),
+per-student notebook materializations, `TestSetupCache` entries on the runner.
+A snapshot therefore needs the three artifacts and nothing more.
+
+Assignment **metadata** — title, due date, visibility, slug, course section,
+BrightSpace grade-item mapping — lives on `assignments` and is deliberately *not*
+content. It is recorded in a snapshot for reference but never written back by a
+restore (see §5).
+
+Student data is never involved. Snapshots hold instructor-authored content only.
+
+---
+
+## 2. Storage
+
+### 2.1 `assignment_versions`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID | PK |
+| `test_setup_id` | string | **No foreign key** — see §7.1 |
+| `assignment_id` | UUID? | denormalized for lookup; nullable so history outlives a deleted assignment |
+| `course_id` | UUID | FK → `courses.id`; the scoping and purge key |
+| `version_number` | Int | monotone per `test_setup_id`; unique index on `(test_setup_id, version_number)` |
+| `manifest` | TEXT | full manifest JSON, stored inline |
+| `manifest_hash` | string | `manifestHash(_:)`, the existing helper |
+| `file_map` | TEXT | JSON object, zip entry path → sha256 |
+| `notebook_hash` | string? | sha256 of the starter notebook, nil when the setup has none |
+| `snapshot_hash` | string | hash over `manifest_hash` + `file_map` + `notebook_hash`; the dedupe key |
+| `actor_user_id` | UUID? | nil for system-originated snapshots |
+| `actor_username` | string? | denormalized at write time, same reason as `audit_log` |
+| `origin` | string | `mcp:update_suite`, `web:save_edit`, `clone`, `import`, `restore:7`, `baseline` |
+| `summary` | string? | one short line, e.g. `pattern family "bmi": 2 cases changed` |
+| `restored_from_version` | Int? | set when this version was produced by a restore |
+| `created_at` | timestamp | |
+
+### 2.2 Blobs
+
+Content-addressed under `testsetups/versions/blobs/<first-2-hex>/<sha256>`.
+
+Per **file**, not per zip. This is load-bearing: `/usr/bin/zip` embeds
+timestamps, so repacking byte-identical content produces a different archive
+every time — hashing whole zips would dedupe nothing at all. Hashing entries
+means a 200-edit authoring session against a setup with a 3 MB dataset and an
+untouched notebook stores those bytes exactly once. That is what makes "never
+delete a version" affordable rather than a disk-fill incident.
+
+The starter notebook is stored as a blob under its own hash, alongside the zip
+entries.
+
+Blobs are written before the row that references them and are only ever deleted
+by the course-purge sweep (§7.4). A blob with any referencing row is never
+removed.
+
+---
+
+## 3. When a snapshot is taken
+
+### 3.1 Post-state, plus a lazy baseline
+
+Snapshots record the state **after** an edit. So version *N* always names a
+state that actually existed, and the newest version always equals current
+content — which makes "restore to *N*" unambiguous and makes verification a
+straight equality check.
+
+On the first snapshot for a setup that has no rows yet, record the **pre-edit**
+state as `v1` (`origin: baseline`) before recording the edit as `v2`. Without
+this, the first agent edit on every assignment that predates the feature is
+precisely the one you cannot undo. It also avoids a migration that would have to
+walk and hash every existing setup on the disk at deploy time.
+
+### 3.2 Self-deduping
+
+`AssignmentVersionStore.record` computes `snapshot_hash` from the current
+on-disk and in-DB state and returns without writing when it equals the newest
+version's. Two consequences:
+
+- No-op writes (a save that changed nothing, a tool called twice) cost one hash
+  and no row.
+- Call sites can be **generous**. Over-calling is free; under-calling is the only
+  real failure mode. This deliberately relaxes the precision required of the
+  chokepoint work in §4.
+
+### 3.3 Granularity
+
+One version per content-changing write call. An agent session may produce
+50–200 rows for a single assignment; with per-file blobs that is a few kilobytes
+of rows and no new bytes. `list_assignment_versions` pages.
+
+Coalescing bursts was considered and rejected: the step you most want back is
+usually in the middle of an agent's run.
+
+---
+
+## 4. Capture points
+
+Versions are recorded at the **service layer**, so web saves and MCP writes both
+produce history. Only MCP gets tools to read and restore in this first cut, but
+a history with browser-shaped holes would let a restore silently discard an
+instructor's work — the exact failure this feature exists to prevent.
+
+### 4.1 MCP
+
+A `finalizeMCPWrite` step that every `content:write` tool funnels through.
+
+This cannot piggyback on `finalizeContentEdit`: only eight tools call that one,
+and `update_solution`, `update_global_inputs`, `update_section_variables`,
+`set_dataset`, `set_time_limit`, `set_grading_mode` and the suite-section tools
+deliberately do not — yet all of them change content that belongs in a snapshot.
+
+A sibling to `MCPContentEditCoverageTests` classifies every `content:write` tool
+as versioning or non-versioning by source scan, so a future write tool that
+skips history is a build failure with instructions, not a silent gap. Same
+discipline, same file shape.
+
+### 4.2 Web
+
+The known manifest/zip write sites, all in `APIServer`:
+
+- `PatternFamilyApplication.applyPatternFamilies` — the shared manifest rebuild
+  plus zip repack; reached from the suite editor, the new-assignment publish
+  path, and `GlobalInputsService`
+- `ScriptCRUDHelpers` — raw script create/update/delete
+- `PublishedAssignmentRoutes+Datasets` — dataset marks
+- `NotebookScaffoldHelpers` and `AssignmentAuthoringService.writeAssignmentNotebook`
+  — starter-notebook saves, including the language re-derivation
+- `SuiteEditHelpers` — the suite payload apply
+- the solution-save path in `RunnerValidationHelpers`
+
+Because `record` dedupes, these can be hooked incrementally without a correctness
+cliff; a missed site shows up as a coarser history, not a wrong one.
+
+### 4.3 Creation paths seed `v1`
+
+`AssignmentAuthoringService.cloneAssignment`, `copyCourse`,
+`AssignmentAuthoringService.createAssignment`, and `.chickadee` bundle import
+each stamp a single `v1` with the appropriate `origin`. The §3.1 lazy baseline
+covers any creation path missed here.
+
+Hidden drafts (the new-assignment flow, setups with no published assignment) are
+skipped — they accumulate edits that are not yet anyone's content.
+
+---
+
+## 5. Restore
+
+`restore_assignment_version(assignmentPublicID, version)`:
+
+1. Authorize: per-course `instructor` via `evaluateCourseWrite`; refuse on an
+   archived course, same as every other write.
+2. Materialize the snapshot's `file_map` into a temp directory from blobs, repack
+   with `repackZipFromDirectory`, write the notebook, write the manifest.
+3. Re-derive: `extractSupportFilesToSharedDirectory`,
+   `SolutionNotebookExtractor.writeSolutionPy`.
+4. Invalidate any instructor notebook working copy (§7.3).
+5. Run `finalizeContentEdit` — close the assignment, manifest-gated regrade,
+   re-kick validation. Restoring changes what is graded, so it takes the same
+   path as any other content edit.
+6. Record a **new** version, `v_{max+1}`, with `restored_from_version: N`.
+7. Write an `AuditAction` entry — a restore is a real staff action.
+
+History is linear and append-only. A restore never rewinds the counter, never
+branches, never deletes, and is itself undoable by restoring the version before
+it.
+
+**Restores put back content only.** Title, due date, visibility, course section,
+and BrightSpace mapping are left alone; the assignment lands closed, as any
+content edit leaves it. A recovery action must never silently reopen an
+assignment or move a deadline students have already seen. The snapshot still
+records metadata, so the tool response can report what the title and due date
+were at the time and the instructor can reapply them deliberately.
+
+The response reports `submissionsRequeued` so the caller sees the blast radius:
+restoring a suite regrades every existing submission on that setup.
+
+---
+
+## 6. MCP surface
+
+Three tools; the catalog goes 47 → 50.
+
+| Tool | Scope | Returns |
+|---|---|---|
+| `list_assignment_versions` | `content:read`, `.ta` | version number, `createdAt`, actor, origin, summary, `manifestHash`, `isCurrent`, `restoredFromVersion`, paged |
+| `get_assignment_version` | `content:read`, `.ta` | the snapshot's manifest-derived suite shape and file list; optional `path` returns one file's body, so an agent can read an old script without restoring anything |
+| `restore_assignment_version` | `content:write`, `.instructor` | new version number, `assignmentClosed`, `submissionsRequeued`, restored file count |
+
+`get_assignment_version` reuses `get_suite`'s authorization exactly. Snapshots
+contain secret-tier tests and reference solutions; the MCP surface is staff-only
+and students cannot reach it, but the file-body path must not become a new way
+around that.
+
+Read tools are additive and safe under `MCP_MODE=read_only`; `restore` requires
+`read_write`. Tool descriptions and `MCPServerInstructions.text` are updated
+together, per the standing rule that the two stay in sync, and
+`docs/mcp-authoring-roadmap.md` gains the three rows.
+
+No UI in this cut. The data model is UI-ready — an instructor "History" panel on
+the assignment edit page is a later slice with no schema change.
+
+---
+
+## 7. Consequences and edge cases
+
+### 7.1 Deleting an assignment must not delete its history
+
+`deleteAssignment` (`InstructorDashboardRoutes.swift:481`) hard-deletes the
+submissions, the results, the zip, the notebook, and the `test_setups` row. If
+`assignment_versions.test_setup_id` carried a foreign key, the history would go
+with it — dying at exactly the moment recovery matters most.
+
+So: `test_setup_id` is a plain string column with no FK, `assignment_id` is
+nullable, and the FK is on `course_id` alone. Versions outlive a deleted setup.
+This also leaves room for an "undelete an assignment" tool later with no schema
+change; that is out of scope here but the shape should not foreclose it.
+
+### 7.2 Clone copies content, not history
+
+`cloneAssignment` and `copyCourse` copy live files into a **new** setup ID, so a
+clone inherits no history for free — it just gets a `v1`. That is the intended
+semantic: a new term starts with the current assignment and a clean slate.
+`.chickadee` bundle export stays history-free; bundles are large enough already.
+
+### 7.3 Notebook working copies
+
+`NotebookWorkingCopyStore` holds an instructor's in-progress JupyterLite edits.
+Restoring the starter notebook underneath an open working copy means their next
+save silently reverts the restore. A restore invalidates the working copy, the
+same way the existing instructor reset-notebook action does.
+
+### 7.4 Retention and disk
+
+Versions are never deleted by an instructor or an agent. They die with the
+course: the `SubmissionRetentionService` purge and course delete drop the
+version rows, then a sweep removes blobs with no remaining referencing row.
+Instructor content is not FIPPA-sensitive the way submissions are, but a purged
+course must not leave bytes on disk.
+
+`testsetups/versions/` joins the admin disk-usage breakdown in `DiskUsage.swift`.
+
+### 7.5 Concurrency
+
+Two concurrent edits could compute the same `version_number`. The unique index
+on `(test_setup_id, version_number)` plus one retry handles it — the same
+discipline as `createAssignmentWithUniquePublicID`.
+
+### 7.6 Manifest schema drift
+
+An old snapshot's manifest can predate a `TestProperties` field. Decoding is
+already lenient (`decodeIfPresent` throughout), so restoring an old manifest
+re-encodes it to the current schema. Worth an explicit test: restore a manifest
+missing `sections` / `testItems` and assert the round trip.
+
+### 7.7 Cache invalidation is already handled
+
+A restore changes the manifest and the zip, so the runner-side `TestSetupCache`
+key (manifest + zip content hash) busts on its own, and generated-script
+`spec_hash` headers travel inside the restored manifest. No action needed.
+
+### 7.8 Personalization is unaffected
+
+Per-student seeds live in `assignment_personalization_seeds` and are untouched
+by a restore, so a restored suite regrades every student against the same seed
+they had. That is the correct behaviour and needs no special handling.
+
+### 7.9 Relationship to issue #421
+
+[#421](https://github.com/jimwallace/chickadee/issues/421) (edit audit trail for
+shared course staff) asks for actor + timestamp + action on every content
+change, and explicitly scopes out diffing and restore. This design delivers that
+half as a side effect — `actor_username`, `created_at`, `origin`, `summary` per
+version — and adds the restore #421 deferred. #421 should be re-scoped to the
+staff/enrollment events versioning does not cover, and to the recent-activity UI
+panel.
+
+---
+
+## 8. Slice plan
+
+1. **Storage core.** `assignment_versions` model plus migration, the
+   content-addressed blob store, `AssignmentVersionStore.record` with dedupe and
+   lazy baseline. Unit tests on hashing, dedupe, and numbering under
+   concurrency.
+2. **Capture.** Wire the web service-layer sites and the `finalizeMCPWrite`
+   chokepoint; add the coverage guard test. No user-visible change yet — history
+   starts accumulating.
+3. **Read tools.** `list_assignment_versions`, `get_assignment_version`, plus
+   instructions and roadmap updates.
+4. **Restore.** `restore_assignment_version` with working-copy invalidation, the
+   audit entry, and the regrade path.
+5. **Lifecycle.** Creation-path `v1` seeding, purge and blob GC, disk-usage
+   reporting.
+
+Slices 1–2 are independently shippable and carry the recovery value on their own
+(a snapshot that exists can always be restored by hand); 3–4 make it
+self-serve.


### PR DESCRIPTION
Design doc plus the storage layer for assignment content versioning. **Nothing calls the store yet** — capture points land in slice 2 — so there is no behaviour change on this PR.

## Design (`docs/assignment-versioning.md`)

Every persisted change to an assignment's *content* records an immutable snapshot; snapshots are never deleted. Course staff can list an assignment's history, read a past version without disturbing the live one, and restore when an edit goes wrong. MCP-only surface in the first cut; the data model is UI-ready for a later History panel with no schema change.

A version captures exactly three artifacts — `test_setups.manifest`, the setup zip's entries, and the starter notebook. `shared/{setupID}/`, the generated `solution.py`, per-student materializations, and runner cache entries all re-derive from those.

## Slice 1 — what's here

- **`APIAssignmentVersion` + `CreateAssignmentVersions`** — append-only per-setup history.
- **`AssignmentVersionBlobStore`** — content-addressed blobs at `testsetups/versions/blobs/{ab}/{sha256}`.
- **`AssignmentVersionSnapshot`** — canonical digest over manifest + sorted file map + notebook.
- **`AssignmentVersionStore`** — `record` / `ensureBaseline`.

## Decisions worth a reviewer's eye

**`test_setup_id` carries no foreign key.** `deleteAssignment` (`InstructorDashboardRoutes.swift:499-509`) hard-deletes the `test_setups` row along with the zip and notebook — an FK would cascade the history away at exactly the moment recovery matters. The FK is on `course_id` alone (history dies with its course, per the retention rules), `assignment_id` is nullable, and `actor_user_id` sets null so a deleted staff account keeps its denormalized attribution. This also leaves room for an "undelete assignment" tool later with no schema change.

**Blobs are hashed per file, not per archive.** `/usr/bin/zip` embeds timestamps, so repacking byte-identical content yields a different archive every time; whole-archive hashing would dedupe nothing and "snapshot every edit, never delete" would become a disk-fill incident. Per-entry hashing means an untouched 3 MB dataset costs nothing across a 200-edit authoring session. `repackingIdenticalContentStillDedupes` pins this directly — and stamps distinct mtimes, because zip's 2-second timestamp granularity otherwise makes two quick packs byte-identical and the test would silently stop testing anything.

**`record` is self-deduping, `ensureBaseline` is a one-shot.** Unchanged content writes no row, so slice 2's capture points may be generous — over-calling is free, under-calling is the only real failure mode. `ensureBaseline` runs *before* a mutation and captures the pre-edit state once per setup, so the first edit on an assignment that predates the feature stays recoverable without a migration that hashes every setup on disk at deploy time.

**Hash shape is validated before any path is built.** Blob paths derive from a database column; the 64-lowercase-hex check is what stops a malformed or tampered row from walking out of the blob directory with `../`. Blob writes land via temp-file-plus-rename, so concurrent writers of the same blob all succeed and a reader never sees a partial one.

**Version numbering retries on conflict.** Two concurrent edits can compute the same next number; the unique index on `(test_setup_id, version_number)` turns that into an insert conflict and the store re-reads the max — same discipline as `createAssignmentWithUniquePublicID`.

## Testing

23 new tests, all passing locally, covering blob round-trip, single-store dedupe, hash-shape rejection (parameterized over traversal / uppercase / short inputs), concurrent blob writes, concurrent version numbering, draft skip, baseline seeding and its no-second-time rule, manifest/script/notebook change detection, nested zip entry paths, and a missing zip snapshotting as an empty file map. `scripts/format.sh`, `scripts/lint.sh`, and `scripts/swiftlint.sh --strict` are clean (0 violations in 869 files).

## Remaining slices

2. Capture — web service-layer sites, `finalizeMCPWrite`, coverage guard
3. Read tools — `list_assignment_versions`, `get_assignment_version`
4. Restore — `restore_assignment_version`
5. Lifecycle — creation-path `v1` seeding, purge + blob GC, disk-usage reporting