### PR TITLE
cleanup(browser): drop the pre-extractR wasm fallback

### DIFF
--- a/Public/browser-runner.js
+++ b/Public/browser-runner.js
@@ -863,26 +863,11 @@
         }));
 
         if (isR) {
-            if (core.extractR) {
-                // Shared RunnerCore implementation: header + an inert
-                // `# ---- chickadee:cell N ----` marker per cell, which the R
-                // grading runtime's chickadee_student_cells() splits on —
-                // byte-identical to the native worker's extraction.
-                files[`${stem}.R`] = core.extractR(cells, filename).source;
-            } else {
-                // Back-compat with a vendored wasm artifact predating
-                // runnerExtractR (the runner-wasm-vendor workflow re-vendors on
-                // merge, one-release lag): the pre-hoist behaviour — verbatim
-                // cells, no markers. Delete this branch once the re-vendored
-                // artifact ships.
-                let code = `# Generated from ${filename}\n\n`;
-                for (const cell of cells) {
-                    if (cell.cell_type !== 'code') continue;
-                    const trimmed = cell.source.replace(/\s+$/, '');
-                    if (trimmed.trim()) code += trimmed + '\n\n';
-                }
-                files[`${stem}.R`] = code;
-            }
+            // Shared RunnerCore implementation: header + an inert
+            // `# ---- chickadee:cell N ----` marker per cell, which the R
+            // grading runtime's chickadee_student_cells() splits on —
+            // byte-identical to the native worker's extraction.
+            files[`${stem}.R`] = core.extractR(cells, filename).source;
             files['.chickadee_student_module'] = `${stem}.R`;
             return;
         }
@@ -930,6 +915,7 @@
         if (_runnerCore) return _runnerCore;
         const ready = () =>
             typeof globalThis.runnerExtractPython === 'function'
+            && typeof globalThis.runnerExtractR === 'function'
             && typeof globalThis.runnerClassifyScript === 'function';
         if (!ready()) {
             const mod = await import('/runner-wasm/runner-core.js');
@@ -940,14 +926,8 @@
         }
         _runnerCore = {
             extractPython: globalThis.runnerExtractPython,
+            extractR: globalThis.runnerExtractR,
             classifyScript: globalThis.runnerClassifyScript,
-            // Optional (not in ready()): absent from a vendored artifact built
-            // before the R-extraction hoist. Callers fall back to the pre-hoist
-            // verbatim extraction until the runner-wasm-vendor workflow ships
-            // the rebuilt artifact; drop the null tolerance with that fallback.
-            extractR: typeof globalThis.runnerExtractR === 'function'
-                ? globalThis.runnerExtractR
-                : null,
         };
         return _runnerCore;
     }

