### PR TITLE
compliance: MCP student-data audit + findings F-1–F-4/F-6/F-8 remediated + UW approval readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1145,8 +1145,9 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
 
 - **MCP authoring-surface expansion (v0.4.328+).**  The agent tool catalog grew
   from twelve to thirty-four content tools in this window — it stands at
-  **40** today (`MCPToolCatalog.live` in `MCPServerRegistration.swift` is the
-  source of truth): `get_server_info`
+  **51** today (`MCPToolCatalog.live` in `MCPServerRegistration.swift` is the
+  source of truth; census re-taken in
+  `docs/compliance/mcp-student-data-audit-2026-07.md`): `get_server_info`
   (version/capability probe), `get_solution` / `update_solution` (read + replace
   the reference solution, re-validating), `author_script` (create/replace a
   hand-written test or support file through the same `applySuiteEdit` path the
@@ -1178,7 +1179,7 @@ The per-version detail again lives in `CHANGELOG.md`; grouped by subsystem:
   (`closeOpenAssignmentForContentEdit`).
 
 - **MCP section / check / grading-mode round (v0.4.353+).**  The catalog reached
-  thirty-four tools at this point (40 today): test-suite section management (`create_suite_section` /
+  thirty-four tools at this point (51 today): test-suite section management (`create_suite_section` /
   `rename_suite_section` / `delete_suite_section`, plus `move_suite_item` to place a
   script/family/check into a section); course-section management
   (`list_course_sections`, `create_course_section`, `rename_course_section`,

--- a/Sources/APIServer/MCP/Admin/RingBufferLogHandler.swift
+++ b/Sources/APIServer/MCP/Admin/RingBufferLogHandler.swift
@@ -51,10 +51,14 @@ struct RingBufferLogHandler: LogHandler {
     }
 
     /// Metadata keys dropped before storage — anything that could identify a
-    /// student.  Matched case-insensitively.
+    /// student.  Matched case-insensitively.  The write-side convention
+    /// (enforced by `LogMessageHygieneTests`) is that identifiers go into
+    /// metadata under one of these keys, never into message text, so dropping
+    /// the key redacts the buffer while console logging keeps full fidelity.
     static let piiKeys: Set<String> = [
         "user_id", "userid", "submission_id", "submissionid", "username", "email",
         "actor_username", "student_id", "studentid", "name",
+        "ip", "remote_ip", "org_defined_id", "user", "row_ids",
     ]
 
     static func redact(_ metadata: Logger.Metadata) -> [String: String] {

--- a/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetBrowserDiagnosticsTool.swift
@@ -9,9 +9,9 @@
 // returned DTO is hand-built and deliberately OMITS user_id. It keeps the
 // failure kind, source, failed checks, error message/stack (JupyterLite/Pyodide
 // infrastructure text only — capture is restricted to the editor-load path,
-// never student-code execution), the user agent, the test-setup id (instructor
-// content, not student data), and the timestamp. No student identifier is ever
-// included.
+// never student-code execution), the coarse browser/OS label (never the raw
+// User-Agent — audit F-4), the test-setup id (instructor content, not student
+// data), and the timestamp. No student identifier is ever included.
 
 import Core
 import Fluent
@@ -32,14 +32,19 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         let count: Int
     }
 
-    /// A single browser-error report, redacted: no user_id.
+    /// A single browser-error report, redacted: no user_id, and the coarse
+    /// browser/OS label rather than the raw User-Agent — a full UA string is
+    /// device-fingerprint-adjacent, and the label is what diagnosis needs
+    /// (compliance audit F-4).
     struct Sample: Encodable, Sendable {
         let kind: String
         let source: String?
         let failedChecks: String?
         let message: String?
         let stack: String?
-        let userAgent: String?
+        /// Coarse "Browser/OS" label (e.g. "Safari/iOS") derived from the
+        /// report's User-Agent; the raw UA is never returned.
+        let browser: String
         let appVersion: String?
         let testSetupID: String?
         let createdAt: Date
@@ -101,7 +106,8 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
         + "localized per device class, and by page-build version (byAppVersion: the ChickadeeVersion the "
         + "client was running; an exec_hang/recover_failed concentrated on an OLD version is a stale-tab / "
         + "cached-bundle symptom, vs. one on the current build meaning the deployed fix is incomplete), over "
-        + "a window, plus recent samples with the error message and stack. Also "
+        + "a window, plus recent samples with the error message and stack (samples carry the coarse "
+        + "browser/OS label, never the raw User-Agent). Also "
         + "returns submitFunnel: the submit_phase breadcrumb counts in phase order "
         + "(grading_start → runtime_loaded → setup_unpacked → suite_started → suite_done → "
         + "result_posting → result_posted) — the drop-off between consecutive phases shows where "
@@ -200,7 +206,7 @@ struct GetBrowserDiagnosticsTool: DiagnosticTool {
                 failedChecks: row.failedChecks,
                 message: row.message,
                 stack: row.stack,
-                userAgent: row.userAgent,
+                browser: Self.browserLabel(forUserAgent: row.userAgent),
                 appVersion: row.appVersion,
                 testSetupID: row.testSetupID,
                 createdAt: row.createdAt ?? Date())

--- a/Sources/APIServer/MCP/Admin/Tools/GetRequestMetricsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/GetRequestMetricsTool.swift
@@ -8,7 +8,10 @@
 // PII boundary: request_metrics carries no user_id, but a concrete path can
 // embed a submission/test-setup id (e.g. /submissions/sub_ab12). This tool
 // NORMALISES those id-like path segments to ":id" before aggregating, so it
-// reports per-route shapes and never a row-level identifier.
+// reports per-route shapes and never a row-level identifier. The pathPrefix
+// input is matched against the normalized routes too — a raw-path match would
+// let a caller probe whether a specific concrete id occurred in the window
+// (compliance audit F-3).
 
 import Core
 import Fluent
@@ -53,7 +56,9 @@ struct GetRequestMetricsTool: DiagnosticTool {
         + "P95 (with request count, error count, and max duration). Optional windowHours (default 24, "
         + "max 720), pathPrefix filter, and limit. Captured for /api/*, /submissions/*, /testsetups/* "
         + "(all paths under verbose timing). Read-only; id-like path segments are normalized to \":id\" "
-        + "so only per-route shapes are reported — never a row-level identifier."
+        + "so only per-route shapes are reported — never a row-level identifier. The pathPrefix filter "
+        + "is matched against the normalized route (a concrete id in the prefix collapses to :id), so "
+        + "it cannot probe for a specific submission or setup."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([
@@ -80,16 +85,18 @@ struct GetRequestMetricsTool: DiagnosticTool {
         let limit = min(max(input.limit ?? 15, 1), 100)
         let since = Date().addingTimeInterval(Double(-windowHours) * 3600)
 
-        var query = APIRequestMetric.query(on: context.db).filter(\.$finishedAt >= since)
-        let prefix = input.pathPrefix.flatMap { $0.isEmpty ? nil : $0 }
-        if let prefix {
-            // Narrow at the DB with a substring match, then refine to a true
-            // prefix in Swift (Fluent has no portable prefix operator).
-            query = query.filter(\.$path ~~ prefix)
-        }
-        var rows = try await query.all()
-        if let prefix {
-            rows = rows.filter { $0.path.hasPrefix(prefix) }
+        var rows = try await APIRequestMetric.query(on: context.db)
+            .filter(\.$finishedAt >= since)
+            .all()
+        // The prefix is normalized and matched against NORMALIZED routes, so a
+        // concrete submission/setup id in the prefix collapses to ":id" and
+        // cannot act as an existence probe for that id (compliance audit F-3).
+        // The former DB-side substring narrowing matched raw paths and is
+        // dropped for the same reason; the no-prefix path always loaded the
+        // full window anyway, so worst-case cost is unchanged.
+        if let rawPrefix = input.pathPrefix, !rawPrefix.isEmpty {
+            let prefix = Self.normalizePath(rawPrefix)
+            rows = rows.filter { Self.normalizePath($0.path).hasPrefix(prefix) }
         }
 
         var statusClasses: [String: Int] = [:]

--- a/Sources/APIServer/MCP/Admin/Tools/QueryLogsTool.swift
+++ b/Sources/APIServer/MCP/Admin/Tools/QueryLogsTool.swift
@@ -46,9 +46,10 @@ struct QueryLogsTool: DiagnosticTool {
     static let description =
         "Recent server log events (warning and above) from an in-process ring buffer, for "
         + "diagnosis. Filter by minLevel, a message substring (contains), and sinceMinutes. "
-        + "Returns most-recent-first entries with level, label, message, and PII-redacted "
-        + "metadata. Read-only; the buffer is per-process and resets on restart, and student "
-        + "identifiers are dropped at capture."
+        + "Returns most-recent-first entries with level, label, message, and metadata with PII "
+        + "keys dropped at capture. Read-only; the buffer is per-process and resets on restart. "
+        + "Messages are infrastructure text — the write-side convention (identifiers go in "
+        + "redacted metadata, never message prose) is pinned by a source-scan guard test."
     static let inputSchema: JSONValue = .object([
         "type": .string("object"),
         "properties": .object([

--- a/Sources/APIServer/MCP/Tools/ContentEditClose.swift
+++ b/Sources/APIServer/MCP/Tools/ContentEditClose.swift
@@ -104,7 +104,7 @@ func finalizeContentEdit(
         requeued = await retestSubmissionsAfterContentEdit(setup: setup, context: context)
     }
     // Pass the acting subject explicitly: an MCP request is bearer-authenticated
-    // with no session `APIUser`, so the helper's `req.auth` fallback would throw
+    // with no session user, so the helper's `req.auth` fallback would throw
     // 401 inside its swallow-all catch and the re-validation would silently
     // never be enqueued (the assignment kept its stale validationStatus).
     let submitterUserID = try? await context.requireEligibleSubject(tool: "validate").id

--- a/Sources/APIServer/MCP/Tools/SupportFileURLFetcher.swift
+++ b/Sources/APIServer/MCP/Tools/SupportFileURLFetcher.swift
@@ -131,8 +131,12 @@ enum SupportFileURLFetcher {
         }
         guard !addresses.isEmpty else { throw SupportFileFetchError.dnsFailed(host: host) }
         for ip in addresses where BlockedIPClassifier.isBlocked(ip) {
+            // The resolved address is instructor-URL infrastructure, not a
+            // client IP, but it still goes in metadata: the admin query_logs
+            // buffer redacts the "ip" key while console logging keeps it.
             request.logger.warning(
-                "mcp.support_file_fetch.blocked host=\(host) ip=\(ip)")
+                "mcp.support_file_fetch.blocked host=\(host)",
+                metadata: ["ip": .string("\(ip)")])
             throw SupportFileFetchError.blockedAddress(host: host, ip: ip)
         }
 

--- a/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
+++ b/Sources/APIServer/MCP/Tools/UpdateSolutionTool.swift
@@ -14,8 +14,8 @@
 //
 // This only ever touches the instructor's solution/validation submission — never
 // a student submission, and never the starter notebook (use update_notebook for
-// that). The MCP bearer context has no `Request.auth` APIUser, so the resolved
-// subject is threaded to the enqueue helper as the submission's author.
+// that). The MCP bearer context carries no session-authenticated user, so the
+// resolved subject is threaded to the enqueue helper as the submission's author.
 
 import Core
 import Fluent
@@ -86,8 +86,8 @@ struct UpdateSolutionTool: ContentTool {
 
         let assignment = try await context.authorizedAssignmentForWrite(
             publicID: input.assignmentPublicID, tool: Self.name, atLeast: .ta)
-        // The bearer context has no `Request.auth` APIUser; resolve the subject
-        // so the validation submission is attributed to the acting account.
+        // The bearer context has no session-authenticated user; resolve the
+        // subject so the validation submission is attributed to the acting account.
         let subject = try await context.requireEligibleSubject(tool: Self.name)
 
         // Content versioning: this tool reaches its setup by id rather than

--- a/Sources/APIServer/MCP/Transport/MCPOAuthRateLimitMiddleware.swift
+++ b/Sources/APIServer/MCP/Transport/MCPOAuthRateLimitMiddleware.swift
@@ -28,7 +28,8 @@ struct MCPOAuthRateLimitMiddleware: AsyncMiddleware {
             on: request.db
         )
         guard allowed else {
-            request.logger.warning("MCP OAuth rate limit exceeded for IP \(ip)")
+            request.logger.warning(
+                "MCP OAuth rate limit exceeded", metadata: ["ip": .string(ip)])
             let response = Response(status: .tooManyRequests)
             response.headers.replaceOrAdd(name: "Retry-After", value: "60")
             response.headers.replaceOrAdd(name: .cacheControl, value: "no-store")

--- a/Sources/APIServer/Middleware/LoginRateLimitMiddleware.swift
+++ b/Sources/APIServer/Middleware/LoginRateLimitMiddleware.swift
@@ -91,7 +91,10 @@ struct LoginRateLimitMiddleware: AsyncMiddleware {
             on: request.db
         )
         if !allowed {
-            request.logger.warning("Login rate limit exceeded for IP \(ip)")
+            // IP in metadata only — an IP is personal information, and message
+            // text reaches the admin query_logs buffer unredacted (audit F-1).
+            request.logger.warning(
+                "Login rate limit exceeded", metadata: ["ip": .string(ip)])
             return try Self.tooManyRequestsResponse()
         }
         await LoginAttemptService.purgeStaleIfDue(

--- a/Sources/APIServer/Routes/BrowserResultRoutes.swift
+++ b/Sources/APIServer/Routes/BrowserResultRoutes.swift
@@ -62,8 +62,11 @@ struct BrowserResultRoutes: RouteCollection {
             // grader produced it.
             let (bounded, didTruncate) = decoded.truncatingOversizedOutput()
             if didTruncate {
+                // Submission id in metadata only — message text reaches the
+                // admin query_logs buffer unredacted (compliance audit F-1).
                 req.logger.warning(
-                    "result_collection_truncated submission=\(bounded.submissionID) source=browser"
+                    "result_collection_truncated source=browser",
+                    metadata: ["submission_id": .string(bounded.submissionID)]
                 )
             }
             collection = bounded

--- a/Sources/APIServer/Routes/ResultRoutes.swift
+++ b/Sources/APIServer/Routes/ResultRoutes.swift
@@ -53,8 +53,11 @@ struct ResultRoutes: RouteCollection {
         // unbounded blob out of the results table either way.
         let (collection, didTruncate) = report.collection.truncatingOversizedOutput()
         if didTruncate {
+            // Submission id in metadata only — message text reaches the admin
+            // query_logs buffer unredacted (compliance audit F-1).
             req.logger.warning(
-                "result_collection_truncated submission=\(collection.submissionID) — runner sent an over-budget collection"
+                "result_collection_truncated — runner sent an over-budget collection",
+                metadata: ["submission_id": .string(collection.submissionID)]
             )
         }
 

--- a/Sources/APIServer/Routes/Web/AuthRoutes.swift
+++ b/Sources/APIServer/Routes/Web/AuthRoutes.swift
@@ -99,7 +99,12 @@ struct AuthRoutes: RouteCollection {
                 on: req.db
             )
             if locked {
-                req.logger.warning("Login locked for user '\(usernameKey)' (too many failures)")
+                // Username goes in metadata, not the message: the admin MCP
+                // query_logs ring buffer redacts PII metadata keys at capture
+                // but stores message text verbatim (compliance audit F-1).
+                req.logger.warning(
+                    "Login locked after too many failures",
+                    metadata: ["username": .string(usernameKey)])
                 await AuditLogger.record(
                     action: .loginLocked,
                     targetType: .auth,

--- a/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
+++ b/Sources/APIServer/Routes/Web/EnrollCSVHelper.swift
@@ -303,7 +303,11 @@ func resolvePendingPreEnrollments(
                 do {
                     try await saveSeededEnrollment(for: user, courseID: courseID, on: db)
                 } catch {
-                    logger.warning("Pre-enrollment resolve: failed to enroll \(username) in \(courseID): \(error)")
+                    // Username in metadata only — message text reaches the
+                    // admin query_logs buffer unredacted (compliance audit F-1).
+                    logger.warning(
+                        "Pre-enrollment resolve: enroll failed in course \(courseID): \(error)",
+                        metadata: ["username": .string(username)])
                     continue
                 }
             }
@@ -311,12 +315,15 @@ func resolvePendingPreEnrollments(
                 try await row.delete(on: db)
             } catch {
                 logger.warning(
-                    "Pre-enrollment resolve: failed to delete pending row for \(username) in \(courseID): \(error)")
+                    "Pre-enrollment resolve: failed to delete pending row in course \(courseID): \(error)",
+                    metadata: ["username": .string(username)])
             }
         }
     } catch {
         // Swallow — the user is already authenticated; missing roster
         // membership is a UX bug, not an auth blocker.
-        logger.warning("Pre-enrollment resolve query failed for \(username): \(error)")
+        logger.warning(
+            "Pre-enrollment resolve query failed: \(error)",
+            metadata: ["username": .string(username)])
     }
 }

--- a/Sources/APIServer/Services/BrightSpaceAPIClient.swift
+++ b/Sources/APIServer/Services/BrightSpaceAPIClient.swift
@@ -72,20 +72,32 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible, LocalizedError {
     case groupCategoriesFetchFailed(orgUnitID: String, status: Int)
     case groupsFetchFailed(orgUnitID: String, categoryID: String, status: Int)
 
+    /// D2L response bodies are embedded in descriptions only up to this many
+    /// characters. The body is D2L-controlled text that can echo user-specific
+    /// detail, and descriptions flow into logs, sync-log detail rows, and the
+    /// admin diagnostic MCP surface (compliance audit F-2) — the truncated
+    /// prefix keeps the error class diagnosable without the full payload.
+    static let describedBodyLimit = 120
+
     var description: String {
         switch self {
         case .notConfigured:
             return "BrightSpace sync is not configured (missing env vars)"
-        case .userLookupFailed(let id, let s):
-            return "BrightSpace user lookup for '\(id)' failed (HTTP \(s))"
-        case .userNotFound(let id):
-            return "BrightSpace user not found for orgDefinedId '\(id)'"
+        case .userLookupFailed(_, let s):
+            // The orgDefinedId (an institutional student identifier) is
+            // deliberately NOT described: descriptions reach the query_logs
+            // buffer and the sync-log detail surfaced over the admin MCP
+            // (compliance audit F-2). The associated value still carries it
+            // for programmatic use.
+            return "BrightSpace user lookup failed (HTTP \(s))"
+        case .userNotFound:
+            return "BrightSpace user not found in the org unit classlist"
         case .gradePushFailed(let s, let b):
-            return "BrightSpace grade push failed (HTTP \(s)): \(b)"
+            return "BrightSpace grade push failed (HTTP \(s))\(Self.describedBody(b))"
         case .missingPoints:
             return "No grade points available to push"
         case .whoamiFailed(let s, let b):
-            return "BrightSpace whoami failed (HTTP \(s))\(b.isEmpty ? "" : ": \(b)")"
+            return "BrightSpace whoami failed (HTTP \(s))\(Self.describedBody(b))"
         case .orgUnitLookupFailed(let id, let s):
             return "BrightSpace org unit lookup for '\(id)' failed (HTTP \(s))"
         case .gradeObjectsFetchFailed(let id, let s):
@@ -99,9 +111,16 @@ enum BrightSpaceSyncError: Error, CustomStringConvertible, LocalizedError {
         }
     }
 
+    /// ": <body prefix>" for a described D2L body, empty when the body is —
+    /// truncated to `describedBodyLimit` (audit F-2).
+    private static func describedBody(_ body: String) -> String {
+        guard !body.isEmpty else { return "" }
+        return ": \(body.prefix(describedBodyLimit))"
+    }
+
     // Surface `description` through `localizedDescription` so the UI's
     // "Connection failed: \(error.localizedDescription)" shows the HTTP status
-    // and D2L's error body, not Swift's generic "(… error N.)".
+    // and the truncated D2L error body, not Swift's generic "(… error N.)".
     var errorDescription: String? { description }
 }
 

--- a/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
+++ b/Sources/APIServer/Services/BrightSpaceGradeSyncService.swift
@@ -91,9 +91,12 @@ func recordSweepFailure(
         row.brightspaceSyncError = error.localizedDescription
         try? await row.save(on: db)
     }
+    // Row ids are result/override rows keyed to a student — metadata only, so
+    // the admin query_logs buffer drops them at capture (compliance audit F-1).
     let ids = rows.map(\.brightspaceSyncRowID).joined(separator: ", ")
     logger.warning(
-        "BrightSpace grade sync \(retryable ? "transient" : "terminal") failure for row(s) \(ids): \(error)")
+        "BrightSpace grade sync \(retryable ? "transient" : "terminal") failure for \(rows.count) row(s): \(error)",
+        metadata: ["row_ids": .string(ids)])
 }
 
 /// Flags a freshly-built (not yet saved) result row for BrightSpace grade sync

--- a/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
+++ b/Sources/APIServer/Services/BrightSpaceSyncSweep.swift
@@ -324,14 +324,13 @@ extension GradeSyncSweep {
             )
         } catch {
             await invalidateCachedUserIDOnNotFound(
-                error, user: target.user, describing: "user \(userID) on '\(assignment.title)'")
+                error, user: target.user, describing: "'\(assignment.title)'")
             // Enrich with item context here (the sweep's catch lacks it), then
             // rethrow so the existing per-group error handling still runs.
             let maxDesc = gradeObject?.maxPoints.map { "\($0)" } ?? "unset"
-            await appendSyncLog(
-                .error, points: pushPoints,
-                detail: "Pushed \(pushPoints) pts to '\(gradeObject?.name ?? gradeObjectID)' "
-                    + "(max \(maxDesc)); D2L rejected it: \(error.localizedDescription)")
+            let detail = brightspacePushRejectionDetail(
+                itemName: gradeObject?.name ?? gradeObjectID, maxPoints: maxDesc, error: error)
+            await appendSyncLog(.error, points: pushPoints, detail: detail)
             throw error
         }
 
@@ -375,8 +374,11 @@ extension GradeSyncSweep {
         else { return }
         user.brightspaceUserID = nil
         try? await user.save(on: db)
+        // User id in metadata only — message text reaches the admin query_logs
+        // buffer unredacted (compliance audit F-1).
         application.logger.warning(
-            "BrightSpace grade push 404 for \(context) — cleared the cached D2L user id so the next attempt re-resolves"
+            "BrightSpace grade push 404 for \(context) — cleared the cached D2L user id so the next attempt re-resolves",
+            metadata: ["user_id": .string(user.id?.uuidString ?? "<nil>")]
         )
     }
 
@@ -691,4 +693,16 @@ extension Application {
 
 struct BrightSpaceSyncConfigKey: StorageKey {
     typealias Value = BrightSpaceSyncConfig
+}
+
+/// The sync-log `detail` string for a rejected grade push. Deliberately takes
+/// no points value: the pushed grade is a student's mark, and this string is
+/// surfaced verbatim by the admin diagnostic MCP surface
+/// (`get_brightspace_sync_status` error samples and the `get_health_alerts`
+/// brightspace rule's `last_error`) — the grade lives only in the `points`
+/// column, which those tools deliberately omit (compliance audit F-2). The
+/// error text is safe to embed because `BrightSpaceSyncError.description`
+/// omits the orgDefinedId and truncates D2L bodies.
+func brightspacePushRejectionDetail(itemName: String, maxPoints: String, error: Error) -> String {
+    "Grade push to '\(itemName)' (max \(maxPoints)) rejected: \(error.localizedDescription)"
 }

--- a/Sources/APIServer/Services/DataExportRecoveryService.swift
+++ b/Sources/APIServer/Services/DataExportRecoveryService.swift
@@ -81,8 +81,11 @@ func failStalePendingDataExports(
         .update()
 
     for export in stale {
+        // User id in metadata only — message text reaches the admin
+        // query_logs buffer unredacted (compliance audit F-1).
         logger.warning(
-            "data_export reaper: failed stale pending export \(export.id?.uuidString ?? "<nil>") for user \(export.userID.uuidString); user can now request a fresh export"
+            "data_export reaper: failed stale pending export \(export.id?.uuidString ?? "<nil>"); user can now request a fresh export",
+            metadata: ["user_id": .string(export.userID.uuidString)]
         )
     }
     return stale.count

--- a/Sources/APIServer/Services/StuckSubmissionReaperService.swift
+++ b/Sources/APIServer/Services/StuckSubmissionReaperService.swift
@@ -49,8 +49,11 @@ func reapStuckAssignedSubmissions(
         .update()
 
     for submission in stuck {
+        // Submission id in metadata only — message text reaches the admin
+        // query_logs buffer unredacted (compliance audit F-1).
         logger.warning(
-            "Reaped stuck submission \(submission.id ?? "<nil>") (was assigned to \(submission.workerID ?? "unknown")); returned to pending queue"
+            "Reaped stuck submission (was assigned to \(submission.workerID ?? "unknown")); returned to pending queue",
+            metadata: ["submission_id": .string(submission.id ?? "<nil>")]
         )
     }
     return stuck.count

--- a/Tests/APITests/BrightSpaceDetailSanitizationTests.swift
+++ b/Tests/APITests/BrightSpaceDetailSanitizationTests.swift
@@ -1,0 +1,65 @@
+// Writer-side sanitization guards for BrightSpace sync error text
+// (compliance audit F-2).
+//
+// The sync-log `detail` string and `BrightSpaceSyncError` descriptions flow
+// into three admin-agent-visible places: `get_brightspace_sync_status` error
+// samples, the `get_health_alerts` brightspace rule's `last_error`, and (via
+// warning logs) the `query_logs` ring buffer. These tests pin the write-side
+// guarantees: no institutional student identifier (orgDefinedId) in any
+// description, D2L response bodies truncated, and the rejection detail built
+// without the pushed grade value.
+
+import Testing
+
+@testable import APIServer
+
+@Suite struct BrightSpaceDetailSanitizationTests {
+    private let sentinelID = "SENTINEL-org-defined-id-20260731"
+
+    @Test func userNotFoundDescriptionOmitsOrgDefinedId() {
+        let error = BrightSpaceSyncError.userNotFound(orgDefinedId: sentinelID)
+        #expect(!error.description.contains(sentinelID))
+        #expect(!error.localizedDescription.contains(sentinelID))
+    }
+
+    @Test func userLookupFailedDescriptionOmitsOrgDefinedId() {
+        let error = BrightSpaceSyncError.userLookupFailed(orgDefinedId: sentinelID, status: 404)
+        #expect(!error.description.contains(sentinelID))
+        #expect(error.description.contains("404"))
+    }
+
+    @Test func gradePushFailedDescriptionTruncatesBody() {
+        let overLimit = String(
+            repeating: "x", count: BrightSpaceSyncError.describedBodyLimit)
+        let body = overLimit + "TRAILING-SENTINEL"
+        let error = BrightSpaceSyncError.gradePushFailed(status: 400, body: body)
+        #expect(error.description.contains("400"))
+        #expect(!error.description.contains("TRAILING-SENTINEL"))
+    }
+
+    @Test func whoamiFailedDescriptionTruncatesBody() {
+        let body =
+            String(repeating: "y", count: BrightSpaceSyncError.describedBodyLimit)
+            + "TRAILING-SENTINEL"
+        let error = BrightSpaceSyncError.whoamiFailed(status: 500, body: body)
+        #expect(!error.description.contains("TRAILING-SENTINEL"))
+    }
+
+    @Test func emptyBodyDescribesWithoutTrailingColon() {
+        let error = BrightSpaceSyncError.gradePushFailed(status: 502, body: "")
+        #expect(error.description == "BrightSpace grade push failed (HTTP 502)")
+    }
+
+    @Test func pushRejectionDetailCarriesNoStudentIdentifierOrGrade() {
+        // The builder takes no points parameter at all — the grade cannot be
+        // embedded. With a user-lookup error, the sanitized description keeps
+        // the orgDefinedId out of the detail too.
+        let detail = brightspacePushRejectionDetail(
+            itemName: "Lab 3",
+            maxPoints: "10.0",
+            error: BrightSpaceSyncError.userNotFound(orgDefinedId: sentinelID))
+        #expect(detail.contains("Lab 3"))
+        #expect(detail.contains("rejected"))
+        #expect(!detail.contains(sentinelID))
+    }
+}

--- a/Tests/APITests/MCP/AdminMCPToolsTests.swift
+++ b/Tests/APITests/MCP/AdminMCPToolsTests.swift
@@ -272,6 +272,32 @@ import VaporTesting
         }
     }
 
+    @Test func getBrowserDiagnosticsSamplesCarryCoarseBrowserLabelNotRawUA() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "bd-admin3", role: "admin")
+            let student = try await makeTestUser(on: app, username: "bd-student3", role: "student")
+            let rawUA =
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+            try await APIClientDiagnostic(
+                userID: try student.requireID(), testSetupID: nil, kind: "editor_error",
+                failedChecks: nil, userAgent: rawUA, message: "boom", stack: nil,
+                source: "onerror"
+            ).save(on: app.db)
+
+            let output = try await GetBrowserDiagnosticsTool().execute(
+                .init(), context(subject: "bd-admin3"))
+            let sample = try #require(output.recentSamples.first)
+            #expect(sample.browser == "Chrome/Windows")
+
+            // F-4 guarantee: the raw (fingerprint-adjacent) User-Agent string
+            // never appears in the serialized output — only the coarse label.
+            let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
+            #expect(!json.contains(rawUA))
+            #expect(!json.contains("AppleWebKit"))
+        }
+    }
+
     @Test func getBrowserDiagnosticsRejectsNonAdmin() async throws {
         try await withApp(app) { app in
             _ = try await makeTestUser(on: app, username: "bd-prof", role: "instructor")
@@ -624,6 +650,30 @@ import VaporTesting
             let json = try #require(String(bytes: JSONEncoder().encode(output), encoding: .utf8))
             #expect(!json.contains("sub_abc12345"))
             #expect(!json.contains("sub_def67890"))
+        }
+    }
+
+    @Test func getRequestMetricsPathPrefixCannotProbeConcreteIDs() async throws {
+        try await withApp(app) { app in
+            _ = try await makeTestUser(on: app, username: "rm-admin2", role: "admin")
+            let now = Date()
+            try await APIRequestMetric(
+                method: "GET", path: "/api/v1/submissions/sub_secret999", requestKind: nil,
+                statusCode: 200, startedAt: now, finishedAt: now, durationMs: 40,
+                submissionID: nil, workerID: nil
+            ).save(on: app.db)
+
+            // F-3 guarantee: a prefix carrying a DIFFERENT concrete id matches
+            // anyway, because both the prefix and the stored path normalize to
+            // "/api/v1/submissions/:id" — so total>0 no longer confirms that a
+            // specific submission id occurred in the window.
+            let probe = try await GetRequestMetricsTool().execute(
+                .init(windowHours: nil, pathPrefix: "/api/v1/submissions/sub_zzzzzz99", limit: nil),
+                context(subject: "rm-admin2"))
+            #expect(probe.total == 1)
+
+            let json = try #require(String(bytes: JSONEncoder().encode(probe), encoding: .utf8))
+            #expect(!json.contains("sub_secret999"))
         }
     }
 

--- a/Tests/APITests/MCP/LogMessageHygieneTests.swift
+++ b/Tests/APITests/MCP/LogMessageHygieneTests.swift
@@ -1,0 +1,77 @@
+// Write-side hygiene guard for the admin query_logs ring buffer.
+//
+// RingBufferLogHandler captures every warning+ log event process-wide and
+// redacts known PII metadata KEYS — but message strings are stored verbatim.
+// The write-side convention is therefore: identifiers (usernames, user ids,
+// submission ids, client IPs) go into metadata under a redacted key, never
+// into the message text. This suite scans APIServer sources for
+// warning/error/critical logger calls whose message interpolates a known
+// identifier variable and fails the build on a match, so the convention
+// cannot silently regress (compliance audit F-1; same source-scan technique
+// as MCPStudentDataWallTests).
+
+import Foundation
+import Testing
+
+@testable import APIServer
+
+@Suite struct LogMessageHygieneTests {
+    /// `Sources/APIServer`, resolved from this test file's location.
+    private static var apiServerSources: URL {
+        var url = URL(fileURLWithPath: #filePath)  // .../Tests/APITests/MCP/<thisFile>
+        for _ in 0..<4 { url.deleteLastPathComponent() }  // -> repo root
+        return url.appendingPathComponent("Sources/APIServer")
+    }
+
+    /// Interpolation fragments that would put an identifier into log MESSAGE
+    /// text. Matched against the message portion (before any `metadata:`
+    /// label) of a warning/error/critical logger call — the call line plus a
+    /// few continuation lines, since messages often wrap.
+    private static let forbiddenMessageFragments = [
+        #"\(username"#, #"\(usernameKey"#, #"\(ip)"#, #"\(userID)"#,
+        #"submission=\("#, #"for user \("#, #"user '\("#, #"\(orgDefinedId"#,
+    ]
+
+    private func swiftFiles(under root: URL) throws -> [URL] {
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: root, includingPropertiesForKeys: nil)
+        else { return [] }
+        return enumerator.compactMap { $0 as? URL }.filter { $0.pathExtension == "swift" }
+    }
+
+    @Test func warningPlusLogMessagesInterpolateNoIdentifiers() throws {
+        let files = try swiftFiles(under: Self.apiServerSources)
+        #expect(!files.isEmpty)  // sanity: the directory resolved
+
+        let callPattern = try NSRegularExpression(
+            pattern: #"logger\s*\.\s*(warning|error|critical)\s*\("#)
+
+        for file in files {
+            let lines = try String(contentsOf: file, encoding: .utf8)
+                .components(separatedBy: "\n")
+            for (index, line) in lines.enumerated() {
+                let range = NSRange(line.startIndex..., in: line)
+                guard callPattern.firstMatch(in: line, options: [], range: range) != nil
+                else { continue }
+                // The message argument comes before any `metadata:` label;
+                // metadata may carry identifiers freely (the ring buffer
+                // redacts those keys at capture).
+                let window = lines[index..<min(index + 4, lines.count)]
+                    .joined(separator: "\n")
+                let message = window.components(separatedBy: "metadata:").first ?? window
+                for fragment in Self.forbiddenMessageFragments {
+                    #expect(
+                        !message.contains(fragment),
+                        """
+                        \(file.lastPathComponent):\(index + 1) interpolates an identifier \
+                        (\(fragment)) into a warning+ log MESSAGE. The admin query_logs ring \
+                        buffer stores message text verbatim — move the identifier into \
+                        structured metadata under a key in RingBufferLogHandler.piiKeys so it \
+                        is redacted at capture (console logging keeps full fidelity).
+                        """)
+                }
+            }
+        }
+    }
+}

--- a/Tests/APITests/MCP/MCPStudentDataWallTests.swift
+++ b/Tests/APITests/MCP/MCPStudentDataWallTests.swift
@@ -21,6 +21,22 @@ import Testing
         return url.appendingPathComponent("Sources/APIServer/MCP/Tools")
     }
 
+    /// The content surface's non-tool directories, in scope for the same wall:
+    /// the transport/dispatch layer and the resource provider run with the
+    /// same MCP database context as the tools (audit F-6). The Admin/ and
+    /// OAuth/ trees are deliberately NOT scanned — the admin diagnostic tools
+    /// legitimately read diagnostic tables behind their own allowlisted DTOs,
+    /// and the OAuth layer resolves the human account by design.
+    private static var additionalContentDirectories: [URL] {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<4 { url.deleteLastPathComponent() }
+        let mcp = url.appendingPathComponent("Sources/APIServer/MCP")
+        return [
+            mcp.appendingPathComponent("Transport"),
+            mcp.appendingPathComponent("Resources"),
+        ]
+    }
+
     /// Student-data models the MCP tool surface must never reference directly.
     /// After the boundary refactor, `APISubmission` / `APIResult` appear only in
     /// `MCPStudentDataBoundary.swift`; every other model here is never named by
@@ -53,6 +69,60 @@ import Testing
                     Route validation-run access through MCPStudentDataBoundary; never query \
                     student submissions, results, or roster/PII from a tool handler.
                     """)
+            }
+        }
+    }
+
+    /// The wall also covers the content surface's transport + resource layers
+    /// (audit F-6): a dispatcher or resource handler must not name a
+    /// student-data model any more than a tool may.
+    @Test func transportAndResourceLayersReferenceNoStudentModels() throws {
+        for dir in Self.additionalContentDirectories {
+            for file in try swiftFiles(in: dir) {
+                let source = try String(contentsOf: file, encoding: .utf8)
+                for model in Self.forbiddenModels {
+                    #expect(
+                        !source.contains(model),
+                        """
+                        MCP content-surface file \(file.lastPathComponent) references \
+                        student-data model \(model). The transport/resource layers sit inside \
+                        the student-data wall; route any legitimate need through a tool + \
+                        MCPStudentDataBoundary instead.
+                        """)
+                }
+            }
+        }
+    }
+
+    /// Identity models (`APIUser`, `APICourseEnrollment`) are not in
+    /// `forbiddenModels` because the authorization layer must query them — but
+    /// ONLY the authorization layer. A tool that named them could list roster
+    /// or enrollment data the DB role cannot block (users/course_enrollments
+    /// are SELECT-granted for authz — audit F-6). Everything outside this
+    /// allowlist must resolve identity through `ToolContext`.
+    private static let identityModels = ["APIUser", "APICourseEnrollment"]
+    private static let identityAllowlist: Set<String> = [
+        "ToolContext.swift",  // requireEligibleSubject / authorizeCourseAccess
+        "MCPCourseGuidance.swift",  // resolves the acting subject's own courses at initialize
+    ]
+
+    @Test func identityModelsConfinedToTheAuthorizationLayer() throws {
+        let directories = [Self.toolsDirectory] + Self.additionalContentDirectories
+        for dir in directories {
+            for file in try swiftFiles(in: dir)
+            where !Self.identityAllowlist.contains(file.lastPathComponent) {
+                let source = try String(contentsOf: file, encoding: .utf8)
+                for model in Self.identityModels {
+                    #expect(
+                        !source.contains(model),
+                        """
+                        MCP content-surface file \(file.lastPathComponent) references identity \
+                        model \(model). Roster/enrollment data must stay unreachable from the \
+                        tool surface — resolve the acting subject through ToolContext \
+                        (requireEligibleSubject / authorizeCourseAccess) instead of querying \
+                        identity models directly.
+                        """)
+                }
             }
         }
     }

--- a/changelog.d/mcp-student-data-audit.md
+++ b/changelog.d/mcp-student-data-audit.md
@@ -1,12 +1,27 @@
 ### Added
 
-- **MCP student-data access audit (2026-07).** New compliance document
-  `docs/compliance/mcp-student-data-audit-2026-07.md`: a full re-audit of both
-  MCP surfaces (content-authoring, 51 tools; admin diagnostics, 19 tools —
-  the latter's first compliance pass) answering "no student data, direct or
-  inferred" ahead of the privacy-team submission. Re-verifies every prior
-  P0/P1 remediation against current code, inventories the admin tools'
-  per-tool PII posture, and records nine findings — the material ones being
-  free-text importers (warning+ log messages carrying student identifiers
-  into `query_logs`; the BrightSpace sync-error detail embedding the pushed
-  grade) with concrete remediations. Documentation only; no behaviour change.
+- **MCP student-data access audit (2026-07) + UW approval readiness plan.**
+  New compliance documents `docs/compliance/mcp-student-data-audit-2026-07.md`
+  and `uw-ai-approval-readiness.md`: a full re-audit of both MCP surfaces
+  (content-authoring, 51 tools; admin diagnostics, 19 tools — the latter's
+  first compliance pass) answering "no student data, direct or inferred" ahead
+  of the privacy-team submission, plus a step-by-step map onto UW IST's
+  AI-tool approval pathway. Companion inventories
+  (`tool-inventory` / `data-flow` / `policy46` / `trust-boundary`) refreshed
+  with 2026-07 addenda covering the current 70-tool census.
+
+### Security
+
+- **Audit findings F-1–F-4, F-6 remediated.** Warning+ log messages no longer
+  interpolate student identifiers (usernames, user ids, submission ids,
+  client IPs move to metadata the admin `query_logs` ring buffer redacts at
+  capture; `RingBufferLogHandler.piiKeys` extended; new
+  `LogMessageHygieneTests` source-scan guard). BrightSpace sync-error text is
+  sanitized at write: the rejection detail no longer embeds the pushed grade,
+  `BrightSpaceSyncError` descriptions omit the orgDefinedId and truncate D2L
+  bodies (new `BrightSpaceDetailSanitizationTests`). `get_request_metrics`
+  matches its `pathPrefix` against normalized routes, closing a
+  concrete-id existence probe. `get_browser_diagnostics` samples carry the
+  coarse browser/OS label instead of the raw User-Agent. The MCP student-data
+  wall test now also scans `Transport/` + `Resources/` and confines identity
+  models to the authorization allowlist.

--- a/changelog.d/mcp-student-data-audit.md
+++ b/changelog.d/mcp-student-data-audit.md
@@ -1,0 +1,12 @@
+### Added
+
+- **MCP student-data access audit (2026-07).** New compliance document
+  `docs/compliance/mcp-student-data-audit-2026-07.md`: a full re-audit of both
+  MCP surfaces (content-authoring, 51 tools; admin diagnostics, 19 tools —
+  the latter's first compliance pass) answering "no student data, direct or
+  inferred" ahead of the privacy-team submission. Re-verifies every prior
+  P0/P1 remediation against current code, inventories the admin tools'
+  per-tool PII posture, and records nine findings — the material ones being
+  free-text importers (warning+ log messages carrying student identifiers
+  into `query_logs`; the BrightSpace sync-error detail embedding the pushed
+  grade) with concrete remediations. Documentation only; no behaviour change.

--- a/docs/compliance/data-flow-inventory.md
+++ b/docs/compliance/data-flow-inventory.md
@@ -1,6 +1,16 @@
 # MCP Data-Flow & Egress Inventory
 
-Audit scope: `Sources/APIServer/MCP/`. Snapshot at `VERSION` 0.4.435.
+Audit scope: `Sources/APIServer/MCP/`. Base snapshot at `VERSION` 0.4.435;
+**refreshed 2026-07 at `VERSION` 0.4.667**. The per-tool flows below remain
+accurate for the base catalog; the tools added since, the second (admin
+diagnostic) surface's read paths, and the upstream-writer sweep of the
+diagnostic stores are covered by `mcp-student-data-audit-2026-07.md` (§2.2 for
+the admin source→fields table, §3 for the free-text findings and their
+remediations) and the `tool-inventory.md` addenda. One flow-relevant note
+from that refresh: `SupportFileURLFetcher` (instructor-supplied support-file
+URLs) is an MCP-tree outbound HTTP call added since the base snapshot —
+SSRF-guarded (blocked-address classifier), redirects disallowed, and it
+fetches instructor content only.
 
 ## The off-boundary path is not where the brief assumes
 

--- a/docs/compliance/mcp-student-data-audit-2026-07.md
+++ b/docs/compliance/mcp-student-data-audit-2026-07.md
@@ -36,32 +36,37 @@ assert their identifiers never appear in serialized tool output. No MCP tool
 returns a student identity, submission, grade row, or enrollment record, and no
 non-MCP route accepts an MCP bearer token.
 
-**The residual risk is free text.** Every finding in this audit is a case of a
-student-linked value riding inside a *prose string* that the structured
-defenses cannot see: log messages interpolating usernames/IPs/submission IDs
-into the `query_logs` ring buffer, and the BrightSpace sync-error `detail`
-embedding the pushed grade value and raw D2L response text. These are narrow,
-concretely fixable, and two of the three are latent (BrightSpace sync is not
-yet enabled in production). None is reachable by a student or instructor
-token — every affected tool is behind the admin-only surface.
+**The residual risk was free text.** Every material finding in this audit is a
+case of a student-linked value riding inside a *prose string* that the
+structured defenses cannot see: log messages interpolating
+usernames/IPs/submission IDs into the `query_logs` ring buffer, and the
+BrightSpace sync-error `detail` embedding the pushed grade value and raw D2L
+response text (latent — sync is not yet enabled in production). None was
+reachable by a student or instructor token — every affected tool is behind the
+admin-only surface — and all of them are narrow and have been **fixed on this
+branch**, each with a source-scan or unit test pinning the fix.
 
-**Recommendation:** fix F-1 and F-2 (small, mechanical changes listed with each
-finding) before submitting to the privacy team; the remaining findings are
-hardening and documentation. With F-1/F-2 closed, the claim "no student data is
-reachable through either MCP surface, directly or by inference" is accurate and
-demonstrable from the repository.
+**Remediation status (updated in this same PR):** F-1, F-2, F-3, F-4, F-6,
+and F-8 have been **remediated** on this branch — the fixes landed alongside
+this document, each with a pinning test (details in each finding's
+"Remediated" note). The remaining open items are F-5 (an explicitly accepted
+residual for the Steward to acknowledge), F-7 (a recorded design decision to
+state plainly in the submission), and F-9 (operator attestation of the
+production environment). With those framed as such, the claim "no student data
+is reachable through either MCP surface, directly or by inference" is accurate
+and demonstrable from the repository.
 
-| ID | Surface | Finding | Severity | Status today |
-|----|---------|---------|----------|--------------|
-| F-1 | Admin (`query_logs`) | Warning+ log **messages** can carry student usernames, institutional IDs, submission IDs, and client IPs; metadata redaction does not apply to message text | **Medium** | Live |
-| F-2 | Admin (`get_brightspace_sync_status`, `get_health_alerts`) | Sync-error `detail` free text embeds the pushed **grade value** and raw D2L response body | **Medium** | Latent (BrightSpace sync not enabled in prod) |
-| F-3 | Admin (`get_request_metrics`) | `pathPrefix` filters **raw** paths before ID normalization → existence oracle for concrete submission/setup IDs | Low | Live |
-| F-4 | Admin (`get_browser_diagnostics`) | Samples return the full raw User-Agent; `message`/`stack` are client-supplied and only client-side-constrained | Low | Live |
-| F-5 | Both | Small-cell aggregate inference (per-bucket distinct counts, count deltas across windows) | Low / accepted | Live |
-| F-6 | Content | Wall guard test scans `MCP/Tools/` only and does not forbid `APIUser` / enrollment models (authz uses them legitimately) | Info / hardening | — |
-| F-7 | Admin | Admin surface runs on the owner DB pool (by recorded design decision); guarantee is code-level DTOs + tests, not DB-enforced | Info / recorded | — |
-| F-8 | Both | Compliance-record drift: `tool-inventory.md` says 36 content tools (now **51**); the 19 admin tools appear in no compliance doc; `CLAUDE.md` says 40 | Info / docs | — |
-| F-9 | Deployment | Repo cannot prove prod env: `MCP_DATABASE_USER` (DB wall), `MCP_ALLOWED_HOSTS/ORIGINS`, `AUDIT_LOG_RETENTION_DAYS` need operator confirmation | Verify | — |
+| ID | Surface | Finding | Severity | Status |
+|----|---------|---------|----------|--------|
+| F-1 | Admin (`query_logs`) | Warning+ log **messages** could carry student usernames, institutional IDs, submission IDs, and client IPs; metadata redaction does not apply to message text | **Medium** | **Remediated** (this PR): identifiers moved to redacted metadata at every found site; `piiKeys` extended; `LogMessageHygieneTests` pins the convention |
+| F-2 | Admin (`get_brightspace_sync_status`, `get_health_alerts`) | Sync-error `detail` free text embedded the pushed **grade value** and raw D2L response body | **Medium** (latent — sync not enabled in prod) | **Remediated** (this PR): detail built without points; orgDefinedId removed from error descriptions; D2L bodies truncated; `BrightSpaceDetailSanitizationTests` |
+| F-3 | Admin (`get_request_metrics`) | `pathPrefix` filtered **raw** paths before ID normalization → existence oracle for concrete submission/setup IDs | Low | **Remediated** (this PR): prefix normalized and matched against normalized routes; probe test added |
+| F-4 | Admin (`get_browser_diagnostics`) | Samples returned the full raw User-Agent; `message`/`stack` are client-supplied and only client-side-constrained | Low | **Remediated** (this PR) for the UA: samples carry the coarse browser/OS label. The client-supplied free-text caveat remains a recorded residual (server caps sizes; capture paths are infrastructure-only by client construction) |
+| F-5 | Both | Small-cell aggregate inference (per-bucket distinct counts, count deltas across windows) | Low / accepted | Open — recorded residual for the Steward |
+| F-6 | Content | Wall guard test scanned `MCP/Tools/` only and did not forbid `APIUser` / enrollment models (authz uses them legitimately) | Info / hardening | **Remediated** (this PR): scan extended to `Transport/` + `Resources/`; identity models confined to an explicit authz allowlist |
+| F-7 | Admin | Admin surface runs on the owner DB pool (by recorded design decision); guarantee is code-level DTOs + tests, not DB-enforced | Info / recorded | Open — state plainly in the submission; DB-view hardening path recorded in `docs/admin-mcp.md` §4.1 |
+| F-8 | Both | Compliance-record drift: `tool-inventory.md` predated 6 content tools and the entire admin surface; `CLAUDE.md` said 40 | Info / docs | **Remediated** (this PR): inventory/data-flow/Policy-46/trust-boundary addenda; `CLAUDE.md` corrected to 51 |
+| F-9 | Deployment | Repo cannot prove prod env: `MCP_DATABASE_USER` (DB wall), `MCP_ALLOWED_HOSTS/ORIGINS`, `AUDIT_LOG_RETENTION_DAYS` need operator confirmation | Verify | Open — operator attestation checklist in §3 F-9 and `uw-ai-approval-readiness.md` §4 |
 
 ---
 
@@ -261,10 +266,21 @@ student-linked values into the message:
 | `Services/BrightSpaceSyncSweep.swift:378` | `BrightSpace grade push 404 for user <UUID> …` — internal user UUID |
 | `Middleware/LoginRateLimitMiddleware.swift:94`, `MCP/Transport/MCPOAuthRateLimitMiddleware.swift:31` | `… rate limit exceeded for IP <ip>` — client IPs |
 | `Routes/ResultRoutes.swift:56`, `Routes/BrowserResultRoutes.swift:65`, `Services/StuckSubmissionReaperService.swift:52` | `… submission=<submissionID>` — pseudonymous submission IDs |
+| `Services/DataExportRecoveryService.swift:84`, `MCP/Tools/SupportFileURLFetcher.swift:134` | (found by the F-1 guard scan while remediating) a user UUID in the data-export reaper warning; a resolved address in the SSRF-block warning |
 
 The tool's self-description ("student identifiers are dropped at capture")
 overclaims relative to message text; the design record (`docs/admin-mcp.md`
 §8) flagged exactly this residual.
+
+**Remediated (this PR).** All sites above now log the identifier as structured
+metadata under a key in `RingBufferLogHandler.piiKeys` (extended with `ip`,
+`remote_ip`, `org_defined_id`, `user`, `row_ids`), so the ring buffer drops it
+at capture while console/ops logging keeps full fidelity. The write-side
+convention is pinned by `LogMessageHygieneTests`, a source scan over every
+warning+ logger call in `Sources/APIServer` that fails the build when a known
+identifier variable is interpolated into message text — which is also how the
+two additional sites in the table were found. The `query_logs` description now
+states exactly what is enforced.
 
 **Remediation (mechanical):**
 1. At each site above, move the identifier out of the message and into
@@ -310,13 +326,18 @@ the leak is in the `detail` string, which the test's seeded rows left benign.
 **Status:** latent — BrightSpace sync awaits production credentials
 (`docs/brightspace-setup.md`), so no real student grade has crossed yet.
 
-**Remediation:** build `detail` without the points value ("Grade push to
-'<item>' rejected: HTTP <status>" + an error *class*); truncate/classify the
-D2L body rather than embedding it; keep `orgDefinedId` out of
-`BrightSpaceSyncError.description` (carry it in a non-described field for the
-web UI if needed). Strengthen the PII test to seed a `detail` containing a
-sentinel points value and orgDefinedId and assert absence. Close this before
-BrightSpace sync is enabled in production.
+**Remediated (this PR), ahead of BrightSpace enablement.** The rejection
+detail is now built by `brightspacePushRejectionDetail` (in
+`BrightSpaceSyncSweep.swift`), which takes no points parameter — the grade
+value structurally cannot enter the string; `BrightSpaceSyncError.description`
+no longer describes the `orgDefinedId` (the associated value remains for
+programmatic use) and truncates D2L bodies to
+`BrightSpaceSyncError.describedBodyLimit`. Writer-side guarantees are pinned
+by `BrightSpaceDetailSanitizationTests` (sentinel orgDefinedId absent, body
+truncation, empty-body shape, and the detail builder's no-grade property).
+Both surfacing tools (`get_brightspace_sync_status` samples,
+`get_health_alerts` `last_error`) inherit the fix because it lands at the
+single write site.
 
 ### F-3 (Low) — `get_request_metrics` `pathPrefix` is an existence oracle for concrete IDs
 
@@ -331,18 +352,21 @@ guessing is impractical; the oracle matters when an ID is already known from
 elsewhere, which is exactly the linkage scenario the normalization exists to
 prevent.
 
-**Remediation:** apply `normalizePath` *before* the prefix comparison (filter
-on normalized routes), or reject prefixes containing id-shaped segments using
-the existing `isIdentifierSegment`.
+**Remediated (this PR).** The prefix is now normalized and matched against
+normalized routes (the DB-side raw-path substring narrowing was removed with
+it); a probe carrying one concrete id matches every id of that route shape, so
+`total` no longer confirms a specific identifier. Pinned by
+`getRequestMetricsPathPrefixCannotProbeConcreteIDs` in `AdminMCPToolsTests`.
 
 ### F-4 (Low) — `get_browser_diagnostics` raw User-Agent in samples; client-supplied free text
 
-- Each returned sample includes the **full raw UA string** (up to 512 chars).
+- Each returned sample included the **full raw UA string** (up to 512 chars).
   The tool already computes a coarse, deliberately PII-safe `byBrowser` label
-  ("Safari/iOS") for exactly this reason; the raw UA in samples reintroduces a
-  device-fingerprint-adjacent value that, combined with small cohorts, weakens
-  the aggregate posture. **Remediation:** return `browserLabel(forUserAgent:)`
-  in samples too (keep raw UA out), or truncate to product tokens.
+  ("Safari/iOS") for exactly this reason; the raw UA in samples reintroduced a
+  device-fingerprint-adjacent value that, combined with small cohorts, weakened
+  the aggregate posture. **Remediated (this PR):** samples now carry
+  `browser` — the coarse `browserLabel(forUserAgent:)` — and never the raw UA;
+  pinned by `getBrowserDiagnosticsSamplesCarryCoarseBrowserLabelNotRawUA`.
 - `message`/`stack` are stored verbatim (1 KB / 4 KB caps) from an
   authenticated client POST (`ClientDiagnosticsRoutes`). The
   "infrastructure text only, never student code" property is real but
@@ -379,10 +403,13 @@ today: no tool file touches `APIUser` outside `ToolContext`/`UpdateSolutionTool`
 (outside the scan) touch only courses/assignments and the acting subject. But
 a future tool that queried `APIUser` or listed enrollments would not trip the
 wall test, and the DB role cannot catch it (`users`/`course_enrollments` are
-SELECT-granted for authz). **Remediation:** extend the scan to `Transport/` +
-`Resources/`, and forbid `APIUser`/`APICourseEnrollment`/`userIsEnrolled`
-outside an explicit allowlist (`ToolContext.swift`, `UpdateSolutionTool.swift`,
-`MCPCourseGuidance.swift`).
+SELECT-granted for authz). **Remediated (this PR):** the wall scan now also
+covers `Transport/` + `Resources/`
+(`transportAndResourceLayersReferenceNoStudentModels`), and a new guard
+confines `APIUser`/`APICourseEnrollment` to an explicit authorization
+allowlist — `ToolContext.swift` and `MCPCourseGuidance.swift`
+(`identityModelsConfinedToTheAuthorizationLayer`); stray comment mentions
+elsewhere were reworded so the allowlist stays minimal.
 
 ### F-7 (Info / recorded decision) — admin surface has no DB-level wall
 
@@ -402,10 +429,14 @@ hardening later, the design of record is PII-free SQL views granted to the
 content tools (v0.4.435); the catalog is now **51**, and the **19 admin tools
 appear in no compliance document** — `docs/admin-mcp.md` §9 itself requires
 the compliance record be updated before the admin surface is enabled in
-production. `CLAUDE.md`'s prose says 40. This document provides the current
-census (§2); the companion inventories should be refreshed or superseded
-before submission, and the P2-3 checklist item ("re-run the census when a tool
-is added") extended to cover `AdminMCPToolCatalog.live`.
+production. `CLAUDE.md`'s prose said 40. **Remediated (this PR):**
+`tool-inventory.md` carries 2026-07 addenda (the six content tools added since
+the base snapshot, and the full 19-tool admin-surface inventory);
+`policy46-classification.md` gained the admin-surface data types (rows 12–17);
+`trust-boundary.md` describes the second audience; `data-flow-inventory.md`
+points at this document for the refreshed flows; `CLAUDE.md` is corrected to
+51. The P2-3 census rule now explicitly covers `AdminMCPToolCatalog.live`
+(stated in the inventory header).
 
 ### F-9 (Verify at deployment) — properties the repo cannot prove
 
@@ -495,26 +526,29 @@ DTOs, redacted ring buffer, per-tool PII + role-refusal tests, and
 
 ---
 
-## 7. Recommended order of work before submission
+## 7. Order of work before submission (status)
 
-1. **F-1** — move identifiers to metadata at the six named call sites, extend
-   `piiKeys`, add the guard test, fix the `query_logs` description. (Small,
-   self-contained; closes the only live Medium.)
-2. **F-2** — sanitize the BrightSpace `detail` writer + error descriptions,
-   strengthen the PII test. (Must land before BrightSpace sync is enabled;
-   cheap now, awkward after.)
-3. **F-3 / F-4** — normalize-before-filter; sample-level `browserLabel`
-   instead of raw UA. (Each is a few lines.)
-4. **F-6** — widen the wall test's scan + forbid identity models outside the
-   authz allowlist. (Keeps the architectural guarantee ahead of future tools.)
-5. **F-8** — refresh/supersede the compliance inventories with the current
-   70-tool census; state F-7's application-layer posture explicitly.
-6. **F-9** — operator attestation of the production env properties.
+1. **F-1** — ✅ done (this PR): identifiers to redacted metadata at every
+   found site, `piiKeys` extended, `LogMessageHygieneTests` guard,
+   `query_logs` description corrected.
+2. **F-2** — ✅ done (this PR), ahead of BrightSpace enablement: sanitized
+   detail writer + error descriptions, `BrightSpaceDetailSanitizationTests`.
+3. **F-3 / F-4** — ✅ done (this PR): normalized-prefix matching; coarse
+   browser label in samples; both pinned by tests.
+4. **F-6** — ✅ done (this PR): wall scan widened; identity models confined
+   to the authz allowlist.
+5. **F-8** — ✅ done (this PR): compliance inventories refreshed with the
+   70-tool census (addenda); F-7's application-layer posture stated here and
+   in the inventory addendum.
+6. **F-9** — remaining: operator attestation of the production env properties
+   (checklist in §3 F-9 / `uw-ai-approval-readiness.md` §4), plus the F-5
+   accepted-residual acknowledgement from the Steward.
 
-With 1–2 done and 5–6 written up, the submission can truthfully state: *no MCP
-tool returns student identity, submissions, results, grades, enrollment, or
-seeds; the two student-data tables the content surface can reach are
+With the above landed, the submission can truthfully state: *no MCP tool
+returns student identity, submissions, results, grades, enrollment, or seeds;
+the two student-data tables the content surface can reach are
 validation-filtered in code, by test, and (when configured) by database RLS;
 the admin surface exposes aggregates and allowlisted infrastructure fields
 pinned by tests that seed student data and assert its absence; and the known
-free-text importers have been closed.*
+free-text importers have been closed, with source-scan guards keeping them
+closed.*

--- a/docs/compliance/mcp-student-data-audit-2026-07.md
+++ b/docs/compliance/mcp-student-data-audit-2026-07.md
@@ -1,0 +1,520 @@
+# MCP Surfaces — Student-Data Access Audit (2026-07)
+
+Prepared for the privacy / Information Steward review of Chickadee's two MCP
+surfaces. The question under audit, as posed by the maintainer:
+
+> Confirm that the MCP endpoints have absolutely no access, direct or inferred,
+> to any student data.
+
+- Repository: `JimWallace/Chickadee`, snapshot `VERSION` **0.4.667**
+- Scope: the **content-authoring MCP surface** (`POST /mcp`, 51 tools) and the
+  **admin diagnostic MCP surface** (`POST /admin-mcp`, 19 tools), the auth and
+  data-access layers they depend on, and — new in this audit — the **upstream
+  writers** that feed the diagnostic data sources those tools read.
+- Method: every tool handler in `Sources/APIServer/MCP/Tools/` and
+  `Sources/APIServer/MCP/Admin/Tools/` was read; every returned DTO was checked
+  field-by-field; the auth/consent/token path was traced; the enforcement tests
+  were reviewed; and the *writers* of the log/diagnostic stores the admin tools
+  expose were swept for student identifiers entering as free text.
+- Relationship to prior work: this supersedes the data-flow portions of
+  `docs/compliance/ira-audit-report.md` (Phase 1, v0.4.435, 36 content tools,
+  **admin surface not yet built**). Every P0/P1 remediation from
+  `docs/compliance/remediation-plan.md` was re-verified against current code
+  (§6). The admin diagnostic surface has never been through a compliance pass
+  before this document — it is the main new ground covered here.
+
+---
+
+## Executive summary
+
+**The architecture is sound and the guarantee is real for structured data.**
+Both surfaces enforce "no student data" in depth: a source-scan-tested
+in-process boundary, an optional database-role wall with row-level security,
+disjoint OAuth audiences/scopes, per-course enrollment authorization, consent
+gates that exclude students, and per-tool PII tests that seed student rows and
+assert their identifiers never appear in serialized tool output. No MCP tool
+returns a student identity, submission, grade row, or enrollment record, and no
+non-MCP route accepts an MCP bearer token.
+
+**The residual risk is free text.** Every finding in this audit is a case of a
+student-linked value riding inside a *prose string* that the structured
+defenses cannot see: log messages interpolating usernames/IPs/submission IDs
+into the `query_logs` ring buffer, and the BrightSpace sync-error `detail`
+embedding the pushed grade value and raw D2L response text. These are narrow,
+concretely fixable, and two of the three are latent (BrightSpace sync is not
+yet enabled in production). None is reachable by a student or instructor
+token — every affected tool is behind the admin-only surface.
+
+**Recommendation:** fix F-1 and F-2 (small, mechanical changes listed with each
+finding) before submitting to the privacy team; the remaining findings are
+hardening and documentation. With F-1/F-2 closed, the claim "no student data is
+reachable through either MCP surface, directly or by inference" is accurate and
+demonstrable from the repository.
+
+| ID | Surface | Finding | Severity | Status today |
+|----|---------|---------|----------|--------------|
+| F-1 | Admin (`query_logs`) | Warning+ log **messages** can carry student usernames, institutional IDs, submission IDs, and client IPs; metadata redaction does not apply to message text | **Medium** | Live |
+| F-2 | Admin (`get_brightspace_sync_status`, `get_health_alerts`) | Sync-error `detail` free text embeds the pushed **grade value** and raw D2L response body | **Medium** | Latent (BrightSpace sync not enabled in prod) |
+| F-3 | Admin (`get_request_metrics`) | `pathPrefix` filters **raw** paths before ID normalization → existence oracle for concrete submission/setup IDs | Low | Live |
+| F-4 | Admin (`get_browser_diagnostics`) | Samples return the full raw User-Agent; `message`/`stack` are client-supplied and only client-side-constrained | Low | Live |
+| F-5 | Both | Small-cell aggregate inference (per-bucket distinct counts, count deltas across windows) | Low / accepted | Live |
+| F-6 | Content | Wall guard test scans `MCP/Tools/` only and does not forbid `APIUser` / enrollment models (authz uses them legitimately) | Info / hardening | — |
+| F-7 | Admin | Admin surface runs on the owner DB pool (by recorded design decision); guarantee is code-level DTOs + tests, not DB-enforced | Info / recorded | — |
+| F-8 | Both | Compliance-record drift: `tool-inventory.md` says 36 content tools (now **51**); the 19 admin tools appear in no compliance doc; `CLAUDE.md` says 40 | Info / docs | — |
+| F-9 | Deployment | Repo cannot prove prod env: `MCP_DATABASE_USER` (DB wall), `MCP_ALLOWED_HOSTS/ORIGINS`, `AUDIT_LOG_RETENTION_DAYS` need operator confirmation | Verify | — |
+
+---
+
+## 1. Threat model and what "student data" means here
+
+The party outside the trust boundary is the **connecting agent** (e.g. the
+Claude connector) and, transitively, its model provider. The humans who can
+hold tokens are course staff and admins, who already see student data through
+the session-authenticated web UI — that surface is out of scope. The guarantee
+under audit is specifically: **nothing that crosses the MCP boundary to the
+agent identifies a student or reveals a student's academic record**, so that
+enabling an agent never widens where student data flows.
+
+"Student data" is read broadly, per FIPPA/PIPEDA practice:
+
+- **Direct identifiers** — username, email, student number / `orgDefinedId`,
+  internal user UUID, D2L user ID.
+- **Academic record** — submissions and their contents, per-test results,
+  grades and grade overrides, achievement awards, extensions, participation.
+- **Behavioural / technical PII** — login times attributable to a person,
+  client IP addresses, device fingerprints.
+- **Inferred access** — aggregates or oracles from which any of the above can
+  be recovered (small cells, existence probes, free-text side channels).
+
+Submission IDs and per-student personalization seeds are treated as
+**pseudonymous student identifiers**: not identities by themselves, but stable
+keys attributable to one student, so the bar applied is "do not emit them
+either." The tools' own DTO designs already hold themselves to this bar
+(e.g. `GetValidationResultTool` drops `submissionID`; `GetRunnerDetailTool`
+omits per-job rows precisely because they carry username + submission id).
+
+---
+
+## 2. The two surfaces and how the guarantee is enforced
+
+### 2.1 Content-authoring surface — `POST /mcp`, 51 tools
+
+Catalog: `MCPToolCatalog.live`
+(`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`). All tools are
+typed `Input`/`Output` structs; there is no untyped escape hatch. Enforcement
+is layered:
+
+1. **In-process student-data boundary (unconditional).**
+   `MCPStudentDataBoundary` (`Sources/APIServer/MCP/Tools/MCPStudentDataBoundary.swift`)
+   is the *only* sanctioned access from the tool surface to `submissions` /
+   `results`, and each accessor hard-filters `kind == .validation` — the
+   instructor's own reference-solution runs. No tool accepts a raw submission
+   ID. `MCPStudentDataWallTests` scans every file in `MCP/Tools/` and fails the
+   build if any handler names `APISubmission`, `APIResult`,
+   `APIGradeOverride`, `APIClientDiagnostic`, `JobExecutionMetric`,
+   `APIClassAchievement`, `APIAchievementResult`, `APIUserActivityEvent`,
+   `APIBrightSpaceSyncLog`, `APIPreEnrollment`, `APIAssignmentParticipation`,
+   or `APIAssignmentExtension` outside the boundary file.
+
+2. **Database-role wall (deployment option, defence in depth).** With
+   `MCP_DATABASE_USER`/`MCP_DATABASE_PASSWORD` set, every content-tool query
+   runs on a dedicated pool (`ToolContext.db` → `DatabaseID.mcp`) as the
+   `chickadee_mcp` Postgres role (`deploy/sql/mcp-least-privilege-role.sql`):
+   deny-by-omission on every student-data table (`grade_overrides`,
+   `client_diagnostics`, `job_execution_metrics`,
+   `assignment_personalization_seeds`, `achievement_results`, `audit_log`,
+   `brightspace_sync_log`, …) and **row-level security** on
+   `submissions`/`results`/`result_collections` restricting SELECT to
+   `kind = 'validation'` rows. Even a future filter-omission bug returns zero
+   student rows. `MCPLeastPrivilegeGrantSyncTests` keeps the SQL file in sync
+   with the tables the boundary actually reads. Note the role *does* hold
+   SELECT on `users` and `course_enrollments` — required for authorization —
+   so non-exposure of identity rests on the code layer (see F-6).
+
+3. **Per-course authorization, agent ⊆ human.** Every resource-accepting tool
+   routes through `authorizeCourseAccess` / `authorizedAssignment*`
+   (`ToolContext.swift`): the token subject must hold an enrollment row in the
+   target course — **admins included** on the agent path. Writes additionally
+   pass `evaluateCourseWrite` (per-course TA/instructor floor + archived
+   block), the same policy core the web uses. `MCPAuthorizationCoverageTests`
+   source-scans every tool file and fails the build if one omits the check.
+
+4. **Students cannot appear on this surface at all.** Consent to authorize an
+   agent requires staff-in-≥1-course (`MCPOAuthSurface.ResolvedSurface.permits`:
+   `isStaffAnywhere`), re-checked at consent submit and on every refresh; and
+   `ToolContext.requireEligibleSubject` re-refuses a plain-student subject on
+   every call, so the guarantee does not rest on token issuance alone.
+
+5. **Deliberate, bounded wall crossings.** Two side effects intentionally
+   touch student rows and are explicitly routed to the privileged pool
+   (`ToolContext.mainDB` / `request.db`), never the MCP pool, and return no
+   row data to the agent:
+   - the **content-edit auto-regrade** (`ContentEditClose.swift`,
+     `retestSubmissionsAfterContentEdit`) — flips student submissions to
+     pending after a suite edit; the agent sees only `submissionsRequeued`, an
+     integer count;
+   - the **acting account's own personalization-seed bookkeeping**
+     (`update_global_inputs` / `update_section_variables` /
+     `preview_personalization`) — ensures the *staff* account's seed only.
+   `MCPSeedMainPoolTests` / `MCPDatabasePoolTests` pin the pool routing.
+
+6. **Per-student personalization exposes no student.** Seeds are 32 CSPRNG
+   bytes per (user, assignment) (`AssignmentSeedStore.generateSeedHex`) —
+   *not* derived from identity, so a seed neither reveals nor is derivable
+   from who a student is. The seeds table is denied to the MCP role and no
+   tool returns another user's seed. `preview_personalization` evaluates an
+   agent-supplied hex seed (or the acting account's own), so it previews a
+   *hypothetical* student; it cannot enumerate or target real ones.
+
+7. **Validation results only.** `get_validation_result` resolves the run from
+   the assignment via the boundary (linked validation submission, else newest
+   `kind == .validation` for the setup), and its DTO drops `submissionID` /
+   `userID`. `get_notebook` returns the starter template (placeholders
+   unresolved), never a student's substituted copy. `get_achievements` returns
+   instructor-authored *definitions*; per-student awards live in
+   `achievement_results`, which is wall-test-forbidden and DB-denied.
+
+### 2.2 Admin diagnostic surface — `POST /admin-mcp`, 19 tools
+
+Catalog: `AdminMCPToolCatalog.live`. Design record: `docs/admin-mcp.md`
+(decision §4: **code-allowlist DTOs asserted by per-tool PII tests**, no
+dedicated DB role for this surface — see F-7). Enforcement:
+
+1. **Admin-only, twice.** Consent for the admin resource requires `isAdmin`
+   (`MCPOAuthSurface`), and every DB-touching tool re-resolves the subject and
+   re-checks `isAdmin` per call (`AdminToolContext.requireAdminSubject`) — an
+   instructor or student with a somehow-obtained token is refused at the tool
+   layer. The per-tool tests assert the instructor-subject refusal for each
+   tool.
+
+2. **Read-only by type construction.** `DiagnosticScope` has exactly one case,
+   `diagnostics:read`; there is no write scope to grant, and the surface stays
+   read-only under `MCP_MODE=read_write`.
+
+3. **Token isolation between surfaces.** Disjoint RFC 8707 audiences
+   (`…/mcp` vs `…/admin-mcp`) enforced by each bearer middleware; a content
+   token cannot call admin tools and vice versa. No route outside the two MCP
+   endpoints reads `bearerAuthorization` at all, so MCP tokens are inert
+   against the web UI and REST API (and web sessions are inert against MCP —
+   the bearer middlewares accept only bearer tokens).
+
+4. **PII-laden sources are exposed as aggregates or hand-allowlisted DTOs.**
+   The table below is the per-tool posture, verified against each handler:
+
+| Tool | Source | What crosses to the agent | Student-data posture |
+|------|--------|---------------------------|----------------------|
+| `get_deployment_info` | static config | version, env name, modes, scopes | clean (DB-free) |
+| `get_deploy_status` / `get_deploy_history` | deployer status/history files | versions, deploy events | clean |
+| `get_metrics_snapshot` / `get_metrics_card_series` / `get_metrics_timeseries` | aggregate builders | counts, percentiles, utilization | aggregates only |
+| `get_active_users_series` | `ActivityChartService` | distinct-user counts per bucket | counts only (F-5) |
+| `get_instructor_card_series` | `instructorCardSeries` | per-bucket submission/active-student/assignment/browser-error counts for one course | counts only; enrolled-student lookup is internal scoping; PII test seeds a student and asserts absence (F-5) |
+| `get_queue_state` | submissions table | pending/in-flight/stuck **counts**, oldest age | counts/ages only |
+| `list_runners` / `get_runner_detail` | worker rows, `job_execution_metrics`, `runner_snapshots` | runner identity/capabilities; **aggregate** timing/status over recent jobs | per-job rows (username + submission id) deliberately omitted; PII test asserts user UUID, submission id, and the substring `username` absent |
+| `get_storage_usage` | storage scan | bytes by component; per-assignment bytes + submission **count** | aggregates; assignment/course IDs are instructor content |
+| `get_request_metrics` | `request_metrics` | status-class counts, latency summary, slowest routes with id segments → `:id` | normalized (but see F-3); table carries no user_id |
+| `get_health_alerts` | rule evaluation | firing flags, summaries, threshold numbers | clean except BrightSpace `last_error` free text (F-2) |
+| `get_browser_diagnostics` | `client_diagnostics` | counts by kind/source/check/browser/appVersion, funnels, recent samples (message/stack/UA) | `user_id` column omitted + PII-tested; free-text caveats (F-4) |
+| `list_connected_agents` | `oauth` grants | agent name, scopes, **owner username**, timestamps, revoked | owners are staff/admins by consent gate — never students; no token material |
+| `get_brightspace_sync_status` | `brightspace_sync_log` | status counts + recent **error** samples (detail, setup, title, org unit) | `username`/`points`/`user_id` columns deliberately omitted + PII-tested; `detail` free text re-imports the grade (F-2) |
+| `query_audit_log` | `audit_log` | **counts only** by action/category | no row, actor, IP, or metadata ever loaded beyond the action column — strongest posture; chosen precisely because actors can be students |
+| `query_logs` | in-process ring buffer | warning+ log events: level, label, **message**, redacted metadata | metadata PII keys dropped at capture; message free text is the gap (F-1) |
+
+5. **Admin tool calls are themselves audited** — one `admin_mcp.tool_called`
+   row per call with tool name + outcome (`AdminMCPDispatcher`), so use of the
+   diagnostic surface is reviewable after the fact.
+
+### 2.3 Token and transport properties common to both
+
+- ES256 JWTs minted by `MCPTokenAuthority`; browser-flow access tokens default
+  **600 s** (`MCPConfig.accessTokenTTLSeconds`), so grant revocation and role
+  loss take effect within minutes; scopes are re-clamped to the `MCP_MODE`
+  ceiling **per request**.
+- Refresh tokens rotate with prior-hash reuse (theft) detection; codes and
+  consent tokens are single-use via atomic conditional UPDATE.
+- Production refuses to mount either MCP transport with open Host/Origin
+  guards unless explicitly overridden
+  (`mcpTransportGuardRefusal`, reused by `registerAdminMCPRoutes`).
+- Tool *arguments* are never written to the audit log or logs; audit rows for
+  content writes are persisted **fail-closed** before the write and stamped
+  with the outcome after (`MCPDispatcher`, `MCPAuditFailClosedTests`,
+  `MCPAuditTargetOutcomeTests`).
+
+---
+
+## 3. Findings
+
+Severity reflects exposure *through the MCP surfaces to the agent*; every
+affected tool is admin-consent-gated, which is why nothing here rates High.
+
+### F-1 (Medium) — `query_logs` free text can carry student identifiers
+
+The ring buffer (`RingBufferLogHandler`) captures **every** warning+ log event
+process-wide and drops known PII **metadata keys** at capture. Message strings
+are stored verbatim, and several warning+ call sites interpolate
+student-linked values into the message:
+
+| Call site | What enters the buffer |
+|-----------|------------------------|
+| `Routes/Web/AuthRoutes.swift:102` | `Login locked for user '<username>' …` — lockout subjects are typically **students** |
+| `Routes/Web/EnrollCSVHelper.swift:306,313,320` | `… failed to enroll <username> in <courseID>…` — roster usernames |
+| `Services/BrightSpaceGradeSyncService.swift:95-96` | `… failure for row(s) <ids>: <error>` — result-row IDs, and the error can be `userNotFound(orgDefinedId:)` → **institutional student ID** in text |
+| `Services/BrightSpaceSyncSweep.swift:378` | `BrightSpace grade push 404 for user <UUID> …` — internal user UUID |
+| `Middleware/LoginRateLimitMiddleware.swift:94`, `MCP/Transport/MCPOAuthRateLimitMiddleware.swift:31` | `… rate limit exceeded for IP <ip>` — client IPs |
+| `Routes/ResultRoutes.swift:56`, `Routes/BrowserResultRoutes.swift:65`, `Services/StuckSubmissionReaperService.swift:52` | `… submission=<submissionID>` — pseudonymous submission IDs |
+
+The tool's self-description ("student identifiers are dropped at capture")
+overclaims relative to message text; the design record (`docs/admin-mcp.md`
+§8) flagged exactly this residual.
+
+**Remediation (mechanical):**
+1. At each site above, move the identifier out of the message and into
+   structured metadata (`logger.warning("Login locked", metadata:
+   ["username": …])`). Console/ops logging keeps full fidelity — the ring
+   buffer's `redact` already drops those keys, so the fix is
+   capture-side-complete without touching the handler.
+2. Add the missing keys to `RingBufferLogHandler.piiKeys` (`ip`, `remote_ip`,
+   `org_defined_id`, `user`) while doing so.
+3. Add a guard test in the spirit of the existing source scans: grep warning+
+   call sites for `\(username`-style interpolations of known identifier
+   variables, or at minimum pin the six sites above.
+4. Re-word the `query_logs` description to claim exactly what is true
+   ("metadata PII keys dropped; messages are infrastructure text, kept clean
+   by convention and test").
+
+### F-2 (Medium, latent) — BrightSpace error `detail` embeds the grade and raw D2L body
+
+`BrightSpaceSyncSweep.swift:331-334` writes, on a failed push:
+
+```
+"Pushed <points> pts to '<item>' (max …); D2L rejected it: <error.localizedDescription>"
+```
+
+- `<points>` is the student's **grade** — the very column the tool
+  deliberately omits (`GetBrightSpaceSyncStatusTool` drops `points`), re-imported
+  via prose. The row is (student, assignment)-scoped; no identity accompanies
+  it through this surface, but "a grade value + assignment + timestamp" is
+  more than the DTO design intends to emit, and identity linkage via external
+  knowledge (e.g. LEARN-side logs) cannot be excluded.
+- `error.localizedDescription` for `gradePushFailed` includes the **raw D2L
+  response body** (`BrightSpaceAPIClient.swift`, `case .gradePushFailed(status:,
+  body:)`), whose contents are D2L's to choose and can echo user-specific
+  detail. `userLookupFailed`/`userNotFound` variants embed `orgDefinedId`.
+
+The same string is re-surfaced by `get_health_alerts` as the
+`brightspace_sync_failing` rule's `last_error` detail
+(`ServerHealthAlertService.swift:392-393`), so it crosses on two tools.
+
+The existing PII test seeds `username`/`points` **columns** and passes because
+the leak is in the `detail` string, which the test's seeded rows left benign.
+
+**Status:** latent — BrightSpace sync awaits production credentials
+(`docs/brightspace-setup.md`), so no real student grade has crossed yet.
+
+**Remediation:** build `detail` without the points value ("Grade push to
+'<item>' rejected: HTTP <status>" + an error *class*); truncate/classify the
+D2L body rather than embedding it; keep `orgDefinedId` out of
+`BrightSpaceSyncError.description` (carry it in a non-described field for the
+web UI if needed). Strengthen the PII test to seed a `detail` containing a
+sentinel points value and orgDefinedId and assert absence. Close this before
+BrightSpace sync is enabled in production.
+
+### F-3 (Low) — `get_request_metrics` `pathPrefix` is an existence oracle for concrete IDs
+
+`GetRequestMetricsTool` normalizes id-like path segments to `:id` **for
+output**, but the `pathPrefix` input filters **raw stored paths**
+(`query.filter(\.$path ~~ prefix)` then `hasPrefix`) before normalization. An
+agent can therefore probe `pathPrefix: "/submissions/sub_ab12cd34"` and learn
+from `total > 0` whether that concrete submission ID was active in a window —
+confirming existence/timing of a specific pseudonymous identifier the output
+layer is designed to withhold. Submission IDs are random enough that blind
+guessing is impractical; the oracle matters when an ID is already known from
+elsewhere, which is exactly the linkage scenario the normalization exists to
+prevent.
+
+**Remediation:** apply `normalizePath` *before* the prefix comparison (filter
+on normalized routes), or reject prefixes containing id-shaped segments using
+the existing `isIdentifierSegment`.
+
+### F-4 (Low) — `get_browser_diagnostics` raw User-Agent in samples; client-supplied free text
+
+- Each returned sample includes the **full raw UA string** (up to 512 chars).
+  The tool already computes a coarse, deliberately PII-safe `byBrowser` label
+  ("Safari/iOS") for exactly this reason; the raw UA in samples reintroduces a
+  device-fingerprint-adjacent value that, combined with small cohorts, weakens
+  the aggregate posture. **Remediation:** return `browserLabel(forUserAgent:)`
+  in samples too (keep raw UA out), or truncate to product tokens.
+- `message`/`stack` are stored verbatim (1 KB / 4 KB caps) from an
+  authenticated client POST (`ClientDiagnosticsRoutes`). The
+  "infrastructure text only, never student code" property is real but
+  **enforced only by our client JS**: capture is wired to editor-load,
+  kernel-boot, and pipeline paths; student Python exceptions become
+  `TestOutcome`s rather than thrown JS errors, and the submit-flow breadcrumb
+  sends only `elapsed_ms` + ≤200 chars of pipeline error
+  (`Public/browser-runner.js`, `recordSubmitPhase`). A hostile or buggy client
+  can still post arbitrary text into a row an admin agent will later read.
+  Residual, not a defect; record it as a known property (the server cannot
+  distinguish infrastructure text from other text) and keep the caps.
+
+### F-5 (Low, accepted) — small-cell aggregates and window differencing
+
+Counts-only tools can support inference at small n: a course with one enrolled
+student makes `get_instructor_card_series`' per-bucket "active students"
+series that student's activity timeline; `query_audit_log` with 1-hour windows
+localizes *when* (never who) auth events occurred; `submissionsRequeued` (a
+content-tool side-effect count) reveals how many students have submissions on
+an assignment. None of these yields an identity through the MCP surfaces
+themselves (no roster is exposed anywhere to join against); the linkage
+requires out-of-band knowledge that course staff already hold with full
+fidelity via the web UI. Recommend recording this as an accepted residual in
+the submission; optionally floor distinct-count buckets (suppress 1–2) if the
+Steward asks for k-anonymity on principle.
+
+### F-6 (Info / hardening) — wall-test scan scope and the identity models
+
+`MCPStudentDataWallTests` scans `Sources/APIServer/MCP/Tools/` only, and its
+forbidden-model list excludes `APIUser` / `APICourseEnrollment` because the
+authorization layer (in-scope `ToolContext.swift`) must query them. Verified
+today: no tool file touches `APIUser` outside `ToolContext`/`UpdateSolutionTool`
+(both resolve the *acting* subject only), and `Transport/` / `Resources/`
+(outside the scan) touch only courses/assignments and the acting subject. But
+a future tool that queried `APIUser` or listed enrollments would not trip the
+wall test, and the DB role cannot catch it (`users`/`course_enrollments` are
+SELECT-granted for authz). **Remediation:** extend the scan to `Transport/` +
+`Resources/`, and forbid `APIUser`/`APICourseEnrollment`/`userIsEnrolled`
+outside an explicit allowlist (`ToolContext.swift`, `UpdateSolutionTool.swift`,
+`MCPCourseGuidance.swift`).
+
+### F-7 (Info / recorded decision) — admin surface has no DB-level wall
+
+`AdminToolContext.db` is the shared owner pool; the admin surface's guarantee
+is the hand-built DTO allowlist + per-tool PII tests, per the revised decision
+in `docs/admin-mcp.md` §4 ("code allowlist, no new DB role"). This is a
+defensible, documented posture — the tests are genuinely strong (seeded
+student rows, serialized-output assertions, per-tool instructor-refusal
+tests) — but the privacy submission should state plainly that for this surface
+the enforcement is application-layer. If the Steward requires DB-enforced
+hardening later, the design of record is PII-free SQL views granted to the
+*existing* `chickadee_mcp` role (admin-mcp.md §4.1), not a second role.
+
+### F-8 (Info / docs) — compliance record drift
+
+`docs/compliance/tool-inventory.md` and `data-flow-inventory.md` describe 36
+content tools (v0.4.435); the catalog is now **51**, and the **19 admin tools
+appear in no compliance document** — `docs/admin-mcp.md` §9 itself requires
+the compliance record be updated before the admin surface is enabled in
+production. `CLAUDE.md`'s prose says 40. This document provides the current
+census (§2); the companion inventories should be refreshed or superseded
+before submission, and the P2-3 checklist item ("re-run the census when a tool
+is added") extended to cover `AdminMCPToolCatalog.live`.
+
+### F-9 (Verify at deployment) — properties the repo cannot prove
+
+For the submission, the operator should attest the production environment:
+
+1. `MCP_DATABASE_USER=chickadee_mcp` is set and
+   `deploy/sql/mcp-least-privilege-role.sql` has been applied (turns the
+   content-surface DB wall on; `docker-compose.yml` does not set it by
+   default — only the `.env.example` templates carry it, commented out).
+   Verification queries are at the bottom of the SQL file.
+2. `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` are set (production refuses to
+   mount otherwise unless `MCP_ALLOW_OPEN_GUARDS=true` — confirm it is not).
+3. `AUDIT_LOG_RETENTION_DAYS` matches the retention the submission states
+   (default 90).
+4. The deployment-layer egress allowlist (`deploy/egress-allowlist.md`) is
+   applied; Chickadee itself calls no model API (re-verified: no model-provider
+   client or key exists in `Sources/` or `Package.swift`).
+
+---
+
+## 4. Inference-channel review (the "indirect access" question)
+
+Checked explicitly, beyond the per-tool DTO review:
+
+- **Join keys.** No tool emits usernames, user UUIDs, emails, student numbers,
+  submission IDs, or seeds (findings F-1/F-2 free-text paths aside). Without a
+  key, cross-tool joins reduce to timestamp correlation over aggregates (F-5).
+- **Existence oracles.** Tool inputs that filter server-side were reviewed for
+  probe value: `get_browser_diagnostics testSetupID` and
+  `get_instructor_card_series courseCode` filter instructor-content
+  identifiers (in scope for an admin); `get_request_metrics pathPrefix` is the
+  one that probes below the output layer's abstraction (F-3).
+- **Error-message side channels.** Content-tool errors return
+  argument-derived, instructor-content detail ("No assignment found with
+  public ID…"); none was found that reflects student-row state. The
+  `executionFailed` wrapper in `get_validation_result` stringifies DB errors —
+  under the least-privilege role those are permission-denied texts, not row
+  data.
+- **Personalization.** Seeds are CSPRNG (not identity-derived), unreachable
+  through both walls; previews are by-seed, not by-student; per-student
+  expression *results* delivered to grading (`_ck_inputs`) never transit MCP.
+- **Free text.** The systemic pattern behind F-1/F-2/F-4: prose fields
+  (`message`, `stack`, `detail`, interpolated log strings) are where
+  structured defenses end. The remediations above close the two live/latent
+  importers; the durable control is the write-side convention "identifiers go
+  in metadata, never in message/detail prose" plus the guard tests.
+
+---
+
+## 5. What an agent can see, in plain terms
+
+Worth stating for the submission, because it is the intuition the architecture
+delivers:
+
+- A **content agent** (staff-authorized) sees and edits instructor-authored
+  course content — assignments, suites, scripts, notebooks, solutions,
+  achievements *definitions*, personalization *specs* — plus the instructor's
+  own validation-run outcomes. It cannot name a student, list an enrollment,
+  see a submission or grade, or learn a seed. Its reach is clamped to the
+  courses its human is enrolled in, per request.
+- An **admin diagnostic agent** sees operational health: versions, deploys,
+  runner fleet, queue depth, metrics series, browser-error breakdowns,
+  grade-sync *health*, audit-log *counts*, and warning+ *log lines*. The log
+  lines are the one place today where a student-linked string can transit
+  (F-1) — everything else is counts, aggregates, or hand-allowlisted
+  infrastructure fields, each pinned by a test that seeds a student and
+  asserts their identifiers never serialize.
+
+---
+
+## 6. Re-verification of the prior audit's remediations (v0.4.435 → v0.4.667)
+
+| Item | Claim in `remediation-plan.md` | Verified now |
+|------|-------------------------------|--------------|
+| P0-1 | Boundary chokepoint + wall test; optional least-privilege pool + RLS | ✅ `MCPStudentDataBoundary` + `MCPStudentDataWallTests`; `deploy/sql/mcp-least-privilege-role.sql` + `MCPDatabasePoolTests` + `MCPLeastPrivilegeGrantSyncTests`; regrade + seed bookkeeping routed to owner pool (`ContentEditClose.swift`, `ToolContext.mainDB`) |
+| P0-2 | Authorization coverage guard | ✅ `MCPAuthorizationCoverageTests` (source scan, all tool files, explicit unscoped allowlist = `GetServerInfoTool` only) |
+| P0-3 | Signing key git-ignored + rotation documented | ✅ `.mcp-signing-key` ignored; `deploy/README.md` |
+| P1-1 | Audit outcome + target | ✅ `MCPDispatcher` records target + stamps outcome post-invoke; `MCPAuditTargetOutcomeTests` |
+| P1-2 | Fail-closed audit for writes | ✅ write tools persist the row pre-invoke and fail closed; reads best-effort; `MCPAuditFailClosedTests` |
+| P1-3 | Solution egress confined | ✅ wall test's `loadExistingSolution` scan restricts the answer key to `get_solution` |
+| P2-2 | Prod transport-guard refusal | ✅ `mcpTransportGuardRefusal`, reused by the admin mount |
+
+The admin surface additionally implements the design record's commitments:
+counts-only audit log, aggregates-only job metrics, allowlisted browser/BS
+DTOs, redacted ring buffer, per-tool PII + role-refusal tests, and
+`admin_mcp.tool_called` auditing.
+
+---
+
+## 7. Recommended order of work before submission
+
+1. **F-1** — move identifiers to metadata at the six named call sites, extend
+   `piiKeys`, add the guard test, fix the `query_logs` description. (Small,
+   self-contained; closes the only live Medium.)
+2. **F-2** — sanitize the BrightSpace `detail` writer + error descriptions,
+   strengthen the PII test. (Must land before BrightSpace sync is enabled;
+   cheap now, awkward after.)
+3. **F-3 / F-4** — normalize-before-filter; sample-level `browserLabel`
+   instead of raw UA. (Each is a few lines.)
+4. **F-6** — widen the wall test's scan + forbid identity models outside the
+   authz allowlist. (Keeps the architectural guarantee ahead of future tools.)
+5. **F-8** — refresh/supersede the compliance inventories with the current
+   70-tool census; state F-7's application-layer posture explicitly.
+6. **F-9** — operator attestation of the production env properties.
+
+With 1–2 done and 5–6 written up, the submission can truthfully state: *no MCP
+tool returns student identity, submissions, results, grades, enrollment, or
+seeds; the two student-data tables the content surface can reach are
+validation-filtered in code, by test, and (when configured) by database RLS;
+the admin surface exposes aggregates and allowlisted infrastructure fields
+pinned by tests that seed student data and assert its absence; and the known
+free-text importers have been closed.*

--- a/docs/compliance/policy46-classification.md
+++ b/docs/compliance/policy46-classification.md
@@ -47,3 +47,21 @@ These are provisional engineering assessments, not an official ruling.
   given course, the read tools that return it (`get_solution`,
   `get_validation_result`, `preview_personalization`) are the controlled set to
   gate or disable via `MCP_MODE=read_only` plus selective tool exposure.
+
+## Addendum (2026-07): admin diagnostic surface data types
+
+The read-only admin diagnostic surface (`/admin-mcp`, 19 tools — see
+`tool-inventory.md` addendum and `mcp-student-data-audit-2026-07.md`) adds
+these outbound data types. Consent for this surface requires the admin role.
+
+| # | Data type | Source / tool | Provisional class | Rationale |
+|---|-----------|---------------|-------------------|-----------|
+| 12 | **Operational aggregates** (queue depth, job/status counts, latency percentiles, utilization series, distinct-user counts, storage bytes) | metrics/queue/storage/series tools | **Confidential** | Deployment-operational numbers; no identity, no content. Small-cell inference is the recorded residual (audit F-5). |
+| 13 | **Runner fleet & deploy state** (runner ids/hostnames/capabilities, deploy versions/events) | `list_runners`, `get_runner_detail`, deploy tools | **Confidential** | Infrastructure topology and CD state; operationally sensitive, no personal information. |
+| 14 | **Warning+ log events & browser-error reports** (level, label, message, redacted metadata; error message/stack, coarse browser label) | `query_logs`, `get_browser_diagnostics` | **Confidential** | Infrastructure free text. Student identifiers are excluded by capture-side redaction plus the write-side hygiene convention (audit F-1, pinned by `LogMessageHygieneTests`); browser samples carry the coarse browser/OS label, never the raw User-Agent (F-4). |
+| 15 | **Audit-log aggregate counts** (totals by action/category) | `query_audit_log` | **Confidential** | Counts only, by construction — no row, actor, IP, or metadata is ever loaded. |
+| 16 | **Grade-sync health** (status counts; error samples: sanitized detail, assignment, org unit) | `get_brightspace_sync_status`, `get_health_alerts` | **Confidential** | Student username, grade (points), and user id columns are omitted; the `detail` string is sanitized at write to exclude the pushed grade, orgDefinedId, and untruncated D2L bodies (audit F-2). |
+| 17 | **MCP grant metadata** (agent name, scopes, owner username, timestamps) | `list_connected_agents` | **Confidential** | The owner is the authorizing staff/admin account (consent-gated — never a student); employee-identity metadata for audit/attribution, no token material. |
+
+No admin-surface data type carries student personal information; row 17 is the
+only personal information at all (the authorizing staff member's username).

--- a/docs/compliance/tool-inventory.md
+++ b/docs/compliance/tool-inventory.md
@@ -1,14 +1,19 @@
 # MCP Tool-Surface Inventory
 
-Audit scope: the Model Context Protocol (MCP) server under
-`Sources/APIServer/MCP/`. Snapshot taken at `VERSION` **0.4.435**.
+Audit scope: the Model Context Protocol (MCP) surfaces under
+`Sources/APIServer/MCP/`. Base snapshot taken at `VERSION` **0.4.435**;
+**refreshed 2026-07 at `VERSION` 0.4.667** (see the addendum section at the
+end and `mcp-student-data-audit-2026-07.md` for the full re-audit).
 
 This is a complete, one-row-per-tool inventory of the MCP capability surface,
 walked from the live registry (`MCPToolCatalog.live`,
-`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift:16-59`) down to
-each tool's handler. The catalog registers **39 tools** (the prose digest in
-`CLAUDE.md` says "thirty-four"; the registry is the source of truth — count it
-from `MCPServerRegistration.swift:18-57`).
+`Sources/APIServer/MCP/Transport/MCPServerRegistration.swift`) down to each
+tool's handler. As of the 2026-07 refresh the content catalog registers
+**51 tools** (the table below plus the six-tool addendum), and a second,
+admin-only diagnostic surface (`AdminMCPToolCatalog.live`) registers
+**19 read-only tools** — inventoried in the addendum. The registries are the
+source of truth; a census re-count is required whenever either changes
+(remediation P2-3).
 
 ## How to read this table
 
@@ -126,3 +131,59 @@ Python/shell that later runs in the grading sandbox. This is identical to the
 existing instructor capability and is mitigated by (a) course-scoped authz,
 (b) the `ScriptRunner` sandbox at execution time, and (c) the audit trail. It
 is *not* a new in-process execution surface.
+
+---
+
+## Addendum (2026-07, v0.4.667): tools added since the base snapshot
+
+Six content tools joined `MCPToolCatalog.live` after v0.4.435. Same
+conventions as the tables above; every one routes through the standard
+authorization chokepoints (pinned registry-wide by
+`MCPAuthorizationCoverageTests`).
+
+| Tool | Handler (`file`) | Resource arg | Authz | Reads / touches | Output |
+|------|------------------|--------------|-------|-----------------|--------|
+| `list_assignment_versions` | `AssignmentVersionTools.swift` | `assignmentPublicID` | course-enrol | `APIAssignmentVersion` (content snapshots) | version list (id, timestamp, actor label) |
+| `get_assignment_version` | `AssignmentVersionTools.swift` | `assignmentPublicID`, version id | course-enrol | `APIAssignmentVersion` | one snapshot's content (suite/notebook state) |
+| `restore_assignment_version` | `RestoreAssignmentVersionTool.swift` | `assignmentPublicID`, version id | course-enrol write (TA+) | `APIAssignmentVersion`, `APITestSetup` | restored content; closes + revalidates via `finalizeContentEdit` |
+| `set_dataset` | `SetDatasetTool.swift` | `assignmentPublicID`, filename | course-enrol write (TA+) | `APITestSetup` manifest (`TestProperties.datasets`) | dataset specs after edit (file, sampleSize) |
+| `set_time_limit` | `SetTimeLimitTool.swift` | `assignmentPublicID` | course-enrol write (TA+) | `APITestSetup` manifest (`timeLimitSeconds`) | updated limit |
+| `set_minimum_runner_version` | `SetMinimumRunnerVersionTool.swift` | `assignmentPublicID` | course-enrol write (TA+) | `APIAssignmentRequirement` | updated requirement |
+
+All six return instructor-authored content or configuration only; none touches
+a student-data model (enforced by `MCPStudentDataWallTests`, whose scan now
+also covers `Transport/` + `Resources/` and confines identity models to the
+authorization layer — 2026-07 audit F-6).
+
+## Addendum (2026-07): the admin diagnostic surface (19 tools)
+
+A second, **read-only** MCP surface at `POST /admin-mcp`
+(`AdminMCPToolCatalog.live`, design record `docs/admin-mcp.md`), mounted with
+the content surface but separated by OAuth audience and scope
+(`diagnostics:read` only — the scope enum has no write case). Consent requires
+`isAdmin` and every DB-touching tool re-checks the subject per call
+(`AdminToolContext.requireAdminSubject`). Every tool's returned DTO was
+verified field-by-field in `mcp-student-data-audit-2026-07.md` §2.2 (which
+carries the full source→fields→posture table); per-tool PII tests seed student
+rows and assert their identifiers never serialize (`AdminMCPToolsTests`).
+
+| Tool | Source | PII posture |
+|------|--------|-------------|
+| `get_deployment_info` | static config (DB-free) | clean |
+| `get_deploy_status` / `get_deploy_history` | deployer status/history files | clean |
+| `get_metrics_snapshot` / `get_metrics_card_series` / `get_metrics_timeseries` | dashboard aggregate builders | aggregates only |
+| `get_active_users_series` | `ActivityChartService` | distinct counts per bucket only |
+| `get_instructor_card_series` | `instructorCardSeries` (one course) | per-bucket counts only; PII-tested |
+| `get_queue_state` | submissions table | counts/ages only |
+| `list_runners` / `get_runner_detail` | worker rows, `job_execution_metrics` | aggregates; per-job rows (username + submission id) deliberately omitted; PII-tested |
+| `get_storage_usage` | storage scan | per-assignment byte/count aggregates |
+| `get_request_metrics` | `request_metrics` | routes normalized to `:id`; prefix filter matches normalized routes (audit F-3) |
+| `get_health_alerts` | live rule evaluation | counts/thresholds; BrightSpace `last_error` writer-sanitized (audit F-2) |
+| `get_browser_diagnostics` | `client_diagnostics` | `user_id` omitted; samples carry the coarse browser/OS label, never the raw User-Agent (audit F-4); PII-tested |
+| `list_connected_agents` | OAuth grants | owner is the authorizing staff/admin (consent-gated), never a student; no token material |
+| `get_brightspace_sync_status` | `brightspace_sync_log` | `username`/`points`/`user_id` columns omitted; `detail` sanitized at write (audit F-2); PII-tested |
+| `query_audit_log` | `audit_log` | counts by action/category only — no row, actor, IP, or metadata ever loaded |
+| `query_logs` | in-process warning+ ring buffer | PII metadata keys dropped at capture; message hygiene pinned by `LogMessageHygieneTests` (audit F-1) |
+
+Admin tool calls are themselves audited (`admin_mcp.tool_called`, with
+outcome).

--- a/docs/compliance/trust-boundary.md
+++ b/docs/compliance/trust-boundary.md
@@ -16,12 +16,23 @@ So the controls that matter for this submission are:
 
 1. **The inbound gate** — who may connect (`MCPBearerAuthMiddleware`) and what
    they may do (per-tool scope + per-course enrolment check).
-2. **The bounded tool surface** — 36 special-purpose tools, no general escape
-   hatch (`tool-inventory.md`).
+2. **The bounded tool surface** — special-purpose typed tools, no general
+   escape hatch: 51 content tools as of the 2026-07 refresh
+   (`tool-inventory.md`, base tables + addendum).
 3. **The student-data wall** — tools read the authoring store and the
    instructor's own validation runs, never student submissions/grades/roster.
 4. **What each tool returns** — because the return value is exactly what the
    agent can forward to its model (`data-flow-inventory.md`).
+
+**Second resource (2026-07): the admin diagnostic surface.** A separate,
+read-only MCP endpoint at `POST /admin-mcp` (19 tools,
+`AdminMCPToolCatalog.live`) with its own RFC 8707 audience, its own scope
+vocabulary (`diagnostics:read` — no write case exists), and a consent gate of
+`isAdmin` re-checked per call. A content token cannot authenticate there and
+vice versa — the audiences are disjoint, so a scope bug in one surface cannot
+leak into the other. Its returned data is operational aggregates and
+allowlisted infrastructure fields only; the per-tool posture and the upstream
+writer hygiene are audited in `mcp-student-data-audit-2026-07.md` §2.2–§3.
 
 There is **no** Chickadee→model-API egress edge to allowlist; the model API is
 reached by the agent. Chickadee's own outbound edges (OIDC/DUO, BrightSpace/D2L,

--- a/docs/compliance/uw-ai-approval-readiness.md
+++ b/docs/compliance/uw-ai-approval-readiness.md
@@ -1,0 +1,170 @@
+# UW AI-Tool Approval — Readiness Plan for the Chickadee MCP Surfaces
+
+Companion to `mcp-student-data-audit-2026-07.md`. Maps the University of
+Waterloo approval process for AI tools using University data
+([IST: Responsible use of AI tools — approval support](https://uwaterloo.ca/information-systems-technology/about/policies-standards-and-guidelines/responsible-use-ai-tools-university-data/approval-support))
+onto Chickadee's current state: what each step will ask, which repo artifact
+answers it, and the gaps to close before intake.
+
+UW's pathway, as published: **(1)** initiation and scoping with early
+Information Steward engagement, **(2)** Information Risk Assessment + Privacy
+Impact Assessment (intake to IST Information Security Services and Legal &
+Immigration Services; a PIA is mandatory when personal information is
+involved), **(3)** contracting and procurement, **(4)** approval and
+onboarding (limited-use cases get unit-level approval), **(5)** ongoing
+review/revalidation (five-year cycle, contract renewal, or major
+vendor/feature/data-handling change). Tools are classified **Approved**
+(contract + IRA/PIA; suitable for Confidential/Restricted data), **Reviewed
+for Limited Use** (IRA/PIA, no contract; publicly-sourced data only),
+**Unreviewed**, or **Problematic**.
+
+---
+
+## 0. The framing decision (settle this first)
+
+Get agreement with the Steward/IST up front on **what is being reviewed**:
+
+- **Chickadee is not the AI tool.** It is the UW-hosted system of record. It
+  calls no model API — there is no model-provider client, key, or SDK in the
+  codebase (re-verified in the 2026-07 audit; original finding in
+  `ira-audit-report.md` §Executive summary). Chickadee's role in the review is
+  to **bound what any connected AI tool can access**, which is exactly what
+  the student-data audit demonstrates.
+- **The AI tool under the framework is the connecting agent** — the Claude
+  connector (or any MCP client) and, transitively, its model provider. The
+  vendor-side properties the process evaluates (retention, no-training, data
+  residency, contract terms) attach to *that* tool, through procurement — not
+  to Chickadee code.
+- **The data that reaches the AI tool is precisely the MCP tool payloads.**
+  This is the whole point of the architecture: the review does not need to
+  reason about "an AI with access to a student-records system," because the
+  boundary makes student records unreachable. The audit + Policy 46
+  classification enumerate everything that can cross.
+
+**Critical-path item outside this repo:** determine the current UW
+classification of the intended connector (e.g. Claude). If it is not
+**Approved** (contract + completed IRA/PIA), the default "Reviewed for
+Limited Use — publicly-sourced data only" posture would not cover
+instructor-authored course content, which classifies **Confidential /
+Restricted** under Policy 46 (answer keys and secret tests are the high-water
+mark — `policy46-classification.md`). In that case the options are:
+(a) procurement of enterprise terms for the connector (no-training,
+bounded retention), or (b) an explicitly scoped limited-use approval that
+accepts the Restricted content classes crossing, with the student-data wall
+as the compensating control. Raise this in the very first Steward
+conversation — everything else can proceed in parallel, but this decides the
+contracting track.
+
+---
+
+## 1. Step 1 — Initiation and scoping: answers to bring
+
+| Scoping question | Answer (with evidence) |
+|------------------|------------------------|
+| Intended use | An agent authors course content (assignments, test suites, notebooks, reference solutions) on an instructor's behalf, and reads operational diagnostics on an admin's behalf. Two separate MCP surfaces; catalog census 51 + 19 tools (`mcp-student-data-audit-2026-07.md` §2). |
+| User groups & access roles | Course staff (per-course TA/instructor) for content; admins for diagnostics. Students are excluded at consent AND per-call (`MCPOAuthSurface.permits`, `requireEligibleSubject`). Agent reach ⊆ the human's enrolled courses, re-checked per request. |
+| Data classification of what crosses | Instructor-authored content: problem statements Confidential; reference solutions / secret tests / personalization expressions **Restricted** (`policy46-classification.md`, to be refreshed — audit F-8). Student personal information: **none by design** once audit F-1/F-2 land; the evidence chain is §2 of the audit. Staff PI: the authorizing account's username for attribution only. |
+| Where data lives / flows | System of record: UW-hosted (self-hosted deployment). Outbound destinations are five known non-model endpoints (`deploy/egress-allowlist.md`). What reaches the AI tool: MCP tool payloads only, over the OAuth-gated endpoints. Agent-side handling is governed by the connector's contract (Step 3). |
+| Business need | Course-content authoring/maintenance assistance and operational diagnosis without widening student-data exposure; the alternative (human copy/paste into an AI tool) has strictly worse data-handling properties. |
+
+**Steward engagement:** bring (a) the framing decision above, (b) the
+connector-classification question, (c) the Policy 46 table for sign-off that
+Restricted-but-not-student-PI content may cross under the contemplated tool
+classification, and (d) the audit's F-5 note (small-cell aggregates) for an
+explicit accepted-residual decision.
+
+## 2. Step 2 — IRA / PIA: the submission package
+
+The IRA/PIA intake (IST Help Portal / LIS) will ask about security controls,
+vendor practices, retention, and privacy risk. The repo-side package:
+
+1. **`mcp-student-data-audit-2026-07.md`** — the central claim ("no student
+   data, direct or inferred") with per-tool evidence, findings, and the
+   enforcement-test inventory. Submit only after F-1 and F-2 are closed so the
+   claim is unqualified.
+2. **Refreshed companions** (audit F-8): `tool-inventory.md` and
+   `data-flow-inventory.md` regenerated for the 51-tool content catalog;
+   admin-surface addenda for both; `policy46-classification.md` extended with
+   the admin surface's data types (operational aggregates → Public/Internal;
+   log/diagnostic text → Confidential); `trust-boundary.md` updated with the
+   second audience (`/admin-mcp`) and the admin-only consent gate.
+3. **PIA scoping answer, pre-drafted:** personal information *involved* in
+   Chickadee at large (student records) vs. personal information *accessible
+   to the AI tool* (none by design; staff attribution identity only). The PIA
+   is expected to be mandatory regardless — the pre-drafted distinction is
+   what keeps its scope tractable.
+4. **Security-controls summary** (all already documented in the audit §2):
+   OAuth 2.1 + PKCE with per-grant revocation; ES256 access tokens, 600 s
+   TTL; disjoint audiences; per-request scope clamping; per-course
+   authorization; consent role gates; fail-closed audit rows with outcome;
+   production transport-guard refusal; single-use codes/consent tokens;
+   refresh rotation with theft detection.
+5. **Retention story:** audit log 90 days default (`AUDIT_LOG_RETENTION_DAYS`,
+   hourly reaper); `query_logs` ring buffer is in-process and dies with the
+   process; OAuth rows reaped hourly; diagnostic tables are operational
+   records under existing schedules. Vendor-side retention belongs to Step 3.
+6. **Verification evidence:** the enforcement tests
+   (`MCPStudentDataWallTests`, `MCPAuthorizationCoverageTests`, per-tool PII
+   tests, `MCPLeastPrivilegeGrantSyncTests`) and the RLS script
+   (`deploy/sql/mcp-least-privilege-role.sql`) — the "reviewer can verify
+   every claim from the repo" property both audits were written to.
+
+## 3. Step 3 — Contracting and procurement (vendor side)
+
+Owned by Procurement & Contract Services; the repo can only pin what the
+product needs from the contract:
+
+- No training on submitted content; bounded retention; the data classes that
+  will cross (Confidential/Restricted instructor content, per the Policy 46
+  table) named in the data-protection terms.
+- Confirm whether an existing UW agreement already covers the connector
+  (Step 0's classification question) before negotiating anything new.
+- Chickadee-side commitments the contract can rely on: no model egress from
+  the server, the egress allowlist, and the student-data wall.
+
+## 4. Step 4 — Approval and onboarding: secure-configuration attestation
+
+The expected path is a **limited-use, unit-level approval** first (one or two
+pilot courses), enterprise later if wanted. The onboarding artifact is the
+deployment attestation from audit F-9, executed on prod:
+
+1. `MCP_DATABASE_USER=chickadee_mcp` set; `mcp-least-privilege-role.sql`
+   applied; the SQL file's verification queries run and recorded.
+2. `MCP_ALLOWED_HOSTS` / `MCP_ALLOWED_ORIGINS` set; `MCP_ALLOW_OPEN_GUARDS`
+   unset.
+3. `MCP_MODE` decision recorded (start `read_only`; move to `read_write` as a
+   deliberate step — the per-request clamp makes rollback instant).
+4. `AUDIT_LOG_RETENTION_DAYS` matching the PIA's stated retention.
+5. Egress allowlist applied at the deployment layer.
+6. BrightSpace sync remains disabled until F-2 is closed (its own enablement
+   is a data-handling change — see Step 5).
+
+## 5. Step 5 — Ongoing review: keep the record current by construction
+
+Revalidation triggers to write into the unit's process, wired to mechanisms
+the repo already has:
+
+- **Tool-census drift:** extend the P2-3 checklist so any change to
+  `MCPToolCatalog.live` or `AdminMCPToolCatalog.live` requires a compliance-doc
+  touch in the same PR (the audit's F-8 remediation; a count-sync guard test
+  in the spirit of `MCPInstructionsCatalogSyncTests` makes it automatic).
+- **Data-handling changes that trigger re-review:** enabling BrightSpace sync;
+  flipping `MCP_MODE` to `read_write` in prod; any new tool that widens a DTO;
+  any change to the consent role gates; connector/vendor change (that one is
+  UW's own five-year/contract-renewal trigger).
+- **Standing evidence:** the enforcement tests run on every PR, so the
+  architectural claims in the submission stay continuously verified between
+  revalidations.
+
+## 6. Ordered gap list before intake
+
+1. Close audit **F-1** (log free-text identifiers) and **F-2** (BrightSpace
+   detail) — the submission's central claim should need no asterisk.
+2. Refresh the compliance companions to the 70-tool census (**F-8**).
+3. Pre-draft the PIA scoping answer (§2.3 above).
+4. Execute and record the deployment attestation (**F-9** / §4).
+5. Resolve the connector's UW classification (§0) and open the Steward
+   conversation with the §1 table.
+
+Items 1–4 are repo/operator work and can land this week; item 5 is the
+institutional critical path and should start immediately in parallel.


### PR DESCRIPTION
## What this is

Three deliverables toward the privacy-team submission, in dependency order:

1. **`docs/compliance/mcp-student-data-audit-2026-07.md`** — full student-data access audit of both MCP surfaces (content-authoring, 51 tools; admin diagnostics, 19 tools — the latter's first compliance pass), answering "no student data, direct or inferred" with repo-verifiable citations. Re-verifies every P0/P1 remediation from the v0.4.435 IRA audit and sweeps the **upstream writers** feeding the admin tools' data stores.
2. **Remediations for findings F-1–F-4, F-6, F-8** (see below) — so the audit's central claim needs no asterisk.
3. **`docs/compliance/uw-ai-approval-readiness.md`** — maps UW IST's five-step AI-tool approval pathway onto Chickadee: which artifact answers each step, the pre-drafted PIA scoping position, the deployment attestation, and the institutional critical path (the connector's own UW tool classification).

## Remediations in this PR

- **F-1 (Medium, live)** — warning+ log *messages* no longer interpolate student identifiers (usernames, user IDs, submission IDs, client IPs) into text the admin `query_logs` ring buffer stores verbatim. Identifiers move to structured metadata under keys `RingBufferLogHandler` redacts at capture; console/ops logging keeps full fidelity. New **`LogMessageHygieneTests`** source-scans every warning+ logger call in `Sources/APIServer` and fails the build on regression — the scan itself found two additional sites beyond the audit's six.
- **F-2 (Medium, latent)** — BrightSpace sync-error text sanitized at the write site, ahead of sync being enabled in prod: the rejection detail is built by a helper that takes **no points parameter** (the grade structurally cannot enter the string surfaced by `get_brightspace_sync_status` / `get_health_alerts`); `BrightSpaceSyncError` descriptions omit the `orgDefinedId` and truncate D2L bodies. New **`BrightSpaceDetailSanitizationTests`**.
- **F-3 (Low)** — `get_request_metrics` matches `pathPrefix` against **normalized** routes, closing the concrete-ID existence probe. Probe test added.
- **F-4 (Low)** — `get_browser_diagnostics` samples carry the coarse browser/OS label, never the raw User-Agent. Test added.
- **F-6 (hardening)** — the student-data wall test now also scans `Transport/` + `Resources/`, and a new guard confines `APIUser`/`APICourseEnrollment` to the authorization allowlist.
- **F-8 (docs)** — compliance record refreshed to the 70-tool census: `tool-inventory.md` addenda (6 new content tools + the full 19-tool admin table), `policy46-classification.md` admin data types, `trust-boundary.md` second audience, `CLAUDE.md` count corrected to 51.

Open by design: **F-5** (small-cell aggregates — accepted residual for the Steward), **F-7** (admin surface's application-layer posture — recorded decision), **F-9** (operator attestation of prod env).

## Verification

- `swift build` green; `scripts/lint.sh` + `scripts/swiftlint.sh --strict` clean.
- Targeted suites all passing: `LogMessageHygieneTests`, `MCPStudentDataWallTests` (incl. the two new guards), `BrightSpaceDetailSanitizationTests`, `AdminMCPToolsTests` (47 tests, incl. the new probe + UA tests), `BrightSpaceGradeSyncTests` (22), `MCPInstructionsCatalogSyncTests`, `MCPOutputSchemaSyncTests`.
- Behavior changes are confined to: log message shapes (identifiers → metadata), BrightSpace error strings, the request-metrics prefix semantics (normalized matching), and the browser-diagnostics sample field (`userAgent` → `browser`). No grading, auth, or student-facing paths touched.
- Changelog fragment included; `VERSION`/`CHANGELOG.md` untouched per the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JDoyqdYwuPwAPv7xsWhJM