### PR TITLE
chore: dead-code removal + single source of truth for R-kernel detection

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -30,6 +30,13 @@
     const statusEl = document.getElementById('browser-runner-status');
     if (statusEl) statusEl.hidden = false;
 
+    // Kernelspec names that mark an R notebook. This is a hand-copy of
+    // AssignmentLanguage.rKernelNames (Sources/Core/AssignmentLanguage.swift) —
+    // the browser cannot import Swift, so the two are pinned together by
+    // Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs, which fails the
+    // build if either side gains or loses an alias. Keep it sorted.
+    const R_KERNEL_NAMES = ['ir', 'r', 'webr', 'xr'];
+
     // -------------------------------------------------------------------------
     // Public API — called by notebook.js on Submit
     // -------------------------------------------------------------------------
@@ -810,12 +817,15 @@
         let notebook;
         try { notebook = JSON.parse(notebookText); } catch (_) { return; }
 
-        // Detect kernel language the same way RunnerDaemon.swift does.
+        // Detect kernel language exactly as AssignmentLanguage.isRNotebookMetadata
+        // does natively. This file cannot import Swift, so R_KERNEL_NAMES is a
+        // hand-copy of AssignmentLanguage.rKernelNames pinned to it by
+        // Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs.
         const meta   = notebook.metadata || {};
         const ks     = meta.kernelspec || {};
         const ksName = (ks.name || '').toLowerCase();
         const liName = ((meta.language_info || {}).name || '').toLowerCase();
-        const isR    = ksName === 'ir' || ksName === 'r' || ksName === 'webr' || ksName === 'xr' || liName === 'r';
+        const isR    = R_KERNEL_NAMES.includes(ksName) || liName === 'r';
         const stem   = filename.replace(/\.ipynb$/i, '');
 
         if (isR) {

--- a/Public/styles.css
+++ b/Public/styles.css
@@ -555,12 +555,6 @@ textarea.form-input {
     color: var(--text-secondary);
 }
 
-.exec-time {
-    font-size: var(--text-base);
-    font-weight: 400;
-    color: var(--gray-600);
-}
-
 .results-table {
     width: 100%;
     border-collapse: collapse;
@@ -678,7 +672,6 @@ th.sort-desc .sort-header::after { content: "↓"; }
 
 .tier-summary-row:last-child { margin-bottom: 0; }
 
-.tier-summary-release { border-left-color: var(--amber); }
 .tier-summary-secret  { border-left-color: var(--purple); }
 
 .tier-summary-counts { font-weight: 500; }
@@ -837,13 +830,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
     border-radius: var(--radius-lg);
     background: var(--surface);
     display: block;
-}
-
-/* ── Alt-submit link ─────────────────────────────────── */
-.alt-submit {
-    font-size: var(--text-base);
-    color: var(--gray-600);
-    margin-top: .75rem;
 }
 
 /* ── Auth pages ──────────────────────────────────────── */
@@ -1109,28 +1095,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 
 .publish-details summary::-webkit-details-marker { display: none; }
 
-.reorder-controls {
-    display: inline-flex;
-    align-items: center;
-    gap: .2rem;
-    margin-right: .35rem;
-}
-
-.reorder-btn {
-    border: 1px solid var(--gray-200);
-    background: var(--surface);
-    border-radius: var(--radius-sm);
-    color: var(--gray-600);
-    font-size: var(--text-xs);
-    line-height: 1;
-    min-width: 1.2rem;
-    min-height: 1.2rem;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-}
-
 #users-table th[data-sort-key]:focus-visible,
 #assignment-submissions-table th[data-sort-key]:focus-visible {
     outline: 2px solid var(--blue);
@@ -1149,19 +1113,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
     min-width: 260px;
 }
 
-/* ── Validate page results panel ─────────────────────── */
-
-#validate-results {
-    margin-top: 1.25rem;
-    padding-bottom: 2rem;
-}
-
-#validate-results .score {
-    font-size: var(--text-lg);
-    font-weight: 600;
-    margin-bottom: .75rem;
-}
-
 /* ── Inline notebook results panel ───────────────────── */
 .nb-results {
     margin-top: 1.25rem;
@@ -1172,12 +1123,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
     font-size: var(--text-lg);
     font-weight: 600;
     margin-bottom: .75rem;
-}
-
-.nb-results-link {
-    display: inline-block;
-    margin-top: .9rem;
-    font-size: var(--text-base);
 }
 
 /* ── Inline "+ Section" popup (assignments.leaf + assignment-edit.leaf) ──
@@ -1357,7 +1302,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 }
 
 .assignment-table { margin-bottom: .5rem; }
-.assignment-table--ungrouped { margin-top: 1rem; }
 
 /* Ungraded content items (reference material shown inside course sections,
    above the assignments — links, notebooks, slides, outlines). Shared by the
@@ -1456,16 +1400,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .checkbox-list { display: flex; flex-direction: column; gap: .6rem; }
 .checkbox-row { display: flex; align-items: center; gap: .6rem; cursor: pointer; }
 
-/* Setup-new / generic option fieldset with radio rows. */
-.option-fieldset {
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    padding: .75rem 1rem;
-    margin-bottom: 1.25rem;
-}
-.option-fieldset > legend { padding: 0 .4rem; font-weight: 600; font-size: var(--text-base); }
-.radio-row { display: flex; align-items: center; gap: .5rem; cursor: pointer; }
-.radio-row + .radio-row { margin-top: .4rem; }
 .field-note { margin-top: .25rem; font-size: var(--text-sm); }
 
 /* Consent: scope list + small print. */
