### PR TITLE
chore(deps): bump JavaScriptKit to 0.56.1 in the wasm bridge

### DIFF
--- a/changelog.d/javascriptkit-0-56.md
+++ b/changelog.d/javascriptkit-0-56.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **JavaScriptKit 0.53.0 → 0.56.1 (wasm bridge).** Brings the upstream
+  Embedded-Swift fixes (JavaScriptEventLoop on newer toolchains,
+  Embedded-compatible error descriptions); minimum Swift is now 6.3, matching
+  the pinned `swift-6.3.2-RELEASE_wasm-embedded` SDK. The manual (non-BridgeJS)
+  bridge compiles unchanged. Verified by a full Embedded-SDK rebuild and the
+  browser contract suite (141/141, including the output-contract and drift
+  tests) against the rebuilt artifact; gzipped wasm grows ~3 KB (0%), within
+  budget. The vendored `Public/runner-wasm/` artifact is deliberately untouched
+  here — the `runner-wasm-vendor` workflow re-vendors it on main after merge.

--- a/wasm/Package.resolved
+++ b/wasm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a7cd299a76ffb637061fd264713ddde896ffcc42a1d48cdc5477614afd413cac",
+  "originHash" : "98f57c4f859eac13924af4322dc61262487a23090b06e43f28401ca2092328f4",
   "pins" : [
     {
       "identity" : "javascriptkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftwasm/JavaScriptKit.git",
       "state" : {
-        "revision" : "403ae956d68503957699b6dc4c07b73caad031b7",
-        "version" : "0.53.0"
+        "revision" : "22905075f8b61834810babe5fb9a2f613f22f398",
+        "version" : "0.56.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     }
   ],

--- a/wasm/Package.swift
+++ b/wasm/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(name: "Chickadee", path: ".."),
-        .package(url: "https://github.com/swiftwasm/JavaScriptKit.git", from: "0.53.0"),
+        .package(url: "https://github.com/swiftwasm/JavaScriptKit.git", from: "0.56.1"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## What

Bumps the `wasm/` sub-package's JavaScriptKit floor **0.53.0 → 0.56.1** (swift-syntax follows 603.0.1 → 603.0.2 transitively). Follow-up to #1242, which deliberately left this out.

Relevant upstream changes:
- **Embedded-Swift fixes we want:** `JavaScriptEventLoop` fix for newer toolchains (swiftwasm/JavaScriptKit#784) and Embedded-compatible error descriptions (#759).
- Minimum Swift raised to 6.3 — matches our pinned `swift-6.3.2-RELEASE_wasm-embedded` SDK.
- The rest of the 0.54–0.56 delta is BridgeJS work Chickadee doesn't use (our bridge is manual interop in `wasm/Sources/RunnerWasm/main.swift`).

## Tested with the real toolchain

Installed Swift 6.3.2 + the pinned Embedded wasm SDK (exactly the `runner-wasm-vendor` CI recipe) and ran the full pipeline locally:

- `scripts/build-runner-wasm.sh` — **compiles clean, zero bridge changes needed** (Embedded mode, `Extern` feature, Unicode-tables linkage all fine)
- `node --test Tests/BrowserRunnerJSTests` against the rebuilt artifact — **141/141 passing**, including `output-contract.test.mjs` and the runtime/grading-worker drift tests
- Size: gzip 503,910 bytes, **+3,006 bytes (0%)** vs baseline — within budget (warn 540,672 / fail 688,128)

## Why `Public/runner-wasm/` is untouched here

By design. The `runner-wasm-vendor` workflow's source hash covers `wasm/Package.resolved`; on merge it detects the drift, rebuilds with the canonical CI toolchain, and commits the re-vendored artifact to main itself (same pipeline as every RunnerCore change). Shipping container-built bytes from this PR would bypass that provenance. Note the documented one-release lag: the fresh artifact ships with the release *after* the vendor commit lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrX4NqzzxXSbQnu3XCFZM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrX4NqzzxXSbQnu3XCFZM6)_