### PR TITLE
fix(browser-runner): preload packages imported by bundled helper modules

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -439,6 +439,10 @@
                     throw new Error('Failed to create work directory: ' + toMessage(e));
                 }
                 writeFilesToPyFS(py, this.workDir, this.files);
+                // Load the packages the setup's .py files import (numpy, pandas,
+                // …) BEFORE any script runs, including imports reached only
+                // through a bundled helper module.
+                await preloadPackagesForFiles(py, this.files);
                 // Add working directory to Python's path and set up builtins.
                 // We cannot rely on sitecustomize.py being auto-imported in
                 // Pyodide (the interpreter is already running, and
@@ -771,6 +775,28 @@
         if (typeof value === 'string') return value;
         try { return new TextDecoder().decode(value instanceof Uint8Array ? value : new Uint8Array(value)); }
         catch (_) { return ''; }
+    }
+
+    // Preload the Pyodide packages every bundled .py file imports.
+    //
+    // loadPackagesFromImports only scans the one source string it is handed, and
+    // does NOT follow imports into local modules.  A test script that imports a
+    // bundled helper which in turn imports numpy would therefore run with numpy
+    // unloaded and die on ModuleNotFoundError — green on the native validation
+    // run (where numpy is installed system-wide) and broken for every student.
+    // Scanning the whole setup up front closes that gap.
+    //
+    // Per-file rather than one concatenated blob, so a single unparseable file
+    // (a student's half-finished submission) cannot suppress every other file's
+    // imports.  Non-fatal throughout: a name Pyodide doesn't ship must never
+    // block the run.
+    async function preloadPackagesForFiles(py, files) {
+        for (const [relPath, value] of Object.entries(files || {})) {
+            if (!relPath.endsWith('.py')) continue;
+            const text = fileAsText(value);
+            if (!text) continue;
+            try { await py.loadPackagesFromImports(text); } catch (_) { /* non-fatal */ }
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -1700,6 +1726,7 @@ for _module_name in _tr.student_module_names_in_load_order():
             removeRecursive,
             writeFilesToPyFS,
             fileAsText,
+            preloadPackagesForFiles,
             makeExecutor,
             MainThreadExecutor,
             GradingWorkerExecutor,

--- a/Public/grading-worker.js
+++ b/Public/grading-worker.js
@@ -85,6 +85,35 @@ function writeFilesToPyFS(py, workDir, files) {
     });
 }
 
+// Preload the Pyodide packages every bundled .py file imports.
+//
+// loadPackagesFromImports only scans the one source string it is handed, and
+// does NOT follow imports into local modules.  A test script that imports a
+// bundled helper which in turn imports numpy would therefore run with numpy
+// unloaded and die on ModuleNotFoundError — green on the native validation run
+// (where numpy is installed system-wide) and broken for every student.
+// Scanning the whole setup up front closes that gap.
+//
+// Per-file rather than one concatenated blob, so a single unparseable file (a
+// student's half-finished submission) cannot suppress every other file's
+// imports.  Non-fatal throughout: a name Pyodide doesn't ship must never block
+// the run.  Mirrors browser-runner.js's preloadPackagesForFiles.
+async function preloadPackagesForFiles(py, files) {
+    var names = Object.keys(files || {});
+    for (var i = 0; i < names.length; i++) {
+        if (!/\.py$/.test(names[i])) continue;
+        var value = files[names[i]];
+        var text = null;
+        if (typeof value === 'string') {
+            text = value;
+        } else if (value) {
+            try { text = new TextDecoder().decode(new Uint8Array(value)); } catch (e) { text = null; }
+        }
+        if (!text) continue;
+        try { await py.loadPackagesFromImports(text); } catch (e) { /* non-fatal */ }
+    }
+}
+
 self.onmessage = async function (e) {
     var msg = e.data || {};
     var id = msg.id;
@@ -102,6 +131,10 @@ self.onmessage = async function (e) {
             _workDir = '/chickadee_work_' + Date.now();
             try { py.FS.mkdir(_workDir); } catch (err) { /* fresh worker; ignore */ }
             writeFilesToPyFS(py, _workDir, msg.files || {});
+            // Load the packages the setup's .py files import (numpy, pandas, …)
+            // BEFORE any script runs, including imports reached only through a
+            // bundled helper module.
+            await preloadPackagesForFiles(py, msg.files || {});
             if (msg.seed !== null && msg.seed !== undefined) {
                 await py.runPythonAsync(assignmentSeedPython(msg.seed));
             }

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -1623,3 +1623,58 @@ test('groupBySection sends a stale/unknown sectionID to the Ungrouped block', as
     ],
   );
 });
