### PR TITLE
fix(brightspace): auto-push browser-graded results and stop unusable 404 pushes

### DIFF
--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -137,6 +137,13 @@ struct BrowserResultRoutes: RouteCollection {
             submissionID: subID,
             source: "browser"
         )
+        // Mark for BrightSpace sync exactly as the worker path does. Without
+        // this a browser-graded assignment never auto-pushed a grade to LEARN:
+        // the 60-second sweep only ever sees rows flagged here, so notebook
+        // labs silently reached LEARN only via an instructor's manual "Push
+        // all" or a retest that routed through a worker.
+        try await flagResultForBrightSpaceSync(
+            browserResult, testSetupID: body.testSetupID, application: req.application, on: req.db)
         // Same transient-SQLite-lock guard as the submission insert above: this
         // second write can also lose a race with a concurrent commit (session
         // write / background monitor) and surface as a 500 otherwise.

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -144,24 +144,11 @@ struct ResultRoutes: RouteCollection {
             submissionID: collection.submissionID
         )
 
-        // Mark for BrightSpace sync if the assignment is configured for it. Gate
-        // on app-level config (not a live global client) so per-instructor-only
-        // deployments still flag results for the per-course sync to pick up.
-        if req.application.brightSpaceAppCredentials != nil {
-            if let assignment = try await APIAssignment.query(on: db)
-                .filter(\.$testSetupID == collection.testSetupID)
-                .first(),
-                let gradeObjectID = assignment.brightspaceGradeObjectID,
-                !gradeObjectID.isEmpty,
-                let course = try await APICourse.find(assignment.courseID, on: db),
-                let orgUnitID = course.brightspaceOrgUnitID,
-                !orgUnitID.isEmpty
-            {
-                let now = Date()
-                result.brightspaceSyncPending = true
-                result.brightspacePendingSince = now
-            }
-        }
+        // Mark for BrightSpace sync if the assignment is configured for it.
+        // Shared with the browser-result path so the two ingest routes can't
+        // drift apart on which grades reach LEARN.
+        try await flagResultForBrightSpaceSync(
+            result, testSetupID: collection.testSetupID, application: req.application, on: db)
 
         // Row + blob side-table row persist together; the caller's
         // transaction (persist + submission status flip) encloses both.

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -96,6 +96,44 @@ func recordSweepFailure(
         "BrightSpace grade sync \(retryable ? "transient" : "terminal") failure for row(s) \(ids): \(error)")
 }
 
+/// Flags a freshly-built (not yet saved) result row for BrightSpace grade sync
+/// when its assignment is actually wired to a LEARN grade item — the gate every
+/// result-ingest path shares.
+///
+/// Mutates `result` in memory only; the caller persists it (both call sites save
+/// the row immediately afterwards, so the flags ride along on the same INSERT).
+///
+/// This lives here, called from BOTH ingest paths, because it used to be inline
+/// in the worker path only: browser-graded results were never flagged, so
+/// notebook assignments never auto-pushed a grade to LEARN at all. Their grades
+/// only appeared when an instructor hit "Push all" (or a retest routed the
+/// submission through a worker), which looks exactly like "sync is broken for
+/// this assignment" — the sweep had nothing to find.
+///
+/// Gates on app-level config (not a live global client) so per-instructor-only
+/// deployments still flag results for the per-course sync to pick up.
+func flagResultForBrightSpaceSync(
+    _ result: APIResult,
+    testSetupID: String,
+    application: Application,
+    on db: Database
+) async throws {
+    guard application.brightSpaceAppCredentials != nil else { return }
+    guard
+        let assignment = try await APIAssignment.query(on: db)
+            .filter(\.$testSetupID == testSetupID)
+            .first(),
+        let gradeObjectID = assignment.brightspaceGradeObjectID,
+        !gradeObjectID.isEmpty,
+        let course = try await APICourse.find(assignment.courseID, on: db),
+        let orgUnitID = course.brightspaceOrgUnitID,
+        !orgUnitID.isEmpty
+    else { return }
+
+    result.brightspaceSyncPending = true
+    result.brightspacePendingSince = Date()
+}
+
 /// Re-queues rows for an immediate push: pending flag set, `pendingSince`
 /// back-dated past any debounce cutoff, recorded error cleared. The ONE place
 /// the `Date.distantPast` "retry immediately" sentinel is written (#1117) —

