### PR TITLE
docs: write down the 0.y.z versioning policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -712,7 +712,11 @@ css-vars + design-token guards too — same as the CI `format-lint` job).
 ## Versioning
 
 Follows Semantic Versioning in the `0.y.z` phase. The version lives in the
-`VERSION` file + `ChickadeeVersion.current` in Core.
+`VERSION` file + `ChickadeeVersion.current` in Core. What each slot means
+here — patches never remove compatibility surface; minors are deliberate
+era/removal boundaries; majors are deployer-gated — is documented in
+"What the numbers mean while we are 0.y.z" in
+[docs/release-process.md](docs/release-process.md).
 
 **Versions are assigned at merge time — do NOT bump them in a PR.** A PR must
 not touch `VERSION`, `Sources/Core/ChickadeeVersion.swift`, or `CHANGELOG.md`

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -64,6 +64,34 @@ follow-up step.
 `scripts/check-version.sh` still enforces `VERSION == ChickadeeVersion.current`;
 the release script writes both together, so they never drift.
 
+## What the numbers mean while we are 0.y.z
+
+SemVer's major-version-zero rule is that nothing is promised yet ("anything
+MAY change at any time"), so the slots below are this project's own policy —
+adopted at the 0.5.0 cut — with the enforceable parts wired into tooling
+rather than left to convention:
+
+- **Patch — auto-cut on every merged fragment.** Routine change. A patch must
+  never remove or break a compatibility surface: an env var, a route, a wire
+  field, a bundle key, a stored format. Auto-release can only produce
+  patches, so "a merge never breaks an operator" is structural, not a review
+  item — if a PR retires something, it is not a patch (see the next bullet)
+  and must wait.
+- **Minor — deliberate and manual.** An era boundary, a batch of
+  compatibility removals, or both. 0.5.0 was both: the capstone on the first
+  full course offering *and* the retirement of the pre-0.5 shims
+  (`WORKER_SHARED_SECRET`, `/admin/workers`, the bundle `isOpen` write side,
+  …). Removals accumulate behind deprecation warnings on patches and land
+  together at the next minor, where the changelog announces them in one
+  place.
+- **Major — manual, and deployer-gated.** Reserved. The deploy daemon holds
+  major bumps for human approval, so 1.0.0 will be the first release that
+  cannot reach production without an explicit operator sign-off. 1.0 is also
+  the point where external contracts — the `.chickadee` bundle format, the
+  MCP surfaces, the runner wire protocol — would become promises to parties
+  other than ourselves; until some other institution consumes one of those,
+  0.y.z's freedom is doing no harm.
+
 ## Cutting a minor (or major) release — manual by design
 
 Auto-release is **patch-only by construction**: `assemble-release.sh` computes


### PR DESCRIPTION
Codifies the versioning convention the 0.5.0 cut inaugurated, so it's written policy rather than convention — new "What the numbers mean while we are 0.y.z" section in `docs/release-process.md`:

- **Patch** (the only thing auto-release can cut): routine change; must never remove or break a compatibility surface (env var, route, wire field, bundle key, stored format). Structural, since auto-release is patch-only by construction.
- **Minor** (deliberate, manual): an era boundary and/or a batch of compatibility removals — 0.5.0 was both. Removals accumulate behind deprecation warnings on patches and land together at the next minor.
- **Major** (manual, deployer-gated): reserved; 1.0.0 will be the first release requiring explicit operator approval, and the point where external contracts (bundle format, MCP surfaces, runner wire protocol) become promises to parties other than ourselves.

CLAUDE.md's Versioning section now points at the new section.

Deliberately no changelog fragment: a docs-only merge shouldn't cut a release, and the process doc explicitly supports fragment-less PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KydLawYuG6T6c5zDzZCmYo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KydLawYuG6T6c5zDzZCmYo)_