### PR TITLE
Assignment versioning: capture content edits (slice 2)

### DIFF
--- a/Sources/APIServer/Bootstrap/AppMiddleware.swift
+++ b/Sources/APIServer/Bootstrap/AppMiddleware.swift
@@ -135,6 +135,11 @@ func bootstrapAppMiddleware(_ app: Application, appConfig: AppConfig) {
         )
     )
     app.middleware.use(UserFileNamespaceMiddleware())
+    // Snapshots assignment content after a successful instructor write. Must
+    // sit after the session authenticator so the version row can be attributed
+    // to the acting user. A no-op (one storage read) on every request that
+    // doesn't resolve a test setup for write.
+    app.middleware.use(AssignmentVersionCaptureMiddleware())
     // Scan-mode seatbelt: when SCAN_MODE=true is set in the environment, the
     // middleware 503s POSTs against destructive routes (submissions, test-setup
     // uploads, retests, user delete/role) so an in-progress vulnerability scan

--- a/Sources/APIServer/MCP/Tools/MCPVersionCapture.swift
+++ b/Sources/APIServer/MCP/Tools/MCPVersionCapture.swift
@@ -1,0 +1,109 @@
+// APIServer/MCP/Tools/MCPVersionCapture.swift
+//
+// Automatic content-version capture for the MCP write tools
+// (docs/assignment-versioning.md).
+//
+// Rather than asking each of the ~16 content-mutating tools to remember two
+// bookkeeping calls, capture hangs off the seam every one of them already goes
+// through: `ToolContext.authorizedAssignmentAndSetupForWrite`. Resolving a
+// setup for write registers it here (and seeds its baseline, which by
+// construction happens before the tool mutates anything); the dispatcher
+// snapshots every registered setup after the call succeeds.
+//
+// The consequence worth stating plainly: a NEW write tool that resolves its
+// setup through the standard seam is versioned without its author doing
+// anything. `MCPVersionCaptureCoverageTests` is what keeps that true — a write
+// tool that reaches a setup another way has to say so out loud.
+//
+// Version rows are written on `ToolContext.mainDB`, never the least-privilege
+// `.mcp` pool. `assignment_versions` is deliberately NOT granted to the
+// `chickadee_mcp` role (deploy/sql/mcp-least-privilege-role.sql): a snapshot is
+// a system side effect of the call, not agent-facing content access — the same
+// reasoning that routes the personalization-seed write and the content-edit
+// regrade to the owner pool.
+
+import Fluent
+import Foundation
+import Vapor
+
+/// Collects the setups an MCP call resolved for write, so the dispatcher can
+/// snapshot them once the call succeeds.
+///
+/// Reference type held by the per-request `ToolContext` (a struct), so a tool
+/// registering a setup is visible to the dispatcher that invoked it.
+final class MCPVersionCaptureScope: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state is `pending`, and every
+    // access is inside `lock`. The box is shared between the tool body and the
+    // dispatcher that awaits it, so it crosses no isolation domain unguarded.
+    private let lock = NSLock()
+    private var pending: [String: APITestSetup] = [:]
+
+    /// Registers a setup as touched by the current call. Idempotent per setup.
+    func register(_ setup: APITestSetup) {
+        guard let id = setup.id else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        pending[id] = setup
+    }
+
+    /// Returns the registered setups and clears the scope, so a batched second
+    /// call can't re-snapshot the first call's setups.
+    func drain() -> [APITestSetup] {
+        lock.lock()
+        defer { lock.unlock() }
+        let setups = Array(pending.values)
+        pending.removeAll()
+        return setups
+    }
+}
+
+extension ToolContext {
+    /// Seeds the pre-edit baseline for `setup` and registers it for a
+    /// post-call snapshot.
+    ///
+    /// Called from the write seam, i.e. before the tool has changed anything —
+    /// which is the only moment the pre-edit state is still capturable, and
+    /// therefore the only moment a first-ever edit can be made recoverable.
+    ///
+    /// Best-effort in both directions: an assignment edit must not fail because
+    /// its history could not be written.
+    func beginContentWrite(setup: APITestSetup) async {
+        versionCapture.register(setup)
+        do {
+            _ = try await AssignmentVersionStore.ensureBaseline(
+                setup: setup,
+                testSetupsDirectory: request.application.testSetupsDirectory,
+                on: mainDB)
+        } catch {
+            logger.warning(
+                "assignment version baseline failed",
+                metadata: [
+                    "setup": .string(setup.id ?? "?"), "error": .string("\(error)"),
+                ])
+        }
+    }
+
+    /// Snapshots every setup registered during this call. Invoked by the
+    /// dispatcher after a write tool returns successfully; a failed call
+    /// registers nothing worth recording because its edit did not persist.
+    func finishContentWrites(tool: String) async {
+        let setups = versionCapture.drain()
+        guard !setups.isEmpty else { return }
+
+        let actor = try? await requireEligibleSubject(tool: tool)
+        for setup in setups {
+            // Re-read: the tool mutated its own in-memory copy, and for a
+            // manifest edit that copy is the one that was saved — but a tool
+            // that reloaded or replaced the row would otherwise be snapshotted
+            // from a stale object.
+            let current = (try? await APITestSetup.find(setup.id ?? "", on: mainDB)) ?? setup
+            _ = await AssignmentVersionStore.recordBestEffort(
+                setup: current,
+                request: AssignmentVersionRequest(
+                    origin: AssignmentVersionOrigin.mcp(tool: tool), actor: actor),
+                testSetupsDirectory: request.application.testSetupsDirectory,
+                logger: logger,
+                on: mainDB)
+        }
+    }
+}

