### PR TITLE
Course activity timeline + assignment lifecycle audit (closes #421)

### DIFF
--- a/Resources/Views/assignments.leaf
+++ b/Resources/Views/assignments.leaf
@@ -5,6 +5,7 @@
 #export("content"):
 <nav class="instructor-tabs" aria-label="Instructor sections">
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/activity"#if(activeInstructorTab == "activity"): aria-current="page"#endif>Activity</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>

--- a/Resources/Views/instructor-activity.leaf
+++ b/Resources/Views/instructor-activity.leaf
@@ -1,0 +1,119 @@
+#extend("base"):
+#export("title"):
+Activity
+#endexport
+#export("content"):
+<nav class="instructor-tabs" aria-label="Instructor sections">
+    <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/activity"#if(activeInstructorTab == "activity"): aria-current="page"#endif>Activity</a>
+    <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
+    <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
+    <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>
+</nav>
+
+#if(!hasActiveCourse):
+<section class="section-block">
+    <p class="empty">Select a course to see its activity.</p>
+</section>
+#else:
+
+<section class="section-block">
+    <div class="section-header">
+        <h2>Recent activity</h2>
+    </div>
+    <p class="activity-intro">
+        Content edits and course events for this course, newest first. Every
+        content edit is a recoverable version of the assignment it names.
+    </p>
+
+    <form class="activity-filter" method="get" action="/instructor/activity">
+        <label class="activity-filter-label" for="activity-actor">Filter by person</label>
+        <input class="filter-input" id="activity-actor" type="text" name="actor"
+               value="#(filterActor)" placeholder="username" autocomplete="off">
+        <button type="submit" class="btn">Filter</button>
+        #if(filtered):
+        <a href="/instructor/activity" class="btn">Clear</a>
+        #endif
+    </form>
+
+    #if(hasRows):
+    <div class="table-scroll">
+        <table class="results-table">
+            <thead>
+                <tr>
+                    <th scope="col" class="activity-col-when">When</th>
+                    <th scope="col" class="activity-col-who">Who</th>
+                    <th scope="col">What</th>
+                    <th scope="col" class="activity-col-where">Where</th>
+                    <th scope="col">Details</th>
+                </tr>
+            </thead>
+            <tbody>
+                #for(row in rows):
+                <tr>
+                    <td>#(row.timestamp)</td>
+                    <td>#(row.actor)</td>
+                    <td>
+                        <span class="activity-category">#(row.category)</span>
+                        <span class="activity-summary">#(row.summary)</span>
+                    </td>
+                    <td>
+                        #if(row.link):
+                        <a href="#(row.link)">#(row.target)</a>
+                        #else:
+                        #(row.target)
+                        #endif
+                    </td>
+                    <td class="activity-detail">#(row.detail)</td>
+                </tr>
+                #endfor
+            </tbody>
+        </table>
+    </div>
+    #else:
+    <p class="empty">
+        #if(filtered):
+        No activity matches that person.
+        #else:
+        No recorded activity for this course yet.
+        #endif
+    </p>
+    #endif
+</section>
+
+#endif
+#endexport
+#endextend
+<style>
+.activity-intro {
+    color: var(--muted);
+    font-size: var(--text-sm);
+    margin-bottom: 1rem;
+}
+.activity-filter {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+.activity-filter-label {
+    font-size: var(--text-sm);
+    color: var(--muted);
+}
+.activity-col-when { width: 11rem; }
+.activity-col-who { width: 9rem; }
+.activity-col-where { width: 14rem; }
+.activity-category {
+    display: inline-block;
+    font-size: var(--text-xs);
+    color: var(--muted);
+    margin-right: .5rem;
+}
+.activity-summary { font-size: var(--text-base); }
+.activity-detail {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    word-break: break-word;
+}
+</style>

--- a/Resources/Views/instructor-brightspace.leaf
+++ b/Resources/Views/instructor-brightspace.leaf
@@ -5,6 +5,7 @@ LEARN
 #export("content"):
 <nav class="instructor-tabs" aria-label="Instructor sections">
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/activity"#if(activeInstructorTab == "activity"): aria-current="page"#endif>Activity</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>

--- a/Resources/Views/instructor-mcp.leaf
+++ b/Resources/Views/instructor-mcp.leaf
@@ -5,6 +5,7 @@ MCP
 #export("content"):
 <nav class="instructor-tabs" aria-label="Instructor sections">
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/activity"#if(activeInstructorTab == "activity"): aria-current="page"#endif>Activity</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>

--- a/Resources/Views/instructor-students.leaf
+++ b/Resources/Views/instructor-students.leaf
@@ -5,6 +5,7 @@ Students
 #export("content"):
 <nav class="instructor-tabs" aria-label="Instructor sections">
     <a class="instructor-tab" href="/instructor"#if(activeInstructorTab == "overview"): aria-current="page"#endif>Overview</a>
+    <a class="instructor-tab" href="/instructor/activity"#if(activeInstructorTab == "activity"): aria-current="page"#endif>Activity</a>
     <a class="instructor-tab" href="/instructor/students"#if(activeInstructorTab == "students"): aria-current="page"#endif>Students</a>
     <a class="instructor-tab" href="/instructor/brightspace"#if(activeInstructorTab == "brightspace"): aria-current="page"#endif>LEARN</a>
     <a class="instructor-tab" href="/instructor/mcp"#if(activeInstructorTab == "mcp"): aria-current="page"#endif>MCP</a>

--- a/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CloneAssignmentTool.swift
@@ -144,6 +144,13 @@ struct CloneAssignmentTool: ContentTool {
             }
         }
 
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentCloned, assignment: cloned.assignment,
+            metadata: [
+                "source_assignment": source.publicID, "title": cloned.assignment.title,
+                "via": "mcp",
+            ], on: context.request)
+
         let courseCode =
             try await APICourse.find(targetCourseID, on: context.db)?.code ?? ""
         return Output(

--- a/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/CreateAssignmentTool.swift
@@ -121,6 +121,10 @@ struct CreateAssignmentTool: ContentTool {
             throw MCPToolError.executionFailed(tool: Self.name, detail: "\(error)")
         }
 
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentCreated, assignment: created.assignment,
+            metadata: ["title": created.assignment.title, "via": "mcp"], on: context.request)
+
         return Output(
             publicID: created.assignment.publicID,
             title: created.assignment.title,

--- a/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateAssignmentTool.swift
@@ -154,6 +154,8 @@ struct UpdateAssignmentTool: ContentTool {
         // Title / due date / open state are lifecycle — instructor-level (#417).
         let assignment = try await context.authorizedAssignmentForWrite(
             publicID: input.assignmentPublicID, tool: Self.name, atLeast: .instructor)
+        let previousDueAt = assignment.dueAt
+        let previousVisibility = assignment.visibility
         do {
             // Title/date metadata first. The legacy `isOpen` is applied here only
             // when `visibility` was not given (visibility is the richer form and
@@ -172,7 +174,27 @@ struct UpdateAssignmentTool: ContentTool {
                 detail: "The assignment cannot be opened until its runner validation has passed.")
         }
 
+        // Lifecycle audit (#421): metadata changes are the events content
+        // versioning deliberately does not record, and an agent moving a
+        // deadline or reopening an assignment is exactly what a lead instructor
+        // wants to see in the course activity view.
         let formatter = ISO8601DateFormatter()
+        if previousDueAt != assignment.dueAt {
+            await AuditLogger.recordAssignmentLifecycle(
+                .assignmentDueDateChanged, assignment: assignment,
+                metadata: [
+                    "previous": previousDueAt.map(formatter.string(from:)) ?? "none",
+                    "current": assignment.dueAt.map(formatter.string(from:)) ?? "none",
+                    "via": "mcp",
+                ], on: context.request)
+        }
+        if previousVisibility != assignment.visibility {
+            await AuditLogger.recordAssignmentLifecycle(
+                .assignmentVisibilityChanged, assignment: assignment,
+                metadata: ["visibility": assignment.visibility.rawValue, "via": "mcp"],
+                on: context.request)
+        }
+
         return Output(
             publicID: assignment.publicID,
             title: assignment.title,

--- a/Sources/APIServer/Migrations/AddAuditLogCourseID.swift
+++ b/Sources/APIServer/Migrations/AddAuditLogCourseID.swift
@@ -1,0 +1,72 @@
+// APIServer/Migrations/AddAuditLogCourseID.swift
+//
+// First-class course scoping for audit events (#421).
+//
+// Course-scoped audit call sites have always stashed `course_id` inside the
+// `metadata` JSON blob. That works for a human reading one row, but it cannot
+// be indexed, cannot be filtered without a full scan, and is silently absent
+// wherever a call site forgot the key. The per-course activity view needs to
+// ask "every event for this course, newest first" on every page load, so the
+// scope becomes a real column.
+//
+// Nullable by design: most audit events (logins, user deletion, runner secret
+// rotation) belong to no course at all.
+//
+// The backfill reads the existing metadata so history predating the column
+// still shows up in the view. It runs in Swift rather than SQL because the
+// JSON accessor differs between Postgres (`metadata::json->>'course_id'`) and
+// SQLite (`json_extract`), and this migration must produce the same result on
+// both.
+
+import Fluent
+import Foundation
+import SQLKit
+
+struct AddAuditLogCourseID: ChickadeeMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("audit_log")
+            .field("course_id", .uuid)
+            .update()
+
+        if let sql = database as? SQLDatabase {
+            try await sql.raw(
+                "CREATE INDEX IF NOT EXISTS idx_audit_log_course_created ON audit_log(course_id, created_at DESC)"
+            ).run()
+        }
+
+        try await backfillFromMetadata(on: database)
+    }
+
+    func revert(on database: Database) async throws {
+        if let sql = database as? SQLDatabase {
+            try await sql.raw("DROP INDEX IF EXISTS idx_audit_log_course_created").run()
+        }
+        try await database.schema("audit_log")
+            .deleteField("course_id")
+            .update()
+    }
+
+    /// Copies `metadata.course_id` into the new column for existing rows.
+    ///
+    /// Best-effort: a row whose metadata is malformed or carries a non-UUID
+    /// course id is left with a nil scope rather than failing the migration.
+    /// An un-scoped historical row means one event missing from a course view;
+    /// a failed migration means the server does not start.
+    private func backfillFromMetadata(on database: Database) async throws {
+        let candidates = try await APIAuditLogEntry.query(on: database)
+            .filter(\.$metadata != nil)
+            .all()
+
+        for entry in candidates where entry.courseID == nil {
+            guard let metadata = entry.metadata,
+                metadata.contains("course_id"),
+                let data = metadata.data(using: .utf8),
+                let decoded = try? JSONDecoder().decode([String: String].self, from: data),
+                let raw = decoded["course_id"],
+                let courseID = UUID(uuidString: raw)
+            else { continue }
+            entry.courseID = courseID
+            try await entry.save(on: database)
+        }
+    }
+}

--- a/Sources/APIServer/Models/APIAuditLogEntry.swift
+++ b/Sources/APIServer/Models/APIAuditLogEntry.swift
@@ -54,6 +54,17 @@ final class APIAuditLogEntry: Model, Content, @unchecked Sendable {
     @OptionalField(key: "metadata")
     var metadata: String?
 
+    /// The course this event belongs to, when it has one.
+    ///
+    /// Course scoping used to live only inside the `metadata` JSON, which is
+    /// unindexable and silently absent wherever a call site forgot the key.
+    /// This is the indexed, first-class form the per-course activity view
+    /// (#421) filters on; `CreateAuditLog` backfills it from the existing
+    /// metadata. Nil for deployment-wide events (logins, runner secret
+    /// rotation, user deletion).
+    @OptionalField(key: "course_id")
+    var courseID: UUID?
+
     @Timestamp(key: "created_at", on: .create)
     var createdAt: Date?
 
@@ -68,7 +79,8 @@ final class APIAuditLogEntry: Model, Content, @unchecked Sendable {
         targetID: String? = nil,
         remoteAddr: String? = nil,
         userAgent: String? = nil,
-        metadata: String? = nil
+        metadata: String? = nil,
+        courseID: UUID? = nil
     ) {
         self.id = id
         self.actorUserID = actorUserID
@@ -79,6 +91,7 @@ final class APIAuditLogEntry: Model, Content, @unchecked Sendable {
         self.remoteAddr = remoteAddr
         self.userAgent = userAgent
         self.metadata = metadata
+        self.courseID = courseID
     }
 }
 
@@ -116,6 +129,17 @@ enum AuditAction: String, Sendable, CaseIterable {
     case enrollmentBulkAdded = "enrollment.bulk_added"
     case enrollmentRemoved = "enrollment.removed"
     case enrollmentRoleChanged = "enrollment.role_changed"
+
+    // Assignment lifecycle (#421). Content edits are recorded separately and in
+    // far more detail by `assignment_versions`; these are the metadata and
+    // existence changes versioning deliberately does NOT cover — a restore
+    // never touches them, and a deleted assignment leaves no version row to
+    // read.
+    case assignmentCreated = "assignment.created"
+    case assignmentCloned = "assignment.cloned"
+    case assignmentDeleted = "assignment.deleted"
+    case assignmentVisibilityChanged = "assignment.visibility_changed"
+    case assignmentDueDateChanged = "assignment.due_date_changed"
 
     // Submissions
     case submissionsPurged = "submission.retention_purged"
@@ -179,6 +203,9 @@ enum AuditAction: String, Sendable, CaseIterable {
             return .courses
         case .enrollmentBulkAdded, .enrollmentRemoved, .enrollmentRoleChanged:
             return .enrollment
+        case .assignmentCreated, .assignmentCloned, .assignmentDeleted,
+            .assignmentVisibilityChanged, .assignmentDueDateChanged:
+            return .assignments
         case .submissionsPurged, .submissionRetestAll, .submissionRetestForStudent:
             return .submissions
         case .extensionGranted, .extensionRevoked, .gradeOverrideSet, .gradeOverrideCleared,
@@ -224,6 +251,11 @@ enum AuditAction: String, Sendable, CaseIterable {
         case .enrollmentBulkAdded: return "Bulk enrollment"
         case .enrollmentRemoved: return "Unenrolled"
         case .enrollmentRoleChanged: return "Per-course role changed"
+        case .assignmentCreated: return "Assignment created"
+        case .assignmentCloned: return "Assignment cloned"
+        case .assignmentDeleted: return "Assignment deleted"
+        case .assignmentVisibilityChanged: return "Assignment visibility changed"
+        case .assignmentDueDateChanged: return "Assignment due date changed"
         case .submissionsPurged: return "Submissions purged"
         case .submissionRetestAll: return "Retest all submissions"
         case .submissionRetestForStudent: return "Retest student submissions"
@@ -271,6 +303,7 @@ enum AuditCategory: String, Sendable, CaseIterable {
     case users = "Users & roles"
     case courses = "Courses"
     case enrollment = "Enrollment"
+    case assignments = "Assignments"
     case submissions = "Submissions"
     case grading = "Grading"
     case runner = "Runner"

--- a/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
+++ b/Sources/APIServer/Routes/Web/DraftAssignmentRoutes+NewAssignment.swift
@@ -589,6 +589,9 @@ extension DraftAssignmentRoutes {
             )
             try await requirement.save(on: req.db)
         }
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentCreated, assignment: assignment,
+            metadata: ["title": assignment.title, "source": "new_assignment"], on: req)
         return assignment
     }
 
@@ -748,6 +751,9 @@ extension DraftAssignmentRoutes {
                 courseID: courseID, sectionID: nil, db: req.db),
             courseID: courseID
         )
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentCreated, assignment: assignment,
+            metadata: ["title": assignment.title, "source": "quick_publish"], on: req)
         // Open the editor to finalize the draft (notebook, solution, suite);
         // saving there validates automatically. (Validation is always tied to
         // a save — there is no separate validate step.)

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Activity.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes+Activity.swift
@@ -1,0 +1,81 @@
+// APIServer/Routes/Web/InstructorDashboardRoutes+Activity.swift
+//
+// GET /instructor/activity — the merged course activity timeline (#421).
+//
+// Visible to all course staff, not just the lead instructor. The `/instructor`
+// group is already gated by `ActiveCourseStaffMiddleware` (TA+ in the ACTIVE
+// course), which is exactly the audience and scope this page wants: a TA sees
+// the course they are staff on, and nothing else. Transparency is the right
+// default here — a shared record of who changed what beats a surveillance tool
+// only the lead can read.
+//
+// Read-only, and scoped to the active course by construction: every query
+// filters on the resolved course id, so there is no way to page into another
+// course's history from this route.
+
+import Fluent
+import Foundation
+import Vapor
+
+extension InstructorDashboardRoutes {
+
+    @Sendable
+    func activityPage(req: Request) async throws -> View {
+        let user = try req.auth.require(APIUser.self)
+        let courseState = try await req.resolveActiveCourse(for: user)
+        let userContext = CurrentUserContext(
+            user: user,
+            activeCourse: courseState.active,
+            enrolledCourses: courseState.all
+        )
+
+        struct ActivityQuery: Content {
+            var actor: String?
+        }
+        let filter = (try? req.query.decode(ActivityQuery.self)) ?? ActivityQuery()
+        let trimmedActor = filter.actor?.trimmingCharacters(in: .whitespaces) ?? ""
+        let actorFilter = trimmedActor.isEmpty ? nil : trimmedActor
+
+        guard let courseID = courseState.activeCourseUUID else {
+            // No active course: render the empty state rather than 404ing, so
+            // the tab behaves like the other instructor tabs.
+            return try await req.view.render(
+                "instructor-activity",
+                InstructorActivityContext(
+                    currentUser: userContext,
+                    activeInstructorTab: "activity",
+                    rows: [],
+                    hasRows: false,
+                    hasActiveCourse: false,
+                    filterActor: trimmedActor,
+                    filtered: actorFilter != nil))
+        }
+
+        let rows = try await CourseActivityService.timeline(
+            courseID: courseID, actorFilter: actorFilter, on: req.db)
+
+        return try await req.view.render(
+            "instructor-activity",
+            InstructorActivityContext(
+                currentUser: userContext,
+                activeInstructorTab: "activity",
+                rows: rows,
+                hasRows: !rows.isEmpty,
+                hasActiveCourse: true,
+                filterActor: trimmedActor,
+                filtered: actorFilter != nil))
+    }
+}
+
+/// Activity tab (`GET /instructor/activity`): the merged content-edit +
+/// course-event timeline for the active course.
+struct InstructorActivityContext: Encodable {
+    let currentUser: CurrentUserContext?
+    let activeInstructorTab: String
+    let rows: [CourseActivityRow]
+    /// Explicit flag — Leaf's `array.isEmpty` is unreliable in this codebase.
+    let hasRows: Bool
+    let hasActiveCourse: Bool
+    let filterActor: String
+    let filtered: Bool
+}

--- a/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
+++ b/Sources/APIServer/Routes/Web/InstructorDashboardRoutes.swift
@@ -37,6 +37,7 @@ struct InstructorDashboardRoutes: RouteCollection {
         // JSON sparkline series for the dashboard diagnostic cards.
         r.get("metrics", "cards", use: metricsCards)
         // Students roster tab + its self-updating poll endpoint.
+        r.get("activity", use: activityPage)
         r.get("students", use: studentsPage)
         r.get("students-data", use: studentsData)
         // Reconcile the roster against the LEARN classlist (flags dropped students).
@@ -364,6 +365,9 @@ struct InstructorDashboardRoutes: RouteCollection {
                 reason: "Assignment cannot be opened until runner validation passes."
             )
         }
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentVisibilityChanged, assignment: assignment,
+            metadata: ["visibility": visibility.rawValue], on: req)
         return req.redirect(to: "/instructor")
     }
 