--- a/Sources/APIServer/Services/BrightSpaceIdentityIndex.swift
+++ b/Sources/APIServer/Services/BrightSpaceIdentityIndex.swift
@@ -36,6 +36,12 @@ struct BrightSpaceIdentityIndex: Sendable {
         self.identities = all
     }
 
+    /// True when the classlist yielded no matchable identity at all. Callers use
+    /// this to tell "this org unit's roster says the student isn't here" from
+    /// "we have no usable roster" — an empty read (a key without classlist
+    /// permission, say) must not be mistaken for an authoritative answer.
+    var isEmpty: Bool { identities.isEmpty }
+
     /// The shared identity normalization: trim + lowercase.
     static func normalize(_ value: String) -> String {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
+++ b/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
@@ -309,7 +309,7 @@ extension GradeSyncSweep {
         let bsUserID = try await resolveBSUserID(for: target.user, orgUnitID: orgUnitID, client: client)
         guard let bsUserID else {
             try await recordTerminalSkip(
-                "Student has no BrightSpace account (orgDefinedId not found)", points: pushPoints)
+                "Student is not on the LEARN classlist for org unit \(orgUnitID)", points: pushPoints)
             return true
         }
 
@@ -323,6 +323,8 @@ extension GradeSyncSweep {
                 on: application
             )
         } catch {
+            await invalidateCachedUserIDOnNotFound(
+                error, user: target.user, describing: "user \(userID) on '\(assignment.title)'")
             // Enrich with item context here (the sweep's catch lacks it), then
             // rethrow so the existing per-group error handling still runs.
             let maxDesc = gradeObject?.maxPoints.map { "\($0)" } ?? "unset"
@@ -349,21 +351,52 @@ extension GradeSyncSweep {
         return true
     }
 
+    /// Drops a student's cached D2L user id after a 404 grade push.
+    ///
+    /// A 404 from the values endpoint is about the *user*, not the item: the
+    /// grade object is fetched successfully immediately before the push, so the
+    /// org unit and the item both exist. The usual cause is a cached
+    /// `brightspaceUserID` for a student who isn't (or is no longer) in this org
+    /// unit — most often one resolved through the LMS-global OrgDefinedId
+    /// lookup. Clearing it makes the next attempt re-resolve against the
+    /// classlist; without this the same unusable id is replayed on every future
+    /// push, for every assignment, and the failure never heals.
+    ///
+    /// Deliberately narrow: any other status says nothing about the identity,
+    /// so the cached id survives it.
+    private func invalidateCachedUserIDOnNotFound(
+        _ error: Error, user: APIUser?, describing context: String
+    ) async {
+        guard let syncError = error as? BrightSpaceSyncError,
+            case .gradePushFailed(let status, _) = syncError,
+            status == 404,
+            let user,
+            user.brightspaceUserID != nil
+        else { return }
+        user.brightspaceUserID = nil
+        try? await user.save(on: db)
+        application.logger.warning(
+            "BrightSpace grade push 404 for \(context) — cleared the cached D2L user id so the next attempt re-resolves"
+        )
+    }
+
     /// Resolves the student's D2L user ID via the course classlist (cached per
-    /// sweep), falling back to the org-level OrgDefinedId lookup. A classlist read
-    /// failure degrades to the fallback rather than aborting the push.
+    /// sweep). A classlist read failure yields a nil index, which
+    /// `resolvedBrightSpaceUserID` treats as "authority unavailable" — distinct
+    /// from a successful read in which the student simply doesn't appear.
     func resolveBSUserID(
         for user: APIUser?,
         orgUnitID: String,
         client: any BrightSpaceGrading
     ) async throws -> String? {
-        var identityIndex = BrightSpaceIdentityIndex(classlist: [])
+        var identityIndex: BrightSpaceIdentityIndex?
         do {
             identityIndex = try await classlistCache.identityIndex(
                 orgUnitID: orgUnitID, client: client, application: application)
         } catch {
             application.logger.warning(
                 "BrightSpace classlist resolve failed for org unit \(orgUnitID): \(error)")
+            identityIndex = nil
         }
         return try await resolvedBrightSpaceUserID(
             for: user, identityIndex: identityIndex, db: db, client: client, application: application)
@@ -372,16 +405,27 @@ extension GradeSyncSweep {
 
 /// Returns the cached D2L user ID for `user`, resolving it on first sync. Takes
 /// the already batch-loaded `APIUser?` (nil when the sweep found no such user)
-/// and the course's pre-built classlist identity map.
+/// and the course's classlist identity map — nil when the classlist read failed.
 ///
 /// Resolution matches the classlist by **username first, student number
 /// second** — the username is the identity Chickadee always has (SSO or local)
 /// and equals the LEARN username at UW, so grade sync works without a
-/// student-number claim. Falls back to the org-level `users/?orgDefinedId=`
-/// lookup only when the classlist match misses but a student number is on file.
+/// student-number claim.
+///
+/// A *populated* classlist is the authority on who can receive a grade in this
+/// org unit. When it was read successfully, has members, and the student isn't
+/// among them, resolution stops there rather than falling through to the
+/// org-level `users/?orgDefinedId=` lookup: that lookup is LMS-GLOBAL and
+/// happily returns the account of a student who is not enrolled in this course,
+/// whose grade push D2L then rejects with a bare HTTP 404 that names no cause.
+/// Returning nil instead surfaces it as the roster problem it is.
+///
+/// An index that is nil (read failed) or empty (e.g. a Valence key without
+/// classlist permission) is NOT an authoritative "not here" — the global
+/// fallback still runs there, so a classlist outage can't strand every push.
 private func resolvedBrightSpaceUserID(
     for user: APIUser?,
-    identityIndex: BrightSpaceIdentityIndex,
+    identityIndex: BrightSpaceIdentityIndex?,
     db: Database,
     client: any BrightSpaceGrading,
     application: Application
@@ -392,9 +436,15 @@ private func resolvedBrightSpaceUserID(
         return cached
     }
 
-    var bsUserID = identityIndex.d2lUserID(username: user.username, studentID: user.studentID)
-    // Fallback: the legacy org-level OrgDefinedId lookup (needs a student number).
-    if bsUserID == nil, let orgDefinedId = user.studentID, !orgDefinedId.isEmpty {
+    var bsUserID = identityIndex?.d2lUserID(username: user.username, studentID: user.studentID)
+
+    if bsUserID == nil {
+        // Only a populated classlist can answer "this student isn't in the
+        // course"; anything else means we have no roster to trust.
+        let classlistIsAuthoritative = (identityIndex.map { !$0.isEmpty }) ?? false
+        if classlistIsAuthoritative { return nil }
+
+        guard let orgDefinedId = user.studentID, !orgDefinedId.isEmpty else { return nil }
         bsUserID = try await client.lookupUserID(orgDefinedId: orgDefinedId, on: application)
     }
 

--- a/Tests/APITests/BrightSpaceGradeSyncTests.swift
+++ b/Tests/APITests/BrightSpaceGradeSyncTests.swift
@@ -401,7 +401,95 @@ private actor FakeBrightSpaceGrading: BrightSpaceGrading {
             #expect(pushes.isEmpty)
             let result = try #require(try await APIResult.query(on: app.db).first())
             #expect(result.brightspaceSyncPending == false)
-            #expect(result.brightspaceSyncError?.contains("no BrightSpace account") == true)
+            #expect(result.brightspaceSyncError?.contains("not on the LEARN classlist") == true)
+        }
+    }
+
+    /// A populated classlist is authoritative: a student who isn't on it is not
+    /// in this org unit, so the LMS-GLOBAL `users/?orgDefinedId=` lookup must not
+    /// be used to manufacture a push target. It would return the student's
+    /// account anyway, D2L would reject the grade with a bare HTTP 404, and the
+    /// unusable id would be cached — making every later push for that student,
+    /// on every assignment, fail identically forever.
+    @Test func studentAbsentFromPopulatedClasslistIsSkippedNotPushed() async throws {
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(studentID: "stu-001")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 8, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            // The classlist has members, but not this student. The global lookup
+            // table *would* resolve them — proving we deliberately didn't ask.
+            let fake = FakeBrightSpaceGrading(
+                userIDsByOrgDefinedId: ["stu-001": "d2l-not-in-course"],
+                classlist: [
+                    BrightSpaceClasslistEntry(
+                        orgDefinedID: "stu-999", username: "someone.else", userID: "d2l-111")
+                ])
+
+            let processed = try await sweep(client: fake)
+
+            #expect(processed == 1)  // a skip is a normal terminal outcome
+            let pushes = await fake.pushes
+            #expect(pushes.isEmpty, "must not push a grade for a student who isn't in the org unit")
+            let lookupCount = await fake.lookupCount
+            #expect(lookupCount == 0, "the LMS-global lookup must not run behind a populated classlist")
+
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncPending == false)
+            #expect(result.brightspaceSyncError?.contains("not on the LEARN classlist") == true)
+            let user = try await APIUser.find(scenario.userID, on: app.db)
+            #expect(user?.brightspaceUserID == nil, "an unusable id must never be cached")
+        }
+    }
+
+    /// A D2L 404 on the push is about the *user*, not the item — the grade
+    /// object was fetched successfully moments earlier. Drop the cached D2L id
+    /// so the next attempt re-resolves against the classlist; otherwise the
+    /// stale id is replayed on every future push and the failure never heals.
+    @Test func gradePush404ClearsCachedUserID() async throws {
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-stale")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 8, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                pushError: BrightSpaceSyncError.gradePushFailed(status: 404, body: "Not Found"))
+
+            _ = try await sweep(client: fake)
+
+            let user = try await APIUser.find(scenario.userID, on: app.db)
+            #expect(
+                user?.brightspaceUserID == nil,
+                "a 404 must invalidate the cached D2L user id so resolution retries")
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncError?.contains("404") == true)
+        }
+    }
+
+    /// The counterpart guard: a non-404 rejection says nothing about the
+    /// identity, so the cached id must survive it.
+    @Test func gradePush500LeavesCachedUserIDIntact() async throws {
+        try await withApp(app) { _ in
+            let scenario = try await makeConfiguredScenario(brightspaceUserID: "d2l-good")
+            try await makePendingResult(
+                submissionID: scenario.submissionID,
+                json: pointsJSON(earned: 8, total: 10),
+                pendingSince: Date().addingTimeInterval(-3600)
+            )
+            let fake = FakeBrightSpaceGrading(
+                pushError: BrightSpaceSyncError.gradePushFailed(status: 500, body: "boom"))
+
+            _ = try await sweep(client: fake)
+
+            let user = try await APIUser.find(scenario.userID, on: app.db)
+            #expect(user?.brightspaceUserID == "d2l-good")
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            // 5xx is transient: the row stays pending so the next sweep retries.
+            #expect(result.brightspaceSyncPending == true)
         }
     }
 