+
+// Regression: Pyodide's loadPackagesFromImports only scans the source string it
+// is handed and does not follow imports into local modules. A test script that
+// imports a bundled helper which itself imports numpy therefore ran with numpy
+// unloaded — green on the native validation run (numpy installed system-wide),
+// ModuleNotFoundError for every student in the browser.
+test('preloadPackagesForFiles scans bundled helpers, not just the test script', async () => {
+  const harness = await loadRunnerHarness({ manifest: { gradingMode: 'browser', testSuites: [] } });
+  const { preloadPackagesForFiles } = harness.hooks;
+
+  // The shape that broke Lab 9: the test script names only the helper; the
+  // third-party import lives one level down, inside the helper.
+  const files = {
+    'publictest_summarize.py': 'import lab9_helpers as H\nH.build_cohort(1)\n',
+    'lab9_helpers.py': 'import numpy as np\nimport pandas as pd\n',
+    'nhanes_bp.csv': 'age,high_bp\n40,1\n',
+  };
+
+  await preloadPackagesForFiles(harness.py, files);
+
+  const scanned = harness.py.state.loadPackageCalls;
+  assert.ok(
+    scanned.some(src => src.includes('import numpy')),
+    'helper source carrying the numpy import must be handed to loadPackagesFromImports',
+  );
+  // Non-Python bundle entries are not source and must not be scanned.
+  assert.ok(
+    !scanned.some(src => src.includes('age,high_bp')),
+    'CSV data files must not be scanned as Python source',
+  );
+});
+
+test('preloadPackagesForFiles isolates each file so one bad source cannot suppress the rest', async () => {
+  const harness = await loadRunnerHarness({ manifest: { gradingMode: 'browser', testSuites: [] } });
+  const { preloadPackagesForFiles } = harness.hooks;
+
+  // Pyodide parses the source to find imports, so an unparseable file throws.
+  // Scanning per-file (not one concatenated blob) keeps a student's
+  // half-finished submission from blocking the helper's packages.
+  const seen = [];
+  const py = {
+    async loadPackagesFromImports(src) {
+      seen.push(src);
+      if (src.includes('def broken(')) throw new SyntaxError('invalid syntax');
+    },
+  };
+
+  await preloadPackagesForFiles(py, {
+    'student_module.py': 'def broken(\n',
+    'lab9_helpers.py': 'import numpy as np\n',
+  });
+
+  assert.equal(seen.length, 2, 'a throwing file must not abort the scan');
+  assert.ok(seen.some(src => src.includes('import numpy')));
+});

--- a/changelog.d/browser-runner-transitive-package-preload.md
+++ b/changelog.d/browser-runner-transitive-package-preload.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Browser grading now preloads packages imported by bundled helper modules.**
+  Pyodide's `loadPackagesFromImports` only scans the single source string it is
+  handed and does not follow imports into local modules, so both browser grading
+  paths scanned the test script alone. A test script that imported a bundled
+  helper which in turn imported `numpy` ran with `numpy` unloaded and failed with
+  `ModuleNotFoundError` for every student — while validation passed, because
+  validation is graded by the native runner (where `numpy`/`pandas` are installed
+  system-wide) even for a `gradingMode: browser` assignment. `browser-runner.js`
+  and `grading-worker.js` now scan every `.py` file in the setup once, up front,
+  before any script runs. Scanning is per-file so one unparseable source (a
+  half-finished student submission) cannot suppress the rest, and remains
+  non-fatal so a name Pyodide does not ship never blocks a run.