--- a/Sources/APIServer/MCP/Tools/ToolContext.swift
+++ b/Sources/APIServer/MCP/Tools/ToolContext.swift
@@ -18,19 +18,24 @@ struct ToolContext {
     /// nil for Phase-1 service tokens.  Carried for audit attribution.
     let actingClientID: String?
     let actingClientName: String?
+    /// Setups this call resolved for write, collected so the dispatcher can
+    /// snapshot their content afterwards. See `MCPVersionCapture.swift`.
+    let versionCapture: MCPVersionCaptureScope
 
     init(
         request: Request,
         subject: String,
         grantedScopes: Set<ContentScope>,
         actingClientID: String? = nil,
-        actingClientName: String? = nil
+        actingClientName: String? = nil,
+        versionCapture: MCPVersionCaptureScope = MCPVersionCaptureScope()
     ) {
         self.request = request
         self.subject = subject
         self.grantedScopes = grantedScopes
         self.actingClientID = actingClientID
         self.actingClientName = actingClientName
+        self.versionCapture = versionCapture
     }
 
     /// The database the MCP tool surface runs on. When a dedicated
@@ -226,6 +231,11 @@ struct ToolContext {
     /// assignment's own course (archived block) before loading the setup. Every
     /// content-mutating suite/manifest/notebook tool resolves through this so an
     /// agent can't edit an archived course's content by id (#417 Slice D-MCP).
+    ///
+    /// Also the content-versioning seam: resolving a setup here seeds its
+    /// pre-edit baseline and registers it for a post-call snapshot, so a tool
+    /// gets version history without its author wiring anything
+    /// (`MCPVersionCapture.swift`).
     func authorizedAssignmentAndSetupForWrite(
         publicID: String, tool: String, atLeast minimum: CourseRole
     ) async throws
@@ -237,6 +247,7 @@ struct ToolContext {
             throw MCPToolError.invalidArguments(
                 tool: tool, detail: "The assignment's test setup could not be found.")
         }
+        await beginContentWrite(setup: setup)
         return (assignment, setup)
     }
 }

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -90,6 +90,14 @@ struct UpdateSolutionTool: ContentTool {
         // so the validation submission is attributed to the acting account.
         let subject = try await context.requireEligibleSubject(tool: Self.name)
 
+        // Content versioning: this tool reaches its setup by id rather than
+        // through `authorizedAssignmentAndSetupForWrite`, so it registers for a
+        // snapshot by hand. Replacing the reference solution rewrites
+        // `solution.ipynb` inside the setup zip, which is versioned content.
+        if let setup = try await APITestSetup.find(assignment.testSetupID, on: context.db) {
+            await context.beginContentWrite(setup: setup)
+        }
+
         let data: Data
         do {
             data = try JSONEncoder().encode(input.notebook)

--- a/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
+++ b/Sources/APIServer/MCP/Transport/MCPDispatcher.swift
@@ -184,6 +184,11 @@ struct MCPDispatcher: Sendable {
         let outcome: MCPToolOutcome
         do {
             let output = try await tool.invoke(call.arguments ?? .object([:]), context)
+            // Snapshot the content of any setup this call resolved for write,
+            // now that the edit has persisted. Only on success: a failed call
+            // changed nothing worth a version. Best-effort inside — history
+            // must never be the reason an instructor's edit fails.
+            await context.finishContentWrites(tool: call.name)
             outcome = .success
             response = .success(id: id, result: mcpToolSuccessResult(output))
         } catch let error as MCPToolError {

--- a/Sources/APIServer/Middleware/AssignmentVersionCaptureMiddleware.swift
+++ b/Sources/APIServer/Middleware/AssignmentVersionCaptureMiddleware.swift
@@ -1,0 +1,138 @@
+// APIServer/Middleware/AssignmentVersionCaptureMiddleware.swift
+//
+// Web-side content-version capture (docs/assignment-versioning.md).
+//
+// The mirror of the MCP arrangement in `MCPVersionCapture.swift`, and for the
+// same reason: rather than asking fifteen instructor write handlers to remember
+// two bookkeeping calls, capture hangs off the seam they already share —
+// `loadAssignmentAndSetupForWrite` registers the setup and seeds its pre-edit
+// baseline, and this middleware snapshots what was registered once the response
+// comes back successful.
+//
+// Web saves are versioned even though only MCP can read or restore the history
+// today. A history with browser-shaped holes would be worse than no history at
+// all: a later restore would silently discard whatever the unrecorded edit did.
+//
+// Only 2xx responses are snapshotted. A handler that threw or redirected to an
+// error page did not persist an edit worth recording, and the dedupe in
+// `AssignmentVersionStore.record` absorbs the rest — a save that changed
+// nothing writes no row, which is what lets the seam be generous about when it
+// fires.
+
+import Fluent
+import Foundation
+import Vapor
+
+/// Per-request collection of setups resolved for write, plus the seeding of
+/// their baselines. Lives in `Request.storage`.
+final class AssignmentVersionCaptureScope: @unchecked Sendable {
+    // @unchecked Sendable: the only mutable state is `pending`, guarded by
+    // `lock` on every access. Shared between the handler and the middleware
+    // that awaits it.
+    private let lock = NSLock()
+    private var pending: [String: APITestSetup] = [:]
+
+    func register(_ setup: APITestSetup) {
+        guard let id = setup.id else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        pending[id] = setup
+    }
+
+    func drain() -> [APITestSetup] {
+        lock.lock()
+        defer { lock.unlock() }
+        let setups = Array(pending.values)
+        pending.removeAll()
+        return setups
+    }
+
+    var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pending.isEmpty
+    }
+}
+
+private struct AssignmentVersionCaptureScopeKey: StorageKey {
+    typealias Value = AssignmentVersionCaptureScope
+}
+
+extension Request {
+    var assignmentVersionCapture: AssignmentVersionCaptureScope {
+        if let existing = storage[AssignmentVersionCaptureScopeKey.self] { return existing }
+        let scope = AssignmentVersionCaptureScope()
+        storage[AssignmentVersionCaptureScopeKey.self] = scope
+        return scope
+    }
+
+    /// Seeds the pre-edit baseline for `setup` and registers it for a snapshot
+    /// once this request succeeds.
+    ///
+    /// Called from the write seam — before the handler has changed anything,
+    /// which is the only moment the pre-edit state is still capturable and
+    /// therefore the only moment a first-ever edit can be made recoverable.
+    /// Best-effort: an instructor's save must not fail because its history
+    /// could not be written.
+    func beginAssignmentContentEdit(setup: APITestSetup) async {
+        assignmentVersionCapture.register(setup)
+        do {
+            _ = try await AssignmentVersionStore.ensureBaseline(
+                setup: setup,
+                testSetupsDirectory: application.testSetupsDirectory,
+                on: db)
+        } catch {
+            logger.warning(
+                "assignment version baseline failed",
+                metadata: [
+                    "setup": .string(setup.id ?? "?"), "error": .string("\(error)"),
+                ])
+        }
+    }
+}
+
+/// Snapshots the content of every setup a successful request resolved for
+/// write. A no-op — one storage read — for the overwhelming majority of
+/// requests, which register nothing.
+struct AssignmentVersionCaptureMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: any AsyncResponder) async throws -> Response {
+        let response = try await next.respond(to: request)
+        guard (200..<300).contains(response.status.code) else {
+            // Failed or redirected-to-error: nothing persisted worth recording.
+            // Drain anyway so a registered setup can't leak into a later
+            // request sharing this storage.
+            _ = request.assignmentVersionCapture.drain()
+            return response
+        }
+        await capture(on: request)
+        return response
+    }
+
+    private func capture(on request: Request) async {
+        let scope = request.assignmentVersionCapture
+        guard !scope.isEmpty else { return }
+        let actor = request.auth.get(APIUser.self)
+        let origin = AssignmentVersionOrigin.web(action: Self.action(for: request))
+
+        for setup in scope.drain() {
+            // Re-read so a handler that reloaded or replaced the row is
+            // snapshotted from what actually persisted, not a stale object.
+            let current = (try? await APITestSetup.find(setup.id ?? "", on: request.db)) ?? setup
+            _ = await AssignmentVersionStore.recordBestEffort(
+                setup: current,
+                request: AssignmentVersionRequest(origin: origin, actor: actor),
+                testSetupsDirectory: request.application.testSetupsDirectory,
+                logger: request.logger,
+                on: request.db)
+        }
+    }
+
+    /// A short, stable label for what produced the version: the matched route
+    /// pattern rather than the concrete URL, so every assignment's history
+    /// reads `web:PUT /instructor/:assignmentID/suite` instead of embedding a
+    /// public ID that is already on the row.
+    static func action(for request: Request) -> String {
+        let path = request.route.map { "/" + $0.path.map(\.description).joined(separator: "/") }
+        return "\(request.method.rawValue) \(path ?? request.url.path)"
+    }
+}

--- a/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
+++ b/Sources/APIServer/Routes/Web/SuiteEditHelpers.swift
@@ -117,6 +117,11 @@ func loadAssignmentAndSetupForWrite(
     let caller = try req.auth.require(APIUser.self)
     try await requireCourseWriteAccess(
         caller: caller, courseID: assignment.courseID, atLeast: atLeast, db: req.db)
+    // Content-versioning seam: seeds the pre-edit baseline and registers the
+    // setup so `AssignmentVersionCaptureMiddleware` snapshots it if this
+    // request succeeds. Handlers that turn out not to change content cost
+    // nothing — the snapshot dedupes to no row.
+    await req.beginAssignmentContentEdit(setup: setup)
     return (assignment, setup)
 }
 

--- a/Tests/APITests/AssignmentVersionCaptureTests.swift
+++ b/Tests/APITests/AssignmentVersionCaptureTests.swift
@@ -1,0 +1,329 @@
+// Tests/APITests/AssignmentVersionCaptureTests.swift
+//
+// End-to-end capture: an assignment content edit — made through the web
+// instructor routes or through an MCP write tool — leaves a version history
+// behind (docs/assignment-versioning.md).
+//
+// The unit-level contract (dedupe, numbering, baseline) is pinned in
+// `AssignmentVersionStoreTests`. What these cover is the wiring: that the write
+// seams actually fire, that the pre-edit baseline lands ahead of the edit, and
+// that a failed or non-mutating request records nothing.
+//
+// `.serialized`: these spawn zip/unzip subprocesses, which hit the Foundation
+// posix_spawn EFAULT race under within-suite parallelism.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class AssignmentVersionCaptureTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-vcap")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeAssignment(
+        scripts: [(String, String)] = [("publictest_a.py", "passed('a')\n")]
+    ) async throws -> (publicID: String, setupID: String) {
+        let courseID = UUID()
+        let course = APICourse(
+            id: courseID, code: "VCAP\(Int.random(in: 100...999))", name: "Capture",
+            enrollmentMode: .auto)
+        try await course.save(on: app.db)
+
+        let setupID = "vcap_\(UUID().uuidString.prefix(8))"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        try writeZip(at: zipPath, entries: [(".placeholder", "x")] + scripts)
+
+        var entries: [ConfiguredSuiteEntry] = []
+        for (index, (name, _)) in scripts.enumerated() {
+            entries.append(
+                ConfiguredSuiteEntry(
+                    script: name, tier: "public", order: index + 1,
+                    dependsOn: [], points: 1, displayName: nil))
+        }
+        let manifest = try makeWorkerManifestJSON(testSuites: entries, includeMakefile: false)
+        let setup = APITestSetup(
+            id: setupID, manifest: manifest, zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: "Capture lab", dueAt: nil, isOpen: true,
+            deadlineOverrideActive: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+        return (assignment.publicID, setupID)
+    }
+
+    private func writeZip(at zipPath: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vcap-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            let url = root.appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try content.data(using: .utf8)?.write(to: url)
+        }
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+        #expect(zip.terminationStatus == 0)
+    }
+
+    private func versions(_ setupID: String) async throws -> [APIAssignmentVersion] {
+        try await APIAssignmentVersion.query(on: app.db)
+            .filter(\.$testSetupID == setupID)
+            .sort(\.$versionNumber)
+            .all()
+    }
+
+    // MARK: - Web capture
+
+    /// The headline behaviour: editing the suite in the browser leaves a
+    /// baseline of what it looked like before, plus the state it landed in.
+    @Test func webSuiteEditRecordsBaselineThenTheEdit() async throws {
+        try await withApp(app) { _ in
+            let (publicID, setupID) = try await makeAssignment(scripts: [
+                ("publictest_a.py", "passed('a')\n"),
+                ("publictest_b.py", "passed('b')\n"),
+            ])
+            let cookie = try await loginUser(
+                username: "vcap_inst", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("vcap_inst", on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/\(publicID)/edit", cookie: cookie, on: app)
+
+            let body = #"""
+                {"items":[
+                    {"kind":"script","script":{"script":"publictest_b.py","tier":"public","points":1,"displayName":null,"dependsOn":[]}},
+                    {"kind":"script","script":{"script":"publictest_a.py","tier":"public","points":1,"displayName":null,"dependsOn":[]}}
+                ]}
+                """#
+            try await app.asyncTest(
+                .PUT, "/instructor/\(publicID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: body)
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "\(res.body.string)")
+                })
+
+            let history = try await versions(setupID)
+            #expect(history.count == 2)
+            #expect(history.first?.versionNumber == 1)
+            #expect(history.first?.origin == AssignmentVersionOrigin.baseline)
+            let edit = try #require(history.last)
+            #expect(edit.versionNumber == 2)
+            #expect(edit.origin.hasPrefix("web:"))
+            #expect(edit.origin.contains("suite"))
+            #expect(edit.actorUsername == "vcap_inst")
+        }
+    }
+
+    /// The baseline must hold the content as it was BEFORE the edit — that is
+    /// the whole reason it is seeded from the write seam rather than after the
+    /// handler runs.
+    @Test func theBaselineHoldsThePreEditContent() async throws {
+        try await withApp(app) { _ in
+            let (publicID, setupID) = try await makeAssignment(scripts: [
+                ("publictest_a.py", "passed('a')\n")
+            ])
+            let before = try #require(try await APITestSetup.find(setupID, on: app.db)).manifest
+
+            let cookie = try await loginUser(
+                username: "vcap_pre", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("vcap_pre", on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/\(publicID)/edit", cookie: cookie, on: app)
+
+            // Retier the script: a real manifest change.
+            let body = #"""
+                {"items":[
+                    {"kind":"script","script":{"script":"publictest_a.py","tier":"secret","points":5,"displayName":null,"dependsOn":[]}}
+                ]}
+                """#
+            try await app.asyncTest(
+                .PUT, "/instructor/\(publicID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: body)
+                },
+                afterResponse: { res in #expect(res.status == .ok, "\(res.body.string)") })
+
+            let history = try await versions(setupID)
+            #expect(history.count == 2)
+            #expect(history.first?.manifest == before)
+            let after = try #require(try await APITestSetup.find(setupID, on: app.db)).manifest
+            #expect(history.last?.manifest == after)
+            #expect(before != after)
+        }
+    }
+
+    /// A read of the editor resolves no setup for write, so it must leave no
+    /// history behind — otherwise every page load would inflate the timeline.
+    @Test func readingTheSuiteRecordsNothing() async throws {
+        try await withApp(app) { _ in
+            let (publicID, setupID) = try await makeAssignment()
+            let cookie = try await loginUser(
+                username: "vcap_read", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("vcap_read", on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/\(publicID)/suite",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in #expect(res.status == .ok) })
+
+            #expect(try await versions(setupID).isEmpty)
+        }
+    }
+
+    /// A rejected write leaves the baseline (seeded at the seam, before the
+    /// handler ran) but no edit version: the middleware gates on a 2xx
+    /// precisely so a failed edit never gets a row describing a state that was
+    /// never reached. Keeping the baseline is deliberate — it is the pre-edit
+    /// content, and it is what makes the NEXT successful edit recoverable.
+    @Test func aRejectedWriteRecordsNoEditVersion() async throws {
+        try await withApp(app) { _ in
+            let (publicID, setupID) = try await makeAssignment()
+            let cookie = try await loginUser(
+                username: "vcap_deny", password: "pw", role: "instructor", on: app)
+            try await promoteToInstructor("vcap_deny", on: app)
+            let (csrf, sessionCookie) = try await csrfFields(
+                for: "/instructor/\(publicID)/edit", cookie: cookie, on: app)
+
+            // Malformed: kind=script with no script payload.
+            try await app.asyncTest(
+                .PUT, "/instructor/\(publicID)/suite",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.headers.add(name: "x-csrf-token", value: csrf)
+                    req.headers.contentType = .json
+                    req.body = ByteBuffer(string: #"{"items":[{"kind":"script"}]}"#)
+                },
+                afterResponse: { res in #expect(res.status != .ok) })
+
+            let history = try await versions(setupID)
+            #expect(history.count == 1)
+            #expect(history.first?.origin == AssignmentVersionOrigin.baseline)
+        }
+    }
+
+    // MARK: - Scope
+
+    // MARK: - MCP capture
+
+    /// An MCP write tool is versioned by the seam it already uses to resolve
+    /// its setup — the tool itself does nothing. `finishContentWrites` is what
+    /// the dispatcher calls after a successful invoke.
+    @Test func mcpWriteToolRecordsBaselineThenTheEdit() async throws {
+        try await withApp(app) { _ in
+            let course = try await makeTestCourse(on: app, code: "VMCP", name: "MCP Capture")
+            let courseID = try course.requireID()
+            let tester = try await makeTestUser(on: app, username: "vmcp", role: "instructor")
+            try await makeTestEnrollment(on: app, userID: tester.requireID(), courseID: courseID)
+
+            let setupID = "vmcp_setup"
+            let manifest = """
+                {"schemaVersion":1,"testSuites":[\
+                {"tier":"public","script":"test_a.sh","points":1}\
+                ],"timeLimitSeconds":10}
+                """
+            try await makeTestSetup(on: app, id: setupID, courseID: courseID, manifest: manifest)
+            try writeZip(
+                at: app.testSetupsDirectory + setupID + ".zip",
+                entries: [(".placeholder", "x"), ("test_a.sh", "exit 0\n")])
+            let assignment = try await makeTestAssignment(
+                on: app, testSetupID: setupID, courseID: courseID, title: "MCP Lab")
+
+            let context = ToolContext(
+                request: Request(application: app, on: app.eventLoopGroup.any()),
+                subject: "vmcp",
+                grantedScopes: [.read, .write])
+
+            _ = try await SetTimeLimitTool().execute(
+                SetTimeLimitTool.Input(
+                    assignmentPublicID: assignment.publicID, seconds: 45),
+                context)
+            await context.finishContentWrites(tool: "set_time_limit")
+
+            let history = try await versions(setupID)
+            #expect(history.count == 2)
+            #expect(history.first?.origin == AssignmentVersionOrigin.baseline)
+            let edit = try #require(history.last)
+            #expect(edit.origin == "mcp:set_time_limit")
+            #expect(edit.actorUsername == "vmcp")
+            #expect(edit.manifest.contains("45"))
+        }
+    }
+
+    /// The scope is drained once recorded, so a second call in the same request
+    /// can't re-snapshot the first call's setups.
+    @Test func drainingLeavesNothingForASecondCall() async throws {
+        try await withApp(app) { _ in
+            let (_, setupID) = try await makeAssignment()
+            let setup = try #require(try await APITestSetup.find(setupID, on: app.db))
+            let scope = MCPVersionCaptureScope()
+
+            scope.register(setup)
+            #expect(scope.drain().count == 1)
+            #expect(scope.drain().isEmpty)
+        }
+    }
+}
+
+/// Guard for the web capture wiring itself.
+///
+/// A struct suite deliberately — it owns no Vapor app, so it can assert against
+/// the production bootstrap without the class-suite `withApp` shutdown dance.
+@Suite struct AssignmentVersionCaptureWiringTests {
+
+    /// Capture rides the middleware chain the production bootstrap builds. The
+    /// test app registers it explicitly (see `makeTestApp`), so nothing else
+    /// would notice if the production registration were dropped — and dropped,
+    /// it means a silent history hole for every browser edit.
+    @Test func productionBootstrapRegistersTheCaptureMiddleware() throws {
+        var url = URL(fileURLWithPath: #filePath)  // .../Tests/APITests/<thisFile>
+        for _ in 0..<3 { url.deleteLastPathComponent() }  // -> repo root
+        let source = try String(
+            contentsOf: url.appendingPathComponent(
+                "Sources/APIServer/Bootstrap/AppMiddleware.swift"),
+            encoding: .utf8)
+        #expect(source.contains("AssignmentVersionCaptureMiddleware()"))
+    }
+
+    /// The web write seam must seed the baseline before a handler mutates
+    /// anything — after the fact the pre-edit content is already gone.
+    @Test func theWebWriteSeamSeedsTheBaseline() throws {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<3 { url.deleteLastPathComponent() }
+        let source = try String(
+            contentsOf: url.appendingPathComponent(
+                "Sources/APIServer/Routes/Web/SuiteEditHelpers.swift"),
+            encoding: .utf8)
+        let seam = try #require(
+            source.components(separatedBy: "func loadAssignmentAndSetupForWrite").last)
+        #expect(
+            seam.prefix(900).contains("beginAssignmentContentEdit("),
+            "loadAssignmentAndSetupForWrite no longer seeds a version baseline — every instructor write route's history depends on it."
+        )
+    }
+}

--- a/Tests/APITests/MCP/MCPVersionCaptureCoverageTests.swift
+++ b/Tests/APITests/MCP/MCPVersionCaptureCoverageTests.swift
@@ -1,0 +1,131 @@
+// Architectural guard for content-version capture on the MCP write tools
+// (docs/assignment-versioning.md).
+//
+// A `content:write` tool that changes an assignment's content must produce a
+// version, or the history has a hole — and a hole is worse than no history,
+// because a later restore would silently discard whatever the unrecorded edit
+// did.
+//
+// Capture hangs off `ToolContext.authorizedAssignmentAndSetupForWrite`, so a
+// tool that resolves its setup the normal way is versioned automatically. This
+// test exists for the tools that DON'T: each must either register by hand
+// (`beginContentWrite`) or be listed here as touching no assignment content,
+// with a reason. Same source-scan shape as `MCPContentEditCoverageTests`, and
+// the same intent — the classification is written down exactly once, and a new
+// write tool that slips through is a build failure with instructions.
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct MCPVersionCaptureCoverageTests {
+    private static var toolsDirectory: URL {
+        var url = URL(fileURLWithPath: #filePath)  // .../Tests/APITests/MCP/<thisFile>
+        for _ in 0..<4 { url.deleteLastPathComponent() }  // -> repo root
+        return url.appendingPathComponent("Sources/APIServer/MCP/Tools")
+    }
+
+    /// Write tools that own no assignment content, so there is nothing to
+    /// snapshot. Adding a file here is a policy decision — say why:
+    private static let noAssignmentContentToolFiles: Set<String> = [
+        // Creates a brand-new assignment. Its first version is seeded by the
+        // creation path itself, not by an edit capture.
+        "CreateAssignmentTool.swift",
+        "CloneAssignmentTool.swift",
+        // Assignment metadata only (title / due date / visibility). None of it
+        // is content: a restore deliberately does not put these back, so
+        // versioning them would record state a restore can't act on.
+        "UpdateAssignmentTool.swift",
+        // Course-section organization and assignment ordering: dashboard
+        // structure, stored on the course/assignment rows, not in any manifest.
+        "CourseSectionTools.swift",
+        "AssignmentOrderingTools.swift",
+        // Ungraded course content items (reference material). They own no test
+        // setup at all.
+        "CourseContentItemTools.swift",
+    ]
+
+    /// Write tools that reach their setup without the standard seam and so
+    /// register for capture by hand.
+    private static let handRegisteredToolFiles: Set<String> = [
+        // Resolves the assignment, then writes solution.ipynb into the setup
+        // zip by id — it never loads the setup through the write seam.
+        "UpdateSolutionTool.swift"
+    ]
+
+    @Test func everyWriteToolIsClassifiedForVersionCapture() throws {
+        let files = try FileManager.default
+            .contentsOfDirectory(at: Self.toolsDirectory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "swift" }
+        #expect(!files.isEmpty)
+
+        var sawAWriteTool = false
+        for file in files {
+            let name = file.lastPathComponent
+            let source = try String(contentsOf: file, encoding: .utf8)
+            guard source.contains(": ContentTool") else { continue }
+            // Matched on the requiredScopes declaration rather than a bare
+            // ".write", which a read tool may mention in other code.
+            let declaresWriteScope =
+                source
+                .components(separatedBy: "requiredScopes")
+                .dropFirst()
+                .contains { $0.prefix(80).contains(".write") }
+            guard declaresWriteScope else { continue }
+            sawAWriteTool = true
+
+            let usesWriteSeam = source.contains("authorizedAssignmentAndSetupForWrite(")
+            let registersByHand = source.contains("beginContentWrite(")
+
+            if Self.handRegisteredToolFiles.contains(name) {
+                #expect(
+                    registersByHand,
+                    "\(name) is classified as hand-registering for version capture but never calls beginContentWrite — its content edits would go unrecorded."
+                )
+                continue
+            }
+
+            if usesWriteSeam || registersByHand { continue }
+
+            #expect(
+                Self.noAssignmentContentToolFiles.contains(name),
+                """
+                \(name) is a content:write tool that neither resolves its setup through \
+                authorizedAssignmentAndSetupForWrite nor calls beginContentWrite, and is \
+                not classified as owning no assignment content. Decide: if it changes \
+                manifest / setup-zip / notebook content, route it through the write seam \
+                (or call beginContentWrite before mutating); otherwise add it to \
+                noAssignmentContentToolFiles with a one-line justification.
+                """)
+        }
+        #expect(sawAWriteTool)
+    }
+
+    /// The seam only works if it actually seeds the baseline and registers the
+    /// setup. Pinned directly, because every tool's coverage above is inferred
+    /// from the mere presence of the call.
+    @Test func theWriteSeamRegistersForCapture() throws {
+        let contextSource = try String(
+            contentsOf: Self.toolsDirectory.appendingPathComponent("ToolContext.swift"),
+            encoding: .utf8)
+        let seam = try #require(
+            contextSource.components(separatedBy: "func authorizedAssignmentAndSetupForWrite").last)
+        #expect(
+            seam.prefix(900).contains("beginContentWrite("),
+            "authorizedAssignmentAndSetupForWrite no longer registers for version capture — every write tool's history depends on it."
+        )
+    }
+
+    /// Capture must run on the owner pool: `assignment_versions` is
+    /// deliberately not granted to the least-privilege `chickadee_mcp` role,
+    /// so writing it through `context.db` would fail with permission denied on
+    /// any deployment that configures the dedicated pool.
+    @Test func captureWritesOnTheOwnerPool() throws {
+        let source = try String(
+            contentsOf: Self.toolsDirectory.appendingPathComponent("MCPVersionCapture.swift"),
+            encoding: .utf8)
+        #expect(source.contains("on: mainDB"))
+        #expect(!source.contains("on: db)"))
+    }
+}

--- a/Tests/APITests/TestHelpers.swift
+++ b/Tests/APITests/TestHelpers.swift
@@ -333,6 +333,15 @@ func makeTestApp(
 
         try await configureTestDatabase(app)
 
+        // Assignment content-version capture. Registered here rather than
+        // inherited from `bootstrapAppMiddleware` (which the test app does not
+        // run) because versioning is part of what the instructor write routes
+        // DO, not an ambient production-only concern — a test app that skips it
+        // would let a capture regression pass CI unnoticed.
+        // `AssignmentVersionCaptureWiringTests` pins the production
+        // registration separately.
+        app.middleware.use(AssignmentVersionCaptureMiddleware())
+
         configureLeaf(app)
         try routes(app)
     }

--- a/changelog.d/assignment-versioning-capture.md
+++ b/changelog.d/assignment-versioning-capture.md
@@ -1,0 +1,11 @@
+### Added
+
+- **Assignment versioning — content edits are now captured (slice 2).** Every
+  assignment content edit, whether made in the browser or through an MCP write
+  tool, records an immutable version: the pre-edit state is seeded as a baseline
+  the first time a setup is touched, and the post-edit state is snapshotted once
+  the request succeeds. Capture hangs off the write seams both surfaces already
+  use (`loadAssignmentAndSetupForWrite` and
+  `authorizedAssignmentAndSetupForWrite`), so a tool or route is versioned
+  without wiring anything, and edits that changed nothing write no row. History
+  is not yet readable or restorable — those are the next slices.


### PR DESCRIPTION
Wires slice 1's snapshot store into the two surfaces that change assignment content, so history starts accumulating. Reading and restoring it are slices 3 and 4. Follows #1223; design in `docs/assignment-versioning.md`.

## Capture rides the existing write seams

Rather than sprinkling two bookkeeping calls across ~30 handlers and tools, capture hangs off the seam each surface already goes through:

- **MCP** — `authorizedAssignmentAndSetupForWrite` seeds the pre-edit baseline and registers the setup; `MCPDispatcher` snapshots what was registered after a successful invoke. A new write tool that resolves its setup the normal way is versioned without its author doing anything.
- **Web** — `loadAssignmentAndSetupForWrite` does the same seeding, and `AssignmentVersionCaptureMiddleware` snapshots on a 2xx.

Baselines are seeded from the seam, i.e. *before* the handler mutates anything — after the fact the pre-edit content is already gone, and that first state is exactly what a first-ever edit needs to be recoverable.

## Decisions worth a reviewer's eye

**Version rows are written on the owner pool, never the least-privilege `.mcp` pool.** `assignment_versions` is deliberately not granted to the `chickadee_mcp` role (`deploy/sql/mcp-least-privilege-role.sql` grants nothing by default and denies by omission), so writing it through `context.db` would fail with permission denied on any deployment that configures the dedicated pool — while passing every test here, since tests run a single pool. Same routing the personalization-seed write and the content-edit regrade already use. A guard test pins it.

**Web saves are versioned even though only MCP will read the history.** A browser-shaped hole would be worse than no history at all: a later restore would silently discard whatever the unrecorded edit did.

**`UpdateSolutionTool` registers by hand.** It reaches its setup by id rather than through the write seam, and replacing the reference solution rewrites `solution.ipynb` inside the setup zip — versioned content. `MCPVersionCaptureCoverageTests` makes every `content:write` tool declare which of the two it is, or state out loud that it owns no assignment content, so a future tool that slips through is a build failure with instructions.

**A rejected write keeps its baseline but records no edit version.** The middleware gates on a 2xx so a failed edit never gets a row describing a state that was never reached; the baseline stays because it is genuine pre-edit content and is what makes the next successful edit recoverable.

## A wiring gap the tests caught

The capture middleware initially lived only in `bootstrapAppMiddleware`, which `makeTestApp` doesn't call — so the web capture path was entirely untested and the first integration test recorded only baselines. `makeTestApp` now registers it, and separate source-scan guards pin the production registration and both write seams, since a dropped registration is otherwise completely silent.

## Testing

11 new tests: baseline-then-edit over a real `PUT /instructor/:id/suite` and a real MCP tool call, the baseline holding pre-edit content, reads and rejected writes recording no edit version, scope draining, plus the three wiring guards. Existing `SuiteRouteTests` and `MCPContentEditCoverageTests` still pass. `scripts/format.sh`, `scripts/lint.sh`, and `scripts/swiftlint.sh --strict` clean (0 violations in 873 files).

## Remaining slices

3. Read tools — `list_assignment_versions`, `get_assignment_version`
4. Restore — `restore_assignment_version`
5. Lifecycle — creation-path `v1` seeding, purge + blob GC, disk-usage reporting

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9dPYxJMzJSSmYLTNEfY6f)_