### PR TITLE
Fix the worker-tests pool-saturation wedge behind the 20-minute CI kills (#1233)

### DIFF
--- a/Sources/Worker/BoundedPipeRead.swift
+++ b/Sources/Worker/BoundedPipeRead.swift
@@ -1,0 +1,55 @@
+// Worker/BoundedPipeRead.swift
+//
+// Deadline-bounded synchronous pipe drain, shared by the subprocess helpers
+// that must read a child's output to EOF without risking an unbounded block
+// on a cooperative-pool thread (issue #1233).
+//
+// EOF on a pipe requires every duplicate of the write end to be closed. A
+// process spawned concurrently with the child — another job's fork, a test's
+// HTTP server — that inherited a non-CLOEXEC duplicate postpones EOF until
+// *it* exits, so a plain `readDataToEndOfFile()` is an unbounded stall in
+// exactly the loaded-parallel-CI conditions of issues #1139/#1233. Pair with
+// `setCloseOnExec(_:)` on the pipe so the leak cannot happen; the deadline
+// here is defence in depth for descriptors leaked by code outside our
+// control.
+
+import Foundation
+
+#if os(Linux)
+import Glibc
+#endif
+
+/// Reads from `descriptor` until EOF or `deadline`, whichever comes first,
+/// and returns whatever accumulated (capped at `maxBytes`; excess is
+/// discarded, mirroring `CapturedPipeBuffer`'s OOM guard). The poll
+/// granularity is 100 ms, so the calling thread is parked in `read(2)` only
+/// while data is actually available — never in an unbounded blocking read.
+func boundedReadToEOF(
+    fromDescriptor descriptor: Int32,
+    deadline: Date,
+    maxBytes: Int = 1_048_576
+) -> Data {
+    var accumulated = Data()
+    var chunk = [UInt8](repeating: 0, count: 65_536)
+    while true {
+        var pollDescriptor = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+        let readyCount = poll(&pollDescriptor, 1, 100)
+        if readyCount == -1 {
+            if errno == EINTR { continue }
+            return accumulated
+        }
+        if readyCount > 0 {
+            let bytesRead = read(descriptor, &chunk, chunk.count)
+            if bytesRead > 0 {
+                let remaining = maxBytes - accumulated.count
+                if remaining > 0 {
+                    accumulated.append(contentsOf: chunk[0..<min(bytesRead, remaining)])
+                }
+                continue
+            }
+            if bytesRead == -1 && errno == EINTR { continue }
+            return accumulated  // 0 = EOF (every write end closed); -1 = unrecoverable.
+        }
+        if Date() >= deadline { return accumulated }
+    }
+}

--- a/Sources/Worker/MimeTypeDetector.swift
+++ b/Sources/Worker/MimeTypeDetector.swift
@@ -1,17 +1,44 @@
 import Foundation
 
+#if os(Linux)
+import Glibc
+#endif
+
 struct MimeTypeDetector {
+    /// Ceiling on one `file` invocation. Typically single-digit milliseconds;
+    /// the bound exists so a leaked pipe descriptor or a wedged `file` can
+    /// pin the calling cooperative-pool thread for at most this long instead
+    /// of forever (issue #1233 — this call runs once per submission file per
+    /// job, unthrottled, so an unbounded stall here can saturate the whole
+    /// pool under parallel-test load).
+    private static let timeoutSeconds: TimeInterval = 30
+
     func detectMimeType(for fileURL: URL) throws -> String {
         let process = Process()
         let stdout = Pipe()
+        // CLOEXEC: without it, any subprocess spawned concurrently with this
+        // one inherits a duplicate of the write end across its exec, and the
+        // drain below then never sees EOF until that unrelated process exits
+        // (the #1139 mechanism, recurring in #1233).
+        setCloseOnExec(stdout)
         process.executableURL = URL(fileURLWithPath: "/usr/bin/file")
         process.arguments = ["--mime-type", "-b", fileURL.path]
         process.standardOutput = stdout
         try process.run()
         // Drain stdout BEFORE waiting: read-after-wait deadlocks once the
         // child fills the pipe buffer, while EOF arrives exactly when the
-        // child exits (docs/ci-flakiness.md, remaining attack order).
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        // child exits (docs/ci-flakiness.md, remaining attack order). The
+        // drain is deadline-bounded — never an unbounded blocking read on a
+        // cooperative-pool thread (issue #1233).
+        let data = boundedReadToEOF(
+            fromDescriptor: stdout.fileHandleForReading.fileDescriptor,
+            deadline: Date().addingTimeInterval(Self.timeoutSeconds)
+        )
+        if process.isRunning {
+            // Deadline hit with `file` still alive: kill it so the reap below
+            // cannot block past the bound. SIGKILL cannot be ignored.
+            kill(process.processIdentifier, SIGKILL)
+        }
         process.waitUntilExit()
 
         guard process.terminationStatus == 0 else {

--- a/Sources/Worker/RunnerProfileDetector.swift
+++ b/Sources/Worker/RunnerProfileDetector.swift
@@ -99,6 +99,12 @@ struct RunnerProfileDetector {
         let process = Process()
         let output = Pipe()
         let error = Pipe()
+        // CLOEXEC + bounded drain: a non-CLOEXEC write end inherited by a
+        // concurrently spawned process postpones EOF until *that* process
+        // exits, turning `readDataToEndOfFile()` into an unbounded stall on
+        // a cooperative-pool thread (issue #1233; same mechanism as #1139).
+        setCloseOnExec(output)
+        setCloseOnExec(error)
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [command] + arguments
         process.standardOutput = output
@@ -119,18 +125,36 @@ struct RunnerProfileDetector {
         let exited = await waitWithTimeout(process: process, command: command, arguments: arguments)
         guard exited, process.terminationStatus == 0 else { return nil }
 
-        let stdout = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        // The child has exited, so with CLOEXEC pipes EOF is already in the
+        // buffer; the deadline only bounds descriptors leaked outside our
+        // control.
+        let drainDeadline = Date().addingTimeInterval(Self.probeTimeoutSeconds)
+        let stdout =
+            String(
+                data: boundedReadToEOF(
+                    fromDescriptor: output.fileHandleForReading.fileDescriptor,
+                    deadline: drainDeadline),
+                encoding: .utf8) ?? ""
+        let stderr =
+            String(
+                data: boundedReadToEOF(
+                    fromDescriptor: error.fileHandleForReading.fileDescriptor,
+                    deadline: drainDeadline),
+                encoding: .utf8) ?? ""
         let combined = (stdout + "\n" + stderr).trimmingCharacters(in: .whitespacesAndNewlines)
         return combined.isEmpty ? nil : combined
     }
 
     private func runStatus(command: String, arguments: [String]) async -> Int32? {
         let process = Process()
+        let output = Pipe()
+        let error = Pipe()
+        setCloseOnExec(output)
+        setCloseOnExec(error)
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [command] + arguments
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
+        process.standardOutput = output
+        process.standardError = error
         do {
             try process.run()
         } catch {

--- a/Sources/Worker/ScriptRunner.swift
+++ b/Sources/Worker/ScriptRunner.swift
@@ -191,7 +191,11 @@ private func installPipeCapture(for pipe: Pipe, buffer: CapturedPipeBuffer) {
 /// process exits (issue #1139's cross-test stall). The intended child still
 /// receives its ends: `dup2`/spawn file actions clear the flag on the
 /// duplicate they install.
-private func setCloseOnExec(_ pipe: Pipe) {
+///
+/// Internal (not private): every worker-side subprocess pipe should go
+/// through this — a single non-CLOEXEC pipe elsewhere re-opens the
+/// EOF-starvation window for everyone (issue #1233).
+func setCloseOnExec(_ pipe: Pipe) {
     for handle in [pipe.fileHandleForReading, pipe.fileHandleForWriting] {
         let descriptor = handle.fileDescriptor
         let flags = fcntl(descriptor, F_GETFD)

--- a/Sources/Worker/TestSetupCache.swift
+++ b/Sources/Worker/TestSetupCache.swift
@@ -25,8 +25,20 @@ actor TestSetupCache {
     /// LRU order — index 0 is least-recently-used, last is most-recently-used.
     private var lruKeys: [String] = []
 
-    /// In-progress population tasks, keyed by testSetupID.
-    private var inProgress: [String: Task<URL, Error>] = [:]
+    /// One in-flight population: the unstructured task doing the download +
+    /// commit, plus the continuation of every acquirer awaiting it. The task
+    /// reports through `finishPopulation(testSetupID:result:)`, never via
+    /// `task.value` — awaiting `Task.value` is not cancellation-responsive,
+    /// and doing so from a job slot was the wait that made `daemon.run()`
+    /// ignore cancellation on the artifact-download path (issue #1233,
+    /// docs/ci-flakiness.md "what in daemon.run() ignores cancellation").
+    private struct InFlightPopulation {
+        var task: Task<Void, Never>
+        var waiters: [UUID: CheckedContinuation<URL, Error>] = [:]
+    }
+
+    /// In-progress populations, keyed by testSetupID.
+    private var inProgress: [String: InFlightPopulation] = [:]
 
     init(
         cacheRoot: URL = TestSetupCache.defaultCacheRoot,
@@ -132,42 +144,95 @@ actor TestSetupCache {
             return AcquireResult(directory: preparedDir, didHit: true)
         }
 
-        // ── Already populating — await in-flight task ─────────────────────
-        if let task = inProgress[testSetupID] {
-            writeStructuredRunnerLog(
-                event: "test_setup_cache_await_in_progress",
-                fields: [
-                    "test_setup_id": testSetupID
-                ])
-            let populated = try await task.value
-            // Another caller may have already registered this key in lruKeys;
-            // touchLRU is idempotent and safe to call from any code path.
-            touchLRU(key: testSetupID)
-            // Awaiting an in-flight populate is a miss from the caller's
-            // perspective — work was still being done on their behalf.
-            return AcquireResult(directory: populated, didHit: false)
+        // ── Miss or in-flight — join the (possibly new) population ──────────
+        // Joining an in-flight populate is a miss from the caller's
+        // perspective — work was still being done on their behalf.
+        let populated = try await awaitPopulation(testSetupID: testSetupID, populate: populate)
+        return AcquireResult(directory: populated, didHit: false)
+    }
+
+    /// Awaits the population of `testSetupID`, starting it if none is in
+    /// flight, and responds to the caller's task cancellation: a cancelled
+    /// acquirer detaches promptly (throwing `CancellationError`) instead of
+    /// riding out the download, and the population task itself is cancelled
+    /// once its last waiter detaches — so a cancelled daemon stops its
+    /// in-flight artifact downloads instead of ignoring cancellation
+    /// (issue #1233).
+    private func awaitPopulation(
+        testSetupID: String,
+        populate: @escaping @Sendable () async throws -> URL
+    ) async throws -> URL {
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                // Runs synchronously on the actor: the miss-check, task
+                // start, and waiter registration form one isolation slice, so
+                // `finishPopulation` cannot interleave between them.
+                if Task.isCancelled {
+                    // Cancellation delivered before registration: onCancel
+                    // already ran against an unregistered waiter, so honour
+                    // it here — nobody else will resume this continuation.
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                if var population = inProgress[testSetupID] {
+                    writeStructuredRunnerLog(
+                        event: "test_setup_cache_await_in_progress",
+                        fields: [
+                            "test_setup_id": testSetupID
+                        ])
+                    population.waiters[waiterID] = continuation
+                    inProgress[testSetupID] = population
+                } else {
+                    writeStructuredRunnerLog(
+                        event: "test_setup_cache_miss",
+                        fields: [
+                            "test_setup_id": testSetupID
+                        ])
+                    var population = InFlightPopulation(
+                        task: makePopulationTask(testSetupID: testSetupID, populate: populate))
+                    population.waiters[waiterID] = continuation
+                    inProgress[testSetupID] = population
+                }
+            }
+        } onCancel: {
+            Task { await self.detachWaiter(testSetupID: testSetupID, waiterID: waiterID) }
         }
+    }
 
-        // ── Cache miss — start population ────────────────────────────────────
-        writeStructuredRunnerLog(
-            event: "test_setup_cache_miss",
-            fields: [
-                "test_setup_id": testSetupID
-            ])
-
+    /// The unstructured population worker. Unstructured on purpose — it is
+    /// shared by every concurrent acquirer of the key and must not be tied to
+    /// any single caller's lifetime; it always reports through
+    /// `finishPopulation`, which resumes whichever waiters remain.
+    private func makePopulationTask(
+        testSetupID: String,
+        populate: @escaping @Sendable () async throws -> URL
+    ) -> Task<Void, Never> {
         let cacheRoot = self.cacheRoot  // capture value type, not actor ref
-        let populateTask = Task<URL, Error> {
-            let stagingDir = try await populate()
-            return try Self.commit(stagingDir: stagingDir, testSetupID: testSetupID, cacheRoot: cacheRoot)
+        // `Task {}` inherits this actor's isolation, so `finishPopulation` is
+        // a synchronous same-actor call here — no interleaving between the
+        // result being ready and the waiters being resumed.
+        return Task {
+            let result: Result<URL, Error>
+            do {
+                let stagingDir = try await populate()
+                result = .success(
+                    try Self.commit(stagingDir: stagingDir, testSetupID: testSetupID, cacheRoot: cacheRoot))
+            } catch {
+                result = .failure(error)
+            }
+            self.finishPopulation(testSetupID: testSetupID, result: result)
         }
-        inProgress[testSetupID] = populateTask
+    }
 
-        do {
-            let populated = try await populateTask.value
-            inProgress.removeValue(forKey: testSetupID)
-            // evictIfNeededForNew checks whether the key is already in lruKeys
-            // (possible if a concurrent awaiter registered it first) so that we
-            // never evict unnecessarily or double-register.
+    /// Terminal bookkeeping for a population: exactly once per key, whether
+    /// it succeeded, failed, or was cancelled after its last waiter left.
+    private func finishPopulation(testSetupID: String, result: Result<URL, Error>) {
+        guard let population = inProgress.removeValue(forKey: testSetupID) else { return }
+        switch result {
+        case .success(let preparedDir):
+            // evictIfNeededForNew checks whether the key is already in
+            // lruKeys so that we never evict unnecessarily or double-register.
             evictIfNeededForNew(key: testSetupID)
             touchLRU(key: testSetupID)
             writeStructuredRunnerLog(
@@ -175,9 +240,10 @@ actor TestSetupCache {
                 fields: [
                     "test_setup_id": testSetupID
                 ])
-            return AcquireResult(directory: populated, didHit: false)
-        } catch {
-            inProgress.removeValue(forKey: testSetupID)
+            for waiter in population.waiters.values {
+                waiter.resume(returning: preparedDir)
+            }
+        case .failure(let error):
             cleanupPartialEntry(testSetupID: testSetupID)
             writeStructuredRunnerLog(
                 event: "test_setup_cache_populate_failed",
@@ -185,7 +251,26 @@ actor TestSetupCache {
                     "test_setup_id": testSetupID,
                     "error_message_summary": String(describing: error),
                 ])
-            throw error
+            for waiter in population.waiters.values {
+                waiter.resume(throwing: error)
+            }
+        }
+    }
+
+    /// Removes a cancelled acquirer's continuation (resuming it with
+    /// `CancellationError`) and, when it was the population's last waiter,
+    /// cancels the population task itself: nobody wants the download any
+    /// more, and a cancelled daemon must not keep transferring artifacts.
+    /// A no-op when the population already finished — the waiter was then
+    /// resumed with the real result before cancellation could land.
+    private func detachWaiter(testSetupID: String, waiterID: UUID) {
+        guard var population = inProgress[testSetupID],
+            let continuation = population.waiters.removeValue(forKey: waiterID)
+        else { return }
+        inProgress[testSetupID] = population
+        continuation.resume(throwing: CancellationError())
+        if population.waiters.isEmpty {
+            population.task.cancel()
         }
     }
 

--- a/Tests/WorkerTests/NotebookExtractorRCellMarkerTests.swift
+++ b/Tests/WorkerTests/NotebookExtractorRCellMarkerTests.swift
@@ -96,12 +96,12 @@ import Testing
     }
 
     /// The marker is an ordinary R comment, so the flattened file still runs.
-    @Test func markersAreInertRComments() throws {
+    @Test func markersAreInertRComments() async throws {
         let extracted = try extract(cells: ["total <- 1 + 1"])
         for line in extracted.split(separator: "\n") where line.hasPrefix("# ---- chickadee") {
             #expect(line.hasPrefix("#"))
         }
-        guard hasRscript() else { return }
+        guard await rscriptIsAvailable() else { return }
         let fm = FileManager.default
         let dir = fm.temporaryDirectory.appendingPathComponent("ck-rcells-run-\(UUID().uuidString)")
         try fm.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -109,13 +109,14 @@ import Testing
         let script = dir.appendingPathComponent("flattened.R")
         try (extracted + "\nstopifnot(total == 2)\n").write(
             to: script, atomically: true, encoding: .utf8)
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        proc.arguments = ["Rscript", script.path]
-        proc.standardOutput = Pipe()
-        proc.standardError = Pipe()
-        try proc.run()
-        proc.waitUntilExit()
+        let proc = try await runProcessRobustly {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            proc.arguments = ["Rscript", script.path]
+            proc.standardOutput = makeCloexecPipe()
+            proc.standardError = makeCloexecPipe()
+            return proc
+        }
         #expect(proc.terminationStatus == 0, "flattened R with cell markers must still run")
     }
 
@@ -139,18 +140,4 @@ import Testing
         #expect(!extracted.contains("chickadee:cell"))
     }
 
-    private func hasRscript() -> Bool {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        proc.arguments = ["Rscript", "--version"]
-        proc.standardOutput = Pipe()
-        proc.standardError = Pipe()
-        do {
-            try proc.run()
-            proc.waitUntilExit()
-            return proc.terminationStatus == 0
-        } catch {
-            return false
-        }
-    }
 }

--- a/Tests/WorkerTests/NotebookExtractorTests.swift
+++ b/Tests/WorkerTests/NotebookExtractorTests.swift
@@ -456,13 +456,13 @@ import Testing
             let proc = Process()
             proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
             proc.arguments = ["python3", "-c", probe]
-            proc.standardOutput = Pipe()
-            proc.standardError = Pipe()
+            proc.standardOutput = makeCloexecPipe()
+            proc.standardError = makeCloexecPipe()
             return proc
         }
 
         let outPipe = try #require(proc.standardOutput as? Pipe)
-        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let outData = readToEOFBounded(outPipe)
         let out = (String(bytes: outData, encoding: .utf8) ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let defined = try #require(try? JSONDecoder().decode([String: Bool].self, from: Data(out.utf8)))

--- a/Tests/WorkerTests/RRuntimeJSONEscapingTests.swift
+++ b/Tests/WorkerTests/RRuntimeJSONEscapingTests.swift
@@ -26,24 +26,13 @@ import Testing
 
 @Suite(.serialized, .timeLimit(.minutes(2))) struct RRuntimeJSONEscapingTests {
 
-    private static var hasRscript: Bool {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        proc.arguments = ["Rscript", "--version"]
-        proc.standardOutput = Pipe()
-        proc.standardError = Pipe()
-        do {
-            try proc.run()
-            proc.waitUntilExit()
-            return proc.terminationStatus == 0
-        } catch {
-            return false
-        }
-    }
-
     /// Runs `passed(<message>)` under the composed runtime and returns the
     /// decoded last stdout line — i.e. exactly what the result interpreter sees.
-    private func emit(_ rMessageLiteral: String) throws -> [String: Any]? {
+    /// Launched through `runProcessRobustly` (throttle + bounded exit wait)
+    /// with CLOEXEC pipes and a bounded drain — a raw `Process` with
+    /// `readDataToEndOfFile()` here pinned a cooperative-pool thread and fed
+    /// the #1233 whole-process wedge.
+    private func emit(_ rMessageLiteral: String) async throws -> [String: Any]? {
         let fm = FileManager.default
         let dir = fm.temporaryDirectory.appendingPathComponent("ck-rjson-\(UUID().uuidString)")
         try fm.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -55,16 +44,17 @@ import Testing
         let scriptURL = dir.appendingPathComponent("probe.R")
         try script.write(to: scriptURL, atomically: true, encoding: .utf8)
 
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        proc.arguments = ["Rscript", scriptURL.path]
-        proc.currentDirectoryURL = dir
-        let out = Pipe()
-        proc.standardOutput = out
-        proc.standardError = Pipe()
-        try proc.run()
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
+        let proc = try await runProcessRobustly {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            proc.arguments = ["Rscript", scriptURL.path]
+            proc.currentDirectoryURL = dir
+            proc.standardOutput = makeCloexecPipe()
+            proc.standardError = makeCloexecPipe()
+            return proc
+        }
+        let out = try #require(proc.standardOutput as? Pipe)
+        let data = readToEOFBounded(out)
 
         guard
             let text = String(data: data, encoding: .utf8),
@@ -75,27 +65,27 @@ import Testing
 
     /// The regression that surfaced it: a regex in the message. Before the fix
     /// this printed invalid JSON and the student saw the raw blob.
-    @Test func backslashesSurviveAsValidJSON() throws {
-        guard Self.hasRscript else { return }
-        let decoded = try #require(try emit(#""Found 1 cell(s) containing `is\\.numeric|summary\\s*\\(`""#))
+    @Test func backslashesSurviveAsValidJSON() async throws {
+        guard await rscriptIsAvailable() else { return }
+        let decoded = try #require(try await emit(#""Found 1 cell(s) containing `is\\.numeric|summary\\s*\\(`""#))
         #expect(
             decoded["shortResult"] as? String
                 == #"Found 1 cell(s) containing `is\.numeric|summary\s*\(`"#)
     }
 
     /// A quote used to emit `\\"`, which closes the JSON string early.
-    @Test func embeddedQuotesDoNotTerminateTheString() throws {
-        guard Self.hasRscript else { return }
-        let decoded = try #require(try emit(#""expected \"underweight\" here""#))
+    @Test func embeddedQuotesDoNotTerminateTheString() async throws {
+        guard await rscriptIsAvailable() else { return }
+        let decoded = try #require(try await emit(#""expected \"underweight\" here""#))
         #expect(decoded["shortResult"] as? String == #"expected "underweight" here"#)
     }
 
     /// A newline used to emit `\\n` — valid JSON, but the student saw a literal
     /// backslash-n instead of a line break. Most R failure messages are
     /// multi-line, so this was visible on nearly every failure.
-    @Test func newlinesTabsAndCarriageReturnsDecodeToRealControlCharacters() throws {
-        guard Self.hasRscript else { return }
-        let decoded = try #require(try emit(#""line one\n  indented\ttabbed\r""#))
+    @Test func newlinesTabsAndCarriageReturnsDecodeToRealControlCharacters() async throws {
+        guard await rscriptIsAvailable() else { return }
+        let decoded = try #require(try await emit(#""line one\n  indented\ttabbed\r""#))
         let result = try #require(decoded["shortResult"] as? String)
         #expect(result.contains("\n"))
         #expect(result.contains("\t"))
@@ -106,9 +96,9 @@ import Testing
 
     /// Everything at once, since the passes run in sequence and an ordering
     /// mistake (escaping quotes before backslashes) only shows when combined.
-    @Test func allEscapesCompose() throws {
-        guard Self.hasRscript else { return }
-        let decoded = try #require(try emit(#""a\\b \"q\" \n\t end""#))
+    @Test func allEscapesCompose() async throws {
+        guard await rscriptIsAvailable() else { return }
+        let decoded = try #require(try await emit(#""a\\b \"q\" \n\t end""#))
         #expect(decoded["shortResult"] as? String == "a\\b \"q\" \n\t end")
         #expect(decoded["status"] as? String == "pass")
     }

--- a/Tests/WorkerTests/Support/LocalHTTPTestServer.swift
+++ b/Tests/WorkerTests/Support/LocalHTTPTestServer.swift
@@ -23,6 +23,8 @@
 
 import Foundation
 
+@testable import chickadee_runner
+
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Darwin)
@@ -45,6 +47,13 @@ final class LocalHTTPTestServer: @unchecked Sendable {
     private init(pythonProgram: String, extraArguments: [String], currentDirectory: URL? = nil) throws {
         let process = Process()
         let stdout = Pipe()
+        // CLOEXEC: the server child still receives its write end (spawn file
+        // actions clear the flag on the descriptor they install), but no
+        // *other* concurrently spawned process inherits a duplicate. Without
+        // this, a leaked duplicate in a long-lived process means the read
+        // loop below never sees EOF if the interpreter dies before printing
+        // — an unbounded stall on a cooperative-pool thread (issue #1233).
+        setCloseOnExec(stdout)
         process.standardOutput = stdout
         process.standardError = FileHandle.nullDevice
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -58,7 +67,10 @@ final class LocalHTTPTestServer: @unchecked Sendable {
                 from: stdout.fileHandleForReading,
                 deadline: Date().addingTimeInterval(10))
         else {
-            process.terminate()
+            // SIGKILL, not terminate(): a child wedged before its first
+            // print may equally ignore SIGTERM, and the caller is about to
+            // abandon it.
+            kill(process.processIdentifier, SIGKILL)
             throw IssueRecorded("python3 is unavailable or never reported a port for the local test HTTP server")
         }
 
@@ -67,25 +79,45 @@ final class LocalHTTPTestServer: @unchecked Sendable {
         self.port = port
     }
 
-    /// Reads the child's first stdout line and parses it as a port.  Loops over
-    /// `availableData` until a newline is buffered so a chunk that arrives
-    /// before the newline isn't misread as a failure; an empty chunk is EOF
-    /// (the interpreter exited without printing — e.g. python3 missing).
+    /// Reads the child's first stdout line and parses it as a port.
+    /// Accumulates until a newline so a chunk that arrives before the
+    /// newline isn't misread as a failure; a zero-byte read is EOF (the
+    /// interpreter exited without printing — e.g. python3 missing).
+    ///
+    /// Poll-based rather than `availableData`: a blocking `availableData`
+    /// only re-checks the deadline *between* chunks, so a child that never
+    /// prints — or a leaked write-end duplicate that keeps EOF from ever
+    /// arriving after the child dies — parked the calling cooperative-pool
+    /// thread indefinitely (one of the #1233 wedge ingredients). `poll(2)`
+    /// with a 100 ms tick keeps the deadline real.
     private static func readPort(from handle: FileHandle, deadline: Date) -> Int? {
+        let descriptor = handle.fileDescriptor
         var buffer = Data()
+        var chunk = [UInt8](repeating: 0, count: 4096)
         while Date() < deadline {
-            let chunk = handle.availableData
-            if chunk.isEmpty { return nil }
-            buffer.append(chunk)
-            guard let newline = buffer.firstIndex(of: 0x0A) else { continue }
-            let lineData = buffer[buffer.startIndex..<newline]
-            guard let line = String(data: lineData, encoding: .utf8) else { return nil }
-            return Int(line.trimmingCharacters(in: .whitespaces))
+            var pollDescriptor = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+            let readyCount = poll(&pollDescriptor, 1, 100)
+            if readyCount == -1 {
+                if errno == EINTR { continue }
+                return nil
+            }
+            if readyCount == 0 { continue }  // quiet tick; deadline re-checked at loop top
+            let bytesRead = read(descriptor, &chunk, chunk.count)
+            if bytesRead > 0 {
+                buffer.append(contentsOf: chunk[0..<bytesRead])
+                guard let newline = buffer.firstIndex(of: 0x0A) else { continue }
+                let lineData = buffer[buffer.startIndex..<newline]
+                guard let line = String(data: lineData, encoding: .utf8) else { return nil }
+                return Int(line.trimmingCharacters(in: .whitespaces))
+            }
+            if bytesRead == -1 && errno == EINTR { continue }
+            return nil  // 0 = EOF (child exited without printing); -1 = unrecoverable.
         }
         return nil
     }
 
     func stop() {
+        WedgeWatchdog.noteActivity()
         if process.isRunning {
             // SIGKILL, not SIGTERM. The server can be parked in a blocking
             // socket syscall while the daemon's HTTP connection is still open,

--- a/Tests/WorkerTests/Support/ScriptRunnerTestSupport.swift
+++ b/Tests/WorkerTests/Support/ScriptRunnerTestSupport.swift
@@ -21,8 +21,15 @@
 
 import Foundation
 import RunnerCore
+import Synchronization
 
 @testable import chickadee_runner
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
 
 /// Runs `script` through `runner` under the shared subprocess-launch throttle,
 /// retrying only the empty `-1` "never launched" sentinel.
@@ -47,6 +54,7 @@ func runScriptRobustly(
             output.stdout.isEmpty, output.stderr.isEmpty
         {
             remaining -= 1
+            WedgeWatchdog.noteActivity()
             output = await runner.run(
                 script: script, workDir: workDir, timeLimitSeconds: timeLimitSeconds, env: env)
         }
@@ -71,14 +79,100 @@ func runProcessRobustly(
         for _ in 0..<(attempts - 1) {
             let process = try makeProcess()
             if (try? process.run()) != nil {
-                process.waitUntilExit()
+                await awaitBoundedExit(of: process)
                 return process
             }
             try? await Task.sleep(for: .milliseconds(100))
         }
         let process = try makeProcess()
         try process.run()
-        process.waitUntilExit()
+        await awaitBoundedExit(of: process)
         return process
     }
+}
+
+/// A `Pipe` whose descriptors are CLOEXEC from birth. Always use this for
+/// test subprocess I/O: a plain `Pipe()`'s write end is inherited by every
+/// concurrently spawned process, and a long-lived inheritor (another test's
+/// HTTP server) then keeps EOF from ever reaching the read side — the
+/// unbounded-stall ingredient of the #1139/#1233 wedges. The intended child
+/// still receives its end; spawn file actions clear the flag on the
+/// descriptor they install.
+func makeCloexecPipe() -> Pipe {
+    let pipe = Pipe()
+    setCloseOnExec(pipe)
+    return pipe
+}
+
+/// Deadline-bounded read-to-EOF for a test subprocess pipe — the drop-in for
+/// `readDataToEndOfFile()`, which parks a cooperative-pool thread until an
+/// EOF that a leaked write-end duplicate can postpone forever (issue #1233).
+/// Returns whatever arrived by the deadline.
+func readToEOFBounded(_ pipe: Pipe, timeoutSeconds: TimeInterval = 30) -> Data {
+    boundedReadToEOF(
+        fromDescriptor: pipe.fileHandleForReading.fileDescriptor,
+        deadline: Date().addingTimeInterval(timeoutSeconds)
+    )
+}
+
+/// Cached Rscript availability probe — one subprocess per test process
+/// instead of one per calling test, launched through the shared throttle
+/// with CLOEXEC pipes and a bounded exit wait (the previous per-file copies
+/// each ran a raw `Process` + `waitUntilExit()` on a pool thread).
+func rscriptIsAvailable() async -> Bool {
+    if let cached = rscriptAvailabilityCache.withLock({ $0 }) {
+        return cached
+    }
+    let available: Bool
+    do {
+        let process = try await runProcessRobustly {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = ["Rscript", "--version"]
+            process.standardOutput = makeCloexecPipe()
+            process.standardError = makeCloexecPipe()
+            return process
+        }
+        available = process.terminationStatus == 0
+    } catch {
+        available = false
+    }
+    rscriptAvailabilityCache.withLock { $0 = available }
+    return available
+}
+
+private let rscriptAvailabilityCache = Mutex<Bool?>(nil)
+
+/// Suspends until `process` exits, without pinning a cooperative-pool thread
+/// the way `waitUntilExit()` does — the pool has ~one thread per core and
+/// never grows, so a handful of concurrent blocking waits can freeze the
+/// whole test process (the #1233 wedge). Escalates to SIGKILL at the
+/// deadline so a hung child bounds the wait instead of inheriting it.
+///
+/// Same single-shot continuation shape as `executeScriptProcess`: the
+/// termination handler is installed after `run()`, so the already-exited
+/// race is guarded by `resumed`.
+func awaitBoundedExit(of process: Process, timeoutSeconds: TimeInterval = 120) async {
+    let killTask = Task {
+        try? await Task.sleep(for: .seconds(timeoutSeconds))
+        guard !Task.isCancelled, process.isRunning else { return }
+        kill(process.processIdentifier, SIGKILL)
+    }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let resumed = Mutex(false)
+        let resumeOnce: @Sendable () -> Void = {
+            let alreadyResumed = resumed.withLock { wasResumed in
+                let previous = wasResumed
+                wasResumed = true
+                return previous
+            }
+            if !alreadyResumed { continuation.resume() }
+        }
+        process.terminationHandler = { _ in resumeOnce() }
+        if !process.isRunning { resumeOnce() }
+    }
+    killTask.cancel()
+    // The handler has fired (or the process was already gone); this reap is
+    // immediate and keeps `terminationStatus` reliably readable.
+    process.waitUntilExit()
 }

--- a/Tests/WorkerTests/Support/SubprocessThrottle.swift
+++ b/Tests/WorkerTests/Support/SubprocessThrottle.swift
@@ -27,8 +27,15 @@ import Foundation
 /// Runs `body` while holding one of a small, fixed number of subprocess-launch
 /// permits.  Wrap the *launch* of any real `Process` (or any `ScriptRunner.run`
 /// that forks one) so concurrent forks stay bounded across every suite.
+///
+/// Tracked by `WedgeWatchdog` (issue #1233): a slot-holder that stops making
+/// progress — or a waiter that can never be granted a permit because the
+/// cooperative pool is pinned — is exactly the in-flight work the watchdog
+/// exists to catch.
 func withSubprocessSlot<R: Sendable>(_ body: @Sendable () async throws -> R) async rethrows -> R {
-    try await SubprocessThrottle.shared.run(body)
+    try await WedgeWatchdog.track {
+        try await SubprocessThrottle.shared.run(body)
+    }
 }
 
 private actor SubprocessThrottle {

--- a/Tests/WorkerTests/Support/WedgeWatchdog.swift
+++ b/Tests/WorkerTests/Support/WedgeWatchdog.swift
@@ -1,0 +1,177 @@
+// Tests/WorkerTests/Support/WedgeWatchdog.swift
+//
+// Process-level wedge watchdog for the WorkerTests target (issue #1233).
+//
+// Twice in one afternoon `worker-tests` rode to the CI job-level 20-minute
+// kill with ~250 tests started, ~55 completed, and the process otherwise
+// silent for 18 minutes: every cooperative-pool thread was pinned in a
+// blocking syscall, so no task — including Swift Testing's `.timeLimit`
+// enforcement and the `awaitCancelledDaemon` bound, both of which need a
+// pool thread to run — could make progress. The only artifact was the
+// *absence* of output.
+//
+// This watchdog runs on a dedicated OS thread (`Thread.detachNewThread`), so
+// pool saturation cannot starve it. Test helpers that can participate in a
+// wedge (subprocess launches, daemon shutdowns, poll loops) report activity;
+// if helpers are in flight and NO activity has been reported for
+// `stallLimitSeconds`, the watchdog dumps every thread's kernel-visible
+// state (`/proc/self/task/*/{comm,wchan,stat}` — `wchan` names the syscall
+// wait each pinned thread is parked in), flushes stdout so buffered
+// structured-log lines aren't lost, and aborts. A wedge then fails in
+// minutes with a thread table pointing at the pinned syscalls, instead of
+// burning 20 minutes and reporting nothing.
+//
+// The stall limit (default 300 s) exceeds every legitimate quiet stretch by
+// a wide margin: per-suite `.timeLimit` is 3 minutes, the longest bounded
+// helper wait is 30 s, and healthy runs report activity every few hundred
+// milliseconds (every `waitUntil` poll tick and every subprocess-slot
+// transition counts). Override with CHICKADEE_WORKERTESTS_STALL_SECONDS
+// (0 disables the abort entirely).
+
+import Foundation
+import Synchronization
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+enum WedgeWatchdog {
+    private struct State {
+        var monitorStarted = false
+        var activeHelpers = 0
+        var lastActivity = Date()
+        var firing = false
+    }
+
+    private static let state = Mutex(State())
+
+    static let stallLimitSeconds: TimeInterval = {
+        guard
+            let raw = ProcessInfo.processInfo.environment["CHICKADEE_WORKERTESTS_STALL_SECONDS"],
+            let parsed = TimeInterval(raw)
+        else { return 300 }
+        return parsed
+    }()
+
+    /// Report liveness. Call from helper poll loops and entry/exit points —
+    /// any call resets the stall clock.
+    static func noteActivity() {
+        state.withLock { current in
+            current.lastActivity = Date()
+            startMonitorIfNeeded(&current)
+        }
+    }
+
+    /// Wrap a helper that can participate in a wedge: while at least one
+    /// tracked call is in flight the watchdog is armed, and a tracked call
+    /// that stops producing activity is what the stall clock measures.
+    static func track<R>(_ body: () async throws -> R) async rethrows -> R {
+        state.withLock { current in
+            current.activeHelpers += 1
+            current.lastActivity = Date()
+            startMonitorIfNeeded(&current)
+        }
+        defer {
+            state.withLock { current in
+                current.activeHelpers -= 1
+                current.lastActivity = Date()
+            }
+        }
+        return try await body()
+    }
+
+    private static func startMonitorIfNeeded(_ current: inout State) {
+        guard !current.monitorStarted, stallLimitSeconds > 0 else { return }
+        current.monitorStarted = true
+        Thread.detachNewThread {
+            monitorLoop()
+        }
+    }
+
+    private static func monitorLoop() {
+        while true {
+            Thread.sleep(forTimeInterval: 15)
+            let stalledSeconds: TimeInterval? = state.withLock { current in
+                guard current.activeHelpers > 0, !current.firing else { return nil }
+                let elapsed = Date().timeIntervalSince(current.lastActivity)
+                guard elapsed >= stallLimitSeconds else { return nil }
+                current.firing = true
+                return elapsed
+            }
+            if let stalledSeconds {
+                abortWedgedProcess(stalledSeconds: stalledSeconds)
+            }
+        }
+    }
+
+    private static func abortWedgedProcess(stalledSeconds: TimeInterval) {
+        dumpThreadStates(
+            reason: "no test-helper activity for \(Int(stalledSeconds))s with helpers in flight — "
+                + "cooperative pool presumed wedged; aborting so CI gets evidence instead of the "
+                + "20-minute job kill (issue #1233)")
+        // Buffered structured-log lines are evidence too — the #1233 wedges
+        // each surfaced their last log line only at kill time. Flushing can
+        // itself block if stdout is the contended resource; the dump above
+        // already reached stderr via raw write(2), and the job-level timeout
+        // remains the outer backstop.
+        fflush(nil)
+        abort()
+    }
+
+    /// Writes every thread's kernel-visible state to stderr with raw
+    /// `write(2)` calls — stdio locks are avoided deliberately, since a
+    /// wedged thread may be holding them.
+    static func dumpThreadStates(reason: String) {
+        var report = "\n==== WedgeWatchdog thread dump (issue #1233) ====\n"
+        report += "reason: \(reason)\n"
+        let taskDir = "/proc/self/task"
+        if let tids = try? FileManager.default.contentsOfDirectory(atPath: taskDir).sorted(
+            by: { (Int($0) ?? 0) < (Int($1) ?? 0) })
+        {
+            report += "thread table (state D/S = blocked; wchan = kernel wait it is parked in):\n"
+            for tid in tids {
+                let comm = readProcFile("\(taskDir)/\(tid)/comm") ?? "?"
+                let wchan = readProcFile("\(taskDir)/\(tid)/wchan") ?? "?"
+                let stat = readProcFile("\(taskDir)/\(tid)/stat") ?? ""
+                report += "  tid \(tid) state=\(threadStateCharacter(fromStat: stat)) "
+                report += "wchan=\(wchan) comm=\(comm)\n"
+            }
+        } else {
+            report += "(/proc/self/task unavailable on this platform — no per-thread table)\n"
+        }
+        report += "==== end thread dump ====\n"
+        writeToStandardError(report)
+    }
+
+    private static func readProcFile(_ path: String) -> String? {
+        guard let data = FileManager.default.contents(atPath: path),
+            let text = String(data: data, encoding: .utf8)
+        else { return nil }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Field 3 of `/proc/.../stat`, located after the parenthesised comm —
+    /// the comm itself may contain spaces or parens, so scan from the last
+    /// closing paren.
+    private static func threadStateCharacter(fromStat stat: String) -> String {
+        guard let closingParen = stat.lastIndex(of: ")") else { return "?" }
+        let tail = stat[stat.index(after: closingParen)...]
+            .trimmingCharacters(in: .whitespaces)
+        return tail.first.map(String.init) ?? "?"
+    }
+
+    private static func writeToStandardError(_ text: String) {
+        let bytes = Array(text.utf8)
+        var offset = 0
+        while offset < bytes.count {
+            let written = bytes[offset...].withUnsafeBytes { buffer -> Int in
+                guard let base = buffer.baseAddress else { return -1 }
+                return write(2, base, buffer.count)
+            }
+            if written <= 0 { return }
+            offset += written
+        }
+    }
+}

--- a/Tests/WorkerTests/TestSetupCacheTests.swift
+++ b/Tests/WorkerTests/TestSetupCacheTests.swift
@@ -260,6 +260,150 @@ private func makeTestStagingDir(name: String = "test_script.sh") throws -> URL {
             "C must be present"
         )
     }
+
+    // MARK: - Cancellation responsiveness (issue #1233)
+
+    // Before #1233, `acquire` awaited the shared population via `Task.value`,
+    // which is not cancellation-responsive: a cancelled acquirer rode out the
+    // whole download, and `daemon.run()` ignored cancellation on the
+    // artifact-download path. These tests pin the fixed semantics. Without
+    // the fix they do not merely fail — they deadlock until the suite
+    // `.timeLimit`, because the gate below is only opened *after* the
+    // cancelled acquirer is required to have thrown.
+
+    @Test func cancelledAcquirerDetachesWhileOthersContinue() async throws {
+        let (cache, _) = makeCache()
+        let populateStarted = TestGate()
+        let populateRelease = TestGate()
+        let populateCount = Counter()
+
+        // First acquirer starts the (gated) population and sees it through.
+        let survivor = Task {
+            try await cache.acquire(testSetupID: "setup-cancel-join") {
+                populateCount.increment()
+                await populateStarted.open()
+                await populateRelease.wait()
+                return try makeTestStagingDir()
+            }
+        }
+        await populateStarted.wait()
+
+        // Second acquirer joins the in-flight population, then is cancelled.
+        // (If cancellation lands before its waiter registration, the
+        // early-cancel path throws instead — both paths are the fix.)
+        let cancelled = Task {
+            try await cache.acquire(testSetupID: "setup-cancel-join") {
+                Issue.record("populate must not run twice for one key")
+                return try makeTestStagingDir()
+            }
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        cancelled.cancel()
+
+        // The cancelled acquirer must throw promptly — the population gate is
+        // still closed, so completing here proves it did not wait for the
+        // download to finish.
+        do {
+            let result = try await cancelled.value
+            try? FileManager.default.removeItem(at: result.directory)
+            Issue.record("cancelled acquire must throw, got a directory")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        // The surviving acquirer still completes once the population is
+        // released — one cancelled waiter must not kill the shared work.
+        await populateRelease.open()
+        let result = try await survivor.value
+        defer { try? FileManager.default.removeItem(at: result.directory) }
+        #expect(populateCount.value == 1)
+        #expect(result.didHit == false)
+    }
+
+    @Test func lastWaiterCancellationCancelsThePopulation() async throws {
+        let (cache, root) = makeCache()
+        let populateStarted = TestGate()
+        let populateSawCancellation = Counter()
+
+        let acquirer = Task {
+            try await cache.acquire(testSetupID: "setup-cancel-last") {
+                await populateStarted.open()
+                do {
+                    // Stands in for the artifact download; cancellation of
+                    // the population task must interrupt it.
+                    try await Task.sleep(for: .seconds(600))
+                } catch {
+                    populateSawCancellation.increment()
+                    throw error
+                }
+                return try makeTestStagingDir()
+            }
+        }
+        await populateStarted.wait()
+
+        acquirer.cancel()
+        do {
+            let result = try await acquirer.value
+            try? FileManager.default.removeItem(at: result.directory)
+            Issue.record("cancelled acquire must throw, got a directory")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        // The population task itself must have been cancelled (its sleep
+        // interrupted) — nobody was left wanting the download.
+        let sawCancellation = await pollUntil { populateSawCancellation.value == 1 }
+        #expect(sawCancellation, "population must be cancelled once its last waiter detaches")
+
+        // And the failed population must leave no partial entry behind.
+        let cleaned = await pollUntil {
+            !FileManager.default.fileExists(atPath: root.appendingPathComponent("setup-cancel-last").path)
+                && !FileManager.default.fileExists(
+                    atPath: root.appendingPathComponent("setup-cancel-last.tmp").path)
+        }
+        #expect(cleaned, "cancelled population must clean up like any failed population")
+
+        // The key must be acquirable again afterwards.
+        let retry = try await cache.acquire(testSetupID: "setup-cancel-last") {
+            try makeTestStagingDir()
+        }
+        defer { try? FileManager.default.removeItem(at: retry.directory) }
+        #expect(retry.didHit == false)
+    }
+
+    private func pollUntil(
+        timeoutSeconds: TimeInterval = 10,
+        _ condition: @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return await condition()
+    }
+}
+
+// MARK: - Async gate
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called (and
+/// returns immediately afterwards). Deliberately not cancellation-responsive
+/// — the cancellation tests above rely on a gated populate closure staying
+/// parked while a *different* waiter is cancelled.
+private actor TestGate {
+    private var opened = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        opened = true
+        for waiter in waiters { waiter.resume() }
+        waiters.removeAll()
+    }
+
+    func wait() async {
+        if opened { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
 }
 
 // MARK: - Thread-safe counter

--- a/Tests/WorkerTests/WedgeWatchdogTests.swift
+++ b/Tests/WorkerTests/WedgeWatchdogTests.swift
@@ -1,0 +1,25 @@
+// Tests/WorkerTests/WedgeWatchdogTests.swift
+
+import Foundation
+import Testing
+
+@Suite struct WedgeWatchdogTests {
+
+    /// The dump is the evidence path for a wedged process (issue #1233): it
+    /// must never crash or throw, and it must not depend on the cooperative
+    /// pool being healthy. This exercises the /proc walk end-to-end; the
+    /// output itself goes to stderr, where CI preserves it.
+    @Test func threadStateDumpDoesNotCrash() {
+        WedgeWatchdog.dumpThreadStates(reason: "WedgeWatchdogTests smoke test — not a real wedge")
+    }
+
+    /// Liveness reporting must be callable from anywhere, repeatedly, without
+    /// arming anything visible to the tests themselves.
+    @Test func activityReportingIsReentrant() async {
+        for _ in 0..<100 {
+            WedgeWatchdog.noteActivity()
+        }
+        let value = await WedgeWatchdog.track { 42 }
+        #expect(value == 42)
+    }
+}

--- a/Tests/WorkerTests/WorkerDaemonTests.swift
+++ b/Tests/WorkerTests/WorkerDaemonTests.swift
@@ -309,29 +309,41 @@ import Testing
     /// observed 2026-07-02 in `workerDaemonContinuesToNextJobAfterProcessingFailure`
     /// (the `.timeLimit` trait attributed it but cannot interrupt it; see
     /// docs/ci-flakiness.md). On timeout the daemon task is left orphaned —
-    /// acceptable in a test process — and the caller should fail the test.
+    /// acceptable in a test process — and the leak is made LOUD (#1233): an
+    /// Issue.record naming the abandoned daemon plus a thread-state dump to
+    /// stderr, so an ignored cancellation produces evidence instead of a
+    /// silent still-running task.
     private func awaitCancelledDaemon(
         _ task: Task<Void, Error>,
         timeoutSeconds: TimeInterval = 30
     ) async -> Bool {
-        task.cancel()
-        let flag = DaemonShutdownFlag()
-        Task {
-            var unexpected: String?
-            do {
-                try await task.value
-            } catch is CancellationError {
-                // Expected on cooperative shutdown.
-            } catch {
-                unexpected = String(describing: error)
+        await WedgeWatchdog.track {
+            task.cancel()
+            let flag = DaemonShutdownFlag()
+            Task {
+                var unexpected: String?
+                do {
+                    try await task.value
+                } catch is CancellationError {
+                    // Expected on cooperative shutdown.
+                } catch {
+                    unexpected = String(describing: error)
+                }
+                await flag.markDone(unexpectedError: unexpected)
             }
-            await flag.markDone(unexpectedError: unexpected)
+            let done = await waitUntil(timeoutSeconds: timeoutSeconds) { await flag.isDone() }
+            if done, let unexpectedError = await flag.failure() {
+                Issue.record("daemon.run() threw a non-cancellation error on shutdown: \(unexpectedError)")
+            }
+            if !done {
+                let leakDescription =
+                    "daemon.run() ignored cancellation for \(Int(timeoutSeconds))s and was abandoned "
+                    + "still running; thread states dumped to stderr (issue #1233)"
+                WedgeWatchdog.dumpThreadStates(reason: leakDescription)
+                Issue.record("\(leakDescription)")
+            }
+            return done
         }
-        let done = await waitUntil(timeoutSeconds: timeoutSeconds) { await flag.isDone() }
-        if done, let unexpectedError = await flag.failure() {
-            Issue.record("daemon.run() threw a non-cancellation error on shutdown: \(unexpectedError)")
-        }
-        return done
     }
 
     private func waitUntil(
@@ -341,6 +353,10 @@ import Testing
     ) async -> Bool {
         let deadline = Date().addingTimeInterval(timeoutSeconds)
         while Date() < deadline {
+            // Every poll tick is watchdog liveness: while any test can still
+            // run this loop, the scheduler is alive and the wedge watchdog
+            // must not fire (issue #1233).
+            WedgeWatchdog.noteActivity()
             if await condition() {
                 return true
             }

--- a/changelog.d/issue-1233-worker-tests-wedge.md
+++ b/changelog.d/issue-1233-worker-tests-wedge.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **`worker-tests` whole-process wedge root-caused and fixed (#1233).** The
+  20-minute CI job kills recurred because the cooperative thread pool was
+  fully pinned by blocking subprocess waits (`MimeTypeDetector`'s per-file
+  `readDataToEndOfFile`, test helpers' `waitUntilExit`/`availableData`),
+  made permanent by non-CLOEXEC pipe write ends leaking into long-lived
+  concurrent subprocesses so EOF never arrived. All worker and test-support
+  subprocess pipes are now CLOEXEC with deadline-bounded drains, the test
+  helpers await child exit without pinning pool threads, and
+  `TestSetupCache.acquire` — the daemon-side wait that ignored cancellation —
+  now uses cancellation-responsive continuations and cancels an in-flight
+  populate once its last waiter detaches.
+
+### Added
+
+- **WorkerTests wedge watchdog (#1233).** A dedicated-OS-thread watchdog
+  aborts the test process with a full per-thread `/proc` state dump (state +
+  `wchan`) after five minutes of in-flight-helper silence, so a future wedge
+  fails in minutes with evidence instead of riding to the silent 20-minute
+  job kill; `awaitCancelledDaemon` likewise records a loud issue plus a
+  thread dump when an abandoned daemon ignores cancellation.

--- a/docs/ci-flakiness.md
+++ b/docs/ci-flakiness.md
@@ -255,18 +255,58 @@ chromium failure is treated as real, first time.
      apply), so this failed the non-required probe — signal, not a
      blocker.
 
-4. **Residual WorkerDaemonTests wedge (2026-07-02 evening).** With the
-   fork bug fixed, worker-tests wedged once more via a different path:
-   `workerDaemonContinuesToNextJobAfterProcessingFailure` failed its
-   10 s wait, then the bare `try await task.value` after `task.cancel()`
-   suspended forever (`Task.value` is not cancellation-responsive) — the
-   `.timeLimit` trait *attributed* the failure but cannot interrupt a
-   non-cancellable wait, so the job still rode to the 20-minute kill.
-   All 12 cancel-then-await sites now go through a bounded
-   `awaitCancelledDaemon` helper (30 s deadline). The underlying
-   question — *what* in `daemon.run()` ignored cancellation under load —
-   is the remaining daemon-side item; suspects are the artifact-download
-   path and any wait not routed through cancellable primitives.
+4. **Residual WorkerDaemonTests wedge — ROOT-CAUSED (issue #1233,
+   2026-07-29).** With the fork bug fixed, worker-tests wedged once more
+   (2026-07-02: `workerDaemonContinuesToNextJobAfterProcessingFailure`
+   failed its 10 s wait, then the bare `try await task.value` after
+   `task.cancel()` suspended forever — `Task.value` is not
+   cancellation-responsive). All cancel-then-await sites were bounded via
+   `awaitCancelledDaemon` (30 s), yet on PR #1230 the 20-minute wedge
+   recurred **twice on one SHA** with the containment in place: 254 tests
+   started, 55 completed, ~18 minutes of total process silence
+   (issue #1233).
+
+   **Mechanism (whole-process, not per-test).** The observed "last log
+   lines" were victims: one was a pure-mock runner mid-`Task.sleep`, the
+   other a test frozen at its first suspension after `job_accepted` —
+   i.e. the *scheduler* stopped, not those tests. The cooperative pool
+   (~one thread per core, never grows) was fully pinned by blocking
+   subprocess waits running on pool threads: `MimeTypeDetector` spawned
+   `/usr/bin/file` per submission file per job with a blocking
+   `readDataToEndOfFile()` (unthrottled — production code, so outside
+   `SubprocessThrottle`), `runProcessRobustly` blocked in
+   `waitUntilExit()`, `LocalHTTPTestServer.readPort` blocked in
+   `availableData` (its deadline was only re-checked *between* chunks),
+   and several test files carried raw read-to-EOF/`waitUntilExit` calls.
+   Each is nominally bounded by its child — but the #1139 CLOEXEC fix
+   covered only ScriptRunner's pipes, so these pipes' write ends leaked
+   into every concurrently spawned process; a long-lived inheritor (a
+   test HTTP server) postpones EOF indefinitely. Once pinned threads ≥
+   pool width, test `defer`s can never run, servers are never killed,
+   the leaked write ends never close — a transient overload becomes a
+   **permanent, self-sustaining wedge**. `.timeLimit` and
+   `awaitCancelledDaemon` need a pool thread to fire, which is why
+   neither could help. Load-dependence, local cleanliness, and
+   pass-on-retry all follow.
+
+   **Fixes (same PR as this note).** (a) CLOEXEC + deadline-bounded
+   drains on every worker/test subprocess pipe (`setCloseOnExec` now
+   internal; `boundedReadToEOF` shared); (b) `runProcessRobustly` awaits
+   exit via termination handler + SIGKILL escalation instead of pinning
+   a pool thread; (c) `readPort` is poll-based so its deadline is real;
+   (d) the daemon-side answer to "what ignores cancellation":
+   `TestSetupCache.acquire` awaited unstructured `Task.value`s — it now
+   uses cancellation-responsive continuations, and the shared populate
+   task is itself cancelled when its last waiter detaches, so a
+   cancelled daemon stops in-flight artifact downloads (regression
+   tests deadlock against the old code); (e) `awaitCancelledDaemon`
+   records a loud Issue + thread dump when it abandons a daemon;
+   (f) a **WedgeWatchdog** on a dedicated OS thread (immune to pool
+   saturation) aborts with a full `/proc/self/task` thread table
+   (state + `wchan` per thread) after 5 minutes of helper-in-flight
+   silence — a future wedge fails in ~6 minutes *with evidence* instead
+   of burning 20 silent ones. `CHICKADEE_WORKERTESTS_STALL_SECONDS`
+   overrides (0 disables).
 2. **Watch the tolerated-webkit warning rate.** The `::warning`
    annotations from the probe and the smoke retries are the flake-rate
    telemetry now; if they show up more than occasionally, the ambient rate


### PR DESCRIPTION
Closes #1233.

## Root cause

The wedge is **whole-process cooperative-pool saturation**, and both of the "last log lines" in the two wedged attempts were victims, not causes. The strongest evidence: the `concurrent_2` shape (attempt 1) comes from `workerDaemonRunsJobsConcurrentlyWhenMaxConcurrentJobsAllows`, whose runner is a pure mock — `Task.sleep(100 ms)`, no subprocess. Its freeze after `test_execution_start` means a *sleep resume never got a pool thread*: the scheduler itself had stopped. Attempt 2's `sub_bad_job` froze at its first suspension after `job_accepted` — same story.

What pinned the pool (2 threads on the CI runner — it only takes two):

1. **Blocking subprocess waits on pool threads.** `MimeTypeDetector` spawns `/usr/bin/file` **per submission file per job** with a blocking `readDataToEndOfFile()` — production code, so outside `SubprocessThrottle`, and the daemon tests run up to 5 jobs concurrently. `runProcessRobustly` blocked in `waitUntilExit()`; `LocalHTTPTestServer.readPort` blocked in `availableData` (its 10 s deadline was only re-checked *between* chunks — an unbounded block in practice); several test files carried raw read-to-EOF/`waitUntilExit` sites.
2. **Non-CLOEXEC pipes made the pins permanent.** The #1139 CLOEXEC fix covered only `ScriptRunner`'s pipes. Every other pipe's write end leaked into every concurrently spawned process; a long-lived inheritor (a test HTTP server) postpones EOF indefinitely. Once pinned threads ≥ pool width: test `defer`s can never run → servers never SIGKILLed → leaked write ends never close → **a transient overload becomes a permanent, self-sustaining wedge**. `.timeLimit` and `awaitCancelledDaemon` both need a pool thread to fire, which is why neither containment helped — consistent with all observations (load-dependence, local 20/20 cleanliness, pass-on-retry of the same SHA, 18 minutes of total silence).

The issue's leak hypothesis was right in spirit, wrong in mechanism: abandoned daemon tasks are *suspended*, not thread-pinning — they can't saturate the pool. The saturation came from blocking waits.

## The daemon-side answer to the doc's open question

*"What in `daemon.run()` ignores cancellation under load?"* — `TestSetupCache.acquire`. It awaited unstructured `Task.value`s (both the starter and join paths), and `Task.value` is not cancellation-responsive; the populate task was never cancelled by anyone. Exactly the doc's "artifact-download path" suspect.

## Changes

**Production (`Sources/Worker`)**
- `TestSetupCache.acquire` now uses cancellation-responsive continuations (register/detach under actor isolation, single-resume guaranteed); a cancelled acquirer throws `CancellationError` promptly, and the shared populate task is itself cancelled once its **last** waiter detaches — a cancelled daemon stops its in-flight artifact downloads. Semantics otherwise unchanged (populate-once per key, LRU, `didHit`, cleanup-on-failure).
- `MimeTypeDetector` / `RunnerProfileDetector`: CLOEXEC pipes, deadline-bounded drains (`boundedReadToEOF`, new shared helper), SIGKILL escalation at the bound.
- `setCloseOnExec` promoted from `private` to module-internal so every worker pipe user shares it.

**Tests (`Tests/WorkerTests`)**
- `runProcessRobustly` awaits child exit via a termination-handler continuation (single-shot, already-exited race guarded — same shape as `executeScriptProcess`) with a 120 s SIGKILL escalation, instead of pinning a pool thread.
- `LocalHTTPTestServer`: CLOEXEC port pipe; `readPort` rewritten poll-based so the deadline is real; failed-boot path SIGKILLs.
- Remaining raw `Process` sites (R runtime JSON tests, notebook-extractor tests, two per-file `hasRscript` copies collapsed into one cached `rscriptIsAvailable()`) moved onto the throttled helpers with CLOEXEC pipes and bounded drains.
- `awaitCancelledDaemon` is now **loud** on timeout (issue ask #2): records an Issue naming the abandoned daemon and dumps all thread states to stderr.
- **New `WedgeWatchdog`** (issue ask #3): a dedicated OS thread — immune to pool saturation — that aborts after 5 minutes of helper-in-flight silence, first writing every thread's `/proc/self/task` state (state char + `wchan`, i.e. exactly which syscall each pinned thread is parked in) to stderr via raw `write(2)` and flushing stdout so buffered structured-log lines survive. A future wedge fails in ~6 minutes **with evidence** instead of burning 20 silent ones. Liveness is fed by every `waitUntil` tick, subprocess-slot transition, and helper entry/exit; `CHICKADEE_WORKERTESTS_STALL_SECONDS` overrides the threshold (0 disables). Job-level `timeout-minutes: 20` stays as the outer backstop.

**Docs**: `docs/ci-flakiness.md` residual item 4 rewritten with the root cause and fix inventory; changelog fragment added.

## Verification

- Full `WorkerTests`: 271 tests / 23 suites, green **8/8 consecutive runs** (~3 s each), sandboxed-runner tests included.
- The two new `TestSetupCache` cancellation tests **deadlock against the old implementation** (verified by reverting the cache fix: the test run hung until an external 90 s kill) — they genuinely pin the fix, not just the happy path.
- `scripts/lint.sh` and `scripts/swiftlint.sh --strict`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR)_