@@ -373,6 +377,9 @@ struct InstructorDashboardRoutes: RouteCollection {
     func closeAssignment(req: Request) async throws -> Response {
         let assignment = try await loadAssignmentForWrite(req, atLeast: .instructor)
         try await AssignmentAuthoringService.setOpenState(assignment, open: false, on: req.db)
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentVisibilityChanged, assignment: assignment,
+            metadata: ["visibility": AssignmentVisibility.closed.rawValue], on: req)
         return req.redirect(to: "/instructor")
     }
 
@@ -401,6 +408,10 @@ struct InstructorDashboardRoutes: RouteCollection {
             targetCourseID: source.courseID,
             setupsDirectory: req.application.testSetupsDirectory,
             on: req.db)
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentCloned, assignment: cloned.assignment,
+            metadata: ["source_assignment": source.publicID, "title": cloned.assignment.title],
+            on: req)
         let notice = "Cloned from \(source.title). Set a due date and re-validate, then open."
         return req.redirect(to: "/instructor/\(cloned.assignment.publicID)/edit?notice=\(urlEncode(notice))")
     }
@@ -506,6 +517,15 @@ struct InstructorDashboardRoutes: RouteCollection {
             try await setup.delete(on: req.db)
         }
 
+        // Recorded BEFORE the row goes: after the delete there is no assignment
+        // to attribute the event to, and no version row survives either — this
+        // is the only trace that the assignment ever existed.
+        await AuditLogger.recordAssignmentLifecycle(
+            .assignmentDeleted, assignment: assignment,
+            metadata: [
+                "title": assignment.title,
+                "submissions_deleted": String(submissionIDs.count),
+            ], on: req)
         try await assignment.delete(on: req.db)
         return req.redirect(to: "/instructor")
     }

