### PR TITLE
Restore nightly coverage parallelism to width 4 (post-#1233)

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -74,8 +74,18 @@ jobs:
         # test process.  This job is the worst case: it runs *all* targets in
         # one process (no --filter split) with code coverage, so it's the most
         # pool-pressured run we have — strictly more so than any single
-        # --filter'd swift-tests.yml job.  So it gets a *tighter* cap than the
-        # per-PR jobs (2 vs. 4) to halve the concurrent-pool count.
+        # --filter'd swift-tests.yml job.
+        #
+        # Width history: capped at 2 (tighter than the per-PR jobs' 4) while
+        # this shared process was ALSO losing cooperative-pool threads to
+        # WorkerTests' blocking subprocess waits — DB-pool pressure and
+        # scheduler starvation compounded.  With #1233 fixed (bounded,
+        # CLOEXEC'd subprocess waits, plus the WedgeWatchdog turning any
+        # residual stall into a fast, evidenced abort), the cap is back to 4,
+        # matching the per-PR jobs.  Measured on a 2-CPU pin, width 2 doubled
+        # the WorkerTests slice alone (6.5 s vs 3.3 s).  The retry+::warning
+        # telemetry below is the guardrail: if pool-pressure warnings recur,
+        # drop back toward 2 (or raise the AsyncKit pool timeout).
         #
         # Second layer: the test step is retried once.  A lone transient
         # pool-pressure flake should not redden the canary or auto-file a
@@ -84,7 +94,7 @@ jobs:
         # preserved).  A flaky first attempt is surfaced as a ::warning:: so
         # the flakiness stays visible instead of being silently swallowed.
         env:
-          SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "2"
+          SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH: "4"
         run: |
           run_tests() { swift test --enable-code-coverage; }
           if run_tests; then

--- a/changelog.d/nightly-coverage-width-4.md
+++ b/changelog.d/nightly-coverage-width-4.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Nightly coverage run parallelism restored to width 4 (from 2).** The
+  tighter cap dated from when the all-targets nightly process was losing
+  cooperative-pool threads to WorkerTests' blocking subprocess waits on top
+  of DB-pool pressure; with the #1233 wedge class fixed and the WedgeWatchdog
+  converting any residual stall into a fast evidenced abort, the nightly runs
+  at the same width as the per-PR jobs (measured 2× on the WorkerTests slice
+  alone). The nightly's retry-once + `::warning` telemetry is the guardrail
+  for re-tightening if pool-pressure flakes recur.


### PR DESCRIPTION
**⚠️ Merge after #1236** — the #1233 wedge fix must be on `main` before the nightly runs wider, since the nightly executes WorkerTests in the shared all-targets process where the wedge class lived.

Follow-up to #1236 (issue #1233), picking speed back up now that the wedge class is fixed.

## What

`test-coverage.yml`: `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` 2 → 4, with the comment block rewritten to record why the tighter cap existed and what changed.

## Why now

The width-2 cap (tighter than the per-PR jobs' 4) was justified by two compounding pressures on the shared all-targets nightly process: AsyncKit/Postgres connection-pool timeouts from the APITests apps, **and** cooperative-pool thread theft by WorkerTests' blocking subprocess waits. #1236 removed the second entirely (bounded, CLOEXEC'd waits), so the nightly can return to the same width as the per-PR jobs.

Measured impact (2-CPU pin, matching the CI runner): width 2 doubles the WorkerTests slice alone — ~6.5 s vs ~3.3 s at width 4 — and the cap applies to every target in the nightly, so the whole test-execution phase benefits.

## Guardrails

- The job's existing **retry-once + `::warning`** telemetry surfaces any transient pool-pressure flake without reddening the canary; if warnings recur, drop back toward 2 (or raise the AsyncKit pool timeout) — the rewritten comment says exactly this.
- The **WedgeWatchdog** from #1236 arms in this process too: a residual stall now aborts in ~6 minutes with a per-thread `/proc` dump instead of burning the nightly silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR)_