@@ -1502,9 +1436,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .page-titlebar h1, .page-titlebar h2 { margin: 0; }
 .page-titlebar--baseline { align-items: baseline; }
 
-/* Secondary text shown next to / under a page title. */
-.page-subtitle { margin: .35rem 0 0; color: var(--text-secondary); }
-
 /* Horizontal cluster of controls (button groups, inline actions). */
 .toolbar { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; }
 .toolbar--end { justify-content: flex-end; }
@@ -1529,9 +1460,6 @@ code { font-family: var(--font-mono); font-size: .9em; }
 
 /* Common block-level bottom spacing for standalone sections/notices. */
 .section-gap { margin-bottom: 1rem; }
-
-/* A button row sitting below form content (relies on .btn + .btn spacing). */
-.form-actions { margin-top: 1rem; }
 
 /* A form that should not affect layout (its children participate directly,
    e.g. a course-tab button inside the tab bar). */
@@ -1883,16 +1811,10 @@ code { font-family: var(--font-mono); font-size: .9em; }
 .assign-header-edit { padding: .75rem 1rem; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--gray-50); }
 .assign-header-edit-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: .6rem; }
 .field-gap { margin-bottom: .5rem; }
-.input-block { display: block; width: 100%; }
 
 /* Global-inputs editor rows (edit page). */
 .global-input-name-input { width: calc(100% - 1.5rem); padding: .2rem .4rem; font-family: monospace; }
 .global-input-value-input { width: 100%; padding: .2rem .4rem; font-family: monospace; }
-
-/* BrightSpace grade-sync collapsible. */
-.bs-summary { cursor: pointer; font-weight: 600; font-size: var(--text-base); padding: .4rem 0; }
-.bs-body { margin-top: .75rem; max-width: 520px; }
-.bs-note { margin: .3rem 0 .6rem; }
 
 /* Suite editor container + editor-block header headings. */
 .suite-editor-section { margin-top: 1.25rem; }
@@ -1986,10 +1908,6 @@ tr.drop-adopt  { outline: 2px solid var(--blue); outline-offset: -2px; }
 .suite-root-drop.drop-hover { background: var(--hover-bg); }
 .suite-child-indent { padding-left: 2rem; white-space: nowrap; }
 .suite-child-connector { color: var(--gray-500); margin-right: .25rem; font-size: .85em; }
-.suite-upload-error { font-size: var(--text-sm); color: var(--red); margin-top: .2rem; }
-.suite-file-hint { font-size: var(--text-xs); color: var(--gray-500); margin-top: .2rem; }
-.suite-file-hint a { color: inherit; }
-#suite-config-table td { vertical-align: top; }
 
 /* ── CodeMirror 6 host + Test Editor modal dark mode (new + edit pages) ───
    Consolidated from two duplicated embedded <style> blocks (UI audit). */