--- a/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
+++ b/Sources/APIServer/Routes/Web/PublishedAssignmentRoutes+SaveEdit.swift
@@ -89,6 +89,7 @@ extension PublishedAssignmentRoutes {
             assignmentTestSetupID: assignment.testSetupID
         )
 
+        let previousDueAt = assignment.dueAt
         assignment.title = title
         assignment.dueAt = due
         assignment.startsAt = starts
@@ -103,6 +104,18 @@ extension PublishedAssignmentRoutes {
         // Editing returns the assignment to closed (re-validation gates the
         // re-open / re-preview), matching the close-on-save contract.
         assignment.visibility = .closed
+
+        // Only when it actually moved: the Save button posts the whole form on
+        // every content edit, so auditing unconditionally would bury the real
+        // deadline changes under one row per save.
+        if previousDueAt != due {
+            await AuditLogger.recordAssignmentLifecycle(
+                .assignmentDueDateChanged, assignment: assignment,
+                metadata: [
+                    "previous": previousDueAt.map(ISO8601DateFormatter().string(from:)) ?? "none",
+                    "current": due.map(ISO8601DateFormatter().string(from:)) ?? "none",
+                ], on: req)
+        }
 
         return try await enqueueValidationForEditedAssignment(
             req: req,

--- a/Sources/APIServer/Services/AuditLogger.swift
+++ b/Sources/APIServer/Services/AuditLogger.swift
@@ -25,11 +25,13 @@ enum AuditLogger {
         metadata: [String: String]? = nil,
         actorOverride: APIUser? = nil,
         actorUsernameOverride: String? = nil,
+        courseID: UUID? = nil,
         on req: Request
     ) async {
         _ = await recordReturning(
             action: action, targetType: targetType, targetID: targetID, metadata: metadata,
-            actorOverride: actorOverride, actorUsernameOverride: actorUsernameOverride, on: req)
+            actorOverride: actorOverride, actorUsernameOverride: actorUsernameOverride,
+            courseID: courseID, on: req)
     }
 
     /// Like `record`, but returns the persisted entry — or nil when the write
@@ -43,6 +45,7 @@ enum AuditLogger {
         metadata: [String: String]? = nil,
         actorOverride: APIUser? = nil,
         actorUsernameOverride: String? = nil,
+        courseID: UUID? = nil,
         on req: Request
     ) async -> APIAuditLogEntry? {
         let actor = actorOverride ?? req.auth.get(APIUser.self)
@@ -56,7 +59,13 @@ enum AuditLogger {
             targetID: targetID,
             remoteAddr: clientIPAddress(from: req, trustForwardedFor: trust),
             userAgent: req.headers.first(name: "User-Agent"),
-            metadata: metadata.flatMap(encodeMetadata)
+            metadata: metadata.flatMap(encodeMetadata),
+            // Fall back to the metadata key every course-scoped call site has
+            // always set. That is what makes the existing enrollment/staff
+            // events show up in a course's activity view without touching any
+            // of their call sites — and it means a new site that sets only the
+            // metadata key still lands scoped rather than orphaned.
+            courseID: courseID ?? metadata.flatMap { $0["course_id"] }.flatMap(UUID.init(uuidString:))
         )
         do {
             try await entry.save(on: req.db)
@@ -95,5 +104,37 @@ enum AuditLogger {
     private static func decodeMetadata(_ json: String) -> [String: String]? {
         guard let data = json.data(using: .utf8) else { return nil }
         return (try? JSONSerialization.jsonObject(with: data)) as? [String: String]
+    }
+}
+
+// MARK: - Assignment lifecycle
+
+extension AuditLogger {
+    /// Records an assignment lifecycle event (#421), course-scoped.
+    ///
+    /// Content edits are recorded far more richly by `assignment_versions`;
+    /// these are the events versioning deliberately does not cover — creation,
+    /// deletion, cloning, and the metadata (visibility, due date) a restore
+    /// never touches. Deletion in particular leaves no version row behind to
+    /// read, so the audit row is the only record that the assignment existed.
+    ///
+    /// Always sets `courseID` so the event reaches the course activity view;
+    /// forgetting it is the failure mode the column exists to prevent.
+    static func recordAssignmentLifecycle(
+        _ action: AuditAction,
+        assignment: APIAssignment,
+        metadata: [String: String] = [:],
+        on req: Request
+    ) async {
+        var merged = metadata
+        merged["assignment"] = assignment.publicID
+        merged["course_id"] = assignment.courseID.uuidString
+        await record(
+            action: action,
+            targetType: .assignment,
+            targetID: assignment.id?.uuidString,
+            metadata: merged,
+            courseID: assignment.courseID,
+            on: req)
     }
 }

--- a/Sources/APIServer/Services/CourseActivityService.swift
+++ b/Sources/APIServer/Services/CourseActivityService.swift
@@ -1,0 +1,216 @@
+// APIServer/Services/CourseActivityService.swift
+//
+// The merged course activity timeline (#421): who changed what in this course,
+// and when.
+//
+// Two records feed it, because two different things happened and neither alone
+// answers the question a lead instructor is actually asking:
+//
+//   - `assignment_versions` — every content edit, from the browser or an agent,
+//     with the actor and what produced it. Rich, but content-only by design.
+//   - `audit_log` — the events content versioning deliberately does not cover:
+//     staff added/removed/re-roled, and the assignment lifecycle (created,
+//     cloned, deleted, visibility, due date). Deletion in particular leaves no
+//     version row behind, so this is the only trace it ever existed.
+//
+// They are merged rather than shown side by side because the question is
+// chronological — "what happened to this course last Tuesday" — and two lists
+// would leave the reader correlating timestamps by eye.
+
+import Fluent
+import Foundation
+import Vapor
+
+/// One row of the timeline, already formatted for display.
+struct CourseActivityRow: Encodable, Sendable {
+    let timestamp: String
+    let actor: String
+    /// Coarse grouping shown as a chip: "Content edit" or the audit category.
+    let category: String
+    /// What happened, in one line.
+    let summary: String
+    /// What it happened to (assignment title, or a person for staff events).
+    let target: String
+    /// Extra context — the version number, the origin, the changed value.
+    let detail: String
+    /// Where to go to see it, when there is somewhere sensible.
+    let link: String?
+}
+
+enum CourseActivityService {
+
+    /// How many events one page of the timeline shows. Deliberately modest: the
+    /// view answers "what changed recently", and an agent authoring session can
+    /// produce hundreds of content versions in an afternoon.
+    static let defaultLimit = 100
+
+    /// Builds the merged timeline for `courseID`, newest first.
+    ///
+    /// `actorFilter` matches an actor username substring; nil shows everyone.
+    static func timeline(
+        courseID: UUID,
+        actorFilter: String? = nil,
+        limit: Int = defaultLimit,
+        on db: any Database
+    ) async throws -> [CourseActivityRow] {
+        // Over-fetch each source by the page size: after the merge only the
+        // newest `limit` survive, and either source could supply all of them.
+        async let versionsFetch = contentEdits(
+            courseID: courseID, actorFilter: actorFilter, limit: limit, on: db)
+        async let eventsFetch = courseEvents(
+            courseID: courseID, actorFilter: actorFilter, limit: limit, on: db)
+
+        let (versions, events) = try await (versionsFetch, eventsFetch)
+        let merged = (versions + events)
+            .sorted { $0.sortKey > $1.sortKey }
+            .prefix(limit)
+
+        let formatter = waterlooDateTimeFormatter()
+        return merged.map { entry in
+            CourseActivityRow(
+                timestamp: formatter.string(from: entry.sortKey),
+                actor: entry.actor,
+                category: entry.category,
+                summary: entry.summary,
+                target: entry.target,
+                detail: entry.detail,
+                link: entry.link)
+        }
+    }
+
+    /// A row before formatting, carrying the real `Date` so the two sources can
+    /// be merged on one comparable key.
+    private struct Entry {
+        let sortKey: Date
+        let actor: String
+        let category: String
+        let summary: String
+        let target: String
+        let detail: String
+        let link: String?
+    }
+
+    // MARK: - Content edits
+
+    private static func contentEdits(
+        courseID: UUID, actorFilter: String?, limit: Int, on db: any Database
+    ) async throws -> [Entry] {
+        var query = APIAssignmentVersion.query(on: db)
+            .filter(\.$courseID == courseID)
+        if let actorFilter {
+            query = query.filter(\.$actorUsername ~~ actorFilter)
+        }
+        let versions =
+            try await query
+            .sort(\.$createdAt, .descending)
+            .limit(limit)
+            .all()
+        guard !versions.isEmpty else { return [] }
+
+        // Resolve titles in one query rather than per row.
+        let assignmentIDs = Set(versions.compactMap(\.assignmentID))
+        let assignments = try await APIAssignment.query(on: db)
+            .filter(\.$id ~~ Array(assignmentIDs))
+            .all()
+        var titleByID: [UUID: (title: String, publicID: String)] = [:]
+        for assignment in assignments where assignment.id != nil {
+            titleByID[assignment.id ?? UUID()] = (assignment.title, assignment.publicID)
+        }
+
+        return versions.compactMap { version in
+            guard let createdAt = version.createdAt else { return nil }
+            let assignment = version.assignmentID.flatMap { titleByID[$0] }
+            return Entry(
+                sortKey: createdAt,
+                // A baseline or a clone seed has no human behind it — say so
+                // rather than showing an empty column.
+                actor: version.actorUsername ?? "system",
+                category: "Content edit",
+                summary: summaryForVersion(version),
+                target: assignment?.title ?? "(deleted assignment)",
+                detail: "v\(version.versionNumber) · \(version.origin)",
+                link: assignment.map { "/instructor/\($0.publicID)/edit" })
+        }
+    }
+
+    /// One line describing what a version represents. The `origin` already
+    /// encodes the surface and the action (`mcp:update_suite`,
+    /// `web:PUT /instructor/:assignmentID/suite`), so this turns it into
+    /// something readable without inventing detail the row does not have.
+    private static func summaryForVersion(_ version: APIAssignmentVersion) -> String {
+        if let summary = version.summary, !summary.isEmpty { return summary }
+        if let restoredFrom = version.restoredFromVersion {
+            return "Restored version \(restoredFrom)"
+        }
+        switch version.origin {
+        case AssignmentVersionOrigin.baseline:
+            return "Baseline captured before first recorded edit"
+        case AssignmentVersionOrigin.clone:
+            return "Content copied from another assignment"
+        case AssignmentVersionOrigin.create:
+            return "Initial content"
+        case AssignmentVersionOrigin.bundleImport:
+            return "Content imported from a course bundle"
+        default:
+            break
+        }
+        if version.origin.hasPrefix("mcp:") {
+            return "Edited by an agent (\(version.origin.dropFirst(4)))"
+        }
+        if version.origin.hasPrefix("web:") {
+            return "Edited in the browser"
+        }
+        return "Content changed"
+    }
+
+    // MARK: - Course events
+
+    private static func courseEvents(
+        courseID: UUID, actorFilter: String?, limit: Int, on db: any Database
+    ) async throws -> [Entry] {
+        var query = APIAuditLogEntry.query(on: db)
+            .filter(\.$courseID == courseID)
+        if let actorFilter {
+            query = query.filter(\.$actorUsername ~~ actorFilter)
+        }
+        let entries =
+            try await query
+            .sort(\.$createdAt, .descending)
+            .limit(limit)
+            .all()
+
+        return entries.compactMap { entry in
+            guard let createdAt = entry.createdAt else { return nil }
+            let display = AuditActionDisplay.categoryLabel(forRaw: entry.action)
+            let metadata = decodedMetadata(entry.metadata)
+            return Entry(
+                sortKey: createdAt,
+                actor: entry.actorUsername ?? "system",
+                category: display.category,
+                summary: display.label,
+                target: metadata["assignment"] ?? metadata["title"]
+                    ?? metadata["subject_user_id"] ?? entry.targetID ?? "—",
+                detail: detailLine(metadata),
+                link: metadata["assignment"].map { "/instructor/\($0)/edit" })
+        }
+    }
+
+    /// The metadata keys worth showing, in a fixed order so the column reads
+    /// consistently. Everything else (ids, internal source markers) stays out —
+    /// the full blob is on `/admin/audit` for anyone who needs it.
+    private static func detailLine(_ metadata: [String: String]) -> String {
+        let interesting = ["visibility", "role", "current", "previous", "source_assignment"]
+        let parts = interesting.compactMap { key -> String? in
+            guard let value = metadata[key], !value.isEmpty else { return nil }
+            return "\(key): \(value)"
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private static func decodedMetadata(_ raw: String?) -> [String: String] {
+        guard let raw, let data = raw.data(using: .utf8),
+            let decoded = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return decoded
+    }
+}

--- a/Sources/APIServer/Utilities/DatabaseConfiguration.swift
+++ b/Sources/APIServer/Utilities/DatabaseConfiguration.swift
@@ -351,6 +351,9 @@ func registerMigrations(on app: Application) {
     // Append-only assignment content-snapshot history. FK references `courses`
     // and `users`; deliberately none on `test_setups` (see the migration).
     app.migrations.add(CreateAssignmentVersions())
+    // First-class course scoping for audit events, backfilled from the
+    // metadata JSON (#421). Must follow CreateAuditLog.
+    app.migrations.add(AddAuditLogCourseID())
     // Index migrations run last: they reference tables created above
     // (runner_snapshots, job_execution_metrics) and only add indexes.
     app.migrations.add(CreateHotPathIndexes())

--- a/Tests/APITests/CourseActivityTests.swift
+++ b/Tests/APITests/CourseActivityTests.swift
@@ -1,0 +1,444 @@
+// Tests/APITests/CourseActivityTests.swift
+//
+// The merged course activity timeline (#421): content edits from
+// `assignment_versions` and course events from `audit_log`, interleaved,
+// scoped to one course, visible to course staff.
+//
+// What these pin is the part a reader depends on and cannot see for
+// themselves: that both sources actually reach the timeline, that it is
+// chronological rather than source-grouped, that another course's history never
+// leaks in, and that the audit half is course-scoped by an indexed column
+// rather than by luck.
+//
+// `.serialized`: the fixtures spawn zip subprocesses to build snapshots.
+
+import Core
+import Fluent
+import Foundation
+import Testing
+import VaporTesting
+
+@testable import APIServer
+
+@Suite(.serialized) final class CourseActivityTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-activity")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeCourse(_ app: Application, code: String) async throws -> UUID {
+        let course = APICourse(code: code, name: "Activity \(code)", enrollmentMode: .auto)
+        try await course.save(on: app.db)
+        return try course.requireID()
+    }
+
+    @discardableResult
+    private func makeAssignment(
+        _ app: Application, courseID: UUID, title: String
+    ) async throws -> (assignment: APIAssignment, setup: APITestSetup) {
+        let setupID = "act_\(UUID().uuidString.prefix(8))"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        try writeZip(at: zipPath, entries: [("test_a.sh", "exit 0\n")])
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#,
+            zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: title, dueAt: nil, isOpen: false,
+            deadlineOverrideActive: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+        return (assignment, setup)
+    }
+
+    private func writeZip(at zipPath: String, entries: [(String, String)]) throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("act-zip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for (name, content) in entries {
+            try Data(content.utf8).write(to: root.appendingPathComponent(name))
+        }
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+        #expect(zip.terminationStatus == 0)
+    }
+
+    /// A version row written directly, so a test can control its timestamp and
+    /// actor without driving a whole edit through the capture path.
+    private func seedVersion(
+        _ app: Application,
+        on target: (assignment: APIAssignment, setup: APITestSetup),
+        actor: String?, origin: String, number: Int, at date: Date, summary: String? = nil
+    ) async throws {
+        let (assignment, setup) = target
+        let blobs = AssignmentVersionBlobStore(testSetupsDirectory: app.testSetupsDirectory)
+        let snapshot = try await AssignmentVersionSnapshotBuilder.build(setup: setup, blobs: blobs)
+        let row = APIAssignmentVersion(
+            testSetupID: setup.id ?? "",
+            assignmentID: assignment.id,
+            courseID: assignment.courseID,
+            versionNumber: number,
+            snapshot: snapshot,
+            actorUsername: actor,
+            origin: origin,
+            summary: summary)
+        try await row.create(on: app.db)
+        row.createdAt = date
+        try await row.update(on: app.db)
+    }
+
+    private func seedAuditEvent(
+        _ app: Application, courseID: UUID?, action: AuditAction, actor: String,
+        at date: Date, metadata: [String: String] = [:]
+    ) async throws {
+        let encoded =
+            try String(
+                data: JSONEncoder().encode(metadata), encoding: .utf8) ?? "{}"
+        let entry = APIAuditLogEntry(
+            actorUsername: actor,
+            action: action.rawValue,
+            targetType: AuditTargetType.assignment.rawValue,
+            metadata: metadata.isEmpty ? nil : encoded,
+            courseID: courseID)
+        try await entry.create(on: app.db)
+        entry.createdAt = date
+        try await entry.update(on: app.db)
+    }
+
+    // MARK: - The merge
+
+    /// The headline: both sources reach the timeline, interleaved by time
+    /// rather than grouped by source. A reader asking "what happened last
+    /// Tuesday" gets one ordered answer.
+    @Test func timelineInterleavesContentEditsAndCourseEvents() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACT1")
+            let (assignment, setup) = try await makeAssignment(
+                app, courseID: courseID, title: "Lab 1")
+            let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+            try await seedVersion(
+                app, on: (assignment, setup), actor: "ta_kim",
+                origin: "web:PUT /instructor/:assignmentID/suite", number: 1,
+                at: base)
+            try await seedAuditEvent(
+                app, courseID: courseID, action: .assignmentVisibilityChanged,
+                actor: "prof_lee", at: base.addingTimeInterval(60),
+                metadata: ["assignment": assignment.publicID, "visibility": "open"])
+            try await seedVersion(
+                app, on: (assignment, setup), actor: "ta_kim",
+                origin: "mcp:update_suite", number: 2,
+                at: base.addingTimeInterval(120))
+
+            let rows = try await CourseActivityService.timeline(courseID: courseID, on: app.db)
+
+            #expect(rows.count == 3)
+            // Newest first, and the audit event sits BETWEEN the two content
+            // edits rather than in a block of its own.
+            #expect(rows[0].category == "Content edit")
+            #expect(rows[1].category == AuditCategory.assignments.rawValue)
+            #expect(rows[2].category == "Content edit")
+            #expect(rows[1].actor == "prof_lee")
+            #expect(rows[1].detail.contains("visibility: open"))
+        }
+    }
+
+    /// A course's timeline must never show another course's history — the whole
+    /// point of scoping it to staff of that course.
+    @Test func anotherCoursesActivityNeverLeaksIn() async throws {
+        try await withApp(app) { app in
+            let mine = try await makeCourse(app, code: "ACTMINE")
+            let theirs = try await makeCourse(app, code: "ACTTHEIRS")
+            let (mineAssignment, mineSetup) = try await makeAssignment(
+                app, courseID: mine, title: "My lab")
+            let (theirsAssignment, theirsSetup) = try await makeAssignment(
+                app, courseID: theirs, title: "Their lab")
+            let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+            try await seedVersion(
+                app, on: (mineAssignment, mineSetup), actor: "me",
+                origin: "web:edit", number: 1, at: base)
+            try await seedVersion(
+                app, on: (theirsAssignment, theirsSetup), actor: "them",
+                origin: "web:edit", number: 1, at: base.addingTimeInterval(10))
+            try await seedAuditEvent(
+                app, courseID: theirs, action: .assignmentDeleted, actor: "them",
+                at: base.addingTimeInterval(20))
+
+            let rows = try await CourseActivityService.timeline(courseID: mine, on: app.db)
+
+            #expect(rows.count == 1)
+            #expect(rows[0].target == "My lab")
+            #expect(!rows.contains { $0.actor == "them" })
+        }
+    }
+
+    /// Deployment-wide events (a login, a runner secret rotation) carry no
+    /// course and must not surface in any course's view.
+    @Test func unscopedAuditEventsAreExcluded() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTUNS")
+            try await seedAuditEvent(
+                app, courseID: nil, action: .runnerSecretRotated, actor: "admin",
+                at: Date(timeIntervalSince1970: 1_700_000_000))
+
+            let rows = try await CourseActivityService.timeline(courseID: courseID, on: app.db)
+            #expect(rows.isEmpty)
+        }
+    }
+
+    @Test func filteringByActorNarrowsBothSources() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTFIL")
+            let (assignment, setup) = try await makeAssignment(
+                app, courseID: courseID, title: "Lab F")
+            let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+            try await seedVersion(
+                app, on: (assignment, setup), actor: "ta_kim",
+                origin: "web:edit", number: 1, at: base)
+            try await seedVersion(
+                app, on: (assignment, setup), actor: "prof_lee",
+                origin: "web:edit", number: 2, at: base.addingTimeInterval(10))
+            try await seedAuditEvent(
+                app, courseID: courseID, action: .assignmentCreated, actor: "ta_kim",
+                at: base.addingTimeInterval(20))
+            try await seedAuditEvent(
+                app, courseID: courseID, action: .assignmentCreated, actor: "prof_lee",
+                at: base.addingTimeInterval(30))
+
+            let rows = try await CourseActivityService.timeline(
+                courseID: courseID, actorFilter: "ta_kim", on: app.db)
+
+            #expect(rows.count == 2)
+            #expect(rows.allSatisfy { $0.actor == "ta_kim" })
+        }
+    }
+
+    /// A version whose assignment was deleted still belongs in the history —
+    /// the deletion is exactly what a reader is trying to understand. It must
+    /// render without a broken link rather than disappear.
+    @Test func aDeletedAssignmentsEditsStillAppear() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTDEL")
+            let (assignment, setup) = try await makeAssignment(
+                app, courseID: courseID, title: "Doomed lab")
+            try await seedVersion(
+                app, on: (assignment, setup), actor: "ta_kim",
+                origin: "web:edit", number: 1,
+                at: Date(timeIntervalSince1970: 1_700_000_000))
+
+            try await assignment.delete(on: app.db)
+
+            let rows = try await CourseActivityService.timeline(courseID: courseID, on: app.db)
+            #expect(rows.count == 1)
+            #expect(rows[0].target == "(deleted assignment)")
+            #expect(rows[0].link == nil)
+        }
+    }
+
+    /// System-originated snapshots (baseline, clone seed) have no human behind
+    /// them; the column says "system" rather than going blank.
+    @Test func systemOriginatedVersionsAreLabelled() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTSYS")
+            let (assignment, setup) = try await makeAssignment(
+                app, courseID: courseID, title: "Seeded lab")
+            try await seedVersion(
+                app, on: (assignment, setup), actor: nil,
+                origin: AssignmentVersionOrigin.baseline, number: 1,
+                at: Date(timeIntervalSince1970: 1_700_000_000))
+
+            let rows = try await CourseActivityService.timeline(courseID: courseID, on: app.db)
+            #expect(rows[0].actor == "system")
+            #expect(rows[0].summary.contains("Baseline"))
+        }
+    }
+
+    @Test func aRestoreReadsAsARestore() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTRES")
+            let (assignment, setup) = try await makeAssignment(
+                app, courseID: courseID, title: "Restored lab")
+            let blobs = AssignmentVersionBlobStore(testSetupsDirectory: app.testSetupsDirectory)
+            let snapshot = try await AssignmentVersionSnapshotBuilder.build(
+                setup: setup, blobs: blobs)
+            let row = APIAssignmentVersion(
+                testSetupID: setup.id ?? "", assignmentID: assignment.id,
+                courseID: courseID, versionNumber: 2, snapshot: snapshot,
+                actorUsername: "prof_lee", origin: AssignmentVersionOrigin.restore(of: 1),
+                restoredFromVersion: 1)
+            try await row.create(on: app.db)
+
+            let rows = try await CourseActivityService.timeline(courseID: courseID, on: app.db)
+            #expect(rows[0].summary == "Restored version 1")
+        }
+    }
+
+    // MARK: - Course scoping of audit rows
+
+    /// Course-scoped call sites have always set `course_id` in the metadata
+    /// JSON. The logger derives the indexed column from it, so every existing
+    /// enrollment/staff event lands in the right course view without its call
+    /// site being touched.
+    @Test func courseScopeIsDerivedFromMetadataWhenNotPassed() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTMETA")
+            let request = Request(application: app, on: app.eventLoopGroup.any())
+
+            await AuditLogger.record(
+                action: .enrollmentRoleChanged,
+                targetType: .enrollment,
+                targetID: UUID().uuidString,
+                metadata: ["course_id": courseID.uuidString, "role": "ta"],
+                on: request)
+
+            let entry = try #require(
+                try await APIAuditLogEntry.query(on: app.db)
+                    .filter(\.$action == AuditAction.enrollmentRoleChanged.rawValue)
+                    .first())
+            #expect(entry.courseID == courseID)
+
+            let rows = try await CourseActivityService.timeline(courseID: courseID, on: app.db)
+            #expect(rows.count == 1)
+            #expect(rows[0].detail.contains("role: ta"))
+        }
+    }
+
+    /// The lifecycle helper always scopes, so a new call site cannot forget.
+    @Test func lifecycleHelperAlwaysScopesToTheAssignmentsCourse() async throws {
+        try await withApp(app) { app in
+            let courseID = try await makeCourse(app, code: "ACTLIFE")
+            let (assignment, _) = try await makeAssignment(
+                app, courseID: courseID, title: "Lifecycle lab")
+            let request = Request(application: app, on: app.eventLoopGroup.any())
+
+            await AuditLogger.recordAssignmentLifecycle(
+                .assignmentDeleted, assignment: assignment,
+                metadata: ["title": assignment.title], on: request)
+
+            let entry = try #require(
+                try await APIAuditLogEntry.query(on: app.db)
+                    .filter(\.$action == AuditAction.assignmentDeleted.rawValue)
+                    .first())
+            #expect(entry.courseID == courseID)
+            #expect(entry.targetID == assignment.id?.uuidString)
+        }
+    }
+}
+
+/// Action-vocabulary checks. A struct suite: it owns no Vapor app.
+@Suite struct AssignmentLifecycleAuditActionTests {
+
+    /// The events content versioning deliberately does NOT record must all
+    /// exist as audit actions — this is the half of #421 versioning left open.
+    @Test(arguments: [
+        AuditAction.assignmentCreated, .assignmentCloned, .assignmentDeleted,
+        .assignmentVisibilityChanged, .assignmentDueDateChanged,
+    ])
+    func lifecycleActionsAreCategorisedAsAssignments(_ action: AuditAction) {
+        #expect(action.category == .assignments)
+        #expect(!action.label.isEmpty)
+    }
+}
+
+/// HTTP-level checks for `GET /instructor/activity`: it renders, it is gated to
+/// course staff, and it shows real rows.
+@Suite(.serialized) final class CourseActivityPageTests {
+
+    let app: Application
+
+    init() async throws {
+        self.app = try await makeTestApp(prefix: "chickadee-activity-page")
+    }
+
+    /// A staff member of a course that already has one recorded content edit.
+    private func fixture(_ app: Application, username: String) async throws -> String {
+        let course = APICourse(code: "ACTPG", name: "Activity Page", enrollmentMode: .auto)
+        try await course.save(on: app.db)
+        let courseID = try course.requireID()
+
+        let setupID = "actpg_setup"
+        let zipPath = app.testSetupsDirectory + setupID + ".zip"
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("actpg-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("exit 0\n".utf8).write(to: root.appendingPathComponent("test_a.sh"))
+        let zip = Process()
+        zip.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
+        zip.currentDirectoryURL = root
+        zip.arguments = ["-q", "-r", zipPath, "."]
+        zip.standardOutput = Pipe()
+        zip.standardError = Pipe()
+        try zip.run()
+        zip.waitUntilExit()
+
+        let setup = APITestSetup(
+            id: setupID,
+            manifest: #"{"schemaVersion":1,"requiredFiles":[],"testSuites":[],"timeLimitSeconds":10}"#,
+            zipPath: zipPath, courseID: courseID)
+        try await setup.save(on: app.db)
+        let assignment = APIAssignment(
+            testSetupID: setupID, title: "Rendered lab", dueAt: nil, isOpen: false,
+            deadlineOverrideActive: false, courseID: courseID)
+        try await assignment.save(on: app.db)
+
+        _ = try await AssignmentVersionStore.record(
+            setup: setup,
+            request: AssignmentVersionRequest(origin: "web:PUT /instructor/:assignmentID/suite"),
+            testSetupsDirectory: app.testSetupsDirectory,
+            on: app.db)
+
+        let cookie = try await loginUser(
+            username: username, password: "pw", role: "instructor", on: app)
+        try await promoteToInstructor(username, on: app)
+        return cookie
+    }
+
+    @Test func activityPageRendersTheTimelineForStaff() async throws {
+        try await withApp(app) { app in
+            let cookie = try await fixture(app, username: "act_inst")
+
+            try await app.asyncTest(
+                .GET, "/instructor/activity",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: cookie) },
+                afterResponse: { res in
+                    #expect(res.status == .ok)
+                    let body = res.body.string
+                    #expect(body.contains("Recent activity"))
+                    #expect(body.contains("Rendered lab"))
+                    #expect(body.contains("Content edit"))
+                })
+        }
+    }
+
+    /// The `/instructor` group is gated by `ActiveCourseStaffMiddleware`, so a
+    /// plain student never reaches the timeline — the scoping this page relies
+    /// on for its "course staff only" guarantee.
+    @Test func activityPageIsClosedToNonStaff() async throws {
+        try await withApp(app) { app in
+            _ = try await fixture(app, username: "act_inst2")
+            let studentCookie = try await loginUser(
+                username: "act_student", password: "pw", role: "user", on: app)
+
+            try await app.asyncTest(
+                .GET, "/instructor/activity",
+                beforeRequest: { req in req.headers.add(name: .cookie, value: studentCookie) },
+                afterResponse: { res in
+                    #expect(res.status != .ok)
+                })
+        }
+    }
+}