--- a/Tests/APITests/BrowserRunnerRoutesTests.swift
+++ b/Tests/APITests/BrowserRunnerRoutesTests.swift
@@ -669,6 +669,148 @@ import VaporTesting
         }
     }
 
+    /// Regression: a browser-graded result must be flagged for BrightSpace grade
+    /// sync exactly as a worker-reported one is. Only the worker path used to do
+    /// this, so notebook assignments never auto-pushed a grade to LEARN at all —
+    /// the 60-second sweep only ever sees rows flagged at ingest, and grades
+    /// reached LEARN only when an instructor hit "Push all" by hand.
+    @Test func browserResultIsFlaggedForBrightSpaceGradeSync() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            let assignment = try await insertAssignment(testSetupID: setupID, isOpen: true)
+
+            // Wire the course + assignment to LEARN, and give the deployment the
+            // app-level credentials the ingest gate checks.
+            let setup = try #require(try await APITestSetup.find(setupID, on: app.db))
+            let course = try #require(try await APICourse.find(setup.courseID, on: app.db))
+            course.brightspaceOrgUnitID = "ou-browser"
+            try await course.save(on: app.db)
+            assignment.brightspaceGradeObjectID = "go-browser"
+            try await assignment.save(on: app.db)
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.example.edu", appID: "app", appKey: "key", debounceSecs: 90)
+            defer { app.brightSpaceAppCredentials = nil }
+
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+            let nb = minimalNotebook()
+
+            let collection = """
+                {
+                  "submissionID": "",
+                  "testSetupID": "\(setupID)",
+                  "attemptNumber": 1,
+                  "buildStatus": "passed",
+                  "compilerOutput": null,
+                  "outcomes": [
+                    {
+                      "testName": "test_public",
+                      "testClass": null,
+                      "tier": "public",
+                      "status": "pass",
+                      "shortResult": "passed",
+                      "longResult": null,
+                      "executionTimeMs": 5,
+                      "memoryUsageBytes": null,
+                      "attemptNumber": 1,
+                      "isFirstPassSuccess": true
+                    }
+                  ],
+                  "totalTests": 1,
+                  "passCount": 1,
+                  "failCount": 0,
+                  "errorCount": 0,
+                  "timeoutCount": 0,
+                  "executionTimeMs": 5,
+                  "runnerVersion": "browser-wasm-runner/1.0",
+                  "timestamp": "2026-01-01T00:00:00Z"
+                }
+                """
+
+            try await app.asyncTest(
+                .POST, "/api/v1/submissions/browser-result",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.body = .init(
+                        buffer: multipartBody(
+                            boundary: "bs-sync-boundary",
+                            fields: [("_csrf", csrf), ("collection", collection), ("testSetupID", setupID)],
+                            file: ("notebook", "notebook.ipynb", nb)
+                        ))
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data",
+                        parameters: ["boundary": "bs-sync-boundary"])
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "browser-result should accept, body: \(res.body.string)")
+                })
+
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.source == "browser")
+            #expect(
+                result.brightspaceSyncPending == true,
+                "a browser-graded result on a LEARN-wired assignment must be queued for grade sync")
+            #expect(result.brightspacePendingSince != nil)
+        }
+    }
+
+    /// The same ingest gate must stay closed when the assignment has no LEARN
+    /// grade item — flagging every browser result would give the sweep a
+    /// permanent backlog of rows it can only ever no-op on.
+    @Test func browserResultIsNotFlaggedWhenAssignmentHasNoGradeItem() async throws {
+        try await withApp(app) { _ in
+            let setupID = try await insertSetup(manifest: simpleManifest())
+            _ = try await insertAssignment(testSetupID: setupID, isOpen: true)
+            app.brightSpaceAppCredentials = BrightSpaceAppCredentials(
+                baseURL: "https://learn.example.edu", appID: "app", appKey: "key", debounceSecs: 90)
+            defer { app.brightSpaceAppCredentials = nil }
+
+            let cookie = try await loginAsStudent()
+            let (csrf, sessionCookie) = try await csrfFields(for: "/login", cookie: cookie, on: app)
+            let nb = minimalNotebook()
+
+            let collection = """
+                {
+                  "submissionID": "",
+                  "testSetupID": "\(setupID)",
+                  "attemptNumber": 1,
+                  "buildStatus": "passed",
+                  "compilerOutput": null,
+                  "outcomes": [],
+                  "totalTests": 0,
+                  "passCount": 0,
+                  "failCount": 0,
+                  "errorCount": 0,
+                  "timeoutCount": 0,
+                  "executionTimeMs": 1,
+                  "runnerVersion": "browser-wasm-runner/1.0",
+                  "timestamp": "2026-01-01T00:00:00Z"
+                }
+                """
+
+            try await app.asyncTest(
+                .POST, "/api/v1/submissions/browser-result",
+                beforeRequest: { req in
+                    req.headers.add(name: .cookie, value: sessionCookie)
+                    req.body = .init(
+                        buffer: multipartBody(
+                            boundary: "bs-nosync-boundary",
+                            fields: [("_csrf", csrf), ("collection", collection), ("testSetupID", setupID)],
+                            file: ("notebook", "notebook.ipynb", nb)
+                        ))
+                    req.headers.contentType = HTTPMediaType(
+                        type: "multipart", subType: "form-data",
+                        parameters: ["boundary": "bs-nosync-boundary"])
+                },
+                afterResponse: { res in
+                    #expect(res.status == .ok, "browser-result should accept, body: \(res.body.string)")
+                })
+
+            let result = try #require(try await APIResult.query(on: app.db).first())
+            #expect(result.brightspaceSyncPending != true)
+        }
+    }
+
     @Test func runnerSubmitRejectsBrowserGradedAssignments() async throws {
         try await withApp(app) { _ in
             let setupID = try await insertSetup(manifest: simpleManifest())

--- a/changelog.d/brightspace-grade-push-failures.md
+++ b/changelog.d/brightspace-grade-push-failures.md
@@ -1,0 +1,26 @@
+### Fixed
+
+- **Browser-graded assignments now auto-push grades to LEARN.** Only the worker
+  result path flagged a result for BrightSpace grade sync, so a notebook
+  (browser-graded) assignment never queued a push at all — the 60-second sweep
+  only ever sees rows flagged at ingest. Grades for those assignments reached
+  LEARN only when an instructor pressed "Push all" by hand, or when a retest
+  happened to route the submission through a worker. The flagging gate is now a
+  shared helper (`flagResultForBrightSpaceSync`) called by both ingest paths.
+
+- **A student missing from the LEARN classlist no longer produces an unusable
+  grade push.** When the classlist lookup missed, resolution fell through to the
+  LMS-global `users/?orgDefinedId=` lookup, which returns the account of a
+  student who is not enrolled in the course. D2L rejected the resulting push
+  with a bare `HTTP 404: Not Found`, and the unusable D2L user id was cached on
+  the user row — so every later push for that student, on every assignment,
+  failed identically forever. A *populated* classlist is now authoritative: a
+  student absent from it is recorded as a skip naming their org unit, instead of
+  a 404. An empty or unreadable classlist is still not treated as authoritative,
+  so a Valence permission gap or transient outage cannot strand every push.
+
+- **A 404 grade push now invalidates the cached D2L user id.** The grade item is
+  fetched successfully immediately before the push, so a 404 from the values
+  endpoint is about the user, not the item. The cached id is dropped so the next
+  attempt re-resolves against the classlist rather than replaying the same
+  failure. Other statuses leave the cached id intact.


### PR DESCRIPTION
Investigates two reported symptoms in HLTH 230: Labs 7 and 8 never pushed grades to LEARN until a manual sync, and Lab 9 is raising a repeated `HTTP 404` grade-push health alert. They turned out to be separate defects, plus a third that kept the second from ever healing.

## Evidence

The prod sync log (admin diagnostics MCP, 72h window) shows **350 successes / 13 errors**. Every error is the same shape, spread across Lab 7, Lab 8 *and* Lab 9, all in org unit `1265792`:

```
Pushed 2.58 pts to 'Lab 9' (max 10.0); D2L rejected it: BrightSpace grade push failed (HTTP 404): Not Found
Pushed 10.0 pts to 'Lab 7' (max 10.0); D2L rejected it: BrightSpace grade push failed (HTTP 404): Not Found
```

Two things follow. The item name and max points are in the message, which means `fetchGradeObject` resolved the item moments before the push — so the org unit and the grade item both exist, and the 404 is about the **user**. And the same failure recurs across three assignments without ever healing, which points at cached state rather than a transient fault.

Lab 7 and Lab 9 are both `gradingMode: "browser"`.

## Fixes

**1. Browser-graded assignments never queued a grade push.**

Only `ResultRoutes.persistToDB` (the worker report path) set `brightspace_sync_pending`. `BrowserResultRoutes` had no BrightSpace reference at all. The sweep only ever selects rows flagged at ingest, so a notebook assignment's grades reached LEARN solely via an instructor's manual "Push all" or a retest that happened to route through a worker. That is Labs 7 and 8 exactly: nothing was pending, so the 60-second sweep had nothing to find, and the manual button fixed it because `brightspacePushAllForAssignment` re-queues every result row unconditionally.

The gate is now one shared helper, `flagResultForBrightSpaceSync`, called by both ingest paths.

**2. A student absent from the LEARN classlist produced a guaranteed-404 push.**

When the classlist match missed, `resolvedBrightSpaceUserID` fell through to the org-level `users/?orgDefinedId=` lookup. That lookup is LMS-**global**: it returns the account of a student who is not enrolled in this org unit. The push then 404s, and — the part that made it permanent — the unusable id was written to `user.brightspaceUserID`, so every later push for that student, on every assignment, replayed the same failure forever. That matches the observed signature of a handful of students failing on 7, 8 and 9 alike while 350 other pushes succeed.

A **populated** classlist is now authoritative: a student absent from it is recorded as a skip naming their org unit, which is an actionable roster problem rather than a bare 404. Deliberately narrow — an index that is nil (read failed) or empty (e.g. a Valence key without classlist permission) is *not* treated as authoritative, so the global fallback still runs there and a permission gap or transient outage cannot strand every push in the course.

**3. A 404 push now invalidates the cached D2L user id.**

Since the item is known-good at that point, a 404 implicates the identity. The cached id is dropped so the next attempt re-resolves against the classlist instead of replaying the failure. Any other status leaves it intact.

## Testing

`swift test --filter "BrightSpace|BrowserRunnerRoutes|ResultRoutes"` — 102 tests across 10 suites pass. `scripts/format.sh`, `scripts/lint.sh`, and `scripts/swiftlint.sh --strict` are clean (the 404 handling was extracted to `invalidateCachedUserIDOnNotFound` to keep `pushGrade` under the `function_body_length` threshold rather than raising it).

New tests:

- `browserResultIsFlaggedForBrightSpaceGradeSync` — a browser result on a LEARN-wired assignment is queued for sync.
- `browserResultIsNotFlaggedWhenAssignmentHasNoGradeItem` — the gate stays closed without a grade item, so the sweep gets no permanent no-op backlog.
- `studentAbsentFromPopulatedClasslistIsSkippedNotPushed` — asserts the global lookup is *not* consulted (`lookupCount == 0`) even though it would have resolved, and that no id is cached.
- `gradePush404ClearsCachedUserID` / `gradePush500LeavesCachedUserIDIntact` — the invalidation is 404-only.

`happyPathPushesGradeAndCachesUserID` is unchanged and still passes, which is the regression guard for the empty-classlist fallback.

## Notes for review

- Fix 1 changes what reaches LEARN automatically. On deploy, new browser-graded submissions in a LEARN-wired course begin pushing on their own; existing result rows are untouched and still need "Push all" once.
- The skip message wording changed, so `noBrightSpaceAccountRecordsSkipMessage` was updated to match.
- Fix 2 is the one carrying real behavioural risk. The empty-vs-populated distinction is what bounds it; `BrightSpaceIdentityIndex.isEmpty` was added for that check.
- The 13 logged errors do not identify students (the diagnostic surface redacts username and points by design), so which students are missing from org unit `1265792` still needs checking against the LEARN classlist. After this change they will be reported as a named skip rather than a 404, which should make them visible on the instructor BrightSpace tab.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcDrb4RH6ij8Z9FkQsGoR1)_