--- a/Sources/APIServer/Helpers/NotebookContentHelpers.swift
+++ b/Sources/APIServer/Helpers/NotebookContentHelpers.swift
@@ -131,7 +131,7 @@ func normalizeNotebookForJupyterLite(_ data: Data) -> Data {
     var kernelSpec = existingKernelSpec ?? [:]
     var languageInfo = metadata["language_info"] as? [String: Any] ?? [:]
 
-    if let name = existingName, name == "ir" || name == "r" || name == "webr" || name == "xr" {
+    if let name = existingName, AssignmentLanguage.rKernelNames.contains(name) {
         // R notebook (IRkernel / legacy webr / xeus-r) → normalize to the vendored xeus-r kernel.
         kernelSpec["name"] = jupyterLiteRKernelName
         kernelSpec["display_name"] = jupyterLiteRKernelDisplayName

--- a/Sources/APIServer/Models/APIUser.swift
+++ b/Sources/APIServer/Models/APIUser.swift
@@ -151,12 +151,6 @@ extension APIUser {
     /// outside the known vocabulary (defensive — should not happen).
     var roleValue: UserRole? { UserRole(rawValue: role) }
 
-    /// Sets the role from the typed enum.  Prefer this over assigning a
-    /// raw string to `role`.
-    func setRole(_ newRole: UserRole) {
-        role = newRole.rawValue
-    }
-
     var isAdmin: Bool { roleValue == .admin }
 
     /// True for MCP service accounts (admin-provisioned, non-loginable agents).

--- a/Sources/APIServer/Routes/Web/AssignmentRequirementHelpers.swift
+++ b/Sources/APIServer/Routes/Web/AssignmentRequirementHelpers.swift
@@ -79,7 +79,9 @@ func detectRequirementSuggestions(
                 let name = (kernelspec["name"] as? String ?? "").lowercased()
                 let language = (kernelspec["language"] as? String ?? "").lowercased()
                 if name == "python" || language == "python" { addLanguage("python") }
-                if ["ir", "r", "webr", "xr"].contains(name) || language == "r" { addLanguage("r") }
+                if AssignmentLanguage.rKernelNames.contains(name) || language == "r" {
+                    addLanguage("r")
+                }
             }
             if let languageInfo = metadata["language_info"] as? [String: Any],
                 let language = languageInfo["name"] as? String

--- a/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
+++ b/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift
@@ -2,8 +2,8 @@
 //
 // Validation-submission lifecycle: enqueue from a saved solution
 // notebook, schedule after a suite edit (debounced + runner availability
-// pre-check), wait for the worker to complete, and the bulk re-test
-// helper that re-queues every student submission for a setup.  Plus the
+// pre-check), and the bulk re-test helper that re-queues every student
+// submission for a setup.  Plus the
 // runner-availability probes that gate validation so we don't sit in
 // queue forever when no compatible runner exists.  Extracted from
 // AssignmentHelpers.swift (issue #442) — no behaviour changes.
@@ -12,12 +12,6 @@ import Core
 import Fluent
 import Foundation
 import Vapor
-
-enum RunnerValidationOutcome {
-    case passed(summary: String)
-    case failed(summary: String)
-    case timedOut
-}
 
 func enqueueRunnerValidationSubmission(
     req: Request,
@@ -467,48 +461,6 @@ func flipSubmissionToPending(
     submission.retestedByUserID = userID
     try await submission.save(on: db)
     return true
-}
-
-func waitForRunnerValidation(
-    req: Request,
-    submissionID: String,
-    timeoutSeconds: TimeInterval = 20
-) async throws -> RunnerValidationOutcome {
-    let started = Date()
-    let decoder = JSONDecoder()
-    decoder.dateDecodingStrategy = .iso8601
-
-    while Date().timeIntervalSince(started) < timeoutSeconds {
-        guard let submission = try await APISubmission.find(submissionID, on: req.db),
-            submission.kind == APISubmission.Kind.validation
-        else {
-            throw WebAssignmentError.notFound(resource: "Validation submission")
-        }
-
-        if submission.statusValue == .complete || submission.statusValue == .failed {
-            guard
-                let result = try await APIResult.query(on: req.db)
-                    .filter(\.$submissionID == submissionID)
-                    .sort(\.$receivedAt, .descending)
-                    .first(),
-                let collectionJSON = try await result.loadCollectionJSON(on: req.db)
-            else {
-                return .failed(summary: "no result payload")
-            }
-
-            let collection = try decoder.decode(
-                TestOutcomeCollection.self, from: Data(collectionJSON.utf8))
-            let summary = "\(collection.passCount)/\(collection.totalTests) passed"
-            let passed =
-                collection.buildStatus == .passed && collection.failCount == 0 && collection.errorCount == 0
-                && collection.timeoutCount == 0
-            return passed ? .passed(summary: summary) : .failed(summary: summary)
-        }
-
-        try await Task.sleep(nanoseconds: 1_000_000_000)
-    }
-
-    return .timedOut
 }
 
 func ensureValidationRunnerAvailability(req: Request) async {

--- a/Sources/APIServer/Routes/Web/WebContextTypes.swift
+++ b/Sources/APIServer/Routes/Web/WebContextTypes.swift
@@ -6,12 +6,6 @@
 import Core
 import Foundation
 
-// MARK: - Shared base context
-
-struct BaseContext: Encodable {
-    let currentUser: CurrentUserContext?
-}
-
 // MARK: - Index page context types
 
 struct TestSetupRow: Encodable {

--- a/Sources/APIServer/Services/BrightSpaceClientRegistry.swift
+++ b/Sources/APIServer/Services/BrightSpaceClientRegistry.swift
@@ -34,10 +34,6 @@ actor BrightSpaceClientRegistry {
     func invalidate(_ key: String) {
         clients.removeValue(forKey: key)
     }
-
-    func invalidateAll() {
-        clients.removeAll()
-    }
 }
 
 /// The effective grade-sync config + cache key for a course: its designated

--- a/Sources/APIServer/Services/ServerHealthAlertService.swift
+++ b/Sources/APIServer/Services/ServerHealthAlertService.swift
@@ -549,11 +549,6 @@ actor ServerHealthAlertMonitor {
         ruleStates
     }
 
-    func resetForTesting() {
-        ruleStates = [:]
-        recentFirings = []
-    }
-
     private func notifier(for application: Application) -> any AlertNotifier {
         guard let url = effectiveWebhookURL(), !url.isEmpty else {
             return NoopNotifier()

--- a/Sources/Core/AssignmentLanguage.swift
+++ b/Sources/Core/AssignmentLanguage.swift
@@ -13,8 +13,14 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
     case r
 
     /// Kernelspec `name` values (and `language_info.name`) that mark an R
-    /// notebook. Single source of truth for the detection currently duplicated
-    /// in the worker's `submissionIsRNotebook` and `extractNotebooksToCode`.
+    /// notebook. The single source of truth for the sniff: every Swift consumer
+    /// reads it through `isRNotebookMetadata(_:)` rather than re-listing the
+    /// aliases, so teaching Chickadee a new R kernel is one edit here.
+    ///
+    /// The browser runner cannot import Swift, so `Public/browser-runner.js`
+    /// keeps its own copy in `R_KERNEL_NAMES`; the two are pinned together by
+    /// `Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs`, which fails
+    /// if this set and that array ever diverge.
     public static let rKernelNames: Set<String> = ["ir", "r", "webr", "xr"]
 
     /// Resolve the language from the manifest and (optionally) the notebook
@@ -45,6 +51,31 @@ public enum AssignmentLanguage: String, Codable, Sendable, CaseIterable {
 }
 
 extension AssignmentLanguage {
+
+    /// True when a notebook's `metadata` marks it as R: `kernelspec.name` is in
+    /// `rKernelNames`, or `language_info.name` is `"r"`.
+    ///
+    /// The one implementation of that two-step sniff. `rederive`, the worker's
+    /// submission routing (`submissionIsRNotebook`) and its notebook→source
+    /// extraction (`extractNotebooksToCode`) all call through here, so the
+    /// alias list lives in exactly one place.
+    public static func isRNotebookMetadata(_ metadata: [String: Any]) -> Bool {
+        if let kernel = (metadata["kernelspec"] as? [String: Any])?["name"] as? String,
+            rKernelNames.contains(kernel.lowercased())
+        {
+            return true
+        }
+        return ((metadata["language_info"] as? [String: Any])?["name"] as? String)?
+            .lowercased() == "r"
+    }
+
+    /// `isRNotebookMetadata(_:)` for a parsed notebook object. A notebook with
+    /// no `metadata` has nothing to sniff and is not R — matching what every
+    /// caller already did on a missing/unparseable metadata dictionary.
+    public static func isRNotebook(_ notebook: [String: Any]) -> Bool {
+        guard let metadata = notebook["metadata"] as? [String: Any] else { return false }
+        return isRNotebookMetadata(metadata)
+    }
 
     /// Resolve including the assignment's starter notebook, read straight from
     /// `.ipynb` bytes.
@@ -109,15 +140,7 @@ extension AssignmentLanguage {
         else {
             return .python
         }
-        if let kernel = (metadata["kernelspec"] as? [String: Any])?["name"] as? String,
-            rKernelNames.contains(kernel.lowercased())
-        {
-            return .r
-        }
-        if ((metadata["language_info"] as? [String: Any])?["name"] as? String)?.lowercased() == "r" {
-            return .r
-        }
-        return .python
+        return isRNotebookMetadata(metadata) ? .r : .python
     }
 }
 

--- a/Sources/Core/NotebookCellSources.swift
+++ b/Sources/Core/NotebookCellSources.swift
@@ -37,17 +37,4 @@ public enum NotebookCellSources {
         if let arr = cell["source"] as? [String] { return arr.joined() }
         return ""
     }
-
-    /// Returns the trimmed `source` of every `code` cell whose source
-    /// is non-empty.  Skips markdown, raw, and empty cells.  Suitable
-    /// for the simple "concat code cells" path; callers that need the
-    /// cell index for "# --- cell N ---" comments should iterate
-    /// `cells(from:)` directly.
-    public static func codeCellSources(_ cells: [[String: Any]]) -> [String] {
-        cells.compactMap { cell -> String? in
-            guard cell["cell_type"] as? String == "code" else { return nil }
-            let trimmed = cellSource(cell).trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        }
-    }
 }

--- a/Sources/RunnerCore/NotebookExtraction.swift
+++ b/Sources/RunnerCore/NotebookExtraction.swift
@@ -18,11 +18,6 @@
 //                           can see the real definitions. Structural-property
 //                           NotebookChecks read this.
 
-public enum NotebookLanguage: String, Sendable, Equatable {
-    case python
-    case r
-}
-
 /// One notebook cell, with its raw (untrimmed) joined source. `cellType` is the
 /// notebook's `cell_type` ("code", "markdown", …). Non-code cells are kept in
 /// the list so cell numbering matches the original notebook positions.

--- a/Sources/Worker/NotebookExtractor.swift
+++ b/Sources/Worker/NotebookExtractor.swift
@@ -87,12 +87,12 @@ struct NotebookExtractor {
 ///
 /// Module-level (not private) so WorkerTests can exercise it directly.
 ///
-/// - Parameter forcedLanguage: when non-nil (`"r"` / `"python"`), every notebook
-///   is extracted to that language regardless of its own kernelspec. The worker
-///   passes `"r"` for a pure-R suite (`manifestTargetsRSubmission`) so a
-///   submission whose kernelspec was rewritten by the in-browser editor still
-///   extracts to `.R`. Nil keeps the per-notebook kernelspec detection.
-func extractNotebooksToCode(in directory: URL, forcedLanguage: String? = nil) throws {
+/// - Parameter forcedLanguage: when non-nil, every notebook is extracted to
+///   that language regardless of its own kernelspec. The worker passes `.r` for
+///   a pure-R suite (`manifestTargetsRSubmission`) so a submission whose
+///   kernelspec was rewritten by the in-browser editor still extracts to `.R`.
+///   Nil keeps the per-notebook kernelspec detection.
+func extractNotebooksToCode(in directory: URL, forcedLanguage: AssignmentLanguage? = nil) throws {
     let items =
         (try? FileManager.default.contentsOfDirectory(
             at: directory,
@@ -111,27 +111,16 @@ func extractNotebooksToCode(in directory: URL, forcedLanguage: String? = nil) th
             let cells = notebook["cells"] as? [[String: Any]]
         else { continue }
 
-        // Detect kernel language: ir/r/webr/xr → R, everything else → Python.
-        // A caller-forced language wins over the notebook's own kernelspec.
-        let language: String =
-            forcedLanguage
-            ?? {
-                if let meta = notebook["metadata"] as? [String: Any] {
-                    if let ks = meta["kernelspec"] as? [String: Any],
-                        let name = (ks["name"] as? String)?.lowercased()
-                    {
-                        if name == "ir" || name == "r" || name == "webr" || name == "xr" { return "r" }
-                    }
-                    if let li = meta["language_info"] as? [String: Any],
-                        (li["name"] as? String)?.lowercased() == "r"
-                    {
-                        return "r"
-                    }
-                }
-                return "python"
-            }()
+        // A caller-forced language wins over the notebook's own kernelspec;
+        // otherwise sniff it with the shared detector.
+        let language =
+            forcedLanguage ?? (AssignmentLanguage.isRNotebook(notebook) ? .r : .python)
 
-        let ext = language == "r" ? "R" : "py"
+        // Deliberately not `generatedScriptExtension`: that property is scoped to
+        // scripts Chickadee *generates* (pattern cases, notebook checks) where the
+        // filename feeds `spec_hash`. Extraction output is a different concern and
+        // must not be coupled to it.
+        let ext = language == .r ? "R" : "py"
         let stem = item.deletingPathExtension().lastPathComponent
         let outURL = directory.appendingPathComponent("\(stem).\(ext)")
 
@@ -143,7 +132,7 @@ func extractNotebooksToCode(in directory: URL, forcedLanguage: String? = nil) th
             while src.last?.isWhitespace == true { src.removeLast() }
             guard !src.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
 
-            if language == "python" {
+            if language == .python {
                 let cellSource = extractor.sanitizeCellForModule(src)
                 guard !cellSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
                 output += extractor.wrapCellForResilientLoad(cellSource, label: "cell \(index + 1)") + "\n\n"

--- a/Sources/Worker/RunnerDaemon+JobProcessing.swift
+++ b/Sources/Worker/RunnerDaemon+JobProcessing.swift
@@ -538,7 +538,7 @@ extension WorkerDaemon {
                 let targetsR = manifestTargetsRSubmission(manifest)
                 try extractNotebooksToCode(
                     in: testSetupDir,
-                    forcedLanguage: targetsR ? "r" : nil)
+                    forcedLanguage: targetsR ? .r : nil)
                 return (
                     [],
                     legacyPreferredStudentModuleFilename(

--- a/Sources/Worker/SubmissionStaging.swift
+++ b/Sources/Worker/SubmissionStaging.swift
@@ -140,9 +140,9 @@ func stagedSubmissionDestination(
 /// legacy `webr`, or xeus-r `xr`), which must be extracted to `.R` by
 /// `extractNotebooksToCode` rather than run through the Python normalizer.
 ///
-/// Mirrors the kernel-language detection in `extractNotebooksToCode`
-/// (NotebookExtractor.swift): kernelspec name in {ir, r, webr, xr}, or
-/// `language_info.name == "r"`. Resolves the named submission when it is an
+/// Detection is `AssignmentLanguage.isRNotebookMetadata` — the same call
+/// `extractNotebooksToCode` makes, so routing and extraction cannot disagree
+/// about what an R notebook is. Resolves the named submission when it is an
 /// `.ipynb`, otherwise the first `.ipynb` staged in `submissionDirectory`
 /// (zip submissions). Any read/parse failure returns false so the caller keeps
 /// its existing (Python) behaviour.
@@ -168,18 +168,7 @@ func submissionIsRNotebook(submissionDirectory: URL, submissionFilename: String?
         return false
     }
 
-    if let kernelSpec = meta["kernelspec"] as? [String: Any],
-        let name = (kernelSpec["name"] as? String)?.lowercased(),
-        name == "ir" || name == "r" || name == "webr" || name == "xr"
-    {
-        return true
-    }
-    if let languageInfo = meta["language_info"] as? [String: Any],
-        (languageInfo["name"] as? String)?.lowercased() == "r"
-    {
-        return true
-    }
-    return false
+    return AssignmentLanguage.isRNotebookMetadata(meta)
 }
 
 /// True when the manifest's graded suite is **pure R** — at least one `.R` test

--- a/Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs
+++ b/Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+// Pins Public/browser-runner.js's R_KERNEL_NAMES to the canonical Swift set,
+// AssignmentLanguage.rKernelNames in Sources/Core/AssignmentLanguage.swift.
+//
+// The R-kernel alias list decides whether a notebook submission is extracted to
+// .R or .py. It used to be hand-inlined in three places — two Swift call sites
+// and this one in JS — so adding an alias meant finding all three, and missing
+// the JS copy would silently grade browser submissions as Python. The Swift
+// sites now all route through AssignmentLanguage.isRNotebookMetadata; the
+// browser cannot import Swift, so this test is what keeps the last copy honest.
+
+const SWIFT_SOURCE = 'Sources/Core/AssignmentLanguage.swift';
+const JS_SOURCE = 'Public/browser-runner.js';
+
+async function read(rel) {
+  return fs.readFile(path.resolve(rel), 'utf8');
+}
+
+/** Parse `public static let rKernelNames: Set<String> = ["ir", "r", ...]`. */
+function parseSwiftKernelNames(src) {
+  const m = src.match(/rKernelNames\s*:\s*Set<String>\s*=\s*\[([^\]]*)\]/);
+  assert.ok(m, `could not find rKernelNames in ${SWIFT_SOURCE}`);
+  return [...m[1].matchAll(/"([^"]+)"/g)].map(x => x[1]);
+}
+
+/** Parse `const R_KERNEL_NAMES = ['ir', 'r', ...];`. */
+function parseJSKernelNames(src) {
+  const m = src.match(/const\s+R_KERNEL_NAMES\s*=\s*\[([^\]]*)\]/);
+  assert.ok(m, `could not find R_KERNEL_NAMES in ${JS_SOURCE}`);
+  return [...m[1].matchAll(/'([^']+)'/g)].map(x => x[1]);
+}
+
+test('browser-runner R_KERNEL_NAMES matches Swift AssignmentLanguage.rKernelNames', async () => {
+  const swift = parseSwiftKernelNames(await read(SWIFT_SOURCE));
+  const js = parseJSKernelNames(await read(JS_SOURCE));
+
+  assert.ok(swift.length > 0, 'Swift kernel-name set parsed empty');
+  assert.deepEqual(
+    [...js].sort(),
+    [...swift].sort(),
+    'browser-runner.js R_KERNEL_NAMES has drifted from AssignmentLanguage.rKernelNames — ' +
+      'update both, or the browser will disagree with the worker about what an R notebook is'
+  );
+});
+
+test('R_KERNEL_NAMES entries are lowercase (the sniff lowercases before comparing)', async () => {
+  const js = parseJSKernelNames(await read(JS_SOURCE));
+  for (const name of js) {
+    assert.equal(name, name.toLowerCase(), `${name} must be lowercase`);
+  }
+});

--- a/Tests/WorkerTests/SubmissionRoutingRNotebookTests.swift
+++ b/Tests/WorkerTests/SubmissionRoutingRNotebookTests.swift
@@ -150,7 +150,7 @@ import Testing
         // The recovery mechanism end-to-end: a Python-kernel notebook, forced to
         // R by the pure-R manifest, is extracted to `solution.R` (not `.py`).
         try stage(Self.pythonNotebook)
-        try extractNotebooksToCode(in: tmpDir, forcedLanguage: "r")
+        try extractNotebooksToCode(in: tmpDir, forcedLanguage: .r)
         #expect(FileManager.default.fileExists(atPath: tmpDir.appendingPathComponent("solution.R").path))
         #expect(
             !FileManager.default.fileExists(atPath: tmpDir.appendingPathComponent("solution.py").path))
@@ -160,7 +160,7 @@ import Testing
         // R extraction must not run the Python cell-sanitizer: the R source is
         // copied through unchanged so `source()` sees the student's code.
         try stage(Self.pythonNotebook)
-        try extractNotebooksToCode(in: tmpDir, forcedLanguage: "r")
+        try extractNotebooksToCode(in: tmpDir, forcedLanguage: .r)
         let produced = try String(
             contentsOf: tmpDir.appendingPathComponent("solution.R"), encoding: .utf8)
         #expect(produced.contains("x = 1"))

--- a/changelog.d/dead-code-audit.md
+++ b/changelog.d/dead-code-audit.md
@@ -1,0 +1,14 @@
+### Removed
+
+- **Dead-code audit sweep.** Removed unreferenced Swift declarations and CSS
+  rules found by a repo-wide reachability sweep. Swift: the unused `BaseContext`
+  Leaf-context struct, the unused `NotebookLanguage` enum in `RunnerCore`
+  (language resolution goes through `Core`'s `AssignmentLanguage`),
+  `NotebookCellSources.codeCellSources(_:)`, `BrightSpaceClientRegistry`'s
+  `invalidateAll()`, `ServerHealthAlertService.resetForTesting()`,
+  `APIUser.setRole(_:)`, and `waitForRunnerValidation(...)` together with the
+  `RunnerValidationOutcome` enum that existed only as its return type.
+  Stylesheet: 18 class rules and 2 id rules in `Public/styles.css` with no
+  remaining markup or JS reference, including `#suite-config-table` (left over
+  from the v0.4.79 server-authoritative suite editor) and `#validate-results`.
+  No behaviour changes.

--- a/changelog.d/r-kernel-names-single-source.md
+++ b/changelog.d/r-kernel-names-single-source.md
@@ -1,0 +1,17 @@
+### Changed
+
+- **One source of truth for R-notebook kernel detection.** The R kernelspec
+  alias list (`ir`, `r`, `webr`, `xr`) was hand-inlined at five sites across two
+  languages, so teaching Chickadee a new R kernel meant finding all five and
+  missing one would silently grade an R submission as Python. Detection now
+  lives in `AssignmentLanguage.isRNotebookMetadata(_:)` / `isRNotebook(_:)`
+  (Core), and every Swift caller routes through it: `AssignmentLanguage.rederive`,
+  the worker's submission routing (`submissionIsRNotebook`) and notebook→source
+  extraction (`extractNotebooksToCode`), assignment requirement scanning, and
+  JupyterLite kernelspec normalization. `extractNotebooksToCode`'s
+  `forcedLanguage` is now a typed `AssignmentLanguage?` instead of a stringly
+  typed `String?`. The browser runner cannot import Swift, so its copy is named
+  (`R_KERNEL_NAMES` in `browser-runner.js`) and pinned to the Swift set by a new
+  drift test, `Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs`, which
+  fails the build if the two ever diverge. Behaviour is unchanged — same aliases,
+  same precedence, generated script bytes untouched.


### PR DESCRIPTION
Two commits: a dead-code audit sweep, and the follow-up refactor it surfaced.

---

# 1. Dead-code removal (`c8b48cc`)

Every removal verified unreferenced across `Sources`, `Tests`, `Resources`,
`Public`, and `scripts`. `-171` lines, no behaviour change.

## Swift

| Symbol | Note |
|---|---|
| `BaseContext` | Leaf context struct, never rendered |
| `NotebookLanguage` (RunnerCore) | Language resolution goes through `Core`'s `AssignmentLanguage`; no callers |
| `NotebookCellSources.codeCellSources(_:)` | Every consumer iterates `cells(from:)` directly |
| `BrightSpaceClientRegistry.invalidateAll()` | Only per-key `invalidate(_:)` is used |
| `ServerHealthAlertService.resetForTesting()` | Test helper with no callers |
| `APIUser.setRole(_:)` | No callers since the #417 role collapse |
| `waitForRunnerValidation(...)` + `RunnerValidationOutcome` | The enum existed only as this function's return type |

## Stylesheet

18 class rules and 2 id rules in `Public/styles.css` with no remaining markup or
JS reference. Two are notable: `#suite-config-table` is left over from the
v0.4.79 server-authoritative suite editor (which removed the
`#suite-config-field` blob but not its table styling), and
`.tier-summary-release` is the never-emitted sibling of `.tier-summary-secret`.

## Deliberately left in place

- **`JSONRPCError.missingRequiredClientCapability(_:)`** — documented in place as
  spec-completeness, and its code constant *is* live in `MCPModernTransport`'s
  HTTP-400 mapping.
- **`.col-hide-tablet`** — documented sibling of the actively-used
  `.col-hide-phone`.
- **`TargetKind.assignmentGrade` / `.suiteItem`** — no Swift call sites, but they
  are raw-value `Codable` vocabulary decoded from persisted achievement specs.
- **`TestProperties` legacy write-side mirroring** — already scheduled for the
  v0.7.0 cleanup.

Checked and fully live, so nothing reclaimed: all Leaf templates, all
`Public/*.js` files and their exports, all 68 migrations (declared == registered),
and all `Package.swift` dependencies.

---

# 2. Single source of truth for R-kernel detection (`4036002`)

The dead `NotebookLanguage` turned out to be a marker for a live problem. The
R kernelspec alias list (`ir`, `r`, `webr`, `xr`) was hand-inlined at **five**
sites across two languages — even though `AssignmentLanguage.rKernelNames`
already existed and its own doc comment called itself "the single source of
truth for the detection currently duplicated in…". It had **zero callers outside
its own file**.

Adding a new R kernel alias meant finding all five sites, and missing the JS one
would silently grade a browser-submitted R notebook as Python.

## The fix

Detection is now one function — `AssignmentLanguage.isRNotebookMetadata(_:)`,
plus `isRNotebook(_:)` for a parsed notebook object. Callers routed through it:

| Site | Was |
|---|---|
| `AssignmentLanguage.rederive` | re-implemented the two-step sniff |
| `Worker.submissionIsRNotebook` | 4 inlined string comparisons |
| `Worker.extractNotebooksToCode` | 4 inlined string comparisons |
| `APIServer.AssignmentRequirementHelpers.scanNotebook` | inlined array literal |
| `APIServer.normalizeNotebookForJupyterLite` | 4 inlined string comparisons |

`extractNotebooksToCode`'s `forcedLanguage` is now a typed
`AssignmentLanguage?` rather than a stringly typed `String?` carrying `"r"` /
`"python"` literals.

## The JS copy

`Public/browser-runner.js` cannot import Swift, so the last remaining copy is
*named* (`R_KERNEL_NAMES`) rather than inlined mid-expression, and pinned to the
Swift set by a new drift test —
`Tests/BrowserRunnerJSTests/r-kernel-names-drift.test.mjs`. It parses both
sources and fails if they diverge, following the existing
`runtime-drift.test.mjs` pattern. Verified against a negative control: removing
an alias from either side fails the test with a message naming the consequence.

The alias list now exists in exactly two places, and the second cannot drift
from the first without turning CI red.

## Explicitly not done

Extraction output's file extension is **not** folded into
`generatedScriptExtension`. That property is scoped to scripts Chickadee
*generates*, where the filename feeds `spec_hash` — coupling extraction to it
would let a change in one silently move the other. The local ternary carries a
comment saying so.

Behaviour is unchanged: same aliases, same precedence, generated script bytes
untouched.

---

## Verification (both commits)

- `swift build` and `swift build --build-tests` — clean
- `CoreTests` + `WorkerTests` — 500 tests, pass
- notebook / requirement / language `APITests` — 359 tests, pass
- `node --test Tests/BrowserRunnerJSTests/*.test.mjs` — 140 tests (138 + 2 new), pass
- `scripts/lint.sh` (swift-format), `scripts/eslint.sh` — clean
- `scripts/swiftlint.sh --strict` — 0 violations in 885 files
- `scripts/check-styles.sh` (incl. css-vars + design-token guards) — OK

Note on CI: `worker-tests` wedged at its 20-minute job timeout twice on the first
commit's SHA, then passed on the identical SHA with no code change. It is a
pre-existing harness flake unrelated to this diff (which touches no
`Sources/Worker/` execution path in commit 1). Two details worth recording for
the flakiness work: `.timeLimit(.minutes(3))` is already on both `WorkerTests`
and `WorkerDaemonTests` and did **not** fire, which points at something Swift
Testing cannot cancel (a task suspended on a never-resumed
`withCheckedContinuation`, or a blocked OS thread); and the documented Family 1(b)
mechanism in `docs/ci-flakiness.md` is provably fixed — `linuxWaitForChild` is now
bounded on every path and kills by both process group and direct pid — so the
20-minute *shape* matched but the cause did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LprdW8YjPXDKgNaSJBpxdH