--- a/changelog.d/course-activity-timeline.md
+++ b/changelog.d/course-activity-timeline.md
@@ -1,0 +1,22 @@
+### Added
+
+- **Course activity timeline (#421).** A new Activity tab in the instructor area
+  shows who changed what in the active course, newest first: content edits (from
+  the assignment version history) and course events (staff added/removed/re-roled,
+  assignments created/cloned/deleted, visibility and due-date changes) interleaved
+  in one chronological list, filterable by person. Visible to all course staff,
+  TAs included, and scoped to the active course — another course's history is
+  never reachable from it.
+- **Assignment lifecycle events are now audited.** Creating, cloning, deleting,
+  changing visibility, and moving a due date each record an audit entry, from the
+  browser and from MCP alike. Content versioning deliberately covers only
+  content, so these previously had no record anywhere — a deleted assignment left
+  no trace it had ever existed.
+
+### Changed
+
+- **`audit_log` gained an indexed `course_id` column**, backfilled from the
+  `course_id` key course-scoped events have always carried in their metadata
+  JSON. Course-scoped queries are now indexed rather than a full scan over an
+  unbounded table, and existing enrollment/staff history appears in the new
+  timeline without its call sites being touched.


### PR DESCRIPTION
Finishes #421, re-scoped against what assignment content versioning (#1223–#1225) already delivered. Re-scope rationale posted on the issue: [#421 (comment)](https://github.com/JimWallace/Chickadee/issues/421#issuecomment-5110048479).

## What #421 still needed

Versioning covers "who changed the content", and staff/enrollment events have been audited since #417. Two things were genuinely missing:

**Assignment lifecycle events were audited nowhere.** Create, clone, delete, visibility, and due-date changes had no record anywhere — content versioning deliberately covers content only (a restore never touches metadata), and there were no `AuditAction` cases for them. A deleted assignment left no trace it had ever existed, since its version rows go with it.

**Course staff had nowhere to read any of it.** `/admin/audit` is deployment-wide and admin-only.

## What's here

**Lifecycle auditing** at every site, web and MCP: create (both publish paths), clone, delete, visibility (status + close), due date. Due-date rows are written **only when the date actually moved** — the Save button posts the whole form on every content edit, so auditing unconditionally would bury real deadline changes under one row per save. The delete audit is written *before* the row goes, since afterwards there is nothing left to attribute it to.

**`audit_log` gains an indexed `course_id` column**, backfilled from the `course_id` key course-scoped call sites have always carried in their metadata JSON. `AuditLogger` derives the column from that key when a caller doesn't pass one, so **every existing enrollment/staff event lands in the right course view without touching a single call site**. The backfill runs in Swift rather than SQL because the JSON accessor differs between Postgres (`metadata::json->>`) and SQLite (`json_extract`) and both must produce the same result.

**`GET /instructor/activity`** merges content edits and course events into one chronological, actor-filterable timeline. Merged rather than shown side by side because the question is chronological — two lists leave the reader correlating timestamps by eye.

## Decisions worth a reviewer's eye

**Visibility falls out of existing gating.** The `/instructor` group is already behind `ActiveCourseStaffMiddleware` (TA+ in the *active* course), which is exactly the audience and scope this page wants. Every query filters on the resolved course id, so there is no way to page into another course's history — pinned by `anotherCoursesActivityNeverLeaksIn`. Per #421's own open question 3, TAs see it too: a shared record beats a surveillance tool only the lead can read.

**Deployment-wide events are excluded.** A login or a runner-secret rotation carries no course and must not appear in any course's view.

**Deleted assignments keep their edits in the timeline**, labelled `(deleted assignment)` and unlinked. The deletion is usually the thing being investigated, so dropping those rows would hide exactly what the reader came for.

**Version rows with no human behind them** (baseline, clone seed) show `system` rather than a blank column.

## Testing

12 new tests: interleaving of the two sources, cross-course isolation, exclusion of unscoped events, actor filtering across both sources, deleted-assignment rows, system-originated labelling, restore summaries, metadata-derived course scoping, the always-scoping lifecycle helper, plus page render and the non-staff gate. Existing `AuditActionDisplayTests` (label/category coverage, uniqueness) still pass with the five new actions.

`format.sh`, `lint.sh`, `swiftlint.sh --strict` (0 violations in 882 files), and `check-styles.sh` all clean — the new page uses shared classes plus a page-local role-named style block, per the UI conventions.

Full local `swift test` is green apart from the pre-existing SSO and data-export failures this sandbox causes (they need outbound network to a local mock OIDC issuer) and one connection-pool timeout under full local parallelism that passes in isolation. CI is the authority on all three.

Closes #421.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9dPYxJMzJSSmYLTNEfY6f)_