### PR TITLE
Build a derived swift-ci test image with the test-job packages baked in

### DIFF
--- a/.github/docker/ci-image/Dockerfile
+++ b/.github/docker/ci-image/Dockerfile
@@ -1,0 +1,27 @@
+# CI test image: the mirrored Swift toolchain plus the system packages the
+# test jobs need.  Before this image, every test job apt-get installed these
+# at job start — 20–40 s per job per run, plus 3×15 s retry loops whenever an
+# Ubuntu mirror flaked.  Built and pushed by mirror-images.yml (weekly, on
+# demand, and on PRs that touch this file or that workflow), immediately
+# after the base mirror refreshes, so the toolchain inside always matches
+# ghcr.io/<owner>/chickadee/swift:6.3-noble.
+#
+# BASE_IMAGE defaults to the GHCR mirror, not docker.io, so building never
+# hits Docker Hub rate limits (the reason the mirror exists — see
+# mirror-images.yml). The workflow overrides it with the lowercased owner.
+#
+# Toolchain identity is unchanged — `swift --version` is byte-identical to
+# the base image, so the `.build` cache keys shared with jobs still on the
+# plain mirror keep matching.
+ARG BASE_IMAGE=ghcr.io/jimwallace/chickadee/swift:6.3-noble
+FROM ${BASE_IMAGE}
+
+# file      — SubmissionNormalizer MIME detection (worker-tests, nightly)
+# python3   — LocalHTTPTestServer + notebook probes (WorkerTests) and
+#             generated pattern-family scripts, `#!/usr/bin/env python3`
+#             (APITests, nightly); noble, unlike jammy, does not bundle it
+# zip/unzip — test-setup and course-bundle fixtures (APITests, nightly)
+# curl      — nightly coverage tooling
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends file python3 zip unzip curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -9,25 +9,35 @@ name: Mirror CI images
 # three-week window audited for #890).  GHCR pulls from Actions runners
 # are same-infrastructure and not rate-limited.
 #
+# Also builds the derived CI test image, swift-ci:6.3-noble — the mirrored
+# toolchain plus the system packages the test jobs need (file, python3,
+# zip, unzip, curl; see .github/docker/ci-image/Dockerfile) — so those jobs
+# don't apt-get at job start.  Built right after the mirror step so the
+# toolchain inside always matches the freshly mirrored base.
+#
 # Runs weekly (Docker Hub tags like swift:6.3-noble are re-pushed with
 # fixes) and on demand.  `docker buildx imagetools create` copies the
-# full multi-arch manifest registry-to-registry without a local pull.
+# full multi-arch manifest registry-to-registry without a local pull; the
+# derived image is a plain single-arch (amd64 — all Actions runners) build.
 #
-# When the toolchain pin changes (e.g. swift:6.4), add the new tag here
-# FIRST, run this workflow, and only then point swift-tests.yml /
-# test-coverage.yml / docker-build.yml at the new mirrored tag.
+# When the toolchain pin changes (e.g. swift:6.4), add the new tag here and
+# in ci-image/Dockerfile's BASE_IMAGE default FIRST, run this workflow, and
+# only then point swift-tests.yml / test-coverage.yml / docker-build.yml at
+# the new mirrored tags.
 
 on:
   schedule:
     - cron: "0 5 * * 1"
   workflow_dispatch:
-  # Also run when this file changes in a PR: it both validates the edit and
-  # solves the bootstrap problem (workflow_dispatch only works once the file
-  # exists on the default branch, but the test workflows can't switch to the
-  # mirrored images until a first run has published them).
+  # Also run when this file (or the derived image's Dockerfile) changes in a
+  # PR: it both validates the edit and solves the bootstrap problem
+  # (workflow_dispatch only works once the file exists on the default
+  # branch, but the test workflows can't switch to the mirrored/derived
+  # images until a first run has published them).
   pull_request:
     paths:
       - ".github/workflows/mirror-images.yml"
+      - ".github/docker/ci-image/**"
 
 permissions:
   contents: read
@@ -43,6 +53,8 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -70,3 +82,27 @@ jobs:
           }
           mirror docker.io/library/swift:6.3-noble swift:6.3-noble
           mirror docker.io/library/postgres:16 postgres:16
+
+      - name: Build and push the derived CI test image
+        # After the mirror step on purpose: the derived image builds FROM the
+        # GHCR mirror just refreshed above, never from Docker Hub.
+        run: |
+          set -euo pipefail
+          owner="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          base="ghcr.io/${owner}/chickadee/swift:6.3-noble"
+          dst="ghcr.io/${owner}/chickadee/swift-ci:6.3-noble"
+          echo "Building ${dst} from ${base}"
+          for attempt in 1 2 3 4 5; do
+            if docker buildx build \
+              --platform linux/amd64 \
+              --build-arg BASE_IMAGE="${base}" \
+              --tag "${dst}" \
+              --push \
+              .github/docker/ci-image; then
+              exit 0
+            fi
+            echo "attempt ${attempt} failed; retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "Failed to build/push ${dst} after 5 attempts" >&2
+          exit 1

--- a/changelog.d/ci-image-swift-ci.md
+++ b/changelog.d/ci-image-swift-ci.md
@@ -1,0 +1,9 @@
+### Added
+
+- **Derived CI test image `swift-ci:6.3-noble`.** `mirror-images.yml` now
+  builds and publishes a CI image layering the test jobs' system packages
+  (`file`, `python3`, `zip`, `unzip`, `curl`) onto the mirrored Swift
+  toolchain, immediately after each mirror refresh. Groundwork for dropping
+  the 20–40 s per-job apt-get steps (adopted by the test workflows in a
+  follow-up); toolchain identity is unchanged so `.build` cache keys keep
+  matching.


### PR DESCRIPTION
Part of the post-#1233 CI speed recovery. **Step 1 of 2** — this PR publishes the image; the adoption PR (switching the test jobs onto it and guarding their apt-get steps) follows separately so nothing depends on an image that doesn't exist yet. This is the same two-step dance `mirror-images.yml`'s header already prescribes for image changes.

## What

- New `.github/docker/ci-image/Dockerfile`: `FROM` the GHCR-mirrored `swift:6.3-noble`, plus `file python3 zip unzip curl` — the union of what the test jobs currently apt-get on every run (~20–40 s per job, plus 3×15 s retry loops when an Ubuntu mirror flakes).
- `mirror-images.yml` builds and pushes `ghcr.io/<owner>/chickadee/swift-ci:6.3-noble` immediately **after** the mirror step (so it always layers on the freshly mirrored base, never touching Docker Hub), with the same 5-attempt retry shape as the mirror. The `pull_request` paths trigger now includes the Dockerfile — the same bootstrap trick the mirror uses, so **this PR's own workflow run publishes the image**.
- Toolchain identity is unchanged (`swift --version` is byte-identical to the base), so the `.build` cache keys shared with jobs still on the plain mirror keep matching.

## Why

Baking the packages in recovers more per-PR wall clock than any parallelism knob measured while investigating #1233: the worker-tests suite itself runs in ~3 s, while the apt-get steps cost 20–40 s in each of three per-PR jobs plus the nightly — and they carry their own flake surface (mirror hiccups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR)_