### PR TITLE
chore(deps): refresh Swift dependency graph

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "1fcda69a269bca152e9916c7d7274be2a793c1fa5b530b6939ecb2756c5e66ff",
+  "originHash" : "79647a7a9344b0db1d9d71d76f8d308ba924e70cd7ba95194eaea6702e7f0fb0",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "7744c2a035c68ec14726c709f031835e3e30bde1",
-        "version" : "1.34.0"
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-kit.git",
       "state" : {
-        "revision" : "ec094096d715593c4944cb9aeb72a633faa82918",
-        "version" : "1.56.0"
+        "revision" : "ca609b2132bde05f9a2d7561e2864587c24fa7b9",
+        "version" : "1.57.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "a93a262fefb0938b799191b54f581ffa43422d96",
-        "version" : "5.5.0"
+        "revision" : "7abc497b0f907191933c87166e9b6a41b9d028d6",
+        "version" : "5.6.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/leaf.git",
       "state" : {
-        "revision" : "b70a6108e4917f338f6b8848407bf655aa7e405f",
-        "version" : "4.5.1"
+        "revision" : "21852a898dc8681ec072f79968f1c21fb87da8cb",
+        "version" : "4.5.2"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/leaf-kit.git",
       "state" : {
-        "revision" : "6044b844caa858a0c5f2505ac166f5a057c990dc",
-        "version" : "1.14.2"
+        "revision" : "64cc0a5c8dcf4fbd03be73b944f6850c0b82e439",
+        "version" : "1.14.3"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/postgres-kit.git",
       "state" : {
-        "revision" : "7c079553e9cda74811e627775bf22e40a9405ad9",
-        "version" : "2.15.1"
+        "revision" : "218aaf6810db9e61398f887aaaf26424142bdb53",
+        "version" : "2.16.1"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/postgres-nio.git",
       "state" : {
-        "revision" : "f2188e05ba3546a76e61a5193c071b82c4d69a45",
-        "version" : "1.33.0"
+        "revision" : "39ce38a93408937bcd27f521f3cdf88266136b80",
+        "version" : "1.33.1"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sqlite-nio.git",
       "state" : {
-        "revision" : "95595bbf0e044ee549fbb64aeaeec8d7f7059a16",
-        "version" : "1.12.8"
+        "revision" : "553a6be0e228085b4d5e7c7ecb6a590186c31136",
+        "version" : "1.13.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -222,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -303,8 +303,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
-        "version" : "2.101.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -312,8 +312,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
-        "version" : "1.34.1"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -321,8 +321,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {
@@ -330,8 +330,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
-        "version" : "2.37.1"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -364,7 +364,7 @@
     {
       "identity" : "swift-service-lifecycle",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle",
       "state" : {
         "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
         "version" : "2.11.0"
@@ -375,8 +375,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     },
     {
@@ -384,8 +384,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "61663f4b6c73824526f6429a4f77b1d18a19e4b3",
-        "version" : "0.64.0"
+        "revision" : "3292bab28e6e92000161348003fdef8edc4e582d",
+        "version" : "0.65.0"
       }
     },
     {
@@ -393,8 +393,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
-        "version" : "4.121.4"
+        "revision" : "748ae8432a33e0965bbf0351fedd4e915e7f460c",
+        "version" : "4.122.0"
       }
     },
     {

--- a/changelog.d/package-dependency-updates.md
+++ b/changelog.d/package-dependency-updates.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Swift dependency refresh.** `swift package update` across the server graph:
+  Vapor 4.121.4 → 4.122.0 (adds an HTTPServer idle-connection timeout option),
+  Leaf 4.5.1 → 4.5.2 with LeafKit 1.14.2 → 1.14.3 (clearer built-in tag errors
+  only — the multi-`#extend` parser bug is *not* fixed upstream, so the editor
+  template decomposition stays on hold), async-http-client 1.34.0 → 1.36.0,
+  swift-crypto 4.5.0 → 4.5.1, SwiftLintPlugins 0.64.0 → 0.65.0 (no new lint
+  rules; safe under `--strict`), and refreshed transitives (swift-nio 2.101.3,
+  fluent-kit 1.57.0, jwt-kit 5.6.0, postgres-kit 2.16.1, postgres-nio 1.33.1,
+  sqlite-nio 1.13.0, swift-log 1.14.0, among others). `Package.swift` ranges
+  already allowed every bump, so this only moves `Package.resolved`.


### PR DESCRIPTION
## What

`swift package update` across the server graph. Every bump was already allowed by the `Package.swift` ranges, so the diff is **`Package.resolved` only** (plus a `changelog.d/` fragment) — no manifest edits, no source changes.

| Package | From | To | Notes |
|---|---|---|---|
| vapor | 4.121.4 | 4.122.0 | adds an HTTPServer idle-connection timeout option |
| leaf / leaf-kit | 4.5.1 / 1.14.2 | 4.5.2 / 1.14.3 | see note below |
| async-http-client | 1.34.0 | 1.36.0 | proxy-header support |
| swift-crypto | 4.5.0 | 4.5.1 | patch |
| SwiftLintPlugins | 0.64.0 | 0.65.0 | no new rules — verified 0 violations under `--strict` |
| transitives | — | — | swift-nio 2.101.3, fluent-kit 1.57.0, jwt-kit 5.6.0, postgres-kit 2.16.1, postgres-nio 1.33.1, sqlite-nio 1.13.0, swift-log 1.14.0, swift-certificates 1.19.4, swift-system 1.7.5, nio-ssl 2.37.2, nio-http2 1.45.0, nio-extras 1.34.3, swift-async-algorithms 1.1.5, swift-atomics 1.3.1 |

## leaf-kit 1.14.3 does NOT unblock the template decomposition

Diffed upstream `1.14.2..1.14.3`: the release only improves error messages in `LeafTag.swift`. `Extend.init` in `LeafSyntax.swift` is untouched, so the multi-inline-`#extend` parser bug is still present and the CLAUDE.md "at most one inline partial `#extend` per template" rule stays in force.

## Deliberately not bumped

- **JavaScriptKit 0.53.0 → 0.56.1** (`wasm/` package): includes Embedded-Swift fixes and raises min Swift to 6.3 (fine with our pinned `swift-6.3.2-RELEASE_wasm-embedded` SDK), but requires a RunnerWasm rebuild + re-vendor gated by the output-contract tests — follow-up PR.
- **jupyterlite-pyodide-kernel 0.8.1 → 0.8.2**: checked the tag — it still pins Pyodide 314.0.1, so bumping buys nothing and costs a full bundle rebuild + sha cascade.
- Upstream Pyodide 314.0.3: not applicable by design (version derives from the kernel pin; parity check enforces it).

## Verification

- `swift build` clean under `.treatAllWarnings(as: .error)`
- `scripts/lint.sh` (swift-format) clean
- `scripts/swiftlint.sh` with the new SwiftLint 0.65 binary: **0 violations in 888 files** under `--strict`
- CoreTests **233 ✔**, WorkerTests **277 ✔**, APITests **2,395 ✔** (run with CI's `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrX4NqzzxXSbQnu3XCFZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrX4NqzzxXSbQnu3XCFZM6)_