--- a/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
+++ b/Tests/BrowserRunnerJSTests/browser-runner.test.mjs
@@ -572,14 +572,29 @@ async function loadRunnerHarness(options = {}) {
     fetch: fetchImpl,
     getCsrfToken: () => options.csrfToken ?? 'csrf-test-token',
     document,
-    // Test seam: preset the RunnerCore extractor so the runner never loads the
-    // real wasm bundle. The actual extraction logic is covered by the Swift
-    // RunnerCore tests; here a stub returns deterministic output.
+    // Test seam: preset the RunnerCore extractors so the runner never loads
+    // the real wasm bundle. The actual extraction logic is covered by the
+    // Swift RunnerCore tests; here stubs return deterministic output.
     runnerExtractPython: options.runnerExtractor ?? ((cells, filename) => ({
       executableModule: `# Generated from ${filename}\n# (stub executable module)\n`,
       introspectableSource: `# Generated from ${filename}\n# (stub introspectable source)\n`,
       codeCellCount: (cells || []).filter(c => c.cell_type === 'code').length,
     })),
+    // Faithful double of RunnerCore.extractR (real logic covered by the Swift
+    // RNotebookExtractionTests): header + a position-numbered marker per kept
+    // cell, trailing whitespace trimmed.
+    runnerExtractR: options.runnerExtractR ?? ((cells, filename) => {
+      let source = `# Generated from ${filename}\n\n`;
+      let codeCellCount = 0;
+      (cells || []).forEach((cell, index) => {
+        if (cell.cell_type !== 'code') return;
+        const trimmed = cell.source.replace(/\s+$/, '');
+        if (!trimmed.trim()) return;
+        codeCellCount += 1;
+        source += `# ---- chickadee:cell ${index + 1} ----\n${trimmed}\n\n`;
+      });
+      return { source, codeCellCount };
+    }),
     // Test seam for the shared classifier (real logic is RunnerCore/Swift,
     // covered by ScriptClassificationTests). This stub mirrors it, returning the
     // interpreter raw value so dispatch wiring can be exercised.
@@ -590,13 +605,6 @@ async function loadRunnerHarness(options = {}) {
     runnerExecuteSuites: options.runnerExecuteSuites ?? executeSuitesStub,
     __CHICKADEE_BROWSER_RUNNER_TEST_HOOKS__: testHooks,
   };
-
-  // Optional seam for the shared R extractor (RunnerCore.extractR via wasm).
-  // Absent by default so the pre-re-vendor fallback branch stays exercised; a
-  // test presets it to prove extraction prefers the wasm path when available.
-  if (options.runnerExtractR) {
-    context.runnerExtractR = options.runnerExtractR;
-  }
 
   // Web-Worker executor seam.  By default the harness exposes NO Worker and no
   // factory override, so the runner falls back to the main-thread Pyodide path
@@ -1346,8 +1354,8 @@ test('extractNotebook delegates Python to RunnerCore (module + introspectable si
     'submission.source.py',
   );
 
-  // R without the wasm extractR export (a vendored artifact predating the
-  // hoist): the fallback emits verbatim cells, no markers, no sidecar.
+  // R extracts through the shared extractR seam (marker-bearing, matching the
+  // native worker); no introspectable sidecar for R.
   await extractNotebook(
     harness.py,
     '/course',
@@ -1360,7 +1368,7 @@ test('extractNotebook delegates Python to RunnerCore (module + introspectable si
   );
   assert.equal(
     harness.py.FS.readFile('/course/lab.R', { encoding: 'utf8' }),
-    '# Generated from lab.ipynb\n\nx <- 2\n\n',
+    '# Generated from lab.ipynb\n\n# ---- chickadee:cell 1 ----\nx <- 2\n\n',
   );
   assert.equal(
     harness.py.FS.readFile('/course/.chickadee_student_module', { encoding: 'utf8' }),
@@ -1368,10 +1376,11 @@ test('extractNotebook delegates Python to RunnerCore (module + introspectable si
   );
 });
 
-test('R notebooks extract through the shared RunnerCore wasm when the export is present', async () => {
-  // Preset the runnerExtractR global (as the re-vendored wasm bridge does) and
-  // assert extraction prefers it over the verbatim fallback — the browser then
-  // produces the same marker-bearing .R the native worker writes.
+test('R notebook extraction feeds the extractR seam cells + filename and writes its result verbatim', async () => {
+  // Override the harness's faithful double with a capturing stub: proves the
+  // browser glue hands the projected cells straight to the shared extractor
+  // (RunnerCore.extractR via wasm in production) and writes whatever it
+  // returns, transforming nothing itself.
   let received = null;
   const harness = await loadRunnerHarness({
     runnerExtractR: (cells, filename) => {

--- a/changelog.d/drop-extractr-fallback.md
+++ b/changelog.d/drop-extractr-fallback.md
@@ -1,0 +1,10 @@
+### Removed
+
+- **Browser fallback for pre-`extractR` wasm artifacts.** The re-vendored
+  RunnerCore artifact carrying the `runnerExtractR` export is on `main`
+  (follow-through from #1235), so the temporary verbatim-extraction branch in
+  `browser-runner.js` is gone: `loadRunnerCore` now requires the export like
+  the other two, and R notebook extraction in the browser always produces the
+  worker-identical marker-bearing `.R`. `runner-core.js` is served `no-cache`,
+  so no deployed client can retain a loader without the export past the next
+  release.

--- a/docs/language-handling-review.md
+++ b/docs/language-handling-review.md
@@ -13,7 +13,8 @@ references are to that commit.
 > for the concrete items to land, including pulling the "on trigger" items
 > forward. Implemented in the same PR as this document (#1235): the §1 hoist
 > (`RunnerCore.extractR` + wasm bridge export + the browser stub deleted, with
-> a fallback branch until the re-vendored artifact ships), the §2 generated
+> a fallback branch that was removed in the follow-up PR once the re-vendored
+> artifact landed on main), the §2 generated
 > fenced block (`scripts/generate-js-constants.sh` + CI check, replacing
 > `r-kernel-names-drift.test.mjs` — action 7 pulled forward), the §3 surface
 > shrink (kernel-name overload now internal to Core; the colliding `rederive`


### PR DESCRIPTION
Follow-through from #1235, as flagged there: the temporary fallback existed only to cover the window between merging the R-extraction hoist and the `runner-wasm-vendor` workflow re-vendoring the browser artifact. That re-vendor has landed on `main` (`d93b9fc`, `RunnerWasm.7c5fce63ac87.wasm`) and the rebuilt module carries the `runnerExtractR` export — so the fallback is dead weight and this removes it.

## Changes

- `extractNotebookToMap`'s R branch calls `core.extractR(cells, filename)` unconditionally — the verbatim no-marker fallback branch is deleted.
- `loadRunnerCore` requires `runnerExtractR` in its `ready()` gate exactly like `extractPython` / `classifyScript`, and the `extractR: null` tolerance is gone.
- The JS test harness gains a faithful `extractR` double as a default seam (mirroring how the other RunnerCore seams are stubbed); the former fallback-path test now asserts the marker-bearing output, and the capturing-stub test is reframed as the seam-wiring test.
- Changelog fragment; one-clause accuracy update to the review doc's Outcome note.

## Why this is safe to ship

- **Release ordering:** the artifact commit precedes this change on `main`, so any release containing the no-fallback code also serves the export-bearing wasm.
- **Client caching:** `RunnerWasmCacheMiddleware` serves `runner-core.js` with `no-cache` (revalidate-before-use), so no browser can retain a loader lacking the export past the next deploy; the wasm itself is content-hashed and busts cleanly.

## Verification

- All 141 BrowserRunnerJS tests pass, including the output-contract suite against the *new* vendored artifact.
- `scripts/generate-js-constants.sh --check` passes (fenced block untouched).
- No Swift changes; `Public/runner-wasm/` untouched.

## Related

- #1235 — the hoist that introduced the fallback; #77 — WebR, which now starts from a browser that already extracts R identically to the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYCaQ2PNtiPcCjMp1k5J43

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYCaQ2PNtiPcCjMp1k5J43)_