### PR DESCRIPTION
## Summary

Pyodide's `loadPackagesFromImports` only scans the one source string it is handed — it does **not** follow imports into local modules. Both browser grading paths scanned the test script alone ([`browser-runner.js:977`](https://github.com/JimWallace/Chickadee/blob/main/Public/browser-runner.js#L977), [`grading-worker.js:139`](https://github.com/JimWallace/Chickadee/blob/main/Public/grading-worker.js#L139)), so a script whose only import was a bundled helper left that helper's third-party imports unloaded.

This fix scans every `.py` file in the setup once, up front, before any script runs.

## How it surfaced

HLTH 230 Lab 9. The four test scripts each do `import lab9_helpers as H`; `lab9_helpers.py` is what does `import numpy as np` / `import pandas as pd`. The scanner saw `lab9_helpers` (not a Pyodide package → loaded nothing), and every test died at the transitive import:

```
File "publictest_summarize.py", line 3, in <module>
    import lab9_helpers as H
File "/chickadee_work_.../lab9_helpers.py", line 18, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
```

## Why validation did not catch it

This is the part worth fixing structurally. Validation is enqueued as a `kind: .validation` submission via `enqueueRunnerValidationSubmission` ([`RunnerValidationHelpers.swift:291`](https://github.com/JimWallace/Chickadee/blob/main/Sources/APIServer/Routes/Web/RunnerValidationHelpers.swift#L291)) and graded by the **native `chickadee-runner`** — where numpy and pandas are installed system-wide — *even for a `gradingMode: browser` assignment*.

So validation and students run on different substrates. A green validation confirms the tests are logically correct; it says nothing about whether imports resolve in Pyodide. Any browser-graded assignment whose helper module imports a third-party package would validate green and fail for every student.

This PR fixes the loader gap. The validation/substrate asymmetry itself is left as-is — worth a separate discussion about whether browser-graded assignments should validate through the browser path.

## Changes

- `Public/browser-runner.js` — new `preloadPackagesForFiles(py, files)`, called after `writeFilesToPyFS` in `_ensureReady`; exported on the test hooks.
- `Public/grading-worker.js` — mirrored helper, called after `writeFilesToPyFS` in the `init` handler.
- Scanning is **per-file**, not one concatenated blob, so a single unparseable source (a half-finished student submission) cannot suppress every other file's imports. Non-fatal throughout, so a name Pyodide does not ship never blocks a run.
- The existing per-script scan is left in place — a no-op once packages are loaded, and still covers a script somehow absent from the file map.

The change sits outside every `CHICKADEE_DRIFT` region (those guard the shared Python snippets), so the drift guard is unaffected.

## Tests

Two regression tests in `Tests/BrowserRunnerJSTests/browser-runner.test.mjs`:

1. A helper module's `import numpy` reaches `loadPackagesFromImports` when only the helper names it — and a bundled `.csv` is not scanned as source.
2. A file that throws during scanning does not abort the scan for the others.

```
node --test Tests/BrowserRunnerJSTests/*.mjs   → 140 pass, 0 fail
scripts/eslint.sh                              → clean
```

## Note on Lab 9 itself

Lab 9 was separately unblocked ahead of its deadline by adding explicit `import numpy` / `import pandas` lines to its four test scripts, so the scanner sees them. Those lines become redundant once this ships, but are harmless — the packages are genuinely used, one level down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152KXm9spjVLug8hmfKxdrX

---
_Generated by [Claude Code](https://claude.ai/code/session_0152KXm9spjVLug8hmfKxdrX)_