### PR TITLE
Run test jobs on the swift-ci image; apt-get steps become stale-image fallbacks

### DIFF
--- a/.github/workflows/swift-tests.yml
+++ b/.github/workflows/swift-tests.yml
@@ -167,7 +167,10 @@ jobs:
     needs: build
     timeout-minutes: 20
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci = the mirrored toolchain + baked-in test packages (see
+      # mirror-images.yml / .github/docker/ci-image); same `swift --version`,
+      # so the `.build` cache key matches the build job's.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -188,10 +191,16 @@ jobs:
           key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
+        # zip/unzip/python3 are baked into the swift-ci image, so this
+        # normally just verifies and exits.  The apt-get path remains as the
+        # fallback for a stale image (e.g. a toolchain bump before the
+        # swift-ci rebuild — see mirror-images.yml), degrading to the old
+        # per-job install instead of failing the job.
         run: |
-          # python3: the noble base image (unlike jammy) does not bundle it, and
-          # APITests run generated pattern-family cases that shell out to
-          # `#!/usr/bin/env python3`.  worker-tests installs it explicitly too.
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null; then
+            echo "test dependencies already baked into the image; skipping apt-get"
+            exit 0
+          fi
           for i in 1 2 3; do
             apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
@@ -222,7 +231,8 @@ jobs:
     needs: build
     timeout-minutes: 25
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci: see the api-tests job note.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -266,10 +276,16 @@ jobs:
           key: ${{ runner.os }}-build-v4-${{ steps.toolchain.outputs.key }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
 
       - name: Install system test dependencies
+        # zip/unzip/python3 are baked into the swift-ci image, so this
+        # normally just verifies and exits.  The apt-get path remains as the
+        # fallback for a stale image (e.g. a toolchain bump before the
+        # swift-ci rebuild — see mirror-images.yml), degrading to the old
+        # per-job install instead of failing the job.
         run: |
-          # python3: the noble base image (unlike jammy) does not bundle it, and
-          # APITests run generated pattern-family cases that shell out to
-          # `#!/usr/bin/env python3`.  worker-tests installs it explicitly too.
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v python3 >/dev/null; then
+            echo "test dependencies already baked into the image; skipping apt-get"
+            exit 0
+          fi
           for i in 1 2 3; do
             apt-get update -qq && apt-get install -y --no-install-recommends zip unzip python3 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."
@@ -322,7 +338,8 @@ jobs:
     # the test process; --parallel would just have the runner schedule
     # them across multiple xctest binaries that don't share the lock.
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci: see the api-tests job note.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -346,8 +363,15 @@ jobs:
         # `file` backs SubmissionNormalizer's MIME detection; `python3` runs the
         # real local HTTP servers (LocalHTTPTestServer) and notebook probes in
         # WorkerDaemonTests / NotebookExtractorTests, which otherwise fail (not
-        # skip) when the interpreter is absent.
-        run: apt-get update -qq && apt-get install -y --no-install-recommends file python3
+        # skip) when the interpreter is absent.  Both are baked into the
+        # swift-ci image; the apt-get path is the stale-image fallback (see
+        # the api-tests job note).
+        run: |
+          if command -v file >/dev/null && command -v python3 >/dev/null; then
+            echo "test dependencies already baked into the image; skipping apt-get"
+            exit 0
+          fi
+          apt-get update -qq && apt-get install -y --no-install-recommends file python3
 
       - name: Run WorkerTests
         # `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4` caps Swift

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -26,7 +26,10 @@ jobs:
     # step would otherwise burn.
     timeout-minutes: 180
     container:
-      image: ghcr.io/jimwallace/chickadee/swift:6.3-noble
+      # swift-ci = the mirrored toolchain + baked-in test packages (see
+      # mirror-images.yml / .github/docker/ci-image). Toolchain-identical to
+      # the plain mirror, so nothing about the clean-build canary changes.
+      image: ghcr.io/jimwallace/chickadee/swift-ci:6.3-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -57,6 +60,13 @@ jobs:
           # *all* targets in one process, so it must match — without it the
           # python3-dependent tests trap (broken pipe / leaked test Application →
           # ServeCommand deinit assertion → SIGILL) and take down the whole run.
+          # All five are baked into the swift-ci image; the apt-get path is the
+          # stale-image fallback (see mirror-images.yml).
+          if command -v zip >/dev/null && command -v unzip >/dev/null && command -v curl >/dev/null \
+            && command -v file >/dev/null && command -v python3 >/dev/null; then
+            echo "test dependencies already baked into the image; skipping apt-get"
+            exit 0
+          fi
           for i in 1 2 3; do
             apt-get update -qq && apt-get install -y --no-install-recommends zip unzip curl file python3 && break
             echo "apt-get failed (attempt $i), retrying in 15s..."

--- a/changelog.d/ci-image-adopt.md
+++ b/changelog.d/ci-image-adopt.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Test jobs run on the `swift-ci` image; per-job apt-get installs drop to
+  a no-op guard.** `api-tests`, `api-tests-postgres`, `worker-tests`, and
+  the nightly coverage run now use the derived CI image with `file`,
+  `python3`, `zip`, `unzip`, and `curl` baked in — removing 20–40 s of
+  apt-get (and its mirror-flake retry loops) from every run of each job.
+  The install steps remain as stale-image fallbacks: if the image ever lags
+  a toolchain bump, the job degrades to the old apt-get path instead of
+  failing.


### PR DESCRIPTION
**Merge after #1238** (step 2 of 2). The `swift-ci:6.3-noble` image already exists in GHCR — #1238's own `pull_request` workflow run published it (completed successfully before this PR was opened) — so this PR's CI pulls it and should be green immediately. The merge-order requirement is about keeping `main` coherent: the weekly rebuild that keeps the image fresh only exists once #1238 lands.

Part of the post-#1233 CI speed recovery.

## What

- `api-tests`, `api-tests-postgres`, `worker-tests` (`swift-tests.yml`) and the nightly `coverage` job (`test-coverage.yml`) switch their container from the plain mirror to `ghcr.io/<owner>/chickadee/swift-ci:6.3-noble`, which has `file`/`python3`/`zip`/`unzip`/`curl` baked in.
- Their "Install … dependencies" steps become **install-if-missing guards**: on the swift-ci image they verify and exit (sub-second); on a stale image (e.g. a toolchain bump before the swift-ci rebuild) they degrade to the exact old apt-get path — with its retry loops — instead of failing the job.

## Impact

Removes 20–40 s of apt-get (plus the mirror-flake retry surface) from each of three per-PR jobs and the nightly, every run. Toolchain identity is unchanged (`swift --version` byte-identical to the base), so the `.build` cache keys shared with the `build` job — which stays on the plain mirror, since it installs nothing — keep matching.

Jobs that never installed packages (build, core-tests, format-lint, browser-runner-tests, the browser probes) are deliberately left on the plain mirror to keep the blast radius minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXPrZEHEgXi87FdXrbkdBR)_