### PR TITLE
chore: allowlist read-only Chickadee MCP tools in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,45 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "mcp__Chickadee__list_courses",
+      "mcp__Chickadee__list_assignments",
+      "mcp__Chickadee__get_assignment",
+      "mcp__Chickadee__get_suite",
+      "mcp__Chickadee__get_notebook",
+      "mcp__Chickadee__get_solution",
+      "mcp__Chickadee__get_support_files",
+      "mcp__Chickadee__get_global_inputs",
+      "mcp__Chickadee__list_course_sections",
+      "mcp__Chickadee__list_content_items",
+      "mcp__Chickadee__get_achievements",
+      "mcp__Chickadee__get_server_info",
+      "mcp__Chickadee__validate_assignment",
+      "mcp__Chickadee__get_validation_result",
+      "mcp__Chickadee__preview_personalization",
+      "mcp__Chickadee__list_assignment_versions",
+      "mcp__Chickadee__get_assignment_version",
+      "mcp__Chickadee_Admin__get_deployment_info",
+      "mcp__Chickadee_Admin__get_deploy_status",
+      "mcp__Chickadee_Admin__get_deploy_history",
+      "mcp__Chickadee_Admin__get_health_alerts",
+      "mcp__Chickadee_Admin__get_queue_state",
+      "mcp__Chickadee_Admin__list_runners",
+      "mcp__Chickadee_Admin__get_runner_detail",
+      "mcp__Chickadee_Admin__query_logs",
+      "mcp__Chickadee_Admin__get_browser_diagnostics",
+      "mcp__Chickadee_Admin__query_audit_log",
+      "mcp__Chickadee_Admin__get_metrics_snapshot",
+      "mcp__Chickadee_Admin__get_metrics_timeseries",
+      "mcp__Chickadee_Admin__get_metrics_card_series",
+      "mcp__Chickadee_Admin__get_instructor_card_series",
+      "mcp__Chickadee_Admin__get_active_users_series",
+      "mcp__Chickadee_Admin__get_request_metrics",
+      "mcp__Chickadee_Admin__get_storage_usage",
+      "mcp__Chickadee_Admin__get_brightspace_sync_status",
+      "mcp__Chickadee_Admin__list_connected_agents"
+    ]
   }
 }


### PR DESCRIPTION
## What

Adds a `permissions.allow` block to `.claude/settings.json` covering the read-only tools on both Chickadee MCP surfaces, so ordinary authoring navigation stops raising a permission prompt per call.

Today every `mcp__Chickadee__*` / `mcp__Chickadee_Admin__*` call prompts. A routine session (`list_courses` → `list_assignments` → `get_assignment` → `get_suite` → `get_notebook`) is five approvals before any work happens.

## How the list was chosen

Not by guesswork or name-matching — from the server's own scope declarations:

- **17 content tools** whose `requiredScopes == [.read]` in `Sources/APIServer/MCP/Tools/`.
- **19 admin diagnostic tools** — `DiagnosticTool.requiredScopes` defaults to `[.read]` and `adminMCPAdvertisedScopes` is `[.read]`, so the surface is read-only by construction.

`validate_assignment` is included: despite the name it only watches an already-enqueued run to completion (`readOnlyHint: true`, `destructiveHint: false`) — the enqueue is a side effect of the *edit* tools, which are not allowlisted.

## What still prompts

All 36 `content:write` tools — `update_*`, `create_*`, `delete_*`, `set_*`, `author_*`, `reorder_*`, `rename_*`, `move_suite_item`, `clone_assignment`, `restore_assignment_version`. Content mutation remains an explicit approval every time.

## Notes

- `.claude/settings.json` is checked in, so this applies to every contributor and CI session. All 36 entries are read-only, which makes that shared scope appropriate.
- Existing `hooks.SessionStart` is preserved unchanged; nothing was added to `permissions.deny` or `permissions.ask`.
- No changelog fragment: this is repo tooling config, not a change to the deployed product.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ueCfBPczzXxCABaEa6bpp)_