### PR TITLE
docs: describe partial-credit `score` semantics in the test-script contract (closes #548)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,8 +250,15 @@ attempted as JSON:
 ```
 If the last line is not valid JSON, it is used as the plain-text `shortResult`.
 If stdout is empty, `shortResult` is synthesized from the exit code
-("passed" / "failed" / "error"). `score` is reserved for partial credit
-(not yet used).
+("passed" / "failed" / "error").
+
+`score` carries partial credit: a `Double` clamped to `0...1` giving the
+fraction of the test's points the submission earned, so the test contributes
+`points × score` to the collection's `earnedPoints`. It is orthogonal to the
+exit code — the exit code drives the pass/fail badge, `score` drives the credit
+— so a script may report a partial `score` on either. A script that emits no
+`score` grades exactly as before: full credit on a pass, none otherwise. A test
+skipped because a `dependsOn` prerequisite failed scores 0.
 
 **stderr:** Captured verbatim as `longResult` (nil if empty).
 

--- a/changelog.d/score-contract-doc.md
+++ b/changelog.d/score-contract-doc.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Test-script contract documents partial credit (#548).** The `CLAUDE.md`
+  stdout-footer section still described `score` as "reserved for partial credit
+  (not yet used)", which has been stale since v0.4.444 wired the field through
+  interpretation, grade rollup, and the student results table. It now states the
+  real semantics: a `Double` clamped to `0...1`, contributing `points × score`
+  to `earnedPoints`, orthogonal to the exit code, defaulting to full credit on a
+  pass and none otherwise when no `score` is emitted. Documentation only — no
+  behaviour change.


### PR DESCRIPTION
## What

Update the Test Script Contract section of `CLAUDE.md` so it describes the
partial-credit `score` field as implemented, and add the changelog fragment.

## Why

The contract still read:

> `score` is reserved for partial credit (not yet used).

That has been stale since v0.4.444. The field is wired end to end:

- `partialCreditScore` in `Sources/RunnerCore/OutputInterpretation.swift:118-124`
  reads the footer `score` and clamps it to `0...1`; with no footer `score` it
  falls back to 1 on a pass and 0 otherwise.
- Grade rollup sums `points × score` into `earnedPoints`
  (`Sources/APIServer/Routes/BrowserResultRoutes.swift:427`).
- The student results table renders the earned fraction (`1.5 / 2 pts`).

"Test script contract documentation updated" was the last open box on #548, so
this closes it.

## What the new text says

`score` is a `Double` clamped to `0...1` giving the fraction of the test's
points earned, contributing `points × score` to the collection's
`earnedPoints`. It is orthogonal to the exit code — the exit code drives the
pass/fail badge, `score` drives the credit — so a script may report a partial
`score` on either. A script that emits no `score` grades exactly as before. A
test skipped because a `dependsOn` prerequisite failed scores 0
(`SuiteExecution.swift:70`).

## Note on #548's remaining bullet

The issue also listed "pattern family generators can optionally emit partial
credit (e.g. 3 of 5 args correct)". That bullet predates the current design: a
family now generates one script per case, so a generated test is inherently
binary and has no fraction to report. Not carried forward here — flagged on the
issue instead.

## Scope

Documentation only. No Swift, Leaf, or CSS touched; no behaviour change; no
version files touched (per the release process, the version is assigned at merge
time from the `changelog.d/` fragment).

---
_Generated by [Claude Code](https://claude.ai/code/session_0113VaDarVFuCQ58cJb8kYDH)_